### PR TITLE
[AMBARI-22668] Moving LDAP related properties to DB upon upgrade to 3.0.0

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfigurationKeys.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfigurationKeys.java
@@ -48,7 +48,7 @@ public enum AmbariLdapConfigurationKeys {
   USER_NAME_ATTRIBUTE("ambari.ldap.attributes.user.name_attr", PLAINTEXT, "uid", "The attribute used for determining the user name, such as 'uid'."),
   USER_GROUP_MEMBER_ATTRIBUTE("ambari.ldap.attributes.user.group_member_attr", PLAINTEXT, "", ""), //TODO
   USER_SEARCH_BASE("ambari.ldap.attributes.user.search_base", PLAINTEXT, "dc=ambari,dc=apache,dc=org", "The base DN to use when filtering LDAP users and groups. This is only used when LDAP authentication is enabled."),
-  USER_BASE("ambari.ldap.attributes.search_user.base", PLAINTEXT, "ou=people,dc=ambari,dc=apache,dc=org", "The filter used when searching for users in LDAP."),
+  USER_BASE("ambari.ldap.attributes.search_user_base", PLAINTEXT, "ou=people,dc=ambari,dc=apache,dc=org", "The filter used when searching for users in LDAP."),
 
   GROUP_OBJECT_CLASS("ambari.ldap.attributes.group.object_class", PLAINTEXT, "ou=groups,dc=ambari,dc=apache,dc=org", "The filter used when searching for groups in LDAP."),
   GROUP_NAME_ATTRIBUTE("ambari.ldap.attributes.group.name_attr", PLAINTEXT, "cn", "The attribute used to determine the group name in LDAP."),

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/AmbariConfigurationEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/AmbariConfigurationEntity.java
@@ -76,7 +76,7 @@ public class AmbariConfigurationEntity {
   @Override
   public String toString() {
     return "AmbariConfigurationEntity{" +
-        ", category=" + categoryName +
+        " category=" + categoryName +
         ", name=" + propertyName +
         ", value=" + propertyValue +
         '}';

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/HostAndPort.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/HostAndPort.java
@@ -25,4 +25,12 @@ public class HostAndPort {
     this.host = host;
     this.port = port;
   }
+
+  public static HostAndPort fromUrl(String url) {
+    return new HostAndPort(url.split(":")[0], Integer.valueOf(url.split(":")[1]));
+  }
+
+  public String portAsString() {
+    return String.valueOf(port);
+  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/HostAndPort.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/HostAndPort.java
@@ -25,12 +25,4 @@ public class HostAndPort {
     this.host = host;
     this.port = port;
   }
-
-  public static HostAndPort fromUrl(String url) {
-    return new HostAndPort(url.split(":")[0], Integer.valueOf(url.split(":")[1]));
-  }
-
-  public String portAsString() {
-    return String.valueOf(port);
-  }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.configuration;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.powermock.api.easymock.PowerMock.mockStatic;
 import static org.powermock.api.easymock.PowerMock.replayAll;
@@ -60,6 +61,8 @@ import org.powermock.api.support.membermodification.MemberMatcher;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.base.Charsets;
 
 import junit.framework.Assert;
 
@@ -928,6 +931,38 @@ public class ConfigurationTest {
   @Test
   public void canReadNonLatin1Properties() {
     Assert.assertEquals("árvíztűrő tükörfúrógép", new Configuration().getProperty("encoding.test"));
+  }
+
+  @Test
+  public void testRemovingAmbariProperties() throws Exception {
+    final File ambariPropertiesFile = new File(Configuration.class.getClassLoader().getResource("ambari.properties").getPath());
+    final String originalContent = FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8);
+    assertTrue(originalContent.indexOf("testPropertyName") == -1);
+    try {
+      final String testambariProperties = "\ntestPropertyName1=testValue1\ntestPropertyName2=testValue2\ntestPropertyName3=testValue3";
+      FileUtils.writeStringToFile(ambariPropertiesFile, testambariProperties, Charsets.UTF_8, true);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName1") > -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName2") > -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName3") > -1);
+
+      final Configuration configuration = new Configuration();
+      configuration.removePropertiesFromAmbariProperties(Arrays.asList("testPropertyName2"));
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName1") > -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName2") == -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName3") > -1);
+
+      configuration.removePropertiesFromAmbariProperties(Arrays.asList("testPropertyName3"));
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName1") > -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName2") == -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName3") == -1);
+
+      configuration.removePropertiesFromAmbariProperties(Arrays.asList("testPropertyName1"));
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName1") == -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName2") == -1);
+      assertTrue(FileUtils.readFileToString(ambariPropertiesFile, Charsets.UTF_8).indexOf("testPropertyName3") == -1);
+    } finally {
+      FileUtils.writeStringToFile(ambariPropertiesFile, originalContent, Charsets.UTF_8);
+    }
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog300Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog300Test.java
@@ -58,7 +58,11 @@ import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
 import org.apache.ambari.server.controller.MaintenanceStateHelper;
 import org.apache.ambari.server.controller.ServiceConfigVersionResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationCategory;
+import org.apache.ambari.server.ldap.domain.AmbariLdapConfigurationKeys;
 import org.apache.ambari.server.orm.DBAccessor;
+import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
+import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -74,7 +78,9 @@ import org.easymock.MockType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import com.google.common.collect.ImmutableMap;
@@ -88,6 +94,8 @@ import com.google.inject.Provider;
 
 @RunWith(EasyMockRunner.class)
 public class UpgradeCatalog300Test {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Mock(type = MockType.STRICT)
   private Provider<EntityManager> entityManagerProvider;
@@ -119,6 +127,9 @@ public class UpgradeCatalog300Test {
   @Mock(type = MockType.NICE)
   private Cluster cluster;
 
+  @Mock(type = MockType.NICE)
+  AmbariConfigurationDAO ambariConfigurationDao;
+
   @Before
   public void init() {
     reset(entityManagerProvider, injector);
@@ -142,6 +153,7 @@ public class UpgradeCatalog300Test {
     Method setStatusOfStagesAndRequests = UpgradeCatalog300.class.getDeclaredMethod("setStatusOfStagesAndRequests");
     Method updateLogSearchConfigs = UpgradeCatalog300.class.getDeclaredMethod("updateLogSearchConfigs");
     Method updateKerberosConfigurations = UpgradeCatalog300.class.getDeclaredMethod("updateKerberosConfigurations");
+    Method upgradeLdapConfiguration = UpgradeCatalog300.class.getDeclaredMethod("upgradeLdapConfiguration");
 
     UpgradeCatalog300 upgradeCatalog300 = createMockBuilder(UpgradeCatalog300.class)
         .addMockedMethod(showHcatDeletedUserMessage)
@@ -149,17 +161,26 @@ public class UpgradeCatalog300Test {
         .addMockedMethod(setStatusOfStagesAndRequests)
         .addMockedMethod(updateLogSearchConfigs)
         .addMockedMethod(updateKerberosConfigurations)
+        .addMockedMethod(upgradeLdapConfiguration)
         .createMock();
 
 
     upgradeCatalog300.addNewConfigurationsFromXml();
+    expectLastCall().once();
+
     upgradeCatalog300.showHcatDeletedUserMessage();
+    expectLastCall().once();
+
     upgradeCatalog300.setStatusOfStagesAndRequests();
+    expectLastCall().once();
 
     upgradeCatalog300.updateLogSearchConfigs();
     expectLastCall().once();
 
     upgradeCatalog300.updateKerberosConfigurations();
+    expectLastCall().once();
+
+    upgradeCatalog300.upgradeLdapConfiguration();
     expectLastCall().once();
 
     replay(upgradeCatalog300);
@@ -171,15 +192,7 @@ public class UpgradeCatalog300Test {
 
   @Test
   public void testExecuteDDLUpdates() throws Exception {
-    Module module = new Module() {
-      @Override
-      public void configure(Binder binder) {
-        binder.bind(DBAccessor.class).toInstance(dbAccessor);
-        binder.bind(OsFamily.class).toInstance(osFamily);
-        binder.bind(EntityManager.class).toInstance(entityManager);
-        binder.bind(Configuration.class).toInstance(configuration);
-      }
-    };
+    Module module = getTestGuiceModule();
 
     Capture<DBAccessor.DBColumnInfo> hrcOpsDisplayNameColumn = newCapture();
     dbAccessor.addColumn(eq(UpgradeCatalog300.HOST_ROLE_COMMAND_TABLE), capture(hrcOpsDisplayNameColumn));
@@ -241,6 +254,20 @@ public class UpgradeCatalog300Test {
     // Ambari configuration table addition...
 
     verify(dbAccessor);
+  }
+
+  private Module getTestGuiceModule() {
+    Module module = new Module() {
+      @Override
+      public void configure(Binder binder) {
+        binder.bind(DBAccessor.class).toInstance(dbAccessor);
+        binder.bind(OsFamily.class).toInstance(osFamily);
+        binder.bind(EntityManager.class).toInstance(entityManager);
+        binder.bind(Configuration.class).toInstance(configuration);
+        binder.bind(AmbariConfigurationDAO.class).toInstance(ambariConfigurationDao);
+      }
+    };
+    return module;
   }
 
   @Test
@@ -506,5 +533,44 @@ public class UpgradeCatalog300Test {
     Assert.assertEquals(2, propertiesWithGroup.size());
     Assert.assertEquals("ambari_managed_identities", propertiesWithGroup.get("group"));
     Assert.assertEquals("host1.example.com", propertiesWithGroup.get("kdc_host"));
+  }
+
+  @Test
+  public void shouldSaveLdapConfigurationIfPropertyIsSetInAmbariProperties() throws Exception {
+    final Module module = getTestGuiceModule();
+    expect(configuration.getProperty("ambari.ldap.isConfigured")).andReturn("true").anyTimes();
+    expect(entityManager.find(anyObject(), anyObject())).andReturn(null).anyTimes();
+    ambariConfigurationDao.create(buildConfigurationEntity(AmbariLdapConfigurationKeys.LDAP_ENABLED, "true"));
+    expectLastCall().once();
+    replay(configuration, entityManager, ambariConfigurationDao);
+
+    final Injector injector = Guice.createInjector(module);
+    final UpgradeCatalog300 upgradeCatalog300 = new UpgradeCatalog300(injector);
+    upgradeCatalog300.upgradeLdapConfiguration();
+    verify(configuration, entityManager, ambariConfigurationDao);
+  }
+
+  @Test
+  public void shouldNotSaveLdapConfigurationIfPropertyIsNotSetInAmbariProperties() throws Exception {
+    final Module module = getTestGuiceModule();
+    expect(entityManager.find(anyObject(), anyObject())).andReturn(null).anyTimes();
+    ambariConfigurationDao.create(buildConfigurationEntity(AmbariLdapConfigurationKeys.LDAP_ENABLED, "true"));
+    replay(configuration, entityManager, ambariConfigurationDao);
+
+    final Injector injector = Guice.createInjector(module);
+    final UpgradeCatalog300 upgradeCatalog300 = new UpgradeCatalog300(injector);
+    upgradeCatalog300.upgradeLdapConfiguration();
+
+    expectedException.expect(AssertionError.class);
+    expectedException.expectMessage("Expectation failure on verify");
+    verify(configuration, entityManager, ambariConfigurationDao);
+  }
+
+  private AmbariConfigurationEntity buildConfigurationEntity(AmbariLdapConfigurationKeys key, String value) {
+    final AmbariConfigurationEntity configurationEntity = new AmbariConfigurationEntity();
+    configurationEntity.setCategoryName(AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName());
+    configurationEntity.setPropertyName(key.key());
+    configurationEntity.setPropertyValue(value);
+    return configurationEntity;
   }
 }


### PR DESCRIPTION
@rlevas @zeroflag @echekanskiy Please review

## What changes were proposed in this pull request?

According to the requirement I needed to move LDAP related properties out from ambari.properties file into our DB table called ambari_configuration with 'ldap-configuration' category name when upgrading to 3.0.0.

## How was this patch tested?

Unit test were added and adopted; local build result:

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:37 h
[INFO] Finished at: 2018-01-12T13:40:34+01:00
[INFO] Final Memory: 207M/802M
[INFO] ------------------------------------------------------------------------

Besides unit testing the following integration test has been executed:

1. installed Ambari 2.6.2
2. executed ambari-server setup-ldap (LDAP related properties appeared in /etc/ambari-server/conf/ambari.properties; made a backup of this file)
3. upgraded to Ambari 3.0.0 (using build 1426 and replaced ambari-server.jar to include my changes): Ambari Server 'upgrade' completed successfully.
4. DB check: all properties I defined in step 2 have been added in ambari_configration table with 'ldap-configuration' category
5. Property file check: LDAP related properties have been removed
