### PR TITLE
[AMBARI-22858] First prereq not displaying for Free IPA method in Enable Kerberos Wizard

### DIFF
--- a/ambari-web/app/controllers/main/admin/kerberos/step1_controller.js
+++ b/ambari-web/app/controllers/main/admin/kerberos/step1_controller.js
@@ -85,7 +85,7 @@ App.KerberosWizardStep1Controller = Em.Controller.extend({
       value: Em.I18n.t('admin.kerberos.wizard.step1.option.ipa'),
       preConditions: [
         PreCondition.create({
-          dsplayText: Em.I18n.t('admin.kerberos.wizard.step1.option.ipa.condition.1'),
+          displayText: Em.I18n.t('admin.kerberos.wizard.step1.option.ipa.condition.1')
         }),
         PreCondition.create({
           displayText: Em.I18n.t('admin.kerberos.wizard.step1.option.ipa.condition.2')


### PR DESCRIPTION
## What changes were proposed in this pull request?
First prereq not displaying for Free IPA method in Enable Kerberos Wizard.

![image](https://user-images.githubusercontent.com/7302947/35461972-0f4aa23c-02b8-11e8-9d5c-214a02f8a223.png)

This is due to a typo at `ambari-web/app/controllers/main/admin/kerberos/step1_controller.js:88`
```
          dsplayText: Em.I18n.t('admin.kerberos.wizard.step1.option.ipa.condition.1'),
```
The code should be 
```
          displayText: Em.I18n.t('admin.kerberos.wizard.step1.option.ipa.condition.1')
```
Notice "dsplayText" vs "displayText".



(Please fill in changes proposed in this fix)

## How was this patch tested?

Changed the offending code and saw that the missing item was displayed as expected. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.