### PR TITLE
[AMBARI-22869]. Log Search: use default page and pageSize to log requests

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
@@ -60,6 +60,10 @@ public class LogSearchConstants {
   public static final String LOGFEEDER_FILTER_NAME = "log_feeder_config";
 
   public static final String SORT = "sort";
+
+  // info features constants
+  public static final String SHIPPER_CONFIG_API_KEY = "metadata_patterns";
+  public static final String AUTH_FEATURE_KEY = "auth";
   
   //Facet Constant
   public static final String FACET_FIELD = "facet.field";
@@ -109,5 +113,7 @@ public class LogSearchConstants {
   public static final String REQUEST_PARAM_UTC_OFFSET = "utcOffset";
   public static final String REQUEST_PARAM_HOSTS = "hostList";
 
+  public static final String REQUEST_PARAM_PAGE_DEFAULT_VALUE = "0";
+  public static final String REQUEST_PARAM_PAGE_SIZE_DEFAULT_VALUE = "1000";
 
 }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/InfoManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/InfoManager.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ambari.logsearch.common.LogSearchConstants;
 import org.apache.ambari.logsearch.conf.AuthPropsConfig;
 import org.apache.ambari.logsearch.common.PropertyDescriptionStorage;
 import org.apache.ambari.logsearch.common.ShipperConfigDescriptionStorage;
@@ -78,8 +79,8 @@ public class InfoManager extends JsonManagerBase {
 
   public Map<String, Object> getFeaturesMap() {
     Map<String, Object> featuresMap = new HashMap<>();
-    featuresMap.put("auth", getAuthMap());
-    featuresMap.put("config_api", logSearchConfigApiConfig.isConfigApiEnabled());
+    featuresMap.put(LogSearchConstants.AUTH_FEATURE_KEY, getAuthMap());
+    featuresMap.put(LogSearchConstants.SHIPPER_CONFIG_API_KEY, logSearchConfigApiConfig.isConfigApiEnabled());
     return featuresMap;
   }
 

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/CommonSearchRequest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/CommonSearchRequest.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.annotation.Nullable;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 
 public class CommonSearchRequest implements SearchRequest, CommonSearchParamDefinition {
@@ -33,9 +34,11 @@ public class CommonSearchRequest implements SearchRequest, CommonSearchParamDefi
   private String startIndex;
 
   @QueryParam(LogSearchConstants.REQUEST_PARAM_PAGE)
+  @DefaultValue(LogSearchConstants.REQUEST_PARAM_PAGE_DEFAULT_VALUE)
   private String page;
 
   @QueryParam(LogSearchConstants.REQUEST_PARAM_PAGE_SIZE)
+  @DefaultValue(LogSearchConstants.REQUEST_PARAM_PAGE_SIZE_DEFAULT_VALUE)
   private String pageSize;
 
   @QueryParam(LogSearchConstants.REQUEST_PARAM_SORT_BY)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use default values for page and pageSize params for Log Search

The patch also contains a small renaming for info features (metadata_patterns)

## How was this patch tested?

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 14.243 s
[INFO] Finished at: 2018-01-29T18:55:38+01:00
[INFO] Final Memory: 57M/652M
[INFO] ------------------------------------------------------------------------


please review @kasakrisz @swagle 