### PR TITLE
AMBARI-20797 : Ambari Metrics Storm Sink compilation error due to storm-1.1.0-SNAPSHOT. (Masahiro Tanaka via avijayan)

### DIFF
--- a/ambari-metrics/ambari-metrics-storm-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-storm-sink/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
   <packaging>jar</packaging>
 
   <properties>
-    <storm.version>1.1.0-SNAPSHOT</storm.version>
+    <storm.version>1.1.0</storm.version>
   </properties>
 
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cherry-pick a commit from trunk that changes storm version from 1.1.0-snapshot to 1.1.0 

## How was this patch tested?
Tested manually