### PR TITLE
AMBARI-22413 fix tar_archive.archive_directory_dereference (benyoka)

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
@@ -25,7 +25,7 @@ from contextlib import closing
 from resource_management.core.resources.system import Execute
 
 def archive_dir(output_filename, input_dir):
-  Execute(('tar', '-zcvf', output_filename, input_dir),
+  Execute(('tar', '-zcf', output_filename, '-C', input_dir, '.'),
     sudo = True,
     tries = 3,
     try_sleep = 1,
@@ -40,7 +40,7 @@ def archive_directory_dereference(archive, directory):
   :return:  None
   """
 
-  Execute(('tar', '-zcvhf', archive, directory),
+  Execute(('tar', '-zchf', archive, '-C', directory, '.'),
     sudo = True,
     tries = 3,
     try_sleep = 1,

--- a/ambari-server/src/test/python/stacks/2.1/FALCON/test_falcon_server.py
+++ b/ambari-server/src/test/python/stacks/2.1/FALCON/test_falcon_server.py
@@ -239,9 +239,11 @@ class TestFalconServer(RMFTestCase):
       action = ['delete'])
 
     self.assertResourceCalled('Execute', ('tar',
-     '-zcvhf',
+     '-zchf',
      '/tmp/falcon-upgrade-backup/falcon-local-backup.tar',
-     u'/hadoop/falcon'),
+     '-C',
+     u'/hadoop/falcon',
+     '.'),
         sudo = True, tries = 3, try_sleep = 1,
     )
     self.assertResourceCalled('Execute', ('ambari-python-wrap', '/usr/bin/hdp-select', 'set', 'falcon-server', u'2.2.1.0-2135'),

--- a/ambari-server/src/test/python/stacks/2.2/KNOX/test_knox_gateway.py
+++ b/ambari-server/src/test/python/stacks/2.2/KNOX/test_knox_gateway.py
@@ -145,9 +145,11 @@ class TestKnoxGateway(RMFTestCase):
                        target = RMFTestCase.TARGET_COMMON_SERVICES)
 
     self.assertResourceCalled('Execute', ('tar',
-     '-zcvhf',
+     '-zchf',
      '/tmp/knox-upgrade-backup/knox-data-backup.tar',
-     '/usr/hdp/current/knox-server/data'),
+     '-C',
+     '/usr/hdp/current/knox-server/data',
+     '.'),
         sudo = True, tries = 3, try_sleep = 1,
     )
     self.assertResourceCalled('Execute', ('ambari-python-wrap', '/usr/bin/hdp-select', 'set', 'knox-server', '2.2.1.0-3242'),
@@ -182,9 +184,11 @@ class TestKnoxGateway(RMFTestCase):
                        mocks_dict = mocks_dict)
 
     self.assertResourceCalled('Execute', ('tar',
-     '-zcvhf',
+     '-zchf',
      '/tmp/knox-upgrade-backup/knox-data-backup.tar',
-     '/usr/hdp/current/knox-server/data'),
+     '-C',
+     '/usr/hdp/current/knox-server/data',
+     '.'),
         sudo = True,  tries = 3, try_sleep = 1,
     )
     self.assertResourceCalledIgnoreEarlier('Execute', ('ambari-python-wrap', '/usr/bin/hdp-select', 'set', 'knox-server', version),sudo = True)
@@ -238,9 +242,11 @@ class TestKnoxGateway(RMFTestCase):
                        mocks_dict = mocks_dict)
 
     self.assertResourceCalled('Execute', ('tar',
-     '-zcvhf',
+     '-zchf',
      '/tmp/knox-upgrade-backup/knox-data-backup.tar',
-     '/usr/hdp/current/knox-server/data'),
+     '-C',
+     '/usr/hdp/current/knox-server/data',
+     '.'),
         sudo = True, tries = 3, try_sleep = 1,
     )
     self.assertResourceCalledIgnoreEarlier('Execute', ('ambari-python-wrap', '/usr/bin/hdp-select', 'set', 'knox-server', version),sudo = True)
@@ -298,9 +304,11 @@ class TestKnoxGateway(RMFTestCase):
                        mocks_dict = mocks_dict)
 
     self.assertResourceCalled('Execute', ('tar',
-     '-zcvhf',
+     '-zchf',
      '/tmp/knox-upgrade-backup/knox-data-backup.tar',
-     "/usr/hdp/current/knox-server/data"),
+     '-C',
+     "/usr/hdp/current/knox-server/data",
+     '.'),
         sudo = True,  tries = 3, try_sleep = 1,
     )
 
@@ -314,10 +322,11 @@ class TestKnoxGateway(RMFTestCase):
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('tar',
-     '-xvf',
+     '-xf',
      '/tmp/knox-upgrade-backup/knox-conf-backup.tar',
      '-C',
-     '/usr/hdp/current/knox-server/conf/'),
+     '/usr/hdp/current/knox-server/conf/',
+     '.'),
         sudo = True,
     )
     self.assertResourceCalled('File', '/usr/hdp/current/knox-server/conf/knox-conf-backup.tar',


### PR DESCRIPTION
Same as https://github.com/apache/ambari/pull/195 but for branch-2.6

## What changes were proposed in this pull request?

Fix archive_directory_dereference in tar_archive.py that caused a customer issue with upgrading Falcon.

Patch was once reviewed and approved on review board: https://reviews.apache.org/r/63725/
 
## How was this patch tested?
- modified python tests
- all python tests succeeded
- manually tested Falcon data backup/restore on service stop/start.