### PR TITLE
[AMBARI-22184] Add default value for hive.server2.thrift.http.port

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK/configuration/spark-hive-site-override.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK/configuration/spark-hive-site-override.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration supports_final="true">
+  <property>
+    <name>hive.server2.thrift.http.port</name>
+    <value>10017</value>
+    <description>
+      Port number of Spark Thrift interface when hive.server2.transport.mode is 'http'.
+    </description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+</configuration>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/spark2-hive-site-override.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/spark2-hive-site-override.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration supports_final="true">
+  <property>
+    <name>hive.server2.thrift.http.port</name>
+    <value>10017</value>
+    <description>
+      Port number of Spark2 Thrift interface when hive.server2.transport.mode is 'http'.
+    </description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+</configuration>


### PR DESCRIPTION
This PR aims to add a defualt value for hive.server2.thrift.http.port.

Indeed, Ambari sets a default for hive.server2.thrift.port, but it doesn't for hive.server2.thrift.http.port. So if you switch from binary to http mode there is a conflict with HiveServer2, since the default port in the code is the same.
