### PR TITLE
[AMBARI-22855]. Log Search: using shipperconfig api should be configurable

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/MessageEnums.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/MessageEnums.java
@@ -34,7 +34,7 @@ public enum MessageEnums {
   ZK_CONFIG_NOT_READY("logsearch.zk.config.error", "Collection configuration has not uploaded yet"),
   SOLR_COLLECTION_NOT_READY("logsearch.solr.collection.error", "Solr has not accessible yet for collection."),
   CONFIGURATION_NOT_AVAILABLE("logsearch.config.not_available", "Log Search configuration is not available"),
-  
+  CONFIGURATION_API_DISABLED("logsearch.config.api.disabled", "Log Search configuration is not available"),
   // Common Validations
   INVALID_PASSWORD("logsearch.validation.invalid_password", "Invalid password"),
   INVALID_INPUT_DATA("logsearch.validation.invalid_input_data", "Invalid input data"),

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchConfigApiConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchConfigApiConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.conf;
+
+import org.apache.ambari.logsearch.config.api.LogSearchPropertyDescription;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PROPERTIES_FILE;
+
+@Configuration
+public class LogSearchConfigApiConfig {
+
+  @Value("${logsearch.config.api.enabled:true}")
+  @LogSearchPropertyDescription(
+    name = "logsearch.config.api.enabled",
+    description = "Enable config API feature and shipperconfig API endpoints.",
+    examples = {"false"},
+    defaultValue = "true",
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  private boolean configApiEnabled;
+
+  public boolean isConfigApiEnabled() {
+    return configApiEnabled;
+  }
+
+  public void setConfigApiEnabled(boolean configApiEnabled) {
+    this.configApiEnabled = configApiEnabled;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchSslConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchSslConfig.java
@@ -27,7 +27,7 @@ import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PR
 @Configuration
 public class LogSearchSslConfig {
 
-  public static final String LOGSEARCH_CERT_DEFAULT_FOLDER = "/etc/ambari-logsearch-portal/conf/keys";
+  public static final String LOGSEARCH_CERT_DEFAULT_FOLDER = "/usr/lib/ambari-logsearch-portal/conf/keys";
   public static final String LOGSEARCH_CERT_DEFAULT_ALGORITHM = "sha256WithRSA";
   public static final String CREDENTIAL_STORE_PROVIDER_PATH = "hadoop.security.credential.provider.path";
 

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 
 import org.apache.ambari.logsearch.conf.global.LogSearchConfigState;
 import org.apache.ambari.logsearch.conf.global.SolrCollectionState;
+import org.apache.ambari.logsearch.config.api.LogSearchPropertyDescription;
 import org.apache.ambari.logsearch.web.authenticate.LogsearchAuthFailureHandler;
 import org.apache.ambari.logsearch.web.authenticate.LogsearchAuthSuccessHandler;
 import org.apache.ambari.logsearch.web.authenticate.LogsearchLogoutSuccessHandler;
@@ -43,7 +44,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
@@ -88,6 +88,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Inject
   private LogSearchConfigState logSearchConfigState;
+
+  @Inject
+  private LogSearchConfigApiConfig logSearchConfigApiConfig;
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
@@ -184,7 +187,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Bean
   public LogSearchConfigStateFilter logSearchConfigStateFilter() {
-    return new LogSearchConfigStateFilter(logsearchConfigRequestMatcher(), logSearchConfigState);
+    return new LogSearchConfigStateFilter(logsearchConfigRequestMatcher(), logSearchConfigState, logSearchConfigApiConfig.isConfigApiEnabled());
   }
 
   @Bean

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/dao/SolrDaoBase.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/dao/SolrDaoBase.java
@@ -22,6 +22,7 @@ package org.apache.ambari.logsearch.dao;
 import org.apache.ambari.logsearch.common.LogSearchContext;
 import org.apache.ambari.logsearch.common.LogType;
 import org.apache.ambari.logsearch.common.MessageEnums;
+import org.apache.ambari.logsearch.conf.LogSearchConfigApiConfig;
 import org.apache.ambari.logsearch.conf.SolrKerberosConfig;
 import org.apache.ambari.logsearch.conf.SolrPropsConfig;
 import org.apache.ambari.logsearch.conf.global.LogSearchConfigState;
@@ -61,6 +62,9 @@ public abstract class SolrDaoBase {
   private LogSearchConfigState logSearchConfigState;
 
   @Inject
+  private LogSearchConfigApiConfig logSearchConfigApiConfig;
+
+  @Inject
   private LogSearchConfigConfigurer logSearchConfigConfigurer;
 
   protected SolrDaoBase(LogType logType) {
@@ -68,9 +72,15 @@ public abstract class SolrDaoBase {
   }
 
   public void waitForLogSearchConfig() {
-    while (!logSearchConfigState.isLogSearchConfigAvailable()) {
-      LOG.info("Log Search config not available yet, waiting...");
-      try { Thread.sleep(1000); } catch (Exception e) { LOG.warn("Exception during waiting for Log Search Config", e); }
+    if (logSearchConfigApiConfig.isConfigApiEnabled()) {
+      while (!logSearchConfigState.isLogSearchConfigAvailable()) {
+        LOG.info("Log Search config not available yet, waiting...");
+        try {
+          Thread.sleep(1000);
+        } catch (Exception e) {
+          LOG.warn("Exception during waiting for Log Search Config", e);
+        }
+      }
     }
   }
 

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/doc/DocConstants.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/doc/DocConstants.java
@@ -101,6 +101,7 @@ public class DocConstants {
   }
 
   public class PublicOperationDescriptions {
+    public static final String GET_FEATURES_LIST = "Get features list.";
     public static final String GET_APP_DETAILS_OD = "Get application details.";
     public static final String GET_AUTH_DETAILS_OD = "Get authentication details.";
     public static final String GET_ALL_PROPERTIES_INFO_OD = "List all available properties for Log Search and Log Feeder";

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/handler/CreateCollectionHandler.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/handler/CreateCollectionHandler.java
@@ -88,7 +88,7 @@ public class CreateCollectionHandler implements SolrZkRequestHandler<Boolean> {
     // Default is true, because if the collection and shard is already there, then it will return true
     boolean returnValue = true;
 
-    List<String> shardsList = new ArrayList<String>();
+    List<String> shardsList = new ArrayList<>();
     for (int i = 0; i < solrPropsConfig.getNumberOfShards(); i++) {
       shardsList.add("shard" + i);
     }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/InfoManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/InfoManager.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.ambari.logsearch.conf.AuthPropsConfig;
 import org.apache.ambari.logsearch.common.PropertyDescriptionStorage;
 import org.apache.ambari.logsearch.common.ShipperConfigDescriptionStorage;
+import org.apache.ambari.logsearch.conf.LogSearchConfigApiConfig;
 import org.apache.ambari.logsearch.model.response.PropertyDescriptionData;
 import org.apache.ambari.logsearch.model.response.ShipperConfigDescriptionData;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,9 +46,11 @@ public class InfoManager extends JsonManagerBase {
   @Value("${java.runtime.version}")
   private String javaRuntimeVersion;
 
-
   @Inject
   private AuthPropsConfig authPropsConfig;
+
+  @Inject
+  private LogSearchConfigApiConfig logSearchConfigApiConfig;
 
   @Inject
   private PropertyDescriptionStorage propertyDescriptionStore;
@@ -71,6 +74,13 @@ public class InfoManager extends JsonManagerBase {
     authMap.put("ldap", authPropsConfig.isAuthLdapEnabled());
     authMap.put("simple", authPropsConfig.isAuthSimpleEnabled());
     return authMap;
+  }
+
+  public Map<String, Object> getFeaturesMap() {
+    Map<String, Object> featuresMap = new HashMap<>();
+    featuresMap.put("auth", getAuthMap());
+    featuresMap.put("config_api", logSearchConfigApiConfig.isConfigApiEnabled());
+    return featuresMap;
   }
 
   public Map<String, List<PropertyDescriptionData>> getPropertyDescriptions() {

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/InfoResource.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/InfoResource.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import static org.apache.ambari.logsearch.doc.DocConstants.PublicOperationDescriptions.GET_ALL_PROPERTIES_INFO_OD;
 import static org.apache.ambari.logsearch.doc.DocConstants.PublicOperationDescriptions.GET_ALL_SHIPPER_CONFIG_INFO_OD;
 import static org.apache.ambari.logsearch.doc.DocConstants.PublicOperationDescriptions.GET_APP_DETAILS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.PublicOperationDescriptions.GET_FEATURES_LIST;
 import static org.apache.ambari.logsearch.doc.DocConstants.PublicOperationDescriptions.GET_LOGSEARCH_PROPERTIES_INFO_OD;
 import static org.apache.ambari.logsearch.doc.DocConstants.PublicOperationDescriptions.GET_AUTH_DETAILS_OD;
 
@@ -58,14 +59,6 @@ public class InfoResource {
   }
 
   @GET
-  @Path("/auth")
-  @Produces({"application/json"})
-  @ApiOperation(GET_AUTH_DETAILS_OD)
-  public Map<String, Boolean> getAuthInfo() {
-    return infoManager.getAuthMap();
-  }
-
-  @GET
   @Path("/properties")
   @Produces({"application/json"})
   @ApiOperation(GET_ALL_PROPERTIES_INFO_OD)
@@ -79,6 +72,22 @@ public class InfoResource {
   @ApiOperation(GET_LOGSEARCH_PROPERTIES_INFO_OD)
   public List<PropertyDescriptionData> getPropertyFileDescription(@PathParam("propertyFile") String propertyFile) {
     return infoManager.getLogSearchPropertyDescriptions(propertyFile);
+  }
+
+  @GET
+  @Path("/features")
+  @Produces({"application/json"})
+  @ApiOperation(GET_FEATURES_LIST)
+  public Map<String, Object> getFeatures() {
+    return infoManager.getFeaturesMap();
+  }
+
+  @GET
+  @Path("/features/auth")
+  @Produces({"application/json"})
+  @ApiOperation(GET_AUTH_DETAILS_OD)
+  public Map<String, Boolean> getAuthInfo() {
+    return infoManager.getAuthMap();
   }
 
   @GET


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make config api configurable, can be useful if logfeeder does not used for shipping logs
Also add new API endpoint for (/info/features) to check is the config api enabled or not. ( if disabled, the UI should hide metadata patterns)

## How was this patch tested?

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13.096 s
[INFO] Finished at: 2018-01-26T18:37:02+01:00
[INFO] Final Memory: 56M/594M
[INFO] ------------------------------------------------------------------------

FT: manually

Please review @kasakrisz @swagle 