### PR TITLE
[AMBARI-22577] Migrate user data for upgrade to improved user account management

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/DBAccessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/DBAccessor.java
@@ -23,6 +23,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.ambari.server.configuration.Configuration.DatabaseType;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.sessions.DatabaseSession;
@@ -852,6 +854,33 @@ public interface DBAccessor {
 
     public void setDbType(FieldTypeDefinition dbType) {
       this.dbType = dbType;
+    }
+
+    @Override
+    public int hashCode() {
+      return new HashCodeBuilder(17, 37)
+          .append(name)
+          .append(type)
+          .append(length)
+          .append(isNullable)
+          .append(defaultValue)
+          .append(dbType)
+          .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      DBColumnInfo that = (DBColumnInfo) o;
+      return new EqualsBuilder()
+          .append(name, that.name)
+          .append(type, that.type)
+          .append(length, that.length)
+          .append(isNullable, that.isNullable)
+          .append(defaultValue, that.defaultValue)
+          .append(dbType, that.dbType)
+          .isEquals();
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/UserAuthenticationDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/UserAuthenticationDAO.java
@@ -63,7 +63,7 @@ public class UserAuthenticationDAO {
   public List<UserAuthenticationEntity> findByTypeAndKey(UserAuthenticationType authenticationType, String key) {
     TypedQuery<UserAuthenticationEntity> query = entityManagerProvider.get().createNamedQuery("UserAuthenticationEntity.findByTypeAndKey", UserAuthenticationEntity.class);
     query.setParameter("authenticationType", authenticationType.name());
-    query.setParameter("authenticationKey", (key == null) ? null : key.getBytes());
+    query.setParameter("authenticationKey", key);
     return daoUtils.selectList(query);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
@@ -29,7 +29,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -74,9 +73,8 @@ public class UserAuthenticationEntity {
   private UserAuthenticationType authenticationType = UserAuthenticationType.LOCAL;
 
   @Column(name = "authentication_key")
-  @Lob
   @Basic
-  private byte[] authenticationKey;
+  private String authenticationKey;
 
   @Column(name = "create_time", nullable = false)
   @Basic
@@ -109,11 +107,11 @@ public class UserAuthenticationEntity {
   }
 
   public String getAuthenticationKey() {
-    return authenticationKey == null ? "" : new String(authenticationKey);
+    return authenticationKey;
   }
 
   public void setAuthenticationKey(String authenticationKey) {
-    this.authenticationKey = (authenticationKey == null) ? null : authenticationKey.getBytes();
+    this.authenticationKey = authenticationKey;
   }
 
   public Date getCreateTime() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProvider.java
@@ -264,7 +264,7 @@ public class AmbariLdapAuthenticationProvider extends AmbariAuthenticationProvid
 
         if (!CollectionUtils.isEmpty(authenticationEntities)) {
           for (UserAuthenticationEntity entity : authenticationEntities) {
-            if (!StringUtils.isEmpty(entity.getAuthenticationKey())) {
+            if (StringUtils.isEmpty(entity.getAuthenticationKey())) {
               // Proven innocent!
               userEntity = _userEntity;
               break;

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
@@ -18,7 +18,9 @@
 package org.apache.ambari.server.upgrade;
 
 
+import java.sql.Clob;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +46,7 @@ import org.apache.ambari.server.orm.dao.DaoUtils;
 import org.apache.ambari.server.orm.dao.RequestDAO;
 import org.apache.ambari.server.orm.entities.RequestEntity;
 import org.apache.ambari.server.orm.entities.StageEntity;
+import org.apache.ambari.server.security.authorization.UserAuthenticationType;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -81,6 +84,42 @@ public class UpgradeCatalog300 extends AbstractUpgradeCatalog {
   protected static final String AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN = "category_name";
   protected static final String AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN = "property_name";
   protected static final String AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN = "property_value";
+
+  protected static final String USER_AUTHENTICATION_TABLE = "user_authentication";
+  protected static final String USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN = "user_authentication_id";
+  protected static final String USER_AUTHENTICATION_USER_ID_COLUMN = "user_id";
+  protected static final String USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN = "authentication_type";
+  protected static final String USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN = "authentication_key";
+  protected static final String USER_AUTHENTICATION_CREATE_TIME_COLUMN = "create_time";
+  protected static final String USER_AUTHENTICATION_UPDATE_TIME_COLUMN = "update_time";
+  protected static final String USER_AUTHENTICATION_PRIMARY_KEY = "PK_user_authentication";
+  protected static final String USER_AUTHENTICATION_USER_AUTHENTICATION_USER_ID_INDEX = "IDX_user_authentication_user_id";
+  protected static final String USER_AUTHENTICATION_USER_AUTHENTICATION_USERS_FOREIGN_KEY = "FK_user_authentication_users";
+
+  protected static final String USERS_TABLE = "users";
+  protected static final String USERS_USER_ID_COLUMN = "user_id";
+  protected static final String USERS_PRINCIPAL_ID_COLUMN = "principal_id";
+  protected static final String USERS_USER_TYPE_COLUMN = "user_type";
+  protected static final String USERS_USER_PASSWORD_COLUMN = "user_password";
+  protected static final String USERS_CREATE_TIME_COLUMN = "create_time";
+  protected static final String USERS_LDAP_USER_COLUMN = "ldap_user";
+  protected static final String USERS_CONSECUTIVE_FAILURES_COLUMN = "consecutive_failures";
+  protected static final String USERS_USER_NAME_COLUMN = "user_name";
+  protected static final String USERS_DISPLAY_NAME_COLUMN = "display_name";
+  protected static final String USERS_LOCAL_USERNAME_COLUMN = "local_username";
+  protected static final String USERS_VERSION_COLUMN = "version";
+  protected static final String UNIQUE_USERS_0_INDEX = "UNQ_users_0";
+
+  protected static final String MEMBERS_TABLE = "members";
+  protected static final String MEMBERS_MEMBER_ID_COLUMN = "member_id";
+  protected static final String MEMBERS_GROUP_ID_COLUMN = "group_id";
+  protected static final String MEMBERS_USER_ID_COLUMN = "user_id";
+
+  protected static final String ADMINPRIVILEGE_TABLE = "adminprivilege";
+  protected static final String ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN = "privilege_id";
+  protected static final String ADMINPRIVILEGE_PERMISSION_ID_COLUMN = "permission_id";
+  protected static final String ADMINPRIVILEGE_RESOURCE_ID_COLUMN = "resource_id";
+  protected static final String ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN = "principal_id";
 
   @Inject
   DaoUtils daoUtils;
@@ -128,6 +167,360 @@ public class UpgradeCatalog300 extends AbstractUpgradeCatalog {
     addOpsDisplayNameColumnToHostRoleCommand();
     removeSecurityState();
     addAmbariConfigurationTable();
+    upgradeUserTables();
+  }
+
+  /**
+   * Upgrade the users table as well as supporting tables.
+   * <p>
+   * Affected table are
+   * <ul>
+   * <li>users</li>
+   * <li>user_authentication (new)</li>
+   * <li>members</li>
+   * <li>adminprivilege</li>
+   * </ul>
+   *
+   * @throws SQLException if an error occurs while executing SQL statements
+   * @see #createUserAuthenticationTable()
+   * @see #updateGroupMembershipRecords()
+   * @see #updateAdminPrivilegeRecords()
+   * @see #updateUsersTable()
+   */
+  protected void upgradeUserTables() throws SQLException {
+    createUserAuthenticationTable();
+    updateGroupMembershipRecords();
+    updateAdminPrivilegeRecords();
+    updateUsersTable();
+  }
+
+  /**
+   * If the <code>users</code> table has not yet been migrated, create the <code>user_authentication</code>
+   * table and generate relevant records for that table based on data in the <code>users</code> table.
+   * <p>
+   * The records in the new <code>user_authentication</code> table represent all of the types associated
+   * with a given (case-insensitive) username.  If <code>UserA:LOCAL</code>, <code>usera:LOCAL</code> and
+   * <code>usera:LDAP</code> exist in the original <code>users</code> table, three records will be created
+   * in the <code>user_authentication</code> table: one for each t
+   * to <code>Role1</code>, the three <code>adminprivilege</code> records will be merged into a single
+   * record for <code>usera</code>.
+   *
+   * @throws SQLException if an error occurs while executing SQL statements
+   */
+  private void createUserAuthenticationTable() throws SQLException {
+    if (!usersTableUpgraded()) {
+      final String temporaryTable = USER_AUTHENTICATION_TABLE + "_tmp";
+
+      List<DBAccessor.DBColumnInfo> columns = new ArrayList<>();
+      columns.add(new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN, Long.class, null, null, false));
+      columns.add(new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_USER_ID_COLUMN, Long.class, null, null, false));
+      columns.add(new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN, String.class, 50, null, false));
+      columns.add(new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN, Clob.class, null, null, true));
+      columns.add(new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_CREATE_TIME_COLUMN, Timestamp.class, null, null, true));
+      columns.add(new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_UPDATE_TIME_COLUMN, Timestamp.class, null, null, true));
+
+      // Make sure the temporary table does not exist
+      dbAccessor.dropTable(temporaryTable);
+
+      // Create temporary table
+      dbAccessor.createTable(temporaryTable, columns);
+
+      dbAccessor.executeUpdate(
+          "insert into " + temporaryTable +
+              "(" + USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN + ", " + USER_AUTHENTICATION_USER_ID_COLUMN + ", " + USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN + ", " + USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN + ", " + USER_AUTHENTICATION_CREATE_TIME_COLUMN + ", " + USER_AUTHENTICATION_UPDATE_TIME_COLUMN + ")" +
+              " select" +
+              "  u." + USERS_USER_ID_COLUMN + "," +
+              "  t.min_user_id," +
+              "  u." + USERS_USER_TYPE_COLUMN + "," +
+              "  u." + USERS_USER_PASSWORD_COLUMN + "," +
+              "  u." + USERS_CREATE_TIME_COLUMN + "," +
+              "  u." + USERS_CREATE_TIME_COLUMN +
+              " from " + USERS_TABLE + " as u inner join" +
+              "   (select" +
+              "     lower(" + USERS_USER_NAME_COLUMN + ") as " + USERS_USER_NAME_COLUMN + "," +
+              "     min(" + USERS_USER_ID_COLUMN + ") as min_user_id" +
+              "    from " + USERS_TABLE +
+              "    group by lower(" + USERS_USER_NAME_COLUMN + ")) as t" +
+              " on (lower(u." + USERS_USER_NAME_COLUMN + ") = lower(t." + USERS_USER_NAME_COLUMN + "))"
+      );
+
+      // Ensure only LOCAL users have keys set in the user_authentication table
+      dbAccessor.executeUpdate("update " + temporaryTable +
+          " set " + USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN + "=null" +
+          " where " + USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN + "!='" + UserAuthenticationType.LOCAL.name() + "'");
+
+      dbAccessor.createTable(USER_AUTHENTICATION_TABLE, columns);
+      dbAccessor.addPKConstraint(USER_AUTHENTICATION_TABLE, USER_AUTHENTICATION_PRIMARY_KEY, USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN);
+      dbAccessor.addFKConstraint(USER_AUTHENTICATION_TABLE, USER_AUTHENTICATION_USER_AUTHENTICATION_USERS_FOREIGN_KEY, USER_AUTHENTICATION_USER_ID_COLUMN, USERS_TABLE, USERS_USER_ID_COLUMN, false);
+
+      dbAccessor.executeUpdate(
+          "insert into " + USER_AUTHENTICATION_TABLE +
+              "(" + USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN + ", " + USER_AUTHENTICATION_USER_ID_COLUMN + ", " + USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN + ", " + USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN + ", " + USER_AUTHENTICATION_CREATE_TIME_COLUMN + ", " + USER_AUTHENTICATION_UPDATE_TIME_COLUMN + ")" +
+              " select distinct " +
+              USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN + ", " + USER_AUTHENTICATION_USER_ID_COLUMN + ", " + USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN + ", " + USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN + ", " + USER_AUTHENTICATION_CREATE_TIME_COLUMN + ", " + USER_AUTHENTICATION_UPDATE_TIME_COLUMN +
+              " from " + temporaryTable
+      );
+
+      // Delete the temporary table
+      dbAccessor.dropTable(temporaryTable);
+    }
+  }
+
+  private boolean usersTableUpgraded() {
+    try {
+      dbAccessor.getColumnType(USERS_TABLE, USERS_USER_TYPE_COLUMN);
+      return false;
+    } catch (SQLException e) {
+      return true;
+    }
+  }
+
+  /**
+   * Update the <code>users</code> table by adjusting the relevant columns, contained data, and indicies.
+   * <p>
+   * This method should be executed after creating the <code>user_authentication</code> table and
+   * adjusting the <code>members</code> and <code>adminprivilege</code> data by merging data while
+   * combine user entries with the same username (but different type).
+   * <p>
+   * <ol>
+   * <li>
+   * Orphaned data is removed.  These will be the records where the usernamne is duplicated but
+   * the user type is different.  Only a single record with a given username should be left.
+   * </li>
+   * <li>
+   * Remove the unique record constraint so it may be added back later declaring new constraints
+   * </li>
+   * <li>
+   * Obsolete columns are removed: <code>user_type</code>, <code>ldap_user</code>, <code>user_password</code>.
+   * These columns are handled by the <codee>user_authentication</codee> table.
+   * </li>
+   * <li>
+   * Add new columns: <code>consecutive_failures</code>, <code>display_name</code>,
+   * <code>local_username</code>, <code>version</code>.
+   * The non-null constraints are to be set after all the date is set properly.
+   * </li>
+   * <li>
+   * Ensure the <code>display_name</code> and <code>local_username</code> columns have properly set data.
+   * </li>
+   * <li>
+   * Add the non-null constraint back for the <code>display_name</code> and <code>local_username</code> columns.
+   * </li>
+   * <li>
+   * Add a unique index on the <code>user_name</code> column
+   * </li>
+   * </ol>
+   *
+   * @throws SQLException if an error occurs while executing SQL statements
+   * @see #createUserAuthenticationTable()
+   * @see #updateGroupMembershipRecords()
+   * @see #updateAdminPrivilegeRecords()
+   */
+  private void updateUsersTable() throws SQLException {
+    // Remove orphaned user records...
+    dbAccessor.executeUpdate("delete from " + USERS_TABLE +
+        " where " + USERS_USER_ID_COLUMN + " not in (select " + USER_AUTHENTICATION_USER_ID_COLUMN + " from " + USER_AUTHENTICATION_TABLE + ")");
+
+    // Update the users table
+    dbAccessor.dropUniqueConstraint(USERS_TABLE, UNIQUE_USERS_0_INDEX);
+    dbAccessor.dropColumn(USERS_TABLE, USERS_USER_TYPE_COLUMN);
+    dbAccessor.dropColumn(USERS_TABLE, USERS_LDAP_USER_COLUMN);
+    dbAccessor.dropColumn(USERS_TABLE, USERS_USER_PASSWORD_COLUMN);
+    dbAccessor.addColumn(USERS_TABLE, new DBAccessor.DBColumnInfo(USERS_CONSECUTIVE_FAILURES_COLUMN, Integer.class, null, 0, false));
+    dbAccessor.addColumn(USERS_TABLE, new DBAccessor.DBColumnInfo(USERS_DISPLAY_NAME_COLUMN, String.class, 255, null, true)); // Set to non-null later
+    dbAccessor.addColumn(USERS_TABLE, new DBAccessor.DBColumnInfo(USERS_LOCAL_USERNAME_COLUMN, String.class, 255, null, true)); // Set to non-null later
+    dbAccessor.addColumn(USERS_TABLE, new DBAccessor.DBColumnInfo(USERS_VERSION_COLUMN, Long.class, null, 0, false));
+
+    // Set the display name and local username values based on the username value
+    dbAccessor.executeUpdate("update " + USERS_TABLE +
+        " set " + USERS_DISPLAY_NAME_COLUMN + "=" + USERS_USER_NAME_COLUMN +
+        ", " + USERS_LOCAL_USERNAME_COLUMN + "= lower(" + USERS_USER_NAME_COLUMN + ")" +
+        ", " + USERS_USER_NAME_COLUMN + "= lower(" + USERS_USER_NAME_COLUMN + ")");
+
+    // Change columns to non-null
+    dbAccessor.alterColumn(USERS_TABLE, new DBAccessor.DBColumnInfo(USERS_DISPLAY_NAME_COLUMN, String.class, 255, null, false));
+    dbAccessor.alterColumn(USERS_TABLE, new DBAccessor.DBColumnInfo(USERS_LOCAL_USERNAME_COLUMN, String.class, 255, null, false));
+
+    // Add a unique constraint on the user_name column
+    dbAccessor.addUniqueConstraint(USERS_TABLE, UNIQUE_USERS_0_INDEX, USERS_USER_NAME_COLUMN);
+  }
+
+  /**
+   * Update the <code>members</code> table to ensure records for the same username but different user
+   * records are referencing the main user record. Duplicate records will be be ignored when updating
+   * the <code>members</code> table.
+   * <p>
+   * If <code>UserA:LOCAL</code>, <code>usera:LOCAL</code> and <code>usera:LDAP</code> all belong to
+   * <code>Group1</code>, the three <code>members</code> records will be merged into a single record
+   * for <code>usera</code>.
+   * <p>
+   * This method may be executed multiple times and will yield the same results each time.
+   *
+   * @throws SQLException if an error occurs while executing SQL statements
+   */
+  private void updateGroupMembershipRecords() throws SQLException {
+    final String temporaryTable = MEMBERS_TABLE + "_tmp";
+
+    // Make sure the temporary table does not exist
+    dbAccessor.dropTable(temporaryTable);
+
+    // Create temporary table
+    List<DBAccessor.DBColumnInfo> columns = new ArrayList<>();
+    columns.add(new DBAccessor.DBColumnInfo(MEMBERS_MEMBER_ID_COLUMN, Long.class, null, null, false));
+    columns.add(new DBAccessor.DBColumnInfo(MEMBERS_USER_ID_COLUMN, Long.class, null, null, false));
+    columns.add(new DBAccessor.DBColumnInfo(MEMBERS_GROUP_ID_COLUMN, Long.class, null, null, false));
+    dbAccessor.createTable(temporaryTable, columns);
+
+    // Insert updated data
+    /* *******
+     * Find the user id for the merged user records for the user that is related to each member record.
+     * - Using the user_id from the original member record, find the user_name of that user.
+     * - Using the found user_name, find the user_id for the _merged_ record.  This will be the value of the
+     *   smallest user_id for all user_ids where the user_name matches that found user_name.
+     * - The user_name value is case-insensitive.
+     * ******* */
+    dbAccessor.executeUpdate(
+        "insert into " + temporaryTable + " (" + MEMBERS_MEMBER_ID_COLUMN + ", " + MEMBERS_USER_ID_COLUMN + ", " + MEMBERS_GROUP_ID_COLUMN + ")" +
+            "  select" +
+            "    m." + MEMBERS_MEMBER_ID_COLUMN + "," +
+            "    u.min_user_id," +
+            "    m." + MEMBERS_GROUP_ID_COLUMN +
+            "  from " + MEMBERS_TABLE + " as m inner join" +
+            "    (" +
+            "      select" +
+            "        iu." + USERS_USER_NAME_COLUMN + "," +
+            "        iu." + USERS_USER_ID_COLUMN + "," +
+            "        t.min_user_id" +
+            "      from " + USERS_TABLE + " iu inner join" +
+            "        (" +
+            "          select" +
+            "           lower(" + USERS_USER_NAME_COLUMN + ") as " + USERS_USER_NAME_COLUMN + "," +
+            "            min(" + USERS_USER_ID_COLUMN + ") as min_user_id" +
+            "          from " + USERS_TABLE +
+            "          group by lower(" + USERS_USER_NAME_COLUMN + ")" +
+            "        ) as t on (lower(t." + USERS_USER_NAME_COLUMN + ") = lower(iu." + USERS_USER_NAME_COLUMN + "))" +
+            "    ) as u on (m." + MEMBERS_USER_ID_COLUMN + " = u." + USERS_USER_ID_COLUMN + ")");
+
+    // Truncate existing membership records
+    dbAccessor.truncateTable(MEMBERS_TABLE);
+
+    // Insert temporary records into members table
+    /*
+     * Copy the generated data to the original <code>members</code> table, effectively skipping
+     * duplicate records.
+     */
+    dbAccessor.executeUpdate(
+        "insert into " + MEMBERS_TABLE + " (" + MEMBERS_MEMBER_ID_COLUMN + ", " + MEMBERS_USER_ID_COLUMN + ", " + MEMBERS_GROUP_ID_COLUMN + ")" +
+            "  select " +
+            "    min(" + MEMBERS_MEMBER_ID_COLUMN + ")," +
+            "    " + MEMBERS_USER_ID_COLUMN + "," +
+            "    " + MEMBERS_GROUP_ID_COLUMN +
+            "  from " + temporaryTable +
+            "  group by " + MEMBERS_USER_ID_COLUMN + ", " + MEMBERS_GROUP_ID_COLUMN);
+
+    // Delete the temporary table
+    dbAccessor.dropTable(temporaryTable);
+  }
+
+  /**
+   * Update the <code>adminprivilege</code> table to ensure records for the same username but different user
+   * records are referencing the main user record. Duplicate records will be be ignored when updating
+   * the <code>adminprivilege</code> table.
+   * <p>
+   * If <code>UserA:LOCAL</code>, <code>usera:LOCAL</code> and <code>usera:LDAP</code> are assigned
+   * to <code>Role1</code>, the three <code>adminprivilege</code> records will be merged into a single
+   * record for <code>usera</code>.
+   * <p>
+   * This method may be executed multiple times and will yield the same results each time.
+   *
+   * @throws SQLException if an error occurs while executing SQL statements
+   */
+  private void updateAdminPrivilegeRecords() throws SQLException {
+    final String temporaryTable = ADMINPRIVILEGE_TABLE + "_tmp";
+
+    // Make sure the temporary table does not exist
+    dbAccessor.dropTable(temporaryTable);
+
+    // Create temporary table
+    List<DBAccessor.DBColumnInfo> columns = new ArrayList<>();
+    columns.add(new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN, Long.class, null, null, false));
+    columns.add(new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_PERMISSION_ID_COLUMN, Long.class, null, null, false));
+    columns.add(new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_RESOURCE_ID_COLUMN, Long.class, null, null, false));
+    columns.add(new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN, Long.class, null, null, false));
+    dbAccessor.createTable(temporaryTable, columns);
+
+    // Insert updated data
+    /* *******
+     * Find the principal id for the merged user records for the user that is related to each relevant
+     * adminprivilege record.
+     * - Using the principal_id from the original adminprivilege record, find the user_name of that user.
+     * - Using the found user_name, find the user_id for the _merged_ record.  This will be the value of the
+     *   smallest user_id for all user_ids where the user_name matches that found user_name.
+     * - Using the found user_id, obtain the relevant principal_id
+     * - The user_name value is case-insensitive.
+     * ******* */
+     dbAccessor.executeUpdate(
+        "insert into " + temporaryTable + " (" + ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN + ", " + ADMINPRIVILEGE_PERMISSION_ID_COLUMN + ", " + ADMINPRIVILEGE_RESOURCE_ID_COLUMN + ", " + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN + ")" +
+            "  select" +
+            "    ap." + ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN + "," +
+            "    ap." + ADMINPRIVILEGE_PERMISSION_ID_COLUMN + "," +
+            "    ap." + ADMINPRIVILEGE_RESOURCE_ID_COLUMN + "," +
+            "    ap." + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN +
+            "  from " + ADMINPRIVILEGE_TABLE + " as ap" +
+            "  where ap." + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN + " not in" +
+            "        (" +
+            "          select " + USERS_PRINCIPAL_ID_COLUMN +
+            "          from " + USERS_TABLE +
+            "        )" +
+            "  union" +
+            "  select" +
+            "    ap." + ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN + "," +
+            "    ap." + ADMINPRIVILEGE_PERMISSION_ID_COLUMN + "," +
+            "    ap." + ADMINPRIVILEGE_RESOURCE_ID_COLUMN + "," +
+            "    t.new_principal_id" +
+            "  from " + ADMINPRIVILEGE_TABLE + " as ap inner join" +
+            "    (" +
+            "      select" +
+            "        u." + USERS_USER_ID_COLUMN + "," +
+            "        u." + USERS_USER_NAME_COLUMN + "," +
+            "        u." + USERS_PRINCIPAL_ID_COLUMN + " as new_principal_id," +
+            "        t1." + USERS_PRINCIPAL_ID_COLUMN + " as orig_principal_id" +
+            "      from " + USERS_TABLE + " as u inner join" +
+            "        (" +
+            "          select" +
+            "            u1." + USERS_USER_NAME_COLUMN + "," +
+            "            u1." + USERS_PRINCIPAL_ID_COLUMN + "," +
+            "            t2.min_user_id" +
+            "          from " + USERS_TABLE + " as u1 inner join" +
+            "            (" +
+            "              select" +
+            "                lower(" + USERS_USER_NAME_COLUMN + ") as " + USERS_USER_NAME_COLUMN + "," +
+            "                min(" + USERS_USER_ID_COLUMN + ") as min_user_id" +
+            "              from " + USERS_TABLE +
+            "              group by lower(" + USERS_USER_NAME_COLUMN + ")" +
+            "            ) as t2 on (lower(u1." + USERS_USER_NAME_COLUMN + ") = lower(t2." + USERS_USER_NAME_COLUMN + "))" +
+            "        ) as t1 on (u." + USERS_USER_ID_COLUMN + " = t1.min_user_id)" +
+            "    ) as t on (ap." + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN + " = t.orig_principal_id);");
+
+    // Truncate existing adminprivilege records
+    dbAccessor.truncateTable(ADMINPRIVILEGE_TABLE);
+
+    // Insert temporary records into adminprivilege table
+    /*
+     * Copy the generated data to the original <code>adminprivilege</code> table, effectively skipping
+     * duplicate records.
+     */
+    dbAccessor.executeUpdate(
+        "insert into " + ADMINPRIVILEGE_TABLE + " (" + ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN + ", " + ADMINPRIVILEGE_PERMISSION_ID_COLUMN + ", " + ADMINPRIVILEGE_RESOURCE_ID_COLUMN + ", " + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN + ")" +
+            "  select " +
+            "    min(" + ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN + ")," +
+            "    " + ADMINPRIVILEGE_PERMISSION_ID_COLUMN + "," +
+            "    " + ADMINPRIVILEGE_RESOURCE_ID_COLUMN + "," +
+            "    " + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN +
+            "  from " + temporaryTable +
+            "  group by " + ADMINPRIVILEGE_PERMISSION_ID_COLUMN + ", " + ADMINPRIVILEGE_RESOURCE_ID_COLUMN + ", " + ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN);
+
+    // Delete the temporary table
+    dbAccessor.dropTable(temporaryTable);
   }
 
   protected void updateStageTable() throws SQLException {

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -285,8 +285,7 @@ CREATE TABLE user_authentication (
   create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
-  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users(user_id)
-);
+  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id));
 
 CREATE TABLE groups (
   group_id INTEGER,

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -301,11 +301,11 @@ CREATE TABLE user_authentication (
   user_authentication_id INTEGER,
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
-  authentication_key LONGBLOB,
+  authentication_key TEXT,
   create_time TIMESTAMP NOT NULL DEFAULT 0,
   update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
-  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users(user_id)
+  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
 CREATE TABLE groups (

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -281,11 +281,11 @@ CREATE TABLE user_authentication (
   user_authentication_id NUMBER(10),
   user_id NUMBER(10) NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
-  authentication_key BLOB,
+  authentication_key CLOB,
   create_time TIMESTAMP NULL,
   update_time TIMESTAMP NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
-  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users(user_id)
+  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
 CREATE TABLE groups (

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -282,12 +282,11 @@ CREATE TABLE user_authentication (
   user_authentication_id INTEGER,
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
-  authentication_key BYTEA,
+  authentication_key TEXT,
   create_time TIMESTAMP DEFAULT NOW(),
   update_time TIMESTAMP DEFAULT NOW(),
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
-  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users(user_id)
-);
+  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id));
 
 CREATE TABLE groups (
   group_id INTEGER,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -278,11 +278,11 @@ CREATE TABLE user_authentication (
   user_authentication_id INTEGER,
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
-  authentication_key IMAGE,
+  authentication_key TEXT,
   create_time TIMESTAMP DEFAULT NOW(),
   update_time TIMESTAMP DEFAULT NOW(),
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
-  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users(user_id)
+  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
 CREATE TABLE groups (

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -284,11 +284,11 @@ CREATE TABLE user_authentication (
   user_authentication_id INTEGER,
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
-  authentication_key VARCHAR(max),
+  authentication_key TEXT,
   create_time DATETIME DEFAULT GETDATE(),
   update_time DATETIME DEFAULT GETDATE(),
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
-  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users(user_id)
+  CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
 
 CREATE TABLE groups (

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/DBAccessorImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/DBAccessorImplTest.java
@@ -19,7 +19,9 @@
 package org.apache.ambari.server.orm;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.matchers.JUnitMatchers.containsString;
 
 import java.io.ByteArrayInputStream;
@@ -754,5 +756,33 @@ public class DBAccessorImplTest {
       targetTableName, targetColumn, "id", "initial");
 
     // should not result in exception due to unknown column in source table
+  }
+
+  @Test
+  public void testDbColumnInfoEqualsAndHash() {
+    DBColumnInfo column1 = new DBColumnInfo("col", String.class, null, null, false);
+    DBColumnInfo equalsColumn1 = new DBColumnInfo("col", String.class, null, null, false);
+    DBColumnInfo notEqualsColumn1Name = new DBColumnInfo("col1", String.class, null, null, false);
+    DBColumnInfo notEqualsColumn1Type = new DBColumnInfo("col", Integer.class, null, null, false);
+    DBColumnInfo notEqualsColumn1Length = new DBColumnInfo("col", String.class, 10, null, false);
+    DBColumnInfo notEqualsColumn1DefaultValue = new DBColumnInfo("col", String.class, null, "default", false);
+    DBColumnInfo notEqualsColumn1DefaultValueEmptyString = new DBColumnInfo("col", String.class, null, "", false);
+    DBColumnInfo notEqualsColumn1Nullable = new DBColumnInfo("col", String.class, null, null, true);
+
+    assertTrue(column1.hashCode() == equalsColumn1.hashCode());
+    assertFalse(column1.hashCode() == notEqualsColumn1Name.hashCode());
+    assertFalse(column1.hashCode() == notEqualsColumn1Type.hashCode());
+    assertFalse(column1.hashCode() == notEqualsColumn1Length.hashCode());
+    assertFalse(column1.hashCode() == notEqualsColumn1DefaultValue.hashCode());
+    assertTrue(column1.hashCode() == notEqualsColumn1DefaultValueEmptyString.hashCode()); // null and "" yield the same hashcode
+    assertFalse(column1.hashCode() == notEqualsColumn1Nullable.hashCode());
+
+    assertTrue(column1.equals(equalsColumn1));
+    assertFalse(column1.equals(notEqualsColumn1Name));
+    assertFalse(column1.equals(notEqualsColumn1Type));
+    assertFalse(column1.equals(notEqualsColumn1Length));
+    assertFalse(column1.equals(notEqualsColumn1DefaultValue));
+    assertFalse(column1.equals(notEqualsColumn1DefaultValueEmptyString));
+    assertFalse(column1.equals(notEqualsColumn1Nullable));
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderTest.java
@@ -191,7 +191,7 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
   public void testAuthenticate() throws Exception {
     assertNull("User alread exists in DB", userDAO.findUserByName("allowedUser"));
     UserEntity userEntity = users.createUser("allowedUser", null, null);
-    users.addLdapAuthentication(userEntity, "some dn");
+    users.addLdapAuthentication(userEntity, "uid=allowedUser,ou=people,dc=ambari,dc=apache,dc=org");
 
     UserEntity ldapUser = userDAO.findUserByName("allowedUser");
     Authentication authentication = new UsernamePasswordAuthenticationToken("allowedUser", "password");
@@ -218,7 +218,7 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
     // Given
     assertNull("User already exists in DB", userDAO.findUserByName("allowedUser@ambari.apache.org"));
     UserEntity userEntity = users.createUser("allowedUser@ambari.apache.org", null, null);
-    users.addLdapAuthentication(userEntity, "some dn");
+    users.addLdapAuthentication(userEntity, "uid=allowedUser,ou=people,dc=ambari,dc=apache,dc=org");
 
     Authentication authentication = new UsernamePasswordAuthenticationToken("allowedUser@ambari.apache.org", "password");
     authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog300Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog300Test.java
@@ -17,14 +17,7 @@
  */
 package org.apache.ambari.server.upgrade;
 
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.AMBARI_CONFIGURATION_TABLE;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.COMPONENT_DESIRED_STATE_TABLE;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.COMPONENT_STATE_TABLE;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.SECURITY_STATE_COLUMN;
-import static org.apache.ambari.server.upgrade.UpgradeCatalog300.SERVICE_DESIRED_STATE_TABLE;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog300.*;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.capture;
@@ -37,15 +30,21 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.startsWith;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.sql.Clob;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +52,7 @@ import javax.persistence.EntityManager;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.ActionManager;
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
@@ -69,6 +69,7 @@ import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
@@ -105,7 +106,7 @@ public class UpgradeCatalog300Test {
   @Mock(type = MockType.NICE)
   private EntityManager entityManager;
 
-  @Mock(type = MockType.NICE)
+  @Mock(type = MockType.DEFAULT)
   private DBAccessor dbAccessor;
 
   @Mock(type = MockType.NICE)
@@ -193,9 +194,21 @@ public class UpgradeCatalog300Test {
   public void testExecuteDDLUpdates() throws Exception {
     Module module = getTestGuiceModule();
 
+    // updateStageTable
+    Capture<DBAccessor.DBColumnInfo> updateStageTableCaptures = newCapture(CaptureType.ALL);
+    dbAccessor.addColumn(eq(STAGE_TABLE), capture(updateStageTableCaptures));
+    expectLastCall().once();
+    dbAccessor.addColumn(eq(STAGE_TABLE), capture(updateStageTableCaptures));
+    expectLastCall().once();
+    dbAccessor.addColumn(eq(REQUEST_TABLE), capture(updateStageTableCaptures));
+    expectLastCall().once();
+
+    // addOpsDisplayNameColumnToHostRoleCommand
     Capture<DBAccessor.DBColumnInfo> hrcOpsDisplayNameColumn = newCapture();
     dbAccessor.addColumn(eq(UpgradeCatalog300.HOST_ROLE_COMMAND_TABLE), capture(hrcOpsDisplayNameColumn));
+    expectLastCall().once();
 
+    // removeSecurityState
     dbAccessor.dropColumn(COMPONENT_DESIRED_STATE_TABLE, SECURITY_STATE_COLUMN);
     expectLastCall().once();
     dbAccessor.dropColumn(COMPONENT_STATE_TABLE, SECURITY_STATE_COLUMN);
@@ -203,20 +216,42 @@ public class UpgradeCatalog300Test {
     dbAccessor.dropColumn(SERVICE_DESIRED_STATE_TABLE, SECURITY_STATE_COLUMN);
     expectLastCall().once();
 
-    // Ambari configuration table addition...
+    // addAmbariConfigurationTable
     Capture<List<DBAccessor.DBColumnInfo>> ambariConfigurationTableColumns = newCapture();
-
     dbAccessor.createTable(eq(AMBARI_CONFIGURATION_TABLE), capture(ambariConfigurationTableColumns));
     expectLastCall().once();
     dbAccessor.addPKConstraint(AMBARI_CONFIGURATION_TABLE, "PK_ambari_configuration", AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN, AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN);
     expectLastCall().once();
-    // Ambari configuration table addition...
+
+    // upgradeUserTable - create user_authentication table
+    Capture<List<DBAccessor.DBColumnInfo>> createUserAuthenticationTableCaptures = newCapture(CaptureType.ALL);
+    Capture<List<DBAccessor.DBColumnInfo>> createMembersTableCaptures = newCapture(CaptureType.ALL);
+    Capture<List<DBAccessor.DBColumnInfo>> createAdminPrincipalTableCaptures = newCapture(CaptureType.ALL);
+    Capture<DBAccessor.DBColumnInfo> updateUserTableCaptures = newCapture(CaptureType.ALL);
+    Capture<DBAccessor.DBColumnInfo> alterUserTableCaptures = newCapture(CaptureType.ALL);
+
+    // Any return value will work here as long as a SQLException is not thrown.
+    expect(dbAccessor.getColumnType(USERS_TABLE, USERS_USER_TYPE_COLUMN)).andReturn(0).anyTimes();
+
+    prepareCreateUserAuthenticationTable(dbAccessor, createUserAuthenticationTableCaptures);
+    prepareUpdateGroupMembershipRecords(dbAccessor, createMembersTableCaptures);
+    prepareUpdateAdminPrivilegeRecords(dbAccessor, createAdminPrincipalTableCaptures);
+    prepareUpdateUsersTable(dbAccessor, updateUserTableCaptures, alterUserTableCaptures);
 
     replay(dbAccessor, configuration);
 
     Injector injector = Guice.createInjector(module);
     UpgradeCatalog300 upgradeCatalog300 = injector.getInstance(UpgradeCatalog300.class);
     upgradeCatalog300.executeDDLUpdates();
+
+    // Validate updateStageTableCaptures
+    Assert.assertTrue(updateStageTableCaptures.hasCaptured());
+    validateColumns(updateStageTableCaptures.getValues(),
+        Arrays.asList(
+            new DBAccessor.DBColumnInfo(STAGE_STATUS_COLUMN, String.class, 255, HostRoleStatus.PENDING, false),
+            new DBAccessor.DBColumnInfo(STAGE_DISPLAY_STATUS_COLUMN, String.class, 255, HostRoleStatus.PENDING, false),
+            new DBAccessor.DBColumnInfo(REQUEST_DISPLAY_STATUS_COLUMN, String.class, 255, HostRoleStatus.PENDING, false))
+    );
 
     DBAccessor.DBColumnInfo capturedOpsDisplayNameColumn = hrcOpsDisplayNameColumn.getValue();
     Assert.assertEquals(UpgradeCatalog300.HRC_OPS_DISPLAY_NAME_COLUMN, capturedOpsDisplayNameColumn.getName());
@@ -225,6 +260,13 @@ public class UpgradeCatalog300Test {
 
     // Ambari configuration table addition...
     Assert.assertTrue(ambariConfigurationTableColumns.hasCaptured());
+    validateColumns(ambariConfigurationTableColumns.getValue(),
+        Arrays.asList(
+            new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN, String.class, 100, null, false),
+            new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN, String.class, 100, null, false),
+            new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN, String.class, 255, null, true))
+    );
+
     List<DBAccessor.DBColumnInfo> columns = ambariConfigurationTableColumns.getValue();
     Assert.assertEquals(3, columns.size());
 
@@ -252,6 +294,11 @@ public class UpgradeCatalog300Test {
     }
     // Ambari configuration table addition...
 
+    validateCreateUserAuthenticationTable(createUserAuthenticationTableCaptures);
+    validateUpdateGroupMembershipRecords(createMembersTableCaptures);
+    validateUpdateAdminPrivilegeRecords(createAdminPrincipalTableCaptures);
+    validateUpdateUsersTable(updateUserTableCaptures, alterUserTableCaptures);
+
     verify(dbAccessor);
   }
 
@@ -268,6 +315,187 @@ public class UpgradeCatalog300Test {
     };
     return module;
   }
+
+  private void prepareCreateUserAuthenticationTable(DBAccessor dbAccessor, Capture<List<DBAccessor.DBColumnInfo>> capturedData)
+      throws SQLException {
+
+    String temporaryTableName = USER_AUTHENTICATION_TABLE + "_tmp";
+
+    dbAccessor.dropTable(eq(temporaryTableName));
+    expectLastCall().times(2);
+    dbAccessor.createTable(eq(temporaryTableName), capture(capturedData));
+    expectLastCall().once();
+
+    expect(dbAccessor.executeUpdate(startsWith("insert into " + temporaryTableName))).andReturn(1).once();
+    expect(dbAccessor.executeUpdate(startsWith("update " + temporaryTableName))).andReturn(1).once();
+
+    dbAccessor.createTable(eq(USER_AUTHENTICATION_TABLE), capture(capturedData));
+    expectLastCall().once();
+    dbAccessor.addPKConstraint(USER_AUTHENTICATION_TABLE, USER_AUTHENTICATION_PRIMARY_KEY, USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN);
+    expectLastCall().once();
+    dbAccessor.addFKConstraint(USER_AUTHENTICATION_TABLE, USER_AUTHENTICATION_USER_AUTHENTICATION_USERS_FOREIGN_KEY, USER_AUTHENTICATION_USER_ID_COLUMN, USERS_TABLE, USERS_USER_ID_COLUMN, false);
+    expectLastCall().once();
+
+    expect(dbAccessor.executeUpdate(startsWith("insert into " + USER_AUTHENTICATION_TABLE))).andReturn(1).once();
+  }
+
+  private void validateCreateUserAuthenticationTable(Capture<List<DBAccessor.DBColumnInfo>> capturedData) {
+    Assert.assertTrue(capturedData.hasCaptured());
+    List<List<DBAccessor.DBColumnInfo>> capturedValues = capturedData.getValues();
+    Assert.assertEquals(2, capturedValues.size());
+    for (List<DBAccessor.DBColumnInfo> capturedValue : capturedValues) {
+      validateColumns(capturedValue,
+          Arrays.asList(
+              new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_USER_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_AUTHENTICATION_TYPE_COLUMN, String.class, 50, null, false),
+              new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_AUTHENTICATION_KEY_COLUMN, Clob.class, null, null, true),
+              new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_CREATE_TIME_COLUMN, Timestamp.class, null, null, true),
+              new DBAccessor.DBColumnInfo(USER_AUTHENTICATION_UPDATE_TIME_COLUMN, Timestamp.class, null, null, true)
+          )
+      );
+    }
+  }
+
+  private void prepareUpdateGroupMembershipRecords(DBAccessor dbAccessor, Capture<List<DBAccessor.DBColumnInfo>> capturedData)
+      throws SQLException {
+    String temporaryTableName = MEMBERS_TABLE + "_tmp";
+
+    dbAccessor.dropTable(eq(temporaryTableName));
+    expectLastCall().times(2);
+    dbAccessor.createTable(eq(temporaryTableName), capture(capturedData));
+    expectLastCall().once();
+
+    expect(dbAccessor.executeUpdate(startsWith("insert into " + temporaryTableName))).andReturn(1).once();
+
+    dbAccessor.truncateTable(MEMBERS_TABLE);
+    expectLastCall().once();
+
+    expect(dbAccessor.executeUpdate(startsWith("insert into " + MEMBERS_TABLE))).andReturn(1).once();
+  }
+
+  private void validateUpdateGroupMembershipRecords(Capture<List<DBAccessor.DBColumnInfo>> capturedData) {
+    Assert.assertTrue(capturedData.hasCaptured());
+    List<List<DBAccessor.DBColumnInfo>> capturedValues = capturedData.getValues();
+    Assert.assertEquals(1, capturedValues.size());
+    for (List<DBAccessor.DBColumnInfo> capturedValue : capturedValues) {
+      validateColumns(capturedValue,
+          Arrays.asList(
+              new DBAccessor.DBColumnInfo(MEMBERS_MEMBER_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(MEMBERS_USER_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(MEMBERS_GROUP_ID_COLUMN, Long.class, null, null, false)
+          )
+      );
+    }
+  }
+
+  private void prepareUpdateAdminPrivilegeRecords(DBAccessor dbAccessor, Capture<List<DBAccessor.DBColumnInfo>> capturedData)
+      throws SQLException {
+    String temporaryTableName = ADMINPRIVILEGE_TABLE + "_tmp";
+
+    dbAccessor.dropTable(eq(temporaryTableName));
+    expectLastCall().times(2);
+    dbAccessor.createTable(eq(temporaryTableName), capture(capturedData));
+    expectLastCall().once();
+
+    expect(dbAccessor.executeUpdate(startsWith("insert into " + temporaryTableName))).andReturn(1).once();
+
+    dbAccessor.truncateTable(ADMINPRIVILEGE_TABLE);
+    expectLastCall().once();
+
+    expect(dbAccessor.executeUpdate(startsWith("insert into " + ADMINPRIVILEGE_TABLE))).andReturn(1).once();
+  }
+
+  private void validateUpdateAdminPrivilegeRecords(Capture<List<DBAccessor.DBColumnInfo>> capturedData) {
+    Assert.assertTrue(capturedData.hasCaptured());
+    List<List<DBAccessor.DBColumnInfo>> capturedValues = capturedData.getValues();
+    Assert.assertEquals(1, capturedValues.size());
+    for (List<DBAccessor.DBColumnInfo> capturedValue : capturedValues) {
+      validateColumns(capturedValue,
+          Arrays.asList(
+              new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_PRIVILEGE_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_PERMISSION_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_RESOURCE_ID_COLUMN, Long.class, null, null, false),
+              new DBAccessor.DBColumnInfo(ADMINPRIVILEGE_PRINCIPAL_ID_COLUMN, Long.class, null, null, false)
+          )
+      );
+    }
+  }
+
+  private void prepareUpdateUsersTable(DBAccessor dbAccessor, Capture<DBAccessor.DBColumnInfo> updateUserTableCaptures, Capture<DBAccessor.DBColumnInfo> alterUserTableCaptures)
+      throws SQLException {
+
+    expect(dbAccessor.executeUpdate(startsWith("delete from " + USERS_TABLE))).andReturn(1).once();
+
+    dbAccessor.dropUniqueConstraint(USERS_TABLE, UNIQUE_USERS_0_INDEX);
+    expectLastCall().once();
+    dbAccessor.dropColumn(USERS_TABLE, USERS_USER_TYPE_COLUMN);
+    expectLastCall().once();
+    dbAccessor.dropColumn(USERS_TABLE, USERS_LDAP_USER_COLUMN);
+    expectLastCall().once();
+    dbAccessor.dropColumn(USERS_TABLE, USERS_USER_PASSWORD_COLUMN);
+    expectLastCall().once();
+
+    dbAccessor.addColumn(eq(USERS_TABLE), capture(updateUserTableCaptures));
+    expectLastCall().atLeastOnce();
+
+    expect(dbAccessor.executeUpdate(startsWith("update " + USERS_TABLE))).andReturn(1).once();
+
+
+    dbAccessor.alterColumn(eq(USERS_TABLE), capture(alterUserTableCaptures));
+    expectLastCall().atLeastOnce();
+
+    dbAccessor.addUniqueConstraint(USERS_TABLE, UNIQUE_USERS_0_INDEX, USERS_USER_NAME_COLUMN);
+    expectLastCall().once();
+  }
+
+  private void validateUpdateUsersTable(Capture<DBAccessor.DBColumnInfo> updateUserTableCaptures, Capture<DBAccessor.DBColumnInfo> alterUserTableCaptures) {
+    Assert.assertTrue(updateUserTableCaptures.hasCaptured());
+    validateColumns(updateUserTableCaptures.getValues(),
+        Arrays.asList(
+            new DBAccessor.DBColumnInfo(USERS_CONSECUTIVE_FAILURES_COLUMN, Integer.class, null, 0, false),
+            new DBAccessor.DBColumnInfo(USERS_DISPLAY_NAME_COLUMN, String.class, 255, null, true),
+            new DBAccessor.DBColumnInfo(USERS_LOCAL_USERNAME_COLUMN, String.class, 255, null, true),
+            new DBAccessor.DBColumnInfo(USERS_VERSION_COLUMN, Long.class, null, 0, false)
+        )
+    );
+
+    Assert.assertTrue(alterUserTableCaptures.hasCaptured());
+    validateColumns(alterUserTableCaptures.getValues(),
+        Arrays.asList(
+            new DBAccessor.DBColumnInfo(USERS_DISPLAY_NAME_COLUMN, String.class, 255, null, false),
+            new DBAccessor.DBColumnInfo(USERS_LOCAL_USERNAME_COLUMN, String.class, 255, null, false)
+        )
+    );
+  }
+
+  private void validateColumns(List<DBAccessor.DBColumnInfo> capturedColumns, List<DBAccessor.DBColumnInfo> expectedColumns) {
+    Assert.assertEquals(expectedColumns.size(), capturedColumns.size());
+
+    // copy these so we can alter them...
+    expectedColumns = new ArrayList<>(expectedColumns);
+    capturedColumns = new ArrayList<>(capturedColumns);
+
+    Iterator<DBAccessor.DBColumnInfo> capturedColumnIterator = capturedColumns.iterator();
+    while (capturedColumnIterator.hasNext()) {
+      DBAccessor.DBColumnInfo capturedColumnInfo = capturedColumnIterator.next();
+
+      Iterator<DBAccessor.DBColumnInfo> expectedColumnIterator = expectedColumns.iterator();
+      while (expectedColumnIterator.hasNext()) {
+        DBAccessor.DBColumnInfo expectedColumnInfo = expectedColumnIterator.next();
+
+        if (expectedColumnInfo.equals(capturedColumnInfo)) {
+          expectedColumnIterator.remove();
+          capturedColumnIterator.remove();
+          break;
+        }
+      }
+    }
+
+    assertTrue("Not all captured columns were expected", capturedColumns.isEmpty());
+    assertTrue("Not all expected columns were captured", expectedColumns.isEmpty());
+  }
+
 
   @Test
   public void testLogSearchUpdateConfigs() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate data from the users table (pre-Ambari 3.0.0) to the updated users table and user_authentication tables.  This includes migrating data in the `memebers` and `adminpriviliges` tables so that records reflect merged user accounts. 

## How was this patch tested?

Manually tested using various upgrade scenarios. 
