### PR TITLE
[AMBARI-22865] Moving out get_service_component_meta to DefaultStackAdvisor so that all children can use this function

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/services/stack_advisor.py
@@ -809,55 +809,6 @@ class HDP206StackAdvisor(DefaultStackAdvisor):
       parentValidators[service].update(configsDict)
 
 
-  def get_service_component_meta(self, service, component, services):
-    """
-    Function retrieve service component meta information as dict from services.json
-    If no service or component found, would be returned empty dict
-
-    Return value example:
-        "advertise_version" : true,
-        "bulk_commands_display_name" : "",
-        "bulk_commands_master_component_name" : "",
-        "cardinality" : "1+",
-        "component_category" : "CLIENT",
-        "component_name" : "HBASE_CLIENT",
-        "custom_commands" : [ ],
-        "decommission_allowed" : false,
-        "display_name" : "HBase Client",
-        "has_bulk_commands_definition" : false,
-        "is_client" : true,
-        "is_master" : false,
-        "reassign_allowed" : false,
-        "recovery_enabled" : false,
-        "service_name" : "HBASE",
-        "stack_name" : "HDP",
-        "stack_version" : "2.5",
-        "hostnames" : [ "host1", "host2" ]
-
-    :type service str
-    :type component str
-    :type services dict
-    :rtype dict
-    """
-    __stack_services = "StackServices"
-    __stack_service_components = "StackServiceComponents"
-
-    if not services:
-      return {}
-
-    service_meta = [item for item in services["services"] if item[__stack_services]["service_name"] == service]
-    if len(service_meta) == 0:
-      return {}
-
-    service_meta = service_meta[0]
-    component_meta = [item for item in service_meta["components"] if item[__stack_service_components]["component_name"] == component]
-
-    if len(component_meta) == 0:
-      return {}
-
-    return component_meta[0][__stack_service_components]
-
-
   def get_components_list(self, service, services):
     """
     Return list of components for specific service

--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -2295,6 +2295,54 @@ class DefaultStackAdvisor(StackAdvisor):
 
     return [service["StackServices"]["service_name"] for service in services["services"]]
 
+  def get_service_component_meta(self, service, component, services):
+    """
+    Function retrieve service component meta information as dict from services.json
+    If no service or component found, would be returned empty dict
+
+    Return value example:
+        "advertise_version" : true,
+        "bulk_commands_display_name" : "",
+        "bulk_commands_master_component_name" : "",
+        "cardinality" : "1+",
+        "component_category" : "CLIENT",
+        "component_name" : "HBASE_CLIENT",
+        "custom_commands" : [ ],
+        "decommission_allowed" : false,
+        "display_name" : "HBase Client",
+        "has_bulk_commands_definition" : false,
+        "is_client" : true,
+        "is_master" : false,
+        "reassign_allowed" : false,
+        "recovery_enabled" : false,
+        "service_name" : "HBASE",
+        "stack_name" : "HDP",
+        "stack_version" : "2.5",
+        "hostnames" : [ "host1", "host2" ]
+
+    :type service str
+    :type component str
+    :type services dict
+    :rtype dict
+    """
+    __stack_services = "StackServices"
+    __stack_service_components = "StackServiceComponents"
+
+    if not services:
+      return {}
+
+    service_meta = [item for item in services["services"] if item[__stack_services]["service_name"] == service]
+    if len(service_meta) == 0:
+      return {}
+
+    service_meta = service_meta[0]
+    component_meta = [item for item in service_meta["components"] if item[__stack_service_components]["component_name"] == component]
+
+    if len(component_meta) == 0:
+      return {}
+
+    return component_meta[0][__stack_service_components]
+
   #region HDFS
   def getHadoopProxyUsersValidationItems(self, properties, services, hosts, configurations):
     validationItems = []


### PR DESCRIPTION
## What changes were proposed in this pull request?

When installed Hive v2.1.0.3.0 (the version we use in HDP 3.0) an error occurred saying there is no `get_service_component_meta` function found in its service advisor code. The solution is to move this (quite general function) from HDP 2.0.6 into the upmost parent so that children classes can use it going forward regardless of their version (or they can overwrite if needed)

## How was this patch tested?

Latest Python test results in ambari-server

```
----------------------------------------------------------------------
Total run:1212
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:59 min
[INFO] Finished at: 2018-01-29T21:07:26+01:00
[INFO] Final Memory: 98M/1616M
[INFO] ------------------------------------------------------------------------

```
Functional testing have been executed manually:

1. the affected files have been copied into my local cluster
2. server/agent instances were restarted
3. tried to install Hive; finished successfully
