### PR TITLE
AMBARI-22696 Whitelist execute latency from Storm Ambari metrics

### DIFF
--- a/ambari-server/src/main/resources/common-services/STORM/1.0.1/configuration/storm-site.xml
+++ b/ambari-server/src/main/resources/common-services/STORM/1.0.1/configuration/storm-site.xml
@@ -128,7 +128,7 @@
   </property>
   <property>
     <name>topology.metrics.consumer.register</name>
-    <value>[{"class": "org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsSink", "parallelism.hint": 1, "whitelist": ["kafkaOffset\\..+/", "__complete-latency", "__process-latency", "__receive\\.population$", "__sendqueue\\.population$", "__execute-count", "__emit-count", "__ack-count", "__fail-count", "memory/heap\\.usedBytes$", "memory/nonHeap\\.usedBytes$", "GC/.+\\.count$", "GC/.+\\.timeMs$"]}]</value>
+    <value>[{"class": "org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsSink", "parallelism.hint": 1, "whitelist": ["kafkaOffset\\..+/", "__complete-latency", "__process-latency", "__execute-latency", "__receive\\.population$", "__sendqueue\\.population$", "__execute-count", "__emit-count", "__ack-count", "__fail-count", "memory/heap\\.usedBytes$", "memory/nonHeap\\.usedBytes$", "GC/.+\\.count$", "GC/.+\\.timeMs$"]}]</value>
     <description></description>
     <value-attributes>
       <overridable>false</overridable>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/stack_advisor.py
@@ -542,6 +542,7 @@ class HDP25StackAdvisor(HDP24StackAdvisor):
                            '[{"class": "org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsSink", '
                            '"parallelism.hint": 1, '
                            '"whitelist": ["kafkaOffset\\\..+/", "__complete-latency", "__process-latency", '
+                           '"__execute-latency", '
                            '"__receive\\\.population$", "__sendqueue\\\.population$", "__execute-count", "__emit-count", '
                            '"__ack-count", "__fail-count", "memory/heap\\\.usedBytes$", "memory/nonHeap\\\.usedBytes$", '
                            '"GC/.+\\\.count$", "GC/.+\\\.timeMs$"]}]')

--- a/ambari-server/src/test/python/stacks/2.5/common/test_stack_advisor.py
+++ b/ambari-server/src/test/python/stacks/2.5/common/test_stack_advisor.py
@@ -6040,6 +6040,7 @@ class TestHDP25StackAdvisor(TestCase):
     self.assertEquals(configurations['storm-site']['properties']['topology.metrics.consumer.register'], '[{"class": "org.apache.hadoop.metrics2.sink.storm.StormTimelineMetricsSink", '
                                                                                                       '"parallelism.hint": 1, '
                                                                                                       '"whitelist": ["kafkaOffset\\\..+/", "__complete-latency", "__process-latency", '
+                                                                                                      '"__execute-latency", '
                                                                                                       '"__receive\\\.population$", "__sendqueue\\\.population$", "__execute-count", "__emit-count", '
                                                                                                       '"__ack-count", "__fail-count", "memory/heap\\\.usedBytes$", "memory/nonHeap\\\.usedBytes$", '
                                                                                                       '"GC/.+\\\.count$", "GC/.+\\\.timeMs$"]}]')


### PR DESCRIPTION
## What changes were proposed in this pull request?

Execute latency is added to whitelist for Storm Ambari metrics, which enables Storm to publish execute latency to AMS and enables AMS to serve it as well.

## How was this patch tested?

Unit tests done. Basically it is just an addition to existing configuration.

This is same patch against branch-2.6. The patch against trunk is #169.