### PR TITLE
[AMBARI-22794] LogSearch Filter Bar Fixes

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.less
@@ -34,7 +34,8 @@
 
   .fixed-filterbar {
     filters-panel {
-      background-color: fadeout(@filters-panel-background-color, 35%);
+      background-color: fadeout(@filters-panel-background-color, 10%);
+      box-shadow: 0 2px 2px rgba(0,0,0,.1);
       left: 0;
       margin: 0;
       position: fixed;


### PR DESCRIPTION
Opacity decreased and the shadow has been added to the sticky filter bar.

## What changes were proposed in this pull request?

The filter bar opacity was to high, so that the content was not readable enough.
A box shadow can help the user to identify the filter bar on the top.

## How was this patch tested?

Manual test and unit tests.

@aBabiichuk please review.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.