### PR TITLE
[AMBARI-22637] Fix misuses of os.path.dirname(path) in yarn.py

### DIFF
--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/yarn.py
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/yarn.py
@@ -443,7 +443,7 @@ def setup_ats():
     )
   # app timeline server 1.5 directories
   if not is_empty(params.entity_groupfs_store_dir):
-    parent_path = os.path.dirname(params.entity_groupfs_store_dir)
+    parent_path = os.path.dirname(os.path.abspath(params.entity_groupfs_store_dir))
     params.HdfsResource(parent_path,
                         type="directory",
                         action="create_on_execute",
@@ -460,7 +460,7 @@ def setup_ats():
                         mode=params.entity_groupfs_store_dir_mode
                         )
   if not is_empty(params.entity_groupfs_active_dir):
-    parent_path = os.path.dirname(params.entity_groupfs_active_dir)
+    parent_path = os.path.dirname(os.path.abspath(params.entity_groupfs_active_dir))
     params.HdfsResource(parent_path,
                         type="directory",
                         action="create_on_execute",

--- a/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/package/scripts/yarn.py
+++ b/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/package/scripts/yarn.py
@@ -445,7 +445,7 @@ def setup_ats():
     )
   # app timeline server 1.5 directories
   if not is_empty(params.entity_groupfs_store_dir):
-    parent_path = os.path.dirname(params.entity_groupfs_store_dir)
+    parent_path = os.path.dirname(os.path.abspath(params.entity_groupfs_store_dir))
     params.HdfsResource(parent_path,
                         type="directory",
                         action="create_on_execute",
@@ -462,7 +462,7 @@ def setup_ats():
                         mode=params.entity_groupfs_store_dir_mode
                         )
   if not is_empty(params.entity_groupfs_active_dir):
-    parent_path = os.path.dirname(params.entity_groupfs_active_dir)
+    parent_path = os.path.dirname(os.path.abspath(params.entity_groupfs_active_dir))
     params.HdfsResource(parent_path,
                         type="directory",
                         action="create_on_execute",

--- a/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/YARN/package/scripts/yarn.py
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/YARN/package/scripts/yarn.py
@@ -339,7 +339,7 @@ def yarn(name=None, config_dir=None):
       )
     # app timeline server 1.5 directories
     if not is_empty(params.entity_groupfs_store_dir):
-      parent_path = os.path.dirname(params.entity_groupfs_store_dir)
+      parent_path = os.path.dirname(os.path.abspath(params.entity_groupfs_store_dir))
       params.HdfsResource(parent_path,
                           type="directory",
                           action="create_on_execute",
@@ -356,7 +356,7 @@ def yarn(name=None, config_dir=None):
                           mode=params.entity_groupfs_store_dir_mode
                           )
     if not is_empty(params.entity_groupfs_active_dir):
-      parent_path = os.path.dirname(params.entity_groupfs_active_dir)
+      parent_path = os.path.dirname(os.path.abspath(params.entity_groupfs_active_dir))
       params.HdfsResource(parent_path,
                           type="directory",
                           action="create_on_execute",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Normalize the input path before using `os.path.dirname`.
Detail: https://issues.apache.org/jira/browse/AMBARI-22637

## How was this patch tested?

Manually tested.