### PR TITLE
[AMBARI-12972] Change default port number for hbase.rest.port in KNOX configuration

### DIFF
--- a/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/params_linux.py
@@ -135,7 +135,7 @@ if type(webhcat_server_hosts) is list:
 else:
   webhcat_server_host = webhcat_server_hosts
 
-hbase_master_port = default('/configurations/hbase-site/hbase.rest.port', "8080")
+hbase_master_port = default('/configurations/hbase-site/hbase.rest.port', "16080")
 hbase_master_hosts = default("/clusterHostInfo/hbase_master_hosts", None)
 if type(hbase_master_hosts) is list:
   hbase_master_host = hbase_master_hosts[0]


### PR DESCRIPTION
Currently, Knox set the default port for "hbase.rest.port" as 8080 which is same as Ambari server port which can cause issue if ambari-server and hbase REST server are on same node.

Changed this port number to "16080" as most of the Hbase ports are n 16000 range.
