### PR TITLE
AMBARI-22833 : change commons-collections-3.2.1.jar being used by amb…

### DIFF
--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -178,6 +178,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.4</version>


### PR DESCRIPTION
…ari views to commons-collections-3.2.2.jar (nitirajrathore)

## What changes were proposed in this pull request?

overriding any usage of commons-collections-3.2.1 with commons-collections-3.2.2 by declaring in dependencyManagement of the parent pom.xml

## How was this patch tested?
[INFO] Reactor Summary:
[INFO]
[INFO] Ambari Contrib Views ............................... SUCCESS [ 36.159 s]
[INFO] Ambari View Utils .................................. SUCCESS [  2.676 s]
[INFO] Ambari View Commons ................................ SUCCESS [  0.256 s]
[INFO] Files .............................................. SUCCESS [ 25.960 s]
[INFO] Jobs ............................................... SUCCESS [  8.524 s]
[INFO] Pig ................................................ SUCCESS [ 45.662 s]
[INFO] Slider ............................................. SUCCESS [01:21 min]
[INFO] Capacity Scheduler ................................. SUCCESS [ 50.860 s]
[INFO] Tez ................................................ SUCCESS [  4.800 s]
[INFO] HAWQ ............................................... SUCCESS [01:06 min]
[INFO] Storm_Monitoring ................................... SUCCESS [  0.432 s]
[INFO] hueambarimigration ................................. SUCCESS [ 15.746 s]
[INFO] Hive Jdbc .......................................... SUCCESS [ 32.788 s]
[INFO] Hive 2.0 ........................................... SUCCESS [ 54.086 s]
[INFO] WF Manager View .................................... SUCCESS [ 49.994 s]
[INFO] Ambari Views Package ............................... SUCCESS [  0.041 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 07:56 min
[INFO] Finished at: 2018-01-25T12:12:04+05:30
[INFO] Final Memory: 90M/347M

and 
find . -iname "commons-collections-3.2.1*" 
gave empty results.

