### PR TITLE
[AMBARI-22805] Blueprints do not handle some failures properly

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CalculatedStatus.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CalculatedStatus.java
@@ -54,7 +54,7 @@ public class CalculatedStatus {
   private final double percent;
 
   /**
-   * A status which represents a COMPLETED state at 0%
+   * A status which represents a COMPLETED state at 100%
    */
   public static final CalculatedStatus COMPLETED = new CalculatedStatus(HostRoleStatus.COMPLETED,
       HostRoleStatus.COMPLETED, 100.0);
@@ -64,6 +64,11 @@ public class CalculatedStatus {
    */
   public static final CalculatedStatus PENDING = new CalculatedStatus(HostRoleStatus.PENDING,
       HostRoleStatus.PENDING, 0.0);
+
+  /**
+   * A status which represents an ABORTED state at -1%
+   */
+  public static final CalculatedStatus ABORTED = new CalculatedStatus(HostRoleStatus.ABORTED, HostRoleStatus.ABORTED, -1);
 
   // ----- Constructors ------------------------------------------------------
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -795,31 +795,18 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       @Override
       public RequestStageContainer invoke() throws AmbariException {
         RequestStageContainer stageContainer = null;
-        int retriesRemaining = 100;
-        do {
-          try {
-            stageContainer = updateHostComponents(stages, requests, request.getRequestInfoProperties(),
-                runSmokeTest);
-          } catch (Exception e) {
-            if (--retriesRemaining == 0) {
-              LOG.info("Caught an exception while updating host components, will not try again: {}", e.getMessage(), e);
-              // !!! IllegalArgumentException results in a 400 response, RuntimeException results in 500.
-              if (IllegalArgumentException.class.isInstance(e)) {
-                throw (IllegalArgumentException) e;
-              } else {
-                throw new RuntimeException("Update Host request submission failed: " + e, e);
-              }
-            } else {
-              LOG.info("Caught an exception while updating host components, retrying : " + e);
-              try {
-                Thread.sleep(250);
-              } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("Update Host request submission failed: " + e, e);
-              }
-            }
+        try {
+          stageContainer = updateHostComponents(stages, requests, request.getRequestInfoProperties(),
+              runSmokeTest);
+        } catch (Exception e) {
+          LOG.info("Caught an exception while updating host components, will not try again: {}", e.getMessage(), e);
+          // !!! IllegalArgumentException results in a 400 response, RuntimeException results in 500.
+          if (e instanceof IllegalArgumentException) {
+            throw (IllegalArgumentException) e;
+          } else {
+            throw new RuntimeException("Update Host request submission failed: " + e, e);
           }
-        } while (stageContainer == null);
+        }
 
         return stageContainer;
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/TopologyHostRequestEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/TopologyHostRequestEntity.java
@@ -17,11 +17,13 @@
  */
 package org.apache.ambari.server.orm.entities;
 
+import java.util.Collection;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -29,8 +31,8 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.TableGenerator;
-import java.util.Collection;
+
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
 
 @Entity
 @Table(name = "topology_host_request")
@@ -48,6 +50,13 @@ public class TopologyHostRequestEntity {
 
   @Column(name = "host_name", length = 255)
   private String hostName;
+
+  @Column(name = "status")
+  @Enumerated(EnumType.STRING)
+  private HostRoleStatus status;
+
+  @Column(name = "status_message")
+  private String statusMessage;
 
   @ManyToOne
   @JoinColumn(name = "logical_request_id", referencedColumnName = "id", nullable = false)
@@ -90,6 +99,22 @@ public class TopologyHostRequestEntity {
 
   public void setHostName(String hostName) {
     this.hostName = hostName;
+  }
+
+  public HostRoleStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(HostRoleStatus status) {
+    this.status = status;
+  }
+
+  public String getStatusMessage() {
+    return statusMessage;
+  }
+
+  public void setStatusMessage(String statusMessage) {
+    this.statusMessage = statusMessage;
   }
 
   public TopologyLogicalRequestEntity getTopologyLogicalRequestEntity() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostOfferResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostOfferResponse.java
@@ -22,7 +22,8 @@ package org.apache.ambari.server.topology;
 import java.util.List;
 import java.util.concurrent.Executor;
 
-import org.apache.ambari.server.topology.tasks.TopologyTask;
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
+import org.apache.ambari.server.topology.tasks.TopologyHostTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +41,9 @@ final class HostOfferResponse {
   private final Answer answer;
   private final String hostGroupName;
   private final long hostRequestId;
-  private final List<TopologyTask> tasks;
+  private final List<TopologyHostTask> tasks;
 
-  static HostOfferResponse createAcceptedResponse(long hostRequestId, String hostGroupName, List<TopologyTask> tasks) {
+  static HostOfferResponse createAcceptedResponse(long hostRequestId, String hostGroupName, List<TopologyHostTask> tasks) {
     return new HostOfferResponse(Answer.ACCEPTED, hostRequestId, hostGroupName, tasks);
   }
 
@@ -50,7 +51,7 @@ final class HostOfferResponse {
     this(answer, -1, null, null);
   }
 
-  private HostOfferResponse(Answer answer, long hostRequestId, String hostGroupName, List<TopologyTask> tasks) {
+  private HostOfferResponse(Answer answer, long hostRequestId, String hostGroupName, List<TopologyHostTask> tasks) {
     this.answer = answer;
     this.hostRequestId = hostRequestId;
     this.hostGroupName = hostGroupName;
@@ -78,12 +79,20 @@ final class HostOfferResponse {
       executor.execute(new Runnable() {
         @Override
         public void run() {
-          for (TopologyTask task : tasks) {
-            LOG.info("Running task for accepted host offer for hostname = {}, task = {}", hostName, task.getType());
-            task.run();
+          for (TopologyHostTask task : tasks) {
+            try {
+              LOG.info("Running task for accepted host offer for hostname = {}, task = {}", hostName, task.getType());
+              task.run();
+            } catch (Exception e) {
+              HostRequest hostRequest = task.getHostRequest();
+              LOG.error("{} task for host {} failed due to", task.getType(), hostRequest.getHostName(), e);
+              hostRequest.markHostRequestFailed(HostRoleStatus.ABORTED, e, ambariContext.getPersistedTopologyState());
+              break;
+            }
           }
         }
       });
     }
   }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/PersistedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/PersistedState.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.controller.internal.BaseClusterRequest;
 import org.apache.ambari.server.state.Host;
 
@@ -86,4 +87,8 @@ public interface PersistedState {
    */
   void removeHostRequests(long logicalRequestId, Collection<HostRequest> hostRequests);
 
+  /**
+   * Update the status of the given host request.
+   */
+  void setHostRequestStatus(long hostRequestId, HostRoleStatus status, String message);
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/PersistedStateImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/PersistedStateImpl.java
@@ -28,6 +28,7 @@ import javax.inject.Singleton;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.api.predicate.InvalidQueryException;
 import org.apache.ambari.server.controller.internal.BaseClusterRequest;
 import org.apache.ambari.server.orm.dao.HostDAO;
@@ -138,6 +139,16 @@ public class PersistedStateImpl implements PersistedState {
       Long topologyRequestId = logicalRequest.getTopologyRequestId();
       topologyLogicalRequestDAO.remove(logicalRequest);
       topologyRequestDAO.removeByPK(topologyRequestId);
+    }
+  }
+
+  @Override
+  public void setHostRequestStatus(long hostRequestId, HostRoleStatus status, String message) {
+    TopologyHostRequestEntity hostRequestEntity = hostRequestDAO.findById(hostRequestId);
+    if (hostRequestEntity != null) {
+      hostRequestEntity.setStatus(status);
+      hostRequestEntity.setStatusMessage(message);
+      hostRequestDAO.merge(hostRequestEntity);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/tasks/TopologyHostTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/tasks/TopologyHostTask.java
@@ -39,6 +39,10 @@ public abstract class TopologyHostTask implements TopologyTask {
     this.hostRequest = hostRequest;
   }
 
+  public HostRequest getHostRequest() {
+    return hostRequest;
+  }
+
   /**
    * Run with an InternalAuthenticationToken as when running these tasks we might not have any active security context.
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/tasks/TopologyTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/tasks/TopologyTask.java
@@ -19,6 +19,12 @@
 
 package org.apache.ambari.server.topology.tasks;
 
+import java.util.Set;
+
+import org.apache.ambari.server.RoleCommand;
+
+import com.google.common.collect.ImmutableSet;
+
 /**
  * Task which is executed by the TopologyManager.
  */
@@ -26,11 +32,23 @@ public interface TopologyTask extends Runnable {
   /**
    * Task type.
    */
-  public enum Type {
+  enum Type {
     RESOURCE_CREATION,
     CONFIGURE,
     INSTALL,
-    START
+    START {
+      @Override
+      public Set<RoleCommand> tasksToAbortOnFailure() {
+        return ImmutableSet.of(RoleCommand.START);
+      }
+    },
+    ;
+
+    private static Set<RoleCommand> ALL_TASKS = ImmutableSet.of(RoleCommand.INSTALL, RoleCommand.START);
+
+    public Set<RoleCommand> tasksToAbortOnFailure() {
+      return ALL_TASKS;
+    }
   }
 
   /**
@@ -38,5 +56,5 @@ public interface TopologyTask extends Runnable {
    *
    * @return the type of task
    */
-  public Type getType();
+  Type getType();
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
@@ -190,6 +190,7 @@ public class SchemaUpgradeHelper {
       catalogBinder.addBinding().to(UpgradeCatalog252.class);
       catalogBinder.addBinding().to(UpgradeCatalog260.class);
       catalogBinder.addBinding().to(UpgradeCatalog261.class);
+      catalogBinder.addBinding().to(UpgradeCatalog262.class);
       catalogBinder.addBinding().to(UpdateAlertScriptPaths.class);
       catalogBinder.addBinding().to(FinalUpgradeCatalog.class);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog262.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog262.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.upgrade;
+
+import java.sql.SQLException;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.orm.DBAccessor;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+/**
+ * The {@link UpgradeCatalog262} upgrades Ambari from 2.6.1 to 2.6.2.
+ */
+public class UpgradeCatalog262 extends AbstractUpgradeCatalog {
+
+  private static final String HOST_REQUEST_TABLE = "topology_host_request";
+  private static final String STATUS_COLUMN = "status";
+  private static final String STATUS_MESSAGE_COLUMN = "status_message";
+
+  @Inject
+  public UpgradeCatalog262(Injector injector) {
+    super(injector);
+  }
+
+  @Override
+  public String getSourceVersion() {
+    return "2.6.1";
+  }
+
+  @Override
+  public String getTargetVersion() {
+    return "2.6.2";
+  }
+
+  @Override
+  protected void executeDDLUpdates() throws AmbariException, SQLException {
+    addHostRequestStatusColumn();
+  }
+
+  private void addHostRequestStatusColumn() throws SQLException {
+    dbAccessor.addColumn(HOST_REQUEST_TABLE, new DBAccessor.DBColumnInfo(STATUS_COLUMN, String.class, 255, null, true));
+    dbAccessor.addColumn(HOST_REQUEST_TABLE, new DBAccessor.DBColumnInfo(STATUS_MESSAGE_COLUMN, String.class, 1024, null, true));
+  }
+
+  @Override
+  protected void executePreDMLUpdates() throws AmbariException, SQLException {
+  }
+
+  @Override
+  protected void executeDMLUpdates() throws AmbariException, SQLException {
+  }
+
+}

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -756,6 +756,8 @@ CREATE TABLE topology_host_request (
   group_id BIGINT NOT NULL,
   stage_id BIGINT NOT NULL,
   host_name VARCHAR(255),
+  status VARCHAR(255),
+  status_message VARCHAR(1024),
   CONSTRAINT PK_topology_host_request PRIMARY KEY (id),
   CONSTRAINT FK_hostreq_group_id FOREIGN KEY (group_id) REFERENCES topology_hostgroup(id),
   CONSTRAINT FK_hostreq_logicalreq_id FOREIGN KEY (logical_request_id) REFERENCES topology_logical_request(id));

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -773,6 +773,8 @@ CREATE TABLE topology_host_request (
   group_id BIGINT NOT NULL,
   stage_id BIGINT NOT NULL,
   host_name VARCHAR(255),
+  status VARCHAR(255),
+  status_message VARCHAR(1024),
   CONSTRAINT PK_topology_host_request PRIMARY KEY (id),
   CONSTRAINT FK_hostreq_group_id FOREIGN KEY (group_id) REFERENCES topology_hostgroup(id),
   CONSTRAINT FK_hostreq_logicalreq_id FOREIGN KEY (logical_request_id) REFERENCES topology_logical_request(id));

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -752,6 +752,8 @@ CREATE TABLE topology_host_request (
   group_id NUMBER(19) NOT NULL,
   stage_id NUMBER(19) NOT NULL,
   host_name VARCHAR(255),
+  status VARCHAR2(255),
+  status_message VARCHAR2(1024),
   CONSTRAINT PK_topology_host_request PRIMARY KEY (id),
   CONSTRAINT FK_hostreq_group_id FOREIGN KEY (group_id) REFERENCES topology_hostgroup(id),
   CONSTRAINT FK_hostreq_logicalreq_id FOREIGN KEY (logical_request_id) REFERENCES topology_logical_request(id));

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -754,6 +754,8 @@ CREATE TABLE topology_host_request (
   group_id BIGINT NOT NULL,
   stage_id BIGINT NOT NULL,
   host_name VARCHAR(255),
+  status VARCHAR(255),
+  status_message VARCHAR(1024),
   CONSTRAINT PK_topology_host_request PRIMARY KEY (id),
   CONSTRAINT FK_hostreq_group_id FOREIGN KEY (group_id) REFERENCES topology_hostgroup(id),
   CONSTRAINT FK_hostreq_logicalreq_id FOREIGN KEY (logical_request_id) REFERENCES topology_logical_request(id));

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -750,6 +750,8 @@ CREATE TABLE topology_host_request (
   group_id NUMERIC(19) NOT NULL,
   stage_id NUMERIC(19) NOT NULL,
   host_name VARCHAR(255),
+  status VARCHAR(255),
+  status_message VARCHAR(1024),
   CONSTRAINT PK_topology_host_request PRIMARY KEY (id),
   CONSTRAINT FK_hostreq_group_id FOREIGN KEY (group_id) REFERENCES topology_hostgroup(id),
   CONSTRAINT FK_hostreq_logicalreq_id FOREIGN KEY (logical_request_id) REFERENCES topology_logical_request(id));

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -771,6 +771,8 @@ CREATE TABLE topology_host_request (
   group_id BIGINT NOT NULL,
   stage_id BIGINT NOT NULL,
   host_name VARCHAR(255),
+  status VARCHAR(255),
+  status_message VARCHAR(1024),
   CONSTRAINT PK_topology_host_request PRIMARY KEY CLUSTERED (id),
   CONSTRAINT FK_hostreq_group_id FOREIGN KEY (group_id) REFERENCES topology_hostgroup(id),
   CONSTRAINT FK_hostreq_logicalreq_id FOREIGN KEY (logical_request_id) REFERENCES topology_logical_request(id));

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
@@ -79,7 +79,7 @@ import org.apache.ambari.server.topology.LogicalRequest;
 import org.apache.ambari.server.topology.PersistedState;
 import org.apache.ambari.server.topology.TopologyManager;
 import org.apache.ambari.server.topology.TopologyRequest;
-import org.apache.ambari.server.topology.tasks.TopologyTask;
+import org.apache.ambari.server.topology.tasks.TopologyHostTask;
 import org.apache.ambari.server.utils.EventBusSynchronizer;
 import org.junit.After;
 import org.junit.Before;
@@ -650,7 +650,7 @@ public class ClustersTest {
     expect(hr.getHostgroupName()).andReturn("MyHostGroup").anyTimes();
     expect(hr.getHostName()).andReturn(hostName).anyTimes();
     expect(hr.getStageId()).andReturn(1L);
-    expect(hr.getTopologyTasks()).andReturn(Collections.<TopologyTask>emptyList());
+    expect(hr.getTopologyTasks()).andReturn(Collections.<TopologyHostTask>emptyList());
 
     replay(hr);
     return hr;

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ConfigureClusterTaskTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ConfigureClusterTaskTest.java
@@ -35,6 +35,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.google.common.base.Functions;
+
 /**
  * Unit test for the ConfigureClusterTask class.
  * As business methods of this class don't return values, the assertions are made by verifying method calls on mocks.
@@ -93,7 +95,7 @@ public class ConfigureClusterTaskTest extends EasyMockSupport {
     clusterConfigurationRequest.process();
     replayAll();
 
-    AsyncCallableService<Boolean> asyncService = new AsyncCallableService<>(testSubject, 5000, 500, "test");
+    AsyncCallableService<Boolean> asyncService = new AsyncCallableService<>(testSubject, 5000, 500, "test", Functions.<Throwable>identity());
 
     // WHEN
     asyncService.call();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -403,6 +403,7 @@ public class TopologyManagerTest {
     List<LogicalRequest> requestList = new ArrayList<>();
     requestList.add(logicalRequest);
     expect(logicalRequest.hasPendingHostRequests()).andReturn(false).anyTimes();
+    expect(logicalRequest.isFinished()).andReturn(false).anyTimes();
     allRequests.put(clusterTopologyMock, requestList);
     expect(requestStatusResponse.getTasks()).andReturn(Collections.<ShortTaskStatus>emptyList()).anyTimes();
     expect(clusterTopologyMock.isClusterKerberosEnabled()).andReturn(true);
@@ -437,6 +438,8 @@ public class TopologyManagerTest {
     expect(persistedState.getAllRequests()).andReturn(Collections.<ClusterTopology,
             List<LogicalRequest>>emptyMap()).anyTimes();
     expect(persistedState.getProvisionRequest(CLUSTER_ID)).andReturn(logicalRequest).anyTimes();
+    expect(logicalRequest.isFinished()).andReturn(true).anyTimes();
+    expect(logicalRequest.isSuccessful()).andReturn(true).anyTimes();
     replayAll();
     topologyManager.provisionCluster(request);
     requestFinished();
@@ -460,6 +463,8 @@ public class TopologyManagerTest {
     expect(persistedState.getAllRequests()).andReturn(Collections.<ClusterTopology,
             List<LogicalRequest>>emptyMap()).anyTimes();
     expect(persistedState.getProvisionRequest(CLUSTER_ID)).andReturn(logicalRequest).anyTimes();
+    expect(logicalRequest.isFinished()).andReturn(true).anyTimes();
+    expect(logicalRequest.isSuccessful()).andReturn(false).anyTimes();
     replayAll();
     topologyManager.provisionCluster(request);
     requestFinished();
@@ -483,6 +488,7 @@ public class TopologyManagerTest {
     expect(persistedState.getAllRequests()).andReturn(Collections.<ClusterTopology,
             List<LogicalRequest>>emptyMap()).anyTimes();
     expect(persistedState.getProvisionRequest(CLUSTER_ID)).andReturn(logicalRequest).anyTimes();
+    expect(logicalRequest.isFinished()).andReturn(false).anyTimes();
     replayAll();
     topologyManager.provisionCluster(request);
     requestFinished();
@@ -523,6 +529,7 @@ public class TopologyManagerTest {
     expect(persistedState.getProvisionRequest(CLUSTER_ID)).andReturn(logicalRequest).anyTimes();
     expect(logicalRequest.hasPendingHostRequests()).andReturn(true).anyTimes();
     expect(logicalRequest.getCompletedHostRequests()).andReturn(Collections.EMPTY_LIST).anyTimes();
+    expect(logicalRequest.isFinished()).andReturn(true).anyTimes();
     expect(requestStatusResponse.getTasks()).andReturn(tasks).anyTimes();
     replayAll();
     EasyMock.replay(clusterTopologyMock);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce ABORTED state for topology host requests (cluster creation, scale hosts) to handle errors that happen in the pre-stage phase (during configure cluster task and other topology tasks).  Return such state and cause of failure in `requests` API (cause is returned in `request_context`).

https://issues.apache.org/jira/browse/AMBARI-22805

## How was this patch tested?

Tested the following scenarios:

 * cluster installation from scratch:
   * successful one
   * with wrong Kerberos admin credential
   * invalid blueprint (no NAMENODE)
 * upscale cluster:
   * directly after install
   * scale request before restart, agent started after server restart
   * both scale request and agent start issued after restart
 * upscale cluster with missing Kerberos credentials (same scenarios)
 * upgrade from Ambari 2.6.1
 * upscale cluster after upgrade

Unit tests:

```
...
Tests run: 4943, Failures: 0, Errors: 0, Skipped: 34
...
Total run:1201
Total errors:0
Total failures:0
OK
...
BUILD SUCCESS
```

Sample failed cluster creation:

```
{
  "href" : "http://localhost:8080/api/v1/clusters/TEST/requests/1",
  "Requests" : {
    "cluster_name" : "TEST",
    "id" : 1,
    "progress_percent" : -1.0,
    "request_context" : "Logical Request: Provision Cluster 'TEST'\nFAILED: Missing KDC administrator credentials.",
    "request_status" : "ABORTED"
  }
}
```

@rnettleton @mhmxs