### PR TITLE
[AMBARI-22854] Fix running service checks with new mpack definitions

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -614,13 +614,6 @@ public class AmbariCustomCommandExecutionHelper {
    * Based on the ServiceComponentHosts that left selects a ServiceComponentHost using following logic:
    *       If possible select a host that's not loaded with tasks. Random otherwise
    *       If possible select a component of the service that the service check runs for. Random otherwise
-   *
-   * @param cluster
-   * @param service
-   * @param candidateHostsList
-   * @param isMaintenanceModeHostExcluded
-   * @return
-   * @throws AmbariException
    */
   ServiceComponentHost calculateServiceComponentHostForServiceCheck(Cluster cluster, Service service,
                                                                             List<String> candidateHostsList, boolean isMaintenanceModeHostExcluded) throws AmbariException {
@@ -679,12 +672,6 @@ public class AmbariCustomCommandExecutionHelper {
    * otherwise just maps all service hosts to components
    *
    * If candidateHostsList is not null and not empty the map will be filtered using given hostnames.
-   *
-   * @param service
-   * @param cluster
-   * @param candidateHostsList
-   * @return
-   * @throws AmbariException
    */
   private Multimap<String, ServiceComponentHost> calculateHostsClientsMultimap(Service service, Cluster cluster, List<String> candidateHostsList) throws AmbariException {
 
@@ -729,13 +716,6 @@ public class AmbariCustomCommandExecutionHelper {
    * Calculates the Multimap that will contain all the hostNames mapped to client components.
    * It will include the client components of the dependent services if the dependent service has such.
    *
-   *
-   * @param service
-   * @param clientComponentName
-   * @param cluster
-   * @param candidateHosts
-   * @return
-   * @throws AmbariException
    */
   private Multimap<String, ServiceComponentHost> calculateClientHostComponentMultiMapUsingDependencies(Service service, String clientComponentName,
                                                                                                       Cluster cluster, List<String> candidateHosts) throws AmbariException {
@@ -798,10 +778,6 @@ public class AmbariCustomCommandExecutionHelper {
    *
    * Returns random ServiceComponentHost from the given collection that belongs to the given Service, if there is such.
    * Otherwise returns random ServiceComponentHost from the given collection.
-   *
-   * @param serviceComponentHosts
-   * @param service
-   * @return
    */
   private ServiceComponentHost selectRandomSCHForServiceCheck(Collection<ServiceComponentHost> serviceComponentHosts, Service service) {
     ServiceComponentHost candidateSCH = null;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -3163,31 +3163,31 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       }
 
       for (Service service : smokeTestServices) { // Creates smoke test commands
-        // find service component host
-        ServiceComponent component = getClientComponentForRunningAction(cluster, service);
-        String componentName = component != null ? component.getName() : null;
-        String clientHost = getClientHostForRunningAction(cluster, service, component);
         String smokeTestRole = actionMetadata.getServiceCheckAction(service.getServiceType());
+        try {
+          // find service component host
+          ServiceComponentHost componentForServiceCheck = customCommandExecutionHelper.
+              calculateServiceComponentHostForServiceCheck(cluster, service);
 
-        if (clientHost == null || smokeTestRole == null) {
-          LOG.info("Nothing to do for service check as could not find role or"
-              + " or host to run check on"
-              + ", clusterName=" + cluster.getClusterName()
-              + ", serviceGroupName=" + service.getServiceGroupName()
-              + ", serviceName=" + service.getName()
-              + ", clientHost=" + clientHost
-              + ", serviceCheckRole=" + smokeTestRole);
-          continue;
+          if (StringUtils.isBlank(stage.getHostParamsStage())) {
+            RepositoryVersionEntity repositoryVersion = componentForServiceCheck.getServiceComponent().getDesiredRepositoryVersion();
+            stage.setHostParamsStage(StageUtils.getGson().toJson(
+                customCommandExecutionHelper.createDefaultHostParams(cluster, repositoryVersion.getStackId())));
+          }
+
+          customCommandExecutionHelper.addServiceCheckAction(stage, componentForServiceCheck.getHostName(), smokeTestRole,
+              nowTimestamp, componentForServiceCheck.getServiceGroupName(), componentForServiceCheck.getServiceName(),
+              componentForServiceCheck.getServiceComponentName(), null, false, false, service.getName());
+
+        } catch (AmbariException e) {
+            LOG.warn("Nothing to do for service check as could not find role or"
+                + " or host to run check on"
+                + ", clusterName=" + cluster.getClusterName()
+                + ", serviceGroupName=" + service.getServiceGroupName()
+                + ", serviceName=" + service.getName()
+                + ", serviceCheckRole=" + smokeTestRole
+                + "Actual reason : " + e.getMessage());
         }
-
-        if (StringUtils.isBlank(stage.getHostParamsStage())) {
-          RepositoryVersionEntity repositoryVersion = component.getDesiredRepositoryVersion();
-          stage.setHostParamsStage(StageUtils.getGson().toJson(
-              customCommandExecutionHelper.createDefaultHostParams(cluster, repositoryVersion.getStackId())));
-        }
-
-        customCommandExecutionHelper.addServiceCheckAction(stage, clientHost, smokeTestRole,
-            nowTimestamp, service.getServiceGroupName(), service.getName(), componentName, null, false, false);
       }
 
       RoleCommandOrder rco = getRoleCommandOrder(cluster);
@@ -3986,79 +3986,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   @Override
   public void updateGroups(Set<GroupRequest> requests) throws AmbariException {
     // currently no group updates are supported
-  }
-
-  protected String getClientHostForRunningAction(Cluster cluster, Service service, ServiceComponent serviceComponent)
-      throws AmbariException {
-    if (serviceComponent != null && !serviceComponent.getServiceComponentHosts().isEmpty()) {
-      Set<String> candidateHosts = serviceComponent.getServiceComponentHosts().keySet();
-      filterHostsForAction(candidateHosts, service, cluster, Resource.Type.Cluster);
-      return getHealthyHost(candidateHosts);
-    }
-    return null;
-  }
-
-  protected ServiceComponent getClientComponentForRunningAction(Cluster cluster,
-      Service service) throws AmbariException {
-    /*
-     * We assume Cluster level here. That means that we never run service
-     * checks on clients/hosts that are in maintenance state.
-     * That also means that we can not run service check if the only host
-     * that has client component is in maintenance state
-     */
-
-    StackId stackId = service.getDesiredStackId();
-    ComponentInfo compInfo =
-        ambariMetaInfo.getService(stackId.getStackName(),
-            stackId.getStackVersion(), service.getServiceType()).getClientComponent();
-    if (compInfo != null) {
-      try {
-        ServiceComponent serviceComponent =
-            service.getServiceComponent(compInfo.getName());
-        if (!serviceComponent.getServiceComponentHosts().isEmpty()) {
-          return serviceComponent;
-        }
-      } catch (ServiceComponentNotFoundException e) {
-        LOG.warn("Could not find required component to run action"
-            + ", clusterName=" + cluster.getClusterName()
-            + ", serviceName=" + service.getName()
-            + ", componentName=" + compInfo.getName());
-      }
-    }
-
-    // any component will do
-    Map<String, ServiceComponent> components = service.getServiceComponents();
-    if (!components.isEmpty()) {
-      for (ServiceComponent serviceComponent : components.values()) {
-        if (!serviceComponent.getServiceComponentHosts().isEmpty()) {
-          return serviceComponent;
-        }
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Utility method that filters out hosts from set based on their maintenance
-   * state status.
-   */
-  protected void filterHostsForAction(Set<String> candidateHosts, Service service,
-                                    final Cluster cluster,
-                                    final Resource.Type level)
-                                    throws AmbariException {
-    Set<String> ignoredHosts = maintenanceStateHelper.filterHostsInMaintenanceState(
-      candidateHosts, new MaintenanceStateHelper.HostPredicate() {
-        @Override
-        public boolean shouldHostBeRemoved(final String hostname)
-          throws AmbariException {
-          Host host = clusters.getHost(hostname);
-          return !maintenanceStateHelper.isOperationAllowed(
-            host, cluster.getClusterId(), level);
-        }
-      }
-    );
-    LOG.debug("Ignoring hosts when selecting available hosts for action due to maintenance state.Ignored hosts ={}, cluster={}, service={}",
-      ignoredHosts, cluster.getClusterName(), service.getName());
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/CommandScriptDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/CommandScriptDefinition.java
@@ -44,6 +44,8 @@ public class CommandScriptDefinition {
    */
   private int timeout = 0;
 
+  private String clientComponentType = null;
+
 
   public String getScript() {
     return script;
@@ -55,6 +57,10 @@ public class CommandScriptDefinition {
 
   public int getTimeout() {
     return timeout;
+  }
+
+  public String getClientComponentType() {
+    return clientComponentType;
   }
 
   public enum Type {
@@ -77,7 +83,8 @@ public class CommandScriptDefinition {
     return new EqualsBuilder().
             append(script, rhs.script).
             append(scriptType, rhs.scriptType).
-            append(timeout, rhs.timeout).isEquals();
+            append(timeout, rhs.timeout).
+            append(clientComponentType, rhs.clientComponentType).isEquals();
   }
 
   @Override
@@ -85,6 +92,7 @@ public class CommandScriptDefinition {
     return new HashCodeBuilder(17, 31).
             append(script).
             append(scriptType).
-            append(timeout).toHashCode();
+            append(timeout).
+            append(clientComponentType).toHashCode();
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -71,7 +71,6 @@ import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.Service;
 import org.apache.ambari.server.state.ServiceComponent;
-import org.apache.ambari.server.state.ServiceGroup;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.State;
@@ -220,6 +219,8 @@ public class AmbariCustomCommandExecutionHelperTest {
 
     EasyMock.replay(hostRoleCommand, actionManager, configHelper);
 
+    createServiceComponentHosts("c1", "CORE", "c1");
+
     ambariManagementController.createAction(actionRequest, requestProperties);
 
     Request request = requestCapture.getValue();
@@ -265,6 +266,8 @@ public class AmbariCustomCommandExecutionHelperTest {
 
     EasyMock.replay(hostRoleCommand, actionManager, configHelper);
 
+    createServiceComponentHosts("c1", "CORE", "c1");
+
     ambariManagementController.createAction(actionRequest, requestProperties);
 
     Request request = requestCapture.getValue();
@@ -301,6 +304,8 @@ public class AmbariCustomCommandExecutionHelperTest {
 
     EasyMock.replay(hostRoleCommand, actionManager, configHelper);
 
+    createServiceComponentHosts("c1", "CORE", "c1");
+
     ambariManagementController.createAction(actionRequest, requestProperties);
 
     Request request = requestCapture.getValue();
@@ -315,10 +320,6 @@ public class AmbariCustomCommandExecutionHelperTest {
 
   @Test
   public void testHostsFilterUnhealthyComponent() throws Exception {
-    // Set custom status to host
-    clusters.getCluster("c1").getService("GANGLIA").getServiceComponent(
-        "GANGLIA_MONITOR").getServiceComponentHost("c1-c6402").setState(State.UNKNOWN);
-
     Map<String, String> requestProperties = new HashMap<String, String>() {
       {
         put("context", "Restart all components for GANGLIA");
@@ -338,6 +339,12 @@ public class AmbariCustomCommandExecutionHelperTest {
       new HashMap<>(), false);
 
     EasyMock.replay(hostRoleCommand, actionManager, configHelper);
+
+    createServiceComponentHosts("c1", "CORE", "c1");
+
+    // Set custom status to host
+    clusters.getCluster("c1").getService("GANGLIA").getServiceComponent(
+        "GANGLIA_MONITOR").getServiceComponentHost("c1-c6402").setState(State.UNKNOWN);
 
     ambariManagementController.createAction(actionRequest, requestProperties);
 
@@ -446,13 +453,8 @@ public class AmbariCustomCommandExecutionHelperTest {
   }
 
   @Test
-  public void testServiceCheckWithOverriddenTimeout() throws Exception {
+  public void testServiceCheckWithOverriddenTimeoutAndHostFiltering() throws Exception {
     AmbariCustomCommandExecutionHelper ambariCustomCommandExecutionHelper = injector.getInstance(AmbariCustomCommandExecutionHelper.class);
-
-    Cluster c1 = clusters.getCluster("c1");
-    Service s = c1.getService("ZOOKEEPER");
-    ServiceComponent sc = s.getServiceComponent("ZOOKEEPER_CLIENT");
-    Assert.assertTrue(sc.getServiceComponentHosts().keySet().size() > 1);
 
     // There are multiple hosts with ZK Client.
     List<RequestResourceFilter> requestResourceFilter = new ArrayList<RequestResourceFilter>() {{
@@ -474,6 +476,13 @@ public class AmbariCustomCommandExecutionHelperTest {
     HashSet<String> localComponents = new HashSet<>();
     EasyMock.expect(execCmd.getLocalComponents()).andReturn(localComponents).anyTimes();
     EasyMock.replay(configHelper, stage, execCmdWrapper, execCmd);
+
+    createServiceComponentHosts("c1", "CORE", "c1");
+
+    Cluster c1 = clusters.getCluster("c1");
+    Service s = c1.getService("ZOOKEEPER");
+    ServiceComponent sc = s.getServiceComponent("ZOOKEEPER_CLIENT");
+    Assert.assertTrue(sc.getServiceComponentHosts().keySet().size() > 1);
 
     ambariCustomCommandExecutionHelper.addExecutionCommandsToStage(actionExecutionContext, stage, new HashMap<>(), null);
     Map<String, String> configMap = timeOutCapture.getValues().get(0);
@@ -500,11 +509,6 @@ public class AmbariCustomCommandExecutionHelperTest {
   public void testServiceCheckPicksRandomHost() throws Exception {
     AmbariCustomCommandExecutionHelper ambariCustomCommandExecutionHelper = injector.getInstance(AmbariCustomCommandExecutionHelper.class);
 
-    Cluster c1 = clusters.getCluster("c1");
-    Service s = c1.getService("ZOOKEEPER");
-    ServiceComponent sc = s.getServiceComponent("ZOOKEEPER_CLIENT");
-    Assert.assertTrue(sc.getServiceComponentHosts().keySet().size() > 1);
-
     // There are multiple hosts with ZK Client.
     List<RequestResourceFilter> requestResourceFilter = new ArrayList<RequestResourceFilter>() {{
       add(new RequestResourceFilter("CORE", "ZOOKEEPER", "ZOOKEEPER_CLIENT", null));
@@ -524,6 +528,87 @@ public class AmbariCustomCommandExecutionHelperTest {
     HashSet<String> localComponents = new HashSet<>();
     EasyMock.expect(execCmd.getLocalComponents()).andReturn(localComponents).anyTimes();
     EasyMock.replay(configHelper, stage, execCmdWrapper, execCmd);
+
+    createServiceComponentHosts("c1", "CORE", "c1");
+
+    Cluster c1 = clusters.getCluster("c1");
+    Service s = c1.getService("ZOOKEEPER");
+    ServiceComponent sc = s.getServiceComponent("ZOOKEEPER_CLIENT");
+    Assert.assertTrue(sc.getServiceComponentHosts().keySet().size() > 1);
+
+    ambariCustomCommandExecutionHelper.addExecutionCommandsToStage(actionExecutionContext, stage, new HashMap<>(), null);
+  }
+
+
+
+  /**
+   * Perform a Service Check for HDFS on the HADOOP_CLIENTS/SOME_CLIENT_FOR_SERVICE_CHECK service component.
+   * The HADOOP_CLIENTS service is the service on which HDFS depends.
+   * The SOME_CLIENT_FOR_SERVICE_CHECK component is defined in HDFS's metainfo file.
+   * This should cause Ambari to execute service check on dependent service client component.
+   *
+   * Also assures that service check doesn't works without dependency defined
+   * @throws Exception
+   */
+  @Test
+  public void testServiceCheckRunsOnDependentClientService() throws Exception {
+    AmbariCustomCommandExecutionHelper ambariCustomCommandExecutionHelper = injector.getInstance(AmbariCustomCommandExecutionHelper.class);
+
+    List<RequestResourceFilter> requestResourceFilter = new ArrayList<RequestResourceFilter>() {{
+      add(new RequestResourceFilter("CORE", "HDFS", null, null));
+    }};
+    ActionExecutionContext actionExecutionContext = new ActionExecutionContext("c1", "SERVICE_CHECK", requestResourceFilter);
+    Stage stage = EasyMock.niceMock(Stage.class);
+    ExecutionCommandWrapper execCmdWrapper = EasyMock.niceMock(ExecutionCommandWrapper.class);
+    ExecutionCommand execCmd = EasyMock.niceMock(ExecutionCommand.class);
+
+    EasyMock.expect(stage.getClusterName()).andReturn("c1");
+    //
+    EasyMock.expect(stage.getExecutionCommandWrapper(EasyMock.eq("c1-c6403"), EasyMock.anyString())).andReturn(execCmdWrapper);
+    EasyMock.expect(execCmdWrapper.getExecutionCommand()).andReturn(execCmd);
+    EasyMock.expect(execCmd.getForceRefreshConfigTagsBeforeExecution()).andReturn(true);
+
+    HashSet<String> localComponents = new HashSet<>();
+    EasyMock.expect(execCmd.getLocalComponents()).andReturn(localComponents).anyTimes();
+    EasyMock.replay(configHelper, stage, execCmdWrapper, execCmd);
+
+    createServiceComponentHosts("c1", "CORE", "c1");
+
+    //add host with client only
+    addHost("c1-c6403", "c1");
+
+    //create client service
+    OrmTestHelper ormTestHelper = injector.getInstance(OrmTestHelper.class);
+    RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.6"), "2.0.6-1234");
+    createService("c1", "CORE", "HADOOP_CLIENTS", repositoryVersion);
+    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
+    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
+
+    //make sure there are no HDFS_CLIENT components from HDFS service
+    Cluster c1 = clusters.getCluster("c1");
+    Service s = c1.getService("HDFS");
+    try {
+      ServiceComponent sc = s.getServiceComponent("HDFS_CLIENT");
+      Assert.assertEquals(0, sc.getServiceComponentHosts().keySet().size());
+    } catch (AmbariException e) {
+      //ignore
+    }
+
+    //make sure the SOME_CLIENT_FOR_SERVICE_CHECK component exists on some hosts
+    Service clientService = c1.getService("HADOOP_CLIENTS");
+    ServiceComponent clientServiceComponent = clientService.getServiceComponent("SOME_CLIENT_FOR_SERVICE_CHECK");
+    Assert.assertEquals(1, clientServiceComponent.getServiceComponentHosts().keySet().size());
+
+    //Check if service check works without dependency defined
+    try {
+      ambariCustomCommandExecutionHelper.addExecutionCommandsToStage(actionExecutionContext, stage, new HashMap<>(), null);
+      Assert.fail("Previous method call should have thrown the exception");
+    } catch (AmbariException e) {
+      Assert.assertTrue(e.getMessage().contains("Couldn't find any client components SOME_CLIENT_FOR_SERVICE_CHECK in the dependent services"));
+    }
+
+    //add dependency from HDFS to HADOOP_CLIENTS
+    c1.addDependencyToService("CORE", "HDFS", clientService.getServiceId());
 
     ambariCustomCommandExecutionHelper.addExecutionCommandsToStage(actionExecutionContext, stage, new HashMap<>(), null);
   }
@@ -556,6 +641,8 @@ public class AmbariCustomCommandExecutionHelperTest {
             }, false);
     actionRequest.getResourceFilters().add(new RequestResourceFilter("CORE", "YARN", "RESOURCEMANAGER", Collections.singletonList("c1-c6401")));
     EasyMock.replay(hostRoleCommand, actionManager, configHelper);
+
+    createServiceComponentHosts("c1", "CORE", "c1");
 
     ambariManagementController.createAction(actionRequest, requestProperties);
 
@@ -606,6 +693,8 @@ public class AmbariCustomCommandExecutionHelperTest {
         Collections.singletonList("c1-c6401")));
 
     EasyMock.replay(hostRoleCommand, actionManager, configHelper);
+
+    createServiceComponentHosts("c1", "CORE", "c1");
 
     ambariManagementController.createAction(actionRequest, requestProperties);
     Request request = requestCapture.getValue();
@@ -690,12 +779,12 @@ public class AmbariCustomCommandExecutionHelperTest {
     addHost(hostC6402, clusterName);
 
     Cluster cluster = clusters.getCluster(clusterName);
-    ServiceGroup serviceGroup = cluster.addServiceGroup("CORE");
     Assert.assertNotNull(cluster);
 
     String serviceGroupName = "CORE";
     ServiceGroupResourceProviderTest.createServiceGroup(ambariManagementController, clusterName, serviceGroupName);
 
+    createService(clusterName, serviceGroupName, "HDFS", repositoryVersion);
     createService(clusterName, serviceGroupName, "YARN", repositoryVersion);
     createService(clusterName, serviceGroupName, "GANGLIA", repositoryVersion);
     createService(clusterName, serviceGroupName, "ZOOKEEPER", repositoryVersion);
@@ -709,7 +798,12 @@ public class AmbariCustomCommandExecutionHelperTest {
 
     // this component should be not installed on any host
     createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", State.INIT);
+  }
 
+
+  private void createServiceComponentHosts(String clusterName, String serviceGroupName, String hostPrefix) throws AmbariException, AuthorizationException {
+    String hostC6401 = hostPrefix + "-c6401";
+    String hostC6402 = hostPrefix + "-c6402";
     createServiceComponentHost(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", hostC6401, null);
     createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6401, null);
     createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", hostC6401, State.INIT);

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerCommonServicesTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerCommonServicesTest.java
@@ -217,6 +217,7 @@ public class StackManagerCommonServicesTest {
     assertEquals(CommandScriptDefinition.Type.PYTHON,
         commandScript.getScriptType());
     assertEquals(300, commandScript.getTimeout());
+    assertEquals("SOME_CLIENT_FOR_SERVICE_CHECK", commandScript.getClientComponentType());
     List<String> configDependencies = pigService.getConfigDependencies();
     assertEquals(1, configDependencies.size());
     assertEquals("global", configDependencies.get(0));

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerTest.java
@@ -247,6 +247,7 @@ public class StackManagerTest {
     assertEquals("scripts/service_check.py", commandScript.getScript());
     assertEquals(CommandScriptDefinition.Type.PYTHON, commandScript.getScriptType());
     assertEquals(300, commandScript.getTimeout());
+    assertEquals("SOME_CLIENT_FOR_SERVICE_CHECK", commandScript.getClientComponentType());
     List<String> configDependencies = pigService.getConfigDependencies();
     assertEquals(1, configDependencies.size());
     assertEquals("global", configDependencies.get(0));

--- a/ambari-server/src/test/resources/common-services/PIG/1.0/metainfo.xml
+++ b/ambari-server/src/test/resources/common-services/PIG/1.0/metainfo.xml
@@ -55,6 +55,7 @@
         <script>scripts/service_check.py</script>
         <scriptType>PYTHON</scriptType>
         <timeout>300</timeout>
+        <clientComponentType>SOME_CLIENT_FOR_SERVICE_CHECK</clientComponentType>
       </commandScript>
 
       <configuration-dependencies>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.5/services/HDFS/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.5/services/HDFS/metainfo.xml
@@ -189,6 +189,7 @@
         <script>scripts/service_check.py</script>
         <scriptType>PYTHON</scriptType>
         <timeout>300</timeout>
+        <clientComponentType>SOME_CLIENT_FOR_SERVICE_CHECK</clientComponentType>
       </commandScript>
 
       <configuration-dependencies>

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/HADOOP_CLIENTS/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/HADOOP_CLIENTS/metainfo.xml
@@ -19,44 +19,23 @@
   <schemaVersion>2.0</schemaVersion>
   <services>
     <service>
-      <name>PIG</name>
-      <comment>This is comment for PIG service</comment>
-      <version>1.0</version>
-
+      <name>HADOOP_CLIENTS</name>
+      <comment>Clients service for testing purposes</comment>
+      <version>0.1.2.0.6</version>
+      <category>CLIENT</category>
       <components>
         <component>
-          <name>PIG</name>
+          <name>SOME_CLIENT_FOR_SERVICE_CHECK</name>
           <category>CLIENT</category>
           <cardinality>0+</cardinality>
-          <commandScript>
-            <script>scripts/pig_client.py</script>
-            <scriptType>PYTHON</scriptType>
-            <timeout>600</timeout>
-          </commandScript>
+          <version>0.95.2.2.0.6.0-hbase-master</version>
         </component>
       </components>
-      <osSpecifics>
-        <osSpecific>
-          <osFamily>centos6</osFamily>
-          <packages>
-            <package>
-              <name>pig</name>
-            </package>
-          </packages>
-        </osSpecific>
-      </osSpecifics>
-
       <commandScript>
         <script>scripts/service_check.py</script>
         <scriptType>PYTHON</scriptType>
         <timeout>300</timeout>
-        <clientComponentType>SOME_CLIENT_FOR_SERVICE_CHECK</clientComponentType>
       </commandScript>
-
-      <configuration-dependencies>
-        <config-type>global</config-type>
-      </configuration-dependencies>
-
     </service>
   </services>
 </metainfo>


### PR DESCRIPTION
## What changes were proposed in this pull request?

breaking the service definition into client and server modules would require the logic for calling service check to be updated because now to run service check for zookeeper, we will need to call ZOOKEEPER-CLIENT/ZOOKEEPER-CLIENT to run the service check. 

## How was this patch tested?

Manual and Unit tests