### PR TITLE
Fix how to check Ambari Collector script's distributed-hbase condition

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/ambari-metrics-collector
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/ambari-metrics-collector
@@ -231,7 +231,7 @@ function start()
   # hbase_daemon "zookeeper" "start"
   #	hbase_daemon "master" "start"
   #	hbase_daemon "regionserver" "start"
-  if [ !"${DISTRIBUTED_HBASE}" ]; then
+  if [[ "${DISTRIBUTED_HBASE}" == "false" || "${DISTRIBUTED_HBASE}" == "False" ]]; then
     echo "$(date) Starting HBase." | tee -a $STARTUPFILE
     hbase_daemon "master" "start"
   else
@@ -332,7 +332,7 @@ function stop()
   fi
 
   #stop hbase daemons
-  if [ !"${DISTRIBUTED_HBASE}" ]; then
+  if [[ "${DISTRIBUTED_HBASE}" == "false" || "${DISTRIBUTED_HBASE}" == "False" ]]; then
     echo "Stopping HBase master" | tee -a $STARTUPFILE
     hbase_daemon "master" "stop"
   fi

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/ambari-metrics-collector
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/ambari-metrics-collector
@@ -231,7 +231,7 @@ function start()
   # hbase_daemon "zookeeper" "start"
   #	hbase_daemon "master" "start"
   #	hbase_daemon "regionserver" "start"
-  if [[ "${DISTRIBUTED_HBASE}" == "false" || "${DISTRIBUTED_HBASE}" == "False" ]]; then
+  if [ "${DISTRIBUTED_HBASE}" = false ]; then
     echo "$(date) Starting HBase." | tee -a $STARTUPFILE
     hbase_daemon "master" "start"
   else
@@ -332,7 +332,7 @@ function stop()
   fi
 
   #stop hbase daemons
-  if [[ "${DISTRIBUTED_HBASE}" == "false" || "${DISTRIBUTED_HBASE}" == "False" ]]; then
+  if [ "${DISTRIBUTED_HBASE}" = false ]; then
     echo "Stopping HBase master" | tee -a $STARTUPFILE
     hbase_daemon "master" "stop"
   fi


### PR DESCRIPTION
There is a problem when use `ambari-metrics-collector` to start/restart ambari-collector using `--distributed`.

Just as `AMS_HBASE_INIT_CHECK_ENABLED` variable in this script, fix the checking condition below.