### PR TITLE
[AMBARI-22771] Ambari loads ambari.properties using ISO 8859-1 encoding

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -31,7 +31,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
-import java.nio.charset.Charset;
 import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
@@ -93,6 +92,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -3200,7 +3200,7 @@ public class Configuration {
 
     // load the properties
     try {
-      properties.load(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
+      properties.load(new InputStreamReader(inputStream, Charsets.UTF_8));
       inputStream.close();
     } catch (FileNotFoundException fnf) {
       LOG.info("No configuration file " + CONFIG_FILE + " found in classpath.", fnf);

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -24,12 +24,14 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Writer;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
 import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
@@ -3198,7 +3200,7 @@ public class Configuration {
 
     // load the properties
     try {
-      properties.load(inputStream);
+      properties.load(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
       inputStream.close();
     } catch (FileNotFoundException fnf) {
       LOG.info("No configuration file " + CONFIG_FILE + " found in classpath.", fnf);

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
@@ -1074,4 +1074,9 @@ public class ConfigurationTest {
     Assert.assertEquals(1024, new Configuration(properties).getTlsEphemeralDhKeySize());
   }
 
+  @Test
+  public void canReadNonLatin1Properties() {
+    Assert.assertEquals("árvíztűrő tükörfúrógép", new Configuration().getProperty("encoding.test"));
+  }
+
 }

--- a/ambari-server/src/test/resources/ambari.properties
+++ b/ambari-server/src/test/resources/ambari.properties
@@ -15,3 +15,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+encoding.test=árvíztűrő tükörfúrógép


### PR DESCRIPTION
## What changes were proposed in this pull request?

Specify UTF-8 encoding when reading `ambari.properties`.  Non-Latin1 characters can occur in several properties if customised, eg. in any directory or file name.

## How was this patch tested?

* Added unit test, which passes fine:

```
[INFO] Tests run: 59, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.718 s - in org.apache.ambari.server.configuration.ConfigurationTest
```

* Manually tested according to steps in [bug description](https://issues.apache.org/jira/browse/AMBARI-22771):

```
$ ls -la /etc/ambari-server/conf/password.*
-rw-r-----. 1 root root 7 Jan 11 11:04 /etc/ambari-server/conf/password.őőő
$ ambari-server start
...
DB configs consistency check: no errors and warnings were found.
Ambari Server 'start' completed successfully.
```

* Deployed a simple cluster via blueprint as a smoketest.