### PR TITLE
Enable repo components for Ubuntu/Debian

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -55,7 +55,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import com.google.gson.reflect.TypeToken;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.ClusterNotFoundException;
 import org.apache.ambari.server.DuplicateResourceException;
@@ -147,6 +146,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
@@ -3104,7 +3104,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         for (OperatingSystemEntity operatingSystem: repositoryVersion.getOperatingSystems()) {
           if (operatingSystem.getOsType().equals(osType)) {
             for (RepositoryEntity repository: operatingSystem.getRepositories()) {
-              final RepositoryResponse response = new RepositoryResponse(repository.getBaseUrl(), osType, repository.getRepositoryId(), repository.getName(), "", "", "");
+              final RepositoryResponse response = new RepositoryResponse(repository.getBaseUrl(), osType, repository.getRepositoryId(), repository.getName(), repository.getRepoComponents(), "", "", "");
               response.setRepositoryVersionId(repositoryVersionId);
               response.setStackName(repositoryVersion.getStackName());
               response.setStackVersion(repositoryVersion.getStackVersion());

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/RepositoryResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/RepositoryResponse.java
@@ -26,17 +26,20 @@ public class RepositoryResponse {
   private String osType;
   private String repoId;
   private String repoName;
+  private String repoComponents;
   private String mirrorsList;
   private String defaultBaseUrl;
   private String latestBaseUrl;
   private Long repositoryVersionId;
 
-  public RepositoryResponse(String baseUrl, String osType, String repoId,
-      String repoName, String mirrorsList, String defaultBaseUrl, String latestBaseUrl) {
+  public RepositoryResponse(String baseUrl, String osType, String repoId, 
+    String repoName, String repoComponents, String mirrorsList,
+    String defaultBaseUrl, String latestBaseUrl) {
     setBaseUrl(baseUrl);
     setOsType(osType);
     setRepoId(repoId);
     setRepoName(repoName);
+    setRepoComponents(repoComponents);
     setMirrorsList(mirrorsList);
     setDefaultBaseUrl(defaultBaseUrl);
     setLatestBaseUrl(latestBaseUrl);
@@ -94,6 +97,14 @@ public class RepositoryResponse {
 
   public void setRepoName(String repoName) {
     this.repoName = repoName;
+  }
+
+  public String getRepoComponents() {
+    return repoComponents;
+  }
+
+  public void setRepoComponents(String repoComponents) {
+    this.repoComponents = repoComponents;
   }
 
   public String getMirrorsList() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryResourceProvider.java
@@ -57,6 +57,7 @@ public class RepositoryResourceProvider extends AbstractControllerResourceProvid
   public static final String REPOSITORY_VERIFY_BASE_URL_PROPERTY_ID       = PropertyHelper.getPropertyId("Repositories", "verify_base_url");
   public static final String REPOSITORY_LATEST_BASE_URL_PROPERTY_ID       = PropertyHelper.getPropertyId("Repositories", "latest_base_url");
   public static final String REPOSITORY_REPOSITORY_VERSION_ID_PROPERTY_ID = PropertyHelper.getPropertyId("Repositories", "repository_version_id");
+  public static final String REPOSITORY_REPO_COMPONENTS_PROPERTY_ID 	  = PropertyHelper.getPropertyId("Repositories", "repo_components");
 
   @SuppressWarnings("serial")
   private static Set<String> pkPropertyIds = new HashSet<String>() {
@@ -82,6 +83,7 @@ public class RepositoryResourceProvider extends AbstractControllerResourceProvid
       add(REPOSITORY_VERIFY_BASE_URL_PROPERTY_ID);
       add(REPOSITORY_LATEST_BASE_URL_PROPERTY_ID);
       add(REPOSITORY_REPOSITORY_VERSION_ID_PROPERTY_ID);
+      add(REPOSITORY_REPO_COMPONENTS_PROPERTY_ID);
     }
   };
 
@@ -162,6 +164,7 @@ public class RepositoryResourceProvider extends AbstractControllerResourceProvid
         setResourceProperty(resource, REPOSITORY_MIRRORS_LIST_PROPERTY_ID, response.getMirrorsList(), requestedIds);
         setResourceProperty(resource, REPOSITORY_DEFAULT_BASE_URL_PROPERTY_ID, response.getDefaultBaseUrl(), requestedIds);
         setResourceProperty(resource, REPOSITORY_LATEST_BASE_URL_PROPERTY_ID, response.getLatestBaseUrl(), requestedIds);
+        setResourceProperty(resource, REPOSITORY_REPO_COMPONENTS_PROPERTY_ID, response.getRepoComponents(), requestedIds);
         if (response.getRepositoryVersionId() != null) {
           setResourceProperty(resource, REPOSITORY_REPOSITORY_VERSION_ID_PROPERTY_ID, response.getRepositoryVersionId(), requestedIds);
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryEntity.java
@@ -24,6 +24,7 @@ public class RepositoryEntity {
 
   private String name;
   private String baseUrl;
+  private String repoComponents;
   private String repositoryId;
 
   public String getName() {
@@ -40,6 +41,14 @@ public class RepositoryEntity {
 
   public void setBaseUrl(String baseUrl) {
     this.baseUrl = baseUrl;
+  }
+
+  public String getRepoComponents() {
+    return repoComponents;
+  }
+
+  public void setRepoComponents(String repoComponents) {
+    this.repoComponents = repoComponents;
   }
 
   public String getRepositoryId() {
@@ -60,6 +69,7 @@ public class RepositoryEntity {
     if (name != null ? !name.equals(that.name) : that.name != null) return false;
     if (baseUrl != null ? !baseUrl.equals(that.baseUrl) : that.baseUrl != null) return false;
     if (repositoryId != null ? !repositoryId.equals(that.repositoryId) : that.repositoryId != null) return false;
+    if (repoComponents != null ? !repoComponents.equals(that.repoComponents) : that.repoComponents != null) return false;
 
     return true;
   }
@@ -69,6 +79,7 @@ public class RepositoryEntity {
     int result = name != null ? name.hashCode() : 0;
     result = 31 * result + (baseUrl != null ? baseUrl.hashCode() : 0);
     result = 31 * result + (repositoryId != null ? repositoryId.hashCode() : 0);
+    result = 31 * result + (repoComponents != null ? repoComponents.hashCode() : 0);
     return result;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackModule.java
@@ -622,6 +622,7 @@ public class StackModule extends BaseModule<StackModule, StackInfo> implements V
     ri.setRepoId(r.getRepoId());
     ri.setRepoName(r.getRepoName());
     ri.setLatestBaseUrl(r.getBaseUrl());
+    ri.setRepoComponents(r.getRepoComponents());
 
     LOG.debug("Checking for override for base_url");
     String updatedUrl = stackContext.getUpdatedRepoUrl(stackInfo.getName(), stackInfo.getVersion(),

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/RepositoryInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/RepositoryInfo.java
@@ -25,6 +25,7 @@ public class RepositoryInfo {
   private String osType;
   private String repoId;
   private String repoName;
+  private String repoComponents;
   private String mirrorsList;
   private String defaultBaseUrl;
   private String latestBaseUrl;
@@ -84,6 +85,21 @@ public class RepositoryInfo {
    */
   public void setRepoName(String repoName) {
     this.repoName = repoName;
+  }
+
+  /**
+   * @return the repoComponents
+   */
+  public String getRepoComponents() {
+    return repoComponents;
+  }
+
+  /**
+   * @param repoComponents
+   *          the repoComponents to set
+   */
+  public void setRepoComponents(String repoComponents) {
+    this.repoComponents = repoComponents;
   }
 
   /**
@@ -149,6 +165,7 @@ public class RepositoryInfo {
         + ", repoId=" + repoId
         + ", baseUrl=" + baseUrl
         + ", repoName=" + repoName
+        + ", repoComponents=" + repoComponents
         + ", mirrorsList=" + mirrorsList
         + " ]";
   }
@@ -156,8 +173,9 @@ public class RepositoryInfo {
 
   public RepositoryResponse convertToResponse()
   {
-    return new RepositoryResponse(getBaseUrl(), getOsType(), getRepoId(),
-        getRepoName(), getMirrorsList(), getDefaultBaseUrl(), getLatestBaseUrl());
+    return new RepositoryResponse(getBaseUrl(), getOsType(), getRepoId(), 
+        getRepoName(), getRepoComponents(), getMirrorsList(), 
+        getDefaultBaseUrl(), getLatestBaseUrl());
   }
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceOsSpecific.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceOsSpecific.java
@@ -17,9 +17,14 @@
  */
 package org.apache.ambari.server.state;
 
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
 
 import com.google.gson.annotations.SerializedName;
 /**
@@ -100,6 +105,8 @@ public class ServiceOsSpecific {
     private String repoid;
     @SerializedName("repoName")
     private String reponame;
+    @SerializedName("repoComponents")
+    private String repocomponents;
 
     private Repo() {
     }
@@ -132,6 +139,13 @@ public class ServiceOsSpecific {
       return reponame;
     }
 
+    /**
+     * @return the repocomponents
+     */
+    public String getRepocomponents() {
+      return repocomponents;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
@@ -143,6 +157,7 @@ public class ServiceOsSpecific {
       if (mirrorslist != null ? !mirrorslist.equals(repo.mirrorslist) : repo.mirrorslist != null) return false;
       if (repoid != null ? !repoid.equals(repo.repoid) : repo.repoid != null) return false;
       if (reponame != null ? !reponame.equals(repo.reponame) : repo.reponame != null) return false;
+      if (repocomponents != null ? !repocomponents.equals(repo.repocomponents) : repo.repocomponents != null) return false;
 
       return true;
     }
@@ -153,6 +168,7 @@ public class ServiceOsSpecific {
       result = 31 * result + (mirrorslist != null ? mirrorslist.hashCode() : 0);
       result = 31 * result + (repoid != null ? repoid.hashCode() : 0);
       result = 31 * result + (reponame != null ? reponame.hashCode() : 0);
+      result = 31 * result + (repocomponents != null ? repocomponents.hashCode() : 0);
       return result;
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/RepositoryXml.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/RepositoryXml.java
@@ -134,6 +134,7 @@ public class RepositoryXml implements Validable{
     private String mirrorslist = null;
     private String repoid = null;
     private String reponame = null;
+    private String repocomponents = null;
     private String latest = null;
 
     private Repo() {
@@ -167,6 +168,13 @@ public class RepositoryXml implements Validable{
       return reponame;
     }
     
+    /**
+     * @return the repocomponents
+     */
+    public String getRepoComponents() {
+      return repocomponents;
+    }
+
     public String getLatestUri() {
       return latest;
     }

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -96,6 +96,7 @@ def load_stack_values(version, filename):
     ostype = ostag.attrib['type']
     for repotag in ostag:
       reponametag = repotag.find('reponame')
+      repocomponentstag = repotag.find('repocomponents')
       repoidtag = repotag.find('repoid')
       baseurltag = repotag.find('baseurl')
       if reponametag is not None and repoidtag is not None and baseurltag is not None:

--- a/ambari-server/src/main/resources/custom_actions/scripts/install_packages.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/install_packages.py
@@ -40,7 +40,7 @@ class InstallPackages(Script):
   For now, repositories are installed into individual files.
   """
 
-  UBUNTU_REPO_COMPONENTS_POSTFIX = ["main"]
+  DEFAULT_UBUNTU_REPO_COMPONENTS_POSTFIX = "main"
   REPO_FILE_NAME_PREFIX = 'HDP-'
 
   def actionexecute(self, env):
@@ -155,7 +155,10 @@ class InstallPackages(Script):
     else:
       repo['mirrorsList'] = url_info['mirrorsList']
 
-    ubuntu_components = [url_info['name']] + self.UBUNTU_REPO_COMPONENTS_POSTFIX
+    if not 'repoComponents' in url_info:
+      repo['repoComponents'] = self.DEFAULT_UBUNTU_REPO_COMPONENTS_POSTFIX
+    
+    ubuntu_components = [url_info['name']] + repo['repoComponents'].split()
     file_name = self.REPO_FILE_NAME_PREFIX + repository_version
 
     Repository(repo['repoName'],

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/hooks/before-INSTALL/scripts/repo_initialization.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/hooks/before-INSTALL/scripts/repo_initialization.py
@@ -20,7 +20,7 @@ from resource_management import *
 import json
 
 # components_lits = repoName + postfix
-_UBUNTU_REPO_COMPONENTS_POSTFIX = ["main"]
+_DEFAULT_UBUNTU_REPO_COMPONENTS_POSTFIX = "main"
 
 def _alter_repo(action, repo_string, repo_template):
   """
@@ -37,8 +37,10 @@ def _alter_repo(action, repo_string, repo_template):
       repo['baseUrl'] = None
     if not 'mirrorsList' in repo:
       repo['mirrorsList'] = None
-    
-    ubuntu_components = [ repo['repoName'] ] + _UBUNTU_REPO_COMPONENTS_POSTFIX
+    if not 'repoComponents' in repo:
+      repo['repoComponents'] = _DEFAULT_UBUNTU_REPO_COMPONENTS_POSTFIX
+
+    ubuntu_components = [ repo['repoName'] ] + repo['repoComponents'].split()
     
     Repository(repo['repoId'],
                action = action,

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RepositoryResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RepositoryResourceProviderTest.java
@@ -48,14 +48,15 @@ public class RepositoryResourceProviderTest {
   private static final String VAL_OS = "centos6";
   private static final String VAL_REPO_ID = "HDP-0.2";
   private static final String VAL_REPO_NAME = "HDP1";
+  private static final String VAL_REPO_COMPONENTS = "main contrib";
   private static final String VAL_BASE_URL = "http://foo.com";
 
   @Test
   public void testGetResources() throws Exception{
     AmbariManagementController managementController = EasyMock.createMock(AmbariManagementController.class);
 
-    RepositoryResponse rr = new RepositoryResponse(VAL_BASE_URL, VAL_OS,
-        VAL_REPO_ID, VAL_REPO_NAME, null, null, null);
+    RepositoryResponse rr = new RepositoryResponse(VAL_BASE_URL, VAL_OS, 
+        VAL_REPO_ID, VAL_REPO_NAME, VAL_REPO_COMPONENTS, null, null, null);
     rr.setStackName(VAL_STACK_NAME);
     rr.setStackVersion(VAL_STACK_VERSION);
     Set<RepositoryResponse> allResponse = new HashSet<RepositoryResponse>();
@@ -76,6 +77,7 @@ public class RepositoryResourceProviderTest {
     propertyIds.add(RepositoryResourceProvider.REPOSITORY_BASE_URL_PROPERTY_ID);
     propertyIds.add(RepositoryResourceProvider.REPOSITORY_OS_TYPE_PROPERTY_ID);
     propertyIds.add(RepositoryResourceProvider.REPOSITORY_REPO_ID_PROPERTY_ID);
+    propertyIds.add(RepositoryResourceProvider.REPOSITORY_REPO_COMPONENTS_PROPERTY_ID);
 
     Predicate predicate =
         new PredicateBuilder().property(RepositoryResourceProvider.REPOSITORY_STACK_NAME_PROPERTY_ID).equals(VAL_STACK_NAME)
@@ -100,6 +102,9 @@ public class RepositoryResourceProviderTest {
       o = resource.getPropertyValue(RepositoryResourceProvider.REPOSITORY_REPO_NAME_PROPERTY_ID);
       Assert.assertEquals(o, VAL_REPO_NAME);
 
+      o = resource.getPropertyValue(RepositoryResourceProvider.REPOSITORY_REPO_COMPONENTS_PROPERTY_ID);
+      Assert.assertEquals(o, VAL_REPO_COMPONENTS);
+
       o = resource.getPropertyValue(RepositoryResourceProvider.REPOSITORY_BASE_URL_PROPERTY_ID);
       Assert.assertEquals(o, VAL_BASE_URL);
 
@@ -121,8 +126,8 @@ public class RepositoryResourceProviderTest {
 
     AmbariManagementController managementController = EasyMock.createMock(AmbariManagementController.class);
 
-    RepositoryResponse rr = new RepositoryResponse(VAL_BASE_URL, VAL_OS,
-        VAL_REPO_ID, VAL_REPO_NAME, null, null ,null);
+    RepositoryResponse rr = new RepositoryResponse(VAL_BASE_URL, VAL_OS, 
+        VAL_REPO_ID, VAL_REPO_NAME, VAL_REPO_COMPONENTS, null, null, null);
     Set<RepositoryResponse> allResponse = new HashSet<RepositoryResponse>();
     allResponse.add(rr);
 


### PR DESCRIPTION
Ubuntu repos have many components i.e. - main, contrib, universe, etc. Adding this capability helps in adding ubuntu repos to existing stacks and install some custom dependencies.
