### PR TITLE
[AMBARI-22716] zeppelin.livy.url is not getting updated after moving livy to a new host

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
@@ -394,6 +394,12 @@ class Master(Script):
          content=json.dumps(config_data, indent=2))
 
     if params.conf_stored_in_hdfs:
+      #delete file from HDFS, as the `replace_existing_files` logic checks length of file which can remain same.
+      params.HdfsResource(self.get_zeppelin_conf_FS(params),
+                          type="file",
+                          action="delete_on_execute")
+
+      #recreate file in HDFS from LocalFS
       params.HdfsResource(self.get_zeppelin_conf_FS(params),
                           type="file",
                           action="create_on_execute",

--- a/ambari-server/src/test/python/stacks/2.6/ZEPPELIN/test_zeppelin_070.py
+++ b/ambari-server/src/test/python/stacks/2.6/ZEPPELIN/test_zeppelin_070.py
@@ -367,6 +367,21 @@ class TestZeppelin070(RMFTestCase):
                           mode=0644
                           )
 
+    self.assertResourceCalled('HdfsResource',
+                              'hdfs:///user/zeppelin/conf/interpreter.json',
+                              security_enabled=False,
+                              hadoop_bin_dir='/usr/hdp/2.5.0.0-1235/hadoop/bin',
+                              keytab=UnknownConfigurationMock(),
+                              default_fs='hdfs://c6401.ambari.apache.org:8020',
+                              hdfs_resource_ignore_file='/var/lib/ambari-agent/data/.hdfs_resource_ignore',
+                              hdfs_site={u'a': u'b'},
+                              kinit_path_local='/usr/bin/kinit',
+                              principal_name=UnknownConfigurationMock(),
+                              user='hdfs',
+                              hadoop_conf_dir='/usr/hdp/2.5.0.0-1235/hadoop/conf',
+                              type='file',
+                              action=['delete_on_execute'],
+                              )
 
     self.assertResourceCalled('HdfsResource',
                               'hdfs:///user/zeppelin/conf/interpreter.json',
@@ -401,6 +416,22 @@ class TestZeppelin070(RMFTestCase):
                               security_enabled=False,
                               hadoop_bin_dir='/usr/hdp/2.5.0.0-1235/hadoop/bin',
                               keytab=UnknownConfigurationMock(),
+                              default_fs='hdfs://c6401.ambari.apache.org:8020',
+                              hdfs_resource_ignore_file='/var/lib/ambari-agent/data/.hdfs_resource_ignore',
+                              hdfs_site={u'a': u'b'},
+                              kinit_path_local='/usr/bin/kinit',
+                              principal_name=UnknownConfigurationMock(),
+                              user='hdfs',
+                              hadoop_conf_dir='/usr/hdp/2.5.0.0-1235/hadoop/conf',
+                              type='file',
+                              action=['delete_on_execute'],
+                              )
+
+    self.assertResourceCalled('HdfsResource',
+                              'hdfs:///user/zeppelin/conf/interpreter.json',
+                              security_enabled=False,
+                              hadoop_bin_dir='/usr/hdp/2.5.0.0-1235/hadoop/bin',
+                              keytab=UnknownConfigurationMock(),
                               source='/etc/zeppelin/conf/interpreter.json',
                               default_fs='hdfs://c6401.ambari.apache.org:8020',
                               replace_existing_files=True,
@@ -422,6 +453,22 @@ class TestZeppelin070(RMFTestCase):
                               owner='zeppelin',
                               group='zeppelin',
                               mode=0644
+                              )
+
+    self.assertResourceCalled('HdfsResource',
+                              'hdfs:///user/zeppelin/conf/interpreter.json',
+                              security_enabled=False,
+                              hadoop_bin_dir='/usr/hdp/2.5.0.0-1235/hadoop/bin',
+                              keytab=UnknownConfigurationMock(),
+                              default_fs='hdfs://c6401.ambari.apache.org:8020',
+                              hdfs_resource_ignore_file='/var/lib/ambari-agent/data/.hdfs_resource_ignore',
+                              hdfs_site={u'a': u'b'},
+                              kinit_path_local='/usr/bin/kinit',
+                              principal_name=UnknownConfigurationMock(),
+                              user='hdfs',
+                              hadoop_conf_dir='/usr/hdp/2.5.0.0-1235/hadoop/conf',
+                              type='file',
+                              action=['delete_on_execute'],
                               )
 
     self.assertResourceCalled('HdfsResource', 'hdfs:///user/zeppelin/conf/interpreter.json',


### PR DESCRIPTION
## What changes were proposed in this pull request?
zeppelin.livy.url is not getting updated after moving livy to a new host

## How was this patch tested?
Manually
zeppelin.livy.url is not getting updated after moving livy to a new host


Steps to reproduce :
1) Create a cluster with both Spark and Spark2 component
2) Delete livy component from current host.
3) Add the livy component on a new host
4) Restart zeppelin server. 
5) Now check the zeppelin interpreter settings. zeppelin.livy.url is still referring to older livy host. 
Its not reflecting the new livy server address.


Note 1 : If I restart zeppelin server after step1 (ie after deleting the livy host) before performing rest of the steps, then changes are getting reflected properly. System test was mistakenly doing this step so didn't fail during nightly run


Note 2 : Issue is happening only when both Spark and Spark2 are installed. If cluster contains only Spark2, this feature works as expected.
Issue is coming if I add Spark(version 1) to it.