### PR TITLE
AMBARI-22767. Kerberos wizard. Advanced kerberos-env password propert…

### DIFF
--- a/ambari-web/app/controllers/main/admin/kerberos/step2_controller.js
+++ b/ambari-web/app/controllers/main/admin/kerberos/step2_controller.js
@@ -133,9 +133,11 @@ App.KerberosWizardStep2Controller = App.WizardStep7Controller.extend(App.KDCCred
     var kdcType = this.get('content.kerberosOption');
     var kerberosWizardController = this.get('controllers.kerberosWizardController');
     var manageIdentitiesConfig = configs.findProperty('name', 'manage_identities');
-
     configs.filterProperty('serviceName', 'KERBEROS').setEach('isVisible', true);
     this.setKDCTypeProperty(configs);
+    if (kdcType !== Em.I18n.t('admin.kerberos.wizard.step1.option.ad')) {
+        kerberosWizardController.overrideVisibility(configs, false, kerberosWizardController.get('exceptionsForNonAdOption'), true);
+    }
     if (kdcType === Em.I18n.t('admin.kerberos.wizard.step1.option.manual')) {
       if (kerberosWizardController.get('skipClientInstall')) {
         kerberosWizardController.overrideVisibility(configs, false, kerberosWizardController.get('exceptionsOnSkipClient'));

--- a/ambari-web/app/controllers/main/admin/kerberos/wizard_controller.js
+++ b/ambari-web/app/controllers/main/admin/kerberos/wizard_controller.js
@@ -23,6 +23,15 @@ App.KerberosWizardController = App.WizardController.extend(App.InstallComponent,
 
   exceptionsOnSkipClient: [{'KDC': 'realm'}, {'KDC': 'kdc_type'}, {'Advanced kerberos-env': 'executable_search_paths'}],
 
+  exceptionsForNonAdOption: [
+    {"Advanced kerberos-env": "password_length"},
+    {"Advanced kerberos-env": "password_min_digits"},
+    {"Advanced kerberos-env": "password_min_lowercase_letters"},
+    {"Advanced kerberos-env": "password_min_punctuation"},
+    {"Advanced kerberos-env": "password_min_uppercase_letters"},
+    {"Advanced kerberos-env": "password_min_whitespace"}
+  ],
+
   name: 'kerberosWizardController',
 
   totalSteps: 8,
@@ -161,14 +170,17 @@ App.KerberosWizardController = App.WizardController.extend(App.InstallComponent,
    * @param {boolean} newValue
    * @param {Array} exceptions
    */
-  overrideVisibility: function (itemsArray, newValue, exceptions) {
+  overrideVisibility: function (itemsArray, newValue, exceptions, inverse) {
     newValue = newValue || false;
 
     for (var i = 0, len = itemsArray.length; i < len; i += 1) {
       if (!App.isEmptyObject(itemsArray[i])) {
         var isException = exceptions.filterProperty(itemsArray[i].category, itemsArray[i].name);
-        if (!isException.length) {
+        if (!isException.length && !inverse) {
           itemsArray[i].isVisible = newValue;
+        }
+        if (isException.length && inverse) {
+            itemsArray[i].isVisible = newValue;
         }
       }
     }

--- a/ambari-web/test/controllers/main/admin/kerberos/step2_controller_test.js
+++ b/ambari-web/test/controllers/main/admin/kerberos/step2_controller_test.js
@@ -418,7 +418,7 @@ describe('App.KerberosWizardStep2Controller', function() {
       controller.set('content.kerberosOption', Em.I18n.t('admin.kerberos.wizard.step1.option.manual'));
       controller.set('controllers.kerberosWizardController.skipClientInstall', true);
       controller.filterConfigs(configs);
-      expect(controller.get('controllers.kerberosWizardController').overrideVisibility.calledOnce).to.be.true;
+      expect(controller.get('controllers.kerberosWizardController').overrideVisibility.called).to.be.true;
     });
 
     it("overrideVisibility results are valid", function() {


### PR DESCRIPTION
…ies should be visible only if the KDC type is 'Active Directory' (alexantonenko)

## What changes were proposed in this pull request?
Kerberos wizard. Advanced kerberos-env password properties should be visible only if the KDC type is "Active Directory"

## How was this patch tested?
Unit tests for changed js files, manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.