### PR TITLE
[AMBARI-22718] Allow security.inter.broker.protocol: SASL_SSL for all stack versions

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/params.py
@@ -162,10 +162,7 @@ if has_metric_collector:
 kerberos_security_enabled = config['configurations']['cluster-env']['security_enabled']
 
 kafka_kerberos_enabled = (('security.inter.broker.protocol' in config['configurations']['kafka-broker']) and
-                         ((config['configurations']['kafka-broker']['security.inter.broker.protocol'] in ("PLAINTEXTSASL", "SASL_PLAINTEXT")) or
-                         ((config['configurations']['kafka-broker']['security.inter.broker.protocol'] == "SASL_SSL") and
-                           check_stack_feature(StackFeature.KAFKA_EXTENDED_SASL_SUPPORT, stack_version_formatted))))
-
+                         (config['configurations']['kafka-broker']['security.inter.broker.protocol'] in ("PLAINTEXTSASL", "SASL_PLAINTEXT", "SASL_SSL")))
 
 kafka_other_sasl_enabled = not kerberos_security_enabled and check_stack_feature(StackFeature.KAFKA_LISTENERS, stack_version_formatted) and \
                           check_stack_feature(StackFeature.KAFKA_EXTENDED_SASL_SUPPORT, stack_version_formatted) and \


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change removes the minimum stack version requirement for `SASL_SSL` in Kafka.

8fce2a1741 added support for `security.inter.broker.protocol: SASL_SSL` in Ambari, but only for stacks with the `KAFKA_EXTENDED_SASL_SUPPORT` flag.  It turned out that the flag is for other SASL features (eg. SASL/SCRAM, etc.), and Kafka supports `SASL_SSL` in earlier versions, too.

This eliminates the need to manually tweak `stack_features.json`.

## How was this patch tested?

Installed kerberized HDP 2.4, 2.5 and 2.6 clusters via blueprints.  Verified that Kafka Brokers in all of these versions work fine with `security.inter.broker.protocol: SASL_SSL`.

Existing unit tests pass:

```
Total run:1201
Total errors:0
Total failures:0
OK
```