### PR TITLE
Add ID to allow maven >=2.2 validation

### DIFF
--- a/contrib/management-packs/odpi-ambari-mpack/src/main/assemblies/odpi-ambari-mpack.xml
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/assemblies/odpi-ambari-mpack.xml
@@ -17,7 +17,7 @@
   limitations under the License.
 -->
 <assembly>
-  <id></id>
+  <id>odpi-ambari-mpack</id>
   <formats>
     <format>dir</format>
     <format>tar.gz</format>


### PR DESCRIPTION
According to:

https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#required-classifiers

The ID is mandatory since maven >=2.2 , and worked only without it before due to a bug.

Concerns BIGTOP-2729