### PR TITLE
[AMBARI-22716] zeppelin.livy.url is not getting updated after moving livy to a new host #161

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
@@ -388,6 +388,12 @@ class Master(Script):
          content=json.dumps(config_data, indent=2))
 
     if params.conf_stored_in_hdfs:
+      #delete file from HDFS, as the `replace_existing_files` logic checks length of file which can remain same.
+      params.HdfsResource(self.get_zeppelin_conf_FS(params),
+                          type="file",
+                          action="delete_on_execute")
+
+      #recreate file in HDFS from LocalFS
       params.HdfsResource(self.get_zeppelin_conf_FS(params),
                           type="file",
                           action="create_on_execute",


### PR DESCRIPTION
## What changes were proposed in this pull request?
zeppelin.livy.url is not getting updated after moving livy to a new host


## How was this patch tested?
Manually
zeppelin.livy.url is not getting updated after moving livy to a new host

Steps to reproduce :

Create a cluster with both Spark and Spark2 component
Delete livy component from current host.
Add the livy component on a new host
Restart zeppelin server.
Now check the zeppelin interpreter settings. zeppelin.livy.url is still referring to older livy host.
Its not reflecting the new livy server address.
Note 1 : If I restart zeppelin server after step1 (ie after deleting the livy host) before performing rest of the steps, then changes are getting reflected properly. System test was mistakenly doing this step so didn't fail during nightly run

Note 2 : Issue is happening only when both Spark and Spark2 are installed. If cluster contains only Spark2, this feature works as expected.
Issue is coming if I add Spark(version 1) to it.