### PR TITLE
AMBARI-7753: DataNode decommision error in secured cluster

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/HDFS/package/scripts/hdfs_namenode.py
@@ -135,7 +135,7 @@ def decommission():
   hdfs_user = params.hdfs_user
   conf_dir = params.hadoop_conf_dir
   user_group = params.user_group
-  dn_kinit_cmd = params.dn_kinit_cmd
+  nn_kinit_cmd = params.nn_kinit_cmd
   
   File(params.exclude_file_path,
        content=Template("exclude_hosts_list.j2"),
@@ -143,7 +143,7 @@ def decommission():
        group=user_group
   )
   
-  Execute(dn_kinit_cmd,
+  Execute(nn_kinit_cmd,
           user=hdfs_user
   )
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/HDFS/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/HDFS/package/scripts/params.py
@@ -182,8 +182,15 @@ if security_enabled:
   _dn_principal_name = _dn_principal_name.replace('_HOST',hostname.lower())
   
   dn_kinit_cmd = format("{kinit_path_local} -kt {_dn_keytab} {_dn_principal_name};")
+
+  _nn_principal_name = config['configurations']['hdfs-site']['dfs.namenode.kerberos.principal']
+  _nn_keytab = config['configurations']['hdfs-site']['dfs.namenode.keytab.file']
+  _nn_principal_name = _nn_principal_name.replace('_HOST',hostname.lower())
+  
+  nn_kinit_cmd = format("{kinit_path_local} -kt {_nn_keytab} {_nn_principal_name};")
 else:
   dn_kinit_cmd = ""
+  nn_kinit_cmd = ""
 
 import functools
 #create partial functions with common arguments for every HdfsDirectory call


### PR DESCRIPTION
Ambari-agent tries to perform HDFS refresh as DataNode principal. This should be done as NameNode principal.

Patch information:
 params.py: add nn_kinit_cmd
 hdfs_namenode.py: decommission using nn_kinit_cmd
