### PR TITLE
MINOR: Replacing "upto" with "up to"

### DIFF
--- a/ambari-client/python-client/src/test/python/json/ambariclient_get_config.json
+++ b/ambari-client/python-client/src/test/python/json/ambariclient_get_config.json
@@ -16,7 +16,7 @@
     {
       "href" : "http://localhost:8080/api/v1/stacks2/HDP/versions/1.3.0/stackServices/HDFS/configurations/dfs.access.time.precision",
       "StackConfigurations" : {
-        "property_description" : "The access time for HDFS file is precise upto this value.\n               The default value is 1 hour. Setting a value of 0 disables\n               access times for HDFS.\n  ",
+        "property_description" : "The access time for HDFS file is precise up to this value.\n               The default value is 1 hour. Setting a value of 0 disables\n               access times for HDFS.\n  ",
         "property_name" : "dfs.access.time.precision",
         "property_value" : "0",
         "service_name" : "HDFS",

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -592,7 +592,7 @@ class PGConfig(LinuxDBMSConfig):
     else:
       # run initdb only on non ubuntu systems as ubuntu does not have initdb cmd.
       if not OSCheck.is_ubuntu_family():
-        print "Running initdb: This may take upto a minute."
+        print "Running initdb: This may take up to a minute."
         retcode, out, err = run_os_command(PGConfig.PG_INITDB_CMD)
         if retcode == 0:
           print out

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/hdfs-site.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/hdfs-site.xml
@@ -388,7 +388,7 @@
     <name>dfs.namenode.accesstime.precision</name>
     <value>0</value>
     <display-name>Access time precision</display-name>
-    <description>The access time for HDFS file is precise upto this value.
+    <description>The access time for HDFS file is precise up to this value.
       The default value is 1 hour. Setting a value of 0 disables
       access times for HDFS.
     </description>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/configuration/hdfs-site.xml
@@ -318,7 +318,7 @@
   <property>
     <name>dfs.namenode.accesstime.precision</name>
     <value>0</value>
-    <description>The access time for HDFS file is precise upto this value.
+    <description>The access time for HDFS file is precise up to this value.
       The default value is 1 hour. Setting a value of 0 disables
       access times for HDFS.
     </description>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/HDFS/configuration/hdfs-site.xml
@@ -401,7 +401,7 @@ don't exist, they will be created with this permission.</description>
   <property>
     <name>dfs.namenode.accesstime.precision</name>
     <value>0</value>
-    <description>The access time for HDFS file is precise upto this value.
+    <description>The access time for HDFS file is precise up to this value.
                  The default value is 1 hour. Setting a value of 0 disables
                  access times for HDFS.
     </description>

--- a/ambari-server/src/test/resources/bad-stacks/HDP/0.1/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/bad-stacks/HDP/0.1/services/HDFS/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/bad-stacks/HDP/0.1/services/MAPREDUCE/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/bad-stacks/HDP/0.1/services/MAPREDUCE/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/bad-stacks/HDP/0.1/services/MAPREDUCE/configuration/mapred-site.xml
+++ b/ambari-server/src/test/resources/bad-stacks/HDP/0.1/services/MAPREDUCE/configuration/mapred-site.xml
@@ -379,7 +379,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/common-services/HDFS/1.0/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/common-services/HDFS/1.0/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/common-services/MAPREDUCE/1.0/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/common-services/MAPREDUCE/1.0/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/common-services/MAPREDUCE/1.0/configuration/mapred-site.xml
+++ b/ambari-server/src/test/resources/common-services/MAPREDUCE/1.0/configuration/mapred-site.xml
@@ -379,7 +379,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/0.1/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/0.1/services/HDFS/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/0.1/services/MAPREDUCE/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/0.1/services/MAPREDUCE/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/0.1/services/MAPREDUCE/configuration/mapred-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/0.1/services/MAPREDUCE/configuration/mapred-site.xml
@@ -379,7 +379,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/0.2/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/0.2/services/HDFS/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/0.2/services/MAPREDUCE/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/0.2/services/MAPREDUCE/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/0.2/services/MAPREDUCE/configuration/mapred-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/0.2/services/MAPREDUCE/configuration/mapred-site.xml
@@ -379,7 +379,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/1.2.0/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/1.2.0/services/HDFS/configuration/hdfs-site.xml
@@ -381,7 +381,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/1.3.0/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/1.3.0/services/HDFS/configuration/hdfs-site.xml
@@ -381,7 +381,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/1.3.1/services/HCFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/1.3.1/services/HCFS/configuration/hdfs-site.xml
@@ -381,7 +381,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/1.3.1/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/1.3.1/services/HDFS/configuration/hdfs-site.xml
@@ -381,7 +381,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.1/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.1/services/HDFS/configuration/hdfs-site.xml
@@ -400,7 +400,7 @@ don't exist, they will be created with this permission.</description>
   <property>
     <name>dfs.access.time.precision</name>
     <value>0</value>
-    <description>The access time for HDFS file is precise upto this value.
+    <description>The access time for HDFS file is precise up to this value.
                  The default value is 1 hour. Setting a value of 0 disables
                  access times for HDFS.
     </description>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.5/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.5/services/HDFS/configuration/hdfs-site.xml
@@ -363,7 +363,7 @@ don't exist, they will be created with this permission.</description>
   <property>
     <name>dfs.namenode.accesstime.precision</name>
     <value>0</value>
-    <description>The access time for HDFS file is precise upto this value.
+    <description>The access time for HDFS file is precise up to this value.
                  The default value is 1 hour. Setting a value of 0 disables
                  access times for HDFS.
     </description>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/HDFS/configuration/hdfs-site.xml
@@ -416,7 +416,7 @@
   <property>
     <name>dfs.namenode.accesstime.precision</name>
     <value>0</value>
-    <description>The access time for HDFS file is precise upto this value.
+    <description>The access time for HDFS file is precise up to this value.
       The default value is 1 hour. Setting a value of 0 disables
       access times for HDFS.
     </description>

--- a/ambari-server/src/test/resources/stacks_with_common_services/HDP/0.2/services/HDFS/configuration/hdfs-site.xml
+++ b/ambari-server/src/test/resources/stacks_with_common_services/HDP/0.2/services/HDFS/configuration/hdfs-site.xml
@@ -375,7 +375,7 @@ don't exist, they will be created with this permission.</description>
   <property>
   <name>dfs.access.time.precision</name>
   <value>0</value>
-  <description>The access time for HDFS file is precise upto this value.
+  <description>The access time for HDFS file is precise up to this value.
                The default value is 1 hour. Setting a value of 0 disables
                access times for HDFS.
   </description>

--- a/ambari-web/app/assets/data/stacks/HDP-2.2/configurations.json
+++ b/ambari-web/app/assets/data/stacks/HDP-2.2/configurations.json
@@ -4510,7 +4510,7 @@
           "href" : "http://c6401:8080/api/v1/stacks/HDP/versions/2.2/services/HDFS/configurations/dfs.namenode.accesstime.precision",
           "StackConfigurations" : {
             "final" : "false",
-            "property_description" : "The access time for HDFS file is precise upto this value.\n      The default value is 1 hour. Setting a value of 0 disables\n      access times for HDFS.\n    ",
+            "property_description" : "The access time for HDFS file is precise up to this value.\n      The default value is 1 hour. Setting a value of 0 disables\n      access times for HDFS.\n    ",
             "property_name" : "dfs.namenode.accesstime.precision",
             "property_type" : [ ],
             "property_value" : "0",

--- a/ambari-web/app/assets/data/wizard/stack/hdp/version2.0.1/HDFS.json
+++ b/ambari-web/app/assets/data/wizard/stack/hdp/version2.0.1/HDFS.json
@@ -292,7 +292,7 @@
     {
       "href" : "http://192.168.56.101:8080/api/v1/stacks2/HDP/versions/2.0.1/stackServices/HDFS/configurations/dfs.namenode.accesstime.precision",
       "StackConfigurations" : {
-        "property_description" : "The access time for HDFS file is precise upto this value.\n                 The default value is 1 hour. Setting a value of 0 disables\n                 access times for HDFS.\n    ",
+        "property_description" : "The access time for HDFS file is precise up to this value.\n                 The default value is 1 hour. Setting a value of 0 disables\n                 access times for HDFS.\n    ",
         "property_name" : "dfs.namenode.accesstime.precision",
         "property_value" : "0",
         "service_name" : "HDFS",


### PR DESCRIPTION
Fixes spelling error throughout documentation
