### PR TITLE
[AMBARI-22766] ambari-server setup with internal database may not work on centos 7 (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/os_check.py
+++ b/ambari-common/src/main/python/ambari_commons/os_check.py
@@ -164,6 +164,8 @@ class OS_CONST_TYPE(type):
 class OSConst:
   __metaclass__ = OS_CONST_TYPE
 
+  systemd_redhat_os_major_versions = ["7"]
+
 
 class OSCheck:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding systemd handling support for internal database installation on `service` package-less systems like CentOS7, RHEL7

cent 7 and rhel 7 installations and docker images could be shipped without `service` package as it is not important after moving to `systemd` hypervisor. Since that, `ambari-server setup` should support installation of internal database on such systems

## How was this patch tested?

Manual ambari server installation with internal databse using `docker` container `centos/systemd:latest` with executin base python UT:

```
[18:12:05]W:   [Step 2/2] Total run:1211
[18:12:05]W:   [Step 2/2] Total errors:0
[18:12:05]W:   [Step 2/2] Total failures:0
```
