### PR TITLE
[AMBARI-22847] Let HBase use ZK principal name set by users when enabling Kerberos (until now it's been hardcoded to 'zookeeper')

### DIFF
--- a/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/configuration/hbase-env.xml
+++ b/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/configuration/hbase-env.xml
@@ -230,7 +230,7 @@ JDK_DEPENDED_OPTS="-XX:PermSize=128m -XX:MaxPermSize=128m"
 {% endif %}
 
 {% if security_enabled %}
-export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log -Djava.security.auth.login.config={{client_jaas_config_file}} -Djava.io.tmpdir={{java_io_tmpdir}}"
+export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log -Djava.security.auth.login.config={{client_jaas_config_file}} -Djava.io.tmpdir={{java_io_tmpdir}} {{zk_security_opts}}"
 export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -Xmx{{master_heapsize}} -Djava.security.auth.login.config={{master_jaas_config_file}} -Djavax.security.auth.useSubjectCredsOnly=false $JDK_DEPENDED_OPTS"
 export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70 -XX:ReservedCodeCacheSize=256m -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}} -Djava.security.auth.login.config={{regionserver_jaas_config_file}} -Djavax.security.auth.useSubjectCredsOnly=false $JDK_DEPENDED_OPTS"
 export PHOENIX_QUERYSERVER_OPTS="$PHOENIX_QUERYSERVER_OPTS -Djava.security.auth.login.config={{queryserver_jaas_config_file}}"

--- a/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/2.0.0.3.0/package/scripts/params_linux.py
@@ -184,6 +184,9 @@ service_check_data = get_unique_id_and_date()
 user_group = config['configurations']['cluster-env']["user_group"]
 
 if security_enabled:
+  zk_principal_name = default("/configurations/zookeeper-env/zookeeper_principal_name", "zookeeper/_HOST@EXAMPLE.COM")
+  zk_principal_user = zk_principal_name.split('/')[0]
+  zk_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username={zk_principal_user} -Dzookeeper.sasl.clientconfig=Client')
   _hostname_lowercase = config['hostname'].lower()
   master_jaas_princ = config['configurations']['hbase-site']['hbase.master.kerberos.principal'].replace('_HOST',_hostname_lowercase)
   master_keytab_path = config['configurations']['hbase-site']['hbase.master.keytab.file']


### PR DESCRIPTION
## What changes were proposed in this pull request?

HBase should handle a customized Zookeeper service principal name.

Currently this is not supported due to hardcoded and implicit values expecting the Zookeeper service principal name to be `zookeeper/_HOST` as opposed to something like `zookeeper-mycluster/_HOST`.

## How was this patch tested?

Latest Python unit test results in ambari-server:

```
Total run:1212
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
Downloading from maven2-repository.dev.java.net: http://download.java.net/maven/2/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from maven2-repository.atlassian: https://maven.atlassian.com/repository/public/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from maven2-glassfish-repository.dev.java.net: http://download.java.net/maven/glassfish/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:43 min
[INFO] Finished at: 2018-01-26T13:42:55+01:00
[INFO] Final Memory: 98M/1379M
[INFO] ------------------------------------------------------------------------
```

Besides unit testing the following integration test steps were executed on a 3-nodes cluster:

1. installed HDFS + ZK and enabled Kerberos where ZK principal has been set to zookeeper_myCluster1/_HOST@${realm} (created a snapshot here)
2. installed HBase; the `Install/Start/Test` step failed (error message was `javax.security.sasl.SaslException: GSS initiate failed [Caused by GSSException: No valid credentials provided (Mechanism level: Server not found in Kerberos database (7) - UNKNOWN_SERVER)]) occurred when evaluating Zookeeper Quorum Member's  received SASL token.`)
3. applied my changes (copied the required XML and Python files in the appropriate folders on each hosts); restarted ambari-server and ambari-agent on each hosts and went back to snapshot created in point 1
4. installed HBase again (the updated template appeared as expected; see screenshot); there was no auth error this time and HBase has been installed successfully

![screen shot 2018-01-26 at 1 04 29 pm](https://user-images.githubusercontent.com/34065904/35442480-b3f97bc0-02a7-11e8-931c-7b8cf143235c.png)


Moreover I checked the OS level processes to see if the expected system variables are populated/replaced:

```
[root@c6403 ~]# ps -ef | grep zookeeper | grep hbase
hbase    27841 27827  2 12:19 ?        00:00:55 /usr/jdk64/jdk1.8.0_112/bin/java -Dproc_regionserver -XX:OnOutOfMemoryError=kill -9 %p -Dhdp.version=3.0.0.0-753 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hbase/hs_err_pid%p.log -Djava.security.auth.login.config=/usr/hdp/current/hbase-regionserver/conf/hbase_client_jaas.conf -Djava.io.tmpdir=/tmp -Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=zookeeper_myCluster1 -Dzookeeper.sasl.clientconfig=Client -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/hbase/gc.log-201801261219 -Xmn200m -XX:CMSInitiatingOccupancyFraction=70 -XX:ReservedCodeCacheSize=256m -Xms1024m -Xmx1024m -Djava.security.auth.login.config=/usr/hdp/current/hbase-regionserver/conf/hbase_regionserver_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dhbase.log.dir=/var/log/hbase -Dhbase.log.file=hbase-hbase-regionserver-c6403.ambari.apache.org.log -Dhbase.home.dir=/usr/hdp/current/hbase-regionserver/bin/.. -Dhbase.id.str=hbase -Dhbase.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/3.0.0.0-753/hadoop/lib/native/Linux-amd64-64:/usr/hdp/3.0.0.0-753/hadoop/lib/native -Dhbase.security.logger=INFO,RFAS org.apache.hadoop.hbase.regionserver.HRegionServer start
```
```
[root@c6401 ~]# ps -ef | grep zookeeper | grep hbase
hbase     8200  8186  2 12:19 ?        00:00:51 /usr/jdk64/jdk1.8.0_112/bin/java -Dproc_master -XX:OnOutOfMemoryError=kill -9 %p -Dhdp.version=3.0.0.0-753 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hbase/hs_err_pid%p.log -Djava.security.auth.login.config=/usr/hdp/current/hbase-master/conf/hbase_client_jaas.conf -Djava.io.tmpdir=/tmp -Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username=zookeeper_myCluster1 -Dzookeeper.sasl.clientconfig=Client -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/hbase/gc.log-201801261219 -Xmx1024m -Djava.security.auth.login.config=/usr/hdp/current/hbase-master/conf/hbase_master_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dhbase.log.dir=/var/log/hbase -Dhbase.log.file=hbase-hbase-master-c6401.ambari.apache.org.log -Dhbase.home.dir=/usr/hdp/current/hbase-master/bin/.. -Dhbase.id.str=hbase -Dhbase.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/3.0.0.0-753/hadoop/lib/native/Linux-amd64-64:/usr/hdp/3.0.0.0-753/hadoop/lib/native -Dhbase.security.logger=INFO,RFAS org.apache.hadoop.hbase.master.HMaster start
```