### PR TITLE
[AMBARI-22824] Let YARN/MR2 use ZK principal name set by users when enabling Kerberos (until now it's been hardcoded to 'zookeeper')

### DIFF
--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/configuration/yarn-env.xml
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/configuration/yarn-env.xml
@@ -243,6 +243,10 @@ if [ "x$JAVA_LIBRARY_PATH" != "x" ]; then
 fi
 YARN_OPTS="$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE"
 YARN_OPTS="$YARN_OPTS -Djava.io.tmpdir={{hadoop_java_io_tmpdir}}"
+
+{% if rm_security_opts is defined %}
+YARN_OPTS="{{rm_security_opts}} $YARN_OPTS"
+{% endif %}
     </value>
     <value-attributes>
       <type>content</type>

--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/params_linux.py
@@ -349,7 +349,7 @@ if security_enabled:
   if stack_supports_zk_security:
     zk_principal_name = default("/configurations/zookeeper-env/zookeeper_principal_name", "zookeeper/_HOST@EXAMPLE.COM")
     zk_principal_user = zk_principal_name.split('/')[0]
-    rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=' + zk_principal_user + ' -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
+    rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username={zk_principal_user} -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
 
   # YARN timeline security options
   if has_ats:

--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/params_linux.py
@@ -347,7 +347,9 @@ if security_enabled:
   rm_kinit_cmd = format("{kinit_path_local} -kt {rm_keytab} {rm_principal_name};")
   yarn_jaas_file = os.path.join(config_dir, 'yarn_jaas.conf')
   if stack_supports_zk_security:
-    rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=zookeeper -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
+    zk_principal_name = default("/configurations/zookeeper-env/zookeeper_principal_name", "zookeeper/_HOST@EXAMPLE.COM")
+    zk_principal_user = zk_principal_name.split('/')[0]
+    rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=' + zk_principal_user + ' -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
 
   # YARN timeline security options
   if has_ats:

--- a/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/package/scripts/params_linux.py
@@ -347,7 +347,7 @@ if security_enabled:
   yarn_jaas_file = os.path.join(config_dir, 'yarn_jaas.conf')
   zk_principal_name = default("/configurations/zookeeper-env/zookeeper_principal_name", "zookeeper/_HOST@EXAMPLE.COM")
   zk_principal_user = zk_principal_name.split('/')[0]
-  rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=' + zk_principal_user + ' -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
+  rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username={zk_principal_user} -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
 
   # YARN timeline security options
   if has_ats:

--- a/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/YARN/3.0.0.3.0/package/scripts/params_linux.py
@@ -345,7 +345,9 @@ if security_enabled:
   rm_keytab = config['configurations']['yarn-site']['yarn.resourcemanager.keytab']
   rm_kinit_cmd = format("{kinit_path_local} -kt {rm_keytab} {rm_principal_name};")
   yarn_jaas_file = os.path.join(config_dir, 'yarn_jaas.conf')
-  rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=zookeeper -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
+  zk_principal_name = default("/configurations/zookeeper-env/zookeeper_principal_name", "zookeeper/_HOST@EXAMPLE.COM")
+  zk_principal_user = zk_principal_name.split('/')[0]
+  rm_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=' + zk_principal_user + ' -Djava.security.auth.login.config={yarn_jaas_file} -Dzookeeper.sasl.clientconfig=Client')
 
   # YARN timeline security options
   if has_ats:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Yarn and MapReduce2 should handle a customized Zookeeper service principal name.

Currently this is not supported due to hardcoded and implicit values expecting the Zookeeper service principal name to be `zookeeper/_HOST` as opposed to something like `zookeeper-mycluster/_HOST`

## How was this patch tested?

Latest Python unit test results in ambari-server:

```
----------------------------------------------------------------------
Total run:1212
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
Downloading from maven2-repository.dev.java.net: http://download.java.net/maven/2/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from maven2-glassfish-repository.dev.java.net: http://download.java.net/maven/glassfish/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from maven2-repository.atlassian: https://maven.atlassian.com/repository/public/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:16 min
[INFO] Finished at: 2018-01-25T14:47:55+01:00
[INFO] Final Memory: 88M/1213M
[INFO] ------------------------------------------------------------------------
```

Besides unit testing the following integration test steps were executed on a 3-nodes cluster:

1. installed HDFS + ZK and enabled Kerberos where ZK principal has been set to `zookeeper_myCluster1/_HOST@${realm}` (created a snapshot here)
2. installed YARN (together with MR2)
3. tried to enable HA for YARN; the following error has been thrown: `org.apache.zookeeper.KeeperException$AuthFailedException: KeeperErrorCode = AuthFailed for /zk_smoketest`
4. applied my changes (copied the required XML and Python files in the appropriate folders), restarted ambari-server and ambari-agent on all hosts and went back to snapshot created in point 1
5. installed YARN and MR2 again and re-tried the 'Enable HA' for YARN; there was no auth error (there were some others - such as DataNode did not start - but they were not security errors)

Moreover I checked the OS level processes to see if the expected system variables are populated/replaced:

```
[root@c6401 ~]# cat /etc/hadoop/3.0.0.0-753/0/yarn-env.sh | grep zookeeper.sasl.client.username
YARN_OPTS="-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=zookeeper_myCluster1 -Djava.security.auth.login.config=/etc/hadoop/3.0.0.0-753/0/yarn_jaas.conf -Dzookeeper.sasl.clientconfig=Client $YARN_OPTS"
```

```
[root@c6402 ~]# ps -ef | grep zookeeper.sasl.client.username
mapred   18588     1  0 13:10 ?        00:00:29 /usr/jdk64/jdk1.8.0_112/bin/java -Dproc_historyserver -Djava.io.tmpdir=/var/lib/ambari-agent/tmp/hadoop_java_io_tmpdir -Dhdp.version=3.0.0.0-753 -Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=zookeeper_myCluster1 -Djava.security.auth.login.config=/etc/hadoop/3.0.0.0-753/0/yarn_jaas.conf -Dzookeeper.sasl.clientconfig=Client -Dhadoop.log.dir=/var/log/hadoop-yarn/mapred -Dyarn.log.dir=/var/log/hadoop-yarn/mapred -Dhadoop.log.file=yarn.log -Dyarn.log.file=yarn.log -Dyarn.home.dir= -Dyarn.id.str= -Dhadoop.root.logger=INFO,console -Dyarn.root.logger=INFO,console -Djava.library.path=:/usr/hdp/3.0.0.0-753/hadoop/lib/native/Linux-amd64-64:/var/lib/ambari-agent/tmp/hadoop_java_io_tmpdir -Dyarn.policy.file=hadoop-policy.xml -Djava.io.tmpdir=/var/lib/ambari-agent/tmp/hadoop_java_io_tmpdir -Djavax.security.auth.useSubjectCredsOnly=false -Dhdp.version=3.0.0.0-753 -Dmapred.jobsummary.logger=INFO,RFA -Djava.security.auth.login.config=/etc/hadoop/3.0.0.0-753/0/mapred_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false -Xmx900m -Dhadoop.home.dir=/usr/hdp/3.0.0.0-753/hadoop -Dhadoop.id.str=mapred -Dhadoop.policy.file=hadoop-policy.xml -Dhadoop.security.logger=INFO,NullAppender org.apache.hadoop.mapreduce.v2.hs.JobHistoryServer
```

In all cases the custom value have been populated instead of the previous (hardcoded) one.