### PR TITLE
Supported kylin4 OS

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/resources/os_family.json
+++ b/ambari-common/src/main/python/ambari_commons/resources/os_family.json
@@ -30,6 +30,15 @@
       7
     ]
   },
+  "kylin": {
+    "extends" : "ubuntu",
+    "distro": [
+      "kylin"
+    ],
+    "versions": [
+      4
+    ]
+  },
   "ubuntu": {
     "distro": [
       "ubuntu"

--- a/ambari-common/src/main/python/resource_management/core/providers/__init__.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/__init__.py
@@ -53,6 +53,9 @@ PROVIDERS = dict(
   debian=dict(
     Package="resource_management.core.providers.package.apt.AptProvider",
   ),
+  kylin=dict(
+    Package="resource_management.core.providers.package.apt.AptProvider",
+  ),
   winsrv=dict(
     Service="resource_management.core.providers.windows.service.ServiceProvider",
     ServiceConfig="resource_management.core.providers.windows.service.ServiceConfigProvider",

--- a/ambari-common/src/main/python/resource_management/libraries/providers/__init__.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/__init__.py
@@ -33,6 +33,9 @@ PROVIDERS = dict(
   debian=dict(
     Repository="resource_management.libraries.providers.repository.UbuntuRepositoryProvider",
   ),
+  kylin=dict(
+    Repository="resource_management.libraries.providers.repository.UbuntuRepositoryProvider",
+  ),
   winsrv=dict(
     Msi="resource_management.libraries.providers.msi.MsiProvider"
   ),

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/metainfo.xml
@@ -86,7 +86,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>ambari-metrics-assembly</name>

--- a/ambari-server/src/main/resources/common-services/GANGLIA/3.5.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/GANGLIA/3.5.0/metainfo.xml
@@ -81,7 +81,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>python-rrdtool</name>

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/metainfo.xml
@@ -193,7 +193,7 @@
         </osSpecific>
         
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>libsnappy1</name>

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/metainfo.xml
@@ -268,7 +268,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>redhat6,debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>redhat6,kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>mysql-server</name>

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/metainfo.xml
@@ -91,7 +91,7 @@
         </osSpecific>
 
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>krb5-kdc</name>

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/metainfo.xml
@@ -130,7 +130,7 @@
         </osSpecific>
         
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>extjs</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/repos/repoinfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/repos/repoinfo.xml
@@ -77,6 +77,19 @@
       <reponame>HDP-UTILS</reponame>
     </repo>
   </os>
+  <os family="kylin4">
+    <repo>
+<!-- Should to change from "/HDP/ubuntu14/2.x" to "/HDP/kylin4/2.x" -->
+      <baseurl>http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.3.0.0</baseurl>
+      <repoid>HDP-2.3</repoid>
+      <reponame>HDP</reponame>
+    </repo>
+    <repo>
+      <baseurl>http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.20/repos/ubuntu12</baseurl>
+      <repoid>HDP-UTILS-1.1.0.20</repoid>
+      <reponame>HDP-UTILS</reponame>
+    </repo>
+  </os>
   <os family="ubuntu14">
     <repo>
       <baseurl>http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.3.0.0</baseurl>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/ACCUMULO/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/ACCUMULO/metainfo.xml
@@ -32,7 +32,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>accumulo-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/ATLAS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/ATLAS/metainfo.xml
@@ -32,7 +32,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>atlas-metadata-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/FALCON/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/FALCON/metainfo.xml
@@ -31,7 +31,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>falcon-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/FLUME/metainfo.xml
@@ -32,7 +32,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>flume-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HBASE/metainfo.xml
@@ -49,7 +49,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>hbase-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/metainfo.xml
@@ -82,7 +82,7 @@
         </osSpecific>
 
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>hadoop-2-3-.*-client</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HIVE/metainfo.xml
@@ -72,7 +72,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>hive-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/KAFKA/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/KAFKA/metainfo.xml
@@ -31,7 +31,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>kafka-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/KNOX/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/KNOX/metainfo.xml
@@ -31,7 +31,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>knox-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/OOZIE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/OOZIE/metainfo.xml
@@ -49,7 +49,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>oozie-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/PIG/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/PIG/metainfo.xml
@@ -34,7 +34,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>pig-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/RANGER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/RANGER/metainfo.xml
@@ -40,7 +40,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>ranger-2-3-.*-admin</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/RANGER_KMS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/RANGER_KMS/metainfo.xml
@@ -34,7 +34,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>ranger-2-3-.*-kms</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/SLIDER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/SLIDER/metainfo.xml
@@ -34,7 +34,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>slider-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/SPARK/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/SPARK/metainfo.xml
@@ -38,7 +38,7 @@
               </packages>
             </osSpecific>
             <osSpecific>
-              <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+              <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
               <packages>
                 <package>
                   <name>spark-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/SQOOP/metainfo.xml
@@ -40,7 +40,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>sqoop-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/STORM/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/STORM/metainfo.xml
@@ -32,7 +32,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>storm-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/TEZ/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/TEZ/metainfo.xml
@@ -32,7 +32,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>tez-2-3-.*</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/YARN/metainfo.xml
@@ -39,7 +39,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>hadoop-2-3-.*-yarn</name>
@@ -65,7 +65,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>hadoop-2-3-.*-mapreduce</name>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/ZOOKEEPER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/ZOOKEEPER/metainfo.xml
@@ -31,7 +31,7 @@
           </packages>
         </osSpecific>
         <osSpecific>
-          <osFamily>debian7,ubuntu12,ubuntu14</osFamily>
+          <osFamily>kylin4,debian7,ubuntu12,ubuntu14</osFamily>
           <packages>
             <package>
               <name>zookeeper-2-3-.*</name>


### PR DESCRIPTION
My team wanted to install ambari-2.2.1 on kylin4, but we got a bad result.
So my team made some changes.