### PR TITLE
AMBARI-22833 : change commons-collections-3.2.1.jar being used by amb…

### DIFF
--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -177,6 +177,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.4</version>


### PR DESCRIPTION
…ari views to commons-collections-3.2.2.jar (nitirajrathore)

## What changes were proposed in this pull request?

overriding any usage of commons-collections-3.2.1 with commons-collections-3.2.2 by declaring in dependencyManagement of the parent pom.xml

## How was this patch tested?

Based on tests and reviews of  https://github.com/apache/ambari/pull/187