### PR TITLE
[AMBARI-22785] Added force_tcp option to KRB5 configuration template

### DIFF
--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/configuration/krb5-conf.xml
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/configuration/krb5-conf.xml
@@ -71,4 +71,15 @@
     </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>force_tcp</name>
+    <display-name>Force TCP</display-name>
+    <description>Indicates whether to use TCP (instead of UDP) when communicating with Kerberos</description>
+	<value>false</value>
+    <value-attributes>
+      <overridable>false</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/params.py
@@ -115,6 +115,7 @@ if config is not None:
     test_keytab_file = None
     encryption_types = None
     manage_krb5_conf = "true"
+    force_tcp = "false"
     krb5_conf_template = None
 
     krb5_conf_data = get_property_value(configurations, 'krb5-conf')
@@ -148,6 +149,7 @@ if config is not None:
       krb5_conf_path = krb5_conf_dir + '/' + krb5_conf_file
 
       manage_krb5_conf = get_property_value(krb5_conf_data, 'manage_krb5_conf', "true")
+      force_tcp = get_property_value(krb5_conf_data, 'force_tcp', "false")
 
     # For backward compatibility, ensure that kdc_host exists. This may be needed if the krb5.conf
     # template in krb5-conf/content had not be updated during the Ambari upgrade to 2.4.0 - which

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/properties/krb5_conf.j2
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/properties/krb5_conf.j2
@@ -25,6 +25,9 @@
   default_ccache_name = /tmp/krb5cc_%{uid}
   #default_tgs_enctypes = {{encryption_types}}
   #default_tkt_enctypes = {{encryption_types}}
+  {%- if force_tcp %}
+  udp_preference_limit = 1
+  {%- endif -%}
 {% if domains %}
 [domain_realm]
 {%- for domain in domains.split(',') %}

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/configuration/krb5-conf.xml
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/configuration/krb5-conf.xml
@@ -71,4 +71,15 @@
     </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>force_tcp</name>
+    <display-name>Force TCP</display-name>
+    <description>Indicates whether to use TCP (instead of UDP) when communicating with Kerberos</description>
+	<value>false</value>
+    <value-attributes>
+      <overridable>false</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/package/scripts/params.py
@@ -115,6 +115,7 @@ if config is not None:
     test_keytab_file = None
     encryption_types = None
     manage_krb5_conf = "true"
+    force_tcp = "false"
     krb5_conf_template = None
 
     krb5_conf_data = get_property_value(configurations, 'krb5-conf')
@@ -148,6 +149,7 @@ if config is not None:
       krb5_conf_path = krb5_conf_dir + '/' + krb5_conf_file
 
       manage_krb5_conf = get_property_value(krb5_conf_data, 'manage_krb5_conf', "true")
+      force_tcp = get_property_value(krb5_conf_data, 'force_tcp', "false")
 
     # For backward compatibility, ensure that kdc_host exists. This may be needed if the krb5.conf
     # template in krb5-conf/content had not be updated during the Ambari upgrade to 2.4.0 - which

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/properties/krb5_conf.j2
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/properties/krb5_conf.j2
@@ -25,6 +25,9 @@
   default_ccache_name = /tmp/krb5cc_%{uid}
   #default_tgs_enctypes = {{encryption_types}}
   #default_tkt_enctypes = {{encryption_types}}
+  {%- if force_tcp %}
+  udp_preference_limit = 1
+  {%- endif -%}
 {% if domains %}
 [domain_realm]
 {%- for domain in domains.split(',') %}

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/KERBEROS/configuration/krb5-conf.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/KERBEROS/configuration/krb5-conf.xml
@@ -71,4 +71,15 @@
     </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>force_tcp</name>
+    <display-name>Force TCP</display-name>
+    <description>Indicates whether to use TCP (instead of UDP) when communicating with Kerberos</description>
+	<value>false</value>
+    <value-attributes>
+      <overridable>false</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
 </configuration>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/KERBEROS/package/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/KERBEROS/package/scripts/params.py
@@ -112,6 +112,7 @@ if config is not None:
     test_keytab_file = None
     encryption_types = None
     manage_krb5_conf = "true"
+    force_tcp = "false"
     krb5_conf_template = None
 
     krb5_conf_data = get_property_value(configurations, 'krb5-conf')
@@ -145,6 +146,7 @@ if config is not None:
       krb5_conf_path = krb5_conf_dir + '/' + krb5_conf_file
 
       manage_krb5_conf = get_property_value(krb5_conf_data, 'manage_krb5_conf', "true")
+      force_tcp = get_property_value(krb5_conf_data, 'force_tcp', "false")
 
     # For backward compatibility, ensure that kdc_host exists. This may be needed if the krb5.conf
     # template in krb5-conf/content had not be updated during the Ambari upgrade to 2.4.0 - which

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/KERBEROS/properties/krb5_conf.j2
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/KERBEROS/properties/krb5_conf.j2
@@ -25,6 +25,9 @@
   default_ccache_name = /tmp/krb5cc_%{uid}
   #default_tgs_enctypes = {{encryption_types}}
   #default_tkt_enctypes = {{encryption_types}}
+  {%- if force_tcp %}
+  udp_preference_limit = 1
+  {%- endif -%}
 {% if domains %}
 [domain_realm]
 {%- for domain in domains.split(',') %}


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on users can indicate whether they want to use TCP over UDP when communicating with Kerberos (default is UDP)

We can accomplish this by setting `udp_preference_limit` to 1 in `krb5.conf`

## How was this patch tested?

I made the required changes in template/Python files and replaced/recompiled them in my local test environment (used HDP 2.6.4 where KERBEROS version is 1.10.3-10). Then I restarted my Ambari server and executed the 'Enable Kerberos' wizard.

When I arrived to Step 2 (Configure Kerberos) the new option appeared together with the edited default Jinja template:

<img width="1599" alt="screen shot 2018-01-16 at 1 53 24 pm" src="https://user-images.githubusercontent.com/34065904/34990986-5b57d05c-fac8-11e7-8f64-ef140ca4e033.png">

Enabling the new property and going to the next step (Install and Test Kerberos Client) resulted in the following krb5.conf:
```
[root@c6401 ~]# cat /etc/krb5.conf 

[libdefaults]
  renew_lifetime = 7d
  forwardable = true
  default_realm = AMBARI.APACHE.ORG
  ticket_lifetime = 24h
  dns_lookup_realm = false
  dns_lookup_kdc = false
  default_ccache_name = /tmp/krb5cc_%{uid}
  #default_tgs_enctypes = aes des3-cbc-sha1 rc4 des-cbc-md5
  #default_tkt_enctypes = aes des3-cbc-sha1 rc4 des-cbc-md5
  udp_preference_limit = 1
[domain_realm]
  ambari.apache.org = AMBARI.APACHE.ORG
  .ambari.apache.org = AMBARI.APACHE.ORG

[logging]
  default = FILE:/var/log/krb5kdc.log
  admin_server = FILE:/var/log/kadmind.log
  kdc = FILE:/var/log/krb5kdc.log

[realms]
  AMBARI.APACHE.ORG = {
    admin_server = c6401.ambari.apache.org
    kdc = c6401.ambari.apache.org
  }
```
After this step I also tested if disabling the new option results in a `krb5.conf` file without `udp_preference_limit = 1`; this test was successful too.

Local test results:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25:50 min
[INFO] Finished at: 2018-01-16T14:34:56+01:00
[INFO] Final Memory: 212M/917M
[INFO] ------------------------------------------------------------------------
```

@rlevas @zeroflag @echekanskiy Please review
