### PR TITLE
[AMBARI-22779] Cannot scale cluster if Ambari Server restarted since blueprint cluster creation

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -496,6 +496,9 @@ public class TopologyManager {
 
     hostNameCheck(request, topology);
     request.setClusterId(clusterId);
+    if (ambariContext.isTopologyResolved(clusterId)) {
+      getOrCreateTopologyTaskExecutor(clusterId).start();
+    }
 
     // this registers/updates all request host groups
     topology.update(request);
@@ -971,7 +974,7 @@ public class TopologyManager {
     persistedState.registerInTopologyHostInfo(host);
   }
 
-  private ExecutorService getOrCreateTopologyTaskExecutor(Long clusterId) {
+  private ManagedThreadPoolExecutor getOrCreateTopologyTaskExecutor(Long clusterId) {
     ManagedThreadPoolExecutor topologyTaskExecutor = this.topologyTaskExecutorServiceMap.get(clusterId);
     if (topologyTaskExecutor == null) {
       LOG.info("Creating TopologyTaskExecutorService for clusterId: {}", clusterId);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow scaling cluster after Ambari Restart.

## How was this patch tested?

Manually tested according to steps in [AMBARI-22779](https://issues.apache.org/jira/browse/AMBARI-22779).

Related unit test is passing:

```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.1 s - in org.apache.ambari.server.topology.TopologyManagerTest
```