### PR TITLE
AMBARI-22772. Log Search / Log Feeder - config symlink cannot be created if etc/ambari-logsearch* folders do not exist

### DIFF
--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/postinstall.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/postinstall.sh
@@ -17,8 +17,11 @@
 LOGFEEDER_SCRIPT_LINK_NAME="/usr/bin/logfeeder"
 LOGFEEDER_SCRIPT_SOURCE="/usr/lib/ambari-logsearch-logfeeder/bin/logfeeder.sh"
 
-LOGFEEDER_CONF_LINK="/etc/ambari-logsearch-logfeeder/conf"
+LOGFEEDER_ETC_FOLDER="/etc/ambari-logsearch-logfeeder"
+LOGFEEDER_CONF_LINK="$LOGFEEDER_ETC_FOLDER/conf"
 LOGFEEDER_CONF_SOURCE="/usr/lib/ambari-logsearch-logfeeder/conf"
+
+mkdir -p $LOGFEEDER_ETC_FOLDER
 
 ln -s $LOGFEEDER_SCRIPT_SOURCE $LOGFEEDER_SCRIPT_LINK_NAME
 ln -s $LOGFEEDER_CONF_SOURCE $LOGFEEDER_CONF_LINK

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/postremove.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/postremove.sh
@@ -15,7 +15,9 @@
 # limitations under the License
 
 LOGFEEDER_SCRIPT_LINK_NAME="/usr/bin/logfeeder"
-LOGFEEDER_CONF_DIR_LINK="/etc/ambari-logsearch-logfeeder/conf"
+LOGFEEDER_ETC_FOLDER="/etc/ambari-logsearch-logfeeder"
+LOGFEEDER_CONF_DIR_LINK="$LOGFEEDER_ETC_FOLDER/conf"
 
 rm -f $LOGFEEDER_SCRIPT_LINK_NAME
 rm -f $LOGFEEDER_CONF_DIR_LINK
+rm -f $LOGFEEDER_ETC_FOLDER

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/postinstall.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/postinstall.sh
@@ -17,8 +17,11 @@
 LOGSEARCH_SCRIPT_LINK_NAME="/usr/bin/logsearch"
 LOGSEARCH_SCRIPT_SOURCE="/usr/lib/ambari-logsearch-portal/bin/logsearch.sh"
 
-LOGSEARCH_CONF_LINK="/etc/ambari-logsearch-portal/conf"
+LOGSEARCH_ETC_FOLDER="/etc/ambari-logsearch-portal"
+LOGSEARCH_CONF_LINK="$LOGSEARCH_ETC_FOLDER/conf"
 LOGSEARCH_CONF_SOURCE="/usr/lib/ambari-logsearch-portal/conf"
+
+mkdir -p $LOGSEARCH_ETC_FOLDER
 
 ln -s $LOGSEARCH_SCRIPT_SOURCE $LOGSEARCH_SCRIPT_LINK_NAME
 ln -s $LOGSEARCH_CONF_SOURCE $LOGSEARCH_CONF_LINK

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/postremove.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/postremove.sh
@@ -15,7 +15,9 @@
 # limitations under the License
 
 LOGSEARCH_SCRIPT_LINK_NAME="/usr/bin/logsearch"
-LOGSEARCH_CONF_DIR_LINK="/etc/ambari-logsearch-portal/conf"
+LOGSEARCH_ETC_FOLDER="/etc/ambari-logsearch-portal"
+LOGSEARCH_CONF_DIR_LINK="$LOGSEARCH_ETC_FOLDER/conf"
 
 rm -f $LOGSEARCH_SCRIPT_LINK_NAME
 rm -f $LOGSEARCH_CONF_DIR_LINK
+rm -f $LOGSEARCH_ETC_FOLDER


### PR DESCRIPTION
## What changes were proposed in this pull request?

On fresh logsearch/logfeeder install /etc/ambari-logsearch-* folders are not created so there wont be symlinks created to conf folders

## How was this patch tested?

Checked with fresh install

@kasakrisz @zeroflag @swagle 