### PR TITLE
[AMBARI-21613] Checkstyle fix (unused import)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatProcessor.java
@@ -19,7 +19,6 @@ package org.apache.ambari.server.agent;
 
 
 import static org.apache.ambari.server.controller.KerberosHelperImpl.CHECK_KEYTABS;
-import static org.apache.ambari.server.controller.KerberosHelperImpl.REMOVE_KEYTAB;
 import static org.apache.ambari.server.controller.KerberosHelperImpl.SET_KEYTAB;
 
 import java.util.ArrayList;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix checkstyle error due to unused import.

```
$ mvn -am -pl ambari-server -DskipTests -Drat.skip clean test
...
[INFO] Starting audit...
[ERROR] ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatProcessor.java:22:15: Unused import - org.apache.ambari.server.controller.KerberosHelperImpl.REMOVE_KEYTAB. [UnusedImports]
Audit done.
```

## How was this patch tested?

```
$ mvn -am -pl ambari-server -DskipTests -Drat.skip clean test
...
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
```