### PR TITLE
Wrong path to ambari SUDO

### DIFF
--- a/ambari-agent/conf/unix/ambari-agent
+++ b/ambari-agent/conf/unix/ambari-agent
@@ -102,15 +102,15 @@ cd $AGENT_WORKING_DIR
 
 change_files_permissions() {
     if [ ! -z "$KEYSDIR" ]; then
-        ambari-sudo.sh chown -R $current_user "$KEYSDIR"
+        /var/lib/ambari-agent/ambari-sudo.sh chown -R $current_user "$KEYSDIR"
     fi
-	ambari-sudo.sh mkdir -p "${AMBARI_PID_DIR:?}"
-	ambari-sudo.sh chown -R $current_user "${AMBARI_PID_DIR:?}/"
-	ambari-sudo.sh mkdir -p "${AMBARI_AGENT_LOG_DIR:?}"
-	ambari-sudo.sh chown -R $current_user:$current_group "${AMBARI_AGENT_LOG_DIR:?}/"
-	ambari-sudo.sh chown -R $current_user "/var/lib/ambari-agent/data/"
-	ambari-sudo.sh chown -R $current_user "/var/lib/ambari-agent/cache/"
-	ambari-sudo.sh chown 	$current_user "/usr/lib/ambari-agent/"
+	/var/lib/ambari-agent/ambari-sudo.sh mkdir -p "${AMBARI_PID_DIR:?}"
+	/var/lib/ambari-agent/ambari-sudo.sh chown -R $current_user "${AMBARI_PID_DIR:?}/"
+	/var/lib/ambari-agent/ambari-sudo.sh mkdir -p "${AMBARI_AGENT_LOG_DIR:?}"
+	/var/lib/ambari-agent/ambari-sudo.sh chown -R $current_user:$current_group "${AMBARI_AGENT_LOG_DIR:?}/"
+	/var/lib/ambari-agent/ambari-sudo.sh chown -R $current_user "/var/lib/ambari-agent/data/"
+	/var/lib/ambari-agent/ambari-sudo.sh chown -R $current_user "/var/lib/ambari-agent/cache/"
+	/var/lib/ambari-agent/ambari-sudo.sh chown 	$current_user "/usr/lib/ambari-agent/"
 }
 
 
@@ -177,7 +177,7 @@ case "${1:-}" in
           PID=`cat $PIDFILE`
           if ! (ps -p $PID >/dev/null 2>/dev/null); then
             echo "$PIDFILE found with no process. Removing $PID..."
-            ambari-sudo.sh rm -f $PIDFILE
+            /var/lib/ambari-agent/ambari-sudo.sh rm -f $PIDFILE
           else
             tput bold
             echo "ERROR: $AMBARI_AGENT already running"
@@ -266,7 +266,7 @@ case "${1:-}" in
             fi
           fi
           echo "Removing PID file at $PIDFILE"
-          ambari-sudo.sh rm -f $PIDFILE
+          /var/lib/ambari-agent/ambari-sudo.sh rm -f $PIDFILE
           tput bold
           echo "$AMBARI_AGENT successfully stopped"
           tput sgr0


### PR DESCRIPTION
I use Version HDP 2.5.1 with ambari 2.4.0.1 (default) over centos 7 machine
I use cloudbreak to deploy cluster.
But then i need add few host to ambari, that was provisioned by my own.(because  cloudbreak  can't create additionional host froup when cluster already setup)

When i try add host i found that problem. I fix it locally and its work.