### PR TITLE
[AMBARI-22697] Throw exception when keytab creation fails due to wrong configuration of key encryption types

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandler.java
@@ -800,7 +800,12 @@ public abstract class KerberosOperationHandler {
       encryptionTypes = ENCRYPTION_TYPE_TRANSLATION_MAP.get(name.toLowerCase());
     }
 
-    return (encryptionTypes == null) ? Collections.emptySet() : encryptionTypes;
+    if (encryptionTypes == null) {
+      LOG.warn("The given encryption type name ({}) is not supported.", name);
+      return Collections.emptySet();
+    }
+
+    return encryptionTypes;
   }
 
   /**
@@ -810,8 +815,10 @@ public abstract class KerberosOperationHandler {
    * @param names     a String containing a delimited list of encryption type names
    * @param delimiter a String declaring the delimiter to use to split names, if null, " " is used.
    * @return a Set of EncryptionType values
+   * @throws KerberosOperationException When all the encryption type names are not supported
    */
-  protected Set<EncryptionType> translateEncryptionTypes(String names, String delimiter) {
+  protected Set<EncryptionType> translateEncryptionTypes(String names, String delimiter)
+      throws KerberosOperationException {
     Set<EncryptionType> encryptionTypes = new HashSet<>();
 
     if (!StringUtils.isEmpty(names)) {
@@ -820,6 +827,9 @@ public abstract class KerberosOperationHandler {
       }
     }
 
+    if (encryptionTypes.isEmpty()) {
+      throw new KerberosOperationException("All the encryption type names you set are not supported. Aborting.");
+    }
     return encryptionTypes;
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandlerTest.java
@@ -351,6 +351,12 @@ public abstract class KerberosOperationHandlerTest extends EasyMockSupport {
     );
   }
 
+  @Test(expected = KerberosOperationException.class)
+  public void testTranslateWrongEncryptionTypes() throws Exception {
+    KerberosOperationHandler handler = createHandler();
+    handler.translateEncryptionTypes("aes-255", " ");
+  }
+
   @Test
   public void testEscapeCharacters() throws KerberosOperationException {
     KerberosOperationHandler handler = createHandler();


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the Kerberos key encryption type are wrongly configured,

* Before: Keytab creation successes and kinit fails. That way it is difficult for users to find the root cause.
* After: Keytab creation fails. (fail-fast)

More information: https://issues.apache.org/jira/browse/AMBARI-22697

## How was this patch tested?

Not tested.