### PR TITLE
Update ambari_server_main.py to fix Ambari server starting too long

### DIFF
--- a/ambari-server/src/main/python/ambari_server_main.py
+++ b/ambari-server/src/main/python/ambari_server_main.py
@@ -60,6 +60,7 @@ SERVER_START_CMD = "{0} " \
     "-XX:+UseConcMarkSweepGC " + \
     "-XX:-UseGCOverheadLimit -XX:CMSInitiatingOccupancyFraction=60 " \
     "-Dsun.zip.disableMemoryMapping=true " + \
+    "-Djava.security.egd=file:/dev/./urandom " + \
     "{1} {2} " \
     "-cp {3} "\
     "org.apache.ambari.server.controller.AmbariServer " \


### PR DESCRIPTION
Starting Ambari server with java.security.egd=file:/dev/./urandom fixes long Ambari startup time (without this option it can take up to 8-10 minutes on CentOS 7 OS to bring Ambari UP and bind to port 8080).
There was a discussion on Ambari mailing list (http://mail-archives.apache.org/mod_mbox/ambari-user/201512.mbox/%3CBA271B73-83B8-4916-B8FB-68D5AB0CC554%40hortonworks.com%3E) and other users suggested the same solution.
