### PR TITLE
[AMBARI-22820] Fix KerberosOperationHandlerTests due to changes from AMBARI-22697

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/ADKerberosOperationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/ADKerberosOperationHandlerTest.java
@@ -29,6 +29,7 @@ import static org.easymock.EasyMock.replay;
 
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,12 +72,14 @@ public class ADKerberosOperationHandlerTest extends KerberosOperationHandlerTest
   private static final String DEFAULT_LDAP_URL = "ldaps://10.0.100.4";
   private static final String DEFAULT_PRINCIPAL_CONTAINER_DN = "ou=HDP,DC=HDP01,DC=LOCAL";
   private static final String DEFAULT_REALM = "HDP01.LOCAL";
-  private static final Map<String, String> KERBEROS_ENV_MAP = new HashMap<String, String>() {
-    {
-      put(ADKerberosOperationHandler.KERBEROS_ENV_PRINCIPAL_CONTAINER_DN, DEFAULT_PRINCIPAL_CONTAINER_DN);
-      put(ADKerberosOperationHandler.KERBEROS_ENV_LDAP_URL, DEFAULT_LDAP_URL);
-    }
-  };
+  private static final Map<String, String> KERBEROS_ENV_MAP;
+
+  static {
+    Map<String, String> map = new HashMap<>(DEFAULT_KERBEROS_ENV_MAP);
+    map.put(ADKerberosOperationHandler.KERBEROS_ENV_PRINCIPAL_CONTAINER_DN, DEFAULT_PRINCIPAL_CONTAINER_DN);
+    map.put(ADKerberosOperationHandler.KERBEROS_ENV_LDAP_URL, DEFAULT_LDAP_URL);
+    KERBEROS_ENV_MAP = Collections.unmodifiableMap(map);
+  }
 
   private static Method methodCreateInitialLdapContext;
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandlerTest.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,16 +40,16 @@ import com.google.inject.Injector;
 
 public class IPAKerberosOperationHandlerTest extends KDCKerberosOperationHandlerTest {
 
-  private static final Map<String, String> KERBEROS_ENV_MAP = new HashMap<String, String>() {
-    {
-      put(IPAKerberosOperationHandler.KERBEROS_ENV_ENCRYPTION_TYPES, null);
-      put(IPAKerberosOperationHandler.KERBEROS_ENV_KDC_HOSTS, "localhost");
-      put(IPAKerberosOperationHandler.KERBEROS_ENV_ADMIN_SERVER_HOST, "localhost");
-      put(IPAKerberosOperationHandler.KERBEROS_ENV_USER_PRINCIPAL_GROUP, "");
-    }
-  };
-
   private static Injector injector;
+
+  private static final Map<String, String> KERBEROS_ENV_MAP;
+
+  static {
+    Map<String, String> map = new HashMap<>(DEFAULT_KERBEROS_ENV_MAP);
+    map.put(IPAKerberosOperationHandler.KERBEROS_ENV_USER_PRINCIPAL_GROUP, "");
+    KERBEROS_ENV_MAP = Collections.unmodifiableMap(map);
+  }
+
 
   @BeforeClass
   public static void beforeIPAKerberosOperationHandlerTest() throws Exception {

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandlerTest.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.serveraction.kerberos;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,15 @@ public abstract class KerberosOperationHandlerTest extends EasyMockSupport {
   static final String DEFAULT_ADMIN_PASSWORD = "hadoop";
   static final String DEFAULT_REALM = "EXAMPLE.COM";
   static final PrincipalKeyCredential DEFAULT_ADMIN_CREDENTIALS = new PrincipalKeyCredential(DEFAULT_ADMIN_PRINCIPAL, DEFAULT_ADMIN_PASSWORD);
+  static final Map<String, String> DEFAULT_KERBEROS_ENV_MAP;
+
+  static {
+    Map<String, String> map = new HashMap<>();
+    map.put(KerberosOperationHandler.KERBEROS_ENV_ENCRYPTION_TYPES, "aes des3-cbc-sha1 rc4 des-cbc-md5");
+    map.put(IPAKerberosOperationHandler.KERBEROS_ENV_KDC_HOSTS, "localhost");
+    map.put(IPAKerberosOperationHandler.KERBEROS_ENV_ADMIN_SERVER_HOST, "localhost");
+    DEFAULT_KERBEROS_ENV_MAP = Collections.unmodifiableMap(map);
+  }
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandlerTest.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.newCapture;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,21 +46,19 @@ import junit.framework.Assert;
 
 public class MITKerberosOperationHandlerTest extends KDCKerberosOperationHandlerTest {
 
-  private static final Map<String, String> KERBEROS_ENV_MAP = new HashMap<String, String>() {
-    {
-      put(MITKerberosOperationHandler.KERBEROS_ENV_ENCRYPTION_TYPES, null);
-      put(MITKerberosOperationHandler.KERBEROS_ENV_KDC_HOSTS, "localhost");
-      put(MITKerberosOperationHandler.KERBEROS_ENV_ADMIN_SERVER_HOST, "localhost");
-      put(MITKerberosOperationHandler.KERBEROS_ENV_AD_CREATE_ATTRIBUTES_TEMPLATE, "AD Create Template");
-      put(MITKerberosOperationHandler.KERBEROS_ENV_KDC_CREATE_ATTRIBUTES, "-attr1 -attr2 foo=345");
-    }
-  };
-
   private static Method methodIsOpen;
 
   private static Method methodPrincipalExists;
 
   private static Method methodInvokeKAdmin;
+
+  private static final Map<String, String> KERBEROS_ENV_MAP;
+
+  static {
+    Map<String, String> map = new HashMap<>(DEFAULT_KERBEROS_ENV_MAP);
+    map.put(MITKerberosOperationHandler.KERBEROS_ENV_KDC_CREATE_ATTRIBUTES, "-attr1 -attr2 foo=345");
+    KERBEROS_ENV_MAP = Collections.unmodifiableMap(map);
+  }
 
   private Injector injector;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix KerberosOperationHandlerTests due to changes from AMBARI-22697.

Fixes include add the `kerberos-env/encryption_types` property to the data used when initializing the relevant Kerberos operation handler during the unit test cases. 

## How was this patch tested?

Executed `mvn clean test package -pl ambari-server`

#### Results:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 28:34 min
[INFO] Finished at: 2018-01-20T15:38:17-05:00
[INFO] Final Memory: 109M/1972M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.