### PR TITLE
Hive server 2 port check condition

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/NAGIOS/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/NAGIOS/package/scripts/params.py
@@ -190,7 +190,13 @@ hbase_master_rpc_port = default('/configurations/hbase-site/hbase.master.port', 
 rm_port = get_port_from_url(config['configurations']['yarn-site'][yarn_rm_webui_property])
 hs_port = get_port_from_url(config['configurations']['mapred-site'][mapreduce_jobhistory_webui_property])
 hive_metastore_port = get_port_from_url(config['configurations']['hive-site']['hive.metastore.uris']) #"9083"
-hive_server_port = default('/configurations/hive-site/hive.server2.thrift.port',"10000")
+hive_server_transport_mode = config['configurations']['hive-site']['hive.server2.transport.mode']
+if hive_server_transport_mode == 'binary':
+  hive_server_port = config['configurations']['hive-site']['hive.server2.thrift.port']
+elif hive_server_transport_mode == 'http':
+  hive_server_port = config['configurations']['hive-site']['hive.server2.thrift.http.port']
+else:
+  hive_server_port = "10000"
 templeton_port = config['configurations']['webhcat-site']['templeton.port'] #"50111"
 hbase_master_port = config['configurations']['hbase-site']['hbase.master.info.port'] #"60010"
 hbase_rs_port = config['configurations']['hbase-site']['hbase.regionserver.info.port'] #"60030"


### PR DESCRIPTION
When hive.server2.transport.mode is set to binary then Nagios has to check on hive.server2.thrift.port (default 10000)
When it's set to http then the check has to be on hive.server2.thrift.http.port (default 10001) : this condition is not checked.
