### PR TITLE
AMBARI-22750. Add custom input / mapper descriptor to config api

### DIFF
--- a/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/CustomDescriptor.java
+++ b/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/CustomDescriptor.java
@@ -16,39 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.ambari.logsearch.config.api.model.inputconfig;
 
 import java.util.Map;
 
-public interface InputDescriptor {
-  String getType();
+public interface CustomDescriptor {
+  Map<String, Object> getProperties();
 
-  String getRowtype();
+  void setProperties(Map<String, Object> properties);
 
-  String getPath();
+  String getMapperClassName();
 
-  Map<String, String> getAddFields();
-
-  String getSource();
-
-  Boolean isTail();
-
-  Boolean isGenEventMd5();
-
-  Boolean isUseEventMd5AsId();
-
-  Boolean isCacheEnabled();
-
-  String getCacheKeyField();
-
-  Boolean getCacheLastDedupEnabled();
-
-  Integer getCacheSize();
-
-  Long getCacheDedupInterval();
-
-  Boolean isEnabled();
-
-  Map<String, Object> getAllProperties();
+  void setMapperClassName(String className);
 }

--- a/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/InputCustomDescriptor.java
+++ b/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/InputCustomDescriptor.java
@@ -16,39 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.ambari.logsearch.config.api.model.inputconfig;
 
-import java.util.Map;
-
-public interface InputDescriptor {
-  String getType();
-
-  String getRowtype();
-
-  String getPath();
-
-  Map<String, String> getAddFields();
-
-  String getSource();
-
-  Boolean isTail();
-
-  Boolean isGenEventMd5();
-
-  Boolean isUseEventMd5AsId();
-
-  Boolean isCacheEnabled();
-
-  String getCacheKeyField();
-
-  Boolean getCacheLastDedupEnabled();
-
-  Integer getCacheSize();
-
-  Long getCacheDedupInterval();
-
-  Boolean isEnabled();
-
-  Map<String, Object> getAllProperties();
+public interface InputCustomDescriptor extends InputDescriptor, CustomDescriptor {
 }

--- a/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/MapCustomDescriptor.java
+++ b/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/MapCustomDescriptor.java
@@ -16,39 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.ambari.logsearch.config.api.model.inputconfig;
 
-import java.util.Map;
-
-public interface InputDescriptor {
-  String getType();
-
-  String getRowtype();
-
-  String getPath();
-
-  Map<String, String> getAddFields();
-
-  String getSource();
-
-  Boolean isTail();
-
-  Boolean isGenEventMd5();
-
-  Boolean isUseEventMd5AsId();
-
-  Boolean isCacheEnabled();
-
-  String getCacheKeyField();
-
-  Boolean getCacheLastDedupEnabled();
-
-  Integer getCacheSize();
-
-  Long getCacheDedupInterval();
-
-  Boolean isEnabled();
-
-  Map<String, Object> getAllProperties();
+public interface MapCustomDescriptor extends MapFieldDescriptor, CustomDescriptor {
 }

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputAdapter.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputAdapter.java
@@ -51,7 +51,9 @@ public class InputAdapter implements JsonDeserializer<InputDescriptorImpl> {
         return (InputDescriptorImpl)context.deserialize(json, InputFileDescriptorImpl.class);
       case "s3_file":
         return (InputDescriptorImpl)context.deserialize(json, InputS3FileDescriptorImpl.class);
-      default:
+      case "custom":
+        return (InputDescriptorImpl)context.deserialize(json, InputCustomDescriptorImpl.class);
+        default:
         throw new IllegalArgumentException("Unknown input type: " + json.getAsJsonObject().get("source").getAsString());
     }
   }

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputCustomDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputCustomDescriptorImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
+import org.apache.ambari.logsearch.config.api.model.inputconfig.InputCustomDescriptor;
+
+import java.util.Map;
+
+public class InputCustomDescriptorImpl extends InputDescriptorImpl implements InputCustomDescriptor {
+
+  @ShipperConfigElementDescription(
+    path = "/input/[]/properties",
+    type = "map",
+    description = "Custom key value pairs",
+    examples = {"{k1 : v1, k2: v2}"},
+    defaultValue = ""
+  )
+  @Expose
+  @SerializedName("properties")
+  private Map<String, Object> properties;
+
+  @ShipperConfigElementDescription(
+    path = "/input/[]/class_name",
+    type = "string",
+    description = "Custom class which implements an input type",
+    examples = {"org.example.MyInputSource"},
+    defaultValue = ""
+  )
+  @Expose
+  @SerializedName("class")
+  private String mapperClassName;
+
+  @Override
+  public Map<String, Object> getProperties() {
+    return this.properties;
+  }
+
+  @Override
+  public String getMapperClassName() {
+    return this.mapperClassName;
+  }
+
+  @Override
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public void setMapperClassName(String className) {
+    this.mapperClassName = className;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputDescriptorImpl.java
@@ -179,6 +179,8 @@ public abstract class InputDescriptorImpl implements InputDescriptor {
   @SerializedName("is_enabled")
   private Boolean isEnabled;
 
+  private Map<String, Object> allProperties;
+
   public String getType() {
     return type;
   }
@@ -289,5 +291,14 @@ public abstract class InputDescriptorImpl implements InputDescriptor {
 
   public void setIsEnabled(Boolean isEnabled) {
     this.isEnabled = isEnabled;
+  }
+
+  @Override
+  public Map<String, Object> getAllProperties() {
+    return allProperties;
+  }
+
+  public void setAllProperties(Map<String, Object> allProperties) {
+    this.allProperties = allProperties;
   }
 }

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapCustomDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapCustomDescriptorImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
+import org.apache.ambari.logsearch.config.api.ShipperConfigTypeDescription;
+import org.apache.ambari.logsearch.config.api.model.inputconfig.MapCustomDescriptor;
+
+import java.util.Map;
+
+@ShipperConfigTypeDescription(
+  name = "Map Custom",
+  description = "The name of the mapping element should be map_custom. The value json element may contain the following parameters:"
+)
+public class MapCustomDescriptorImpl implements MapCustomDescriptor {
+
+  @ShipperConfigElementDescription(
+    path = "/filter/[]/post_map_values/{field_name}/[]/map_custom/properties",
+    type = "map",
+    description = "Custom key value pairs",
+    examples = {"{k1 : v1, k2: v2}"},
+    defaultValue = ""
+  )
+  @Expose
+  @SerializedName("properties")
+  private Map<String, Object> properties;
+
+  @ShipperConfigElementDescription(
+    path = "/filter/[]/post_map_values/{field_name}/[]/map_custom/class_name",
+    type = "string",
+    description = "Custom class which implements a mapper type",
+    examples = {"org.example.MyMapper"},
+    defaultValue = ""
+  )
+  @Expose
+  @SerializedName("class")
+  private String mapperClassName;
+
+  @Override
+  public Map<String, Object> getProperties() {
+    return this.properties;
+  }
+
+  @Override
+  public String getMapperClassName() {
+    return this.mapperClassName;
+  }
+
+  @Override
+  public String getJsonName() {
+    return "map_custom";
+  }
+
+  @Override
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public void setMapperClassName(String className) {
+    this.mapperClassName = className;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/PostMapValuesAdapter.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/PostMapValuesAdapter.java
@@ -55,20 +55,22 @@ public class PostMapValuesAdapter implements JsonDeserializer<List<PostMapValues
     for (Map.Entry<String, JsonElement> m : e.getAsJsonObject().entrySet()) {
       switch (m.getKey()) {
         case "map_date":
-          mappers.add((MapDateDescriptorImpl)context.deserialize(m.getValue(), MapDateDescriptorImpl.class));
+          mappers.add(context.deserialize(m.getValue(), MapDateDescriptorImpl.class));
           break;
         case "map_fieldcopy":
-          mappers.add((MapFieldCopyDescriptorImpl)context.deserialize(m.getValue(), MapFieldCopyDescriptorImpl.class));
+          mappers.add(context.deserialize(m.getValue(), MapFieldCopyDescriptorImpl.class));
           break;
         case "map_fieldname":
-          mappers.add((MapFieldNameDescriptorImpl)context.deserialize(m.getValue(), MapFieldNameDescriptorImpl.class));
+          mappers.add(context.deserialize(m.getValue(), MapFieldNameDescriptorImpl.class));
           break;
         case "map_fieldvalue":
-          mappers.add((MapFieldValueDescriptorImpl)context.deserialize(m.getValue(), MapFieldValueDescriptorImpl.class));
+          mappers.add(context.deserialize(m.getValue(), MapFieldValueDescriptorImpl.class));
           break;
         case "map_anonymize":
-          mappers.add((MapAnonymizeDescriptorImpl)context.deserialize(m.getValue(), MapAnonymizeDescriptorImpl.class));
+          mappers.add(context.deserialize(m.getValue(), MapAnonymizeDescriptorImpl.class));
           break;
+        case "map_custom":
+          mappers.add(context.deserialize(m.getValue(), MapCustomDescriptorImpl.class));
         default:
           System.out.println("Unknown key: " + m.getKey());
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

New custom input and mapper blocks for the logsearch config api:
```bash
{ 
inputs :
[  
  "source":"custom"
  "class": "..."
  "properties": { "k1": "v1", "k2": "v2"}
]
#... and same for mappers inside filters 
```
## How was this patch tested?

With docker based environment, logfeeder still behave as the same way.
The more detailed testing will be added after logfeeder will be pluggable

@kasakrisz @swagle @zeroflag