### PR TITLE
AMBARI-22749. ADDENDUM: Create Pull Request Template - fix rat check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
+            <exclude>.github/</exclude>
             <exclude>**/repo_*.j2</exclude>
             <exclude>**/ambari-log4j.spec</exclude>
             <exclude>**/version.txt</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apache build fails becase PR template file is not excluded from rat check, see for example:
https://builds.apache.org/job/Ambari-trunk-Commit/8587/consoleFull

```bash
[INFO] Rat check: Summary of files. Unapproved: 1 unknown: 1 generated: 0 approved: 2895 licence.
```
So we need to exclude the .github folder

## How was this patch tested?

I started a mvn clean install, output is:
```bash
[INFO] Rat check: Summary of files. Unapproved: 0 unknown: 0 generated: 0 approved: 2897 licence.
```
@adoroszlai @jonathan-hurley @zeroflag @vivekratnavel 