### PR TITLE
Ranger solr: fix deprecated mergepolicy configs

### DIFF
--- a/ambari-server/src/main/resources/common-services/RANGER/0.7.0/properties/ranger-solrconfig.xml.j2
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.7.0/properties/ranger-solrconfig.xml.j2
@@ -210,31 +210,18 @@
 
     <!-- Expert: Merge Policy
          The Merge Policy in Lucene controls how merging of segments is done.
-         The default since Solr/Lucene 3.3 is TieredMergePolicy.
-         The default since Lucene 2.3 was the LogByteSizeMergePolicy,
-         Even older versions of Lucene used LogDocMergePolicy.
-      -->
-    <!--
-        <mergePolicy class="org.apache.lucene.index.TieredMergePolicy">
-          <int name="maxMergeAtOnce">10</int>
-          <int name="segmentsPerTier">10</int>
-        </mergePolicy>
       -->
 
-    <!-- Merge Factor
-         The merge factor controls how many segments will get merged at a time.
-         For TieredMergePolicy, mergeFactor is a convenience parameter which
-         will set both MaxMergeAtOnce and SegmentsPerTier at once.
-         For LogByteSizeMergePolicy, mergeFactor decides how many new segments
-         will be allowed before they are merged into one.
-         Default is 10 for both merge policies.
-      -->
-    <!--
-    <mergeFactor>10</mergeFactor>
-      -->
-
-    <!-- Ranger customization. Set to 5 to trigger purging of deleted documents more often -->
-    <mergeFactor>{{ranger_audit_logs_merge_factor}}</mergeFactor>
+    <mergePolicyFactory class="org.apache.solr.index.TieredMergePolicyFactory">
+      <!-- "ranger_audit_logs_merge_factor" is set to 5 by default to trigger purging of deleted documents more often -->
+      <int name="maxMergeAtOnce">{{ranger_audit_logs_merge_factor}}</int> <!-- Solr default: 10 -->
+      <int name="segmentsPerTier">{{ranger_audit_logs_merge_factor}}</int> <!-- Solr default: 10 -->
+      <int name="maxMergeAtOnceExplicit">30</int> <!-- Solr default: 30 -->
+      <int name="floorSegmentMB">2048</int> <!-- Solr default: 2048 -->
+      <int name="maxMergedSegmentMB">5120</int> <!-- Solr default: 5120 -->
+      <double name="reclaimDeletesWeight">4.0</double> <!-- Solr default: ??? -->
+      <double name="forceMergeDeletesPctAllowed">10.0</double> <!-- Solr default: 10.0 -->
+    </mergePolicyFactory>
 
     <!-- Expert: Merge Scheduler
          The Merge Scheduler in Lucene controls how merges are

--- a/ambari-server/src/main/resources/common-services/RANGER/0.7.0/properties/ranger-solrconfig.xml.j2
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.7.0/properties/ranger-solrconfig.xml.j2
@@ -214,13 +214,13 @@
 
     <mergePolicyFactory class="org.apache.solr.index.TieredMergePolicyFactory">
       <!-- "ranger_audit_logs_merge_factor" is set to 5 by default to trigger purging of deleted documents more often -->
-      <int name="maxMergeAtOnce">{{ranger_audit_logs_merge_factor}}</int> <!-- Solr default: 10 -->
-      <int name="segmentsPerTier">{{ranger_audit_logs_merge_factor}}</int> <!-- Solr default: 10 -->
-      <int name="maxMergeAtOnceExplicit">30</int> <!-- Solr default: 30 -->
-      <int name="floorSegmentMB">2048</int> <!-- Solr default: 2048 -->
-      <int name="maxMergedSegmentMB">5120</int> <!-- Solr default: 5120 -->
-      <double name="reclaimDeletesWeight">4.0</double> <!-- Solr default: ??? -->
-      <double name="forceMergeDeletesPctAllowed">10.0</double> <!-- Solr default: 10.0 -->
+      <int name="maxMergeAtOnce">{{ranger_audit_logs_merge_factor}}</int><!-- Solr default: 10 -->
+      <int name="segmentsPerTier">{{ranger_audit_logs_merge_factor}}</int><!-- Solr default: 10 -->
+      <int name="maxMergeAtOnceExplicit">30</int><!-- Solr default: 30 -->
+      <int name="floorSegmentMB">2048</int><!-- Solr default: 2048 -->
+      <int name="maxMergedSegmentMB">5120</int><!-- Solr default: 5120 -->
+      <double name="reclaimDeletesWeight">2.0</double><!-- Solr default: 2.0 -->
+      <double name="forceMergeDeletesPctAllowed">10.0</double><!-- Solr default: 10.0 -->
     </mergePolicyFactory>
 
     <!-- Expert: Merge Scheduler


### PR DESCRIPTION
Ranger solrconfig.xml currently uses deprecated merge options. See "Upgrading from Solr 5.4" section at https://apache.googlesource.com/lucene-solr/+/branch_5x/solr/CHANGES.txt for more details.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.