### PR TITLE
[AMBARI-22829] Add --noproxy option to curl command

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
@@ -216,7 +216,7 @@ class WebHDFSUtil:
     for k,v in request_args.iteritems():
       url = format("{url}&{k}={v}")
     
-    cmd = ["curl", "-sS","-L", "-w", "%{http_code}", "-X", method]
+    cmd = ["curl", "--noproxy", "*", "-sS","-L", "-w", "%{http_code}", "-X", method]
 
     # When operation is "OPEN" the target is actually the DFS file to download and the file_to_put is actually the target see _download_file
     if operation == "OPEN":


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR includes the changes to prevent services depending on HDFS from failing on start up when the Ambari installation is behind a corporate proxy. Adding the --noproxy option to the curl command avoids this problem.

## How was this patch tested?

This patch has been manually tested in a production cluster deployment. Before the change we were not able to deploy any service that depends on HDFS. After applying this change to descriptor the services were installed without any problems.