### PR TITLE
[AMBARI-22725] Expose Conditional Elements For Tasks on Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ClusterGrouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ClusterGrouping.java
@@ -197,6 +197,15 @@ public class ClusterGrouping extends Grouping {
             }
           }
 
+          // tasks can have their own condition, so check that too
+          if (null != execution.task.condition
+              && !execution.task.condition.isSatisfied(upgradeContext)) {
+            LOG.info("Skipping {} while building upgrade orchestration due to {}", execution,
+                execution.task.condition);
+
+            continue;
+          }
+
           Task task = execution.task;
 
           StageWrapper wrapper = null;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapperBuilder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapperBuilder.java
@@ -229,7 +229,15 @@ public abstract class StageWrapperBuilder {
 
     List<Task> tasks = new ArrayList<>();
     for (Task t : interim) {
-      if (context.isScoped(t.scope)) {
+      boolean taskPassesScoping = context.isScoped(t.scope);
+      boolean taskPassesCondition = true;
+
+      // tasks can have conditions on them, so check to make sure the condition is satisfied
+      if (null != t.condition && !t.condition.isSatisfied(context)) {
+        taskPassesCondition = false;
+      }
+
+      if (taskPassesScoping && taskPassesCondition) {
         tasks.add(t);
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Task.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Task.java
@@ -48,6 +48,13 @@ public abstract class Task {
   public String timeoutConfig = null;
 
   /**
+   * A condition element with can prevent this task from being scheduled in the
+   * upgrade.
+   */
+  @XmlElement(name = "condition")
+  public Condition condition;
+
+  /**
    * @return the type of the task
    */
   public abstract Type getType();

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -272,6 +272,7 @@
 
   <xs:complexType name="abstract-task-type" abstract="true">
     <xs:sequence>
+      <xs:element name="condition" type="abstract-condition-type" minOccurs="0" maxOccurs="1"/>
       <xs:element name="scope" minOccurs="0" type="scope-type" />
       <xs:element name="summary" minOccurs="0" />
     </xs:sequence>

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -2218,9 +2218,15 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     UpgradeContext context = getMockUpgradeContext(cluster, Direction.UPGRADE, UpgradeType.ROLLING);
 
-    // initially, no conditions should be met
+    // initially, no conditions should be met, so only 1 group should be
+    // available
     List<UpgradeGroupHolder> groups = m_upgradeHelper.createSequence(upgrade, context);
-    assertEquals(0, groups.size());
+    assertEquals(1, groups.size());
+
+    // from that 1 group, only 1 task is condition-less
+    List<StageWrapper> stageWrappers = groups.get(0).items;
+    assertEquals(1, stageWrappers.size());
+    assertEquals(1, stageWrappers.get(0).getTasks().size());
 
     // set the configuration property and try again
     Map<String, String> fooConfigs = new HashMap<>();
@@ -2239,14 +2245,14 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     // the config condition should now be set
     groups = m_upgradeHelper.createSequence(upgrade, context);
-    assertEquals(1, groups.size());
+    assertEquals(2, groups.size());
     assertEquals("ZOOKEEPER_CONFIG_CONDITION_TEST", groups.get(0).name);
 
     // now change the cluster security so the other conditions come back too
     cluster.setSecurityType(SecurityType.KERBEROS);
 
     groups = m_upgradeHelper.createSequence(upgrade, context);
-    assertEquals(3, groups.size());
+    assertEquals(4, groups.size());
   }
 
   /**

--- a/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test_conditions.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test_conditions.xml
@@ -46,15 +46,33 @@
         <task xsi:type="manual">
           <message>Foo</message>
         </task>
-      </execute-stage>
+      </execute-stage>      
      </group>
+     
+    <group xsi:type="cluster" name="TASK_SECURITY_CONDITION_TEST" title="Task Security Condition Test">
+      <!-- no condition -->      
+      <execute-stage title="Confirm 1">
+        <task xsi:type="manual">
+          <message>Foo</message>
+        </task>
+      </execute-stage>
+
+      <!-- condition -->
+      <execute-stage title="Confirm 2">
+        <task xsi:type="manual">
+          <condition xsi:type="security" type="kerberos"/>
+          <message>Task based on security condition</message>
+        </task>
+      </execute-stage>      
+     </group>     
+          
   </order>
 
   <processing>
     <service name="ZOOKEEPER">
       <component name="ZOOKEEPER_SERVER">
         <upgrade>
-          <task xsi:type="restart-task" />
+          <task xsi:type="restart-task" />          
         </upgrade>
       </component>
     </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I decided to break out the work of having condition tasks with upgrading Kerberos-related properties (see AMBARI-22803 for the RPC/Kerberos related work)

Some upgrade tasks, such as configuration tasks, need to leverage the conditional elements which change the flow of control if the cluster is Kerberized (or based on other configuration values). For example, today we have this:

```
<execute-stage service="RANGER_KMS" component="RANGER_KMS_SERVER" title="Calculating Proxy Properties under kms-site">
  <condition xsi:type="security" type="kerberos"/>
  <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.RangerKmsProxyConfig"/>
</execute-stage>
```
 

Where `condition` elements can be added to an `execute-stage` or a `group`. However, since `execute-stage` may only contain one task, it makes doing this work on a per-task level impossible. This particularly impacts the `processing` element. We want something like this:

```
<task xsi:type="configure" id="hdp_2_6_hadoop_rpc_protection">
  <condition xsi:type="security" type="kerberos"/>
</task>
```
 
So that `task` elements defined in the `pre-upgrade` section of `processing` can also be conditionally invoked.

## How was this patch tested?
```
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 26:52 min
[INFO] Finished at: 2018-01-17T14:12:56-05:00
[INFO] Final Memory: 69M/783M
[INFO] ------------------------------------------------------------------------
```