### PR TITLE
[AMBARI-22771] Ambari loads ambari.properties using ISO 8859-1 encoding

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -24,6 +24,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Writer;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -90,6 +91,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -2839,7 +2841,7 @@ public class Configuration {
 
     // load the properties
     try {
-      properties.load(inputStream);
+      properties.load(new InputStreamReader(inputStream, Charsets.UTF_8));
       inputStream.close();
     } catch (FileNotFoundException fnf) {
       LOG.info("No configuration file " + CONFIG_FILE + " found in classpath.", fnf);

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
@@ -925,4 +925,9 @@ public class ConfigurationTest {
     Assert.assertEquals(1024, new Configuration(properties).getTlsEphemeralDhKeySize());
   }
 
+  @Test
+  public void canReadNonLatin1Properties() {
+    Assert.assertEquals("árvíztűrő tükörfúrógép", new Configuration().getProperty("encoding.test"));
+  }
+
 }

--- a/ambari-server/src/test/resources/ambari.properties
+++ b/ambari-server/src/test/resources/ambari.properties
@@ -15,3 +15,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+encoding.test=árvíztűrő tükörfúrógép


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #104, but for trunk, and the two commits squashed.

## How was this patch tested?

Unit tests:

```
[INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.631 s - in org.apache.ambari.server.configuration.ConfigurationTest
```