### PR TITLE
[AMBARI-22874]. Log Search: Return with 500 error for shipper config te…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
@@ -33,7 +33,7 @@ public class LogSearchConstants {
   public static final String TRACE = "TRACE";
   public static final String FATAL = "FATAL";
   public static final String UNKNOWN = "UNKNOWN";
-  
+
   public static final String[] SUPPORTED_LOG_LEVELS = {FATAL, ERROR, WARN, INFO, DEBUG, TRACE, UNKNOWN};
 
   // Application Constants
@@ -64,7 +64,7 @@ public class LogSearchConstants {
   // info features constants
   public static final String SHIPPER_CONFIG_API_KEY = "metadata_patterns";
   public static final String AUTH_FEATURE_KEY = "auth";
-  
+
   //Facet Constant
   public static final String FACET_FIELD = "facet.field";
   public static final String FACET_PIVOT = "facet.pivot";
@@ -113,8 +113,9 @@ public class LogSearchConstants {
   public static final String REQUEST_PARAM_UTC_OFFSET = "utcOffset";
   public static final String REQUEST_PARAM_HOSTS = "hostList";
   public static final String REQUEST_PARAM_USERS = "userList";
-
   public static final String REQUEST_PARAM_PAGE_DEFAULT_VALUE = "0";
   public static final String REQUEST_PARAM_PAGE_SIZE_DEFAULT_VALUE = "1000";
-
+  public static final String REQUEST_PARAM_SHIPPER_CONFIG = "shipperConfig";
+  public static final String REQUEST_PARAM_LOG_ID = "logId";
+  public static final String REQUEST_PARAM_TEST_ENTRY = "testEntry";
 }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/ShipperConfigTestParams.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/ShipperConfigTestParams.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.model.request;
+
+import io.swagger.annotations.ApiParam;
+import org.apache.ambari.logsearch.common.LogSearchConstants;
+
+import java.util.Map;
+
+import static org.apache.ambari.logsearch.doc.DocConstants.CommonDescriptions.TOP;
+
+public interface ShipperConfigTestParams {
+
+  Map<String, Object> getShipperConfig();
+
+  @ApiParam(value = TOP, name = LogSearchConstants.REQUEST_PARAM_SHIPPER_CONFIG, required = true)
+  void setShipperConfig(Map<String, Object> shipperConfig);
+
+  String getLogId();
+
+  @ApiParam(value = TOP, name = LogSearchConstants.REQUEST_PARAM_LOG_ID, required = true)
+  void setLogId(String logId);
+
+  String getTestEntry();
+
+  @ApiParam(value = TOP, name = LogSearchConstants.REQUEST_PARAM_TEST_ENTRY, required = true)
+  void setTestEntry(String testEntry);
+
+}

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/ShipperConfigTestRequest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/ShipperConfigTestRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.model.request.impl;
+
+import org.apache.ambari.logsearch.model.request.ShipperConfigTestParams;
+import org.hibernate.validator.constraints.NotBlank;
+
+import java.util.Map;
+
+public class ShipperConfigTestRequest implements ShipperConfigTestParams {
+
+  @NotBlank
+  private String logId;
+
+  @NotBlank
+  private String testEntry;
+
+  @NotBlank
+  private Map<String, Object> shipperConfig;
+
+  @Override
+  public String getLogId() {
+    return logId;
+  }
+
+  @Override
+  public void setLogId(String logId) {
+    this.logId = logId;
+  }
+
+  @Override
+  public Map<String, Object> getShipperConfig() {
+    return shipperConfig;
+  }
+
+  @Override
+  public void setShipperConfig(Map<String, Object> shipperConfig) {
+    this.shipperConfig = shipperConfig;
+  }
+
+  @Override
+  public String getTestEntry() {
+    return testEntry;
+  }
+
+  public void setTestEntry(String testEntry) {
+    this.testEntry = testEntry;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ShipperConfigResource.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ShipperConfigResource.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.validation.Valid;
 import javax.validation.executable.ValidateOnExecution;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -38,10 +37,10 @@ import io.swagger.annotations.ApiOperation;
 import org.apache.ambari.logsearch.manager.ShipperConfigManager;
 import org.apache.ambari.logsearch.model.common.LSServerInputConfig;
 import org.apache.ambari.logsearch.model.common.LSServerLogLevelFilterMap;
+import org.apache.ambari.logsearch.model.request.impl.ShipperConfigTestRequest;
 import org.springframework.context.annotation.Scope;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.apache.ambari.logsearch.doc.DocConstants.ShipperConfigOperationDescriptions.GET_LOG_LEVEL_FILTER_OD;
 import static org.apache.ambari.logsearch.doc.DocConstants.ShipperConfigOperationDescriptions.GET_SERVICE_NAMES_OD;
@@ -100,9 +99,8 @@ public class ShipperConfigResource {
   @Path("/input/{clusterName}/test")
   @Produces({"application/json"})
   @ApiOperation(TEST_SHIPPER_CONFIG_OD)
-  public Map<String, Object> testShipperConfig(@FormParam("shipper_config") String shipperConfig, @FormParam("log_id") String logId,
-      @FormParam("test_entry") String testEntry, @PathParam("clusterName") String clusterName) {
-    return shipperConfigManager.testShipperConfig(shipperConfig, logId, testEntry, clusterName);
+  public Response testShipperConfig(@Valid ShipperConfigTestRequest request, @PathParam("clusterName") String clusterName) {
+    return shipperConfigManager.testShipperConfig(request.getShipperConfig(), request.getLogId(), request.getTestEntry(), clusterName);
   }
 
   @GET


### PR DESCRIPTION
…sting if an exception occurred.

## What changes were proposed in this pull request?

Right now test api for shipperconfig returns with 200 status code anyway.
We should return with 500 when an error happened.
Also return 400 if the request is invalid

## How was this patch tested?

FT: manually.
UTs passed.

please review @kasakrisz @swagle 