### PR TITLE
[AMBARI-22857] Fix the if statement where & is used instead of &&

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
@@ -117,7 +117,7 @@ public class DefaultServiceCalculatedState implements ServiceCalculatedState {
                 hasDisabled = true;
               }
 
-              if (isInMaintenance & !componentInfo.isClient()) {
+              if (isInMaintenance && !componentInfo.isClient()) {
                 hasMM = true;
                 if ( maxMMState == null || state.ordinal() > maxMMState.ordinal()) {
                   maxMMState = state;


### PR DESCRIPTION
## What changes were proposed in this pull request?
AMBARI-22857
DefaultServiceCalculatedState.java in a if statement '&' is used instead of '&&' which might cause a unwanted behaviour
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.