### PR TITLE
[AMBARI-22806] Unable to delete files from HDFS using Ambari File View …

### DIFF
--- a/contrib/views/commons/src/main/java/org/apache/ambari/view/commons/hdfs/FileOperationService.java
+++ b/contrib/views/commons/src/main/java/org/apache/ambari/view/commons/hdfs/FileOperationService.java
@@ -323,7 +323,7 @@ public class FileOperationService extends HdfsService {
    * @param request remove request
    * @return response with success
    */
-  @DELETE
+  @POST
   @Path("/moveToTrash")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
@@ -380,7 +380,7 @@ public class FileOperationService extends HdfsService {
    * @param request remove request
    * @return response with success
    */
-  @DELETE
+  @POST
   @Path("/remove")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)

--- a/contrib/views/files/src/main/resources/ui/app/services/file-operation.js
+++ b/contrib/views/files/src/main/resources/ui/app/services/file-operation.js
@@ -72,7 +72,7 @@ export default Ember.Service.extend(FileOperationMixin, {
     };
     var adapter = this.get('store').adapterFor('file');
     return new Ember.RSVP.Promise((resolve, reject) => {
-      adapter.ajax(opsUrl, "DELETE", {data: data}).then(
+      adapter.ajax(opsUrl, "POST", {data: data}).then(
         (response) => {
           return resolve(response);
         }, (rejectResponse) => {


### PR DESCRIPTION
…when Ambari Views is accessed via Knox(Venkata Sairam)

## What changes were proposed in this pull request?

The HTTP request is changed from delete to post as knox will discard http body for delete call.

## How was this patch tested?

Manual testing done to verify and sanity tests are run for files view.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@gauravn7 @nitirajrathore @pallavkul @padmapriyanitt @dipayanb @r-kamath 