### PR TITLE
[AMBARI-22815]   Change requiredServices in metainfo xml

### DIFF
--- a/ambari-funtest/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
@@ -57,7 +57,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
@@ -55,7 +55,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
@@ -57,7 +57,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
@@ -55,7 +55,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
@@ -118,8 +118,14 @@
         <timeout>50</timeout>
       </commandScript>
       <requiredServices>
-        <service>HDFS</service>
-        <service>TEZ</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       <configuration-dependencies>
         <config-type>global</config-type>

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
@@ -120,11 +120,11 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       <configuration-dependencies>

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
@@ -116,7 +116,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+          <service>
+              <name>ZOOKEEPER</name>
+              <scope>INSTALL</scope>
+          </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-funtest/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
@@ -118,7 +118,7 @@
       <requiredServices>
           <service>
               <name>ZOOKEEPER</name>
-              <scope>INSTALL</scope>
+              <dependencyType>INSTALL</dependencyType>
           </service>
       </requiredServices>
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.state.CustomCommandDefinition;
+import org.apache.ambari.server.state.RequiredService;
 import org.apache.ambari.server.state.ServiceInfo;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -48,7 +49,7 @@ public class StackServiceResponse {
 
   private Set<String> excludedConfigTypes;
 
-  private List<String> requiredServices;
+  private List<RequiredService> requiredServices;
 
   private Map<String, String> serviceProperties;
 
@@ -208,11 +209,11 @@ public class StackServiceResponse {
   }
 
   @ApiModelProperty(name = "required_services")
-  public List<String> getRequiredServices() {
+  public List<RequiredService> getRequiredServices() {
     return requiredServices;
   }
 
-  public void setRequiredServices(List<String> requiredServices) {
+  public void setRequiredServices(List<RequiredService> requiredServices) {
     this.requiredServices = requiredServices;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/RequiredService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/RequiredService.java
@@ -37,9 +37,9 @@ public class RequiredService {
     this.name = name;
   }
 
-  public RequiredService(String name, Scope scope) {
+  public RequiredService(String name, ServiceDependencyType dependencyType) {
     this.name = name;
-    this.scope = scope;
+    this.dependencyType = dependencyType;
   }
 
   /**
@@ -47,34 +47,17 @@ public class RequiredService {
    */
   private String name;
   /**
-   * Required service scope
+   * Required service dependency type
    * By default is set to INSTALL
    */
-  private Scope scope = Scope.INSTALL;
+  private ServiceDependencyType dependencyType = ServiceDependencyType.INSTALL;
 
   public String getName() {
     return name;
   }
 
-  public Scope getScope() {
-    return scope;
-  }
-
-  /**
-   * Scope of the required service
-   * We could have an INSTALL time dependency (i.e. we should also install the dependent service)
-   * or a RUNTIME dependency (i.e. there should be a running instance of the service in the cluster)
-   */
-  public enum Scope {
-    /**
-     * We should also install the dependent service. Is used as a default scope
-     */
-    INSTALL,
-
-    /**
-     * There should be a running instance of the service in the cluster
-     */
-    RUNTIME
+  public ServiceDependencyType getDependencyType() {
+    return dependencyType;
   }
 }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/RequiredService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/RequiredService.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.state;
+
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+/**
+ * Required service
+ * Is defined for some services in the service level metainfo.xml
+ * Specifies required service name and scope
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RequiredService {
+
+  public RequiredService() {
+  }
+
+  public RequiredService(String name) {
+    this.name = name;
+  }
+
+  public RequiredService(String name, Scope scope) {
+    this.name = name;
+    this.scope = scope;
+  }
+
+  /**
+   * Required service name
+   */
+  private String name;
+  /**
+   * Required service scope
+   * By default is set to INSTALL
+   */
+  private Scope scope = Scope.INSTALL;
+
+  public String getName() {
+    return name;
+  }
+
+  public Scope getScope() {
+    return scope;
+  }
+
+  /**
+   * Scope of the required service
+   * We could have an INSTALL time dependency (i.e. we should also install the dependent service)
+   * or a RUNTIME dependency (i.e. there should be a running instance of the service in the cluster)
+   */
+  public enum Scope {
+    /**
+     * We should also install the dependent service. Is used as a default scope
+     */
+    INSTALL,
+
+    /**
+     * There should be a running instance of the service in the cluster
+     */
+    RUNTIME
+  }
+}
+

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceDependencyType.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceDependencyType.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.state;
+
+/**
+ * Dependency type of the required service
+ * We could have an INSTALL time dependency (i.e. we should also install the dependent service)
+ * or a RUNTIME dependency (i.e. there should be a running instance of the service in the cluster)
+ */
+public enum ServiceDependencyType {
+  /**
+   * We should also install the dependent service. Is used as a default scope
+   */
+  INSTALL,
+
+  /**
+   * There should be a running instance of the service in the cluster
+   */
+  RUNTIME
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -284,7 +284,7 @@ public class ServiceInfo implements Validable, Cloneable {
 
   @XmlElementWrapper(name="requiredServices")
   @XmlElement(name="service")
-  private List<String> requiredServices = new ArrayList<>();
+  private List<RequiredService> requiredServices = new ArrayList<>();
 
   /**
    * Meaning: stores subpath from stack root to exact directory, that contains
@@ -417,7 +417,7 @@ public class ServiceInfo implements Validable, Cloneable {
   public void setComment(String comment) {
     this.comment = comment;
   }
-  public List<String> getRequiredServices() {
+  public List<RequiredService> getRequiredServices() {
     return requiredServices;
   }
 
@@ -437,7 +437,7 @@ public class ServiceInfo implements Validable, Cloneable {
     this.metricsFileName = metricsFileName;
   }
 
-  public void setRequiredServices(List<String> requiredServices) {
+  public void setRequiredServices(List<RequiredService> requiredServices) {
     this.requiredServices = requiredServices;
   }
   public List<PropertyInfo> getProperties() {

--- a/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/metainfo.xml
@@ -195,8 +195,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/metainfo.xml
@@ -197,11 +197,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA/0.1.0/metainfo.xml
@@ -132,7 +132,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA/0.1.0/metainfo.xml
@@ -130,7 +130,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <themes>

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/metainfo.xml
@@ -221,7 +221,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/metainfo.xml
@@ -223,7 +223,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.2.5/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.2.5/metainfo.xml
@@ -61,7 +61,10 @@
       </quickLinksConfigurations>
 
       <requiredServices>
-        <service>KAFKA</service>
+        <service>
+          <name>KAFKA</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <themes>

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.2.5/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.2.5/metainfo.xml
@@ -63,7 +63,7 @@
       <requiredServices>
         <service>
           <name>KAFKA</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.3.0/metainfo.xml
@@ -119,7 +119,10 @@
       </quickLinksConfigurations>
 
       <requiredServices>
-        <service>KAFKA</service>
+        <service>
+          <name>KAFKA</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <themes>

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.3.0/metainfo.xml
@@ -121,7 +121,7 @@
       <requiredServices>
         <service>
           <name>KAFKA</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/DRUID/0.10.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/DRUID/0.10.1/metainfo.xml
@@ -201,7 +201,10 @@
         <timeout>300</timeout>
       </commandScript>
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       <configuration-dependencies>
         <config-type>druid-common</config-type>

--- a/ambari-server/src/main/resources/common-services/DRUID/0.10.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/DRUID/0.10.1/metainfo.xml
@@ -203,7 +203,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/FALCON/0.5.0.2.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/FALCON/0.5.0.2.1/metainfo.xml
@@ -114,7 +114,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>OOZIE</service>
+        <service>
+          <name>OOZIE</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/FALCON/0.5.0.2.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/FALCON/0.5.0.2.1/metainfo.xml
@@ -116,7 +116,7 @@
       <requiredServices>
         <service>
           <name>OOZIE</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/HAWQ/2.0.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HAWQ/2.0.0/metainfo.xml
@@ -158,7 +158,10 @@
       </components>
 
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <osSpecifics>

--- a/ambari-server/src/main/resources/common-services/HAWQ/2.0.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HAWQ/2.0.0/metainfo.xml
@@ -160,7 +160,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/metainfo.xml
@@ -151,8 +151,14 @@
       </commandScript>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/metainfo.xml
@@ -153,11 +153,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/metainfo.xml
@@ -170,8 +170,14 @@
       </commandScript>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/metainfo.xml
@@ -172,11 +172,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/metainfo.xml
@@ -332,15 +332,15 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/metainfo.xml
@@ -330,9 +330,18 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>YARN</service>
-        <service>TEZ</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/HIVE/2.1.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HIVE/2.1.0.3.0/metainfo.xml
@@ -489,23 +489,23 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>SLIDER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <!-- TODO AMBARI-20753
         Re-add after Pig service is being packaged.

--- a/ambari-server/src/main/resources/common-services/HIVE/2.1.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HIVE/2.1.0.3.0/metainfo.xml
@@ -487,15 +487,30 @@
       </quickLinksConfigurations>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
-        <service>YARN</service>
-        <service>TEZ</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>SLIDER</name>
+          <scope>INSTALL</scope>
+        </service>
         <!-- TODO AMBARI-20753
         Re-add after Pig service is being packaged.
         <service>PIG</service>
         -->
-        <service>SLIDER</service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.10.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.10.0.3.0/metainfo.xml
@@ -73,7 +73,7 @@
             <requiredServices>
                 <service>
                     <name>ZOOKEEPER</name>
-                    <scope>INSTALL</scope>
+                    <dependencyType>INSTALL</dependencyType>
                 </service>
             </requiredServices>
             <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.10.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.10.0.3.0/metainfo.xml
@@ -71,7 +71,10 @@
                 <timeout>300</timeout>
             </commandScript>
             <requiredServices>
-                <service>ZOOKEEPER</service>
+                <service>
+                    <name>ZOOKEEPER</name>
+                    <scope>INSTALL</scope>
+                </service>
             </requiredServices>
             <configuration-dependencies>
                 <config-type>kafka-broker</config-type>

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/metainfo.xml
@@ -73,7 +73,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/metainfo.xml
@@ -71,7 +71,10 @@
         <timeout>300</timeout>
       </commandScript>
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       <configuration-dependencies>
         <config-type>kafka-broker</config-type>

--- a/ambari-server/src/main/resources/common-services/MAHOUT/1.0.0.2.3/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/MAHOUT/1.0.0.2.3/metainfo.xml
@@ -66,7 +66,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/MAHOUT/1.0.0.2.3/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/MAHOUT/1.0.0.2.3/metainfo.xml
@@ -68,7 +68,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/metainfo.xml
@@ -154,7 +154,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/metainfo.xml
@@ -156,7 +156,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.2.3/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.2.3/metainfo.xml
@@ -161,7 +161,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.2.3/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.2.3/metainfo.xml
@@ -163,7 +163,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.3.0/metainfo.xml
@@ -167,7 +167,10 @@
       </quickLinksConfigurations>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
        <themes>

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.2.0.3.0/metainfo.xml
@@ -169,7 +169,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/PIG/0.12.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/PIG/0.12.0.2.0/metainfo.xml
@@ -72,7 +72,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/PIG/0.12.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/PIG/0.12.0.2.0/metainfo.xml
@@ -74,7 +74,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/PIG/0.16.1.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/PIG/0.16.1.3.0/metainfo.xml
@@ -86,8 +86,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
-        <service>TEZ</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/PIG/0.16.1.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/PIG/0.16.1.3.0/metainfo.xml
@@ -88,11 +88,11 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/PXF/3.0.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/PXF/3.0.0/metainfo.xml
@@ -45,7 +45,7 @@
       <requiredServices>
         <service>
           <name>HAWQ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/PXF/3.0.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/PXF/3.0.0/metainfo.xml
@@ -43,7 +43,10 @@
       </components>
 
       <requiredServices>
-         <service>HAWQ</service>
+        <service>
+          <name>HAWQ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <osSpecifics>

--- a/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/metainfo.xml
@@ -78,11 +78,11 @@
       <requiredServices>
         <service>
           <name>RANGER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       

--- a/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/metainfo.xml
@@ -76,8 +76,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>RANGER</service>
-        <service>HDFS</service>
+        <service>
+          <name>RANGER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       
     </service>

--- a/ambari-server/src/main/resources/common-services/RANGER_KMS/1.0.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/RANGER_KMS/1.0.0.3.0/metainfo.xml
@@ -97,11 +97,11 @@
       <requiredServices>
         <service>
           <name>RANGER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/RANGER_KMS/1.0.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/RANGER_KMS/1.0.0.3.0/metainfo.xml
@@ -95,8 +95,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>RANGER</service>
-        <service>HDFS</service>
+        <service>
+          <name>RANGER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <themes>

--- a/ambari-server/src/main/resources/common-services/SLIDER/0.60.0.2.2/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SLIDER/0.60.0.2.2/metainfo.xml
@@ -93,9 +93,18 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
-        <service>HDFS</service>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/SLIDER/0.60.0.2.2/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SLIDER/0.60.0.2.2/metainfo.xml
@@ -95,15 +95,15 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/SLIDER/0.91.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SLIDER/0.91.0.3.0/metainfo.xml
@@ -93,9 +93,18 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
-        <service>HDFS</service>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/SLIDER/0.91.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SLIDER/0.91.0.3.0/metainfo.xml
@@ -95,15 +95,15 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/metainfo.xml
@@ -149,11 +149,11 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/metainfo.xml
@@ -147,8 +147,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
-        <service>TEZ</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <osSpecifics>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.3.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.3.1/metainfo.xml
@@ -137,7 +137,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.3.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.3.1/metainfo.xml
@@ -135,7 +135,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
     </service>
   </services>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.4.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.4.1/metainfo.xml
@@ -95,7 +95,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.4.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.4.1/metainfo.xml
@@ -93,7 +93,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
     </service>
   </services>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.5.2/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.5.2/metainfo.xml
@@ -26,7 +26,10 @@
           <version>1.5.2</version>
           <extends>common-services/SPARK/1.4.1</extends>
           <requiredServices>
-            <service>YARN</service>
+              <service>
+                  <name>YARN</name>
+                  <scope>INSTALL</scope>
+              </service>
           </requiredServices>
           <!-- No new components compared to 1.4.1 -->
           <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.5.2/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.5.2/metainfo.xml
@@ -28,7 +28,7 @@
           <requiredServices>
               <service>
                   <name>YARN</name>
-                  <scope>INSTALL</scope>
+                  <dependencyType>INSTALL</dependencyType>
               </service>
           </requiredServices>
           <!-- No new components compared to 1.4.1 -->

--- a/ambari-server/src/main/resources/common-services/SPARK/1.6.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.6.0/metainfo.xml
@@ -36,9 +36,18 @@
             <config-type>spark-thrift-fairscheduler</config-type>
           </configuration-dependencies>
           <requiredServices>
-            <service>HDFS</service>
-            <service>YARN</service>
-            <service>HIVE</service>
+              <service>
+                  <name>HDFS</name>
+                  <scope>INSTALL</scope>
+              </service>
+              <service>
+                  <name>YARN</name>
+                  <scope>INSTALL</scope>
+              </service>
+              <service>
+                  <name>HIVE</name>
+                  <scope>INSTALL</scope>
+              </service>
           </requiredServices>
         </service>
     </services>

--- a/ambari-server/src/main/resources/common-services/SPARK/1.6.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.6.0/metainfo.xml
@@ -38,15 +38,15 @@
           <requiredServices>
               <service>
                   <name>HDFS</name>
-                  <scope>INSTALL</scope>
+                  <dependencyType>INSTALL</dependencyType>
               </service>
               <service>
                   <name>YARN</name>
-                  <scope>INSTALL</scope>
+                  <dependencyType>INSTALL</dependencyType>
               </service>
               <service>
                   <name>HIVE</name>
-                  <scope>INSTALL</scope>
+                  <dependencyType>INSTALL</dependencyType>
               </service>
           </requiredServices>
         </service>

--- a/ambari-server/src/main/resources/common-services/SPARK/2.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/2.2.0/metainfo.xml
@@ -235,9 +235,18 @@
       </commandScript>
 
       <requiredServices>
-        <service>HDFS</service>
-        <service>YARN</service>
-        <service>HIVE</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HIVE</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <!-- TODO, change these to "spark" and "livy" after RPM switches the name. -->

--- a/ambari-server/src/main/resources/common-services/SPARK/2.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK/2.2.0/metainfo.xml
@@ -237,15 +237,15 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HIVE</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/metainfo.xml
@@ -193,15 +193,15 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HIVE</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/metainfo.xml
@@ -191,9 +191,18 @@
       </commandScript>
 
       <requiredServices>
-        <service>HDFS</service>
-        <service>YARN</service>
-        <service>HIVE</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HIVE</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <osSpecifics>

--- a/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.2.0/metainfo.xml
@@ -84,7 +84,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.2.0/metainfo.xml
@@ -86,7 +86,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       

--- a/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.3.0/metainfo.xml
@@ -92,7 +92,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.3.0/metainfo.xml
@@ -94,7 +94,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       

--- a/ambari-server/src/main/resources/common-services/STORM/0.9.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/STORM/0.9.1/metainfo.xml
@@ -155,7 +155,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/STORM/0.9.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/STORM/0.9.1/metainfo.xml
@@ -153,7 +153,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/STORM/1.0.1.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/STORM/1.0.1.3.0/metainfo.xml
@@ -148,7 +148,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/STORM/1.0.1.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/STORM/1.0.1.3.0/metainfo.xml
@@ -150,7 +150,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/TEZ/0.4.0.2.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/TEZ/0.4.0.2.1/metainfo.xml
@@ -90,7 +90,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/TEZ/0.4.0.2.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/TEZ/0.4.0.2.1/metainfo.xml
@@ -92,7 +92,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/TEZ/0.9.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/TEZ/0.9.0.3.0/metainfo.xml
@@ -98,7 +98,10 @@
             </commandScript>
 
             <requiredServices>
-                <service>YARN</service>
+                <service>
+                    <name>YARN</name>
+                    <scope>INSTALL</scope>
+                </service>
             </requiredServices>
 
             <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/TEZ/0.9.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/TEZ/0.9.0.3.0/metainfo.xml
@@ -100,7 +100,7 @@
             <requiredServices>
                 <service>
                     <name>YARN</name>
-                    <scope>INSTALL</scope>
+                    <dependencyType>INSTALL</dependencyType>
                 </service>
             </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/metainfo.xml
@@ -163,9 +163,18 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
-        <service>MAPREDUCE2</service>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>MAPREDUCE2</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>
@@ -287,7 +296,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dir>configuration-mapred</configuration-dir>

--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/metainfo.xml
@@ -165,15 +165,15 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>MAPREDUCE2</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -298,7 +298,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/metainfo.xml
@@ -212,9 +212,18 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
-        <service>MAPREDUCE2</service>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>MAPREDUCE2</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <themes>
@@ -355,7 +364,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <themes-dir>themes-mapred</themes-dir>

--- a/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/metainfo.xml
@@ -214,15 +214,15 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>MAPREDUCE2</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -366,7 +366,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/metainfo.xml
@@ -81,7 +81,10 @@ limitations under the License.
       </commandScript>
 
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/metainfo.xml
@@ -83,7 +83,7 @@ limitations under the License.
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/metainfo.xml
@@ -81,7 +81,10 @@ limitations under the License.
       </commandScript>
 
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/metainfo.xml
@@ -83,7 +83,7 @@ limitations under the License.
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/FLUME/metainfo.xml
@@ -57,7 +57,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/FLUME/metainfo.xml
@@ -55,7 +55,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HBASE/metainfo.xml
@@ -137,11 +137,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HBASE/metainfo.xml
@@ -135,8 +135,14 @@
       </commandScript>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/metainfo.xml
@@ -246,7 +246,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/metainfo.xml
@@ -244,7 +244,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HIVE/metainfo.xml
@@ -273,7 +273,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>YARN</service>
       </requiredServices>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HIVE/metainfo.xml
@@ -271,7 +271,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
         <service>YARN</service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/OOZIE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/OOZIE/metainfo.xml
@@ -142,7 +142,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/OOZIE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/OOZIE/metainfo.xml
@@ -144,7 +144,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/PIG/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/PIG/metainfo.xml
@@ -71,7 +71,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/PIG/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/PIG/metainfo.xml
@@ -73,7 +73,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/YARN/metainfo.xml
@@ -170,7 +170,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -269,7 +269,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/YARN/metainfo.xml
@@ -168,7 +168,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>
@@ -264,7 +267,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dir>configuration-mapred</configuration-dir>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/HBASE/metainfo.xml
@@ -28,11 +28,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/HBASE/metainfo.xml
@@ -26,9 +26,15 @@
       <version>0.96.1.2.0.6.1</version>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>GLUSTERFS</service>
-      </requiredServices>      
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
+      </requiredServices>
     </service>
   </services>
 </metainfo>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/SQOOP/metainfo.xml
@@ -27,7 +27,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/SQOOP/metainfo.xml
@@ -25,8 +25,11 @@
       </comment>
       <version>1.4.4.2.0.6.0</version>
       <requiredServices>
-        <service>GLUSTERFS</service>
-      </requiredServices>      
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
+      </requiredServices>
     </service>
   </services>
 </metainfo>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/YARN/metainfo.xml
@@ -56,7 +56,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>GLUSTERFS</service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>
@@ -128,7 +131,10 @@
       <configuration-dir>configuration-mapred</configuration-dir>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6.GlusterFS/services/YARN/metainfo.xml
@@ -58,7 +58,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -133,7 +133,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FALCON/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FALCON/metainfo.xml
@@ -89,7 +89,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>OOZIE</service>
+        <service>
+          <name>OOZIE</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FALCON/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FALCON/metainfo.xml
@@ -91,7 +91,7 @@
       <requiredServices>
         <service>
           <name>OOZIE</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FLUME/metainfo.xml
@@ -26,7 +26,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/FLUME/metainfo.xml
@@ -24,8 +24,11 @@
       <version>1.4.0.2.1</version>
       
       <requiredServices>
-        <service>GLUSTERFS</service>
-      </requiredServices>      
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
+      </requiredServices>
     </service>
   </services>
 </metainfo>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/HBASE/metainfo.xml
@@ -28,11 +28,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/HBASE/metainfo.xml
@@ -26,9 +26,15 @@
       <version>0.98.0.2.1</version>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>GLUSTERFS</service>
-      </requiredServices>      
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
+      </requiredServices>
     </service>
   </services>
 </metainfo>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/SQOOP/metainfo.xml
@@ -25,7 +25,10 @@
       </comment>
       <version>1.4.4.2.1</version>
       <requiredServices>
-        <service>GLUSTERFS</service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>      
     </service>
   </services>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/SQOOP/metainfo.xml
@@ -27,7 +27,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>      
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/TEZ/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/TEZ/metainfo.xml
@@ -60,7 +60,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/TEZ/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/TEZ/metainfo.xml
@@ -62,7 +62,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/YARN/metainfo.xml
@@ -57,7 +57,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -132,7 +132,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.1.GlusterFS/services/YARN/metainfo.xml
@@ -55,7 +55,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>GLUSTERFS</service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>
@@ -127,7 +130,10 @@
       <configuration-dir>configuration-mapred</configuration-dir>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/HDP/2.2/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.2/services/HIVE/metainfo.xml
@@ -141,7 +141,7 @@
       <requiredServices>
         <service>
           <name>PIG</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.2/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.2/services/HIVE/metainfo.xml
@@ -139,7 +139,10 @@
       </themes>
 
       <requiredServices>
-        <service>PIG</service>
+        <service>
+          <name>PIG</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.2/services/PIG/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.2/services/PIG/metainfo.xml
@@ -43,7 +43,7 @@
       <requiredServices>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.2/services/PIG/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.2/services/PIG/metainfo.xml
@@ -41,7 +41,10 @@
         </osSpecific>
       </osSpecifics>
       <requiredServices>
-        <service>TEZ</service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
     </service>
   </services>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HBASE/metainfo.xml
@@ -49,8 +49,14 @@
         </component>
       </components>
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>ECS</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ECS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
     </service>
   </services>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HBASE/metainfo.xml
@@ -51,11 +51,11 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ECS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HIVE/metainfo.xml
@@ -80,9 +80,18 @@
 	  </components>
       
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>YARN</service>
-        <service>TEZ</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
             
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/HIVE/metainfo.xml
@@ -82,15 +82,15 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
             

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/YARN/metainfo.xml
@@ -25,15 +25,15 @@
       <requiredServices>
         <service>
           <name>ECS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>MAPREDUCE2</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       <components>
@@ -146,7 +146,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.ECS/services/YARN/metainfo.xml
@@ -23,9 +23,18 @@
       <name>YARN</name>
       <version>2.7.1.2.3</version>
       <requiredServices>
-        <service>ECS</service>
-        <service>MAPREDUCE2</service>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ECS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>MAPREDUCE2</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       <components>
         <component>
@@ -135,7 +144,10 @@
       </components>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dir>configuration-mapred</configuration-dir>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/ACCUMULO/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/ACCUMULO/metainfo.xml
@@ -41,7 +41,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/ACCUMULO/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/ACCUMULO/metainfo.xml
@@ -43,7 +43,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/FLUME/metainfo.xml
@@ -44,7 +44,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/FLUME/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/FLUME/metainfo.xml
@@ -42,7 +42,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>GLUSTERFS</service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/HBASE/metainfo.xml
@@ -50,7 +50,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/HBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/HBASE/metainfo.xml
@@ -48,7 +48,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SLIDER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SLIDER/metainfo.xml
@@ -47,8 +47,14 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>YARN</service>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SLIDER/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SLIDER/metainfo.xml
@@ -49,11 +49,11 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SQOOP/metainfo.xml
@@ -41,7 +41,10 @@
       </osSpecifics>
 
       <requiredServices>
-        <service>GLUSTERFS</service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>      
       
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SQOOP/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/SQOOP/metainfo.xml
@@ -43,7 +43,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>      
       

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/YARN/metainfo.xml
@@ -52,7 +52,10 @@
       </osSpecifics>
       
       <requiredServices>
-        <service>GLUSTERFS</service>
+        <service>
+          <name>GLUSTERFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>
@@ -88,7 +91,10 @@
       <configuration-dir>configuration-mapred</configuration-dir>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3.GlusterFS/services/YARN/metainfo.xml
@@ -54,7 +54,7 @@
       <requiredServices>
         <service>
           <name>GLUSTERFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -93,7 +93,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/metainfo.xml
@@ -133,12 +133,30 @@
       </quickLinksConfigurations>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
-        <service>YARN</service>
-        <service>TEZ</service>
-        <service>PIG</service>
-        <service>SLIDER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>PIG</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>SLIDER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       <osSpecifics>
         <osSpecific>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/metainfo.xml
@@ -135,27 +135,27 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>PIG</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>SLIDER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       <osSpecifics>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHBASE/metainfo.xml
@@ -189,11 +189,11 @@
       <requiredServices>
         <service>
           <name>FAKEZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>FAKEHDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHBASE/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHBASE/metainfo.xml
@@ -187,8 +187,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>FAKEZOOKEEPER</service>
-        <service>FAKEHDFS</service>
+        <service>
+          <name>FAKEZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>FAKEHDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
     </service>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHDFS/metainfo.xml
@@ -223,7 +223,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>FAKEZOOKEEPER</service>
+        <service>
+          <name>FAKEZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHDFS/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEHDFS/metainfo.xml
@@ -225,7 +225,7 @@
       <requiredServices>
         <service>
           <name>FAKEZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEYARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEYARN/metainfo.xml
@@ -219,8 +219,14 @@
       </commandScript>
 
       <requiredServices>
-        <service>FAKEHDFS</service>
-        <service>FAKEMAPREDUCE2</service>
+        <service>
+          <name>FAKEHDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>FAKEMAPREDUCE2</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <!-- No packages to install. -->
@@ -323,7 +329,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>FAKEYARN</service>
+        <service>
+          <name>FAKEYARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEYARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/services/FAKEYARN/metainfo.xml
@@ -221,11 +221,11 @@
       <requiredServices>
         <service>
           <name>FAKEHDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>FAKEMAPREDUCE2</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -331,7 +331,7 @@
       <requiredServices>
         <service>
           <name>FAKEYARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
@@ -46,6 +46,7 @@ import org.apache.ambari.server.state.CredentialStoreInfo;
 import org.apache.ambari.server.state.CustomCommandDefinition;
 import org.apache.ambari.server.state.OsSpecific;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.RequiredService;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.ServicePropertyInfo;
 import org.junit.Test;
@@ -141,9 +142,15 @@ public class ServiceModuleTest {
 
   @Test
   public void testResolve_RequiredServices() throws Exception {
-    List<String> requiredServices = new ArrayList<>();
-    requiredServices.add("foo");
-    requiredServices.add("bar");
+    List<RequiredService> requiredServices = new ArrayList<>();
+    //the default scope is INSTALL
+    RequiredService installService = new RequiredService("foo");
+    assertEquals(RequiredService.Scope.INSTALL, installService.getScope());
+
+    RequiredService runtimeService = new RequiredService("bar", RequiredService.Scope.RUNTIME);
+
+    requiredServices.add(installService);
+    requiredServices.add(runtimeService);
 
     // specified in child only
     ServiceInfo info = new ServiceInfo();
@@ -162,7 +169,7 @@ public class ServiceModuleTest {
 
     // specified in both
     info.setRequiredServices(requiredServices);
-    parentInfo.setRequiredServices(Collections.singletonList("other"));
+    parentInfo.setRequiredServices(Collections.singletonList(new RequiredService("other", RequiredService.Scope.INSTALL)));
 
     service = resolveService(info, parentInfo);
     assertEquals(requiredServices, service.getModuleInfo().getRequiredServices());

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.state.CustomCommandDefinition;
 import org.apache.ambari.server.state.OsSpecific;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.state.RequiredService;
+import org.apache.ambari.server.state.ServiceDependencyType;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.ServicePropertyInfo;
 import org.junit.Test;
@@ -145,9 +146,9 @@ public class ServiceModuleTest {
     List<RequiredService> requiredServices = new ArrayList<>();
     //the default scope is INSTALL
     RequiredService installService = new RequiredService("foo");
-    assertEquals(RequiredService.Scope.INSTALL, installService.getScope());
+    assertEquals(ServiceDependencyType.INSTALL, installService.getDependencyType());
 
-    RequiredService runtimeService = new RequiredService("bar", RequiredService.Scope.RUNTIME);
+    RequiredService runtimeService = new RequiredService("bar", ServiceDependencyType.RUNTIME);
 
     requiredServices.add(installService);
     requiredServices.add(runtimeService);
@@ -169,7 +170,7 @@ public class ServiceModuleTest {
 
     // specified in both
     info.setRequiredServices(requiredServices);
-    parentInfo.setRequiredServices(Collections.singletonList(new RequiredService("other", RequiredService.Scope.INSTALL)));
+    parentInfo.setRequiredServices(Collections.singletonList(new RequiredService("other", ServiceDependencyType.INSTALL)));
 
     service = resolveService(info, parentInfo);
     assertEquals(requiredServices, service.getModuleInfo().getRequiredServices());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceInfoTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceInfoTest.java
@@ -117,6 +117,48 @@ public class ServiceInfoTest {
   }
 
   @Test
+  public void testRequiredServices() throws Exception {
+
+    String serviceInfoXml = "<metainfo>\n" +
+            "  <schemaVersion>2.0</schemaVersion>\n" +
+            "  <services>\n" +
+            "    <service>\n" +
+            "      <name>CUSTOM</name>\n" +
+            "      <requiredServices>\n" +
+            "        <service>\n" +
+            "          <name>INSTALL_DEP</name>\n" +
+            "          <dependencyType>INSTALL</dependencyType>\n" +
+            "        </service>\n" +
+            "        <service>\n" +
+            "          <name>RUNTIME_DEP</name>\n" +
+            "          <dependencyType>RUNTIME</dependencyType>\n" +
+            "        </service>" +
+            "      </requiredServices>\n" +
+            "    </service>\n" +
+            "    <service>\n" +
+            "      <name>DEFAULT</name>\n" +
+            "    </service>\n" +
+            "  </services>\n" +
+            "</metainfo>\n";
+
+    Map<String, ServiceInfo> serviceInfoMap = getServiceInfo(serviceInfoXml);
+
+    List<RequiredService> requiredServices = serviceInfoMap.get("CUSTOM").getRequiredServices();
+    assertFalse(requiredServices.isEmpty());
+    assertEquals(2, requiredServices.size());
+    for (RequiredService requiredService : requiredServices) {
+      if (requiredService.getName().equals("INSTALL_DEP")) {
+        assertEquals(ServiceDependencyType.INSTALL, requiredService.getDependencyType());
+      }
+      if (requiredService.getName().equals("RUNTIME_DEP")) {
+        assertEquals(ServiceDependencyType.RUNTIME, requiredService.getDependencyType());
+      }
+    }
+
+    assertTrue(serviceInfoMap.get("DEFAULT").getRequiredServices().isEmpty());
+  }
+
+  @Test
   public void testSelectionField() throws Exception {
     String serviceInfoXmlDeprecated = "<metainfo>\n" +
         "  <schemaVersion>2.0</schemaVersion>\n" +

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
@@ -57,7 +57,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.6.1/services/FLUME/metainfo.xml
@@ -55,7 +55,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
@@ -57,7 +57,7 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/FLUME/metainfo.xml
@@ -55,7 +55,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
@@ -118,8 +118,14 @@
         <timeout>50</timeout>
       </commandScript>
       <requiredServices>
-        <service>HDFS</service>
-        <service>TEZ</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>TEZ</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
       <configuration-dependencies>
         <config-type>global</config-type>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/HBASE/metainfo.xml
@@ -120,11 +120,11 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>TEZ</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
       <configuration-dependencies>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/OOZIE/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/OOZIE/metainfo.xml
@@ -114,7 +114,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/OOZIE/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.7/services/OOZIE/metainfo.xml
@@ -116,7 +116,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
@@ -117,7 +117,7 @@
       <requiredServices>
         <service>
           <name>ZOOKEEPER</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/services/AMBARI_METRICS/metainfo.xml
@@ -115,7 +115,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>ZOOKEEPER</service>
+        <service>
+          <name>ZOOKEEPER</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>

--- a/contrib/management-packs/hdf-ambari-mpack/src/main/resources/common-services/NIFI/1.0.0/metainfo.xml
+++ b/contrib/management-packs/hdf-ambari-mpack/src/main/resources/common-services/NIFI/1.0.0/metainfo.xml
@@ -117,7 +117,10 @@
             </commandScript>
 
       	    <requiredServices>
-      	       <service>ZOOKEEPER</service>
+                <service>
+                    <name>ZOOKEEPER</name>
+                    <scope>INSTALL</scope>
+                </service>
       	    </requiredServices>
             
       	    <configuration-dependencies>

--- a/contrib/management-packs/hdf-ambari-mpack/src/main/resources/common-services/NIFI/1.0.0/metainfo.xml
+++ b/contrib/management-packs/hdf-ambari-mpack/src/main/resources/common-services/NIFI/1.0.0/metainfo.xml
@@ -119,7 +119,7 @@
       	    <requiredServices>
                 <service>
                     <name>ZOOKEEPER</name>
-                    <scope>INSTALL</scope>
+                    <dependencyType>INSTALL</dependencyType>
                 </service>
       	    </requiredServices>
             

--- a/contrib/management-packs/microsoft-r_mpack/src/main/resources/common-services/MICROSOFT_R_SERVER/8.0.5/metainfo.xml
+++ b/contrib/management-packs/microsoft-r_mpack/src/main/resources/common-services/MICROSOFT_R_SERVER/8.0.5/metainfo.xml
@@ -46,7 +46,10 @@
       </commandScript>
 
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
     </service>
   </services>

--- a/contrib/management-packs/microsoft-r_mpack/src/main/resources/common-services/MICROSOFT_R_SERVER/8.0.5/metainfo.xml
+++ b/contrib/management-packs/microsoft-r_mpack/src/main/resources/common-services/MICROSOFT_R_SERVER/8.0.5/metainfo.xml
@@ -48,7 +48,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
     </service>

--- a/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/HIVE/metainfo.xml
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/HIVE/metainfo.xml
@@ -351,9 +351,18 @@
         <timeout>300</timeout>
     </commandScript>
     <requiredServices>
-        <service>ZOOKEEPER</service>
-        <service>HDFS</service>
-        <service>YARN</service>
+        <service>
+            <name>ZOOKEEPER</name>
+            <scope>INSTALL</scope>
+        </service>
+        <service>
+            <name>HDFS</name>
+            <scope>INSTALL</scope>
+        </service>
+        <service>
+            <name>YARN</name>
+            <scope>INSTALL</scope>
+        </service>
     </requiredServices>
 </service></services>
 </metainfo>

--- a/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/HIVE/metainfo.xml
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/HIVE/metainfo.xml
@@ -353,15 +353,15 @@
     <requiredServices>
         <service>
             <name>ZOOKEEPER</name>
-            <scope>INSTALL</scope>
+            <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
             <name>HDFS</name>
-            <scope>INSTALL</scope>
+            <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
             <name>YARN</name>
-            <scope>INSTALL</scope>
+            <dependencyType>INSTALL</dependencyType>
         </service>
     </requiredServices>
 </service></services>

--- a/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/YARN/metainfo.xml
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/YARN/metainfo.xml
@@ -179,11 +179,11 @@
       <requiredServices>
         <service>
           <name>HDFS</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
         <service>
           <name>MAPREDUCE2</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 
@@ -295,7 +295,7 @@
       <requiredServices>
         <service>
           <name>YARN</name>
-          <scope>INSTALL</scope>
+          <dependencyType>INSTALL</dependencyType>
         </service>
       </requiredServices>
 

--- a/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/YARN/metainfo.xml
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/services/YARN/metainfo.xml
@@ -177,8 +177,14 @@
       </commandScript>
       
       <requiredServices>
-        <service>HDFS</service>
-        <service>MAPREDUCE2</service>
+        <service>
+          <name>HDFS</name>
+          <scope>INSTALL</scope>
+        </service>
+        <service>
+          <name>MAPREDUCE2</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dependencies>
@@ -287,7 +293,10 @@
       </commandScript>
       
       <requiredServices>
-        <service>YARN</service>
+        <service>
+          <name>YARN</name>
+          <scope>INSTALL</scope>
+        </service>
       </requiredServices>
 
       <configuration-dir>configuration-mapred</configuration-dir>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Today we define requiredServices as follows

<requiredServices>
    <service>ZOOKEEPER</service>
</requiredServices>

In the mpack model we need to categorize the scope of service dependency. We could have an INSTALL time dependency (i.e. we should also install the dependent service) or a RUNTIME dependency (i.e. there should be a running instance of the service in the cluster).

For example HIVE in EDW mpack, will have an install-time dependency on ZOOKEEPER-CLIENT but a RUNTIME dependency on ZOOKEEPER.

<requiredServices>
  <service>
      <name>ZOOKEEPER-CLIENT</name>
      <scope>INSTALL</scope>
   </service>
  <service>
      <name>ZOOKEEPER</name>
      <scope>RUNTIME</scope>
   </service>
</requiredServices>

## How was this patch tested?

Tested manually and with Unit tests