### PR TITLE
basic mention of the /blueprints endpoint in the API reference

### DIFF
--- a/ambari-server/docs/api/v1/index.md
+++ b/ambari-server/docs/api/v1/index.md
@@ -32,6 +32,7 @@ The Ambari API facilitates the management and monitoring of the resources of an 
 - [Temporal Metrics](#temporal-metrics)
 - [Pagination](#pagination)
 - [Errors](#errors)
+- [Blueprints](#blueprints)
 
 
 Release Version
@@ -1166,4 +1167,9 @@ Errors
                 	 resource type Cluster."
 	}
 
+Blueprints
+----
+
+The `/api/v1/blueprints` endpoint was added in 1.6.
+For more information on this, see [the wiki](https://cwiki.apache.org/confluence/display/AMBARI/Blueprints).
 


### PR DESCRIPTION
We hadn't even realized that this was available until Rakesh told us today.  The documentation added here is minimal, but will hopefully save others from such gross ignorance. :)
