### PR TITLE
Fix formatting of multiple markdown files in ambari-server api docs, ambari-views docs and other

### DIFF
--- a/ambari-logsearch/ambari-logsearch-appender/README.md
+++ b/ambari-logsearch/ambari-logsearch-appender/README.md
@@ -17,7 +17,7 @@ Ambari Logsearch Appender is a log4j base appender that write logs in json forma
     	  <version>${version}</version>
     	</dependency>
 ```
-####Dependent dependency 
+#### Dependent dependency 
 ```xml   
 		 <dependency>
 		  <groupId>log4j</groupId>

--- a/ambari-logsearch/ambari-logsearch-server/README.md
+++ b/ambari-logsearch/ambari-logsearch-server/README.md
@@ -21,9 +21,9 @@ limitations under the License.
 mvn clean compile package
 
 #Deploy
-##Copy to remote
+## Copy to remote
 copy target/logsearch-portal.tar.gz to host machine
-##Setup environment
+## Setup environment
 ```bash
 mkdir /opt/logsearch
 cd /opt/logsearch

--- a/ambari-server/docs/api/v1/cluster-resources.md
+++ b/ambari-server/docs/api/v1/cluster-resources.md
@@ -18,14 +18,14 @@ limitations under the License.
 # Cluster Resources
 Cluster resources represent named Hadoop clusters.  Clusters are top level resources.
 
-###API Summary
+### API Summary
 
 - [List clusters](clusters.md)
 - [View cluster information](clusters-cluster.md)
 - [Create cluster](create-cluster.md)
 - [Delete cluster](delete-cluster.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/component-resources.md
+++ b/ambari-server/docs/api/v1/component-resources.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Component Resources
 Component resources are the individual components of a service (e.g. HDFS/NameNode and MapReduce/JobTracker).  Components are sub-resources of services.
 
-###API Summary 
+### API Summary 
 
 - [List service components](components.md)
 - [View component information](components-component.md)
@@ -26,7 +26,7 @@ Component resources are the individual components of a service (e.g. HDFS/NameNo
 
 
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/configuration.md
+++ b/ambari-server/docs/api/v1/configuration.md
@@ -172,7 +172,7 @@ To list the desired configs for a host:
 
 Notice overrides for a configuration type are listed with the key as the config group id and value is the tag identifying the configuration resource.
 
-##Actual Configuration
+## Actual Configuration
 Actual configuration represents the set of `tag`s that identify the cluster's current configuration.  When configurations are changed, they are saved into the backing database, even if the host has not yet received the change.  When a 
 host receives the desired configuration changes AND applies them, it will respond with the applied tags. This is called the actual configuration.
 

--- a/ambari-server/docs/api/v1/credential-resources.md
+++ b/ambari-server/docs/api/v1/credential-resources.md
@@ -20,7 +20,7 @@ Credential resources represent named principal/key pairs related to a particular
 
 Credential resources may be stored in the persisted credential store or the temporary credential store. If stored in the persisted credential store, the credential will be stored until deleted. If stored in the temporary credential store, the credential will be stored until a timeout is met (default 90 minutes) or Ambari is restarted. 
 
-###API Summary
+### API Summary
 
 - [List credentials](credential-list.md)
 - [Get credential](credential-get.md)
@@ -28,7 +28,7 @@ Credential resources may be stored in the persisted credential store or the temp
 - [Update credential](credential-update.md)
 - [Delete credential](credential-delete.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/host-component-resources.md
+++ b/ambari-server/docs/api/v1/host-component-resources.md
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 # Host Component Resources
-###API Summary
+### API Summary
 
 
 - [List host components](host-components.md)
@@ -24,7 +24,7 @@ limitations under the License.
 - [Create host component](create-hostcomponent.md)
 - [Update host component](update-hostcomponent.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -67,7 +67,7 @@ limitations under the License.
 
 
 
-###States
+### States
 
 The current state of a host component resource can be determined by looking at the ServiceComponentInfo/state property.
 
@@ -147,13 +147,13 @@ The following table lists the possible values of the service resource ServiceCom
 </table>
 
 
-###Starting a Host Component
+### Starting a Host Component
 A component can be started through the API by setting its state to be STARTED (see [update host component](update-hostcomponent.md)).
 
-###Stopping a Host Component
+### Stopping a Host Component
 A component can be stopped through the API by setting its state to be INSTALLED (see [update host component](update-hostcomponent.md)).
 
-###Maintenance
+### Maintenance
 
 The user can update the desired state of a host component through the API to be MAINTENANCE (see [update host component](update-hostcomponent.md)).  When a host component is into maintenance state it is basically taken off line. This state can be used, for example, to move a component like NameNode.  The NameNode component can be put in MAINTENANCE mode and then a new NameNode can be created for the service. 
 

--- a/ambari-server/docs/api/v1/host-resources.md
+++ b/ambari-server/docs/api/v1/host-resources.md
@@ -18,13 +18,13 @@ limitations under the License.
 # Host Resources
  
  
-###API Summary 
+### API Summary 
 
 - [List hosts](hosts.md)
 - [View host information](hosts-host.md)
 - [Create host](create-host.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -97,7 +97,7 @@ limitations under the License.
   </tr>
 </table>
 
-###States
+### States
 
 The current state of a host resource can be determined by looking at the Hosts/host_state property.
 

--- a/ambari-server/docs/api/v1/index.md
+++ b/ambari-server/docs/api/v1/index.md
@@ -52,7 +52,7 @@ Monitoring
 ----
 The Ambari API provides access to monitoring and metrics information of an Apache Hadoop cluster.
 
-###GET
+### GET
 Use the GET method to read the properties, metrics and sub-resources of an Ambari resource.  Calling the GET method returns the requested resources and produces no side-effects.  A response code of 200 indicates that the request was successfully processed with the requested resource included in the response body.
  
 **Example**
@@ -113,7 +113,7 @@ Management
 ----
 The Ambari API provides for the management of the resources of an Apache Hadoop cluster.  This includes the creation, deletion and updating of resources.
 
-###POST
+### POST
 The POST method creates a new resource. If a new resource is created then a 201 response code is returned.  The code 202 can also be returned to indicate that the instruction was accepted by the server (see [asynchronous response](#asynchronous-response)). 
 
 **Example**
@@ -128,7 +128,7 @@ Create the HDFS service.
 
     201 Created
 
-###PUT
+### PUT
 Use the PUT method to update resources.  If an existing resource is modified then a 200 response code is retrurned to indicate successful completion of the request.  The response code 202 can also be returned to indicate that the instruction was accepted by the server (see [asynchronous response](#asynchronous-response)).
 
 **Example**
@@ -161,7 +161,7 @@ The response code 202 indicates that the server has accepted the instruction to 
     }
 
 
-###DELETE
+### DELETE
 Use the DELETE method to delete a resource. If an existing resource is deleted then a 200 response code is retrurned to indicate successful completion of the request.  The response code 202 can also be returned which indicates that the instruction was accepted by the server and the resource was marked for deletion (see [asynchronous response](#asynchronous-response)).
 
 **Example**
@@ -174,7 +174,7 @@ Delete the cluster named 'c1'.
 
     200 OK
 
-###Asynchronous Response
+### Asynchronous Response
 
 The managment APIs can return a response code of 202 which indicates that the request has been accepted.  The body of the response contains the ID and href of the request resource that was created to carry out the instruction. 
     
@@ -241,7 +241,7 @@ The returned task resources can be used to determine the status of the request.
 
 Resources
 ----
-###Collection Resources
+### Collection Resources
 
 
 A collection resource is a set of resources of the same type, rather than any specific resource. For example:
@@ -250,7 +250,7 @@ A collection resource is a set of resources of the same type, rather than any sp
 
   _Refers to a collection of clusters_
 
-###Instance Resources
+### Instance Resources
 
 An instance resource is a single specific resource. For example:
 
@@ -258,7 +258,7 @@ An instance resource is a single specific resource. For example:
 
   _Refers to the cluster resource identified by the id "c1"_
 
-###Types
+### Types
 Resources are grouped into types.  This allows the user to query for collections of resources of the same type.  Some resource types are composed of subtypes (e.g. services are sub-resources of clusters).
 
 The following is a list of some of the Ambari resource types with descriptions and usage examples.
@@ -693,7 +693,7 @@ Query Predicates
 
 Used to limit which data is returned by a query.  This is synonymous to the “where” clause in a SQL query.  Providing query parameters does not result in any link expansion in the data that is returned, with the exception of the fields used in the predicates.  Query predicates can only be applied to collection resources.  A predicate consists of at least one relational expression.  Predicates with multiple relational expressions also contain logical operators, which connect the relational expressions.  Predicates may also use brackets for explicit grouping of expressions. 
 
-###Relational Query Operators
+### Relational Query Operators
 
 <table>
   <tr>
@@ -733,7 +733,7 @@ Used to limit which data is returned by a query.  This is synonymous to the “w
   </tr>  
 </table>
 
-###Logical Query Operators
+### Logical Query Operators
 
 <table>
   <tr>
@@ -762,7 +762,7 @@ Used to limit which data is returned by a query.  This is synonymous to the “w
 
 Standard logical operator precedence rules apply.  The above logical operators are listed in order of precedence starting with the lowest priority.  
 
-###Brackets
+### Brackets
 
 <table>
   <tr>
@@ -782,7 +782,7 @@ Standard logical operator precedence rules apply.  The above logical operators a
   
 Brackets can be used to provide explicit grouping of expressions. Expressions within brackets have the highest precedence.
 
-###Operator Functions
+### Operator Functions
  
 <table>
   <tr>
@@ -803,7 +803,7 @@ Brackets can be used to provide explicit grouping of expressions. Expressions wi
 </table>
 Operator functions behave like relational operators and provide additional functionality.  Some operator functions, such as in(), act as binary operators like the above relational operators, where there is a left and right operand.  Some operator functions are unary operators, such as isEmpty(), where there is only a single operand.
 
-###Query Examples
+### Query Examples
 
 **Example – Get all hosts with “HEALTHY” status that have 2 or more cpu**
 	
@@ -889,7 +889,7 @@ RequestInfo allows the user to specify additional properties in the body of a re
   </tr>
 </table>
 
-###query
+### query
 
 
 The query property allows the user to specify the query string as part of the request body.  This is sometimes required in the case of a very long query string that causes the request to exceed the limits of the URL.
@@ -952,7 +952,7 @@ The query property can also be applied to the elements of a [batch request](#bat
     ]
 
 
-###context
+### context
 In some cases a request will return a 202 to indicate that the instruction was accepted by the server (see [asynchronous response](#asynchronous-response)).  In these cases the body of the response contains the ID and href of the request resource that was created to carry out the instruction.  It may be desirable to attach a context string to the request which will then be assigned to the resulting request response.
 
 In the following example a request is made to stop the HDFS service.  Notice that a context is passed as a RequestInfo property.

--- a/ambari-server/docs/api/v1/permission-resources.md
+++ b/ambari-server/docs/api/v1/permission-resources.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Permission Resources
 Permission resources help to determine access control for a user upon a resource (Ambari, a cluster, a view, etc...).
 
-###API Summary
+### API Summary
 
 - [List permissions](permission-list.md)
 - [Get permission](permission-get.md)
@@ -26,7 +26,7 @@ Permission resources help to determine access control for a user upon a resource
 - [Update permission](permission-update.md)
 - [Delete permission](permission-delete.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/repository-version-resources.md
+++ b/ambari-server/docs/api/v1/repository-version-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Repository Version Resources
 
-#####Create Instance
+##### Create Instance
 New repository versions may be created through the API. At least one set of base repository URLs should be provided.
 
     POST http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/
@@ -51,7 +51,7 @@ New repository versions may be created through the API. At least one set of base
       ]
     }
 
-#####Get Repository Versions
+##### Get Repository Versions
 The user may query for all repository versions of a particular stack.
 
     GET http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/
@@ -78,7 +78,7 @@ The user may query for all repository versions of a particular stack.
       ]
     }
 
-#####Get Repository Version
+##### Get Repository Version
 Returns single repository version.
 
     GET http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/1
@@ -115,12 +115,12 @@ Returns single repository version.
       ]
     }
     
-#####Delete Repository Version
+##### Delete Repository Version
 Deregisters repository version. It won't be possible to remove repository version which is installed on any of the clusters.
 
     DELETE http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/1
 
-#####Update Repository Version
+##### Update Repository Version
 Updates repository version. It is possible to change display name and base URLs. 
 
     PUT http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/1
@@ -161,7 +161,7 @@ Updates repository version. It is possible to change display name and base URLs.
       ]
     }
     
-#####Validate Base URL
+##### Validate Base URL
 User may validate URLs of repositories before persisting.
 
     POST http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/operating_systems/redhat5/repositories/HDP-UTILS-1.1.0.20?validate_only=true

--- a/ambari-server/docs/api/v1/request-resources.md
+++ b/ambari-server/docs/api/v1/request-resources.md
@@ -18,11 +18,11 @@ limitations under the License.
 # Request Resources
  
  
-###API Summary 
+### API Summary 
 
 - [List requests](requests.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/rolling-upgrade-check-resources.md
+++ b/ambari-server/docs/api/v1/rolling-upgrade-check-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Rolling Upgrade Check Resources
 
-#####Get Check Results
+##### Get Check Results
 Retrieves results of rolling upgrade checks. All checks should have status PASS before running rolling upgrade.
 
     GET http://<server>:8080/api/v1/clusters/<cluster_name>/rolling_upgrades_check/
@@ -42,7 +42,7 @@ Retrieves results of rolling upgrade checks. All checks should have status PASS 
       ]
     }
 
-#####Example of checks execution
+##### Example of checks execution
 Successful and unsuccessful check.
 
     {

--- a/ambari-server/docs/api/v1/service-resources.md
+++ b/ambari-server/docs/api/v1/service-resources.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Service Resources
 Service resources are services of a Hadoop cluster (e.g. HDFS, MapReduce and Ganglia).  Service resources are sub-resources of clusters. 
 
-###API Summary
+### API Summary
 
 - [List services](services.md)
 - [View service information](services-service.md)
@@ -26,7 +26,7 @@ Service resources are services of a Hadoop cluster (e.g. HDFS, MapReduce and Gan
 - [Update services](update-services.md)
 - [Update service](update-service.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -53,7 +53,7 @@ Service resources are services of a Hadoop cluster (e.g. HDFS, MapReduce and Gan
 
 
 
-###States
+### States
 
 The current state of a service resource can be determined by looking at the ServiceInfo/state property.
 
@@ -131,10 +131,10 @@ The following table lists the possible values of the service resource ServiceInf
   </tr>
 </table>
 
-###Starting a Service
+### Starting a Service
 A service can be started through the API by setting its state to be STARTED (see [update service](update-service.md)).
 
-###Stopping a Service
+### Stopping a Service
 A service can be stopped through the API by setting its state to be INSTALLED (see [update service](update-service.md)).
 
 

--- a/ambari-server/docs/api/v1/stack-version-resources.md
+++ b/ambari-server/docs/api/v1/stack-version-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Stack Version Resources
 
-#####Get Stack Versions
+##### Get Stack Versions
 Retrieves all stack versions.
 
 For cluster:
@@ -60,7 +60,7 @@ For host:
       ]
     }
     
-#####Get Stack Version
+##### Get Stack Version
 Retrieves single stack version.
 
 For cluster:
@@ -141,7 +141,7 @@ For host:
       ]
     }
     
-#####Install Repository Version
+##### Install Repository Version
 Performs install of given repository version on the resource.
 
 For cluster:

--- a/ambari-server/docs/api/v1/task-resources.md
+++ b/ambari-server/docs/api/v1/task-resources.md
@@ -18,11 +18,11 @@ limitations under the License.
 # Task Resources
  
  
-###API Summary 
+### API Summary
 
 - [List tasks](tasks.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -84,7 +84,7 @@ limitations under the License.
 </table>
 
 
-###Status
+### Status
 
 The current status of a task resource can be determined by looking at the Tasks/status property.
 

--- a/ambari-server/docs/api/v1/view-resources.md
+++ b/ambari-server/docs/api/v1/view-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # View Resources
 
-#####Get Views
+##### Get Views
 The user may query for all of the deployed views.  Note that views are a top level resources (they are not sub-resources of a cluster).
 
     GET http://<server>:8080/api/v1/views/
@@ -40,7 +40,7 @@ The user may query for all of the deployed views.  Note that views are a top lev
       ]
     }
 
-#####Get View
+##### Get View
 To get a specific view, request it by name.  Note that the response shows all of the versions of the view as sub-resources.
 
     GET http://<server>:8080/api/v1/views/FILES/
@@ -62,7 +62,7 @@ To get a specific view, request it by name.  Note that the response shows all of
     }
 
 
-#####Get Versions
+##### Get Versions
 The user may request all of the versions of a named view.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/
@@ -80,7 +80,7 @@ The user may request all of the versions of a named view.
       ]
     }
 
-#####Get Version
+##### Get Version
 A specific version can be requested.  Note that all of the instances of the view version are included in the response.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/
@@ -117,7 +117,7 @@ A specific version can be requested.  Note that all of the instances of the view
       ]
     }
 
-#####Get Instances
+##### Get Instances
 The user may request all of the instances of a view.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/
@@ -137,7 +137,7 @@ The user may request all of the instances of a view.
     }
 
 
-#####Get Instance
+##### Get Instance
 A specific view instance may be requested by specifying its name.  Note that the instance resources are listed as sub-resources.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_1
@@ -165,12 +165,12 @@ A specific view instance may be requested by specifying its name.  Note that the
       ]
     }
     
-#####Create Instance
+##### Create Instance
 New view instances may be created through the API.
 
     POST http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
     
-#####Update Instance
+##### Update Instance
 The properties of a view instance may be updated through the API.
 
     PUT http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
@@ -182,20 +182,20 @@ The properties of a view instance may be updated through the API.
         }
     }]
 
-#####Delete Instance
+##### Delete Instance
 A view instances may be deleted through the API.
 
     DELETE http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
     
 
-#####Resources
+##### Resources
 A view resource may be accessed through the REST API.  The href for each view resource can be found in a request for the parent view instance.  The resource endpoints and behavior depends on the implementation of the JAX-RS annotated service class specified for the resource element in the view.xml. 
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_1/resources/files/fileops/listdir?path=%2F
     
     [{"path":"/app-logs","replication":0,"isDirectory":true,"len":0,"owner":"yarn","group":"hadoop","permission":"-rwxrwxrwx","accessTime":0,"modificationTime":1400006792122,"blockSize":0},{"path":"/mapred","replication":0,"isDirectory":true,"len":0,"owner":"mapred","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006653817,"blockSize":0},{"path":"/mr-history","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006653822,"blockSize":0},{"path":"/tmp","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxrwxrwx","accessTime":0,"modificationTime":1400006720415,"blockSize":0},{"path":"/user","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006610050,"blockSize":0}]
 
-#####Managed Resources
+##### Managed Resources
 Any managed resources for a view may also be accessed through the REST API.  Note that instances of a managed resource appear as sub-resources of an instance under the plural name specified for the resource in the view.xml.  In this example, a list of managed resources named **'scripts'** is included in the response for the view instance … 
  
     GET http://<server>:8080/api/v1/views/PIG/versions/0.1.0/instances/INSTANCE_1

--- a/ambari-views/docs/index.md
+++ b/ambari-views/docs/index.md
@@ -32,14 +32,14 @@ View examples can be found under ambari-views/examples of the Apache Ambari proj
 
 Basics
 -----
-###View Instances
+### View Instances
 A view may have multiple instances.  Each instance of a view has a name that is unique for that view.  An instance may provide property values for the parameters of the view.
 
 
 For example, a file browser view may define a file system URI parameter.  A view deployer may define multiple instances of the file browser view, each with a different file system URI property value.
 
 
-###View Context
+### View Context
 The view context gives the view components access to the runtime context that the Ambari container provides.  The context remains associated with the view instance for the duration of its lifetime.
 
 An instance of the view context may be injected by the container into the various view components, such as resources, resource providers and servlets.
@@ -202,12 +202,12 @@ The context interface provides access to information about the associated view i
        */
       public ImpersonatorSetting getImpersonatorSetting();
  
-###UI Components
+### UI Components
 The view archive may contain components of a web application such as html or JavaSript. 
 
 See [View UI](#View UI).
 
-#####WEB-INF/web.xml
+##### WEB-INF/web.xml
 The web.xml is the deployment descriptor used to deploy the view as a web app.  The Java EE standards apply for the descriptor.  
 
 For example …
@@ -225,7 +225,7 @@ For example …
 For this simple hello world example a single servlet named **HelloServlet** is mapped to the context path **'/ui'**.
 
 
-#####Servlets
+##### Servlets
 
 Servlets contained in a view archive will be deployed as part of the view and mapped as described in the web.xml.
 
@@ -263,12 +263,12 @@ For example, in the doGet() method of the servlet we can use the view context in
       }
 
 
-###Resources
+### Resources
 Resources may be exposed for a view.  Each resource is defined in the view.xml descriptor.  All resource descriptions specify a resource name and service class.  See [view.xml](#viewxml).
 
 Each resource endpoint may then be accessed through the Ambari API.  See [API](#api).
 
-#####Service Class
+##### Service Class
 
 The service class uses JAX-RS annotations to define the view resource endpoint.  Note that the injected ViewContext.
 
@@ -296,12 +296,12 @@ The service class uses JAX-RS annotations to define the view resource endpoint. 
 
 
 
-####Managed Resources
+#### Managed Resources
 A managed resource is a resource that is managed through the Ambari API framework.  In addition to a name and service class, a managed resource definition includes plural name, resource class and provider class.  See [view.xml](#viewxml).
  
 The advantage of using a managed resource over a simple resource is that any queries through the REST API for managed resource may take advantage of any of the features of the API framework.  These include partial response, query predicates, pagination, sub-resource queries, etc.  See [API](#API).
 
-#####Service Class
+##### Service Class
 
 This service class uses JAX-RS annotations to define the actions to get the resources.  
 This example shows how a service class could handle a request by delegating to the API framework.  Note that the injected ViewResourceHandler is used to pass control to the API framework.
@@ -321,7 +321,7 @@ This example shows how a service class could handle a request by delegating to t
 
 
 
-#####Resource Class
+##### Resource Class
 
 A resource class is a JavaBean that exposes the attributes of the resource.
 
@@ -347,7 +347,7 @@ For example …
     }
   
 
-#####Resource Provider Class
+##### Resource Provider Class
 
 The resource provider class is an implementation of the ResourceProvider interface.  It provides access to resource for the Ambari API framework.
 
@@ -375,10 +375,10 @@ For example …
         ... 
       }
 
-###Permissions
+### Permissions
 The permission VIEW.USER can be granted on any view instance by an administrator.  A user that has VIEW.USER privilege on a view instance will be able to access the view instance.  See [API](#api).
   
-###Custom Permissions
+### Custom Permissions
 A view can define permissions in the view.xml descriptor. 
   
       <view>
@@ -428,7 +428,7 @@ The view implementation code can use the view context to check custom permission
         return Response.ok("<b>You have accessed a restricted resource.</b>").type("text/html").build();
       } 
 
-###Impersonation
+### Impersonation
 
 Views can utilize the viewContext to facilitate calls that require impersonating a user. For example, a service may expose an endpoint that accepts parameters like "doAs=johndoe" to perform some action on behalf of that user.
 The HttpImpersonator Interface provides a contract for how to perform an HTTP GET request on a URL that supports some type of "doAs" parameter, and the username.
@@ -439,7 +439,7 @@ The HttpImpersonator Interface provides a contract for how to perform an HTTP GE
 
 The ImpersonatorSetting class contains the variables that are added to the URL params. Its default constructor sets "doAs" as the default query parameter name, and the currently logged on user as its value; both of these can be changed with the overloaded constructors.
 
-###Persistence
+### Persistence
 
 The application data map is different than the view instance properties that are specified to instantiate the view.  The application data map may contain any arbitrary string values that the view needs to persist and may be updated or queried at any point during the life of the view instance by the application logic. 
 
@@ -475,7 +475,7 @@ The view context contains methods to put and get values from the application dat
        * @param key  the key
        */
 
-#####DataStore
+##### DataStore
 The data store allows view instances to save JavaBean entities in the Ambari database.
 
 The view components may acquire a data store instance through the injected view context.  The view context exposes a data store object … 
@@ -539,11 +539,11 @@ The DataStore object exposes a simple interface for persisting view entities.  T
       
 Each entity to be persisted by the view should be specified in the view.xml.  See [view.xml](#viewxml).   
 
-###Events
+### Events
 
 
 
-#####View Lifecycle Events
+##### View Lifecycle Events
 
 A view can monitor its own lifecycle events by implementing the View interface.
 
@@ -579,11 +579,11 @@ Destroy   |An instance of the view has been destroyed. |The destroyed view insta
 
 
 
-#####Custom Events
+##### Custom Events
 
 A view can send out notification of custom events through the view framework and listen for custom view events from other deployed views.
 
-#####Listeners
+##### Listeners
 
 To listen for event notifications, a view needs to implement a listener and register it with the view framework.
 
@@ -608,7 +608,7 @@ The notify method of the listener will be called when the subject view fires an 
     }
 
 
-#####ViewController
+##### ViewController
 
 The ViewController allows a view to register event listeners and to fire event notifications.
 
@@ -670,10 +670,10 @@ All views are packaged as a view archive.  The view archive contains the configu
 
 The view resource also contains all of the view UI components such as html, JavaSript and servlets.
 
-###Dependencies
+### Dependencies
 The view may include dependency classes and jars directly into the archive.  Classes should be included under **WEB-INF/classes**.  Jars should be included under **WEB-INF/lib**.
 
-###view.xml
+### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -694,7 +694,7 @@ permission   |Defines a custom permission for the view.
 persistence   |Describe a view entities for persistence. 
 instance |Define an instances of a view.
 
-#####parameter
+##### parameter
 Element | Description
 ---|---
 name    |The parameter name.
@@ -702,7 +702,7 @@ description    |The parameter description.
 required    |Determines whether or not the parameter is required.
 masked    |Indicated this parameter value is to be "masked" in the Ambari Web UI (i.e. not shown in the clear). Omitting this element default to not-masked. Otherwise, if true, the parameter value will be "masked" in the Web UI.
 
-#####resource
+##### resource
 Element | Description
 ---|---
 name    |The resource name (i.e file).
@@ -732,18 +732,18 @@ For example …
     </resource>
 
 
-#####permission
+##### permission
 Element | Description
 ---|---
 name | The permission name.
 description | The permission description.
 
-#####persistence
+##### persistence
 Element | Description
 ---|---
 entity | An entity that may be persisted through the DataStore.
 
-#####entity
+##### entity
 Element | Description
 ---|---
 class | The class ot the JavaBean that contains the attributes of an entity.
@@ -766,7 +766,7 @@ For example …
       </entity>
     </persistence> 
 
-#####instance
+##### instance
 Element | Description
 ---|---
 name | The unique instance name (required).
@@ -777,7 +777,7 @@ icon | Overrides the view icon for this specific view instance.
 visible | If true, for the view instance to show up in the users view instance list.  The default value is true.
 property | Specifies configuration parameters values for the view instance.
 
-#####property
+##### property
 Element | Description
 ---|---
 key | The property key (must match view parameter name).
@@ -828,7 +828,7 @@ To deploy a view, simply place the view archive in the views folder of the ambar
     /var/lib/ambari-server/resources/views
 
 
-###Exploded Archive
+### Exploded Archive
 When a view is deployed, the contents of the archive are expanded under the views folder.  By default the exploded view archives are located at … 
 
     /var/lib/ambari-server/resources/views/work/:viewName{:viewVersion}
@@ -841,9 +841,9 @@ Once deployed, the user may make changes directly to the view components.  Chang
 
 Use
 -----
-###API
+### API
 
-#####Get Views
+##### Get Views
 The user may query for all of the deployed views.  Note that views are a top-level resources (they are not sub-resources of a cluster).
 
     GET http://<server>:8080/api/v1/views/
@@ -866,7 +866,7 @@ The user may query for all of the deployed views.  Note that views are a top-lev
       ]
     }
 
-#####Get View
+##### Get View
 To get a specific view, request it by name.  Note that the response shows all of the versions of the view as sub-resources.
 
     GET http://<server>:8080/api/v1/views/FILES/
@@ -888,7 +888,7 @@ To get a specific view, request it by name.  Note that the response shows all of
     }
 
 
-#####Get Versions
+##### Get Versions
 The user may request all of the versions of a named view.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/
@@ -906,7 +906,7 @@ The user may request all of the versions of a named view.
       ]
     }
 
-#####Get Version
+##### Get Version
 A specific version can be requested.  Note that all of the instances of the view version are included in the response.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/
@@ -943,7 +943,7 @@ A specific version can be requested.  Note that all of the instances of the view
       ]
     }
 
-#####Get Instances
+##### Get Instances
 The user may request all of the instances of a view.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/
@@ -963,7 +963,7 @@ The user may request all of the instances of a view.
     }
 
 
-#####Get Instance
+##### Get Instance
 A specific view instance may be requested by specifying its name.  Note that the instance resources are listed as sub-resources.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_1
@@ -991,12 +991,12 @@ A specific view instance may be requested by specifying its name.  Note that the
       ]
     }
     
-#####Create Instance
+##### Create Instance
 New view instances may be created through the API.
 
     POST http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
     
-#####Update Instance
+##### Update Instance
 The properties of a view instance may be updated through the API.
 
     PUT http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
@@ -1008,20 +1008,20 @@ The properties of a view instance may be updated through the API.
         }
     }]
 
-#####Delete Instance
+##### Delete Instance
 A view instances may be deleted through the API.
 
     DELETE http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
     
 
-#####Resources
+##### Resources
 A view resource may be accessed through the REST API.  The href for each view resource can be found in a request for the parent view instance.  The resource endpoints and behavior depends on the implementation of the JAX-RS annotated service class specified for the resource element in the view.xml. 
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_1/resources/files/fileops/listdir?path=%2F
     
     [{"path":"/app-logs","replication":0,"isDirectory":true,"len":0,"owner":"yarn","group":"hadoop","permission":"-rwxrwxrwx","accessTime":0,"modificationTime":1400006792122,"blockSize":0},{"path":"/mapred","replication":0,"isDirectory":true,"len":0,"owner":"mapred","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006653817,"blockSize":0},{"path":"/mr-history","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006653822,"blockSize":0},{"path":"/tmp","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxrwxrwx","accessTime":0,"modificationTime":1400006720415,"blockSize":0},{"path":"/user","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006610050,"blockSize":0}]
 
-#####Managed Resources
+##### Managed Resources
 Any managed resources for a view may also be accessed through the REST API.  Note that instances of a managed resource appear as sub-resources of an instance under the plural name specified for the resource in the view.xml.  In this example, a list of managed resources named **'scripts'** is included in the response for the view instance … 
  
     GET http://<server>:8080/api/v1/views/PIG/versions/0.1.0/instances/INSTANCE_1
@@ -1083,7 +1083,7 @@ Because the resource is managed through the Ambari API framework, it may be quer
     GET http://<server>:8080/api/v1/views/PIG/versions/0.1.0/instances/INSTANCE_1/scripts?fields=pythonScript&owner=jsmith
     
 
-#####Grant view privileges
+##### Grant view privileges
 
 To grant privileges to access the restricted resource we can create a privilege sub-resource for the view instance.  The following API will grant RESTICTED permission to the user 'bob' for the view instance 'INSTANCE_1' of the 'RESTRICTED' view. 
 
@@ -1099,7 +1099,7 @@ To grant privileges to access the restricted resource we can create a privilege 
       }
     ]
 
-#####Get a view privilege
+##### Get a view privilege
 
 We can see a privilege sub resource for a view instance.
 
@@ -1119,7 +1119,7 @@ We can see a privilege sub resource for a view instance.
       }
     }
 
-###View UI
+### View UI
 The context root of a view instance is …
     
     /views/:viewName/:viewVersion/:viewInstance/

--- a/ambari-views/examples/README.md
+++ b/ambari-views/examples/README.md
@@ -46,23 +46,23 @@ Report any issues via the [Ambari JIRA](https://issues.apache.org/jira/browse/AM
 
 ## Build
 
-####Examples
+#### Examples
 
-######Requirements
+###### Requirements
 * JDK 1.6
 * Maven 3.0
 
-######Maven modules
+###### Maven modules
 * ambari-views (ambari view interfaces)
 
-######Maven build goals
+###### Maven build goals
  * Clean : mvn clean
  * Compile : mvn compile
  * Run tests : mvn test
  * Create JARS : mvn package
  * Install JARS in M2 cache : mvn install
 
-######Tests options
+###### Tests options
   * -DskipTests to skip tests when running the following Maven goals:
     'package', 'install', 'deploy' or 'verify'
   * -Dtest=\<TESTCLASSNAME>,\<TESTCLASSNAME#METHODNAME>,....

--- a/ambari-views/examples/calculator-view/docs/index.md
+++ b/ambari-views/examples/calculator-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -45,7 +45,7 @@ The configuration in this case defines a view named CALCULATOR that has a single
 
 
 
-#####CalculatorResource.java
+##### CalculatorResource.java
 
 The CalculatorResource class defines the calculator resource for the view.  It uses JAX-RS annotations to define the actions that can be performed on the resource.
 

--- a/ambari-views/examples/cluster-view/docs/index.md
+++ b/ambari-views/examples/cluster-view/docs/index.md
@@ -27,13 +27,13 @@ Package
 All views are packaged as a view archive. The view archive contains the configuration
 file and various optional components of the view.
 
-###view.xml
+### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
 Note the following in the view.xml for the CLUSTER view:
 
-#####cluster-config
+##### cluster-config
 
 Some of the parameter elements in the view.xml are created with a cluster-config element.
 
@@ -48,7 +48,7 @@ Some of the parameter elements in the view.xml are created with a cluster-config
 Including a cluster-config element means that the value for the parameter's property will be acquired from cluster configuration if the view instance is associated with a cluster.  
 In this example, if an instance of this view is associated with a cluster then the value returned for the 'hdfs_user' property will come from the cluster's 'hadoop-env/hdfs_user' configuration. 
 
-#####auto-instance
+##### auto-instance
 
 The view.xml contains an auto-instance element.
 

--- a/ambari-views/examples/favorite-view/docs/index.md
+++ b/ambari-views/examples/favorite-view/docs/index.md
@@ -26,7 +26,7 @@ Package
 All views are packaged as a view archive. The view archive contains the configuration
 file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 The view.xml for this example defines two required parameters for configuring a view instance: what.is.the.question and i.do.not.know. The view also

--- a/ambari-views/examples/hello-servlet-view/docs/index.md
+++ b/ambari-views/examples/hello-servlet-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -59,7 +59,7 @@ The view.xml file is the only required file for a view archive.  The view.xml is
 The configuration in this case defines a view named HELLO_SERVLET that has a multiple instances.  You can see that the view includes an optional parameter called name.  Each view instance may assign a property value to the name parameter.  In this case the view instances TOM and JERRY both assign a name value, while the instance USER does not.
 
 
-#####WEB-INF/web.xml
+##### WEB-INF/web.xml
 The web.xml is the deployment descriptor used to deploy the view as a web app.  The Java EE standards apply for the descriptor.  We can see that for this example a single servlet is mapped to the root context path.
 
       <servlet>
@@ -71,7 +71,7 @@ The web.xml is the deployment descriptor used to deploy the view as a web app.  
         <url-pattern>/</url-pattern>
       </servlet-mapping>
 
-#####HelloServlet.java
+##### HelloServlet.java
 
 The servlet HelloServlet will be deployed as part of the view and mapped as described in the web.xml.
 

--- a/ambari-views/examples/hello-spring-view/docs/index.md
+++ b/ambari-views/examples/hello-spring-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -40,7 +40,7 @@ The view.xml file is the only required file for a view archive.  The view.xml is
 The configuration in this case defines a view named HELLO_SPRING that has a single instance.
 
 
-#####HelloController.java
+##### HelloController.java
 
 The HelloController class is the controller for the Spring MVC app.
 
@@ -60,7 +60,7 @@ For this app, the controller saves a customized greeting to a model attribute.
 
 
 
-#####WEB-INF/web.xml
+##### WEB-INF/web.xml
 The web.xml is the deployment descriptor used to deploy the view as a web app.  The Java EE standards apply for the descriptor.  We can see that for this example a single servlet is mapped to the root context path.  The class for the servlet is the Spring DispatcherServlet.
 
         <servlet>
@@ -74,7 +74,7 @@ The web.xml is the deployment descriptor used to deploy the view as a web app.  
         </servlet-mapping>
       </web-app>
 
-#####WEB-INF/hello-spring.xml
+##### WEB-INF/hello-spring.xml
 
 This hello-spring.xml file contains the bean configuration.
 
@@ -90,7 +90,7 @@ In the above servlet.xml file, we have defined a tag <context:component-scan> . 
 Note that in the HelloController class we return the bean name "hello" which will resolve to the view /WEB-INF/jsp/hello.jsp.
 
 
-#####WEB-INF/jsp/hello.jsp
+##### WEB-INF/jsp/hello.jsp
 
 The Spring MVC app view for this example will display the customized greeting message saved in the HelloController class.
 

--- a/ambari-views/examples/helloworld-view/docs/index.md
+++ b/ambari-views/examples/helloworld-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -40,7 +40,7 @@ The view.xml file is the only required file for a view archive.  The view.xml is
 The configuration in this case defines a view named HELLO_WORLD that has a single instance named INSTANCE_1.
 
 
-#####index.html
+##### index.html
 
 The index.html is the static web content being exposed by this view.
 

--- a/ambari-views/examples/phone-list-upgrade-view/docs/index.md
+++ b/ambari-views/examples/phone-list-upgrade-view/docs/index.md
@@ -45,7 +45,7 @@ In order to support data migration, view should implement the ViewDataMigrator i
 NOTE: Data migration for instances of same data-versions (including those which does not define data-version) IS supported
 and in fact just copies all data - the class defined in the data-migrator-class in view.xml WILL NOT be instantiated.
 
-#####view.xml
+##### view.xml
 
 View can define the data version and ViewDataMigrator implementation in the view.xml.
 
@@ -60,7 +60,7 @@ View can define the data version and ViewDataMigrator implementation in the view
 If data-version is not defined, 0 is implied.
 
 
-#####DataMigrator.java
+##### DataMigrator.java
 
 To support migrations between different data versions, view should implement ViewDataMigrator interface.
 Views framework calls beforeMigration() method to check if view is ready to migrate data.

--- a/ambari-views/examples/phone-list-view/docs/index.md
+++ b/ambari-views/examples/phone-list-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -43,7 +43,7 @@ The view.xml file is the only required file for a view archive.  The view.xml is
 The configuration in this case defines a view named PHONE_LIST that has a multiple instances.  Each view instance will have its own data persisted to the Ambari database.
 
 
-#####WEB-INF/web.xml
+##### WEB-INF/web.xml
 The web.xml is the deployment descriptor used to deploy the view as a web app.  The Java EE standards apply for the descriptor.  We can see that for this example a single servlet is mapped to the root context path.
 
         <servlet>
@@ -55,7 +55,7 @@ The web.xml is the deployment descriptor used to deploy the view as a web app.  
           <url-pattern>/</url-pattern>
         </servlet-mapping>
         
-#####PhoneListServlet.java
+##### PhoneListServlet.java
 
 The servlet PhoneListServlet will be deployed as part of the view and mapped as described in the web.xml.
 
@@ -237,7 +237,7 @@ Use the view API to add new numbers to the phone list.  Click on any name in the
 
 ![image](phone_2.png)
 
-#####Different Instance
+##### Different Instance
 Each instance of the Phone List view has its own data so you can maintain separate lists.  Access the UI for a different view instance and you will see a different phone list…
 
 
@@ -249,7 +249,7 @@ We can look at the Ambari database and see that the view instance data is being 
 
 ![image](phone_4.png)
 
-#####New Instance
+##### New Instance
 Notice that the two instances above were defined in the view.xml for the Phone List view.  We can also create new instances through the API.  For example, if you POST the following…
 
 

--- a/ambari-views/examples/property-validator-view/docs/index.md
+++ b/ambari-views/examples/property-validator-view/docs/index.md
@@ -34,7 +34,7 @@ Package
 All views are packaged as a view archive. The view archive contains the configuration
 file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 

--- a/ambari-views/examples/property-view/docs/index.md
+++ b/ambari-views/examples/property-view/docs/index.md
@@ -27,7 +27,7 @@ Package
 All views are packaged as a view archive. The view archive contains the configuration
 file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 

--- a/ambari-views/examples/restricted-view/docs/index.md
+++ b/ambari-views/examples/restricted-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -55,7 +55,7 @@ The configuration in this case defines a view named RESTRICTED that has a single
 
 
 
-#####UnrestrictedResource.java
+##### UnrestrictedResource.java
 
 The UnrestrictedResource class defines a simple resource for the view.  It uses JAX-RS annotations to define the actions that can be performed on the resource.
 
@@ -71,7 +71,7 @@ For example ...
 
      http://<server>:8080/api/v1/views/RESTRICTED/versions/1.0.0/instances/INSTANCE_1/resources/unrestricted
 
-#####RestrictedResource.java
+##### RestrictedResource.java
 
 The RestrictedResource class defines a simple resource for the view.  It uses JAX-RS annotations to define the actions that can be performed on the resource.
 

--- a/ambari-views/examples/simple-view/docs/index.md
+++ b/ambari-views/examples/simple-view/docs/index.md
@@ -28,7 +28,7 @@ Package
 All views are packaged as a view archive. The view archive contains the configuration
 file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 The view.xml for this example defines one required parameter for configuring a view instance: what.is.the.value. The view also

--- a/ambari-views/examples/weather-view/docs/index.md
+++ b/ambari-views/examples/weather-view/docs/index.md
@@ -24,7 +24,7 @@ Package
 
 All views are packaged as a view archive.  The view archive contains the configuration file and various optional components of the view.
 
-#####view.xml
+##### view.xml
 
 The view.xml file is the only required file for a view archive.  The view.xml is the configuration that describes the view and view instances for Ambari.
 
@@ -110,7 +110,7 @@ The view.xml file is the only required file for a view archive.  The view.xml is
 The configuration in this case defines a view named WEATHER that has a multiple instances.  You can see that the view includes a required parameter called **'cities'** and an optional parameter called **'units'**.  The view also contains an entry for a managed resource named **'city'**.  Because the resource is managed by Ambari, it is accessible as a sub-resource of the view instance through the Ambari REST API.
 
 
-#####WEB-INF/web.xml
+##### WEB-INF/web.xml
 The web.xml is the deployment descriptor used to deploy the view as a web app.  The Java EE standards apply for the descriptor.  We can see that for this example a single servlet named **WeatherServlet** is mapped to the context path **'/ui'**.
 
       <servlet>
@@ -122,7 +122,7 @@ The web.xml is the deployment descriptor used to deploy the view as a web app.  
         <url-pattern>/ui</url-pattern>
       </servlet-mapping>
 
-#####WeatherServlet.java
+##### WeatherServlet.java
 
 The servlet WeatherServlet will be deployed as part of the view and mapped as described in the web.xml.
 
@@ -166,7 +166,7 @@ The doGet() method of the servlet accesses the view context and the CityResource
         }
       }
 
-#####CityResource.java
+##### CityResource.java
 
  The CityResource class is a JavaBean that contains the attributes of a city resource for the Weather view.
 
@@ -188,7 +188,7 @@ The doGet() method of the servlet accesses the view context and the CityResource
         ...
       }
 
-#####CityResourceProvider.java
+##### CityResourceProvider.java
 
 The CityResourceProvider class is an implementation of the ResourceProvider interface that provides access to city resources for the Ambari API framework.
 
@@ -214,7 +214,7 @@ The CityResourceProvider class is an implementation of the ResourceProvider inte
         ...
       }
 
-#####CityService.java
+##### CityService.java
 
 The CityService uses JAX-RS annotations to define the actions to get the city resources.  Note that the injected ViewResourceHandler is used to pass control to the API framework.
 

--- a/contrib/ambari-scom/README.md
+++ b/contrib/ambari-scom/README.md
@@ -33,32 +33,32 @@ Report any issues via the [Ambari JIRA](https://issues.apache.org/jira/browse/AM
 
 ## Build
 
-####Ambari-SCOM and Metrics Sink
+#### Ambari-SCOM and Metrics Sink
 
-######Requirements
+###### Requirements
 * JDK 1.6
 * Maven 3.0
     
-######Maven modules
+###### Maven modules
 * ambari-scom-project (Parent POM for all modules)
   * ambari-scom (ambari MSI and SQL Server provider)
   * metrics-sink (Metrics SQL Server sink)       
   
-######Maven build goals
+###### Maven build goals
  * Clean : mvn clean
  * Compile : mvn compile
  * Run tests : mvn test 
  * Create JAR : mvn package
  * Install JAR in M2 cache : mvn install     
     
-######Tests options
+###### Tests options
   * -DskipTests to skip tests when running the following Maven goals:
     'package', 'install', 'deploy' or 'verify'
   * -Dtest=\<TESTCLASSNAME>,\<TESTCLASSNAME#METHODNAME>,....
   * -Dtest.exclude=\<TESTCLASSNAME>
   * -Dtest.exclude.pattern=\*\*/\<TESTCLASSNAME1>.java,\*\*/\<TESTCLASSNAME2>.java
 
-####Management Pack
+#### Management Pack
 
 See [Building the Management Pack](management-pack/Hadoop_MP/BUILDING.md) for more information.
 

--- a/contrib/ambari-scom/ambari-scom-server/Ambari-SCOM-install-instructions.md
+++ b/contrib/ambari-scom/ambari-scom-server/Ambari-SCOM-install-instructions.md
@@ -17,7 +17,7 @@ Instructions to setup ambari-scom
 ======
 
 
-###Setup the HadoopMonitoring database
+### Setup the HadoopMonitoring database
 
 
 1. Setup SQLServer for mixed mode authentication (the metrics2 sink and Ambari metrics provider will connect through SQLServer authentication).
@@ -26,7 +26,7 @@ Instructions to setup ambari-scom
 4. Run the DDL script from the ambari-scom project to create the HadoopMoitoring database.  The script should be available as **db/MonitoringDatabase.sql** in the ambari-scom project folder.
 5. Download the SqlServer JDBC driver jar **(sqljdbc4.jar)** from [here](http://msdn.microsoft.com/en-us/data/aa937724.aspx).
 
-###Install Hadoop and SQLServerSink
+### Install Hadoop and SQLServerSink
 
 
 1. Follow the hadoop install instructions [here](http://docs.hortonworks.com/HDPDocuments/HDP1/HDP-Win-1.3.0/index.html), making sure you download the 1.3 MSI.
@@ -62,7 +62,7 @@ For example, '-classpath C:\ambari-scom\target\ambari-scom-1.0.jar;C:\hadoop\sql
    The table should not be empty.
 
 
-###Run AmbariServer
+### Run AmbariServer
 
 
 1. Edit the **ambari.properties** file from the ambari-scom project (ambari-scom/config/ambari.properties or unzip target/ambari-scom-1.0-conf.zip to desired location).  Add the following properties ...
@@ -85,7 +85,7 @@ For example, '-classpath C:\ambari-scom\target\ambari-scom-1.0.jar;C:\hadoop\sql
         java -server -XX:NewRatio=3 -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -XX:CMSInitiatingOccupancyFraction=60 -Xms512m -Xmx2048m -cp "c:\ambari-scom\conf;c:\hadoop\sqljdbc4.jar;c:\ambari-scom\target\ambari-scom-1.0.jar;c:\ambari-scom\target\lib\*" org.apache.ambari.scom.AmbariServer
 
 
-###Test the API
+### Test the API
 
 
 1. From a browser access the API...

--- a/contrib/views/commons/README.md
+++ b/contrib/views/commons/README.md
@@ -76,7 +76,7 @@ public class FileBrowserService {
 ```
 
 
-####Also, look into the various ember addons that are included in `src/main/resources/ui`.
+#### Also, look into the various ember addons that are included in `src/main/resources/ui`.
 Currently we have:
 
 * hdfs-directory-viewer


### PR DESCRIPTION
Several md files in `ambari-server/doc/api/v1`, `ambari-views/docs/`,`ambari-views/docs/examples` and other have incorrect heading formating (missing space after #).