### PR TITLE
fixed parent component typo

### DIFF
--- a/ambari-server/docs/api/v1/host-component-resources.md
+++ b/ambari-server/docs/api/v1/host-component-resources.md
@@ -45,7 +45,7 @@ limitations under the License.
   </tr>
   <tr>
     <td>HostRoles/component_name</td>
-    <td>The name of the parenbt component</td>  
+    <td>The name of the parent component</td>  
   </tr>
   <tr>
     <td>HostRoles/state</td>


### PR DESCRIPTION
There was a typo in the API docs, here's a patch fix.

Regards,

Hari
