### PR TITLE
[AMBARI-22774] Handle configs update in the middle of request (RU).

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/DisableBatchingRemoteEndpointFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/DisableBatchingRemoteEndpointFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server;
+
+import org.eclipse.jetty.websocket.api.BatchMode;
+import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.extensions.OutgoingFrames;
+import org.eclipse.jetty.websocket.common.LogicalConnection;
+import org.eclipse.jetty.websocket.common.RemoteEndpointFactory;
+import org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint;
+
+
+public class DisableBatchingRemoteEndpointFactory implements RemoteEndpointFactory {
+  @Override
+  public RemoteEndpoint newRemoteEndpoint(LogicalConnection connection, OutgoingFrames outgoingFrames, BatchMode batchMode) {
+    return new WebSocketRemoteEndpoint(connection,outgoingFrames,BatchMode.OFF);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
@@ -21,10 +21,13 @@ import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.events.AgentConfigsUpdateEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -32,12 +35,18 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class AgentConfigsHolder extends AgentHostDataHolder<AgentConfigsUpdateEvent> {
+  public static final Logger LOG = LoggerFactory.getLogger(AgentConfigsHolder.class);
 
   @Inject
   private ConfigHelper configHelper;
 
   @Inject
   private Provider<Clusters> clusters;
+
+  @Inject
+  public AgentConfigsHolder(AmbariEventPublisher ambariEventPublisher) {
+    ambariEventPublisher.register(this);
+  }
 
   @Override
   public AgentConfigsUpdateEvent getCurrentData(Long hostId) throws AmbariException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AbstractUpgradeServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AbstractUpgradeServerAction.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ambari.server.serveraction.upgrades;
 
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.orm.dao.UpgradeDAO;
 import org.apache.ambari.server.orm.entities.UpgradeEntity;
 import org.apache.ambari.server.serveraction.AbstractServerAction;
@@ -58,6 +59,9 @@ public abstract class AbstractUpgradeServerAction extends AbstractServerAction {
    */
   @Inject
   private UpgradeContextFactory m_upgradeContextFactory;
+
+  @Inject
+  protected AgentConfigsHolder agentConfigsHolder;
 
   /**
    * Gets an initialized {@link UpgradeContext} for the in-progress upgrade.

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AtlasProxyUserConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AtlasProxyUserConfigCalculation.java
@@ -20,12 +20,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 public class AtlasProxyUserConfigCalculation extends AbstractUpgradeServerAction {
 
@@ -55,6 +57,7 @@ public class AtlasProxyUserConfigCalculation extends AbstractUpgradeServerAction
     currentAtlasApplicationProperties.put("atlas.proxyusers", atlasProxyUsers);
     atlasApplicationProperties.setProperties(currentAtlasApplicationProperties);
     atlasApplicationProperties.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     outputMessage = outputMessage + MessageFormat.format("Successfully updated {0} config type.\n", ATLAS_APPLICATION_PROPERTIES_CONFIG_TYPE);
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", outputMessage, "");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixCapacitySchedulerOrderingPolicy.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixCapacitySchedulerOrderingPolicy.java
@@ -23,12 +23,14 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * In HDP-2.6, the parent queue's cannot have a ordering-policy other than {@code utilization} or
@@ -109,6 +111,7 @@ public class FixCapacitySchedulerOrderingPolicy extends AbstractUpgradeServerAct
 
     config.setProperties(properties);
     config.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", stdout.toString(), "");
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixLzoCodecPath.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixLzoCodecPath.java
@@ -22,12 +22,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -71,6 +73,7 @@ public class FixLzoCodecPath extends AbstractUpgradeServerAction {
       }
       config.setProperties(properties);
       config.save();
+      agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
     }
     if (modifiedProperties.isEmpty()) {
       return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixOozieAdminUsers.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixOozieAdminUsers.java
@@ -20,12 +20,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -82,6 +84,7 @@ public class FixOozieAdminUsers extends AbstractUpgradeServerAction {
 
     oozieConfig.setProperties(oozieProperties);
     oozieConfig.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
             String.format("Set oozie admin users to %s", newOozieAdminUsers), "");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixYarnWebServiceUrl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FixYarnWebServiceUrl.java
@@ -19,12 +19,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * yarn.log.server.web-service.url is added in HDP 2.6
@@ -89,6 +91,7 @@ public class FixYarnWebServiceUrl extends AbstractUpgradeServerAction {
 
         config.setProperties(properties);
         config.save();
+        agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
         return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
                 String.format("The %s/%s property was changed based on %s. ", SOURCE_CONFIG_TYPE, YARN_LOGSERVER_WEBSERVICE_URL, YARN_HTTP_POLICY),"");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HBaseConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HBaseConfigCalculation.java
@@ -21,12 +21,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Computes HBase properties.  This class is only used when moving from
@@ -87,6 +89,7 @@ public class HBaseConfigCalculation extends AbstractUpgradeServerAction {
 
     config.setProperties(properties);
     config.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
                   String.format("%s was set to %s", NEW_LOWER_LIMIT_PROPERTY_NAME, lowerLimitNew.toString()), "");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HBaseEnvMaxDirectMemorySizeAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HBaseEnvMaxDirectMemorySizeAction.java
@@ -22,12 +22,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Computes HBase Env content property.
@@ -74,6 +76,7 @@ public class HBaseEnvMaxDirectMemorySizeAction extends AbstractUpgradeServerActi
 
     config.setProperties(properties);
     config.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
       String.format("The %s/%s property was appended with %s", SOURCE_CONFIG_TYPE, CONTENT_NAME, APPEND_CONTENT_LINE),"");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HiveEnvClasspathAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HiveEnvClasspathAction.java
@@ -22,12 +22,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Append hive-env config type with HIVE_HOME and HIVE_CONF_DIR variables if they are absent
@@ -98,6 +100,7 @@ public class HiveEnvClasspathAction extends AbstractUpgradeServerAction {
 
     config.setProperties(properties);
     config.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
       String.format("Added %s, %s to content at %s", HIVE_CONF_DIR, HIVE_HOME, TARGET_CONFIG_TYPE), "");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HiveZKQuorumConfigAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/HiveZKQuorumConfigAction.java
@@ -19,12 +19,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * The {@link HiveZKQuorumConfigAction} is used to ensure that the following
@@ -77,6 +79,7 @@ public class HiveZKQuorumConfigAction extends AbstractUpgradeServerAction {
 
     hiveSite.setProperties(hiveSiteProperties);
     hiveSite.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
         String.format("Successfully set %s and %s in %s", HIVE_SITE_ZK_QUORUM,

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/OozieConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/OozieConfigCalculation.java
@@ -22,12 +22,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Changes oozie-env during upgrade (adds -Dhdp.version to $HADOOP_OPTS variable)
@@ -62,6 +64,7 @@ public class OozieConfigCalculation extends AbstractUpgradeServerAction {
 
     config.setProperties(properties);
     config.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
                   String.format("Added -Dhdp.version to $HADOOP_OPTS variable at %s", TARGET_CONFIG_TYPE), "");

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerConfigCalculation.java
@@ -20,12 +20,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Computes Ranger properties.  This class is only used when moving from
@@ -141,6 +143,7 @@ public class RangerConfigCalculation extends AbstractUpgradeServerAction {
     targetValues.put("ranger_privelege_user_jdbc_url", userJDBCUrl);
     config.setProperties(targetValues);
     config.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", stdout.toString(), "");
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerKerberosConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerKerberosConfigCalculation.java
@@ -20,12 +20,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.commons.lang.StringUtils;
 
@@ -253,6 +255,8 @@ public class RangerKerberosConfigCalculation extends AbstractUpgradeServerAction
     if(!errMsg.equalsIgnoreCase("")) {
       outputMsg = outputMsg + MessageFormat.format("\n {0}", errMsg, RANGER_ADMIN_SITE_CONFIG_TYPE);
     }
+    //TODO only when configs were changed
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", outputMsg, "");
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerKmsProxyConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerKmsProxyConfig.java
@@ -78,7 +78,8 @@ public class RangerKmsProxyConfig extends AbstractUpgradeServerAction {
       targetValues.put(hostProp, "*");
       kmsSite.setProperties(targetValues);
       kmsSite.save();
-      agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
+      agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream()
+          .map(Host::getHostId).collect(Collectors.toList()));
       outputMsg = outputMsg + MessageFormat.format("Successfully added properties to {0}", RANGER_KMS_SITE_CONFIG_TYPE);
     } else {
       outputMsg = outputMsg +  MessageFormat.format("Kerberos not enable, not setting proxy properties to {0}", RANGER_KMS_SITE_CONFIG_TYPE);

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerKmsProxyConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerKmsProxyConfig.java
@@ -20,12 +20,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.SecurityType;
 
 /**
@@ -76,6 +78,7 @@ public class RangerKmsProxyConfig extends AbstractUpgradeServerAction {
       targetValues.put(hostProp, "*");
       kmsSite.setProperties(targetValues);
       kmsSite.save();
+      agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
       outputMsg = outputMsg + MessageFormat.format("Successfully added properties to {0}", RANGER_KMS_SITE_CONFIG_TYPE);
     } else {
       outputMsg = outputMsg +  MessageFormat.format("Kerberos not enable, not setting proxy properties to {0}", RANGER_KMS_SITE_CONFIG_TYPE);

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerUsersyncConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/RangerUsersyncConfigCalculation.java
@@ -21,12 +21,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Computes Ranger Usersync ldap grouphierarchylevels property. This class is only used when upgrading from
@@ -81,6 +83,7 @@ public class RangerUsersyncConfigCalculation extends AbstractUpgradeServerAction
   targetRangerEnvConfig.put("is_nested_groupsync_enabled", enableSyncNestedGroup);
   rangerEnvConfig.setProperties(targetRangerEnvConfig);
   rangerEnvConfig.save();
+  agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
   outputMsg = outputMsg + MessageFormat.format("Successfully updated {0} config type.\n", RANGER_ENV_CONFIG_TYPE);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/SparkShufflePropertyConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/SparkShufflePropertyConfig.java
@@ -23,12 +23,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -82,6 +84,7 @@ public class SparkShufflePropertyConfig extends AbstractUpgradeServerAction {
       yarnSiteProperties.put(YARN_NODEMANAGER_AUX_SERVICES_SPARK_SHUFFLE_CLASS, YARN_NODEMANAGER_AUX_SERVICES_SPARK_SHUFFLE_CLASS_VALUE);
       yarnSiteConfig.setProperties(yarnSiteProperties);
     yarnSiteConfig.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
       return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
         String.format("%s was set from %s to %s. %s was set to %s",

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/YarnConfigCalculation.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/YarnConfigCalculation.java
@@ -20,12 +20,14 @@ package org.apache.ambari.server.serveraction.upgrades;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.Host;
 
 /**
  * Computes Yarn properties.  This class is only used when moving from
@@ -61,6 +63,7 @@ public class YarnConfigCalculation extends AbstractUpgradeServerAction {
     yarnSiteProperties.put(HADOOP_REGISTRY_ZK_QUORUM_PROPERTY_NAME, zkServersStr);
     yarnSiteConfig.setProperties(yarnSiteProperties);
     yarnSiteConfig.save();
+    agentConfigsHolder.updateData(cluster.getClusterId(), cluster.getHosts().stream().map(Host::getHostId).collect(Collectors.toList()));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}",
         String.format("%s was set from %s to %s. %s was set from %s to %s",

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigImpl.java
@@ -378,19 +378,8 @@ public class ConfigImpl implements Config {
    * {@inheritDoc}
    */
   @Override
-  public void save() {
-    ClusterConfigEntity entity = saveWithoutPublishing();
-    if (entity != null) {
-      // broadcast the change event for the configuration
-      ClusterConfigChangedEvent event = new ClusterConfigChangedEvent(cluster.getClusterName(),
-          getType(), getTag(), getVersion());
-
-      eventPublisher.publish(event);
-    }
-  }
-
   @Transactional
-  public ClusterConfigEntity saveWithoutPublishing() {
+  public void save() {
     ClusterConfigEntity entity = clusterDAO.findConfig(configId);
     ClusterEntity clusterEntity = clusterDAO.findById(entity.getClusterId());
 
@@ -407,7 +396,12 @@ public class ConfigImpl implements Config {
 
       // re-load the entity associations for the cluster
       cluster.refresh();
+
+      // broadcast the change event for the configuration
+      ClusterConfigChangedEvent event = new ClusterConfigChangedEvent(cluster.getClusterName(),
+          getType(), getTag(), getVersion());
+
+      eventPublisher.publish(event);
     }
-    return entity;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -34,8 +34,11 @@ import java.util.regex.Pattern;
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
+import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
 import org.apache.ambari.server.controller.internal.TaskResourceProvider;
 import org.apache.ambari.server.controller.predicate.AndPredicate;
 import org.apache.ambari.server.controller.spi.ClusterController;
@@ -197,7 +200,13 @@ public class UpgradeHelper {
    * Used to update the configuration properties.
    */
   @Inject
-  private Provider<AmbariManagementController> m_controllerProvider;
+  private Provider<AmbariManagementControllerImpl> m_controllerProvider;
+
+  @Inject
+  private Provider<MetadataHolder> m_metadataHolder;
+
+  @Inject
+  private Provider<AgentConfigsHolder> m_agentConfigsHolder;
 
   /**
    * Used to get configurations by service name.
@@ -950,6 +959,7 @@ public class UpgradeHelper {
 
     Set<String> clusterConfigTypes = new HashSet<>();
     Set<String> processedClusterConfigTypes = new HashSet<>();
+    boolean configsChanged = false;
 
     // merge or revert configurations for any service that needs it
     for (String serviceName : servicesInUpgrade) {
@@ -974,6 +984,7 @@ public class UpgradeHelper {
       // downgrade is easy - just remove the new and make the old current
       if (direction == Direction.DOWNGRADE) {
         cluster.applyLatestConfigurations(targetStackId, serviceName);
+        configsChanged = true;
         continue;
       }
 
@@ -1149,7 +1160,12 @@ public class UpgradeHelper {
 
         configHelper.createConfigTypes(cluster, targetStackId, controller,
             newServiceDefaultConfigsByType, userName, serviceVersionNote);
+        configsChanged = true;
       }
+    }
+    if (configsChanged) {
+      m_metadataHolder.get().updateData(m_controllerProvider.get().getClusterMetadataOnConfigsUpdate(cluster));
+      m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
     }
   }
 

--- a/ambari-server/src/main/resources/META-INF/services/org.eclipse.jetty.websocket.common.RemoteEndpointFactory
+++ b/ambari-server/src/main/resources/META-INF/services/org.eclipse.jetty.websocket.common.RemoteEndpointFactory
@@ -1,0 +1,17 @@
+#   Licensed to the Apache Software Foundation (ASF) under one
+#   or more contributor license agreements.  See the NOTICE file
+#   distributed with this work for additional information
+#   regarding copyright ownership.  The ASF licenses this file
+#   to you under the Apache License, Version 2.0 (the
+#   "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+org.apache.ambari.server.DisableBatchingRemoteEndpointFactory

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeResourceProviderTest.java
@@ -51,6 +51,7 @@ import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.actionmanager.Stage;
 import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.agent.ExecutionCommand.KeyNames;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
@@ -146,6 +147,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
   private Clusters clusters;
   private AmbariManagementController amc;
   private ConfigHelper configHelper;
+  private AgentConfigsHolder agentConfigsHolder = createNiceMock(AgentConfigsHolder.class);
   private StackDAO stackDAO;
   private TopologyManager topologyManager;
   private ConfigFactory configFactory;
@@ -2044,6 +2046,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     @Override
     public void configure(Binder binder) {
       binder.bind(ConfigHelper.class).toInstance(configHelper);
+      binder.bind(AgentConfigsHolder.class).toInstance(agentConfigsHolder);
     }
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/FixOozieAdminUsersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/FixOozieAdminUsersTest.java
@@ -18,12 +18,16 @@
 package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,6 +35,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -46,14 +51,17 @@ import com.google.inject.Injector;
 public class FixOozieAdminUsersTest {
   private Injector injector;
   private Clusters clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Cluster cluster;
   private Field clustersField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     injector = EasyMock.createMock(Injector.class);
     clusters = EasyMock.createMock(Clusters.class);
     cluster = EasyMock.createMock(Cluster.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
 
     Map<String, String> mockProperties = new HashMap<String, String>() {{
       put("falcon_user", "falcon");
@@ -73,13 +81,19 @@ public class FixOozieAdminUsersTest {
 
     expect(cluster.getDesiredConfigByType("falcon-env")).andReturn(falconEnvConfig).atLeastOnce();
     expect(cluster.getDesiredConfigByType("oozie-env")).andReturn(oozieEnvConfig).atLeastOnce();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
 
     expect(clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
     expect(injector.getInstance(Clusters.class)).andReturn(clusters).atLeastOnce();
-    replay(injector, clusters, falconEnvConfig, oozieEnvConfig);
+    replay(injector, clusters, falconEnvConfig, oozieEnvConfig, agentConfigsHolder);
 
     clustersField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     clustersField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
 
   }
 
@@ -105,6 +119,7 @@ public class FixOozieAdminUsersTest {
 
     FixOozieAdminUsers action = new FixOozieAdminUsers();
     clustersField.set(action, clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
 
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/HiveEnvClasspathActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/HiveEnvClasspathActionTest.java
@@ -18,12 +18,16 @@
 package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -33,6 +37,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -50,12 +55,15 @@ import junit.framework.Assert;
 public class HiveEnvClasspathActionTest {
   private Injector m_injector;
   private Clusters m_clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Field m_clusterField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     m_injector = EasyMock.createMock(Injector.class);
     m_clusters = EasyMock.createMock(Clusters.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
     Cluster cluster = EasyMock.createMock(Cluster.class);
 
     Map<String, String> mockProperties = new HashMap<String, String>() {{
@@ -115,12 +123,19 @@ public class HiveEnvClasspathActionTest {
     expect(cluster.getDesiredConfigByType("hive-env")).andReturn(hiveEnv).atLeastOnce();
 
     expect(m_clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
+
     expect(m_injector.getInstance(Clusters.class)).andReturn(m_clusters).atLeastOnce();
 
-    replay(m_injector, m_clusters, cluster, hiveEnv);
+    replay(m_injector, m_clusters, cluster, hiveEnv, agentConfigsHolder);
 
     m_clusterField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     m_clusterField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
   }
 
 
@@ -143,6 +158,7 @@ public class HiveEnvClasspathActionTest {
     HiveEnvClasspathAction action = new HiveEnvClasspathAction();
 
     m_clusterField.set(action, m_clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
 
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/KerberosKeytabsActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/KerberosKeytabsActionTest.java
@@ -33,6 +33,7 @@ import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.dao.StackDAO;
@@ -103,6 +104,7 @@ public class KerberosKeytabsActionTest {
         bind(StackDAO.class).toInstance(EasyMock.createNiceMock(StackDAO.class));
         bind(EntityManager.class).toInstance(EasyMock.createNiceMock(EntityManager.class));
         bind(DBAccessor.class).toInstance(EasyMock.createNiceMock(DBAccessor.class));
+        bind(AmbariMetaInfo.class).toInstance(EasyMock.createNiceMock(AmbariMetaInfo.class));
       }
     });
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerConfigCalculationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerConfigCalculationTest.java
@@ -18,13 +18,17 @@
 package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +36,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -48,12 +53,15 @@ public class RangerConfigCalculationTest {
 
   private Injector m_injector;
   private Clusters m_clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Field m_clusterField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     m_injector = EasyMock.createMock(Injector.class);
     m_clusters = EasyMock.createMock(Clusters.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
     Cluster cluster = EasyMock.createMock(Cluster.class);
 
     Map<String, String> mockProperties = new HashMap<String, String>() {{
@@ -83,12 +91,19 @@ public class RangerConfigCalculationTest {
     expect(cluster.getDesiredConfigByType("ranger-env")).andReturn(rangerEnv).atLeastOnce();
 
     expect(m_clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
+
     expect(m_injector.getInstance(Clusters.class)).andReturn(m_clusters).atLeastOnce();
 
-    replay(m_injector, m_clusters, cluster, adminConfig, adminSiteConfig, rangerEnv);
+    replay(m_injector, m_clusters, cluster, adminConfig, adminSiteConfig, rangerEnv, agentConfigsHolder);
 
     m_clusterField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     m_clusterField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
   }
 
   @Test
@@ -109,6 +124,7 @@ public class RangerConfigCalculationTest {
 
     RangerConfigCalculation action = new RangerConfigCalculation();
     m_clusterField.set(action, m_clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
 
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerKerberosConfigCalculationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerKerberosConfigCalculationTest.java
@@ -18,7 +18,10 @@
 package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -33,6 +36,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -51,13 +55,16 @@ public class RangerKerberosConfigCalculationTest {
 
   private Injector m_injector;
   private Clusters m_clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Field m_clusterField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     m_injector = EasyMock.createMock(Injector.class);
     m_clusters = EasyMock.createMock(Clusters.class);
     Cluster cluster = EasyMock.createMock(Cluster.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
 
     Config hadoopConfig = EasyMock.createNiceMock(Config.class);
     expect(hadoopConfig.getType()).andReturn("hadoop-env").anyTimes();
@@ -118,12 +125,18 @@ public class RangerKerberosConfigCalculationTest {
     expect(m_clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
     expect(m_injector.getInstance(Clusters.class)).andReturn(m_clusters).atLeastOnce();
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
 
     replay(m_injector, m_clusters, cluster, hadoopConfig, hiveConfig, yarnConfig, hbaseConfig,
-        knoxConfig, stormConfig, kafkaConfig, kmsConfig, hdfsSiteConfig, adminSiteConfig);
+        knoxConfig, stormConfig, kafkaConfig, kmsConfig, hdfsSiteConfig, adminSiteConfig, agentConfigsHolder);
 
     m_clusterField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     m_clusterField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
   }
 
   @Test
@@ -144,6 +157,7 @@ public class RangerKerberosConfigCalculationTest {
 
     RangerKerberosConfigCalculation action = new RangerKerberosConfigCalculation();
     m_clusterField.set(action, m_clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
 
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerKmsProxyConfigTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerKmsProxyConfigTest.java
@@ -18,13 +18,17 @@
 package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +36,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -46,12 +51,15 @@ import com.google.inject.Injector;
 public class RangerKmsProxyConfigTest {
   private Injector m_injector;
   private Clusters m_clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Field m_clusterField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     m_injector = EasyMock.createMock(Injector.class);
     m_clusters = EasyMock.createMock(Clusters.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
     Cluster cluster = EasyMock.createMock(Cluster.class);
 
     Map<String, String> mockProperties = new HashMap<String, String>() {
@@ -73,11 +81,17 @@ public class RangerKmsProxyConfigTest {
     expect(m_clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
     expect(m_injector.getInstance(Clusters.class)).andReturn(m_clusters).atLeastOnce();
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
 
-    replay(m_injector, m_clusters, cluster, rangerEnv, kmsSite);
+    replay(m_injector, m_clusters, cluster, rangerEnv, kmsSite, agentConfigsHolder);
 
     m_clusterField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     m_clusterField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
   }
 
   @Test
@@ -98,6 +112,7 @@ public class RangerKmsProxyConfigTest {
 
     RangerKmsProxyConfig action = new RangerKmsProxyConfig();
     m_clusterField.set(action, m_clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
 
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerUsersyncConfigCalculationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/RangerUsersyncConfigCalculationTest.java
@@ -19,11 +19,13 @@ package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,6 +33,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -44,12 +47,15 @@ public class RangerUsersyncConfigCalculationTest {
 
   private Injector m_injector;
   private Clusters m_clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Field m_clusterField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     m_injector = createMock(Injector.class);
     m_clusters = createMock(Clusters.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
     Cluster cluster = createMock(Cluster.class);
 
     Map<String, String> mockRangerUsersyncProperties = new HashMap<String, String>() {
@@ -78,11 +84,17 @@ public class RangerUsersyncConfigCalculationTest {
     expect(cluster.getDesiredConfigByType("ranger-env")).andReturn(rangerEnvConfig).atLeastOnce();
     expect(m_clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
     expect(m_injector.getInstance(Clusters.class)).andReturn(m_clusters).atLeastOnce();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
 
-    replay(m_injector, m_clusters, cluster, rangerUsersyncConfig, rangerEnvConfig);
+    replay(m_injector, m_clusters, cluster, rangerUsersyncConfig, rangerEnvConfig, agentConfigsHolder);
 
     m_clusterField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     m_clusterField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
 
   }
 
@@ -104,6 +116,7 @@ public class RangerUsersyncConfigCalculationTest {
 
     RangerUsersyncConfigCalculation action = new RangerUsersyncConfigCalculation();
     m_clusterField.set(action, m_clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
 
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/SparkShufflePropertyConfigTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/SparkShufflePropertyConfigTest.java
@@ -19,13 +19,17 @@
 package org.apache.ambari.server.serveraction.upgrades;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +37,7 @@ import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
@@ -48,13 +53,16 @@ import com.google.inject.Injector;
 public class SparkShufflePropertyConfigTest {
   private Injector m_injector;
   private Clusters m_clusters;
+  private AgentConfigsHolder agentConfigsHolder;
   private Cluster cluster;
   private Field clusterField;
+  private Field agentConfigsHolderField;
 
   @Before
   public void setup() throws Exception {
     m_injector = EasyMock.createMock(Injector.class);
     m_clusters = EasyMock.createMock(Clusters.class);
+    agentConfigsHolder = createMock(AgentConfigsHolder.class);
     cluster = EasyMock.createMock(Cluster.class);
 
     Map<String, String> mockProperties = new HashMap<String, String>() {{
@@ -69,11 +77,17 @@ public class SparkShufflePropertyConfigTest {
 
     expect(m_clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
     expect(m_injector.getInstance(Clusters.class)).andReturn(m_clusters).atLeastOnce();
+    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
+    expect(cluster.getHosts()).andReturn(Collections.emptyList()).atLeastOnce();
+    agentConfigsHolder.updateData(eq(1L), eq(Collections.emptyList()));
+    expectLastCall().atLeastOnce();
 
-    replay(m_injector, m_clusters, yarnConfig);
+    replay(m_injector, m_clusters, yarnConfig, agentConfigsHolder);
 
     clusterField = AbstractUpgradeServerAction.class.getDeclaredField("m_clusters");
     clusterField.setAccessible(true);
+    agentConfigsHolderField = AbstractUpgradeServerAction.class.getDeclaredField("agentConfigsHolder");
+    agentConfigsHolderField.setAccessible(true);
   }
 
   @Test
@@ -93,6 +107,7 @@ public class SparkShufflePropertyConfigTest {
     replay(cluster, hrc);
 
     clusterField.set(action, m_clusters);
+    agentConfigsHolderField.set(action, agentConfigsHolder);
     action.setExecutionCommand(executionCommand);
     action.setHostRoleCommand(hrc);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -48,6 +48,7 @@ import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.H2DatabaseCleaner;
 import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ClusterRequest;
@@ -2369,12 +2370,11 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     Capture<Map<String, Map<String, String>>> expectedConfigurationsCapture = EasyMock.newCapture();
 
-    configHelper.createConfigTypes(EasyMock.anyObject(Cluster.class),
+    expect(configHelper.createConfigTypes(EasyMock.anyObject(Cluster.class),
         EasyMock.anyObject(StackId.class), EasyMock.anyObject(AmbariManagementController.class),
         EasyMock.capture(expectedConfigurationsCapture), EasyMock.anyObject(String.class),
-        EasyMock.anyObject(String.class));
+        EasyMock.anyObject(String.class))).andReturn(true);
 
-    expectLastCall().once();
     EasyMock.replay(configHelperProvider, configHelper);
 
     // mock the service config DAO and replay it
@@ -2480,15 +2480,14 @@ public class UpgradeHelperTest extends EasyMockSupport {
     expect(m_configHelper.getDefaultProperties(newStack, "HIVE")).andReturn(stackMap).atLeastOnce();
     expect(m_configHelper.getDefaultProperties(oldStack, "ZOOKEEPER")).andReturn(stackMap).atLeastOnce();
     expect(m_configHelper.getDefaultProperties(newStack, "ZOOKEEPER")).andReturn(stackMap).atLeastOnce();
-    m_configHelper.createConfigTypes(
+    expect(m_configHelper.createConfigTypes(
         EasyMock.capture(captureCluster),
         EasyMock.capture(captureStackId),
         EasyMock.capture(captureAmc),
         EasyMock.capture(cap),
 
         EasyMock.capture(captureUsername),
-        EasyMock.capture(captureNote));
-    expectLastCall().atLeastOnce();
+        EasyMock.capture(captureNote))).andReturn(true);
 
     replay(m_configHelper);
 
@@ -2844,6 +2843,7 @@ public class UpgradeHelperTest extends EasyMockSupport {
     public void configure(Binder binder) {
       binder.install(new FactoryModuleBuilder().build(UpgradeContextFactory.class));
       binder.bind(ConfigHelper.class).toInstance(m_configHelper);
+      binder.bind(AgentConfigsHolder.class).toInstance(createNiceMock(AgentConfigsHolder.class));
     }
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/testutils/PartialNiceMockBinder.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/testutils/PartialNiceMockBinder.java
@@ -131,7 +131,7 @@ public class PartialNiceMockBinder implements Module {
       return this;
     }
 
-    public Builder addAmbariMetaInfoBinding() {
+    public Builder addAmbariMetaInfoBinding(AmbariManagementController ambariManagementController) {
       PartialNiceMockBinder.this.configurers.add((Binder binder) -> {
           binder.bind(PersistedState.class).toInstance(easyMockSupport.createNiceMock(PersistedState.class));
           binder.bind(HostRoleCommandFactory.class).to(HostRoleCommandFactoryImpl.class);
@@ -145,7 +145,7 @@ public class PartialNiceMockBinder implements Module {
           binder.bind(ServiceComponentHostFactory.class).toInstance(easyMockSupport.createNiceMock(ServiceComponentHostFactory.class));
           binder.bind(AbstractRootServiceResponseFactory.class).to(RootServiceResponseFactory.class);
           binder.bind(CredentialStoreService.class).toInstance(easyMockSupport.createNiceMock(CredentialStoreService.class));
-          binder.bind(AmbariManagementController.class).toInstance(easyMockSupport.createNiceMock(AmbariManagementController.class));
+          binder.bind(AmbariManagementController.class).toInstance(ambariManagementController);
           binder.bind(ExecutionScheduler.class).to(ExecutionSchedulerImpl.class);
       });
       addConfigsBindings();
@@ -153,8 +153,17 @@ public class PartialNiceMockBinder implements Module {
       return this;
     }
 
+    public Builder addAmbariMetaInfoBinding() {
+      return addAmbariMetaInfoBinding(easyMockSupport.createNiceMock(AmbariManagementController.class));
+    }
+
     public Builder addAlertDefinitionDAOBinding() {
       addAmbariMetaInfoBinding();
+      return this;
+    }
+
+    public Builder addClustersBinding(AmbariManagementController ambariManagementController) {
+      addAmbariMetaInfoBinding(ambariManagementController);
       return this;
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/update/HostUpdateHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/update/HostUpdateHelperTest.java
@@ -37,6 +37,8 @@ import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
 import org.apache.ambari.server.actionmanager.HostRoleCommandFactoryImpl;
 import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.actionmanager.StageFactoryImpl;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.audit.AuditLoggerDefaultImpl;
 import org.apache.ambari.server.configuration.Configuration;
@@ -249,11 +251,15 @@ public class HostUpdateHelperTest {
     final Injector mockInjector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
-        bind(AmbariManagementController.class).toInstance(mockAmbariManagementController);
+        PartialNiceMockBinder.newBuilder().addClustersBinding(mockAmbariManagementController).build().configure(binder());
+        bind(StackManagerFactory.class).toInstance(easyMockSupport.createNiceMock(StackManagerFactory.class));
         bind(DBAccessor.class).toInstance(dbAccessor);
         bind(EntityManager.class).toInstance(entityManager);
         bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));
         bind(ClusterDAO.class).toInstance(mockClusterDAO);
+        bind(Clusters.class).toInstance(createNiceMock(Clusters.class));
+        bind(AmbariMetaInfo.class).toInstance(EasyMock.createNiceMock(AmbariMetaInfo.class));
+        bind(AgentConfigsHolder.class).toInstance(EasyMock.createNiceMock(AgentConfigsHolder.class));
 
         install(new FactoryModuleBuilder().implement(Config.class, ConfigImpl.class).build(ConfigFactory.class));
       }
@@ -275,6 +281,10 @@ public class HostUpdateHelperTest {
 
     expect(mockClusters.getCluster("cl1")).andReturn(mockCluster).once();
     expect(mockCluster.getClusterId()).andReturn(1L).anyTimes();
+
+    Host host = easyMockSupport.createNiceMock(Host.class);
+    expect(mockCluster.getHost(anyString())).andReturn(host).anyTimes();
+    expect(host.getHostId()).andReturn(1L).anyTimes();
 
     expect(mockClusterEntity1.getClusterConfigEntities()).andReturn(clusterConfigEntities1).atLeastOnce();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Config updates are now sent to agent if updated by server task
Disabled Jetty websocket batching, as agent is not able to handle it currently

## How was this patch tested?
unit and manual tests.
