### PR TITLE
AMBARI-6903: Fix Maven deprecation warnings

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -395,7 +395,7 @@
         </executions>
         <configuration>
           <controlDir>${basedir}/src/main/package/deb/control</controlDir>
-          <deb>${basedir}/target/${artifactId}_${package-version}-${package-release}.deb</deb>
+          <deb>${basedir}/target/${project.artifactId}_${package-version}-${package-release}.deb</deb>
           <dataSet>
             <data>
               <src>${project.build.directory}/${project.artifactId}-${project.version}/ambari_agent</src>

--- a/ambari-client/python-client/pom.xml
+++ b/ambari-client/python-client/pom.xml
@@ -183,7 +183,7 @@
         </executions>
         <configuration>
           <controlDir>${basedir}/src/main/package/deb/control</controlDir>
-          <deb>${basedir}/target/${artifactId}_${package-version}-${package-release}.deb</deb>
+          <deb>${basedir}/target/${project.artifactId}_${package-version}-${package-release}.deb</deb>
           <dataSet>
             <data>
               <src>${project.build.directory}/${project.artifactId}-${project.version}/ambari_client</src>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -528,7 +528,7 @@
         </executions>
         <configuration>
           <controlDir>${basedir}/src/main/package/deb/control</controlDir>
-          <deb>${basedir}/target/${artifactId}_${package-version}-${package-release}.deb</deb>
+          <deb>${basedir}/target/${project.artifactId}_${package-version}-${package-release}.deb</deb>
           <dataSet>
             <data>
               <type>template</type>
@@ -1078,7 +1078,7 @@
   </profiles>
   <dependencies>
     <dependency>
-      <groupId>${pom.groupId}</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>ambari-views</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/ambari-shell/ambari-python-shell/pom.xml
+++ b/ambari-shell/ambari-python-shell/pom.xml
@@ -195,7 +195,7 @@
         </executions>
         <configuration>
           <controlDir>${basedir}/src/main/package/deb/control</controlDir>
-          <deb>${basedir}/target/${artifactId}_${package-version}-${package-release}.deb</deb>
+          <deb>${basedir}/target/${project.artifactId}_${package-version}-${package-release}.deb</deb>
           <dataSet>
             <data>
               <src>${project.build.directory}/${project.artifactId}-${project.version}/ambari_shell</src>


### PR DESCRIPTION
Certain `pom.xml` files are using old/ deprecated property references.
Replace and use new property references.
