### PR TITLE
Add KRB5_CONFIG to environment.

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/shell.py
+++ b/ambari-common/src/main/python/resource_management/core/shell.py
@@ -182,6 +182,7 @@ def _call(command, logoutput=None, throw_on_failure=True, stdout=subprocess.PIPE
     env['PATH'] = os.pathsep.join([env['PATH'], path])
   
   # prepare command cmd
+  env['KRB5_CONFIG'] = os.getenv('KRB5_CONFIG','/etc/krb5.conf')
   if sudo:
     command = as_sudo(command, env=env)
   elif user:


### PR DESCRIPTION
Add KRB5_CONFIG to environment. Used if krb5.conf is not located under /etc
