### PR TITLE
AMBARI-22635: Ambari should create a dummy core-site.xml for Ranger p…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
@@ -240,14 +240,14 @@ def setup_ranger_plugin_keystore(service_name, audit_db_is_enabled, stack_versio
     mode = 0640
   )
 
-def setup_core_site_for_required_plugins(component_user, component_group, create_core_site_path, config):
+def setup_core_site_for_required_plugins(component_user, component_group, create_core_site_path, configurations = {}, configuration_attributes = {}):
   XmlConfig('core-site.xml',
-    conf_dir=create_core_site_path,
-    configurations=config['configurations']['core-site'],
-    configuration_attributes=config['configuration_attributes']['core-site'],
-    owner=component_user,
-    group=component_group,
-    mode=0644
+    conf_dir = create_core_site_path,
+    configurations = configurations,
+    configuration_attributes = configuration_attributes,
+    owner = component_user,
+    group = component_group,
+    mode = 0644
   )
 
 def get_audit_configs(config):

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/setup_ranger_kafka.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/setup_ranger_kafka.py
@@ -81,9 +81,18 @@ def setup_ranger_kafka():
         group = params.user_group,
         mode = 0755
       )
-    if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_kafka and params.has_namenode and params.kerberos_security_enabled:
-      Logger.info("Stack supports core-site.xml creation for Ranger plugin, creating create core-site.xml from namenode configuraitions")
-      setup_core_site_for_required_plugins(component_user=params.kafka_user,component_group=params.user_group,create_core_site_path = params.conf_dir, config = params.config)
+    if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_kafka and params.kerberos_security_enabled:
+      if params.has_namenode:
+        Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
+        setup_core_site_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
+                                             create_core_site_path = params.conf_dir, configurations = params.config['configurations']['core-site'],
+                                             configuration_attributes = params.config['configuration_attributes']['core-site'])
+      else:
+        Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
+        setup_core_site_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
+                                             create_core_site_path = params.conf_dir, configurations = { 'hadoop.security.authentication' : 'kerberos' if params.kerberos_security_enabled else 'simple' },
+                                             configuration_attributes = {})
+
     else:
       Logger.info("Stack does not support core-site.xml creation for Ranger plugin, skipping core-site.xml configurations")
   else:

--- a/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/setup_ranger_knox.py
+++ b/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/setup_ranger_knox.py
@@ -108,12 +108,20 @@ def setup_ranger_knox(upgrade_type=None):
                         plugin_security_properties=params.config['configurations']['ranger-knox-security'], plugin_security_attributes=params.config['configuration_attributes']['ranger-knox-security'],
                         plugin_policymgr_ssl_properties=params.config['configurations']['ranger-knox-policymgr-ssl'], plugin_policymgr_ssl_attributes=params.config['configuration_attributes']['ranger-knox-policymgr-ssl'],
                         component_list=['knox-server'], audit_db_is_enabled=params.xa_audit_db_is_enabled,
-                        credential_file=params.credential_file, xa_audit_db_password=params.xa_audit_db_password, 
+                        credential_file=params.credential_file, xa_audit_db_password=params.xa_audit_db_password,
                         ssl_truststore_password=params.ssl_truststore_password, ssl_keystore_password=params.ssl_keystore_password,
                         stack_version_override = stack_version, skip_if_rangeradmin_down= not params.retryAble)
-    if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_knox and params.has_namenode and params.security_enabled:
-      Logger.info("Stack supports core-site.xml creation for Ranger plugin, creating core-site.xml from namenode configuraitions")
-      setup_core_site_for_required_plugins(component_user=params.knox_user, component_group=params.knox_group,create_core_site_path = params.knox_conf_dir, config = params.config)
+    if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_knox and params.security_enabled:
+      if params.has_namenode:
+        Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
+        setup_core_site_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
+                                             create_core_site_path = params.knox_conf_dir, configurations = params.config['configurations']['core-site'],
+                                             configuration_attributes = params.config['configuration_attributes']['core-site'])
+      else:
+        Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
+        setup_core_site_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
+                                             create_core_site_path = params.knox_conf_dir, configurations = { 'hadoop.security.authentication' : 'kerberos' if params.security_enabled else 'simple' },
+                                             configuration_attributes = {})
     else:
       Logger.info("Stack does not support core-site.xml creation for Ranger plugin, skipping core-site.xml configurations")
 

--- a/ambari-server/src/main/resources/common-services/STORM/0.9.1/package/scripts/setup_ranger_storm.py
+++ b/ambari-server/src/main/resources/common-services/STORM/0.9.1/package/scripts/setup_ranger_storm.py
@@ -111,9 +111,18 @@ def setup_ranger_storm(upgrade_type=None):
             cd_access = 'a'
             )
 
-    if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_storm and params.has_namenode and params.security_enabled:
-      Logger.info("Stack supports core-site.xml creation for Ranger plugin, creating create core-site.xml from namenode configuraitions")
-      setup_core_site_for_required_plugins(component_user=params.storm_user,component_group=params.user_group,create_core_site_path = site_files_create_path, config = params.config)
+    if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_storm and params.security_enabled:
+      if params.has_namenode:
+        Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
+        setup_core_site_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
+                                             create_core_site_path = site_files_create_path, configurations = params.config['configurations']['core-site'],
+                                             configuration_attributes = params.config['configuration_attributes']['core-site'])
+      else:
+        Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
+        setup_core_site_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
+                                             create_core_site_path = site_files_create_path, configurations = { 'hadoop.security.authentication' : 'kerberos' if params.security_enabled else 'simple' },
+                                             configuration_attributes = {})
+
       if len(params.namenode_hosts) > 1:
         Logger.info('Ranger Storm plugin is enabled along with security and NameNode is HA , creating hdfs-site.xml')
         XmlConfig("hdfs-site.xml",


### PR DESCRIPTION
AMBARI-22635: Ambari should create a dummy core-site.xml for Ranger plugins when namenode is not installed

## What changes were proposed in this pull request?
For Ranger plugins to work properly in kerberised environments where HDFS is not installed. We need to create a core-site.xml for Storm and Kafka plugins so that the plugins can work to fetch latest policies from with kerberised calls from Ranger.
The patch is committed on trunk branch, this pull request is for branch-2.6.
## How was this patch tested?

Verified with installation on Cent-OS 6.

@swagle /  @jonathan-hurley request to kindly merge this change.