### PR TITLE
[AMBARI-22809] Tez shown in red in the left nav for no apparent reason…

### DIFF
--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -1144,7 +1144,7 @@ a.services-menu-blocks{
     margin-left: 4px;
     margin-right: 4px;
   }
-  .menu-item-name.INSTALLED {
+  .menu-item-name.INSTALLED:not(.client-only-service) {
     color: @health-status-red;
   }
   .menu-item-name.UNKNOWN {

--- a/ambari-web/app/templates/main/service/menu_item.hbs
+++ b/ambari-web/app/templates/main/service/menu_item.hbs
@@ -23,7 +23,7 @@
   {{#if view.content.alertsCount}}
     <span {{bindAttr class=":icon-circle view.hasCriticalAlerts:service-alerts-critical:service-alerts-warning"}}></span>
   {{/if}}
-  <span {{bindAttr class=":menu-item-name view.content.workStatus" data-original-title="view.content.toolTipContent"}} rel="serviceHealthTooltip">
+  <span {{bindAttr class="view.isClientOnlyService:client-only-service :menu-item-name view.content.workStatus" data-original-title="view.content.toolTipContent"}} rel="serviceHealthTooltip">
       {{unbound view.content.displayName}}
   </span>
 </a>

--- a/ambari-web/app/views/main/menu.js
+++ b/ambari-web/app/views/main/menu.js
@@ -216,6 +216,10 @@ App.SideNavServiceMenuView = Em.CollectionView.extend({
 
     hasCriticalAlerts: Em.computed.alias('content.hasCriticalAlerts'),
 
+    isClientOnlyService : function(){
+      return App.get('services.clientOnly').contains(this.get('content.serviceName'));
+    }.property('content.serviceName'),
+
     isConfigurable: function () {
       return !App.get('services.noConfigTypes').contains(this.get('content.serviceName'));
     }.property('App.services.noConfigTypes','content.serviceName'),


### PR DESCRIPTION
… (alexantonenko)

## What changes were proposed in this pull request?
Client only services are displaying in right colors if they are in "INSTALLED" state

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.