### PR TITLE
[AMBARI-22779] Cannot scale cluster if Ambari Server restarted since blueprint cluster creation

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -496,6 +496,9 @@ public class TopologyManager {
 
     hostNameCheck(request, topology);
     request.setClusterId(clusterId);
+    if (ambariContext.isTopologyResolved(clusterId)) {
+      getOrCreateTopologyTaskExecutor(clusterId).start();
+    }
 
     // this registers/updates all request host groups
     topology.update(request);
@@ -968,7 +971,7 @@ public class TopologyManager {
     persistedState.registerInTopologyHostInfo(host);
   }
 
-  private ExecutorService getOrCreateTopologyTaskExecutor(Long clusterId) {
+  private ManagedThreadPoolExecutor getOrCreateTopologyTaskExecutor(Long clusterId) {
     ManagedThreadPoolExecutor topologyTaskExecutor = this.topologyTaskExecutorServiceMap.get(clusterId);
     if (topologyTaskExecutor == null) {
       LOG.info("Creating TopologyTaskExecutorService for clusterId: {}", clusterId);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #112, but for trunk.

## How was this patch tested?

Related unit test passes:

```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.802 s - in org.apache.ambari.server.topology.TopologyManagerTest
```