### PR TITLE
[AMBARI-22875] Blueprint cluster creation using manually installed mpacks

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
@@ -69,6 +69,8 @@ import org.apache.ambari.server.topology.SecurityConfigurationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Iterables;
+
 /**
  * Renderer which renders a cluster resource as a blueprint.
  */
@@ -196,9 +198,12 @@ public class ClusterBlueprintRenderer extends BaseRenderer implements Renderer {
     BlueprintConfigurationProcessor configProcessor = new BlueprintConfigurationProcessor(topology);
     configProcessor.doUpdateForBlueprintExport();
 
-    StackId stackId = topology.getBlueprint().getStackId();
-    blueprintResource.setProperty("Blueprints/stack_name", stackId.getStackName());
-    blueprintResource.setProperty("Blueprints/stack_version", stackId.getStackVersion());
+    Set<StackId> stackIds = topology.getBlueprint().getStackIds();
+    if (stackIds.size() == 1) {
+      StackId stackId = Iterables.getOnlyElement(stackIds);
+      blueprintResource.setProperty("Blueprints/stack_name", stackId.getStackName());
+      blueprintResource.setProperty("Blueprints/stack_version", stackId.getStackVersion());
+    }
 
     if (topology.isClusterKerberosEnabled()) {
       Map<String, Object> securityConfigMap = new LinkedHashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
@@ -45,7 +45,6 @@ import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.internal.ExportBlueprintRequest;
 import org.apache.ambari.server.controller.internal.RequestImpl;
 import org.apache.ambari.server.controller.internal.ResourceImpl;
-import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.controller.spi.ClusterController;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.NoSuchResourceException;
@@ -56,6 +55,7 @@ import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.PredicateBuilder;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.AmbariContext;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.ClusterTopologyImpl;
@@ -67,6 +67,8 @@ import org.apache.ambari.server.topology.InvalidTopologyTemplateException;
 import org.apache.ambari.server.topology.SecurityConfigurationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Iterables;
 
 /**
  * Renderer which renders a cluster resource as a blueprint.
@@ -195,9 +197,12 @@ public class ClusterBlueprintRenderer extends BaseRenderer implements Renderer {
     BlueprintConfigurationProcessor configProcessor = new BlueprintConfigurationProcessor(topology);
     configProcessor.doUpdateForBlueprintExport();
 
-    Stack stack = topology.getBlueprint().getStack();
-    blueprintResource.setProperty("Blueprints/stack_name", stack.getName());
-    blueprintResource.setProperty("Blueprints/stack_version", stack.getVersion());
+    Set<StackId> stackIds = topology.getBlueprint().getStackIds();
+    if (stackIds.size() == 1) {
+      StackId stackId = Iterables.getOnlyElement(stackIds);
+      blueprintResource.setProperty("Blueprints/stack_name", stackId.getStackName());
+      blueprintResource.setProperty("Blueprints/stack_version", stackId.getStackVersion());
+    }
 
     if (topology.isClusterKerberosEnabled()) {
       Map<String, Object> securityConfigMap = new LinkedHashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
@@ -45,7 +45,6 @@ import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.internal.ExportBlueprintRequest;
 import org.apache.ambari.server.controller.internal.RequestImpl;
 import org.apache.ambari.server.controller.internal.ResourceImpl;
-import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.controller.spi.ClusterController;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.NoSuchResourceException;
@@ -56,6 +55,7 @@ import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.PredicateBuilder;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.AmbariContext;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.ClusterTopologyImpl;
@@ -196,9 +196,9 @@ public class ClusterBlueprintRenderer extends BaseRenderer implements Renderer {
     BlueprintConfigurationProcessor configProcessor = new BlueprintConfigurationProcessor(topology);
     configProcessor.doUpdateForBlueprintExport();
 
-    Stack stack = topology.getBlueprint().getStack();
-    blueprintResource.setProperty("Blueprints/stack_name", stack.getName());
-    blueprintResource.setProperty("Blueprints/stack_version", stack.getVersion());
+    StackId stackId = topology.getBlueprint().getStackId();
+    blueprintResource.setProperty("Blueprints/stack_name", stackId.getStackName());
+    blueprintResource.setProperty("Blueprints/stack_version", stackId.getStackVersion());
 
     if (topology.isClusterKerberosEnabled()) {
       Map<String, Object> securityConfigMap = new LinkedHashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorBlueprintProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorBlueprintProcessor.java
@@ -18,7 +18,6 @@
 
 package org.apache.ambari.server.api.services.stackadvisor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -77,26 +76,27 @@ public class StackAdvisorBlueprintProcessor {
    * @param userProvidedConfigurations User configurations of cluster provided in Blueprint + Cluster template
    */
   public void adviseConfiguration(ClusterTopology clusterTopology, Map<String, Map<String, String>> userProvidedConfigurations) throws ConfigurationTopologyException {
-    StackAdvisorRequest request = createStackAdvisorRequest(clusterTopology, StackAdvisorRequestType.CONFIGURATIONS);
-    try {
-      RecommendationResponse response = stackAdvisorHelper.recommend(request);
-      addAdvisedConfigurationsToTopology(response, clusterTopology, userProvidedConfigurations);
-    } catch (StackAdvisorException e) {
-      throw new ConfigurationTopologyException(RECOMMENDATION_FAILED, e);
-    } catch (IllegalArgumentException e) {
-      throw new ConfigurationTopologyException(INVALID_RESPONSE, e);
+    for (StackId stackId : clusterTopology.getBlueprint().getStackIds()) {
+      StackAdvisorRequest request = createStackAdvisorRequest(clusterTopology, stackId, StackAdvisorRequestType.CONFIGURATIONS);
+      try {
+        RecommendationResponse response = stackAdvisorHelper.recommend(request);
+        addAdvisedConfigurationsToTopology(response, clusterTopology, userProvidedConfigurations);
+      } catch (StackAdvisorException e) {
+        throw new ConfigurationTopologyException(RECOMMENDATION_FAILED, e);
+      } catch (IllegalArgumentException e) {
+        throw new ConfigurationTopologyException(INVALID_RESPONSE, e);
+      }
     }
   }
 
-  private StackAdvisorRequest createStackAdvisorRequest(ClusterTopology clusterTopology, StackAdvisorRequestType requestType) {
-    StackId stackId = clusterTopology.getBlueprint().getStackId();
+  private StackAdvisorRequest createStackAdvisorRequest(ClusterTopology clusterTopology, StackId stackId, StackAdvisorRequestType requestType) {
     Map<String, Set<String>> hgComponentsMap = gatherHostGroupComponents(clusterTopology);
     Map<String, Set<String>> hgHostsMap = gatherHostGroupBindings(clusterTopology);
     Map<String, Set<String>> componentHostsMap = gatherComponentsHostsMap(hgComponentsMap,
             hgHostsMap);
     return StackAdvisorRequest.StackAdvisorRequestBuilder
       .forStack(stackId)
-      .forServices(new ArrayList<>(clusterTopology.getBlueprint().getServices()))
+      .forServices(clusterTopology.getBlueprint().getStack().getServices(stackId))
       .forHosts(gatherHosts(clusterTopology))
       .forHostsGroupBindings(gatherHostGroupBindings(clusterTopology))
       .forHostComponents(gatherHostGroupComponents(clusterTopology))

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorBlueprintProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorBlueprintProcessor.java
@@ -18,7 +18,6 @@
 
 package org.apache.ambari.server.api.services.stackadvisor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,7 +28,7 @@ import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest.St
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse.BlueprintConfigurations;
 import org.apache.ambari.server.controller.internal.ConfigurationTopologyException;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.AdvisedConfiguration;
 import org.apache.ambari.server.topology.Blueprint;
@@ -77,26 +76,27 @@ public class StackAdvisorBlueprintProcessor {
    * @param userProvidedConfigurations User configurations of cluster provided in Blueprint + Cluster template
    */
   public void adviseConfiguration(ClusterTopology clusterTopology, Map<String, Map<String, String>> userProvidedConfigurations) throws ConfigurationTopologyException {
-    StackAdvisorRequest request = createStackAdvisorRequest(clusterTopology, StackAdvisorRequestType.CONFIGURATIONS);
-    try {
-      RecommendationResponse response = stackAdvisorHelper.recommend(request);
-      addAdvisedConfigurationsToTopology(response, clusterTopology, userProvidedConfigurations);
-    } catch (StackAdvisorException e) {
-      throw new ConfigurationTopologyException(RECOMMENDATION_FAILED, e);
-    } catch (IllegalArgumentException e) {
-      throw new ConfigurationTopologyException(INVALID_RESPONSE, e);
+    for (StackId stackId : clusterTopology.getBlueprint().getStackIds()) {
+      StackAdvisorRequest request = createStackAdvisorRequest(clusterTopology, stackId, StackAdvisorRequestType.CONFIGURATIONS);
+      try {
+        RecommendationResponse response = stackAdvisorHelper.recommend(request);
+        addAdvisedConfigurationsToTopology(response, clusterTopology, userProvidedConfigurations);
+      } catch (StackAdvisorException e) {
+        throw new ConfigurationTopologyException(RECOMMENDATION_FAILED, e);
+      } catch (IllegalArgumentException e) {
+        throw new ConfigurationTopologyException(INVALID_RESPONSE, e);
+      }
     }
   }
 
-  private StackAdvisorRequest createStackAdvisorRequest(ClusterTopology clusterTopology, StackAdvisorRequestType requestType) {
-    Stack stack = clusterTopology.getBlueprint().getStack(); // TODO: implement multi-stack
+  private StackAdvisorRequest createStackAdvisorRequest(ClusterTopology clusterTopology, StackId stackId, StackAdvisorRequestType requestType) {
     Map<String, Set<String>> hgComponentsMap = gatherHostGroupComponents(clusterTopology);
     Map<String, Set<String>> hgHostsMap = gatherHostGroupBindings(clusterTopology);
     Map<String, Set<String>> componentHostsMap = gatherComponentsHostsMap(hgComponentsMap,
             hgHostsMap);
     return StackAdvisorRequest.StackAdvisorRequestBuilder
-      .forStack(stack.getName(), stack.getVersion())
-      .forServices(new ArrayList<>(clusterTopology.getBlueprint().getServices()))
+      .forStack(stackId)
+      .forServices(clusterTopology.getBlueprint().getStack().getServices(stackId))
       .forHosts(gatherHosts(clusterTopology))
       .forHostsGroupBindings(gatherHostGroupBindings(clusterTopology))
       .forHostComponents(gatherHostGroupComponents(clusterTopology))

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorBlueprintProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorBlueprintProcessor.java
@@ -29,7 +29,7 @@ import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest.St
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse.BlueprintConfigurations;
 import org.apache.ambari.server.controller.internal.ConfigurationTopologyException;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.AdvisedConfiguration;
 import org.apache.ambari.server.topology.Blueprint;
@@ -89,13 +89,13 @@ public class StackAdvisorBlueprintProcessor {
   }
 
   private StackAdvisorRequest createStackAdvisorRequest(ClusterTopology clusterTopology, StackAdvisorRequestType requestType) {
-    Stack stack = clusterTopology.getBlueprint().getStack();
+    StackId stackId = clusterTopology.getBlueprint().getStackId();
     Map<String, Set<String>> hgComponentsMap = gatherHostGroupComponents(clusterTopology);
     Map<String, Set<String>> hgHostsMap = gatherHostGroupBindings(clusterTopology);
     Map<String, Set<String>> componentHostsMap = gatherComponentsHostsMap(hgComponentsMap,
             hgHostsMap);
     return StackAdvisorRequest.StackAdvisorRequestBuilder
-      .forStack(stack.getName(), stack.getVersion())
+      .forStack(stackId)
       .forServices(new ArrayList<>(clusterTopology.getBlueprint().getServices()))
       .forHosts(gatherHosts(clusterTopology))
       .forHostsGroupBindings(gatherHostGroupBindings(clusterTopology))

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorHelper.java
@@ -33,11 +33,11 @@ import org.apache.ambari.server.api.services.stackadvisor.commands.StackAdvisorC
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
 import org.apache.ambari.server.api.services.stackadvisor.validations.ValidationResponse;
 import org.apache.ambari.server.configuration.Configuration;
-
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -122,9 +122,7 @@ public class StackAdvisorHelper {
       throws StackAdvisorException {
       requestId = generateRequestId();
 
-    // TODO, need to pass the service Name that was modified.
-    // For now, hardcode
-    String serviceName = "ZOOKEEPER";
+    String serviceName = Iterables.getFirst(request.getServices(), null);
 
     ServiceInfo.ServiceAdvisorType serviceAdvisorType = getServiceAdvisorType(request.getStackName(), request.getStackVersion(), serviceName);
     StackAdvisorCommand<RecommendationResponse> command = createRecommendationCommand(serviceName, request);

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorHelper.java
@@ -37,7 +37,6 @@ import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -122,7 +121,7 @@ public class StackAdvisorHelper {
       throws StackAdvisorException {
       requestId = generateRequestId();
 
-    String serviceName = Iterables.getFirst(request.getServices(), null);
+    String serviceName = request.getServices().stream().findAny().orElse(null);
 
     ServiceInfo.ServiceAdvisorType serviceAdvisorType = getServiceAdvisorType(request.getStackName(), request.getStackVersion(), serviceName);
     StackAdvisorCommand<RecommendationResponse> command = createRecommendationCommand(serviceName, request);

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorRequest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
 import org.apache.ambari.server.state.ChangedConfigInfo;
+import org.apache.ambari.server.state.StackId;
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Preconditions;
@@ -144,6 +145,10 @@ public class StackAdvisorRequest {
 
     public static StackAdvisorRequestBuilder forStack(String stackName, String stackVersion) {
       return new StackAdvisorRequestBuilder(stackName, stackVersion);
+    }
+
+    public static StackAdvisorRequestBuilder forStack(StackId stackId) {
+      return new StackAdvisorRequestBuilder(stackId.getStackName(), stackId.getStackVersion());
     }
 
     public StackAdvisorRequestBuilder ofType(StackAdvisorRequestType requestType) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorRunner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorRunner.java
@@ -52,7 +52,7 @@ public class StackAdvisorRunner {
    */
   public void runScript(ServiceInfo.ServiceAdvisorType serviceAdvisorType, StackAdvisorCommandType saCommandType, File actionDirectory)
       throws StackAdvisorException {
-    LOG.info(String.format("StackAdvisorRunner. serviceAdvisorType=%s, actionDirectory=%s, command=%s", serviceAdvisorType.toString(), actionDirectory,
+    LOG.info(String.format("StackAdvisorRunner. serviceAdvisorType=%s, actionDirectory=%s, command=%s", serviceAdvisorType, actionDirectory,
         saCommandType));
 
     String outputFile = actionDirectory + File.separator + "stackadvisor.out";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -63,7 +63,6 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.internal.AbstractControllerResourceProvider;
 import org.apache.ambari.server.controller.internal.AmbariPrivilegeResourceProvider;
 import org.apache.ambari.server.controller.internal.BaseClusterRequest;
-import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterPrivilegeResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.HostResourceProvider;
@@ -940,9 +939,6 @@ public class AmbariServer {
     SecurityFilter.init(injector.getInstance(Configuration.class));
     StackDefinedPropertyProvider.init(injector);
     AbstractControllerResourceProvider.init(injector.getInstance(ResourceProviderFactory.class));
-    BlueprintResourceProvider.init(injector.getInstance(BlueprintFactory.class),
-        injector.getInstance(BlueprintDAO.class), injector.getInstance(SecurityConfigurationFactory.class),
-        injector.getInstance(Gson.class), ambariMetaInfo);
     StackDependencyResourceProvider.init(ambariMetaInfo);
     ClusterResourceProvider.init(injector.getInstance(TopologyManager.class),
         injector.getInstance(TopologyRequestFactoryImpl.class), injector.getInstance(SecurityConfigurationFactory

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -63,7 +63,6 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.internal.AbstractControllerResourceProvider;
 import org.apache.ambari.server.controller.internal.AmbariPrivilegeResourceProvider;
 import org.apache.ambari.server.controller.internal.BaseClusterRequest;
-import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterPrivilegeResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.HostResourceProvider;
@@ -940,8 +939,6 @@ public class AmbariServer {
     SecurityFilter.init(injector.getInstance(Configuration.class));
     StackDefinedPropertyProvider.init(injector);
     AbstractControllerResourceProvider.init(injector.getInstance(ResourceProviderFactory.class));
-    BlueprintResourceProvider.init(injector.getInstance(BlueprintFactory.class),
-        injector.getInstance(BlueprintDAO.class), injector.getInstance(SecurityConfigurationFactory.class), ambariMetaInfo);
     StackDependencyResourceProvider.init(ambariMetaInfo);
     ClusterResourceProvider.init(injector.getInstance(TopologyManager.class),
         injector.getInstance(TopologyRequestFactoryImpl.class), injector.getInstance(SecurityConfigurationFactory

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
@@ -63,6 +63,7 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.configuration.Configuration.ConnectionPoolType;
 import org.apache.ambari.server.configuration.Configuration.DatabaseType;
 import org.apache.ambari.server.controller.internal.AlertTargetResourceProvider;
+import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterSettingResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterStackVersionResourceProvider;
 import org.apache.ambari.server.controller.internal.ComponentResourceProvider;
@@ -168,6 +169,8 @@ import org.apache.ambari.server.state.scheduler.RequestExecutionImpl;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostImpl;
 import org.apache.ambari.server.topology.BlueprintFactory;
+import org.apache.ambari.server.topology.BlueprintValidator;
+import org.apache.ambari.server.topology.BlueprintValidatorImpl;
 import org.apache.ambari.server.topology.PersistedState;
 import org.apache.ambari.server.topology.PersistedStateImpl;
 import org.apache.ambari.server.topology.SecurityConfigurationFactory;
@@ -506,6 +509,7 @@ public class ControllerModule extends AbstractModule {
         .implement(ResourceProvider.class, Names.named("alertTarget"), AlertTargetResourceProvider.class)
         .implement(ResourceProvider.class, Names.named("viewInstance"), ViewInstanceResourceProvider.class)
         .implement(ResourceProvider.class, Names.named("rootServiceHostComponentConfiguration"), RootServiceComponentConfigurationResourceProvider.class)
+        .implement(ResourceProvider.class, Names.named(BlueprintResourceProvider.NAME), BlueprintResourceProvider.class)
         .build(ResourceProviderFactory.class));
 
     install(new FactoryModuleBuilder().implement(
@@ -537,6 +541,7 @@ public class ControllerModule extends AbstractModule {
     bind(RegistryFactory.class).to(RegistryFactoryImpl.class);
     bind(HostRoleCommandFactory.class).to(HostRoleCommandFactoryImpl.class);
     bind(SecurityHelper.class).toInstance(SecurityHelperImpl.getInstance());
+    bind(BlueprintValidator.class).to(BlueprintValidatorImpl.class);
     bind(BlueprintFactory.class);
 
     install(new FactoryModuleBuilder().implement(AmbariEvent.class, Names.named("userCreated"), UserCreatedEvent.class).build(AmbariEventFactory.class));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ResourceProviderFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ResourceProviderFactory.java
@@ -22,6 +22,7 @@ package org.apache.ambari.server.controller;
 import javax.inject.Named;
 
 import org.apache.ambari.server.controller.internal.AlertTargetResourceProvider;
+import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterStackVersionResourceProvider;
 import org.apache.ambari.server.controller.internal.UpgradeResourceProvider;
 import org.apache.ambari.server.controller.internal.ViewInstanceResourceProvider;
@@ -88,5 +89,10 @@ public interface ResourceProviderFactory {
 
   @Named("viewInstance")
   ViewInstanceResourceProvider getViewInstanceResourceProvider();
+
+  @Named(BlueprintResourceProvider.NAME)
+  BlueprintResourceProvider getBlueprintResourceProvider(
+    AmbariManagementController managementController
+  );
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractControllerResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractControllerResourceProvider.java
@@ -226,7 +226,7 @@ public abstract class AbstractControllerResourceProvider extends AbstractAuthori
       case HostComponentProcess:
         return new HostComponentProcessResourceProvider(managementController);
       case Blueprint:
-        return new BlueprintResourceProvider(managementController);
+        return resourceProviderFactory.getBlueprintResourceProvider(managementController);
       case KerberosDescriptor:
         return resourceProviderFactory.getKerberosDescriptorResourceProvider(managementController);
       case Recommendation:

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -66,6 +66,7 @@ import com.google.common.collect.Sets;
  * Updates configuration properties based on cluster topology.  This is done when exporting
  * a blueprint and when a cluster is provisioned via a blueprint.
  */
+// TODO move to topology package
 public class BlueprintConfigurationProcessor {
 
   private static final Logger LOG = LoggerFactory.getLogger(BlueprintConfigurationProcessor.class);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -437,7 +438,7 @@ public class BlueprintConfigurationProcessor {
 
   private void trimProperties(Configuration clusterConfig, ClusterTopology clusterTopology) {
     Blueprint blueprint = clusterTopology.getBlueprint();
-    Stack stack = blueprint.getStack();
+    StackDefinition stack = blueprint.getStack();
 
     Map<String, Map<String, String>> configTypes = clusterConfig.getFullProperties();
     for (String configType : configTypes.keySet()) {
@@ -448,7 +449,7 @@ public class BlueprintConfigurationProcessor {
     }
   }
 
-  private void trimPropertyValue(Configuration clusterConfig, Stack stack, String configType, Map<String, String> properties, String propertyName) {
+  private void trimPropertyValue(Configuration clusterConfig, StackDefinition stack, String configType, Map<String, String> properties, String propertyName) {
     if (propertyName != null && properties.get(propertyName) != null) {
 
       TrimmingStrategy trimmingStrategy =
@@ -2880,7 +2881,7 @@ public class BlueprintConfigurationProcessor {
    * @param configTypesUpdated
    * @param stack
    */
-  private void addExcludedConfigProperties(Configuration configuration, Set<String> configTypesUpdated, Stack stack) {
+  private void addExcludedConfigProperties(Configuration configuration, Set<String> configTypesUpdated, StackDefinition stack) {
     Collection<String> blueprintServices = clusterTopology.getBlueprint().getServices();
 
     LOG.debug("Handling excluded properties for blueprint services: {}", blueprintServices);
@@ -2971,38 +2972,41 @@ public class BlueprintConfigurationProcessor {
    * @param configTypesUpdated
    *          the list of configuration types updated (cluster-env will be added
    *          to this).
-   * @throws ConfigurationTopologyException
    */
   private void setStackToolsAndFeatures(Configuration configuration, Set<String> configTypesUpdated)
       throws ConfigurationTopologyException {
     ConfigHelper configHelper = clusterTopology.getAmbariContext().getConfigHelper();
-    Stack stack = clusterTopology.getBlueprint().getStack();
-    String stackName = stack.getName();
-    String stackVersion = stack.getVersion();
 
-    StackId stackId = new StackId(stackName, stackVersion);
-
-    Set<String> properties = Sets.newHashSet(ConfigHelper.CLUSTER_ENV_STACK_NAME_PROPERTY,
-        ConfigHelper.CLUSTER_ENV_STACK_ROOT_PROPERTY, ConfigHelper.CLUSTER_ENV_STACK_TOOLS_PROPERTY,
-        ConfigHelper.CLUSTER_ENV_STACK_FEATURES_PROPERTY,
-        ConfigHelper.CLUSTER_ENV_STACK_PACKAGES_PROPERTY);
+    Set<String> properties = ImmutableSet.of(
+      ConfigHelper.CLUSTER_ENV_STACK_NAME_PROPERTY,
+      ConfigHelper.CLUSTER_ENV_STACK_ROOT_PROPERTY,
+      ConfigHelper.CLUSTER_ENV_STACK_TOOLS_PROPERTY,
+      ConfigHelper.CLUSTER_ENV_STACK_FEATURES_PROPERTY,
+      ConfigHelper.CLUSTER_ENV_STACK_PACKAGES_PROPERTY
+    );
 
     try {
-      Map<String, Map<String, String>> defaultStackProperties = configHelper.getDefaultStackProperties(stackId);
-      Map<String,String> clusterEnvDefaultProperties = defaultStackProperties.get(CLUSTER_ENV_CONFIG_TYPE_NAME);
+      for (StackId stackId : clusterTopology.getBlueprint().getStackIds()) {
+        Map<String, Map<String, String>> defaultStackProperties = configHelper.getDefaultStackProperties(stackId);
+        if (defaultStackProperties.containsKey(CLUSTER_ENV_CONFIG_TYPE_NAME)) {
+          Map<String, String> clusterEnvDefaultProperties = defaultStackProperties.get(CLUSTER_ENV_CONFIG_TYPE_NAME);
 
-      for( String property : properties ){
-        if (clusterEnvDefaultProperties.containsKey(property)) {
-          configuration.setProperty(CLUSTER_ENV_CONFIG_TYPE_NAME, property,
-              clusterEnvDefaultProperties.get(property));
+          for (String property : properties) {
+            if (clusterEnvDefaultProperties.containsKey(property)) {
+              configuration.setProperty(CLUSTER_ENV_CONFIG_TYPE_NAME, property,
+                clusterEnvDefaultProperties.get(property)
+              );
 
-          // make sure to include the configuration type as being updated
-          configTypesUpdated.add(CLUSTER_ENV_CONFIG_TYPE_NAME);
+              // make sure to include the configuration type as being updated
+              configTypesUpdated.add(CLUSTER_ENV_CONFIG_TYPE_NAME);
+            }
+          }
+
+          break;
         }
       }
-    } catch( AmbariException ambariException ){
-      throw new ConfigurationTopologyException("Unable to retrieve the stack tools and features",
-          ambariException);
+    } catch (AmbariException e) {
+      throw new ConfigurationTopologyException("Unable to retrieve the stack tools and features", e);
     }
   }
 
@@ -3101,7 +3105,7 @@ public class BlueprintConfigurationProcessor {
      */
     @Override
     public boolean isPropertyIncluded(String propertyName, String propertyValue, String configType, ClusterTopology topology) {
-        Stack stack = topology.getBlueprint().getStack();
+        StackDefinition stack = topology.getBlueprint().getStack();
         final String serviceName = stack.getServiceForConfigType(configType);
         return !(stack.isPasswordProperty(serviceName, configType, propertyName) ||
                 stack.isKerberosPrincipalNameProperty(serviceName, configType, propertyName));
@@ -3198,7 +3202,7 @@ public class BlueprintConfigurationProcessor {
      */
     @Override
     public boolean isPropertyIncluded(String propertyName, String propertyValue, String configType, ClusterTopology topology) {
-      Stack stack = topology.getBlueprint().getStack();
+      StackDefinition stack = topology.getBlueprint().getStack();
       Configuration configuration = topology.getConfiguration();
 
       final String serviceName = stack.getServiceForConfigType(configType);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -438,7 +438,7 @@ public class BlueprintConfigurationProcessor {
 
   private void trimProperties(Configuration clusterConfig, ClusterTopology clusterTopology) {
     Blueprint blueprint = clusterTopology.getBlueprint();
-    StackInfo stack = blueprint.getStack();
+    StackDefinition stack = blueprint.getStack();
 
     Map<String, Map<String, String>> configTypes = clusterConfig.getFullProperties();
     for (String configType : configTypes.keySet()) {
@@ -449,7 +449,7 @@ public class BlueprintConfigurationProcessor {
     }
   }
 
-  private void trimPropertyValue(Configuration clusterConfig, StackInfo stack, String configType, Map<String, String> properties, String propertyName) {
+  private void trimPropertyValue(Configuration clusterConfig, StackDefinition stack, String configType, Map<String, String> properties, String propertyName) {
     if (propertyName != null && properties.get(propertyName) != null) {
 
       TrimmingStrategy trimmingStrategy =
@@ -2881,7 +2881,7 @@ public class BlueprintConfigurationProcessor {
    * @param configTypesUpdated
    * @param stack
    */
-  private void addExcludedConfigProperties(Configuration configuration, Set<String> configTypesUpdated, StackInfo stack) {
+  private void addExcludedConfigProperties(Configuration configuration, Set<String> configTypesUpdated, StackDefinition stack) {
     Collection<String> blueprintServices = clusterTopology.getBlueprint().getServices();
 
     LOG.debug("Handling excluded properties for blueprint services: {}", blueprintServices);
@@ -3105,7 +3105,7 @@ public class BlueprintConfigurationProcessor {
      */
     @Override
     public boolean isPropertyIncluded(String propertyName, String propertyValue, String configType, ClusterTopology topology) {
-        StackInfo stack = topology.getBlueprint().getStack();
+        StackDefinition stack = topology.getBlueprint().getStack();
         final String serviceName = stack.getServiceForConfigType(configType);
         return !(stack.isPasswordProperty(serviceName, configType, propertyName) ||
                 stack.isKerberosPrincipalNameProperty(serviceName, configType, propertyName));
@@ -3202,7 +3202,7 @@ public class BlueprintConfigurationProcessor {
      */
     @Override
     public boolean isPropertyIncluded(String propertyName, String propertyValue, String configType, ClusterTopology topology) {
-      StackInfo stack = topology.getBlueprint().getStack();
+      StackDefinition stack = topology.getBlueprint().getStack();
       Configuration configuration = topology.getConfiguration();
 
       final String serviceName = stack.getServiceForConfigType(configType);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -437,7 +437,7 @@ public class BlueprintConfigurationProcessor {
 
   private void trimProperties(Configuration clusterConfig, ClusterTopology clusterTopology) {
     Blueprint blueprint = clusterTopology.getBlueprint();
-    Stack stack = blueprint.getStack();
+    StackInfo stack = blueprint.getStack();
 
     Map<String, Map<String, String>> configTypes = clusterConfig.getFullProperties();
     for (String configType : configTypes.keySet()) {
@@ -448,7 +448,7 @@ public class BlueprintConfigurationProcessor {
     }
   }
 
-  private void trimPropertyValue(Configuration clusterConfig, Stack stack, String configType, Map<String, String> properties, String propertyName) {
+  private void trimPropertyValue(Configuration clusterConfig, StackInfo stack, String configType, Map<String, String> properties, String propertyName) {
     if (propertyName != null && properties.get(propertyName) != null) {
 
       TrimmingStrategy trimmingStrategy =
@@ -2880,7 +2880,7 @@ public class BlueprintConfigurationProcessor {
    * @param configTypesUpdated
    * @param stack
    */
-  private void addExcludedConfigProperties(Configuration configuration, Set<String> configTypesUpdated, Stack stack) {
+  private void addExcludedConfigProperties(Configuration configuration, Set<String> configTypesUpdated, StackInfo stack) {
     Collection<String> blueprintServices = clusterTopology.getBlueprint().getServices();
 
     LOG.debug("Handling excluded properties for blueprint services: {}", blueprintServices);
@@ -2976,11 +2976,7 @@ public class BlueprintConfigurationProcessor {
   private void setStackToolsAndFeatures(Configuration configuration, Set<String> configTypesUpdated)
       throws ConfigurationTopologyException {
     ConfigHelper configHelper = clusterTopology.getAmbariContext().getConfigHelper();
-    Stack stack = clusterTopology.getBlueprint().getStack();
-    String stackName = stack.getName();
-    String stackVersion = stack.getVersion();
-
-    StackId stackId = new StackId(stackName, stackVersion);
+    StackId stackId = clusterTopology.getBlueprint().getStackId();
 
     Set<String> properties = Sets.newHashSet(ConfigHelper.CLUSTER_ENV_STACK_NAME_PROPERTY,
         ConfigHelper.CLUSTER_ENV_STACK_ROOT_PROPERTY, ConfigHelper.CLUSTER_ENV_STACK_TOOLS_PROPERTY,
@@ -3101,7 +3097,7 @@ public class BlueprintConfigurationProcessor {
      */
     @Override
     public boolean isPropertyIncluded(String propertyName, String propertyValue, String configType, ClusterTopology topology) {
-        Stack stack = topology.getBlueprint().getStack();
+        StackInfo stack = topology.getBlueprint().getStack();
         final String serviceName = stack.getServiceForConfigType(configType);
         return !(stack.isPasswordProperty(serviceName, configType, propertyName) ||
                 stack.isKerberosPrincipalNameProperty(serviceName, configType, propertyName));
@@ -3198,7 +3194,7 @@ public class BlueprintConfigurationProcessor {
      */
     @Override
     public boolean isPropertyIncluded(String propertyName, String propertyValue, String configType, ClusterTopology topology) {
-      Stack stack = topology.getBlueprint().getStack();
+      StackInfo stack = topology.getBlueprint().getStack();
       Configuration configuration = topology.getConfiguration();
 
       final String serviceName = stack.getServiceForConfigType(configType);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -2985,15 +2985,18 @@ public class BlueprintConfigurationProcessor {
 
     try {
       Map<String, Map<String, String>> defaultStackProperties = configHelper.getDefaultStackProperties(stackId);
-      Map<String,String> clusterEnvDefaultProperties = defaultStackProperties.get(CLUSTER_ENV_CONFIG_TYPE_NAME);
+      if (defaultStackProperties.containsKey(CLUSTER_ENV_CONFIG_TYPE_NAME)) {
+        Map<String, String> clusterEnvDefaultProperties = defaultStackProperties.get(CLUSTER_ENV_CONFIG_TYPE_NAME);
 
-      for( String property : properties ){
-        if (clusterEnvDefaultProperties.containsKey(property)) {
-          configuration.setProperty(CLUSTER_ENV_CONFIG_TYPE_NAME, property,
-              clusterEnvDefaultProperties.get(property));
+        for (String property : properties) {
+          if (clusterEnvDefaultProperties.containsKey(property)) {
+            configuration.setProperty(CLUSTER_ENV_CONFIG_TYPE_NAME, property,
+              clusterEnvDefaultProperties.get(property)
+            );
 
-          // make sure to include the configuration type as being updated
-          configTypesUpdated.add(CLUSTER_ENV_CONFIG_TYPE_NAME);
+            // make sure to include the configuration type as being updated
+            configTypesUpdated.add(CLUSTER_ENV_CONFIG_TYPE_NAME);
+          }
         }
       }
     } catch( AmbariException ambariException ){

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -22,24 +22,27 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.DependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
+import org.apache.commons.lang3.tuple.Pair;
 
 // FIXME temporary
 /** Combine multiple mpacks into a single stack. */
 public class CompositeStack implements StackInfo {
 
-  private final Set<StackInfo> mpacks;
+  private final Set<Stack> mpacks;
   private final Collection<String> services;
   private final Map<String, Collection<String>> components;
 
-  public CompositeStack(Set<StackInfo> mpacks) {
+  public CompositeStack(Set<Stack> mpacks) {
     this.mpacks = mpacks;
 
     services = mpacks.stream()
@@ -49,6 +52,14 @@ public class CompositeStack implements StackInfo {
     components = mpacks.stream()
       .flatMap(m -> m.getComponents().entrySet().stream())
       .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  public Collection<StackId> getStacksForService(String serviceName) {
+    return mpacks.stream()
+      .map(m -> Pair.of(m.getStackId(), m.getServices()))
+      .filter(p -> p.getRight().contains(serviceName))
+      .map(Pair::getLeft)
+      .collect(toSet());
   }
 
   @Override
@@ -70,6 +81,7 @@ public class CompositeStack implements StackInfo {
   public ComponentInfo getComponentInfo(String component) {
     return mpacks.stream()
       .map(m -> m.getComponentInfo(component))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }
@@ -160,6 +172,7 @@ public class CompositeStack implements StackInfo {
   public String getServiceForComponent(String component) {
     return mpacks.stream()
       .map(m -> m.getServiceForComponent(component))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }
@@ -175,6 +188,7 @@ public class CompositeStack implements StackInfo {
   public String getServiceForConfigType(String config) {
     return mpacks.stream()
       .map(m -> m.getServiceForConfigType(config))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }
@@ -190,6 +204,7 @@ public class CompositeStack implements StackInfo {
   public String getConditionalServiceForDependency(DependencyInfo dependency) {
     return mpacks.stream()
       .map(m -> m.getConditionalServiceForDependency(dependency))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }
@@ -198,6 +213,7 @@ public class CompositeStack implements StackInfo {
   public String getExternalComponentConfig(String component) {
     return mpacks.stream()
       .map(m -> m.getExternalComponentConfig(component))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }
@@ -206,6 +222,7 @@ public class CompositeStack implements StackInfo {
   public Cardinality getCardinality(String component) {
     return mpacks.stream()
       .map(m -> m.getCardinality(component))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }
@@ -214,6 +231,7 @@ public class CompositeStack implements StackInfo {
   public AutoDeployInfo getAutoDeployInfo(String component) {
     return mpacks.stream()
       .map(m -> m.getAutoDeployInfo(component))
+      .filter(Objects::nonNull)
       .findAny()
       .orElse(null);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
@@ -201,6 +202,16 @@ public class CompositeStack implements StackInfo {
     if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
       return null;
     }
+    return getServicesForConfigType(config)
+      .findAny()
+      .orElseThrow(() -> new IllegalArgumentException(Stack.formatMissingServiceForConfigType(config, "ANY")));
+  }
+
+  @Override
+  public Stream<String> getServicesForConfigType(String config) {
+    if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
+      return Stream.empty();
+    }
     return mpacks.stream()
       .map(m -> {
         try {
@@ -209,9 +220,7 @@ public class CompositeStack implements StackInfo {
           return null;
         }
       })
-      .filter(Objects::nonNull)
-      .findAny()
-      .orElseThrow(() -> new IllegalArgumentException(Stack.formatMissingServiceForConfigType(config, "ANY")));
+      .filter(Objects::nonNull);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -40,7 +40,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import com.google.common.collect.ImmutableSet;
 
 /** Combines multiple mpacks into a single stack. */
-public class CompositeStack implements StackInfo {
+public class CompositeStack implements StackDefinition {
 
   private final Set<Stack> mpacks;
   private final Collection<String> services;
@@ -283,7 +283,7 @@ public class CompositeStack implements StackInfo {
   public Configuration getConfiguration() {
     // FIXME probably too costly
     return mpacks.stream()
-      .map(StackInfo::getConfiguration)
+      .map(StackDefinition::getConfiguration)
       .reduce(Configuration.createEmpty(), Configuration::combine);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -46,7 +46,7 @@ public class CompositeStack implements StackDefinition {
 
   private final Set<Stack> stacks;
 
-  public CompositeStack(Set<Stack> stacks) {
+  CompositeStack(Set<Stack> stacks) {
     this.stacks = stacks;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -41,6 +41,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 /** Combines multiple mpacks into a single stack. */
+// TODO move to topology package
 public class CompositeStack implements StackDefinition {
 
   private final Set<Stack> stacks;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.controller.internal;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.ambari.server.state.AutoDeployInfo;
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.topology.Cardinality;
+import org.apache.ambari.server.topology.Configuration;
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+/** Combines multiple mpacks into a single stack. */
+public class CompositeStack implements StackDefinition {
+
+  private final Set<Stack> stacks;
+
+  public CompositeStack(Set<Stack> stacks) {
+    this.stacks = stacks;
+  }
+
+  @Override
+  public Set<StackId> getStacksForService(String serviceName) {
+    return stacks.stream()
+      .map(m -> Pair.of(m.getStackId(), m.getServices()))
+      .filter(p -> p.getRight().contains(serviceName))
+      .map(Pair::getLeft)
+      .collect(toSet());
+  }
+
+  @Override
+  public Set<String> getServices(StackId stackId) {
+    return stacks.stream()
+      .filter(m -> stackId.equals(m.getStackId()))
+      .findAny()
+      .flatMap(m -> Optional.of(ImmutableSet.copyOf(m.getServices())))
+      .orElse(ImmutableSet.of());
+  }
+
+  @Override
+  public Set<StackId> getStackIds() {
+    return stacks.stream()
+      .map(Stack::getStackId)
+      .collect(toSet());
+  }
+
+  @Override
+  public Collection<String> getServices() {
+    return stacks.stream()
+      .flatMap(s -> s.getServices().stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Collection<String> getComponents(String service) {
+    return stacks.stream()
+      .map(Stack::getComponents)
+      .map(m -> m.get(service))
+      .filter(Objects::nonNull)
+      .flatMap(Collection::stream)
+      .collect(toSet());
+  }
+
+  @Override
+  public Map<String, Collection<String>> getComponents() {
+    return stacks.stream()
+      .map(Stack::getComponents)
+      .reduce(ImmutableMap.of(), (m1, m2) -> ImmutableMap.<String, Collection<String>>builder().putAll(m1).putAll(m2).build());
+  }
+
+  @Override
+  public ComponentInfo getComponentInfo(String component) {
+    return stacks.stream()
+      .map(m -> m.getComponentInfo(component))
+      .filter(Objects::nonNull)
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Collection<String> getAllConfigurationTypes(String service) {
+    return stacks.stream()
+      .flatMap(m -> m.getAllConfigurationTypes(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Collection<String> getConfigurationTypes(String service) {
+    return stacks.stream()
+      .flatMap(m -> m.getConfigurationTypes(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Set<String> getExcludedConfigurationTypes(String service) {
+    return stacks.stream()
+      .flatMap(m -> m.getExcludedConfigurationTypes(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Map<String, String> getConfigurationProperties(String service, String type) {
+    return stacks.stream()
+      .flatMap(m -> m.getConfigurationProperties(service, type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, Stack.ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type) {
+    return stacks.stream()
+      .flatMap(m -> m.getConfigurationPropertiesWithMetadata(service, type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service) {
+    return stacks.stream()
+      .flatMap(m -> m.getRequiredConfigurationProperties(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType) {
+    return stacks.stream()
+      .flatMap(m -> m.getRequiredConfigurationProperties(service, propertyType).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public boolean isPasswordProperty(String service, String type, String propertyName) {
+    return stacks.stream()
+      .anyMatch(s -> s.isPasswordProperty(service, type, propertyName));
+  }
+
+  @Override
+  public Map<String, String> getStackConfigurationProperties(String type) {
+    return stacks.stream()
+      .flatMap(m -> m.getStackConfigurationProperties(type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName) {
+    return stacks.stream()
+      .anyMatch(s -> s.isKerberosPrincipalNameProperty(service, type, propertyName));
+  }
+
+  @Override
+  public Map<String, Map<String, String>> getConfigurationAttributes(String service, String type) {
+    return stacks.stream()
+      .flatMap(m -> m.getConfigurationAttributes(service, type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, Map<String, String>> getStackConfigurationAttributes(String type) {
+    return stacks.stream()
+      .flatMap(m -> m.getStackConfigurationAttributes(type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public String getServiceForComponent(String component) {
+    return stacks.stream()
+      .map(m -> m.getServiceForComponent(component))
+      .filter(Objects::nonNull)
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Collection<String> getServicesForComponents(Collection<String> components) {
+    return stacks.stream()
+      .flatMap(m -> m.getServicesForComponents(components).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public String getServiceForConfigType(String config) {
+    if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
+      return null;
+    }
+    return getServicesForConfigType(config)
+      .findAny()
+      .orElseThrow(() -> new IllegalArgumentException(Stack.formatMissingServiceForConfigType(config, "ANY")));
+  }
+
+  @Override
+  public Stream<String> getServicesForConfigType(String config) {
+    if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
+      return Stream.empty();
+    }
+    return stacks.stream()
+      .map(m -> {
+        try {
+          return m.getServiceForConfigType(config);
+        } catch (IllegalArgumentException e) {
+          return null;
+        }
+      })
+      .filter(Objects::nonNull);
+  }
+
+  @Override
+  public Collection<DependencyInfo> getDependenciesForComponent(String component) {
+    return stacks.stream()
+      .flatMap(m -> m.getDependenciesForComponent(component).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public String getConditionalServiceForDependency(DependencyInfo dependency) {
+    return stacks.stream()
+      .map(m -> m.getConditionalServiceForDependency(dependency))
+      .filter(Objects::nonNull)
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public String getExternalComponentConfig(String component) {
+    return stacks.stream()
+      .map(m -> m.getExternalComponentConfig(component))
+      .filter(Objects::nonNull)
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Cardinality getCardinality(String component) {
+    return stacks.stream()
+      .map(m -> m.getCardinality(component))
+      .filter(Objects::nonNull)
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public AutoDeployInfo getAutoDeployInfo(String component) {
+    return stacks.stream()
+      .map(m -> m.getAutoDeployInfo(component))
+      .filter(Objects::nonNull)
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public boolean isMasterComponent(String component) {
+    return stacks.stream()
+      .anyMatch(s -> s.isMasterComponent(component));
+  }
+
+  @Override
+  public Configuration getConfiguration(Collection<String> services) {
+    // FIXME probably too costly
+    return stacks.stream()
+      .map(m -> m.getConfiguration(services))
+      .reduce(Configuration.createEmpty(), Configuration::combine);
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    // FIXME probably too costly
+    return stacks.stream()
+      .map(StackDefinition::getConfiguration)
+      .reduce(Configuration.createEmpty(), Configuration::combine);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.toSet;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.ambari.server.state.AutoDeployInfo;
@@ -34,6 +35,8 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.collect.ImmutableSet;
 
 // FIXME temporary
 /** Combine multiple mpacks into a single stack. */
@@ -55,12 +58,20 @@ public class CompositeStack implements StackInfo {
       .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  public Collection<StackId> getStacksForService(String serviceName) {
+  public Set<StackId> getStacksForService(String serviceName) {
     return mpacks.stream()
       .map(m -> Pair.of(m.getStackId(), m.getServices()))
       .filter(p -> p.getRight().contains(serviceName))
       .map(Pair::getLeft)
       .collect(toSet());
+  }
+
+  public Set<String> getServices(StackId stackId) {
+    return mpacks.stream()
+      .filter(m -> stackId.equals(m.getStackId()))
+      .findAny()
+      .flatMap(m -> Optional.of(ImmutableSet.copyOf(m.getServices())))
+      .orElse(ImmutableSet.of());
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -39,8 +39,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.collect.ImmutableSet;
 
-// FIXME temporary
-/** Combine multiple mpacks into a single stack. */
+/** Combines multiple mpacks into a single stack. */
 public class CompositeStack implements StackInfo {
 
   private final Set<Stack> mpacks;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.controller.internal;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.state.AutoDeployInfo;
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.topology.Cardinality;
+import org.apache.ambari.server.topology.Configuration;
+
+// FIXME temporary
+/** Combine multiple mpacks into a single stack. */
+public class CompositeStack implements StackInfo {
+
+  private final Set<StackInfo> mpacks;
+  private final Collection<String> services;
+  private final Map<String, Collection<String>> components;
+
+  public CompositeStack(Set<StackInfo> mpacks) {
+    this.mpacks = mpacks;
+
+    services = mpacks.stream()
+      .flatMap(s -> s.getServices().stream())
+      .collect(toSet());
+
+    components = mpacks.stream()
+      .flatMap(m -> m.getComponents().entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Collection<String> getServices() {
+    return services;
+  }
+
+  @Override
+  public Collection<String> getComponents(String service) {
+    return components.get(service);
+  }
+
+  @Override
+  public Map<String, Collection<String>> getComponents() {
+    return components;
+  }
+
+  @Override
+  public ComponentInfo getComponentInfo(String component) {
+    return mpacks.stream()
+      .map(m -> m.getComponentInfo(component))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Collection<String> getAllConfigurationTypes(String service) {
+    return mpacks.stream()
+      .flatMap(m -> m.getAllConfigurationTypes(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Collection<String> getConfigurationTypes(String service) {
+    return mpacks.stream()
+      .flatMap(m -> m.getConfigurationTypes(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Set<String> getExcludedConfigurationTypes(String service) {
+    return mpacks.stream()
+      .flatMap(m -> m.getExcludedConfigurationTypes(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Map<String, String> getConfigurationProperties(String service, String type) {
+    return mpacks.stream()
+      .flatMap(m -> m.getConfigurationProperties(service, type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, Stack.ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type) {
+    return mpacks.stream()
+      .flatMap(m -> m.getConfigurationPropertiesWithMetadata(service, type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service) {
+    return mpacks.stream()
+      .flatMap(m -> m.getRequiredConfigurationProperties(service).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType) {
+    return mpacks.stream()
+      .flatMap(m -> m.getRequiredConfigurationProperties(service, propertyType).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public boolean isPasswordProperty(String service, String type, String propertyName) {
+    return mpacks.stream()
+      .anyMatch(s -> s.isPasswordProperty(service, type, propertyName));
+  }
+
+  @Override
+  public Map<String, String> getStackConfigurationProperties(String type) {
+    return mpacks.stream()
+      .flatMap(m -> m.getStackConfigurationProperties(type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName) {
+    return mpacks.stream()
+      .anyMatch(s -> s.isKerberosPrincipalNameProperty(service, type, propertyName));
+  }
+
+  @Override
+  public Map<String, Map<String, String>> getConfigurationAttributes(String service, String type) {
+    return mpacks.stream()
+      .flatMap(m -> m.getConfigurationAttributes(service, type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, Map<String, String>> getStackConfigurationAttributes(String type) {
+    return mpacks.stream()
+      .flatMap(m -> m.getStackConfigurationAttributes(type).entrySet().stream())
+      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public String getServiceForComponent(String component) {
+    return mpacks.stream()
+      .map(m -> m.getServiceForComponent(component))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Collection<String> getServicesForComponents(Collection<String> components) {
+    return mpacks.stream()
+      .flatMap(m -> m.getServicesForComponents(components).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public String getServiceForConfigType(String config) {
+    return mpacks.stream()
+      .map(m -> m.getServiceForConfigType(config))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Collection<DependencyInfo> getDependenciesForComponent(String component) {
+    return mpacks.stream()
+      .flatMap(m -> m.getDependenciesForComponent(component).stream())
+      .collect(toSet());
+  }
+
+  @Override
+  public String getConditionalServiceForDependency(DependencyInfo dependency) {
+    return mpacks.stream()
+      .map(m -> m.getConditionalServiceForDependency(dependency))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public String getExternalComponentConfig(String component) {
+    return mpacks.stream()
+      .map(m -> m.getExternalComponentConfig(component))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public Cardinality getCardinality(String component) {
+    return mpacks.stream()
+      .map(m -> m.getCardinality(component))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public AutoDeployInfo getAutoDeployInfo(String component) {
+    return mpacks.stream()
+      .map(m -> m.getAutoDeployInfo(component))
+      .findAny()
+      .orElse(null);
+  }
+
+  @Override
+  public boolean isMasterComponent(String component) {
+    return mpacks.stream()
+      .anyMatch(s -> s.isMasterComponent(component));
+  }
+
+  @Override
+  public Configuration getConfiguration(Collection<String> services) {
+    // FIXME probably too costly
+    return mpacks.stream()
+      .map(m -> m.getConfiguration(services))
+      .reduce(Configuration.createEmpty(), Configuration::combine);
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    // FIXME probably too costly
+    return mpacks.stream()
+      .map(StackInfo::getConfiguration)
+      .reduce(Configuration.createEmpty(), Configuration::combine);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -58,6 +58,7 @@ public class CompositeStack implements StackDefinition {
       .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
+  @Override
   public Set<StackId> getStacksForService(String serviceName) {
     return mpacks.stream()
       .map(m -> Pair.of(m.getStackId(), m.getServices()))
@@ -66,12 +67,20 @@ public class CompositeStack implements StackDefinition {
       .collect(toSet());
   }
 
+  @Override
   public Set<String> getServices(StackId stackId) {
     return mpacks.stream()
       .filter(m -> stackId.equals(m.getStackId()))
       .findAny()
       .flatMap(m -> Optional.of(ImmutableSet.copyOf(m.getServices())))
       .orElse(ImmutableSet.of());
+  }
+
+  @Override
+  public Set<StackId> getStackIds() {
+    return mpacks.stream()
+      .map(Stack::getStackId)
+      .collect(toSet());
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequest.java
@@ -138,7 +138,7 @@ public class ExportBlueprintRequest implements TopologyRequest {
       hostGroups.add(new HostGroupImpl(exportedHostGroup.getName(), bpName, stack, componentList,
           exportedHostGroup.getConfiguration(), String.valueOf(exportedHostGroup.getCardinality())));
     }
-    ImmutableSet<StackId> stackIds = ImmutableSet.of(new StackId(stack.getName(), stack.getVersion()));
+    ImmutableSet<StackId> stackIds = ImmutableSet.of(stack.getStackId());
     blueprint = new BlueprintImpl(bpName, hostGroups, stack, stackIds, configuration, null, null);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequest.java
@@ -38,6 +38,7 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.state.DesiredConfig;
 import org.apache.ambari.server.state.HostConfig;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.BlueprintImpl;
 import org.apache.ambari.server.topology.Component;
@@ -49,6 +50,8 @@ import org.apache.ambari.server.topology.InvalidTopologyTemplateException;
 import org.apache.ambari.server.topology.TopologyRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Request to export a blueprint from an existing cluster.
@@ -135,7 +138,8 @@ public class ExportBlueprintRequest implements TopologyRequest {
       hostGroups.add(new HostGroupImpl(exportedHostGroup.getName(), bpName, stack, componentList,
           exportedHostGroup.getConfiguration(), String.valueOf(exportedHostGroup.getCardinality())));
     }
-    blueprint = new BlueprintImpl(bpName, hostGroups, stack, configuration, null);
+    ImmutableSet<StackId> stackIds = ImmutableSet.of(new StackId(stack.getName(), stack.getVersion()));
+    blueprint = new BlueprintImpl(bpName, hostGroups, stack, stackIds, configuration, null, null);
   }
 
   private void createHostGroupInfo(Collection<ExportedHostGroup> exportedHostGroups) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequest.java
@@ -38,6 +38,7 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.state.DesiredConfig;
 import org.apache.ambari.server.state.HostConfig;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.BlueprintImpl;
 import org.apache.ambari.server.topology.Component;
@@ -49,6 +50,8 @@ import org.apache.ambari.server.topology.InvalidTopologyTemplateException;
 import org.apache.ambari.server.topology.TopologyRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Request to export a blueprint from an existing cluster.
@@ -132,10 +135,11 @@ public class ExportBlueprintRequest implements TopologyRequest {
         componentList.add(new Component(component));
       }
 
-      hostGroups.add(new HostGroupImpl(exportedHostGroup.getName(), bpName, Collections.singleton(stack), componentList,
+      hostGroups.add(new HostGroupImpl(exportedHostGroup.getName(), bpName, stack, componentList,
           exportedHostGroup.getConfiguration(), String.valueOf(exportedHostGroup.getCardinality())));
     }
-    blueprint = new BlueprintImpl(bpName, hostGroups, stack, configuration, null, null);
+    ImmutableSet<StackId> stackIds = ImmutableSet.of(stack.getStackId());
+    blueprint = new BlueprintImpl(bpName, hostGroups, stack, stackIds, Collections.emptySet(), configuration, null, null);
   }
 
   private void createHostGroupInfo(Collection<ExportedHostGroup> exportedHostGroups) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PropertyValueTrimmingStrategyDefiner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PropertyValueTrimmingStrategyDefiner.java
@@ -60,7 +60,7 @@ public class PropertyValueTrimmingStrategyDefiner {
     }
   }
 
-  public static TrimmingStrategy defineTrimmingStrategy(Stack stack, String propertyName, String configType) {
+  public static TrimmingStrategy defineTrimmingStrategy(StackInfo stack, String propertyName, String configType) {
     TrimmingStrategy result = null;
     String service = stack.getServiceForConfigType(configType);
     if (service != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PropertyValueTrimmingStrategyDefiner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PropertyValueTrimmingStrategyDefiner.java
@@ -60,7 +60,7 @@ public class PropertyValueTrimmingStrategyDefiner {
     }
   }
 
-  public static TrimmingStrategy defineTrimmingStrategy(StackInfo stack, String propertyName, String configType) {
+  public static TrimmingStrategy defineTrimmingStrategy(StackDefinition stack, String propertyName, String configType) {
     TrimmingStrategy result = null;
     String service = stack.getServiceForConfigType(configType);
     if (service != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PropertyValueTrimmingStrategyDefiner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PropertyValueTrimmingStrategyDefiner.java
@@ -60,7 +60,7 @@ public class PropertyValueTrimmingStrategyDefiner {
     }
   }
 
-  public static TrimmingStrategy defineTrimmingStrategy(Stack stack, String propertyName, String configType) {
+  public static TrimmingStrategy defineTrimmingStrategy(StackDefinition stack, String propertyName, String configType) {
     TrimmingStrategy result = null;
     String service = stack.getServiceForConfigType(configType);
     if (service != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -1102,7 +1102,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
         LOG.debug("Received a createService request, clusterId={}, serviceName={}, request={}", clusterName, serviceName, request);
       }
 
-      if(!AuthorizationHelper.isAuthorized(ResourceType.CLUSTER, getClusterResourceId(clusterName), RoleAuthorization.SERVICE_ADD_DELETE_SERVICES)) {
+      if (!AuthorizationHelper.isAuthorized(ResourceType.CLUSTER, getClusterResourceId(clusterName), RoleAuthorization.SERVICE_ADD_DELETE_SERVICES)) {
         throw new AuthorizationException("The user is not authorized to create services");
       }
 
@@ -1121,8 +1121,8 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
         State state = State.valueOf(request.getDesiredState());
         if (!state.isValidDesiredState() || state != State.INIT) {
           throw new IllegalArgumentException("Invalid desired state"
-                  + " only INIT state allowed during creation"
-                  + ", providedDesiredState=" + request.getDesiredState());
+            + " only INIT state allowed during creation"
+            + ", providedDesiredState=" + request.getDesiredState());
         }
       }
 
@@ -1148,7 +1148,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
       if (null == desiredRepositoryVersion) {
         Set<Long> repoIds = new HashSet<>();
 
-        if(desiredStackId != null) {
+        if (desiredStackId != null) {
           //Todo : How to filter out the right repoversion entity based on the stack id?
           List<RepositoryVersionEntity> list = repositoryVersionDAO.findByStack(desiredStackId);
           RepositoryVersionEntity serviceRepo = list.remove(0);
@@ -1169,13 +1169,14 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
         }
 
         LOG.info("{} was not specified; the following repository ids were found: {}",
-            SERVICE_DESIRED_REPO_VERSION_ID_PROPERTY_ID, StringUtils.join(repoIds, ','));
+          SERVICE_DESIRED_REPO_VERSION_ID_PROPERTY_ID, StringUtils.join(repoIds, ',')
+        );
 
         if (CollectionUtils.isEmpty(repoIds)) {
           throw new IllegalArgumentException("No repositories were found for service installation");
         } else if (repoIds.size() > 1) {
           throw new IllegalArgumentException(String.format("%s was not specified, and the cluster " +
-              "contains more than one standard-type repository", SERVICE_DESIRED_REPO_VERSION_ID_PROPERTY_ID));
+            "contains more than one standard-type repository", SERVICE_DESIRED_REPO_VERSION_ID_PROPERTY_ID));
         } else {
           desiredRepositoryVersion = repoIds.iterator().next();
         }
@@ -1191,8 +1192,10 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
         throw new IllegalArgumentException(String.format("Could not find any repositories defined by %d", desiredRepositoryVersion));
       }
 
-      StackId stackId = repositoryVersion.getStackId();
-      //StackId stackId = desiredStackId; //Todo Replace after UI is ready
+      StackId stackId = desiredStackId;
+      if (stackId == null) {
+        stackId = repositoryVersion.getStackId();
+      }
 
       request.setResolvedRepository(repositoryVersion);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -42,9 +42,12 @@ import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.DependencyInfo;
 import org.apache.ambari.server.state.PropertyDependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Encapsulates stack information.
@@ -198,9 +201,17 @@ public class Stack implements StackInfo {
     return version;
   }
 
+  public StackId getStackId() {
+    return new StackId(name, version);
+  }
 
   Map<DependencyInfo, String> getDependencyConditionalServiceMap() {
     return dependencyConditionalServiceMap;
+  }
+
+  @Override
+  public Collection<StackId> getStacksForService(String serviceName) {
+    return Collections.singleton(getStackId());
   }
 
   /**
@@ -273,7 +284,8 @@ public class Stack implements StackInfo {
    */
   @Override
   public Collection<String> getAllConfigurationTypes(String service) {
-    return serviceConfigurations.get(service).keySet();
+    Map<String, Map<String, ConfigProperty>> serviceConfigs = serviceConfigurations.get(service);
+    return serviceConfigs != null ? serviceConfigs.keySet() : ImmutableSet.of();
   }
 
   /**
@@ -286,9 +298,8 @@ public class Stack implements StackInfo {
    */
   @Override
   public Collection<String> getConfigurationTypes(String service) {
-    Set<String> serviceTypes = new HashSet<>(serviceConfigurations.get(service).keySet());
+    Set<String> serviceTypes = new HashSet<>(getAllConfigurationTypes(service));
     serviceTypes.removeAll(getExcludedConfigurationTypes(service));
-
     return serviceTypes;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -38,6 +38,7 @@ import org.apache.ambari.server.state.PropertyDependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
@@ -50,12 +51,12 @@ import com.google.common.collect.ImmutableSet;
  * Encapsulates a single, identifiable stack definition.
  */
 // TODO move to topology package
-public class Stack implements StackInfo {
+public class Stack implements StackDefinition {
 
   /**
    * Stack info
    */
-  private final org.apache.ambari.server.state.StackInfo stackInfo;
+  private final StackInfo stackInfo;
 
   /**
    * Map of service name to components
@@ -144,7 +145,7 @@ public class Stack implements StackInfo {
     this(ctrl.getAmbariMetaInfo().getStack(name, version));
   }
 
-  public Stack(org.apache.ambari.server.state.StackInfo stackInfo) {
+  public Stack(StackInfo stackInfo) {
     Preconditions.checkNotNull(stackInfo);
     this.stackInfo = stackInfo;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -18,47 +18,44 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ReadOnlyConfigurationResponse;
-import org.apache.ambari.server.controller.StackConfigurationRequest;
-import org.apache.ambari.server.controller.StackLevelConfigurationRequest;
-import org.apache.ambari.server.controller.StackServiceComponentRequest;
-import org.apache.ambari.server.controller.StackServiceComponentResponse;
-import org.apache.ambari.server.controller.StackServiceRequest;
-import org.apache.ambari.server.controller.StackServiceResponse;
-import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.DependencyInfo;
 import org.apache.ambari.server.state.PropertyDependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 /**
- * Encapsulates stack information.
+ * Encapsulates a single, identifiable stack definition.
  */
-public class Stack {
-  /**
-   * Stack name
-   */
-  private String name;
+// TODO move to topology package
+public class Stack implements StackDefinition {
 
   /**
-   * Stack version
+   * Stack info
    */
-  private String version;
+  private final StackInfo stackInfo;
 
   /**
    * Map of service name to components
@@ -130,53 +127,25 @@ public class Stack {
   private Map<String, Set<String>> excludedConfigurationTypes =
     new HashMap<>();
 
-  /**
-   * Ambari Management Controller, used to obtain Stack definitions
-   */
-  private final AmbariManagementController controller;
-
-
-  /**
-   * Constructor.
-   *
-   * @param stack
-   *          the stack (not {@code null}).
-   * @param ambariManagementController
-   *          the management controller (not {@code null}).
-   * @throws AmbariException
-   */
-  public Stack(StackEntity stack, AmbariManagementController ambariManagementController) throws AmbariException {
-    this(stack.getStackName(), stack.getStackVersion(), ambariManagementController);
+  public Stack(String name, String version, AmbariManagementController ctrl) throws AmbariException { // FIXME remove or at least change to use metainfo directly
+    this(ctrl.getAmbariMetaInfo().getStack(name, version));
   }
 
-  /**
-   * Constructor.
-   *
-   * @param name     stack name
-   * @param version  stack version
-   *
-   * @throws AmbariException an exception occurred getting stack information
-   *                         for the specified name and version
-   */
-  //todo: don't pass management controller in constructor
-  public Stack(String name, String version, AmbariManagementController controller) throws AmbariException {
-    this.name = name;
-    this.version = version;
-    this.controller = controller;
+  public Stack(StackInfo stackInfo) {
+    Preconditions.checkNotNull(stackInfo);
+    this.stackInfo = stackInfo;
 
-    Set<StackServiceResponse> stackServices = controller.getStackServices(
-        Collections.singleton(new StackServiceRequest(name, version, null)));
+    parseStackConfigurations();
 
-    for (StackServiceResponse stackService : stackServices) {
-      String serviceName = stackService.getServiceName();
-      parseComponents(serviceName);
+    for (ServiceInfo stackService : stackInfo.getServices()) {
+      parseComponents(stackService);
       parseExcludedConfigurations(stackService);
       parseConfigurations(stackService);
-      registerConditionalDependencies();
     }
 
-    //todo: already done for each service
-    parseStackConfigurations();
+    if (!stackInfo.getServices().isEmpty()) {
+      registerConditionalDependencies();
+    }
   }
 
   /**
@@ -185,7 +154,7 @@ public class Stack {
    * @return stack name
    */
   public String getName() {
-    return name;
+    return stackInfo.getName();
   }
 
   /**
@@ -194,39 +163,47 @@ public class Stack {
    * @return stack version
    */
   public String getVersion() {
-    return version;
+    return stackInfo.getVersion();
   }
 
+  public StackId getStackId() {
+    return new StackId(getName(), getVersion());
+  }
 
   Map<DependencyInfo, String> getDependencyConditionalServiceMap() {
     return dependencyConditionalServiceMap;
   }
 
-  /**
-   * Get services contained in the stack.
-   *
-   * @return collection of all services for the stack
-   */
+  @Override
+  public Set<StackId> getStackIds() {
+    return ImmutableSet.of(getStackId());
+  }
+
+  @Override
+  public Set<StackId> getStacksForService(String serviceName) {
+    return serviceComponents.keySet().contains(serviceName)
+      ? ImmutableSet.of(getStackId())
+      : ImmutableSet.of();
+  }
+
+  @Override
+  public Set<String> getServices(StackId stackId) {
+    return stackId.equals(getStackId())
+      ? ImmutableSet.copyOf(getServices())
+      : ImmutableSet.of();
+  }
+
+  @Override
   public Collection<String> getServices() {
     return serviceComponents.keySet();
   }
 
-  /**
-   * Get components contained in the stack for the specified service.
-   *
-   * @param service  service name
-   *
-   * @return collection of component names for the specified service
-   */
+  @Override
   public Collection<String> getComponents(String service) {
     return serviceComponents.get(service);
   }
 
-  /**
-   * Get all service components
-   *
-   * @return map of service to associated components
-   */
+  @Override
   public Map<String, Collection<String>> getComponents() {
     Map<String, Collection<String>> serviceComponents = new HashMap<>();
     for (String service : getServices()) {
@@ -237,97 +214,55 @@ public class Stack {
     return serviceComponents;
   }
 
-  /**
-   * Get info for the specified component.
-   *
-   * @param component  component name
-   *
-   * @return component information for the requested component
-   *         or null if the component doesn't exist in the stack
-   */
+  @Override
   public ComponentInfo getComponentInfo(String component) {
-    ComponentInfo componentInfo = null;
     String service = getServiceForComponent(component);
     if (service != null) {
-      try {
-        componentInfo = controller.getAmbariMetaInfo().getComponent(
-            getName(), getVersion(), service, component);
-      } catch (AmbariException e) {
-        // just return null if component doesn't exist
+      ServiceInfo serviceInfo = stackInfo.getService(service);
+      if (serviceInfo != null) {
+        return serviceInfo.getComponentByName(component);
       }
     }
-    return componentInfo;
+    return null;
   }
 
-  /**
-   * Get all configuration types, including excluded types for the specified service.
-   *
-   * @param service  service name
-   *
-   * @return collection of all configuration types for the specified service
-   */
+  @Override
   public Collection<String> getAllConfigurationTypes(String service) {
-    return serviceConfigurations.get(service).keySet();
+    Map<String, Map<String, ConfigProperty>> serviceConfigs = getServiceConfigurations(service);
+    return serviceConfigs != null ? serviceConfigs.keySet() : ImmutableSet.of();
   }
 
-  /**
-   * Get configuration types for the specified service.
-   * This doesn't include any service excluded types.
-   *
-   * @param service  service name
-   *
-   * @return collection of all configuration types for the specified service
-   */
+  @Override
   public Collection<String> getConfigurationTypes(String service) {
-    Set<String> serviceTypes = new HashSet<>(serviceConfigurations.get(service).keySet());
+    Set<String> serviceTypes = new HashSet<>(getAllConfigurationTypes(service));
     serviceTypes.removeAll(getExcludedConfigurationTypes(service));
-
     return serviceTypes;
   }
 
-  /**
-   * Get the set of excluded configuration types for this service.
-   *
-   * @param service service name
-   *
-   * @return Set of names of excluded config types. Will not return null.
-   */
+  @Override
   public Set<String> getExcludedConfigurationTypes(String service) {
     return excludedConfigurationTypes.containsKey(service) ?
         excludedConfigurationTypes.get(service) :
         Collections.emptySet();
   }
 
-  /**
-   * Get config properties for the specified service and configuration type.
-   *
-   * @param service  service name
-   * @param type     configuration type
-   *
-   * @return map of property names to values for the specified service and configuration type
-   */
+  @Override
   public Map<String, String> getConfigurationProperties(String service, String type) {
     Map<String, String> configMap = new HashMap<>();
-    Map<String, ConfigProperty> configProperties = serviceConfigurations.get(service).get(type);
-    if (configProperties != null) {
-      for (Map.Entry<String, ConfigProperty> configProperty : configProperties.entrySet()) {
-        configMap.put(configProperty.getKey(), configProperty.getValue().getValue());
-      }
+    Map<String, ConfigProperty> configProperties = getConfigurationPropertiesWithMetadata(service, type);
+    for (Map.Entry<String, ConfigProperty> configProperty : configProperties.entrySet()) {
+      configMap.put(configProperty.getKey(), configProperty.getValue().getValue());
     }
     return configMap;
   }
 
+  @Override
   public Map<String, ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type) {
-    return serviceConfigurations.get(service).get(type);
+    Map<String, ConfigProperty> map = getServiceConfigurations(service).get(type);
+    return map != null ? ImmutableMap.copyOf(map) : ImmutableMap.of();
   }
 
-  /**
-   * Get all required config properties for the specified service.
-   *
-   * @param service  service name
-   *
-   * @return collection of all required properties for the given service
-   */
+  @Override
   public Collection<ConfigProperty> getRequiredConfigurationProperties(String service) {
     Collection<ConfigProperty> requiredConfigProperties = new HashSet<>();
     Map<String, Map<String, ConfigProperty>> serviceProperties = requiredServiceConfigurations.get(service);
@@ -339,14 +274,7 @@ public class Stack {
     return requiredConfigProperties;
   }
 
-  /**
-   * Get required config properties for the specified service which belong to the specified property type.
-   *
-   * @param service       service name
-   * @param propertyType  property type
-   *
-   * @return collection of required properties for the given service and property type
-   */
+  @Override
   public Collection<ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType) {
     Collection<ConfigProperty> matchingProperties = new HashSet<>();
     Map<String, Map<String, ConfigProperty>> requiredProperties = requiredServiceConfigurations.get(service);
@@ -363,15 +291,17 @@ public class Stack {
     return matchingProperties;
   }
 
+  @Override
   public boolean isPasswordProperty(String service, String type, String propertyName) {
-    return (serviceConfigurations.containsKey(service) &&
-            serviceConfigurations.get(service).containsKey(type) &&
-            serviceConfigurations.get(service).get(type).containsKey(propertyName) &&
-            serviceConfigurations.get(service).get(type).get(propertyName).getPropertyTypes().
+    Map<String, Map<String, ConfigProperty>> serviceConfigurations = getServiceConfigurations(service);
+    return (serviceConfigurations.containsKey(type) &&
+            serviceConfigurations.get(type).containsKey(propertyName) &&
+            serviceConfigurations.get(type).get(propertyName).getPropertyTypes().
                 contains(PropertyInfo.PropertyType.PASSWORD));
   }
 
   //todo
+  @Override
   public Map<String, String> getStackConfigurationProperties(String type) {
     Map<String, String> configMap = new HashMap<>();
     Map<String, ConfigProperty> configProperties = stackConfigurations.get(type);
@@ -383,25 +313,19 @@ public class Stack {
     return configMap;
   }
 
+  @Override
   public boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName) {
-    return (serviceConfigurations.containsKey(service) &&
-            serviceConfigurations.get(service).containsKey(type) &&
-            serviceConfigurations.get(service).get(type).containsKey(propertyName) &&
-            serviceConfigurations.get(service).get(type).get(propertyName).getPropertyTypes().
+    Map<String, Map<String, ConfigProperty>> serviceConfigurations = getServiceConfigurations(service);
+    return (serviceConfigurations.containsKey(type) &&
+            serviceConfigurations.get(type).containsKey(propertyName) &&
+            serviceConfigurations.get(type).get(propertyName).getPropertyTypes().
                 contains(PropertyInfo.PropertyType.KERBEROS_PRINCIPAL));
   }
-  /**
-   * Get config attributes for the specified service and configuration type.
-   *
-   * @param service  service name
-   * @param type     configuration type
-   *
-   * @return  map of attribute names to map of property names to attribute values
-   *          for the specified service and configuration type
-   */
+
+  @Override
   public Map<String, Map<String, String>> getConfigurationAttributes(String service, String type) {
     Map<String, Map<String, String>> attributesMap = new HashMap<>();
-    Map<String, ConfigProperty> configProperties = serviceConfigurations.get(service).get(type);
+    Map<String, ConfigProperty> configProperties = getServiceConfigurations(service).get(type);
     if (configProperties != null) {
       for (Map.Entry<String, ConfigProperty> configProperty : configProperties.entrySet()) {
         String propertyName = configProperty.getKey();
@@ -411,12 +335,9 @@ public class Stack {
             String attributeName = propertyAttribute.getKey();
             String attributeValue = propertyAttribute.getValue();
             if (attributeValue != null) {
-              Map<String, String> attributes = attributesMap.get(attributeName);
-              if (attributes == null) {
-                  attributes = new HashMap<>();
-                  attributesMap.put(attributeName, attributes);
-              }
-              attributes.put(propertyName, attributeValue);
+              attributesMap
+                .computeIfAbsent(attributeName, k -> new HashMap<>())
+                .put(propertyName, attributeValue);
             }
           }
         }
@@ -425,7 +346,12 @@ public class Stack {
     return attributesMap;
   }
 
-  //todo:
+  private Map<String, Map<String, ConfigProperty>> getServiceConfigurations(String service) {
+    Map<String, Map<String, ConfigProperty>> map = serviceConfigurations.get(service);
+    return map != null ? ImmutableMap.copyOf(map) : ImmutableMap.of();
+  }
+
+  @Override
   public Map<String, Map<String, String>> getStackConfigurationAttributes(String type) {
     Map<String, Map<String, String>> attributesMap = new HashMap<>();
     Map<String, ConfigProperty> configProperties = stackConfigurations.get(type);
@@ -437,12 +363,9 @@ public class Stack {
           for (Map.Entry<String, String> propertyAttribute : propertyAttributes.entrySet()) {
             String attributeName = propertyAttribute.getKey();
             String attributeValue = propertyAttribute.getValue();
-            Map<String, String> attributes = attributesMap.get(attributeName);
-            if (attributes == null) {
-              attributes = new HashMap<>();
-              attributesMap.put(attributeName, attributes);
-            }
-            attributes.put(propertyName, attributeValue);
+            attributesMap
+              .computeIfAbsent(attributeName, k -> new HashMap<>())
+              .put(propertyName, attributeValue);
           }
         }
       }
@@ -450,24 +373,12 @@ public class Stack {
     return attributesMap;
   }
 
-  /**
-   * Get the service for the specified component.
-   *
-   * @param component  component name
-   *
-   * @return service name that contains tha specified component
-   */
+  @Override
   public String getServiceForComponent(String component) {
     return componentService.get(component);
   }
 
-  /**
-   * Get the names of the services which contains the specified components.
-   *
-   * @param components collection of components
-   *
-   * @return collection of services which contain the specified components
-   */
+  @Override
   public Collection<String> getServicesForComponents(Collection<String> components) {
     Set<String> services = new HashSet<>();
     for (String component : components) {
@@ -477,14 +388,11 @@ public class Stack {
     return services;
   }
 
-  /**
-   * Obtain the service name which corresponds to the specified configuration.
-   *
-   * @param config  configuration type
-   *
-   * @return name of service which corresponds to the specified configuration type
-   */
+  @Override
   public String getServiceForConfigType(String config) {
+    if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
+      return null;
+    }
     for (Map.Entry<String, Map<String, Map<String, ConfigProperty>>> entry : serviceConfigurations.entrySet()) {
       Map<String, Map<String, ConfigProperty>> typeMap = entry.getValue();
       String serviceName = entry.getKey();
@@ -492,69 +400,53 @@ public class Stack {
         return serviceName;
       }
     }
-    throw new IllegalArgumentException(
-        "Specified configuration type is not associated with any service: " + config);
+    throw new IllegalArgumentException(formatMissingServiceForConfigType(config, getStackId().toString()));
   }
 
-  public List<String> getServicesForConfigType(String config) {
-    List<String> serviceNames = new ArrayList<>();
-    for (Map.Entry<String, Map<String, Map<String, ConfigProperty>>> entry : serviceConfigurations.entrySet()) {
-      Map<String, Map<String, ConfigProperty>> typeMap = entry.getValue();
-      String serviceName = entry.getKey();
-      if (typeMap.containsKey(config) && !getExcludedConfigurationTypes(serviceName).contains(config)) {
-        serviceNames.add(serviceName);
-      }
-    }
-    return serviceNames;
+  static String formatMissingServiceForConfigType(String config, String stackId) {
+    return String.format("Specified configuration type %s is not associated with any service in %s stack.", config, stackId);
   }
 
-  /**
-   * Return the dependencies specified for the given component.
-   *
-   * @param component  component to get dependency information for
-   *
-   * @return collection of dependency information for the specified component
-   */
-  //todo: full dependency graph
+  @Override
+  public Stream<String> getServicesForConfigType(String config) {
+    return serviceConfigurations.entrySet().stream()
+      .filter(e -> e.getValue().containsKey(config))
+      .filter(e -> !getExcludedConfigurationTypes(e.getKey()).contains(config))
+      .map(Map.Entry::getKey);
+  }
+
+  @Override
   public Collection<DependencyInfo> getDependenciesForComponent(String component) {
     return dependencies.containsKey(component) ? dependencies.get(component) :
         Collections.emptySet();
   }
 
-  /**
-   * Get the service, if any, that a component dependency is conditional on.
-   *
-   * @param dependency  dependency to get conditional service for
-   *
-   * @return conditional service for provided component or null if dependency
-   *         is not conditional on a service
-   */
+  @Override
   public String getConditionalServiceForDependency(DependencyInfo dependency) {
     return dependencyConditionalServiceMap.get(dependency);
   }
 
+  @Override
   public String getExternalComponentConfig(String component) {
     return dbDependencyInfo.get(component);
   }
 
-  /**
-   * Obtain the required cardinality for the specified component.
-   */
+  @Override
   public Cardinality getCardinality(String component) {
     return new Cardinality(cardinalityRequirements.get(component));
   }
 
-  /**
-   * Obtain auto-deploy information for the specified component.
-   */
+  @Override
   public AutoDeployInfo getAutoDeployInfo(String component) {
     return componentAutoDeployInfo.get(component);
   }
 
+  @Override
   public boolean isMasterComponent(String component) {
     return masterComponents.contains(component);
   }
 
+  @Override
   public Configuration getConfiguration(Collection<String> services) {
     Map<String, Map<String, Map<String, String>>> attributes = new HashMap<>();
     Map<String, Map<String, String>> properties = new HashMap<>();
@@ -562,12 +454,9 @@ public class Stack {
     for (String service : services) {
       Collection<String> serviceConfigTypes = getConfigurationTypes(service);
       for (String type : serviceConfigTypes) {
-        Map<String, String> typeProps = properties.get(type);
-        if (typeProps == null) {
-          typeProps = new HashMap<>();
-          properties.put(type, typeProps);
-        }
-        typeProps.putAll(getConfigurationProperties(service, type));
+        properties
+          .computeIfAbsent(type, k -> new HashMap<>())
+          .putAll(getConfigurationProperties(service, type));
 
         Map<String, Map<String, String>> stackTypeAttributes = getConfigurationAttributes(service, type);
         if (!stackTypeAttributes.isEmpty()) {
@@ -577,12 +466,9 @@ public class Stack {
           Map<String, Map<String, String>> typeAttributes = attributes.get(type);
           for (Map.Entry<String, Map<String, String>> attribute : stackTypeAttributes.entrySet()) {
             String attributeName = attribute.getKey();
-            Map<String, String> attributeProps = typeAttributes.get(attributeName);
-            if (attributeProps == null) {
-              attributeProps = new HashMap<>();
-              typeAttributes.put(attributeName, attributeProps);
-            }
-            attributeProps.putAll(attribute.getValue());
+            typeAttributes
+              .computeIfAbsent(attributeName, k -> new HashMap<>())
+              .putAll(attribute.getValue());
           }
         }
       }
@@ -590,18 +476,16 @@ public class Stack {
     return new Configuration(properties, attributes);
   }
 
-  public Configuration getConfiguration() {
+  @Override
+  public Configuration getConfiguration() { // TODO get rid of duplication between this and #getConfiguration(Collection<String>)
     Map<String, Map<String, Map<String, String>>> stackAttributes = new HashMap<>();
     Map<String, Map<String, String>> stackConfigs = new HashMap<>();
 
     for (String service : getServices()) {
       for (String type : getAllConfigurationTypes(service)) {
-        Map<String, String> typeProps = stackConfigs.get(type);
-        if (typeProps == null) {
-          typeProps = new HashMap<>();
-          stackConfigs.put(type, typeProps);
-        }
-        typeProps.putAll(getConfigurationProperties(service, type));
+        stackConfigs
+          .computeIfAbsent(type, k -> new HashMap<>())
+          .putAll(getConfigurationProperties(service, type));
 
         Map<String, Map<String, String>> stackTypeAttributes = getConfigurationAttributes(service, type);
         if (!stackTypeAttributes.isEmpty()) {
@@ -611,12 +495,9 @@ public class Stack {
           Map<String, Map<String, String>> typeAttrs = stackAttributes.get(type);
           for (Map.Entry<String, Map<String, String>> attribute : stackTypeAttributes.entrySet()) {
             String attributeName = attribute.getKey();
-            Map<String, String> attributes = typeAttrs.get(attributeName);
-            if (attributes == null) {
-              attributes = new HashMap<>();
-              typeAttrs.put(attributeName, attributes);
-            }
-            attributes.putAll(attribute.getValue());
+            typeAttrs
+              .computeIfAbsent(attributeName, k -> new HashMap<>())
+              .putAll(attribute.getValue());
           }
         }
       }
@@ -626,20 +507,16 @@ public class Stack {
 
   /**
    * Parse components for the specified service from the stack definition.
-   *
-   * @param service  service name
-   *
-   * @throws AmbariException an exception occurred getting components from the stack definition
    */
-  private void parseComponents(String service) throws AmbariException{
+  private void parseComponents(ServiceInfo serviceInfo) {
     Collection<String> componentSet = new HashSet<>();
 
-    Set<StackServiceComponentResponse> components = controller.getStackComponents(
-        Collections.singleton(new StackServiceComponentRequest(name, version, service, null)));
+    String service = serviceInfo.getName();
+    Collection<ComponentInfo> components = serviceInfo.getComponents();
 
     // stack service components
-    for (StackServiceComponentResponse component : components) {
-      String componentName = component.getComponentName();
+    for (ComponentInfo component : components) {
+      String componentName = component.getName();
       componentSet.add(componentName);
       componentService.put(componentName, service);
       String cardinality = component.getCardinality();
@@ -652,10 +529,7 @@ public class Stack {
       }
 
       // populate component dependencies
-      //todo: remove usage of AmbariMetaInfo
-      Collection<DependencyInfo> componentDependencies = controller.getAmbariMetaInfo().getComponentDependencies(
-          name, version, service, componentName);
-
+      Collection<DependencyInfo> componentDependencies = component.getDependencies();
       if (componentDependencies != null && ! componentDependencies.isEmpty()) {
         dependencies.put(componentName, componentDependencies);
       }
@@ -671,50 +545,40 @@ public class Stack {
    * Parse configurations for the specified service from the stack definition.
    *
    * @param stackService  service to parse the stack configuration for
-   *
-   * @throws AmbariException an exception occurred getting configurations from the stack definition
    */
-  private void parseConfigurations(StackServiceResponse stackService) throws AmbariException {
-    String service = stackService.getServiceName();
+  private void parseConfigurations(ServiceInfo stackService) {
+    String service = stackService.getName();
     Map<String, Map<String, ConfigProperty>> mapServiceConfig = new HashMap<>();
     Map<String, Map<String, ConfigProperty>> mapRequiredServiceConfig = new HashMap<>();
-
 
     serviceConfigurations.put(service, mapServiceConfig);
     requiredServiceConfigurations.put(service, mapRequiredServiceConfig);
 
-    Set<ReadOnlyConfigurationResponse> serviceConfigs = controller.getStackConfigurations(
-        Collections.singleton(new StackConfigurationRequest(name, version, service, null)));
-    Set<ReadOnlyConfigurationResponse> stackLevelConfigs = controller.getStackLevelConfigurations(
-        Collections.singleton(new StackLevelConfigurationRequest(name, version, null)));
+    Collection<PropertyInfo> serviceConfigs = stackService.getProperties();
+    Collection<PropertyInfo> stackLevelConfigs = stackInfo.getProperties();
     serviceConfigs.addAll(stackLevelConfigs);
 
     // shouldn't have any required properties in stack level configuration
-    for (ReadOnlyConfigurationResponse config : serviceConfigs) {
+    for (PropertyInfo pi : serviceConfigs) {
+      ReadOnlyConfigurationResponse config = pi.convertToResponse(); // TODO get rid of intermediate object
       ConfigProperty configProperty = new ConfigProperty(config);
       String type = configProperty.getType();
 
-      Map<String, ConfigProperty> mapTypeConfig = mapServiceConfig.get(type);
-      if (mapTypeConfig == null) {
-        mapTypeConfig = new HashMap<>();
-        mapServiceConfig.put(type, mapTypeConfig);
-      }
+      Map<String, ConfigProperty> mapTypeConfig = mapServiceConfig.computeIfAbsent(type, __ -> new HashMap<>());
 
-      mapTypeConfig.put(config.getPropertyName(), configProperty);
+      String name = config.getPropertyName();
+      mapTypeConfig.put(name, configProperty);
       if (config.isRequired()) {
-        Map<String, ConfigProperty> requiredTypeConfig = mapRequiredServiceConfig.get(type);
-        if (requiredTypeConfig == null) {
-          requiredTypeConfig = new HashMap<>();
-          mapRequiredServiceConfig.put(type, requiredTypeConfig);
-        }
-        requiredTypeConfig.put(config.getPropertyName(), configProperty);
+        mapRequiredServiceConfig
+          .computeIfAbsent(type, __ -> new HashMap<>())
+          .put(name, configProperty);
       }
     }
 
     // So far we added only config types that have properties defined
     // in stack service definition. Since there might be config types
     // with no properties defined we need to add those separately
-    Set<String> configTypes = stackService.getConfigTypes().keySet();
+    Set<String> configTypes = stackService.getConfigTypeAttributes().keySet();
     for (String configType: configTypes) {
       if (!mapServiceConfig.containsKey(configType)) {
         mapServiceConfig.put(configType, Collections.emptyMap());
@@ -722,23 +586,17 @@ public class Stack {
     }
   }
 
-  private void parseStackConfigurations () throws AmbariException {
+  private void parseStackConfigurations() {
+    Collection<PropertyInfo> stackLevelConfigs = stackInfo.getProperties();
 
-    Set<ReadOnlyConfigurationResponse> stackLevelConfigs = controller.getStackLevelConfigurations(
-        Collections.singleton(new StackLevelConfigurationRequest(name, version, null)));
-
-    for (ReadOnlyConfigurationResponse config : stackLevelConfigs) {
+    for (PropertyInfo pi : stackLevelConfigs) {
+      ReadOnlyConfigurationResponse config = pi.convertToResponse(); // TODO get rid of intermediate object
       ConfigProperty configProperty = new ConfigProperty(config);
       String type = configProperty.getType();
 
-      Map<String, ConfigProperty> mapTypeConfig = stackConfigurations.get(type);
-      if (mapTypeConfig == null) {
-        mapTypeConfig = new HashMap<>();
-        stackConfigurations.put(type, mapTypeConfig);
-      }
-
-      mapTypeConfig.put(config.getPropertyName(),
-          configProperty);
+      stackConfigurations
+        .computeIfAbsent(type, __ -> new HashMap<>())
+        .put(config.getPropertyName(), configProperty);
     }
   }
 
@@ -747,8 +605,8 @@ public class Stack {
    *
    * @param stackServiceResponse the response object associated with this stack service
    */
-  private void parseExcludedConfigurations(StackServiceResponse stackServiceResponse) {
-    excludedConfigurationTypes.put(stackServiceResponse.getServiceName(), stackServiceResponse.getExcludedConfigTypes());
+  private void parseExcludedConfigurations(ServiceInfo stackServiceResponse) {
+    excludedConfigurationTypes.put(stackServiceResponse.getName(), stackServiceResponse.getExcludedConfigTypes());
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -18,14 +18,13 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.AmbariManagementController;
@@ -544,16 +543,12 @@ public class Stack implements StackInfo {
     return String.format("Specified configuration type %s is not associated with any service in %s stack.", config, stackId);
   }
 
-  public List<String> getServicesForConfigType(String config) {
-    List<String> serviceNames = new ArrayList<>();
-    for (Map.Entry<String, Map<String, Map<String, ConfigProperty>>> entry : serviceConfigurations.entrySet()) {
-      Map<String, Map<String, ConfigProperty>> typeMap = entry.getValue();
-      String serviceName = entry.getKey();
-      if (typeMap.containsKey(config) && !getExcludedConfigurationTypes(serviceName).contains(config)) {
-        serviceNames.add(serviceName);
-      }
-    }
-    return serviceNames;
+  @Override
+  public Stream<String> getServicesForConfigType(String config) {
+    return serviceConfigurations.entrySet().stream()
+      .filter(e -> e.getValue().containsKey(config))
+      .filter(e -> !getExcludedConfigurationTypes(e.getKey()).contains(config))
+      .map(Map.Entry::getKey);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -190,12 +190,16 @@ public class Stack implements StackDefinition {
 
   @Override
   public Set<StackId> getStacksForService(String serviceName) {
-    return Collections.singleton(getStackId());
+    return serviceComponents.keySet().contains(serviceName)
+      ? ImmutableSet.of(getStackId())
+      : ImmutableSet.of();
   }
 
   @Override
   public Set<String> getServices(StackId stackId) {
-    return stackId.equals(getStackId()) ? ImmutableSet.copyOf(getServices()) : ImmutableSet.of();
+    return stackId.equals(getStackId())
+      ? ImmutableSet.copyOf(getServices())
+      : ImmutableSet.of();
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -212,8 +212,13 @@ public class Stack implements StackInfo {
   }
 
   @Override
-  public Collection<StackId> getStacksForService(String serviceName) {
+  public Set<StackId> getStacksForService(String serviceName) {
     return Collections.singleton(getStackId());
+  }
+
+  @Override
+  public Set<String> getServices(StackId stackId) {
+    return stackId.equals(getStackId()) ? ImmutableSet.copyOf(getServices()) : ImmutableSet.of();
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -284,7 +285,7 @@ public class Stack implements StackInfo {
    */
   @Override
   public Collection<String> getAllConfigurationTypes(String service) {
-    Map<String, Map<String, ConfigProperty>> serviceConfigs = serviceConfigurations.get(service);
+    Map<String, Map<String, ConfigProperty>> serviceConfigs = getServiceConfigurations(service);
     return serviceConfigs != null ? serviceConfigs.keySet() : ImmutableSet.of();
   }
 
@@ -328,7 +329,7 @@ public class Stack implements StackInfo {
   @Override
   public Map<String, String> getConfigurationProperties(String service, String type) {
     Map<String, String> configMap = new HashMap<>();
-    Map<String, ConfigProperty> configProperties = serviceConfigurations.get(service).get(type);
+    Map<String, ConfigProperty> configProperties = getServiceConfigurations(service).get(type);
     if (configProperties != null) {
       for (Map.Entry<String, ConfigProperty> configProperty : configProperties.entrySet()) {
         configMap.put(configProperty.getKey(), configProperty.getValue().getValue());
@@ -339,7 +340,7 @@ public class Stack implements StackInfo {
 
   @Override
   public Map<String, ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type) {
-    return serviceConfigurations.get(service).get(type);
+    return getServiceConfigurations(service).get(type);
   }
 
   /**
@@ -388,10 +389,10 @@ public class Stack implements StackInfo {
 
   @Override
   public boolean isPasswordProperty(String service, String type, String propertyName) {
-    return (serviceConfigurations.containsKey(service) &&
-            serviceConfigurations.get(service).containsKey(type) &&
-            serviceConfigurations.get(service).get(type).containsKey(propertyName) &&
-            serviceConfigurations.get(service).get(type).get(propertyName).getPropertyTypes().
+    Map<String, Map<String, ConfigProperty>> serviceConfigurations = getServiceConfigurations(service);
+    return (serviceConfigurations.containsKey(type) &&
+            serviceConfigurations.get(type).containsKey(propertyName) &&
+            serviceConfigurations.get(type).get(propertyName).getPropertyTypes().
                 contains(PropertyInfo.PropertyType.PASSWORD));
   }
 
@@ -410,10 +411,10 @@ public class Stack implements StackInfo {
 
   @Override
   public boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName) {
-    return (serviceConfigurations.containsKey(service) &&
-            serviceConfigurations.get(service).containsKey(type) &&
-            serviceConfigurations.get(service).get(type).containsKey(propertyName) &&
-            serviceConfigurations.get(service).get(type).get(propertyName).getPropertyTypes().
+    Map<String, Map<String, ConfigProperty>> serviceConfigurations = getServiceConfigurations(service);
+    return (serviceConfigurations.containsKey(type) &&
+            serviceConfigurations.get(type).containsKey(propertyName) &&
+            serviceConfigurations.get(type).get(propertyName).getPropertyTypes().
                 contains(PropertyInfo.PropertyType.KERBEROS_PRINCIPAL));
   }
   /**
@@ -428,7 +429,7 @@ public class Stack implements StackInfo {
   @Override
   public Map<String, Map<String, String>> getConfigurationAttributes(String service, String type) {
     Map<String, Map<String, String>> attributesMap = new HashMap<>();
-    Map<String, ConfigProperty> configProperties = serviceConfigurations.get(service).get(type);
+    Map<String, ConfigProperty> configProperties = getServiceConfigurations(service).get(type);
     if (configProperties != null) {
       for (Map.Entry<String, ConfigProperty> configProperty : configProperties.entrySet()) {
         String propertyName = configProperty.getKey();
@@ -450,6 +451,11 @@ public class Stack implements StackInfo {
       }
     }
     return attributesMap;
+  }
+
+  private Map<String, Map<String, ConfigProperty>> getServiceConfigurations(String service) {
+    Map<String, Map<String, ConfigProperty>> map = serviceConfigurations.get(service);
+    return map != null ? ImmutableMap.copyOf(map) : ImmutableMap.of();
   }
 
   //todo:

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -187,6 +187,13 @@ public class Stack implements StackDefinition {
   }
 
   @Override
+  public Set<StackId> getStacksForComponent(String componentName) {
+    return componentService.keySet().contains(componentName)
+      ? ImmutableSet.of(getStackId())
+      : ImmutableSet.of();
+  }
+
+  @Override
   public Set<String> getServices(StackId stackId) {
     return stackId.equals(getStackId())
       ? ImmutableSet.copyOf(getServices())
@@ -204,14 +211,8 @@ public class Stack implements StackDefinition {
   }
 
   @Override
-  public Map<String, Collection<String>> getComponents() {
-    Map<String, Collection<String>> serviceComponents = new HashMap<>();
-    for (String service : getServices()) {
-      Collection<String> components = new HashSet<>();
-      components.addAll(getComponents(service));
-      serviceComponents.put(service, components);
-    }
-    return serviceComponents;
+  public Collection<String> getComponents() {
+    return componentService.keySet();
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -49,7 +49,8 @@ import org.apache.ambari.server.topology.Configuration;
 /**
  * Encapsulates stack information.
  */
-public class Stack {
+// TODO move to topology package
+public class Stack implements StackInfo {
   /**
    * Stack name
    */
@@ -207,6 +208,7 @@ public class Stack {
    *
    * @return collection of all services for the stack
    */
+  @Override
   public Collection<String> getServices() {
     return serviceComponents.keySet();
   }
@@ -218,6 +220,7 @@ public class Stack {
    *
    * @return collection of component names for the specified service
    */
+  @Override
   public Collection<String> getComponents(String service) {
     return serviceComponents.get(service);
   }
@@ -227,6 +230,7 @@ public class Stack {
    *
    * @return map of service to associated components
    */
+  @Override
   public Map<String, Collection<String>> getComponents() {
     Map<String, Collection<String>> serviceComponents = new HashMap<>();
     for (String service : getServices()) {
@@ -245,6 +249,7 @@ public class Stack {
    * @return component information for the requested component
    *         or null if the component doesn't exist in the stack
    */
+  @Override
   public ComponentInfo getComponentInfo(String component) {
     ComponentInfo componentInfo = null;
     String service = getServiceForComponent(component);
@@ -266,6 +271,7 @@ public class Stack {
    *
    * @return collection of all configuration types for the specified service
    */
+  @Override
   public Collection<String> getAllConfigurationTypes(String service) {
     return serviceConfigurations.get(service).keySet();
   }
@@ -278,6 +284,7 @@ public class Stack {
    *
    * @return collection of all configuration types for the specified service
    */
+  @Override
   public Collection<String> getConfigurationTypes(String service) {
     Set<String> serviceTypes = new HashSet<>(serviceConfigurations.get(service).keySet());
     serviceTypes.removeAll(getExcludedConfigurationTypes(service));
@@ -292,6 +299,7 @@ public class Stack {
    *
    * @return Set of names of excluded config types. Will not return null.
    */
+  @Override
   public Set<String> getExcludedConfigurationTypes(String service) {
     return excludedConfigurationTypes.containsKey(service) ?
         excludedConfigurationTypes.get(service) :
@@ -306,6 +314,7 @@ public class Stack {
    *
    * @return map of property names to values for the specified service and configuration type
    */
+  @Override
   public Map<String, String> getConfigurationProperties(String service, String type) {
     Map<String, String> configMap = new HashMap<>();
     Map<String, ConfigProperty> configProperties = serviceConfigurations.get(service).get(type);
@@ -317,6 +326,7 @@ public class Stack {
     return configMap;
   }
 
+  @Override
   public Map<String, ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type) {
     return serviceConfigurations.get(service).get(type);
   }
@@ -328,6 +338,7 @@ public class Stack {
    *
    * @return collection of all required properties for the given service
    */
+  @Override
   public Collection<ConfigProperty> getRequiredConfigurationProperties(String service) {
     Collection<ConfigProperty> requiredConfigProperties = new HashSet<>();
     Map<String, Map<String, ConfigProperty>> serviceProperties = requiredServiceConfigurations.get(service);
@@ -347,6 +358,7 @@ public class Stack {
    *
    * @return collection of required properties for the given service and property type
    */
+  @Override
   public Collection<ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType) {
     Collection<ConfigProperty> matchingProperties = new HashSet<>();
     Map<String, Map<String, ConfigProperty>> requiredProperties = requiredServiceConfigurations.get(service);
@@ -363,6 +375,7 @@ public class Stack {
     return matchingProperties;
   }
 
+  @Override
   public boolean isPasswordProperty(String service, String type, String propertyName) {
     return (serviceConfigurations.containsKey(service) &&
             serviceConfigurations.get(service).containsKey(type) &&
@@ -372,6 +385,7 @@ public class Stack {
   }
 
   //todo
+  @Override
   public Map<String, String> getStackConfigurationProperties(String type) {
     Map<String, String> configMap = new HashMap<>();
     Map<String, ConfigProperty> configProperties = stackConfigurations.get(type);
@@ -383,6 +397,7 @@ public class Stack {
     return configMap;
   }
 
+  @Override
   public boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName) {
     return (serviceConfigurations.containsKey(service) &&
             serviceConfigurations.get(service).containsKey(type) &&
@@ -399,6 +414,7 @@ public class Stack {
    * @return  map of attribute names to map of property names to attribute values
    *          for the specified service and configuration type
    */
+  @Override
   public Map<String, Map<String, String>> getConfigurationAttributes(String service, String type) {
     Map<String, Map<String, String>> attributesMap = new HashMap<>();
     Map<String, ConfigProperty> configProperties = serviceConfigurations.get(service).get(type);
@@ -426,6 +442,7 @@ public class Stack {
   }
 
   //todo:
+  @Override
   public Map<String, Map<String, String>> getStackConfigurationAttributes(String type) {
     Map<String, Map<String, String>> attributesMap = new HashMap<>();
     Map<String, ConfigProperty> configProperties = stackConfigurations.get(type);
@@ -457,6 +474,7 @@ public class Stack {
    *
    * @return service name that contains tha specified component
    */
+  @Override
   public String getServiceForComponent(String component) {
     return componentService.get(component);
   }
@@ -468,6 +486,7 @@ public class Stack {
    *
    * @return collection of services which contain the specified components
    */
+  @Override
   public Collection<String> getServicesForComponents(Collection<String> components) {
     Set<String> services = new HashSet<>();
     for (String component : components) {
@@ -484,6 +503,7 @@ public class Stack {
    *
    * @return name of service which corresponds to the specified configuration type
    */
+  @Override
   public String getServiceForConfigType(String config) {
     for (Map.Entry<String, Map<String, Map<String, ConfigProperty>>> entry : serviceConfigurations.entrySet()) {
       Map<String, Map<String, ConfigProperty>> typeMap = entry.getValue();
@@ -516,6 +536,7 @@ public class Stack {
    * @return collection of dependency information for the specified component
    */
   //todo: full dependency graph
+  @Override
   public Collection<DependencyInfo> getDependenciesForComponent(String component) {
     return dependencies.containsKey(component) ? dependencies.get(component) :
         Collections.emptySet();
@@ -529,10 +550,12 @@ public class Stack {
    * @return conditional service for provided component or null if dependency
    *         is not conditional on a service
    */
+  @Override
   public String getConditionalServiceForDependency(DependencyInfo dependency) {
     return dependencyConditionalServiceMap.get(dependency);
   }
 
+  @Override
   public String getExternalComponentConfig(String component) {
     return dbDependencyInfo.get(component);
   }
@@ -540,6 +563,7 @@ public class Stack {
   /**
    * Obtain the required cardinality for the specified component.
    */
+  @Override
   public Cardinality getCardinality(String component) {
     return new Cardinality(cardinalityRequirements.get(component));
   }
@@ -547,14 +571,17 @@ public class Stack {
   /**
    * Obtain auto-deploy information for the specified component.
    */
+  @Override
   public AutoDeployInfo getAutoDeployInfo(String component) {
     return componentAutoDeployInfo.get(component);
   }
 
+  @Override
   public boolean isMasterComponent(String component) {
     return masterComponents.contains(component);
   }
 
+  @Override
   public Configuration getConfiguration(Collection<String> services) {
     Map<String, Map<String, Map<String, String>>> attributes = new HashMap<>();
     Map<String, Map<String, String>> properties = new HashMap<>();
@@ -590,6 +617,7 @@ public class Stack {
     return new Configuration(properties, attributes);
   }
 
+  @Override
   public Configuration getConfiguration() {
     Map<String, Map<String, Map<String, String>>> stackAttributes = new HashMap<>();
     Map<String, Map<String, String>> stackConfigs = new HashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ReadOnlyConfigurationResponse;
-import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.ConfigHelper;
@@ -128,19 +127,6 @@ public class Stack implements StackDefinition {
   private Map<String, Set<String>> excludedConfigurationTypes =
     new HashMap<>();
 
-  /**
-   * Constructor.
-   *
-   * @param stack
-   *          the stack (not {@code null}).
-   *
-   * @throws AmbariException an exception occurred getting stack information
-   *                         for the specified name and version
-   */
-  public Stack(StackEntity stack, AmbariManagementController ctrl) throws AmbariException { // FIXME seems to be unused
-    this(stack.getStackName(), stack.getStackVersion(), ctrl);
-  }
-
   public Stack(String name, String version, AmbariManagementController ctrl) throws AmbariException { // FIXME remove or at least change to use metainfo directly
     this(ctrl.getAmbariMetaInfo().getStack(name, version));
   }
@@ -186,6 +172,11 @@ public class Stack implements StackDefinition {
 
   Map<DependencyInfo, String> getDependencyConditionalServiceMap() {
     return dependencyConditionalServiceMap;
+  }
+
+  @Override
+  public Set<StackId> getStackIds() {
+    return ImmutableSet.of(getStackId());
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -47,7 +47,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Encapsulates stack information.
+ * Encapsulates a single, identifiable stack definition.
  */
 // TODO move to topology package
 public class Stack implements StackInfo {
@@ -197,33 +197,16 @@ public class Stack implements StackInfo {
     return stackId.equals(getStackId()) ? ImmutableSet.copyOf(getServices()) : ImmutableSet.of();
   }
 
-  /**
-   * Get services contained in the stack.
-   *
-   * @return collection of all services for the stack
-   */
   @Override
   public Collection<String> getServices() {
     return serviceComponents.keySet();
   }
 
-  /**
-   * Get components contained in the stack for the specified service.
-   *
-   * @param service  service name
-   *
-   * @return collection of component names for the specified service
-   */
   @Override
   public Collection<String> getComponents(String service) {
     return serviceComponents.get(service);
   }
 
-  /**
-   * Get all service components
-   *
-   * @return map of service to associated components
-   */
   @Override
   public Map<String, Collection<String>> getComponents() {
     Map<String, Collection<String>> serviceComponents = new HashMap<>();
@@ -235,14 +218,6 @@ public class Stack implements StackInfo {
     return serviceComponents;
   }
 
-  /**
-   * Get info for the specified component.
-   *
-   * @param component  component name
-   *
-   * @return component information for the requested component
-   *         or null if the component doesn't exist in the stack
-   */
   @Override
   public ComponentInfo getComponentInfo(String component) {
     String service = getServiceForComponent(component);
@@ -255,27 +230,12 @@ public class Stack implements StackInfo {
     return null;
   }
 
-  /**
-   * Get all configuration types, including excluded types for the specified service.
-   *
-   * @param service  service name
-   *
-   * @return collection of all configuration types for the specified service
-   */
   @Override
   public Collection<String> getAllConfigurationTypes(String service) {
     Map<String, Map<String, ConfigProperty>> serviceConfigs = getServiceConfigurations(service);
     return serviceConfigs != null ? serviceConfigs.keySet() : ImmutableSet.of();
   }
 
-  /**
-   * Get configuration types for the specified service.
-   * This doesn't include any service excluded types.
-   *
-   * @param service  service name
-   *
-   * @return collection of all configuration types for the specified service
-   */
   @Override
   public Collection<String> getConfigurationTypes(String service) {
     Set<String> serviceTypes = new HashSet<>(getAllConfigurationTypes(service));
@@ -283,13 +243,6 @@ public class Stack implements StackInfo {
     return serviceTypes;
   }
 
-  /**
-   * Get the set of excluded configuration types for this service.
-   *
-   * @param service service name
-   *
-   * @return Set of names of excluded config types. Will not return null.
-   */
   @Override
   public Set<String> getExcludedConfigurationTypes(String service) {
     return excludedConfigurationTypes.containsKey(service) ?
@@ -297,14 +250,6 @@ public class Stack implements StackInfo {
         Collections.emptySet();
   }
 
-  /**
-   * Get config properties for the specified service and configuration type.
-   *
-   * @param service  service name
-   * @param type     configuration type
-   *
-   * @return map of property names to values for the specified service and configuration type
-   */
   @Override
   public Map<String, String> getConfigurationProperties(String service, String type) {
     Map<String, String> configMap = new HashMap<>();
@@ -321,13 +266,6 @@ public class Stack implements StackInfo {
     return map != null ? ImmutableMap.copyOf(map) : ImmutableMap.of();
   }
 
-  /**
-   * Get all required config properties for the specified service.
-   *
-   * @param service  service name
-   *
-   * @return collection of all required properties for the given service
-   */
   @Override
   public Collection<ConfigProperty> getRequiredConfigurationProperties(String service) {
     Collection<ConfigProperty> requiredConfigProperties = new HashSet<>();
@@ -340,14 +278,6 @@ public class Stack implements StackInfo {
     return requiredConfigProperties;
   }
 
-  /**
-   * Get required config properties for the specified service which belong to the specified property type.
-   *
-   * @param service       service name
-   * @param propertyType  property type
-   *
-   * @return collection of required properties for the given service and property type
-   */
   @Override
   public Collection<ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType) {
     Collection<ConfigProperty> matchingProperties = new HashSet<>();
@@ -395,15 +325,7 @@ public class Stack implements StackInfo {
             serviceConfigurations.get(type).get(propertyName).getPropertyTypes().
                 contains(PropertyInfo.PropertyType.KERBEROS_PRINCIPAL));
   }
-  /**
-   * Get config attributes for the specified service and configuration type.
-   *
-   * @param service  service name
-   * @param type     configuration type
-   *
-   * @return  map of attribute names to map of property names to attribute values
-   *          for the specified service and configuration type
-   */
+
   @Override
   public Map<String, Map<String, String>> getConfigurationAttributes(String service, String type) {
     Map<String, Map<String, String>> attributesMap = new HashMap<>();
@@ -455,25 +377,11 @@ public class Stack implements StackInfo {
     return attributesMap;
   }
 
-  /**
-   * Get the service for the specified component.
-   *
-   * @param component  component name
-   *
-   * @return service name that contains tha specified component
-   */
   @Override
   public String getServiceForComponent(String component) {
     return componentService.get(component);
   }
 
-  /**
-   * Get the names of the services which contains the specified components.
-   *
-   * @param components collection of components
-   *
-   * @return collection of services which contain the specified components
-   */
   @Override
   public Collection<String> getServicesForComponents(Collection<String> components) {
     Set<String> services = new HashSet<>();
@@ -484,13 +392,6 @@ public class Stack implements StackInfo {
     return services;
   }
 
-  /**
-   * Obtain the service name which corresponds to the specified configuration.
-   *
-   * @param config  configuration type
-   *
-   * @return name of service which corresponds to the specified configuration type
-   */
   @Override
   public String getServiceForConfigType(String config) {
     if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
@@ -518,28 +419,12 @@ public class Stack implements StackInfo {
       .map(Map.Entry::getKey);
   }
 
-  /**
-   * Return the dependencies specified for the given component.
-   *
-   * @param component  component to get dependency information for
-   *
-   * @return collection of dependency information for the specified component
-   */
-  //todo: full dependency graph
   @Override
   public Collection<DependencyInfo> getDependenciesForComponent(String component) {
     return dependencies.containsKey(component) ? dependencies.get(component) :
         Collections.emptySet();
   }
 
-  /**
-   * Get the service, if any, that a component dependency is conditional on.
-   *
-   * @param dependency  dependency to get conditional service for
-   *
-   * @return conditional service for provided component or null if dependency
-   *         is not conditional on a service
-   */
   @Override
   public String getConditionalServiceForDependency(DependencyInfo dependency) {
     return dependencyConditionalServiceMap.get(dependency);
@@ -550,17 +435,11 @@ public class Stack implements StackInfo {
     return dbDependencyInfo.get(component);
   }
 
-  /**
-   * Obtain the required cardinality for the specified component.
-   */
   @Override
   public Cardinality getCardinality(String component) {
     return new Cardinality(cardinalityRequirements.get(component));
   }
 
-  /**
-   * Obtain auto-deploy information for the specified component.
-   */
   @Override
   public AutoDeployInfo getAutoDeployInfo(String component) {
     return componentAutoDeployInfo.get(component);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -30,6 +30,11 @@ public interface StackDefinition {
   Set<StackId> getStacksForService(String serviceName);
 
   /**
+   * @return the IDs of the set of stacks that the given component is defined in
+   */
+  Set<StackId> getStacksForComponent(String componentName);
+
+  /**
    * @return the names of services defined the given stack
    */
   Set<String> getServices(StackId stackId);
@@ -53,9 +58,9 @@ public interface StackDefinition {
   /**
    * Get all service components
    *
-   * @return map of service to associated components
+   * @return collection of all components for the stack
    */
-  Map<String, Collection<String>> getComponents();
+  Collection<String> getComponents();
 
   /**
    * Get info for the specified component.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -1,0 +1,218 @@
+package org.apache.ambari.server.controller.internal;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.ambari.server.state.AutoDeployInfo;
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.topology.Cardinality;
+import org.apache.ambari.server.topology.Configuration;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * Encapsulates stack information.
+ */
+public interface StackDefinition {
+
+  /**
+   * @return the IDs for the set of stacks that this stacks is (possibly) composed of.
+   */
+  Set<StackId> getStackIds();
+
+  /**
+   * @return the IDs of the set of stacks that the given service is defined in
+   */
+  Set<StackId> getStacksForService(String serviceName);
+
+  /**
+   * @return the names of services defined the given stack
+   */
+  Set<String> getServices(StackId stackId);
+
+  /**
+   * Get services contained in the stack.
+   *
+   * @return collection of all services for the stack
+   */
+  Collection<String> getServices();
+
+  /**
+   * Get components contained in the stack for the specified service.
+   *
+   * @param service  service name
+   *
+   * @return collection of component names for the specified service
+   */
+  Collection<String> getComponents(String service);
+
+  /**
+   * Get all service components
+   *
+   * @return map of service to associated components
+   */
+  Map<String, Collection<String>> getComponents();
+
+  /**
+   * Get info for the specified component.
+   *
+   * @param component  component name
+   *
+   * @return component information for the requested component
+   *         or null if the component doesn't exist in the stack
+   */
+  ComponentInfo getComponentInfo(String component);
+
+  /**
+   * Get all configuration types, including excluded types for the specified service.
+   *
+   * @param service  service name
+   *
+   * @return collection of all configuration types for the specified service
+   */
+  Collection<String> getAllConfigurationTypes(String service);
+
+  /**
+   * Get configuration types for the specified service.
+   * This doesn't include any service excluded types.
+   *
+   * @param service  service name
+   * @return collection of all configuration types for the specified service
+   */
+  Collection<String> getConfigurationTypes(String service);
+
+  /**
+   * Get the set of excluded configuration types for this service.
+   *
+   * @param service service name
+   * @return Set of names of excluded config types. Will not return null.
+   */
+  Set<String> getExcludedConfigurationTypes(String service);
+
+  /**
+   * Get config properties for the specified service and configuration type.
+   *
+   * @param service  service name
+   * @param type     configuration type
+   * @return map of property names to values for the specified service and configuration type
+   */
+  Map<String, String> getConfigurationProperties(String service, String type);
+
+  Map<String, Stack.ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type);
+
+  /**
+   * Get all required config properties for the specified service.
+   *
+   * @param service  service name
+   * @return collection of all required properties for the given service
+   */
+  Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service);
+
+  /**
+   * Get required config properties for the specified service which belong to the specified property type.
+   *
+   * @param service       service name
+   * @param propertyType  property type
+   *
+   * @return collection of required properties for the given service and property type
+   */
+  Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType);
+
+  boolean isPasswordProperty(String service, String type, String propertyName);
+
+  Map<String, String> getStackConfigurationProperties(String type);
+
+  boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName);
+
+  /**
+   * Get config attributes for the specified service and configuration type.
+   *
+   * @param service  service name
+   * @param type     configuration type
+   *
+   * @return  map of attribute names to map of property names to attribute values
+   *          for the specified service and configuration type
+   */
+  Map<String, Map<String, String>> getConfigurationAttributes(String service, String type);
+
+  Map<String, Map<String, String>> getStackConfigurationAttributes(String type);
+
+  /**
+   * Get the service for the specified component.
+   *
+   * @param component  component name
+   *
+   * @return service name that contains tha specified component
+   */
+  String getServiceForComponent(String component);
+
+  /**
+   * Get the names of the services which contains the specified components.
+   *
+   * @param components collection of components
+   *
+   * @return collection of services which contain the specified components
+   */
+  Collection<String> getServicesForComponents(Collection<String> components);
+
+  /**
+   * Obtain the service name which corresponds to the specified configuration.
+   *
+   * @param config  configuration type
+   *
+   * @return name of service which corresponds to the specified configuration type
+   */
+  String getServiceForConfigType(String config);
+
+  Stream<String> getServicesForConfigType(String config);
+
+  /**
+   * Return the dependencies specified for the given component.
+   *
+   * @param component  component to get dependency information for
+   *
+   * @return collection of dependency information for the specified component
+   */
+  //todo: full dependency graph
+  Collection<DependencyInfo> getDependenciesForComponent(String component);
+
+  /**
+   * Get the service, if any, that a component dependency is conditional on.
+   *
+   * @param dependency  dependency to get conditional service for
+   *
+   * @return conditional service for provided component or null if dependency
+   *         is not conditional on a service
+   */
+  String getConditionalServiceForDependency(DependencyInfo dependency);
+
+  String getExternalComponentConfig(String component);
+
+  /**
+   * Obtain the required cardinality for the specified component.
+   */
+  Cardinality getCardinality(String component);
+
+  /**
+   * Obtain auto-deploy information for the specified component.
+   */
+  AutoDeployInfo getAutoDeployInfo(String component);
+
+  boolean isMasterComponent(String component);
+
+  Configuration getConfiguration(Collection<String> services);
+
+  Configuration getConfiguration();
+
+  static StackDefinition of(Set<Stack> stacks) {
+    return stacks.size() > 1
+      ? new CompositeStack(stacks)
+      : Iterables.getFirst(stacks, null);
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -13,6 +13,8 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
+import com.google.common.collect.Iterables;
+
 /**
  * Encapsulates stack information.
  */
@@ -206,4 +208,11 @@ public interface StackDefinition {
   Configuration getConfiguration(Collection<String> services);
 
   Configuration getConfiguration();
+
+  static StackDefinition of(Set<Stack> stacks) {
+    return stacks.size() > 1
+      ? new CompositeStack(stacks)
+      : Iterables.getFirst(stacks, null);
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -16,7 +16,7 @@ import org.apache.ambari.server.topology.Configuration;
 /**
  * Encapsulates stack information.
  */
-public interface StackInfo {
+public interface StackDefinition {
 
   Set<StackId> getStacksForService(String serviceName);
   Set<String> getServices(StackId stackId);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -13,11 +13,10 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
-import com.google.common.collect.Iterables;
-
 /**
  * Encapsulates stack information.
  */
+// TODO move to topology package
 public interface StackDefinition {
 
   /**
@@ -103,6 +102,13 @@ public interface StackDefinition {
    */
   Map<String, String> getConfigurationProperties(String service, String type);
 
+  /**
+   * Get config properties with metadata attributes for the specified service and configuration type.
+   *
+   * @param service  service name
+   * @param type     configuration type
+   * @return map of property names to properties for the specified service and configuration type
+   */
   Map<String, Stack.ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type);
 
   /**
@@ -123,10 +129,21 @@ public interface StackDefinition {
    */
   Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType);
 
+  /**
+   * @return true if the given property for the specified service and config type is a password-type property
+   * @see org.apache.ambari.server.state.PropertyInfo.PropertyType#PASSWORD
+   */
   boolean isPasswordProperty(String service, String type, String propertyName);
 
+  /**
+   * @return map of stack-level property names to properties for the specified configuration type
+   */
   Map<String, String> getStackConfigurationProperties(String type);
 
+  /**
+   * @return true if the given property for the specified service and config type is a Kerberos principal-type property
+   * @see org.apache.ambari.server.state.PropertyInfo.PropertyType#KERBEROS_PRINCIPAL
+   */
   boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName);
 
   /**
@@ -140,6 +157,14 @@ public interface StackDefinition {
    */
   Map<String, Map<String, String>> getConfigurationAttributes(String service, String type);
 
+  /**
+   * Get stack-level config attributes for the specified configuration type.
+   *
+   * @param type     configuration type
+   *
+   * @return  map of attribute names to map of property names to attribute values
+   *          for the specified configuration type
+   */
   Map<String, Map<String, String>> getStackConfigurationAttributes(String type);
 
   /**
@@ -169,6 +194,9 @@ public interface StackDefinition {
    */
   String getServiceForConfigType(String config);
 
+  /**
+   * @return stream of service names which correspond to the specified configuration type name
+   */
   Stream<String> getServicesForConfigType(String config);
 
   /**
@@ -191,6 +219,16 @@ public interface StackDefinition {
    */
   String getConditionalServiceForDependency(DependencyInfo dependency);
 
+  /**
+   * Get the custom "descriptor" that is used to decide whether component
+   * is a managed or non-managed dependency.  The descriptor is formatted as:
+   * "config_type/property_name".  Currently it is only used for Hive Metastore's
+   * database.
+   *
+   * @param component component to get dependency information for
+   * @return the descriptor of form "config_type/property_name"
+   * @see org.apache.ambari.server.topology.BlueprintValidatorImpl#isDependencyManaged
+   */
   String getExternalComponentConfig(String component);
 
   /**
@@ -203,16 +241,33 @@ public interface StackDefinition {
    */
   AutoDeployInfo getAutoDeployInfo(String component);
 
+  /**
+   * @return true if the given component is a master component
+   */
   boolean isMasterComponent(String component);
 
+  /**
+   * @return subset of the stack's configuration for the given services
+   */
   Configuration getConfiguration(Collection<String> services);
 
+  /**
+   * @return the stack's configuration
+   */
   Configuration getConfiguration();
 
+  /**
+   * Create a stack definition for one or more stacks.
+   * When given multiple stacks, it returns a composite stack,
+   * while a single stack is returned as is.
+   *
+   * @param stacks the stack(s) to combine
+   * @return composite or single stack
+   */
   static StackDefinition of(Set<Stack> stacks) {
     return stacks.size() > 1
       ? new CompositeStack(stacks)
-      : Iterables.getFirst(stacks, null);
+      : stacks.stream().findAny().orElse(null);
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -18,7 +18,19 @@ import org.apache.ambari.server.topology.Configuration;
  */
 public interface StackDefinition {
 
+  /**
+   * @return the IDs for the set of stacks that this stacks is (possibly) composed of.
+   */
+  Set<StackId> getStackIds();
+
+  /**
+   * @return the IDs of the set of stacks that the given service is defined in
+   */
   Set<StackId> getStacksForService(String serviceName);
+
+  /**
+   * @return the names of services defined the given stack
+   */
   Set<String> getServices(StackId stackId);
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
@@ -12,6 +12,7 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
+// FIXME move javadoc
 public interface StackInfo {
 
   Collection<StackId> getStacksForService(String serviceName);
@@ -40,14 +41,12 @@ public interface StackInfo {
 
   boolean isPasswordProperty(String service, String type, String propertyName);
 
-  //todo
   Map<String, String> getStackConfigurationProperties(String type);
 
   boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName);
 
   Map<String, Map<String, String>> getConfigurationAttributes(String service, String type);
 
-  //todo:
   Map<String, Map<String, String>> getStackConfigurationAttributes(String type);
 
   String getServiceForComponent(String component);
@@ -56,7 +55,6 @@ public interface StackInfo {
 
   String getServiceForConfigType(String config);
 
-  //todo: full dependency graph
   Collection<DependencyInfo> getDependenciesForComponent(String component);
 
   String getConditionalServiceForDependency(DependencyInfo dependency);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
@@ -8,10 +8,14 @@ import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.DependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
 public interface StackInfo {
+
+  Collection<StackId> getStacksForService(String serviceName);
+
   Collection<String> getServices();
 
   Collection<String> getComponents(String service);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
@@ -1,0 +1,71 @@
+package org.apache.ambari.server.controller.internal;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.state.AutoDeployInfo;
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.topology.Cardinality;
+import org.apache.ambari.server.topology.Configuration;
+
+public interface StackInfo {
+  Collection<String> getServices();
+
+  Collection<String> getComponents(String service);
+
+  Map<String, Collection<String>> getComponents();
+
+  ComponentInfo getComponentInfo(String component);
+
+  Collection<String> getAllConfigurationTypes(String service);
+
+  Collection<String> getConfigurationTypes(String service);
+
+  Set<String> getExcludedConfigurationTypes(String service);
+
+  Map<String, String> getConfigurationProperties(String service, String type);
+
+  Map<String, Stack.ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type);
+
+  Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service);
+
+  Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType);
+
+  boolean isPasswordProperty(String service, String type, String propertyName);
+
+  //todo
+  Map<String, String> getStackConfigurationProperties(String type);
+
+  boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName);
+
+  Map<String, Map<String, String>> getConfigurationAttributes(String service, String type);
+
+  //todo:
+  Map<String, Map<String, String>> getStackConfigurationAttributes(String type);
+
+  String getServiceForComponent(String component);
+
+  Collection<String> getServicesForComponents(Collection<String> components);
+
+  String getServiceForConfigType(String config);
+
+  //todo: full dependency graph
+  Collection<DependencyInfo> getDependenciesForComponent(String component);
+
+  String getConditionalServiceForDependency(DependencyInfo dependency);
+
+  String getExternalComponentConfig(String component);
+
+  Cardinality getCardinality(String component);
+
+  AutoDeployInfo getAutoDeployInfo(String component);
+
+  boolean isMasterComponent(String component);
+
+  Configuration getConfiguration(Collection<String> services);
+
+  Configuration getConfiguration();
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
@@ -3,6 +3,7 @@ package org.apache.ambari.server.controller.internal;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
@@ -55,6 +56,7 @@ public interface StackInfo {
   Collection<String> getServicesForComponents(Collection<String> components);
 
   String getServiceForConfigType(String config);
+  Stream<String> getServicesForConfigType(String config);
 
   Collection<DependencyInfo> getDependenciesForComponent(String component);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
@@ -15,7 +15,8 @@ import org.apache.ambari.server.topology.Configuration;
 // FIXME move javadoc
 public interface StackInfo {
 
-  Collection<StackId> getStacksForService(String serviceName);
+  Set<StackId> getStacksForService(String serviceName);
+  Set<String> getServices(StackId stackId);
 
   Collection<String> getServices();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackInfo.java
@@ -13,32 +13,100 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 
-// FIXME move javadoc
+/**
+ * Encapsulates stack information.
+ */
 public interface StackInfo {
 
   Set<StackId> getStacksForService(String serviceName);
   Set<String> getServices(StackId stackId);
 
+  /**
+   * Get services contained in the stack.
+   *
+   * @return collection of all services for the stack
+   */
   Collection<String> getServices();
 
+  /**
+   * Get components contained in the stack for the specified service.
+   *
+   * @param service  service name
+   *
+   * @return collection of component names for the specified service
+   */
   Collection<String> getComponents(String service);
 
+  /**
+   * Get all service components
+   *
+   * @return map of service to associated components
+   */
   Map<String, Collection<String>> getComponents();
 
+  /**
+   * Get info for the specified component.
+   *
+   * @param component  component name
+   *
+   * @return component information for the requested component
+   *         or null if the component doesn't exist in the stack
+   */
   ComponentInfo getComponentInfo(String component);
 
+  /**
+   * Get all configuration types, including excluded types for the specified service.
+   *
+   * @param service  service name
+   *
+   * @return collection of all configuration types for the specified service
+   */
   Collection<String> getAllConfigurationTypes(String service);
 
+  /**
+   * Get configuration types for the specified service.
+   * This doesn't include any service excluded types.
+   *
+   * @param service  service name
+   * @return collection of all configuration types for the specified service
+   */
   Collection<String> getConfigurationTypes(String service);
 
+  /**
+   * Get the set of excluded configuration types for this service.
+   *
+   * @param service service name
+   * @return Set of names of excluded config types. Will not return null.
+   */
   Set<String> getExcludedConfigurationTypes(String service);
 
+  /**
+   * Get config properties for the specified service and configuration type.
+   *
+   * @param service  service name
+   * @param type     configuration type
+   * @return map of property names to values for the specified service and configuration type
+   */
   Map<String, String> getConfigurationProperties(String service, String type);
 
   Map<String, Stack.ConfigProperty> getConfigurationPropertiesWithMetadata(String service, String type);
 
+  /**
+   * Get all required config properties for the specified service.
+   *
+   * @param service  service name
+   * @return collection of all required properties for the given service
+   */
   Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service);
 
+  /**
+   * Get required config properties for the specified service which belong to the specified property type.
+   *
+   * @param service       service name
+   * @param propertyType  property type
+   *
+   * @return collection of required properties for the given service and property type
+   */
   Collection<Stack.ConfigProperty> getRequiredConfigurationProperties(String service, PropertyInfo.PropertyType propertyType);
 
   boolean isPasswordProperty(String service, String type, String propertyName);
@@ -47,25 +115,78 @@ public interface StackInfo {
 
   boolean isKerberosPrincipalNameProperty(String service, String type, String propertyName);
 
+  /**
+   * Get config attributes for the specified service and configuration type.
+   *
+   * @param service  service name
+   * @param type     configuration type
+   *
+   * @return  map of attribute names to map of property names to attribute values
+   *          for the specified service and configuration type
+   */
   Map<String, Map<String, String>> getConfigurationAttributes(String service, String type);
 
   Map<String, Map<String, String>> getStackConfigurationAttributes(String type);
 
+  /**
+   * Get the service for the specified component.
+   *
+   * @param component  component name
+   *
+   * @return service name that contains tha specified component
+   */
   String getServiceForComponent(String component);
 
+  /**
+   * Get the names of the services which contains the specified components.
+   *
+   * @param components collection of components
+   *
+   * @return collection of services which contain the specified components
+   */
   Collection<String> getServicesForComponents(Collection<String> components);
 
+  /**
+   * Obtain the service name which corresponds to the specified configuration.
+   *
+   * @param config  configuration type
+   *
+   * @return name of service which corresponds to the specified configuration type
+   */
   String getServiceForConfigType(String config);
+
   Stream<String> getServicesForConfigType(String config);
 
+  /**
+   * Return the dependencies specified for the given component.
+   *
+   * @param component  component to get dependency information for
+   *
+   * @return collection of dependency information for the specified component
+   */
+  //todo: full dependency graph
   Collection<DependencyInfo> getDependenciesForComponent(String component);
 
+  /**
+   * Get the service, if any, that a component dependency is conditional on.
+   *
+   * @param dependency  dependency to get conditional service for
+   *
+   * @return conditional service for provided component or null if dependency
+   *         is not conditional on a service
+   */
   String getConditionalServiceForDependency(DependencyInfo dependency);
 
   String getExternalComponentConfig(String component);
 
+  /**
+   * Obtain the required cardinality for the specified component.
+   */
   Cardinality getCardinality(String component);
 
+  /**
+   * Obtain auto-deploy information for the specified component.
+   */
   AutoDeployInfo getAutoDeployInfo(String component);
 
   boolean isMasterComponent(String component);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
@@ -69,18 +69,18 @@ public class UnitUpdater implements BlueprintConfigurationProcessor.PropertyUpda
     private static final String DEFAULT_UNIT = "m";
     private final String unit;
 
-    public static PropertyUnit of(StackInfo stack, UnitValidatedProperty property) {
+    public static PropertyUnit of(StackDefinition stack, UnitValidatedProperty property) {
       return PropertyUnit.of(stack, property.getServiceName(), property.getConfigType(), property.getPropertyName());
     }
 
-    public static PropertyUnit of(StackInfo stack, String serviceName, String configType, String propertyName) {
+    public static PropertyUnit of(StackDefinition stack, String serviceName, String configType, String propertyName) {
       return new PropertyUnit(
         stackUnit(stack, serviceName, configType, propertyName)
           .map(PropertyUnit::toJvmUnit)
           .orElse(DEFAULT_UNIT));
     }
 
-    private static Optional<String> stackUnit(StackInfo stack, String serviceName, String configType, String propertyName) {
+    private static Optional<String> stackUnit(StackDefinition stack, String serviceName, String configType, String propertyName) {
       try {
         return Optional.ofNullable(
           stack.getConfigurationPropertiesWithMetadata(serviceName, configType)

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
@@ -69,18 +69,18 @@ public class UnitUpdater implements BlueprintConfigurationProcessor.PropertyUpda
     private static final String DEFAULT_UNIT = "m";
     private final String unit;
 
-    public static PropertyUnit of(Stack stack, UnitValidatedProperty property) {
+    public static PropertyUnit of(StackDefinition stack, UnitValidatedProperty property) {
       return PropertyUnit.of(stack, property.getServiceName(), property.getConfigType(), property.getPropertyName());
     }
 
-    public static PropertyUnit of(Stack stack, String serviceName, String configType, String propertyName) {
+    public static PropertyUnit of(StackDefinition stack, String serviceName, String configType, String propertyName) {
       return new PropertyUnit(
         stackUnit(stack, serviceName, configType, propertyName)
           .map(PropertyUnit::toJvmUnit)
           .orElse(DEFAULT_UNIT));
     }
 
-    private static Optional<String> stackUnit(Stack stack, String serviceName, String configType, String propertyName) {
+    private static Optional<String> stackUnit(StackDefinition stack, String serviceName, String configType, String propertyName) {
       try {
         return Optional.ofNullable(
           stack.getConfigurationPropertiesWithMetadata(serviceName, configType)

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
@@ -69,18 +69,18 @@ public class UnitUpdater implements BlueprintConfigurationProcessor.PropertyUpda
     private static final String DEFAULT_UNIT = "m";
     private final String unit;
 
-    public static PropertyUnit of(Stack stack, UnitValidatedProperty property) {
+    public static PropertyUnit of(StackInfo stack, UnitValidatedProperty property) {
       return PropertyUnit.of(stack, property.getServiceName(), property.getConfigType(), property.getPropertyName());
     }
 
-    public static PropertyUnit of(Stack stack, String serviceName, String configType, String propertyName) {
+    public static PropertyUnit of(StackInfo stack, String serviceName, String configType, String propertyName) {
       return new PropertyUnit(
         stackUnit(stack, serviceName, configType, propertyName)
           .map(PropertyUnit::toJvmUnit)
           .orElse(DEFAULT_UNIT));
     }
 
-    private static Optional<String> stackUnit(Stack stack, String serviceName, String configType, String propertyName) {
+    private static Optional<String> stackUnit(StackInfo stack, String serviceName, String configType, String propertyName) {
       try {
         return Optional.ofNullable(
           stack.getConfigurationPropertiesWithMetadata(serviceName, configType)

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/BlueprintMpackInstanceEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/BlueprintMpackInstanceEntity.java
@@ -52,10 +52,10 @@ public class BlueprintMpackInstanceEntity {
   @Column(name = "id", nullable = false, updatable = false)
   private Long id;
 
-  @Column(name = "mpack_name")
+  @Column(name = "mpack_name", nullable = false)
   private String mpackName;
 
-  @Column(name = "mpack_version")
+  @Column(name = "mpack_version", nullable = false)
   private String mpackVersion;
 
   @Column(name = "mpack_uri")
@@ -68,7 +68,7 @@ public class BlueprintMpackInstanceEntity {
   private Collection<BlueprintMpackConfigEntity> configurations = new ArrayList<>();
 
   @ManyToOne
-  @JoinColumn(name = "mpack_id", referencedColumnName = "id", nullable = true)
+  @JoinColumn(name = "mpack_id", referencedColumnName = "id")
   private MpackEntity mpackEntity;
 
   @ManyToOne

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/NoSuchStackException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/NoSuchStackException.java
@@ -18,10 +18,15 @@
 
 package org.apache.ambari.server.stack;
 
+import org.apache.ambari.server.state.StackId;
+
 /**
- * Indicates that the requested Stack doesn't esist.
+ * Indicates that the requested Stack doesn't exist.
  */
-public class NoSuchStackException extends Exception {
+public class NoSuchStackException extends IllegalArgumentException {
+  public NoSuchStackException(StackId stackId) {
+    this(stackId.getStackName(), stackId.getStackVersion());
+  }
   public NoSuchStackException(String stackName, String stackVersion) {
     super(String.format("The requested stack doesn't exist. Name='%s' Version='%s'", stackName, stackVersion));
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/NoSuchStackException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/NoSuchStackException.java
@@ -18,10 +18,15 @@
 
 package org.apache.ambari.server.stack;
 
+import org.apache.ambari.server.state.StackId;
+
 /**
  * Indicates that the requested Stack doesn't exist.
  */
 public class NoSuchStackException extends IllegalArgumentException {
+  public NoSuchStackException(StackId stackId) {
+    this(stackId.getStackName(), stackId.getStackVersion());
+  }
   public NoSuchStackException(String stackName, String stackVersion) {
     super(String.format("The requested stack doesn't exist. Name='%s' Version='%s'", stackName, stackVersion));
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/NoSuchStackException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/NoSuchStackException.java
@@ -19,9 +19,9 @@
 package org.apache.ambari.server.stack;
 
 /**
- * Indicates that the requested Stack doesn't esist.
+ * Indicates that the requested Stack doesn't exist.
  */
-public class NoSuchStackException extends Exception {
+public class NoSuchStackException extends IllegalArgumentException {
   public NoSuchStackException(String stackName, String stackVersion) {
     super(String.format("The requested stack doesn't exist. Name='%s' Version='%s'", stackName, stackVersion));
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -68,7 +68,7 @@ import org.apache.ambari.server.controller.internal.ServiceDependencyResourcePro
 import org.apache.ambari.server.controller.internal.ServiceGroupDependencyResourceProvider;
 import org.apache.ambari.server.controller.internal.ServiceGroupResourceProvider;
 import org.apache.ambari.server.controller.internal.ServiceResourceProvider;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.internal.VersionDefinitionResourceProvider;
 import org.apache.ambari.server.controller.predicate.EqualsPredicate;
 import org.apache.ambari.server.controller.spi.ClusterController;
@@ -760,7 +760,7 @@ public class AmbariContext {
    */
   private void createConfigGroupsAndRegisterHost(ClusterTopology topology, String groupName) throws AmbariException {
     Map<String, Map<String, Config>> groupConfigs = new HashMap<>();
-    StackInfo stack = topology.getBlueprint().getStack();
+    StackDefinition stack = topology.getBlueprint().getStack();
 
     // get the host-group config with cluster creation template overrides
     Configuration topologyHostGroupConfig = topology.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -67,7 +67,7 @@ import org.apache.ambari.server.controller.internal.ServiceDependencyResourcePro
 import org.apache.ambari.server.controller.internal.ServiceGroupDependencyResourceProvider;
 import org.apache.ambari.server.controller.internal.ServiceGroupResourceProvider;
 import org.apache.ambari.server.controller.internal.ServiceResourceProvider;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.controller.internal.VersionDefinitionResourceProvider;
 import org.apache.ambari.server.controller.predicate.EqualsPredicate;
 import org.apache.ambari.server.controller.spi.ClusterController;
@@ -213,8 +213,7 @@ public class AmbariContext {
 
   public void createAmbariResources(ClusterTopology topology, String clusterName, SecurityType securityType,
                                     String repoVersionString, Long repoVersionId) {
-    Stack stack = topology.getBlueprint().getStack();
-    StackId stackId = new StackId(stack.getName(), stack.getVersion());
+    StackId stackId = topology.getBlueprint().getStackId();
 
     RepositoryVersionEntity repoVersion = null;
     if (StringUtils.isEmpty(repoVersionString) && null == repoVersionId) {
@@ -298,12 +297,12 @@ public class AmbariContext {
           repoVersion));
     }
 
-    createAmbariClusterResource(clusterName, stack.getName(), stack.getVersion(), securityType);
+    createAmbariClusterResource(clusterName, stackId, securityType);
     createAmbariServiceAndComponentResources(topology, clusterName, stackId, repoVersion.getId());
   }
 
-  public void createAmbariClusterResource(String clusterName, String stackName, String stackVersion, SecurityType securityType) {
-    String stackInfo = String.format("%s-%s", stackName, stackVersion);
+  public void createAmbariClusterResource(String clusterName, StackId stackId, SecurityType securityType) {
+    String stackInfo = stackId.toString();
     final ClusterRequest clusterRequest = new ClusterRequest(null, clusterName, null, securityType, stackInfo, null);
 
     try {
@@ -522,11 +521,10 @@ public class AmbariContext {
    * installed and started and that the monitoring screen for the cluster should be displayed to the user.
    *
    * @param clusterName  cluster name
-   * @param stackName    stack name
-   * @param stackVersion stack version
+   * @param stackId    stack ID
    */
-  public void persistInstallStateForUI(String clusterName, String stackName, String stackVersion) {
-    String stackInfo = String.format("%s-%s", stackName, stackVersion);
+  public void persistInstallStateForUI(String clusterName, StackId stackId) {
+    String stackInfo = stackId.toString();
     final ClusterRequest clusterRequest = new ClusterRequest(null, clusterName, "INSTALLED", null, stackInfo, null);
 
     try {
@@ -743,7 +741,7 @@ public class AmbariContext {
    */
   private void createConfigGroupsAndRegisterHost(ClusterTopology topology, String groupName) throws AmbariException {
     Map<String, Map<String, Config>> groupConfigs = new HashMap<>();
-    Stack stack = topology.getBlueprint().getStack();
+    StackInfo stack = topology.getBlueprint().getStack();
 
     // get the host-group config with cluster creation template overrides
     Configuration topologyHostGroupConfig = topology.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.topology;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.Collection;
@@ -91,12 +92,11 @@ import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.configgroup.ConfigGroup;
 import org.apache.ambari.server.utils.RetryHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.directory.api.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Striped;
@@ -213,92 +213,110 @@ public class AmbariContext {
 
   public void createAmbariResources(ClusterTopology topology, String clusterName, SecurityType securityType,
                                     String repoVersionString, Long repoVersionId) {
-    StackId stackId = topology.getBlueprint().getStackId();
+    Map<StackId, Long> repoVersionByStack = new HashMap<>();
 
-    RepositoryVersionEntity repoVersion = null;
-    if (StringUtils.isEmpty(repoVersionString) && null == repoVersionId) {
-      List<RepositoryVersionEntity> stackRepoVersions = repositoryVersionDAO.findByStack(stackId);
-
-      if (stackRepoVersions.isEmpty()) {
-        // !!! no repos, try to get the version for the stack
-        VersionDefinitionResourceProvider vdfProvider = getVersionDefinitionResourceProvider();
-
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(VersionDefinitionResourceProvider.VERSION_DEF_AVAILABLE_DEFINITION, stackId.toString());
-
-        Request request = new RequestImpl(Collections.<String>emptySet(),
-            Collections.singleton(properties), Collections.<String, String>emptyMap(), null);
-
-        Long defaultRepoVersionId = null;
-
-        try {
-          RequestStatus requestStatus = vdfProvider.createResources(request);
-          if (!requestStatus.getAssociatedResources().isEmpty()) {
-            Resource resource = requestStatus.getAssociatedResources().iterator().next();
-            defaultRepoVersionId = (Long) resource.getPropertyValue(VersionDefinitionResourceProvider.VERSION_DEF_ID);
-          }
-        } catch (Exception e) {
-          throw new IllegalArgumentException(String.format(
-              "Failed to create a default repository version definition for stack %s. "
-              + "This typically is a result of not loading the stack correctly or being able "
-              + "to load information about released versions.  Create a repository version "
-              + " and try again.", stackId), e);
-        }
-
-        repoVersion = repositoryVersionDAO.findByPK(defaultRepoVersionId);
-        // !!! better not!
-        if (null == repoVersion) {
-          throw new IllegalArgumentException(String.format(
-              "Failed to load the default repository version definition for stack %s. "
-              + "Check for a valid repository version and try again.", stackId));
-        }
-
-      } else if (stackRepoVersions.size() > 1) {
-
-        Function<RepositoryVersionEntity, String> function = new Function<RepositoryVersionEntity, String>() {
-          @Override
-          public String apply(RepositoryVersionEntity input) {
-            return input.getVersion();
-          }
-        };
-
-        Collection<String> versions = Collections2.transform(stackRepoVersions, function);
-
-        throw new IllegalArgumentException(String.format("Several repositories were found for %s:  %s.  Specify the version"
-            + " with '%s'", stackId, StringUtils.join(versions, ", "), ProvisionClusterRequest.REPO_VERSION_PROPERTY));
-      } else {
-        repoVersion = stackRepoVersions.get(0);
-        LOG.warn("Cluster is being provisioned using the single matching repository version {}", repoVersion.getVersion());
+    Set<StackId> stackIds = topology.getBlueprint().getStackIds();
+    for (StackId stackId : stackIds) {
+      RepositoryVersionEntity repoVersion = null;
+      if (stackIds.size() == 1) {
+        repoVersion = findSpecifiedRepo(repoVersionString, repoVersionId, stackId);
       }
-    } else if (null != repoVersionId){
+      if (null == repoVersion) {
+        repoVersion = findRepoForStack(stackId);
+      }
+      Preconditions.checkNotNull(repoVersion);
+      // only use a STANDARD repo when creating a new cluster
+      if (repoVersion.getType() != RepositoryType.STANDARD) {
+        throw new IllegalArgumentException(String.format(
+          "Unable to create a cluster using the following repository since it is not a STANDARD type: %s",
+          repoVersion
+        ));
+      }
+    }
+
+    StackId stackId = topology.getBlueprint().getStackId();
+    createAmbariClusterResource(clusterName, stackId, securityType);
+    createAmbariServiceAndComponentResources(topology, clusterName, repoVersionByStack);
+  }
+
+  private RepositoryVersionEntity findRepoForStack(StackId stackId) {
+    RepositoryVersionEntity repoVersion;
+    List<RepositoryVersionEntity> stackRepoVersions = repositoryVersionDAO.findByStack(stackId);
+    if (stackRepoVersions.isEmpty()) {
+      // !!! no repos, try to get the version for the stack
+      VersionDefinitionResourceProvider vdfProvider = getVersionDefinitionResourceProvider();
+
+      Map<String, Object> properties = new HashMap<>();
+      properties.put(VersionDefinitionResourceProvider.VERSION_DEF_AVAILABLE_DEFINITION, stackId.toString());
+
+      Request request = new RequestImpl(Collections.emptySet(),
+        Collections.singleton(properties), Collections.emptyMap(), null
+      );
+
+      Long defaultRepoVersionId = null;
+
+      try {
+        RequestStatus requestStatus = vdfProvider.createResources(request);
+        if (!requestStatus.getAssociatedResources().isEmpty()) {
+          Resource resource = requestStatus.getAssociatedResources().iterator().next();
+          defaultRepoVersionId = (Long) resource.getPropertyValue(VersionDefinitionResourceProvider.VERSION_DEF_ID);
+        }
+      } catch (Exception e) {
+        throw new IllegalArgumentException(String.format(
+          "Failed to create a default repository version definition for stack %s. "
+            + "This typically is a result of not loading the stack correctly or being able "
+            + "to load information about released versions.  Create a repository version "
+            + " and try again.", stackId), e);
+      }
+
+      repoVersion = repositoryVersionDAO.findByPK(defaultRepoVersionId);
+      // !!! better not!
+      if (null == repoVersion) {
+        throw new IllegalArgumentException(String.format(
+          "Failed to load the default repository version definition for stack %s. "
+            + "Check for a valid repository version and try again.", stackId));
+      }
+
+    } else if (stackRepoVersions.size() > 1) {
+      String versions = stackRepoVersions.stream()
+        .map(RepositoryVersionEntity::getVersion)
+        .collect(joining(", "));
+
+      throw new IllegalArgumentException(String.format(
+        "Several repositories were found for %s:  %s.  Specify the version with '%s'",
+        stackId, versions, ProvisionClusterRequest.REPO_VERSION_PROPERTY
+      ));
+    } else {
+      repoVersion = stackRepoVersions.get(0);
+      LOG.info("Found single matching repository version {} for stack {}", repoVersion.getVersion(), stackId);
+    }
+    return repoVersion;
+  }
+
+  private RepositoryVersionEntity findSpecifiedRepo(String repoVersionString, Long repoVersionId, StackId stackId) {
+    RepositoryVersionEntity repoVersion = null;
+    if (null != repoVersionId) {
       repoVersion = repositoryVersionDAO.findByPK(repoVersionId);
 
       if (null == repoVersion) {
         throw new IllegalArgumentException(String.format(
           "Could not identify repository version with repository version id %s for installing services. "
             + "Specify a valid repository version id with '%s'",
-          repoVersionId, ProvisionClusterRequest.REPO_VERSION_ID_PROPERTY));
+          repoVersionId, ProvisionClusterRequest.REPO_VERSION_ID_PROPERTY
+        ));
       }
-    } else {
+    } else if (Strings.isNotEmpty(repoVersionString)) {
       repoVersion = repositoryVersionDAO.findByStackAndVersion(stackId, repoVersionString);
 
       if (null == repoVersion) {
         throw new IllegalArgumentException(String.format(
           "Could not identify repository version with stack %s and version %s for installing services. "
             + "Specify a valid version with '%s'",
-          stackId, repoVersionString, ProvisionClusterRequest.REPO_VERSION_PROPERTY));
+          stackId, repoVersionString, ProvisionClusterRequest.REPO_VERSION_PROPERTY
+        ));
       }
     }
-
-    // only use a STANDARD repo when creating a new cluster
-    if (repoVersion.getType() != RepositoryType.STANDARD) {
-      throw new IllegalArgumentException(String.format(
-          "Unable to create a cluster using the following repository since it is not a STANDARD type: %s",
-          repoVersion));
-    }
-
-    createAmbariClusterResource(clusterName, stackId, securityType);
-    createAmbariServiceAndComponentResources(topology, clusterName, stackId, repoVersion.getId());
+    return repoVersion;
   }
 
   public void createAmbariClusterResource(String clusterName, StackId stackId, SecurityType securityType) {
@@ -324,9 +342,7 @@ public class AmbariContext {
     }
   }
 
-  public void createAmbariServiceAndComponentResources(ClusterTopology topology, String clusterName,
-      StackId stackId, Long repositoryVersionId) {
-
+  public void createAmbariServiceAndComponentResources(ClusterTopology topology, String clusterName, Map<StackId, Long> repoVersionByStack) {
     Set<String> serviceGroups = Sets.newHashSet(DEFAULT_SERVICE_GROUP_NAME);
     Collection<String> services = topology.getBlueprint().getServices();
 
@@ -346,8 +362,11 @@ public class AmbariContext {
     Set<ServiceComponentRequest> componentRequests = new HashSet<>();
     for (String service : services) {
       String credentialStoreEnabled = topology.getBlueprint().getCredentialStoreEnabled(service);
+      StackId stackId = topology.getBlueprint().getStackIdForService(service);
+      Long repositoryVersionId = repoVersionByStack.get(stackId);
       serviceRequests.add(new ServiceRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, service,
-              repositoryVersionId, null, credentialStoreEnabled, null));
+        repositoryVersionId, null, credentialStoreEnabled, stackId
+      ));
 
       for (String component : topology.getBlueprint().getComponents(service)) {
         String recoveryEnabled = topology.getBlueprint().getRecoveryEnabled(service, component);

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.topology;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.Collection;
@@ -67,7 +68,7 @@ import org.apache.ambari.server.controller.internal.ServiceDependencyResourcePro
 import org.apache.ambari.server.controller.internal.ServiceGroupDependencyResourceProvider;
 import org.apache.ambari.server.controller.internal.ServiceGroupResourceProvider;
 import org.apache.ambari.server.controller.internal.ServiceResourceProvider;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.internal.VersionDefinitionResourceProvider;
 import org.apache.ambari.server.controller.predicate.EqualsPredicate;
 import org.apache.ambari.server.controller.spi.ClusterController;
@@ -91,12 +92,11 @@ import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.configgroup.ConfigGroup;
 import org.apache.ambari.server.utils.RetryHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.directory.api.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Striped;
@@ -213,97 +213,114 @@ public class AmbariContext {
 
   public void createAmbariResources(ClusterTopology topology, String clusterName, SecurityType securityType,
                                     String repoVersionString, Long repoVersionId) {
-    Stack stack = topology.getBlueprint().getStack();
-    StackId stackId = new StackId(stack.getName(), stack.getVersion());
+    Map<StackId, Long> repoVersionByStack = new HashMap<>();
 
-    RepositoryVersionEntity repoVersion = null;
-    if (StringUtils.isEmpty(repoVersionString) && null == repoVersionId) {
-      List<RepositoryVersionEntity> stackRepoVersions = repositoryVersionDAO.findByStack(stackId);
-
-      if (stackRepoVersions.isEmpty()) {
-        // !!! no repos, try to get the version for the stack
-        VersionDefinitionResourceProvider vdfProvider = getVersionDefinitionResourceProvider();
-
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(VersionDefinitionResourceProvider.VERSION_DEF_AVAILABLE_DEFINITION, stackId.toString());
-
-        Request request = new RequestImpl(Collections.<String>emptySet(),
-            Collections.singleton(properties), Collections.<String, String>emptyMap(), null);
-
-        Long defaultRepoVersionId = null;
-
-        try {
-          RequestStatus requestStatus = vdfProvider.createResources(request);
-          if (!requestStatus.getAssociatedResources().isEmpty()) {
-            Resource resource = requestStatus.getAssociatedResources().iterator().next();
-            defaultRepoVersionId = (Long) resource.getPropertyValue(VersionDefinitionResourceProvider.VERSION_DEF_ID);
-          }
-        } catch (Exception e) {
-          throw new IllegalArgumentException(String.format(
-              "Failed to create a default repository version definition for stack %s. "
-              + "This typically is a result of not loading the stack correctly or being able "
-              + "to load information about released versions.  Create a repository version "
-              + " and try again.", stackId), e);
-        }
-
-        repoVersion = repositoryVersionDAO.findByPK(defaultRepoVersionId);
-        // !!! better not!
-        if (null == repoVersion) {
-          throw new IllegalArgumentException(String.format(
-              "Failed to load the default repository version definition for stack %s. "
-              + "Check for a valid repository version and try again.", stackId));
-        }
-
-      } else if (stackRepoVersions.size() > 1) {
-
-        Function<RepositoryVersionEntity, String> function = new Function<RepositoryVersionEntity, String>() {
-          @Override
-          public String apply(RepositoryVersionEntity input) {
-            return input.getVersion();
-          }
-        };
-
-        Collection<String> versions = Collections2.transform(stackRepoVersions, function);
-
-        throw new IllegalArgumentException(String.format("Several repositories were found for %s:  %s.  Specify the version"
-            + " with '%s'", stackId, StringUtils.join(versions, ", "), ProvisionClusterRequest.REPO_VERSION_PROPERTY));
-      } else {
-        repoVersion = stackRepoVersions.get(0);
-        LOG.warn("Cluster is being provisioned using the single matching repository version {}", repoVersion.getVersion());
+    Set<StackId> stackIds = topology.getBlueprint().getStackIds();
+    for (StackId stackId : stackIds) {
+      RepositoryVersionEntity repoVersion = null;
+      if (stackIds.size() == 1) {
+        repoVersion = findSpecifiedRepo(repoVersionString, repoVersionId, stackId);
       }
-    } else if (null != repoVersionId){
+      if (null == repoVersion) {
+        repoVersion = findRepoForStack(stackId);
+      }
+      Preconditions.checkNotNull(repoVersion);
+      // only use a STANDARD repo when creating a new cluster
+      if (repoVersion.getType() != RepositoryType.STANDARD) {
+        throw new IllegalArgumentException(String.format(
+          "Unable to create a cluster using the following repository since it is not a STANDARD type: %s",
+          repoVersion
+        ));
+      }
+    }
+
+    StackId stackId = Iterables.getFirst(topology.getBlueprint().getStackIds(), null);
+    createAmbariClusterResource(clusterName, stackId, securityType);
+    createAmbariServiceAndComponentResources(topology, clusterName, repoVersionByStack);
+  }
+
+  private RepositoryVersionEntity findRepoForStack(StackId stackId) {
+    RepositoryVersionEntity repoVersion;
+    List<RepositoryVersionEntity> stackRepoVersions = repositoryVersionDAO.findByStack(stackId);
+    if (stackRepoVersions.isEmpty()) {
+      // !!! no repos, try to get the version for the stack
+      VersionDefinitionResourceProvider vdfProvider = getVersionDefinitionResourceProvider();
+
+      Map<String, Object> properties = new HashMap<>();
+      properties.put(VersionDefinitionResourceProvider.VERSION_DEF_AVAILABLE_DEFINITION, stackId.toString());
+
+      Request request = new RequestImpl(Collections.emptySet(),
+        Collections.singleton(properties), Collections.emptyMap(), null
+      );
+
+      Long defaultRepoVersionId = null;
+
+      try {
+        RequestStatus requestStatus = vdfProvider.createResources(request);
+        if (!requestStatus.getAssociatedResources().isEmpty()) {
+          Resource resource = requestStatus.getAssociatedResources().iterator().next();
+          defaultRepoVersionId = (Long) resource.getPropertyValue(VersionDefinitionResourceProvider.VERSION_DEF_ID);
+        }
+      } catch (Exception e) {
+        throw new IllegalArgumentException(String.format(
+          "Failed to create a default repository version definition for stack %s. "
+            + "This typically is a result of not loading the stack correctly or being able "
+            + "to load information about released versions.  Create a repository version "
+            + " and try again.", stackId), e);
+      }
+
+      repoVersion = repositoryVersionDAO.findByPK(defaultRepoVersionId);
+      // !!! better not!
+      if (null == repoVersion) {
+        throw new IllegalArgumentException(String.format(
+          "Failed to load the default repository version definition for stack %s. "
+            + "Check for a valid repository version and try again.", stackId));
+      }
+
+    } else if (stackRepoVersions.size() > 1) {
+      String versions = stackRepoVersions.stream()
+        .map(RepositoryVersionEntity::getVersion)
+        .collect(joining(", "));
+
+      throw new IllegalArgumentException(String.format(
+        "Several repositories were found for %s:  %s.  Specify the version with '%s'",
+        stackId, versions, ProvisionClusterRequest.REPO_VERSION_PROPERTY
+      ));
+    } else {
+      repoVersion = stackRepoVersions.get(0);
+      LOG.info("Found single matching repository version {} for stack {}", repoVersion.getVersion(), stackId);
+    }
+    return repoVersion;
+  }
+
+  private RepositoryVersionEntity findSpecifiedRepo(String repoVersionString, Long repoVersionId, StackId stackId) {
+    RepositoryVersionEntity repoVersion = null;
+    if (null != repoVersionId) {
       repoVersion = repositoryVersionDAO.findByPK(repoVersionId);
 
       if (null == repoVersion) {
         throw new IllegalArgumentException(String.format(
           "Could not identify repository version with repository version id %s for installing services. "
             + "Specify a valid repository version id with '%s'",
-          repoVersionId, ProvisionClusterRequest.REPO_VERSION_ID_PROPERTY));
+          repoVersionId, ProvisionClusterRequest.REPO_VERSION_ID_PROPERTY
+        ));
       }
-    } else {
+    } else if (Strings.isNotEmpty(repoVersionString)) {
       repoVersion = repositoryVersionDAO.findByStackAndVersion(stackId, repoVersionString);
 
       if (null == repoVersion) {
         throw new IllegalArgumentException(String.format(
           "Could not identify repository version with stack %s and version %s for installing services. "
             + "Specify a valid version with '%s'",
-          stackId, repoVersionString, ProvisionClusterRequest.REPO_VERSION_PROPERTY));
+          stackId, repoVersionString, ProvisionClusterRequest.REPO_VERSION_PROPERTY
+        ));
       }
     }
-
-    // only use a STANDARD repo when creating a new cluster
-    if (repoVersion.getType() != RepositoryType.STANDARD) {
-      throw new IllegalArgumentException(String.format(
-          "Unable to create a cluster using the following repository since it is not a STANDARD type: %s",
-          repoVersion));
-    }
-
-    createAmbariClusterResource(clusterName, stack.getName(), stack.getVersion(), securityType);
-    createAmbariServiceAndComponentResources(topology, clusterName, stackId, repoVersion.getId());
+    return repoVersion;
   }
 
-  public void createAmbariClusterResource(String clusterName, String stackName, String stackVersion, SecurityType securityType) {
-    String stackInfo = String.format("%s-%s", stackName, stackVersion);
+  public void createAmbariClusterResource(String clusterName, StackId stackId, SecurityType securityType) {
+    String stackInfo = stackId.toString();
     final ClusterRequest clusterRequest = new ClusterRequest(null, clusterName, null, securityType, stackInfo, null);
 
     try {
@@ -325,9 +342,7 @@ public class AmbariContext {
     }
   }
 
-  public void createAmbariServiceAndComponentResources(ClusterTopology topology, String clusterName,
-      StackId stackId, Long repositoryVersionId) {
-
+  public void createAmbariServiceAndComponentResources(ClusterTopology topology, String clusterName, Map<StackId, Long> repoVersionByStack) {
     Set<String> serviceGroups = Sets.newHashSet(DEFAULT_SERVICE_GROUP_NAME);
     Collection<String> services = topology.getBlueprint().getServices();
 
@@ -347,8 +362,11 @@ public class AmbariContext {
     Set<ServiceComponentRequest> componentRequests = new HashSet<>();
     for (String service : services) {
       String credentialStoreEnabled = topology.getBlueprint().getCredentialStoreEnabled(service);
+      StackId stackId = Iterables.getOnlyElement(topology.getBlueprint().getStackIdsForService(service)); // FIXME temporarily assume each service is defined in only one mpack
+      Long repositoryVersionId = repoVersionByStack.get(stackId);
       serviceRequests.add(new ServiceRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, service,
-              repositoryVersionId, null, credentialStoreEnabled, null));
+        repositoryVersionId, null, credentialStoreEnabled, stackId
+      ));
 
       for (String component : topology.getBlueprint().getComponentNames(service)) {
         String recoveryEnabled = topology.getBlueprint().getRecoveryEnabled(service, component);
@@ -522,11 +540,10 @@ public class AmbariContext {
    * installed and started and that the monitoring screen for the cluster should be displayed to the user.
    *
    * @param clusterName  cluster name
-   * @param stackName    stack name
-   * @param stackVersion stack version
+   * @param stackId    stack ID
    */
-  public void persistInstallStateForUI(String clusterName, String stackName, String stackVersion) {
-    String stackInfo = String.format("%s-%s", stackName, stackVersion);
+  public void persistInstallStateForUI(String clusterName, StackId stackId) {
+    String stackInfo = stackId.toString();
     final ClusterRequest clusterRequest = new ClusterRequest(null, clusterName, "INSTALLED", null, stackInfo, null);
 
     try {
@@ -743,7 +760,7 @@ public class AmbariContext {
    */
   private void createConfigGroupsAndRegisterHost(ClusterTopology topology, String groupName) throws AmbariException {
     Map<String, Map<String, Config>> groupConfigs = new HashMap<>();
-    Stack stack = topology.getBlueprint().getStack();
+    StackDefinition stack = topology.getBlueprint().getStack();
 
     // get the host-group config with cluster creation template overrides
     Configuration topologyHostGroupConfig = topology.
@@ -756,11 +773,12 @@ public class AmbariContext {
     // iterate over topo host group configs which were defined in
     for (Map.Entry<String, Map<String, String>> entry : userProvidedGroupProperties.entrySet()) {
       String type = entry.getKey();
-      List<String> services = stack.getServicesForConfigType(type);
-      String service = services.stream()
+      String service = stack.getServicesForConfigType(type)
         .filter(each -> topology.getBlueprint().getServices().contains(each))
         .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("Specified configuration type is not associated with any service: " + type));
+        // TODO check if this is required at all (might be handled by the "orphan" removal)
+        // TODO move this validation earlier
+        .orElseThrow(() -> new IllegalArgumentException("Specified configuration type is not associated with any service in the blueprint: " + type));
 
       Config config = configFactory.createReadOnly(type, groupName, entry.getValue(), null);
       //todo: attributes

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -234,7 +234,7 @@ public class AmbariContext {
       }
     }
 
-    StackId stackId = topology.getBlueprint().getStackId();
+    StackId stackId = Iterables.getFirst(topology.getBlueprint().getStackIds(), null);
     createAmbariClusterResource(clusterName, stackId, securityType);
     createAmbariServiceAndComponentResources(topology, clusterName, repoVersionByStack);
   }
@@ -362,7 +362,7 @@ public class AmbariContext {
     Set<ServiceComponentRequest> componentRequests = new HashSet<>();
     for (String service : services) {
       String credentialStoreEnabled = topology.getBlueprint().getCredentialStoreEnabled(service);
-      StackId stackId = topology.getBlueprint().getStackIdForService(service);
+      StackId stackId = Iterables.getOnlyElement(topology.getBlueprint().getStackIdsForService(service)); // FIXME temporarily assume each service is defined in only one mpack
       Long repositoryVersionId = repoVersionByStack.get(stackId);
       serviceRequests.add(new ServiceRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, service,
         repositoryVersionId, null, credentialStoreEnabled, stackId

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -773,11 +773,12 @@ public class AmbariContext {
     // iterate over topo host group configs which were defined in
     for (Map.Entry<String, Map<String, String>> entry : userProvidedGroupProperties.entrySet()) {
       String type = entry.getKey();
-      List<String> services = stack.getServicesForConfigType(type);
-      String service = services.stream()
+      String service = stack.getServicesForConfigType(type)
         .filter(each -> topology.getBlueprint().getServices().contains(each))
         .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("Specified configuration type is not associated with any service: " + type));
+        // TODO check if this is required at all (might be handled by the "orphan" removal)
+        // TODO move this validation earlier
+        .orElseThrow(() -> new IllegalArgumentException("Specified configuration type is not associated with any service in the blueprint: " + type));
 
       Config config = configFactory.createReadOnly(type, groupName, entry.getValue(), null);
       //todo: attributes

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -41,15 +41,15 @@ public interface Blueprint {
 
   /**
    * Get the hot groups contained in the blueprint.
+   *
    * @return map of host group name to host group
    */
   Map<String, HostGroup> getHostGroups();
 
   /**
-   * Get a hostgroup specified by name.
+   * Get a host group specified by name.
    *
    * @param name  name of the host group to get
-   *
    * @return the host group with the given name or null
    */
   HostGroup getHostGroup(String name);
@@ -116,14 +116,26 @@ public interface Blueprint {
 
   /**
    * Get the stack associated with the blueprint.
+   * For mpack-based installation this is a composite stack
+   * that provides a single unified view of all underlying mpacks,
+   * but does not have any identifier.
    *
    * @return associated stack
    */
   StackInfo getStack();
-  StackId getStackId();
+
+  /**
+   * @return the set of stack (mpack) IDs associated with the blueprint
+   */
   Set<StackId> getStackIds();
-  StackId getStackIdForService(String service);
-  Collection<StackId> getStackIdsForService(String service); // will be used for validation
+
+  /**
+   * Look up the stacks that define <code>service</code>.
+   * To be used only after checking that services map to
+   * @param service the name of the service as defined in the stack (mpack), eg. ZOOKEEPER
+   * @return the ID of the stack that defines the given service
+   */
+  Set<StackId> getStackIdsForService(String service);
 
   /**
    * Get the host groups which contain components for the specified service.
@@ -161,10 +173,7 @@ public interface Blueprint {
   void validateRequiredProperties() throws InvalidTopologyException, GPLLicenseNotAcceptedException;
 
   /**
-   *
    * A config type is valid if there are services related to except cluster-env and global.
-   * @param configType
-   * @return
    */
   boolean isValidConfigType(String configType);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
 import org.apache.ambari.server.state.StackId;
 
@@ -122,7 +122,7 @@ public interface Blueprint {
    *
    * @return associated stack
    */
-  StackInfo getStack();
+  StackDefinition getStack();
 
   /**
    * @return the set of stack (mpack) IDs associated with the blueprint

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -21,9 +21,11 @@ package org.apache.ambari.server.topology;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
+import org.apache.ambari.server.state.StackId;
 
 /**
  * Blueprint representation.
@@ -39,15 +41,15 @@ public interface Blueprint {
 
   /**
    * Get the hot groups contained in the blueprint.
+   *
    * @return map of host group name to host group
    */
   Map<String, HostGroup> getHostGroups();
 
   /**
-   * Get a hostgroup specified by name.
+   * Get a host group specified by name.
    *
    * @param name  name of the host group to get
-   *
    * @return the host group with the given name or null
    */
   HostGroup getHostGroup(String name);
@@ -124,19 +126,26 @@ public interface Blueprint {
 
   /**
    * Get the stack associated with the blueprint.
+   * For mpack-based installation this is a composite stack
+   * that provides a single unified view of all underlying mpacks,
+   * but does not have any identifier.
    *
    * @return associated stack
    */
-  @Deprecated
-  Stack getStack();
+  StackDefinition getStack();
 
   /**
-   * Get the stacks associated with the blueprint.
-   *
-   * @return associated stacks
+   * @return the set of stack (mpack) IDs associated with the blueprint
    */
-  Collection<Stack> getStacks();
+  Set<StackId> getStackIds();
 
+  /**
+   * Look up the stacks that define <code>service</code>.
+   * To be used only after checking that services map to
+   * @param service the name of the service as defined in the stack (mpack), eg. ZOOKEEPER
+   * @return the ID of the stack that defines the given service
+   */
+  Set<StackId> getStackIdsForService(String service);
 
   /**
    * Get the mpacks associated with the blueprint.
@@ -167,24 +176,7 @@ public interface Blueprint {
   SecurityConfiguration getSecurity();
 
   /**
-   * Validate the blueprint topology.
-   *
-   * @throws InvalidTopologyException if the topology is invalid
-   */
-  void validateTopology() throws InvalidTopologyException;
-
-  /**
-   * Validate that the blueprint contains all of the required properties.
-   *
-   * @throws InvalidTopologyException if the blueprint doesn't contain all required properties
-   */
-  void validateRequiredProperties() throws InvalidTopologyException, GPLLicenseNotAcceptedException;
-
-  /**
-   *
    * A config type is valid if there are services related to except cluster-env and global.
-   * @param configType
-   * @return
    */
   boolean isValidConfigType(String configType);
 
@@ -196,15 +188,5 @@ public interface Blueprint {
   BlueprintEntity toEntity();
 
   List<RepositorySetting> getRepositorySettings();
-
-  /**
-   * @return a boolean indicating if all mpack referenced by the blueprints are resolved (installed on the system)
-   */
-  boolean isAllMpacksResolved();
-
-  /**
-   * @return a collection of the names unresolved mpacks in {name}-{version} format.
-   */
-  Collection<String> getUnresolvedMpackNames();
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -123,7 +123,7 @@ public interface Blueprint {
   StackId getStackId();
   Set<StackId> getStackIds();
   StackId getStackIdForService(String service);
-  Collection<StackId> getStackIdsForService(String service);
+  Collection<StackId> getStackIdsForService(String service); // will be used for validation
 
   /**
    * Get the host groups which contain components for the specified service.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -159,20 +159,6 @@ public interface Blueprint {
   SecurityConfiguration getSecurity();
 
   /**
-   * Validate the blueprint topology.
-   *
-   * @throws InvalidTopologyException if the topology is invalid
-   */
-  void validateTopology() throws InvalidTopologyException;
-
-  /**
-   * Validate that the blueprint contains all of the required properties.
-   *
-   * @throws InvalidTopologyException if the blueprint doesn't contain all required properties
-   */
-  void validateRequiredProperties() throws InvalidTopologyException, GPLLicenseNotAcceptedException;
-
-  /**
    * A config type is valid if there are services related to except cluster-env and global.
    */
   boolean isValidConfigType(String configType);

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.topology;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
@@ -120,6 +121,9 @@ public interface Blueprint {
    */
   StackInfo getStack();
   StackId getStackId();
+  Set<StackId> getStackIds();
+  StackId getStackIdForService(String service);
+  Collection<StackId> getStackIdsForService(String service);
 
   /**
    * Get the host groups which contain components for the specified service.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -22,8 +22,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
+import org.apache.ambari.server.state.StackId;
 
 /**
  * Blueprint representation.
@@ -117,7 +118,8 @@ public interface Blueprint {
    *
    * @return associated stack
    */
-  Stack getStack();
+  StackInfo getStack();
+  StackId getStackId();
 
   /**
    * Get the host groups which contain components for the specified service.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
@@ -93,7 +93,7 @@ public class BlueprintFactory {
     BlueprintEntity entity = blueprintDAO.findByName(blueprintName);
     if (entity != null) {
       Set<StackId> stackIds = fakeStackIds();
-      StackInfo stack = createCompositeStack(stackIds);
+      StackInfo stack = composeStacks(stackIds);
       return new BlueprintImpl(entity, stack, stackIds);
     }
     return null;
@@ -116,7 +116,7 @@ public class BlueprintFactory {
     }
 
     Set<StackId> stackIds = fakeStackIds();
-    StackInfo stack = createCompositeStack(stackIds);
+    StackInfo stack = composeStacks(stackIds);
     Collection<HostGroup> hostGroups = processHostGroups(name, stack, properties);
     Configuration configuration = configFactory.getConfiguration((Collection<Map<String, String>>)
             properties.get(CONFIGURATION_PROPERTY_ID));
@@ -125,8 +125,12 @@ public class BlueprintFactory {
     return new BlueprintImpl(name, hostGroups, stack, stackIds, configuration, securityConfiguration, setting);
   }
 
-  CompositeStack createCompositeStack(Set<StackId> stackIds) {
-    return new CompositeStack(stackIds.stream().map(this::createStack).collect(toSet()));
+  public StackInfo composeStacks(Set<StackId> stackIds) {
+    if (stackIds.size() == 1) {
+      return createStack(stackIds.iterator().next());
+    }
+    Set<Stack> stacks = stackIds.stream().map(this::createStack).collect(toSet());
+    return new CompositeStack(stacks);
   }
 
   static Set<StackId> fakeStackIds() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
@@ -143,9 +143,9 @@ public class BlueprintFactory {
   protected Stack createStack(StackId stackId) {
     try {
       //todo: don't pass in controller
-      return stackFactory.createStack(stackId.getStackName(), stackId.getStackVersion(), AmbariServer.getController());
+      return stackFactory.createStack(stackId, AmbariServer.getController());
     } catch (ObjectNotFoundException e) {
-      throw new NoSuchStackException(stackId.getStackName(), stackId.getStackVersion());
+      throw new NoSuchStackException(stackId);
     } catch (AmbariException e) {
       //todo:
       throw new RuntimeException("An error occurred parsing the stack information.", e);
@@ -253,7 +253,7 @@ public class BlueprintFactory {
    * simulate various Stack or error conditions.
    */
   interface StackFactory {
-      Stack createStack(String stackName, String stackVersion, AmbariManagementController managementController) throws AmbariException;
+      Stack createStack(StackId stackId, AmbariManagementController managementController) throws AmbariException;
   }
 
   /**
@@ -264,8 +264,8 @@ public class BlueprintFactory {
    */
   private static class DefaultStackFactory implements StackFactory {
     @Override
-    public Stack createStack(String stackName, String stackVersion, AmbariManagementController managementController) throws AmbariException {
-      return new Stack(stackName, stackVersion, managementController);
+    public Stack createStack(StackId stackId, AmbariManagementController managementController) throws AmbariException {
+      return new Stack(stackId.getStackName(), stackId.getStackVersion(), managementController);
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
@@ -36,7 +36,7 @@ import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.internal.CompositeStack;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.controller.internal.Stack;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.orm.dao.BlueprintDAO;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
@@ -93,7 +93,7 @@ public class BlueprintFactory {
     BlueprintEntity entity = blueprintDAO.findByName(blueprintName);
     if (entity != null) {
       Set<StackId> stackIds = fakeStackIds();
-      StackInfo stack = composeStacks(stackIds);
+      StackDefinition stack = composeStacks(stackIds);
       return new BlueprintImpl(entity, stack, stackIds);
     }
     return null;
@@ -116,7 +116,7 @@ public class BlueprintFactory {
     }
 
     Set<StackId> stackIds = fakeStackIds();
-    StackInfo stack = composeStacks(stackIds);
+    StackDefinition stack = composeStacks(stackIds);
     Collection<HostGroup> hostGroups = processHostGroups(name, stack, properties);
     Configuration configuration = configFactory.getConfiguration((Collection<Map<String, String>>)
             properties.get(CONFIGURATION_PROPERTY_ID));
@@ -125,7 +125,7 @@ public class BlueprintFactory {
     return new BlueprintImpl(name, hostGroups, stack, stackIds, configuration, securityConfiguration, setting);
   }
 
-  public StackInfo composeStacks(Set<StackId> stackIds) {
+  public StackDefinition composeStacks(Set<StackId> stackIds) {
     if (stackIds.size() == 1) {
       return createStack(stackIds.iterator().next());
     }
@@ -154,7 +154,7 @@ public class BlueprintFactory {
 
   //todo: Move logic to HostGroupImpl
   @SuppressWarnings("unchecked")
-  private Collection<HostGroup> processHostGroups(String bpName, StackInfo stack, Map<String, Object> properties) {
+  private Collection<HostGroup> processHostGroups(String bpName, StackDefinition stack, Map<String, Object> properties) {
     Set<HashMap<String, Object>> hostGroupProps = (HashSet<HashMap<String, Object>>)
         properties.get(HOST_GROUP_PROPERTY_ID);
 
@@ -186,7 +186,7 @@ public class BlueprintFactory {
     return hostGroups;
   }
 
-  private Collection<Component> processHostGroupComponents(StackInfo stack, String groupName, HashSet<HashMap<String, String>>  componentProps) {
+  private Collection<Component> processHostGroupComponents(StackDefinition stack, String groupName, HashSet<HashMap<String, String>>  componentProps) {
     if (componentProps == null || componentProps.isEmpty()) {
       throw new IllegalArgumentException("Host group '" + groupName + "' must contain at least one component");
     }
@@ -224,7 +224,7 @@ public class BlueprintFactory {
    * @return collection of component names for the specified stack
    * @throws IllegalArgumentException if the specified stack doesn't exist
    */
-  private Collection<String> getAllStackComponents(StackInfo stack) {
+  private Collection<String> getAllStackComponents(StackDefinition stack) {
     Collection<String> allComponents = new HashSet<>();
     for (Collection<String> components: stack.getComponents().values()) {
       allComponents.addAll(components);

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
@@ -135,8 +135,8 @@ public class BlueprintFactory {
 
   static Set<StackId> fakeStackIds() {
     return ImmutableSet.of(
-      new StackId("HDP", "3.0.0"),
-      new StackId("HDS", "3.0.0")
+      new StackId("AmbariInfra", "3.0.0"),
+      new StackId("HDP", "3.0.0")
     );
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
@@ -33,7 +33,6 @@ import org.apache.ambari.server.ObjectNotFoundException;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.RootComponent;
-import org.apache.ambari.server.controller.internal.CompositeStack;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.controller.internal.StackDefinition;
@@ -45,7 +44,6 @@ import org.apache.ambari.server.stack.NoSuchStackException;
 import org.apache.ambari.server.state.StackId;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
 /**
@@ -138,9 +136,7 @@ public class BlueprintFactory {
     Set<Stack> stacks = stackIds.stream()
       .map(this::createStack)
       .collect(toSet());
-    return stacks.size() > 1
-      ? new CompositeStack(stacks)
-      : Iterables.getFirst(stacks, null);
+    return StackDefinition.of(stacks);
   }
 
   private static Set<StackId> fakeStackIds() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -608,12 +608,8 @@ public class BlueprintImpl implements Blueprint {
     if (ConfigHelper.CLUSTER_ENV.equals(configType) || "global".equals(configType)) {
       return true;
     }
-    try {
-      String service = getStack().getServiceForConfigType(configType);
-      return getServices().contains(service);
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
+    String service = getStack().getServiceForConfigType(configType);
+    return getServices().contains(service);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -55,7 +55,6 @@ public class BlueprintImpl implements Blueprint {
 
   private final Set<StackId> stackIds;
   private Configuration configuration;
-  private BlueprintValidator validator;
   private SecurityConfiguration security;
   private Setting setting;
   private List<RepositorySetting> repoSettings;
@@ -74,7 +73,6 @@ public class BlueprintImpl implements Blueprint {
     processConfiguration(entity.getConfigurations());
     parseBlueprintHostGroups(entity);
     configuration.setParentConfiguration(stack.getConfiguration(getServices()));
-    validator = new BlueprintValidatorImpl(this);
     processSetting(entity.getSettings());
     processRepoSettings();
   }
@@ -95,7 +93,6 @@ public class BlueprintImpl implements Blueprint {
     if (configuration.getParentConfiguration() == null) {
       configuration.setParentConfiguration(stack.getConfiguration(getServices()));
     }
-    validator = new BlueprintValidatorImpl(this);
     this.setting = setting;
   }
 
@@ -314,11 +311,6 @@ public class BlueprintImpl implements Blueprint {
     return resultGroups;
   }
 
-  @Override
-  public void validateTopology() throws InvalidTopologyException {
-    validator.validateTopology();
-  }
-
   public BlueprintEntity toEntity() {
 
     BlueprintEntity entity = new BlueprintEntity();
@@ -337,17 +329,6 @@ public class BlueprintImpl implements Blueprint {
     createBlueprintSettingEntities(entity);
 
     return entity;
-  }
-
-  /**
-   * Validate blueprint configuration.
-   *
-   * @throws InvalidTopologyException if the blueprint configuration is invalid
-   * @throws GPLLicenseNotAcceptedException ambari was configured to use gpl software, but gpl license is not accepted
-   */
-  @Override
-  public void validateRequiredProperties() throws InvalidTopologyException, GPLLicenseNotAcceptedException {
-    validator.validateRequiredProperties();
   }
 
   private Map<String, HostGroup> parseBlueprintHostGroups(BlueprintEntity entity) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -119,6 +119,16 @@ public class BlueprintImpl implements Blueprint {
     return stackIds;
   }
 
+  @Override
+  public StackId getStackIdForService(String service) {
+    return Iterables.getOnlyElement(stack.getStacksForService(service));
+  }
+
+  @Override
+  public Collection<StackId> getStackIdsForService(String service) {
+    return stack.getStacksForService(service);
+  }
+
   public SecurityConfiguration getSecurity() {
     return security;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -49,8 +49,7 @@ public class BlueprintImpl implements Blueprint {
 
   private String name;
   private Map<String, HostGroup> hostGroups = new HashMap<>();
-  private StackDefinition stack;
-
+  private final StackDefinition stack;
   private final Set<StackId> stackIds;
   private Configuration configuration;
   private SecurityConfiguration security;

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.orm.entities.BlueprintConfigEntity;
 import org.apache.ambari.server.orm.entities.BlueprintConfiguration;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
@@ -35,13 +35,11 @@ import org.apache.ambari.server.orm.entities.BlueprintSettingEntity;
 import org.apache.ambari.server.orm.entities.HostGroupComponentEntity;
 import org.apache.ambari.server.orm.entities.HostGroupConfigEntity;
 import org.apache.ambari.server.orm.entities.HostGroupEntity;
-import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.stack.NoSuchStackException;
 import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.StackId;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 
 /**
@@ -51,7 +49,7 @@ public class BlueprintImpl implements Blueprint {
 
   private String name;
   private Map<String, HostGroup> hostGroups = new HashMap<>();
-  private StackInfo stack;
+  private StackDefinition stack;
 
   private final Set<StackId> stackIds;
   private Configuration configuration;
@@ -59,7 +57,7 @@ public class BlueprintImpl implements Blueprint {
   private Setting setting;
   private List<RepositorySetting> repoSettings;
 
-  public BlueprintImpl(BlueprintEntity entity, StackInfo stack, Set<StackId> stackIds) throws NoSuchStackException {
+  public BlueprintImpl(BlueprintEntity entity, StackDefinition stack, Set<StackId> stackIds) throws NoSuchStackException {
     this.name = entity.getBlueprintName();
     if (entity.getSecurityType() != null) {
       this.security = new SecurityConfiguration(entity.getSecurityType(), entity.getSecurityDescriptorReference(),
@@ -77,7 +75,7 @@ public class BlueprintImpl implements Blueprint {
     processRepoSettings();
   }
 
-  public BlueprintImpl(String name, Collection<HostGroup> groups, StackInfo stack, Set<StackId> stackIds, Configuration configuration,
+  public BlueprintImpl(String name, Collection<HostGroup> groups, StackDefinition stack, Set<StackId> stackIds, Configuration configuration,
                        SecurityConfiguration security, Setting setting) {
     this.name = name;
     this.stack = stack;
@@ -271,7 +269,7 @@ public class BlueprintImpl implements Blueprint {
   }
 
   @Override
-  public StackInfo getStack() {
+  public StackDefinition getStack() {
     return stack;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -608,11 +608,12 @@ public class BlueprintImpl implements Blueprint {
     if (ConfigHelper.CLUSTER_ENV.equals(configType) || "global".equals(configType)) {
       return true;
     }
-    String service = getStack().getServiceForConfigType(configType);
-    if (getServices().contains(service)) {
-        return true;
+    try {
+      String service = getStack().getServiceForConfigType(configType);
+      return getServices().contains(service);
+    } catch (IllegalArgumentException e) {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -103,29 +103,12 @@ public class BlueprintImpl implements Blueprint {
     return name;
   }
 
-  public StackId getStackId() {
-    return Iterables.getFirst(stackIds, new StackId());
-  }
-
-  public String getStackName() {
-    return getStackId().getStackName();
-  }
-
-  public String getStackVersion() {
-    return getStackId().getStackVersion();
-  }
-
   public Set<StackId> getStackIds() {
     return stackIds;
   }
 
   @Override
-  public StackId getStackIdForService(String service) {
-    return Iterables.getOnlyElement(stack.getStacksForService(service));
-  }
-
-  @Override
-  public Collection<StackId> getStackIdsForService(String service) {
+  public Set<StackId> getStackIdsForService(String service) {
     return stack.getStacksForService(service);
   }
 
@@ -614,8 +597,7 @@ public class BlueprintImpl implements Blueprint {
 
   /**
    * Parse stack repo info stored in the blueprint_settings table
-   * @return set of repositories
-   * */
+   */
   private void processRepoSettings(){
     repoSettings = new ArrayList<>();
     if (setting != null){

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidator.java
@@ -16,9 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.ambari.server.topology;
-
 
 /**
  * Provides blueprint validation.
@@ -29,7 +27,7 @@ public interface BlueprintValidator {
    *
    * @throws InvalidTopologyException if the topology is invalid
    */
-  void validateTopology() throws InvalidTopologyException;
+  void validateTopology(Blueprint blueprint) throws InvalidTopologyException;
 
   /**
    * Validate that required properties are provided.
@@ -38,5 +36,5 @@ public interface BlueprintValidator {
    * @throws InvalidTopologyException if required properties are not set in blueprint
    * @throws GPLLicenseNotAcceptedException ambari was configured to use gpl software, but gpl license is not accepted
    */
-  void validateRequiredProperties() throws InvalidTopologyException, GPLLicenseNotAcceptedException;
+  void validateRequiredProperties(Blueprint blueprint) throws InvalidTopologyException, GPLLicenseNotAcceptedException;
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidator.java
@@ -25,6 +25,7 @@ public interface BlueprintValidator {
   /**
    * Validate blueprint topology.
    *
+   * @param blueprint the blueprint to validate
    * @throws InvalidTopologyException if the topology is invalid
    */
   void validateTopology(Blueprint blueprint) throws InvalidTopologyException;
@@ -33,8 +34,9 @@ public interface BlueprintValidator {
    * Validate that required properties are provided.
    * This doesn't include password properties.
    *
+   * @param blueprint the blueprint to validate
    * @throws InvalidTopologyException if required properties are not set in blueprint
-   * @throws GPLLicenseNotAcceptedException ambari was configured to use gpl software, but gpl license is not accepted
+   * @throws GPLLicenseNotAcceptedException if the blueprint requires use of GPL software, but GPL license was not accepted
    */
   void validateRequiredProperties(Blueprint blueprint) throws InvalidTopologyException, GPLLicenseNotAcceptedException;
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.configuration.Configuration;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.DependencyConditionInfo;
 import org.apache.ambari.server.state.DependencyInfo;
@@ -58,7 +58,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
   @Override
   public void validateTopology(Blueprint blueprint) throws InvalidTopologyException {
     LOGGER.info("Validating topology for blueprint: [{}]", blueprint.getName());
-    StackInfo stack = blueprint.getStack();
+    StackDefinition stack = blueprint.getStack();
     Collection<HostGroup> hostGroups = blueprint.getHostGroups().values();
     Map<String, Map<String, Collection<DependencyInfo>>> missingDependencies = new HashMap<>();
 
@@ -204,7 +204,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
     return cardinalityFailures;
   }
 
-  private Map<String, Collection<DependencyInfo>> validateHostGroup(Blueprint blueprint, StackInfo stack, HostGroup group) {
+  private Map<String, Collection<DependencyInfo>> validateHostGroup(Blueprint blueprint, StackDefinition stack, HostGroup group) {
     LOGGER.info("Validating hostgroup: {}", group.getName());
     Map<String, Collection<DependencyInfo>> missingDependencies = new HashMap<>();
 
@@ -284,7 +284,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    *
    * @return collection of missing component information
    */
-  private Collection<String> verifyComponentCardinalityCount(Blueprint blueprint, StackInfo stack, String component, Cardinality cardinality, AutoDeployInfo autoDeploy) {
+  private Collection<String> verifyComponentCardinalityCount(Blueprint blueprint, StackDefinition stack, String component, Cardinality cardinality, AutoDeployInfo autoDeploy) {
 
     Map<String, Map<String, String>> configProperties = blueprint.getConfiguration().getProperties();
     Collection<String> cardinalityFailures = new HashSet<>();
@@ -329,7 +329,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    *
    * @return true if the specified component managed by the cluster; false otherwise
    */
-  protected boolean isDependencyManaged(StackInfo stack, String component, Map<String, Map<String, String>> clusterConfig) {
+  protected boolean isDependencyManaged(StackDefinition stack, String component, Map<String, Map<String, String>> clusterConfig) {
     boolean isManaged = true;
     String externalComponentConfig = stack.getExternalComponentConfig(component);
     if (externalComponentConfig != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
@@ -27,10 +27,11 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.StaticallyInject;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.DependencyConditionInfo;
 import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.utils.SecretReference;
 import org.apache.ambari.server.utils.VersionUtils;
 import org.slf4j.Logger;
@@ -46,7 +47,8 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintValidatorImpl.class);
   private final Blueprint blueprint;
-  private final Stack stack;
+  private final StackInfo stack;
+  private final StackId stackId;
 
   public static final String LZO_CODEC_CLASS_PROPERTY_NAME = "io.compression.codec.lzo.class";
   public static final String CODEC_CLASSES_PROPERTY_NAME = "io.compression.codecs";
@@ -58,6 +60,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
   public BlueprintValidatorImpl(Blueprint blueprint) {
     this.blueprint = blueprint;
     this.stack = blueprint.getStack();
+    this.stackId = blueprint.getStackId();
   }
 
   @Override
@@ -182,8 +185,8 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
           Map<String, String> hiveEnvConfig = clusterConfigurations.get("hive-env");
           if (hiveEnvConfig != null && !hiveEnvConfig.isEmpty() && hiveEnvConfig.get("hive_database") != null
             && hiveEnvConfig.get("hive_database").equals("Existing SQL Anywhere Database")
-            && VersionUtils.compareVersions(stack.getVersion(), "2.3.0.0") < 0
-            && stack.getName().equalsIgnoreCase("HDP")) {
+            && VersionUtils.compareVersions(stackId.getStackVersion(), "2.3.0.0") < 0
+            && stackId.getStackName().equalsIgnoreCase("HDP")) {
             throw new InvalidTopologyException("Incorrect configuration: SQL Anywhere db is available only for stack HDP-2.3+ " +
               "and repo version 2.3.2+!");
           }
@@ -193,8 +196,8 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
           Map<String, String> oozieEnvConfig = clusterConfigurations.get("oozie-env");
           if (oozieEnvConfig != null && !oozieEnvConfig.isEmpty() && oozieEnvConfig.get("oozie_database") != null
             && oozieEnvConfig.get("oozie_database").equals("Existing SQL Anywhere Database")
-            && VersionUtils.compareVersions(stack.getVersion(), "2.3.0.0") < 0
-            && stack.getName().equalsIgnoreCase("HDP")) {
+            && VersionUtils.compareVersions(stackId.getStackVersion(), "2.3.0.0") < 0
+            && stackId.getStackName().equalsIgnoreCase("HDP")) {
             throw new InvalidTopologyException("Incorrect configuration: SQL Anywhere db is available only for stack HDP-2.3+ " +
               "and repo version 2.3.2+!");
           }
@@ -354,7 +357,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    *
    * @return true if the specified component managed by the cluster; false otherwise
    */
-  protected boolean isDependencyManaged(Stack stack, String component, Map<String, Map<String, String>> clusterConfig) {
+  protected boolean isDependencyManaged(StackInfo stack, String component, Map<String, Map<String, String>> clusterConfig) {
     boolean isManaged = true;
     String externalComponentConfig = stack.getExternalComponentConfig(component);
     if (externalComponentConfig != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
@@ -26,56 +26,45 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.StaticallyInject;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.DependencyConditionInfo;
 import org.apache.ambari.server.state.DependencyInfo;
 import org.apache.ambari.server.utils.SecretReference;
-import org.apache.ambari.server.utils.VersionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 
 /**
  * Default blueprint validator.
  */
-@StaticallyInject
 public class BlueprintValidatorImpl implements BlueprintValidator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintValidatorImpl.class);
-  private final Blueprint blueprint;
-  private final Stack stack;
 
   public static final String LZO_CODEC_CLASS_PROPERTY_NAME = "io.compression.codec.lzo.class";
   public static final String CODEC_CLASSES_PROPERTY_NAME = "io.compression.codecs";
   public static final String LZO_CODEC_CLASS = "com.hadoop.compression.lzo.LzoCodec";
 
-  @Inject
-  private static org.apache.ambari.server.configuration.Configuration configuration;
+  private final Configuration configuration;
 
-  public BlueprintValidatorImpl(Blueprint blueprint) {
-    this.blueprint = blueprint;
-    this.stack = blueprint.getStack();
+  @Inject
+  public BlueprintValidatorImpl(Configuration configuration) {
+    this.configuration = configuration;
   }
 
   @Override
-  public void validateTopology() throws InvalidTopologyException {
+  public void validateTopology(Blueprint blueprint) throws InvalidTopologyException {
     LOGGER.info("Validating topology for blueprint: [{}]", blueprint.getName());
 
-    if (!blueprint.isAllMpacksResolved()) {
-      LOGGER.warn("The following macks are not resolved: [{}] Skipping topology validation.",
-        Joiner.on(", ").join(blueprint.getUnresolvedMpackNames()));
-      return;
-    }
-
+    StackDefinition stack = blueprint.getStack();
     Collection<HostGroup> hostGroups = blueprint.getHostGroups().values();
     Map<String, Map<String, Collection<DependencyInfo>>> missingDependencies = new HashMap<>();
 
     for (HostGroup group : hostGroups) {
-      Map<String, Collection<DependencyInfo>> missingGroupDependencies = validateHostGroup(group);
+      Map<String, Collection<DependencyInfo>> missingGroupDependencies = validateHostGroup(blueprint, stack, group);
       if (!missingGroupDependencies.isEmpty()) {
         missingDependencies.put(group.getName(), missingGroupDependencies);
       }
@@ -89,10 +78,10 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
         Cardinality cardinality = stack.getCardinality(component);
         AutoDeployInfo autoDeploy = stack.getAutoDeployInfo(component);
         if (cardinality.isAll()) {
-          cardinalityFailures.addAll(verifyComponentInAllHostGroups(new Component(component), autoDeploy));
+          cardinalityFailures.addAll(verifyComponentInAllHostGroups(blueprint, new Component(component), autoDeploy));
         } else {
           cardinalityFailures.addAll(verifyComponentCardinalityCount(
-            new Component(component), cardinality, autoDeploy));
+            blueprint, stack, new Component(component), cardinality, autoDeploy));
         }
       }
     }
@@ -103,7 +92,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
   }
 
   @Override
-  public void validateRequiredProperties() throws InvalidTopologyException, GPLLicenseNotAcceptedException {
+  public void validateRequiredProperties(Blueprint blueprint) throws InvalidTopologyException, GPLLicenseNotAcceptedException {
 
     // we don't want to include default stack properties so we can't just use hostGroup full properties
     Map<String, Map<String, String>> clusterConfigurations = blueprint.getConfiguration().getProperties();
@@ -161,57 +150,30 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
           }
         }
         if (ClusterTopologyImpl.isNameNodeHAEnabled(clusterConfigurations) && component.equals("NAMENODE")) {
-            Map<String, String> hadoopEnvConfig = clusterConfigurations.get("hadoop-env");
-            if(hadoopEnvConfig != null && !hadoopEnvConfig.isEmpty() && hadoopEnvConfig.containsKey("dfs_ha_initial_namenode_active") && hadoopEnvConfig.containsKey("dfs_ha_initial_namenode_standby")) {
-              ArrayList<HostGroup> hostGroupsForComponent = new ArrayList<>(blueprint.getHostGroupsForComponent(component));
-              Set<String> givenHostGroups = new HashSet<>();
-              givenHostGroups.add(hadoopEnvConfig.get("dfs_ha_initial_namenode_active"));
-              givenHostGroups.add(hadoopEnvConfig.get("dfs_ha_initial_namenode_standby"));
-              if(givenHostGroups.size() != hostGroupsForComponent.size()) {
-                 throw new IllegalArgumentException("NAMENODE HA host groups mapped incorrectly for properties 'dfs_ha_initial_namenode_active' and 'dfs_ha_initial_namenode_standby'. Expected Host groups are :" + hostGroupsForComponent);
-              }
-              if(HostGroup.HOSTGROUP_REGEX.matcher(hadoopEnvConfig.get("dfs_ha_initial_namenode_active")).matches() && HostGroup.HOSTGROUP_REGEX.matcher(hadoopEnvConfig.get("dfs_ha_initial_namenode_standby")).matches()){
-                for (HostGroup hostGroupForComponent : hostGroupsForComponent) {
-                   Iterator<String> itr = givenHostGroups.iterator();
-                   while(itr.hasNext()){
-                      if(itr.next().contains(hostGroupForComponent.getName())){
-                         itr.remove();
-                      }
-                   }
+          Map<String, String> hadoopEnvConfig = clusterConfigurations.get("hadoop-env");
+          if(hadoopEnvConfig != null && !hadoopEnvConfig.isEmpty() && hadoopEnvConfig.containsKey("dfs_ha_initial_namenode_active") && hadoopEnvConfig.containsKey("dfs_ha_initial_namenode_standby")) {
+            ArrayList<HostGroup> hostGroupsForComponent = new ArrayList<>(blueprint.getHostGroupsForComponent(component));
+            Set<String> givenHostGroups = new HashSet<>();
+            givenHostGroups.add(hadoopEnvConfig.get("dfs_ha_initial_namenode_active"));
+            givenHostGroups.add(hadoopEnvConfig.get("dfs_ha_initial_namenode_standby"));
+            if(givenHostGroups.size() != hostGroupsForComponent.size()) {
+               throw new IllegalArgumentException("NAMENODE HA host groups mapped incorrectly for properties 'dfs_ha_initial_namenode_active' and 'dfs_ha_initial_namenode_standby'. Expected Host groups are :" + hostGroupsForComponent);
+            }
+            if(HostGroup.HOSTGROUP_REGEX.matcher(hadoopEnvConfig.get("dfs_ha_initial_namenode_active")).matches() && HostGroup.HOSTGROUP_REGEX.matcher(hadoopEnvConfig.get("dfs_ha_initial_namenode_standby")).matches()){
+              for (HostGroup hostGroupForComponent : hostGroupsForComponent) {
+                 Iterator<String> itr = givenHostGroups.iterator();
+                 while(itr.hasNext()){
+                    if(itr.next().contains(hostGroupForComponent.getName())){
+                       itr.remove();
+                    }
                  }
-                 if(!givenHostGroups.isEmpty()){
-                    throw new IllegalArgumentException("NAMENODE HA host groups mapped incorrectly for properties 'dfs_ha_initial_namenode_active' and 'dfs_ha_initial_namenode_standby'. Expected Host groups are :" + hostGroupsForComponent);
-                 }
-                }
               }
-          }
+            }
 
-        if (blueprint.isAllMpacksResolved()) {
-          if (component.equals("HIVE_METASTORE")) {
-            Map<String, String> hiveEnvConfig = clusterConfigurations.get("hive-env");
-            if (hiveEnvConfig != null && !hiveEnvConfig.isEmpty() && hiveEnvConfig.get("hive_database") != null
-              && hiveEnvConfig.get("hive_database").equals("Existing SQL Anywhere Database")
-              && VersionUtils.compareVersions(stack.getVersion(), "2.3.0.0") < 0
-              && stack.getName().equalsIgnoreCase("HDP")) {
-              throw new InvalidTopologyException("Incorrect configuration: SQL Anywhere db is available only for stack HDP-2.3+ " +
-                "and repo version 2.3.2+!");
+            if(!givenHostGroups.isEmpty()){
+              throw new IllegalArgumentException("NAMENODE HA host groups mapped incorrectly for properties 'dfs_ha_initial_namenode_active' and 'dfs_ha_initial_namenode_standby'. Expected Host groups are :" + hostGroupsForComponent);
             }
           }
-
-          if (component.equals("OOZIE_SERVER")) {
-            Map<String, String> oozieEnvConfig = clusterConfigurations.get("oozie-env");
-            if (oozieEnvConfig != null && !oozieEnvConfig.isEmpty() && oozieEnvConfig.get("oozie_database") != null
-              && oozieEnvConfig.get("oozie_database").equals("Existing SQL Anywhere Database")
-              && VersionUtils.compareVersions(stack.getVersion(), "2.3.0.0") < 0
-              && stack.getName().equalsIgnoreCase("HDP")) {
-              throw new InvalidTopologyException("Incorrect configuration: SQL Anywhere db is available only for stack HDP-2.3+ " +
-                "and repo version 2.3.2+!");
-            }
-          }
-        }
-        else {
-          LOGGER.warn("The following macks are not resolved: [{}] Skipping validation of HIVE_METASTORE and OOZIE_SERVER properties.",
-            Joiner.on(", ").join(blueprint.getUnresolvedMpackNames()));
         }
       }
     }
@@ -221,13 +183,14 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    * Verify that a component is included in all host groups.
    * For components that are auto-install enabled, will add component to topology if needed.
    *
+   *
+   * @param blueprint
    * @param component   component to validate
    * @param autoDeploy  auto-deploy information for component
    *
    * @return collection of missing component information
    */
-  private Collection<String> verifyComponentInAllHostGroups(Component component, AutoDeployInfo autoDeploy) {
-
+  private Collection<String> verifyComponentInAllHostGroups(Blueprint blueprint, Component component, AutoDeployInfo autoDeploy) {
     Collection<String> cardinalityFailures = new HashSet<>();
     int actualCount = blueprint.getHostGroupsForComponent(component.getName()).size();
     Map<String, HostGroup> hostGroups = blueprint.getHostGroups();
@@ -243,7 +206,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
     return cardinalityFailures;
   }
 
-  private Map<String, Collection<DependencyInfo>> validateHostGroup(HostGroup group) {
+  private Map<String, Collection<DependencyInfo>> validateHostGroup(Blueprint blueprint, StackDefinition stack, HostGroup group) {
     LOGGER.info("Validating hostgroup: {}", group.getName());
     Map<String, Collection<DependencyInfo>> missingDependencies = new HashMap<>();
 
@@ -288,7 +251,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
         }
         if (dependencyScope.equals("cluster")) {
           Collection<String> missingDependencyInfo = verifyComponentCardinalityCount(
-              new Component(componentName), new Cardinality("1+"), autoDeployInfo);
+            blueprint, stack, new Component(componentName), new Cardinality("1+"), autoDeployInfo);
 
           resolved = missingDependencyInfo.isEmpty();
         } else if (dependencyScope.equals("host")) {
@@ -315,16 +278,21 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    * Verify that a component meets cardinality requirements.  For components that are
    * auto-install enabled, will add component to topology if needed.
    *
+   *
+   * @param stack
    * @param component    component to validate
    * @param cardinality  required cardinality
    * @param autoDeploy   auto-deploy information for component
    *
    * @return collection of missing component information
    */
-  public Collection<String> verifyComponentCardinalityCount(Component component,
-                                                            Cardinality cardinality,
-                                                            AutoDeployInfo autoDeploy) {
-
+  private Collection<String> verifyComponentCardinalityCount(
+    Blueprint blueprint,
+    StackDefinition stack,
+    Component component,
+    Cardinality cardinality,
+    AutoDeployInfo autoDeploy
+  ) {
     Map<String, Map<String, String>> configProperties = blueprint.getConfiguration().getProperties();
     Collection<String> cardinalityFailures = new HashSet<>();
     //todo: don't hard code this HA logic here
@@ -368,7 +336,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    *
    * @return true if the specified component managed by the cluster; false otherwise
    */
-  protected boolean isDependencyManaged(Stack stack, String component, Map<String, Map<String, String>> clusterConfig) {
+  protected boolean isDependencyManaged(StackDefinition stack, String component, Map<String, Map<String, String>> clusterConfig) {
     boolean isManaged = true;
     String externalComponentConfig = stack.getExternalComponentConfig(component);
     if (externalComponentConfig != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintValidatorImpl.java
@@ -81,7 +81,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
           cardinalityFailures.addAll(verifyComponentInAllHostGroups(blueprint, new Component(component), autoDeploy));
         } else {
           cardinalityFailures.addAll(verifyComponentCardinalityCount(
-            blueprint, stack, new Component(component), cardinality, autoDeploy));
+            stack, blueprint, new Component(component), cardinality, autoDeploy));
         }
       }
     }
@@ -184,7 +184,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    * For components that are auto-install enabled, will add component to topology if needed.
    *
    *
-   * @param blueprint
+   * @param blueprint   blueprint to validate
    * @param component   component to validate
    * @param autoDeploy  auto-deploy information for component
    *
@@ -251,7 +251,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
         }
         if (dependencyScope.equals("cluster")) {
           Collection<String> missingDependencyInfo = verifyComponentCardinalityCount(
-            blueprint, stack, new Component(componentName), new Cardinality("1+"), autoDeployInfo);
+            stack, blueprint, new Component(componentName), new Cardinality("1+"), autoDeployInfo);
 
           resolved = missingDependencyInfo.isEmpty();
         } else if (dependencyScope.equals("host")) {
@@ -279,7 +279,8 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    * auto-install enabled, will add component to topology if needed.
    *
    *
-   * @param stack
+   * @param stack        stack definition
+   * @param blueprint    blueprint to validate
    * @param component    component to validate
    * @param cardinality  required cardinality
    * @param autoDeploy   auto-deploy information for component
@@ -287,8 +288,8 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    * @return collection of missing component information
    */
   private Collection<String> verifyComponentCardinalityCount(
-    Blueprint blueprint,
     StackDefinition stack,
+    Blueprint blueprint,
     Component component,
     Cardinality cardinality,
     AutoDeployInfo autoDeploy
@@ -330,7 +331,7 @@ public class BlueprintValidatorImpl implements BlueprintValidator {
    * Determine if a component is managed, meaning that it is running inside of the cluster
    * topology.  Generally, non-managed dependencies will be database components.
    *
-   * @param stack          stack instance
+   * @param stack          stack definition
    * @param component      component to determine if it is managed
    * @param clusterConfig  cluster configuration
    *

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
@@ -36,7 +36,7 @@ import org.apache.ambari.server.controller.ConfigurationRequest;
 import org.apache.ambari.server.controller.internal.BlueprintConfigurationProcessor;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.ConfigurationTopologyException;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.serveraction.kerberos.KerberosInvalidConfigurationException;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.SecurityType;
@@ -63,7 +63,7 @@ public class ClusterConfigurationRequest {
   private ClusterTopology clusterTopology;
   private BlueprintConfigurationProcessor configurationProcessor;
   private StackAdvisorBlueprintProcessor stackAdvisorBlueprintProcessor;
-  private StackInfo stack;
+  private StackDefinition stack;
   private boolean configureSecurity = false;
 
   public ClusterConfigurationRequest(AmbariContext ambariContext, ClusterTopology topology, boolean setInitial, StackAdvisorBlueprintProcessor stackAdvisorBlueprintProcessor, boolean configureSecurity) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
@@ -36,7 +36,7 @@ import org.apache.ambari.server.controller.ConfigurationRequest;
 import org.apache.ambari.server.controller.internal.BlueprintConfigurationProcessor;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.ConfigurationTopologyException;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.serveraction.kerberos.KerberosInvalidConfigurationException;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.SecurityType;
@@ -63,7 +63,7 @@ public class ClusterConfigurationRequest {
   private ClusterTopology clusterTopology;
   private BlueprintConfigurationProcessor configurationProcessor;
   private StackAdvisorBlueprintProcessor stackAdvisorBlueprintProcessor;
-  private Stack stack;
+  private StackDefinition stack;
   private boolean configureSecurity = false;
 
   public ClusterConfigurationRequest(AmbariContext ambariContext, ClusterTopology topology, boolean setInitial, StackAdvisorBlueprintProcessor stackAdvisorBlueprintProcessor, boolean configureSecurity) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
@@ -36,7 +36,7 @@ import org.apache.ambari.server.controller.ConfigurationRequest;
 import org.apache.ambari.server.controller.internal.BlueprintConfigurationProcessor;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.ConfigurationTopologyException;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.serveraction.kerberos.KerberosInvalidConfigurationException;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.SecurityType;
@@ -63,7 +63,7 @@ public class ClusterConfigurationRequest {
   private ClusterTopology clusterTopology;
   private BlueprintConfigurationProcessor configurationProcessor;
   private StackAdvisorBlueprintProcessor stackAdvisorBlueprintProcessor;
-  private Stack stack;
+  private StackInfo stack;
   private boolean configureSecurity = false;
 
   public ClusterConfigurationRequest(AmbariContext ambariContext, ClusterTopology topology, boolean setInitial, StackAdvisorBlueprintProcessor stackAdvisorBlueprintProcessor, boolean configureSecurity) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Configurable.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Configurable.java
@@ -18,8 +18,8 @@
 
 package org.apache.ambari.server.topology;
 
-import static org.apache.ambari.server.topology.BlueprintFactory.PROPERTIES_ATTRIBUTES_PROPERTY_ID;
-import static org.apache.ambari.server.topology.BlueprintFactory.PROPERTIES_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.BlueprintResourceProvider.PROPERTIES_ATTRIBUTES_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.BlueprintResourceProvider.PROPERTIES_PROPERTY_ID;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,7 +42,7 @@ public interface Configurable {
   Configuration getConfiguration();
 
   @JsonProperty("configurations")
-  default void setConfigs(Collection<? extends Map<String, ? extends Object>> configs) {
+  default void setConfigs(Collection<? extends Map<String, ?>> configs) {
     Configuration configuration;
     if (!configs.isEmpty() && configs.iterator().next().keySet().iterator().next().contains("/")) {
       // Configuration has keys with slashes like "zk.cfg/properties/dataDir" means it is coming through
@@ -73,9 +73,9 @@ public interface Configurable {
   }
 
   @JsonProperty("configurations")
-  default Collection<Map<String, Map<String, ? extends Object>>> getConfigs() {
+  default Collection<Map<String, Map<String, ?>>> getConfigs() {
     Configuration configuration = getConfiguration();
-    Collection<Map<String, Map<String, ? extends Object>>> configurations = new ArrayList<>();
+    Collection<Map<String, Map<String, ?>>> configurations = new ArrayList<>();
     Set<String> allConfigTypes = Sets.union(configuration.getProperties().keySet(), configuration.getAttributes().keySet());
     for (String configType: allConfigTypes) {
       Map<String, Map<String, ? extends Object>> configData = new HashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
@@ -43,6 +43,10 @@ public class Configuration {
    */
   private Configuration parentConfiguration;
 
+  public static Configuration createEmpty() {
+    return new Configuration(new HashMap<>(), new HashMap<>());
+  }
+
   /**
    * Constructor.
    *
@@ -358,5 +362,20 @@ public class Configuration {
     if (parentConfiguration != null) {
       parentConfiguration.removeConfigType(configType);
     }
+  }
+
+  public static Configuration combine(Configuration c1, Configuration c2) {
+    if (c1 == null || (c1.getProperties().isEmpty() && c1.getAttributes().isEmpty())) {
+      return c2;
+    }
+    if (c2 == null || (c2.getProperties().isEmpty() && c2.getAttributes().isEmpty())) {
+      return c1;
+    }
+    Configuration combined = new Configuration(new HashMap<>(), new HashMap<>());
+    combined.getProperties().putAll(c1.getProperties());
+    combined.getProperties().putAll(c2.getProperties());
+    combined.getAttributes().putAll(c1.getAttributes());
+    combined.getAttributes().putAll(c2.getAttributes());
+    return combined;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
@@ -43,10 +43,13 @@ public class Configuration {
    */
   private Configuration parentConfiguration;
 
-
   public Configuration() {
     properties = new HashMap<>();
     attributes = new HashMap<>();
+  }
+
+  public static Configuration createEmpty() {
+    return new Configuration(new HashMap<>(), new HashMap<>());
   }
 
   /**
@@ -364,5 +367,20 @@ public class Configuration {
     if (parentConfiguration != null) {
       parentConfiguration.removeConfigType(configType);
     }
+  }
+
+  public static Configuration combine(Configuration c1, Configuration c2) {
+    if (c1 == null || (c1.getProperties().isEmpty() && c1.getAttributes().isEmpty())) {
+      return c2;
+    }
+    if (c2 == null || (c2.getProperties().isEmpty() && c2.getAttributes().isEmpty())) {
+      return c1;
+    }
+    Configuration combined = new Configuration(new HashMap<>(), new HashMap<>());
+    combined.getProperties().putAll(c1.getProperties());
+    combined.getProperties().putAll(c2.getProperties());
+    combined.getAttributes().putAll(c1.getAttributes());
+    combined.getAttributes().putAll(c2.getAttributes());
+    return combined;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ConfigurationFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ConfigurationFactory.java
@@ -10,14 +10,16 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distribut
- * ed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
 package org.apache.ambari.server.topology;
+
+import static org.apache.ambari.server.controller.internal.BlueprintResourceProvider.PROPERTIES_ATTRIBUTES_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.BlueprintResourceProvider.PROPERTIES_PROPERTY_ID;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -59,8 +61,8 @@ public class ConfigurationFactory {
       String propertiesType = keyNameTokens[1];
       if (levels == 2) {
         return new ConfigurationStrategyV1();
-      } else if ((levels == 3 && BlueprintFactory.PROPERTIES_PROPERTY_ID.equals(propertiesType))
-          || (levels == 4 && BlueprintFactory.PROPERTIES_ATTRIBUTES_PROPERTY_ID.equals(propertiesType))) {
+      } else if ((levels == 3 && PROPERTIES_PROPERTY_ID.equals(propertiesType))
+          || (levels == 4 && PROPERTIES_ATTRIBUTES_PROPERTY_ID.equals(propertiesType))) {
         return new ConfigurationStrategyV2();
       } else {
         throw new IllegalArgumentException(SCHEMA_IS_NOT_SUPPORTED_MESSAGE);
@@ -111,9 +113,9 @@ public class ConfigurationFactory {
     @Override
     protected void setConfiguration(Configuration configuration, String[] propertyNameTokens, String propertyValue) {
       String type = propertyNameTokens[0];
-      if (BlueprintFactory.PROPERTIES_PROPERTY_ID.equals(propertyNameTokens[1])) {
+      if (PROPERTIES_PROPERTY_ID.equals(propertyNameTokens[1])) {
         configuration.setProperty(type, propertyNameTokens[2], propertyValue);
-      } else if (BlueprintFactory.PROPERTIES_ATTRIBUTES_PROPERTY_ID.equals(propertyNameTokens[1])) {
+      } else if (PROPERTIES_ATTRIBUTES_PROPERTY_ID.equals(propertyNameTokens[1])) {
         configuration.setAttribute(type, propertyNameTokens[3], propertyNameTokens[2], propertyValue);
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroup.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.regex.Pattern;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 
 /**
  * Host Group representation.
@@ -109,8 +109,6 @@ public interface HostGroup {
 
   /**
    * Add a component to the host group
-   * @param component
-   * @return
    */
   boolean addComponent(Component component);
 
@@ -142,15 +140,7 @@ public interface HostGroup {
    *
    * @return associated stack
    */
-  @Deprecated
-  Stack getStack();
-
-  /**
-   * Get the stack associated with the host group.
-   *
-   * @return associated stacks
-   */
-  Collection<Stack> getStacks();
+  StackDefinition getStack();
 
   /**
    * Get the cardinality value that was specified for the host group.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroup.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.regex.Pattern;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 
 /**
  * Host Group representation.
@@ -137,7 +137,7 @@ public interface HostGroup {
    *
    * @return associated stack
    */
-  Stack getStack();
+  StackInfo getStack();
 
   /**
    * Get the cardinality value that was specified for the host group.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroup.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.regex.Pattern;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 
 /**
  * Host Group representation.
@@ -137,7 +137,7 @@ public interface HostGroup {
    *
    * @return associated stack
    */
-  StackInfo getStack();
+  StackDefinition getStack();
 
   /**
    * Get the cardinality value that was specified for the host group.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroupImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroupImpl.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.orm.entities.HostGroupComponentEntity;
 import org.apache.ambari.server.orm.entities.HostGroupConfigEntity;
 import org.apache.ambari.server.orm.entities.HostGroupEntity;
@@ -66,11 +66,11 @@ public class HostGroupImpl implements HostGroup {
 
   private boolean containsMasterComponent = false;
 
-  private StackInfo stack;
+  private StackDefinition stack;
 
   private String cardinality = "NOT SPECIFIED";
 
-  public HostGroupImpl(HostGroupEntity entity, String blueprintName, StackInfo stack) {
+  public HostGroupImpl(HostGroupEntity entity, String blueprintName, StackDefinition stack) {
     this.name = entity.getName();
     this.cardinality = entity.getCardinality();
     this.blueprintName = blueprintName;
@@ -80,7 +80,7 @@ public class HostGroupImpl implements HostGroup {
     parseConfigurations(entity);
   }
 
-  public HostGroupImpl(String name, String bpName, StackInfo stack, Collection<Component> components, Configuration configuration, String cardinality) {
+  public HostGroupImpl(String name, String bpName, StackDefinition stack, Collection<Component> components, Configuration configuration, String cardinality) {
     this.name = name;
     this.blueprintName = bpName;
     this.stack = stack;
@@ -236,7 +236,7 @@ public class HostGroupImpl implements HostGroup {
   }
 
   @Override
-  public StackInfo getStack() {
+  public StackDefinition getStack() {
     return stack;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroupImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostGroupImpl.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.orm.entities.HostGroupComponentEntity;
 import org.apache.ambari.server.orm.entities.HostGroupConfigEntity;
 import org.apache.ambari.server.orm.entities.HostGroupEntity;
@@ -66,11 +66,11 @@ public class HostGroupImpl implements HostGroup {
 
   private boolean containsMasterComponent = false;
 
-  private Stack stack;
+  private StackInfo stack;
 
   private String cardinality = "NOT SPECIFIED";
 
-  public HostGroupImpl(HostGroupEntity entity, String blueprintName, Stack stack) {
+  public HostGroupImpl(HostGroupEntity entity, String blueprintName, StackInfo stack) {
     this.name = entity.getName();
     this.cardinality = entity.getCardinality();
     this.blueprintName = blueprintName;
@@ -80,7 +80,7 @@ public class HostGroupImpl implements HostGroup {
     parseConfigurations(entity);
   }
 
-  public HostGroupImpl(String name, String bpName, Stack stack, Collection<Component> components, Configuration configuration, String cardinality) {
+  public HostGroupImpl(String name, String bpName, StackInfo stack, Collection<Component> components, Configuration configuration, String cardinality) {
     this.name = name;
     this.blueprintName = bpName;
     this.stack = stack;
@@ -236,7 +236,7 @@ public class HostGroupImpl implements HostGroup {
   }
 
   @Override
-  public Stack getStack() {
+  public StackInfo getStack() {
     return stack;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
@@ -34,7 +34,7 @@ import org.apache.ambari.server.api.predicate.InvalidQueryException;
 import org.apache.ambari.server.api.predicate.PredicateCompiler;
 import org.apache.ambari.server.controller.internal.HostResourceProvider;
 import org.apache.ambari.server.controller.internal.ResourceImpl;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.orm.entities.HostRoleCommandEntity;
@@ -257,7 +257,7 @@ public class HostRequest implements Comparable<HostRequest> {
           "PENDING HOST ASSIGNMENT : HOSTGROUP=" + getHostgroupName();
 
       AmbariContext context = topology.getAmbariContext();
-      Stack stack = hostGroup.getStack();
+      StackInfo stack = hostGroup.getStack();
 
       // Skip INSTALL task in case server component is marked as START_ONLY, or the cluster provision_action is
       // START_ONLY, unless component is marked with INSTALL_ONLY or INSTALL_AND_START.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
@@ -34,7 +34,7 @@ import org.apache.ambari.server.api.predicate.InvalidQueryException;
 import org.apache.ambari.server.api.predicate.PredicateCompiler;
 import org.apache.ambari.server.controller.internal.HostResourceProvider;
 import org.apache.ambari.server.controller.internal.ResourceImpl;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.orm.entities.HostRoleCommandEntity;
@@ -257,7 +257,7 @@ public class HostRequest implements Comparable<HostRequest> {
           "PENDING HOST ASSIGNMENT : HOSTGROUP=" + getHostgroupName();
 
       AmbariContext context = topology.getAmbariContext();
-      StackInfo stack = hostGroup.getStack();
+      StackDefinition stack = hostGroup.getStack();
 
       // Skip INSTALL task in case server component is marked as START_ONLY, or the cluster provision_action is
       // START_ONLY, unless component is marked with INSTALL_ONLY or INSTALL_AND_START.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
@@ -34,7 +34,7 @@ import org.apache.ambari.server.api.predicate.InvalidQueryException;
 import org.apache.ambari.server.api.predicate.PredicateCompiler;
 import org.apache.ambari.server.controller.internal.HostResourceProvider;
 import org.apache.ambari.server.controller.internal.ResourceImpl;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.orm.entities.HostRoleCommandEntity;
@@ -257,7 +257,7 @@ public class HostRequest implements Comparable<HostRequest> {
           "PENDING HOST ASSIGNMENT : HOSTGROUP=" + getHostgroupName();
 
       AmbariContext context = topology.getAmbariContext();
-      Stack stack = hostGroup.getStack();
+      StackDefinition stack = hostGroup.getStack();
 
       // Skip INSTALL task in case server component is marked as START_ONLY, or the cluster provision_action is
       // START_ONLY, unless component is marked with INSTALL_ONLY or INSTALL_AND_START.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/MpackInstance.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/MpackInstance.java
@@ -122,7 +122,7 @@ public class MpackInstance implements Configurable {
     mpackEntity.setMpackName(mpackName);
     mpackEntity.setMpackVersion(mpackVersion);
     Collection<BlueprintMpackConfigEntity> mpackConfigEntities =
-      BlueprintImpl.toConfigEntities(configuration, () -> new BlueprintMpackConfigEntity());
+      BlueprintImpl.toConfigEntities(configuration, BlueprintMpackConfigEntity::new);
     mpackConfigEntities.forEach( configEntity -> configEntity.setMpackInstance(mpackEntity) );
     mpackEntity.setConfigurations(mpackConfigEntities);
 
@@ -131,7 +131,7 @@ public class MpackInstance implements Configurable {
       serviceEntity.setName(serviceInstance.getName());
       serviceEntity.setType(serviceInstance.getType());
       Collection<BlueprintServiceConfigEntity> serviceConfigEntities =
-        BlueprintImpl.toConfigEntities(serviceInstance.getConfiguration(), () -> new BlueprintServiceConfigEntity());
+        BlueprintImpl.toConfigEntities(serviceInstance.getConfiguration(), BlueprintServiceConfigEntity::new);
       serviceConfigEntities.forEach( configEntity -> configEntity.setService(serviceEntity) );
       serviceEntity.setConfigurations(serviceConfigEntities);
       mpackEntity.getServiceInstances().add(serviceEntity);

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
@@ -28,6 +28,8 @@ import org.apache.ambari.server.state.SecurityType;
  */
 public class SecurityConfiguration {
 
+  public static final SecurityConfiguration NONE = new SecurityConfiguration(SecurityType.NONE);
+
   /**
    * Security Type
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -51,7 +51,7 @@ import org.apache.ambari.server.controller.internal.CredentialResourceProvider;
 import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
 import org.apache.ambari.server.controller.internal.RequestImpl;
 import org.apache.ambari.server.controller.internal.ScaleClusterRequest;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.RequestStatus;
 import org.apache.ambari.server.controller.spi.Resource;
@@ -277,7 +277,7 @@ public class TopologyManager {
 
     final ClusterTopology topology = new ClusterTopologyImpl(ambariContext, request);
     final String clusterName = request.getClusterName();
-    final StackInfo stack = topology.getBlueprint().getStack();
+    final StackDefinition stack = topology.getBlueprint().getStack();
     final String repoVersion = request.getRepositoryVersion();
     final Long repoVersionID = request.getRepositoryVersionId();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -51,7 +51,7 @@ import org.apache.ambari.server.controller.internal.CredentialResourceProvider;
 import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
 import org.apache.ambari.server.controller.internal.RequestImpl;
 import org.apache.ambari.server.controller.internal.ScaleClusterRequest;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.RequestStatus;
 import org.apache.ambari.server.controller.spi.Resource;
@@ -71,6 +71,7 @@ import org.apache.ambari.server.orm.entities.StageEntity;
 import org.apache.ambari.server.security.authorization.AuthorizationHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.host.HostImpl;
 import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfile;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
@@ -81,6 +82,7 @@ import org.apache.ambari.server.utils.RetryHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Iterables;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Singleton;
 import com.google.inject.persist.Transactional;
@@ -275,7 +277,7 @@ public class TopologyManager {
 
     final ClusterTopology topology = new ClusterTopologyImpl(ambariContext, request);
     final String clusterName = request.getClusterName();
-    final Stack stack = topology.getBlueprint().getStack(); // TODO: implement multi-stack
+    final StackDefinition stack = topology.getBlueprint().getStack();
     final String repoVersion = request.getRepositoryVersion();
     final Long repoVersionID = request.getRepositoryVersionId();
 
@@ -347,7 +349,8 @@ public class TopologyManager {
     //todo: this should be invoked as part of a generic lifecycle event which could possibly
     //todo: be tied to cluster state
 
-    ambariContext.persistInstallStateForUI(clusterName, stack.getName(), stack.getVersion());
+    StackId stackId = Iterables.getFirst(topology.getBlueprint().getStackIds(), null); // FIXME need for stackId in ClusterRequest will be removed
+    ambariContext.persistInstallStateForUI(clusterName, stackId);
     clusterProvisionWithBlueprintCreateRequests.put(clusterId, logicalRequest);
     return getRequestStatus(logicalRequest.getRequestId());
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -51,7 +51,7 @@ import org.apache.ambari.server.controller.internal.CredentialResourceProvider;
 import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
 import org.apache.ambari.server.controller.internal.RequestImpl;
 import org.apache.ambari.server.controller.internal.ScaleClusterRequest;
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.RequestStatus;
 import org.apache.ambari.server.controller.spi.Resource;
@@ -71,6 +71,7 @@ import org.apache.ambari.server.orm.entities.StageEntity;
 import org.apache.ambari.server.security.authorization.AuthorizationHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.host.HostImpl;
 import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfile;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
@@ -275,7 +276,8 @@ public class TopologyManager {
 
     final ClusterTopology topology = new ClusterTopologyImpl(ambariContext, request);
     final String clusterName = request.getClusterName();
-    final Stack stack = topology.getBlueprint().getStack();
+    final StackId stackId = topology.getBlueprint().getStackId();
+    final StackInfo stack = topology.getBlueprint().getStack();
     final String repoVersion = request.getRepositoryVersion();
     final Long repoVersionID = request.getRepositoryVersionId();
 
@@ -347,7 +349,7 @@ public class TopologyManager {
     //todo: this should be invoked as part of a generic lifecycle event which could possibly
     //todo: be tied to cluster state
 
-    ambariContext.persistInstallStateForUI(clusterName, stack.getName(), stack.getVersion());
+    ambariContext.persistInstallStateForUI(clusterName, stackId);
     clusterProvisionWithBlueprintCreateRequests.put(clusterId, logicalRequest);
     return getRequestStatus(logicalRequest.getRequestId());
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -82,6 +82,7 @@ import org.apache.ambari.server.utils.RetryHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Iterables;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Singleton;
 import com.google.inject.persist.Transactional;
@@ -276,7 +277,6 @@ public class TopologyManager {
 
     final ClusterTopology topology = new ClusterTopologyImpl(ambariContext, request);
     final String clusterName = request.getClusterName();
-    final StackId stackId = topology.getBlueprint().getStackId();
     final StackInfo stack = topology.getBlueprint().getStack();
     final String repoVersion = request.getRepositoryVersion();
     final Long repoVersionID = request.getRepositoryVersionId();
@@ -349,6 +349,7 @@ public class TopologyManager {
     //todo: this should be invoked as part of a generic lifecycle event which could possibly
     //todo: be tied to cluster state
 
+    StackId stackId = Iterables.getFirst(topology.getBlueprint().getStackIds(), null); // FIXME need for stackId in ClusterRequest will be removed
     ambariContext.persistInstallStateForUI(clusterName, stackId);
     clusterProvisionWithBlueprintCreateRequests.put(clusterId, logicalRequest);
     return getRequestStatus(logicalRequest.getRequestId());

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.internal.Stack;
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.ClusterTopology;
@@ -83,7 +83,7 @@ public class RequiredPasswordValidator implements TopologyValidator {
 
       Collection<String> processedServices = new HashSet<>();
       Blueprint blueprint = topology.getBlueprint();
-      StackInfo stack = blueprint.getStack();
+      StackDefinition stack = blueprint.getStack();
 
       HostGroup hostGroup = blueprint.getHostGroup(hostGroupName);
       for (String component : hostGroup.getComponentNames()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.ClusterTopology;
@@ -82,7 +83,7 @@ public class RequiredPasswordValidator implements TopologyValidator {
 
       Collection<String> processedServices = new HashSet<>();
       Blueprint blueprint = topology.getBlueprint();
-      Stack stack = blueprint.getStack();
+      StackInfo stack = blueprint.getStack();
 
       HostGroup hostGroup = blueprint.getHostGroup(hostGroupName);
       for (String component : hostGroup.getComponentNames()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.ClusterTopology;
@@ -82,7 +83,7 @@ public class RequiredPasswordValidator implements TopologyValidator {
 
       Collection<String> processedServices = new HashSet<>();
       Blueprint blueprint = topology.getBlueprint();
-      Stack stack = blueprint.getStack();
+      StackDefinition stack = blueprint.getStack();
 
       HostGroup hostGroup = blueprint.getHostGroup(hostGroupName);
       for (String component : hostGroup.getComponentNames()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
@@ -22,7 +22,7 @@ import static org.apache.ambari.server.controller.internal.UnitUpdater.PropertyV
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.StackInfo;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.internal.UnitUpdater.PropertyUnit;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.HostGroupInfo;
@@ -42,33 +42,33 @@ public class UnitValidator implements TopologyValidator {
 
   @Override
   public void validate(ClusterTopology topology) throws InvalidTopologyException {
-    StackInfo stack = topology.getBlueprint().getStack();
+    StackDefinition stack = topology.getBlueprint().getStack();
     validateConfig(topology.getConfiguration().getFullProperties(), stack);
     for (HostGroupInfo hostGroup : topology.getHostGroupInfo().values()) {
       validateConfig(hostGroup.getConfiguration().getFullProperties(), stack);
     }
   }
 
-  private void validateConfig(Map<String, Map<String, String>> configuration, StackInfo stack) {
+  private void validateConfig(Map<String, Map<String, String>> configuration, StackDefinition stack) {
     for (Map.Entry<String, Map<String, String>> each : configuration.entrySet()) {
       validateConfigType(each.getKey(), each.getValue(), stack);
     }
   }
 
-  private void validateConfigType(String configType, Map<String, String> config, StackInfo stack) {
+  private void validateConfigType(String configType, Map<String, String> config, StackDefinition stack) {
     for (String propertyName : config.keySet()) {
       validateProperty(configType, config, propertyName, stack);
     }
   }
 
-  private void validateProperty(String configType, Map<String, String> config, String propertyName, StackInfo stack) {
+  private void validateProperty(String configType, Map<String, String> config, String propertyName, StackDefinition stack) {
     relevantProps.stream()
       .filter(each -> each.hasTypeAndName(configType, propertyName))
       .findFirst()
       .ifPresent(relevantProperty -> checkUnit(config, stack, relevantProperty));
   }
 
-  private void checkUnit(Map<String, String> configToBeValidated, StackInfo stack, UnitValidatedProperty prop) {
+  private void checkUnit(Map<String, String> configToBeValidated, StackDefinition stack, UnitValidatedProperty prop) {
     PropertyUnit stackUnit = PropertyUnit.of(stack, prop);
     PropertyValue value = PropertyValue.of(prop.getPropertyName(), configToBeValidated.get(prop.getPropertyName()));
     if (value.hasAnyUnit() && !value.hasUnit(stackUnit)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
@@ -22,7 +22,7 @@ import static org.apache.ambari.server.controller.internal.UnitUpdater.PropertyV
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackInfo;
 import org.apache.ambari.server.controller.internal.UnitUpdater.PropertyUnit;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.HostGroupInfo;
@@ -42,33 +42,33 @@ public class UnitValidator implements TopologyValidator {
 
   @Override
   public void validate(ClusterTopology topology) throws InvalidTopologyException {
-    Stack stack = topology.getBlueprint().getStack();
+    StackInfo stack = topology.getBlueprint().getStack();
     validateConfig(topology.getConfiguration().getFullProperties(), stack);
     for (HostGroupInfo hostGroup : topology.getHostGroupInfo().values()) {
       validateConfig(hostGroup.getConfiguration().getFullProperties(), stack);
     }
   }
 
-  private void validateConfig(Map<String, Map<String, String>> configuration, Stack stack) {
+  private void validateConfig(Map<String, Map<String, String>> configuration, StackInfo stack) {
     for (Map.Entry<String, Map<String, String>> each : configuration.entrySet()) {
       validateConfigType(each.getKey(), each.getValue(), stack);
     }
   }
 
-  private void validateConfigType(String configType, Map<String, String> config, Stack stack) {
+  private void validateConfigType(String configType, Map<String, String> config, StackInfo stack) {
     for (String propertyName : config.keySet()) {
       validateProperty(configType, config, propertyName, stack);
     }
   }
 
-  private void validateProperty(String configType, Map<String, String> config, String propertyName, Stack stack) {
+  private void validateProperty(String configType, Map<String, String> config, String propertyName, StackInfo stack) {
     relevantProps.stream()
       .filter(each -> each.hasTypeAndName(configType, propertyName))
       .findFirst()
       .ifPresent(relevantProperty -> checkUnit(config, stack, relevantProperty));
   }
 
-  private void checkUnit(Map<String, String> configToBeValidated, Stack stack, UnitValidatedProperty prop) {
+  private void checkUnit(Map<String, String> configToBeValidated, StackInfo stack, UnitValidatedProperty prop) {
     PropertyUnit stackUnit = PropertyUnit.of(stack, prop);
     PropertyValue value = PropertyValue.of(prop.getPropertyName(), configToBeValidated.get(prop.getPropertyName()));
     if (value.hasAnyUnit() && !value.hasUnit(stackUnit)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
@@ -22,7 +22,7 @@ import static org.apache.ambari.server.controller.internal.UnitUpdater.PropertyV
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.internal.UnitUpdater.PropertyUnit;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.HostGroupInfo;
@@ -42,33 +42,33 @@ public class UnitValidator implements TopologyValidator {
 
   @Override
   public void validate(ClusterTopology topology) throws InvalidTopologyException {
-    Stack stack = topology.getBlueprint().getStack();
+    StackDefinition stack = topology.getBlueprint().getStack();
     validateConfig(topology.getConfiguration().getFullProperties(), stack);
     for (HostGroupInfo hostGroup : topology.getHostGroupInfo().values()) {
       validateConfig(hostGroup.getConfiguration().getFullProperties(), stack);
     }
   }
 
-  private void validateConfig(Map<String, Map<String, String>> configuration, Stack stack) {
+  private void validateConfig(Map<String, Map<String, String>> configuration, StackDefinition stack) {
     for (Map.Entry<String, Map<String, String>> each : configuration.entrySet()) {
       validateConfigType(each.getKey(), each.getValue(), stack);
     }
   }
 
-  private void validateConfigType(String configType, Map<String, String> config, Stack stack) {
+  private void validateConfigType(String configType, Map<String, String> config, StackDefinition stack) {
     for (String propertyName : config.keySet()) {
       validateProperty(configType, config, propertyName, stack);
     }
   }
 
-  private void validateProperty(String configType, Map<String, String> config, String propertyName, Stack stack) {
+  private void validateProperty(String configType, Map<String, String> config, String propertyName, StackDefinition stack) {
     relevantProps.stream()
       .filter(each -> each.hasTypeAndName(configType, propertyName))
       .findFirst()
       .ifPresent(relevantProperty -> checkUnit(config, stack, relevantProperty));
   }
 
-  private void checkUnit(Map<String, String> configToBeValidated, Stack stack, UnitValidatedProperty prop) {
+  private void checkUnit(Map<String, String> configToBeValidated, StackDefinition stack, UnitValidatedProperty prop) {
     PropertyUnit stackUnit = PropertyUnit.of(stack, prop);
     PropertyValue value = PropertyValue.of(prop.getPropertyName(), configToBeValidated.get(prop.getPropertyName()));
     if (value.hasAnyUnit() && !value.hasUnit(stackUnit)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/JsonUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/JsonUtils.java
@@ -17,8 +17,13 @@
  */
 package org.apache.ambari.server.utils;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import org.apache.commons.lang.StringUtils;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
@@ -27,7 +32,12 @@ import com.google.gson.JsonSyntaxException;
  */
 public class JsonUtils {
 
+  /**
+   * Used to serialize to/from json.
+   */
   public static JsonParser jsonParser = new JsonParser();
+
+  private static final ObjectMapper JSON_SERIALIZER = new ObjectMapper();
 
   /**
    * Checks if an input string is in valid JSON format
@@ -44,6 +54,25 @@ public class JsonUtils {
       return true;
     } catch (JsonSyntaxException jse) {
       return false;
+    }
+  }
+
+  public static <T> T fromJson(String json, TypeReference<? extends T> valueType) {
+    if (null == json) {
+      return  null;
+    }
+    try {
+      return JSON_SERIALIZER.readValue(json, valueType);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  public static String toJson(Object object) {
+    try {
+      return JSON_SERIALIZER.writeValueAsString(object);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/JsonUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/JsonUtils.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
@@ -38,6 +39,7 @@ public class JsonUtils {
   public static JsonParser jsonParser = new JsonParser();
 
   private static final ObjectMapper JSON_SERIALIZER = new ObjectMapper();
+  private static final ObjectWriter JSON_WRITER = JSON_SERIALIZER.writer();
 
   /**
    * Checks if an input string is in valid JSON format
@@ -62,7 +64,7 @@ public class JsonUtils {
       return  null;
     }
     try {
-      return JSON_SERIALIZER.readValue(json, valueType);
+      return JSON_SERIALIZER.reader(valueType).readValue(json);
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }
@@ -70,7 +72,7 @@ public class JsonUtils {
 
   public static String toJson(Object object) {
     try {
-      return JSON_SERIALIZER.writeValueAsString(object);
+      return JSON_WRITER.writeValueAsString(object);
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -594,7 +594,7 @@ CREATE TABLE blueprint_mpack_instance(
   blueprint_name VARCHAR(255) NOT NULL,
   mpack_name VARCHAR(255) NOT NULL,
   mpack_version VARCHAR(255) NOT NULL,
-  mpack_uri VARCHAR(255) NOT NULL,
+  mpack_uri VARCHAR(255),
   mpack_id BIGINT,
   CONSTRAINT PK_blueprint_mpack_inst PRIMARY KEY (id),
   CONSTRAINT FK_mpi_blueprint_name FOREIGN KEY (blueprint_name) REFERENCES blueprint(blueprint_name),

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -612,7 +612,7 @@ CREATE TABLE blueprint_mpack_instance(
   blueprint_name VARCHAR(255) NOT NULL,
   mpack_name VARCHAR(255) NOT NULL,
   mpack_version VARCHAR(255) NOT NULL,
-  mpack_uri VARCHAR(255) NOT NULL,
+  mpack_uri VARCHAR(255),
   mpack_id BIGINT,
   CONSTRAINT PK_blueprint_mpack_inst PRIMARY KEY (id),
   CONSTRAINT FK_mpi_blueprint_name FOREIGN KEY (blueprint_name) REFERENCES blueprint(blueprint_name),

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -592,7 +592,7 @@ CREATE TABLE blueprint_mpack_instance(
   blueprint_name VARCHAR2(255) NOT NULL,
   mpack_name VARCHAR2(255) NOT NULL,
   mpack_version VARCHAR2(255) NOT NULL,
-  mpack_uri VARCHAR2(255) NOT NULL,
+  mpack_uri VARCHAR2(255),
   mpack_id NUMBER(19),
   CONSTRAINT PK_blueprint_mpack_inst PRIMARY KEY (id),
   CONSTRAINT FK_mpi_blueprint_name FOREIGN KEY (blueprint_name) REFERENCES blueprint(blueprint_name),

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -593,7 +593,7 @@ CREATE TABLE blueprint_mpack_instance(
   blueprint_name VARCHAR(255) NOT NULL,
   mpack_name VARCHAR(255) NOT NULL,
   mpack_version VARCHAR(255) NOT NULL,
-  mpack_uri VARCHAR(255) NOT NULL,
+  mpack_uri VARCHAR(255),
   mpack_id BIGINT,
   CONSTRAINT PK_blueprint_mpack_inst PRIMARY KEY (id),
   CONSTRAINT FK_mpi_blueprint_name FOREIGN KEY (blueprint_name) REFERENCES blueprint(blueprint_name),

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -589,7 +589,7 @@ CREATE TABLE blueprint_mpack_instance(
   blueprint_name VARCHAR(255) NOT NULL,
   mpack_name VARCHAR(255) NOT NULL,
   mpack_version VARCHAR(255) NOT NULL,
-  mpack_uri VARCHAR(255) NOT NULL,
+  mpack_uri VARCHAR(255),
   mpack_id NUMERIC(19),
   CONSTRAINT PK_blueprint_mpack_inst PRIMARY KEY (id),
   CONSTRAINT FK_mpi_blueprint_name FOREIGN KEY (blueprint_name) REFERENCES blueprint(blueprint_name),

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -598,7 +598,7 @@ CREATE TABLE blueprint_mpack_instance(
   blueprint_name VARCHAR(255) NOT NULL,
   mpack_name VARCHAR(255) NOT NULL,
   mpack_version VARCHAR(255) NOT NULL,
-  mpack_uri VARCHAR(255) NOT NULL,
+  mpack_uri VARCHAR(255),
   mpack_id BIGINT,
   CONSTRAINT PK_blueprint_mpack_inst PRIMARY KEY (id),
   CONSTRAINT FK_mpi_blueprint_name FOREIGN KEY (blueprint_name) REFERENCES blueprint(blueprint_name),

--- a/ambari-server/src/main/resources/key_properties.json
+++ b/ambari-server/src/main/resources/key_properties.json
@@ -123,9 +123,6 @@
     "Cluster": "RequestSchedule/cluster_name",
     "RequestSchedule": "RequestSchedule/id"
   },
-  "Blueprint": {
-    "Blueprint": "Blueprints/blueprint_name"
-  },
   "Recommendation": {
     "Recommendation": "Recommendation/id",
     "Stack": "Versions/stack_name",

--- a/ambari-server/src/main/resources/properties.json
+++ b/ambari-server/src/main/resources/properties.json
@@ -369,19 +369,6 @@
         "RootServiceHostComponents/component_version",
         "RootServiceHostComponents/properties"
      ],
-    "Blueprint":[
-        "Blueprints/blueprint_name",
-        "Blueprints/stack_name",
-        "Blueprints/stack_version",
-        "Blueprints/security",
-        "host_groups",
-        "host_groups/components",
-        "host_groups/cardinality",
-        "configurations",
-        "validate_topology",
-        "settings",
-        "mpack_instances"
-    ],
     "Recommendation":[
         "Recommendation/id",
         "Versions/stack_name",

--- a/ambari-server/src/main/resources/properties.json
+++ b/ambari-server/src/main/resources/properties.json
@@ -369,18 +369,6 @@
         "RootServiceHostComponents/component_version",
         "RootServiceHostComponents/properties"
      ],
-    "Blueprint":[
-        "Blueprints/blueprint_name",
-        "Blueprints/stack_name",
-        "Blueprints/stack_version",
-        "Blueprints/security",
-        "host_groups",
-        "host_groups/components",
-        "host_groups/cardinality",
-        "configurations",
-        "validate_topology",
-        "settings"
-    ],
     "Recommendation":[
         "Recommendation/id",
         "Versions/stack_name",

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -230,7 +230,7 @@ if has_hbase_masters:
 repo_info = config['hostLevelParams']['repo_info']
 service_repo_info = default("/hostLevelParams/service_repo_info",None)
 
-user_to_groups_dict = {}
+user_to_groups_dict = collections.defaultdict(lambda:())
 
 #Append new user-group mapping to the dict
 try:
@@ -242,7 +242,7 @@ except ValueError:
 
 user_to_gid_dict = collections.defaultdict(lambda:user_group)
 
-user_list = json.loads(config['hostLevelParams']['user_list'])
+user_list = set(json.loads(config['hostLevelParams']['user_list']) + [smoke_user])
 group_list = set(json.loads(config['hostLevelParams']['group_list']) + [user_group])
 host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
 

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -230,7 +230,7 @@ if has_hbase_masters:
 repo_info = config['hostLevelParams']['repo_info']
 service_repo_info = default("/hostLevelParams/service_repo_info",None)
 
-user_to_groups_dict = {}
+user_to_groups_dict = collections.defaultdict(lambda:())
 
 #Append new user-group mapping to the dict
 try:
@@ -242,8 +242,8 @@ except ValueError:
 
 user_to_gid_dict = collections.defaultdict(lambda:user_group)
 
-user_list = json.loads(config['hostLevelParams']['user_list'])
-group_list = json.loads(config['hostLevelParams']['group_list'])
+user_list = set(json.loads(config['hostLevelParams']['user_list']) + [smoke_user])
+group_list = set(json.loads(config['hostLevelParams']['group_list']) + [user_group])
 host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
 
 tez_am_view_acls = config['configurations']['tez-site']["tez.am.view-acls"]

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -230,7 +230,7 @@ if has_hbase_masters:
 repo_info = config['hostLevelParams']['repo_info']
 service_repo_info = default("/hostLevelParams/service_repo_info",None)
 
-user_to_groups_dict = collections.defaultdict(lambda:())
+user_to_groups_dict = {}
 
 #Append new user-group mapping to the dict
 try:
@@ -242,7 +242,7 @@ except ValueError:
 
 user_to_gid_dict = collections.defaultdict(lambda:user_group)
 
-user_list = set(json.loads(config['hostLevelParams']['user_list']) + [smoke_user])
+user_list = json.loads(config['hostLevelParams']['user_list'])
 group_list = set(json.loads(config['hostLevelParams']['group_list']) + [user_group])
 host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
 

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -243,7 +243,7 @@ except ValueError:
 user_to_gid_dict = collections.defaultdict(lambda:user_group)
 
 user_list = json.loads(config['hostLevelParams']['user_list'])
-group_list = json.loads(config['hostLevelParams']['group_list'])
+group_list = set(json.loads(config['hostLevelParams']['group_list']) + [user_group])
 host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
 
 tez_am_view_acls = config['configurations']['tez-site']["tez.am.view-acls"]

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorHelperTest.java
@@ -42,6 +42,8 @@ import org.apache.ambari.server.state.ServiceInfo;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * StackAdvisorHelper unit tests.
  */
@@ -112,8 +114,11 @@ public class StackAdvisorHelperTest {
     StackAdvisorCommand<RecommendationResponse> command = mock(StackAdvisorCommand.class);
     RecommendationResponse expected = mock(RecommendationResponse.class);
     StackAdvisorRequestType requestType = StackAdvisorRequestType.HOST_GROUPS;
-    StackAdvisorRequest request = StackAdvisorRequestBuilder.forStack("stackName", "stackVersion")
-        .ofType(requestType).build();
+    StackAdvisorRequest request = StackAdvisorRequestBuilder
+      .forStack("stackName", "stackVersion")
+      .forServices(ImmutableSet.of("ZOOKEEPER"))
+      .ofType(requestType)
+      .build();
 
     when(command.invoke(request, ServiceInfo.ServiceAdvisorType.PYTHON)).thenReturn(expected);
     doReturn(command).when(helper).createRecommendationCommand("ZOOKEEPER", request);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BaseBlueprintProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BaseBlueprintProcessorTest.java
@@ -1,8 +1,5 @@
 package org.apache.ambari.server.controller.internal;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.isA;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collection;
@@ -11,11 +8,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.StackLevelConfigurationRequest;
-import org.apache.ambari.server.controller.StackServiceResponse;
 import org.apache.ambari.server.state.DependencyInfo;
-import org.easymock.EasyMockSupport;
+import org.apache.ambari.server.state.StackInfo;
 import org.junit.Test;
 
 /**
@@ -42,15 +36,7 @@ public class BaseBlueprintProcessorTest {
   //todo: BaseBluprintProcess no longer exists.
   @Test
   public void testStackRegisterConditionalDependencies() throws Exception {
-    EasyMockSupport mockSupport = new EasyMockSupport();
-    AmbariManagementController mockMgmtController = mockSupport.createMock(AmbariManagementController.class);
-
-    // setup mock expectations
-    expect(mockMgmtController.getStackServices(isA(Set.class))).andReturn(
-        Collections.<StackServiceResponse> emptySet());
-
-    expect(mockMgmtController.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
+    StackInfo stackInfo = new StackInfo();
 
         // test dependencies
     final DependencyInfo hCatDependency = new TestDependencyInfo("HIVE/HCAT");
@@ -63,10 +49,8 @@ public class BaseBlueprintProcessorTest {
     final DependencyInfo oozieClientDependency = new TestDependencyInfo(
         "OOZIE/OOZIE_CLIENT");
 
-    mockSupport.replayAll();
-
     // create stack for testing
-    Stack testStack = new Stack("HDP", "2.1", mockMgmtController) {
+    Stack testStack = new Stack(stackInfo) {
       @Override
       public Collection<DependencyInfo> getDependenciesForComponent(
           String component) {
@@ -138,22 +122,10 @@ public class BaseBlueprintProcessorTest {
         "OOZIE",
         testStack.getDependencyConditionalServiceMap().get(
             oozieClientDependency));
-
-    mockSupport.verifyAll();
   }
 
   @Test
   public void testStackRegisterConditionalDependenciesNoHCAT() throws Exception {
-    EasyMockSupport mockSupport = new EasyMockSupport();
-    AmbariManagementController mockMgmtController = mockSupport.createMock(AmbariManagementController.class);
-
-    // setup mock expectations
-    expect(mockMgmtController.getStackServices(isA(Set.class))).andReturn(
-        Collections.<StackServiceResponse> emptySet());
-
-    expect(mockMgmtController.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-
     // test dependencies
     final DependencyInfo yarnClientDependency = new TestDependencyInfo(
         "YARN/YARN_CLIENT");
@@ -164,10 +136,8 @@ public class BaseBlueprintProcessorTest {
     final DependencyInfo oozieClientDependency = new TestDependencyInfo(
         "OOZIE/OOZIE_CLIENT");
 
-    mockSupport.replayAll();
-
     // create stack for testing
-    Stack testStack = new Stack("HDP", "2.1", mockMgmtController) {
+    Stack testStack = new Stack(new StackInfo()) {
       @Override
       public Collection<DependencyInfo> getDependenciesForComponent(
           String component) {
@@ -236,23 +206,11 @@ public class BaseBlueprintProcessorTest {
         "OOZIE",
         testStack.getDependencyConditionalServiceMap().get(
             oozieClientDependency));
-
-    mockSupport.verifyAll();
   }
 
   @Test
   public void testStackRegisterConditionalDependenciesNoYarnClient()
       throws Exception {
-    EasyMockSupport mockSupport = new EasyMockSupport();
-    AmbariManagementController mockMgmtController = mockSupport.createMock(AmbariManagementController.class);
-
-    // setup mock expectations
-    expect(mockMgmtController.getStackServices(isA(Set.class))).andReturn(
-        Collections.<StackServiceResponse> emptySet());
-
-    expect(mockMgmtController.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-
     // test dependencies
     final DependencyInfo hCatDependency = new TestDependencyInfo("HIVE/HCAT");
     final DependencyInfo tezClientDependency = new TestDependencyInfo(
@@ -262,10 +220,8 @@ public class BaseBlueprintProcessorTest {
     final DependencyInfo oozieClientDependency = new TestDependencyInfo(
         "OOZIE/OOZIE_CLIENT");
 
-    mockSupport.replayAll();
-
     // create stack for testing
-    Stack testStack = new Stack("HDP", "2.1", mockMgmtController) {
+    Stack testStack = new Stack(new StackInfo()) {
       @Override
       public Collection<DependencyInfo> getDependenciesForComponent(
           String component) {
@@ -332,23 +288,11 @@ public class BaseBlueprintProcessorTest {
         "OOZIE",
         testStack.getDependencyConditionalServiceMap().get(
             oozieClientDependency));
-
-    mockSupport.verifyAll();
   }
 
   @Test
   public void testStackRegisterConditionalDependenciesNoTezClient()
       throws Exception {
-    EasyMockSupport mockSupport = new EasyMockSupport();
-    AmbariManagementController mockMgmtController = mockSupport.createMock(AmbariManagementController.class);
-
-    // setup mock expectations
-    expect(mockMgmtController.getStackServices(isA(Set.class))).andReturn(
-        Collections.<StackServiceResponse> emptySet());
-
-    expect(mockMgmtController.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-
     // test dependencies
     final DependencyInfo hCatDependency = new TestDependencyInfo("HIVE/HCAT");
     final DependencyInfo yarnClientDependency = new TestDependencyInfo(
@@ -358,10 +302,8 @@ public class BaseBlueprintProcessorTest {
     final DependencyInfo oozieClientDependency = new TestDependencyInfo(
         "OOZIE/OOZIE_CLIENT");
 
-    mockSupport.replayAll();
-
     // create stack for testing
-    Stack testStack = new Stack("HDP", "2.1", mockMgmtController) {
+    Stack testStack = new Stack(new StackInfo()) {
       @Override
       public Collection<DependencyInfo> getDependenciesForComponent(
           String component) {
@@ -430,23 +372,11 @@ public class BaseBlueprintProcessorTest {
         "OOZIE",
         testStack.getDependencyConditionalServiceMap().get(
             oozieClientDependency));
-
-    mockSupport.verifyAll();
   }
 
   @Test
   public void testStackRegisterConditionalDependenciesNoMapReduceClient()
       throws Exception {
-    EasyMockSupport mockSupport = new EasyMockSupport();
-    AmbariManagementController mockMgmtController = mockSupport.createMock(AmbariManagementController.class);
-
-    // setup mock expectations
-    expect(mockMgmtController.getStackServices(isA(Set.class))).andReturn(
-        Collections.<StackServiceResponse> emptySet());
-
-    expect(mockMgmtController.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-
     // test dependencies
     final DependencyInfo hCatDependency = new TestDependencyInfo("HIVE/HCAT");
     final DependencyInfo yarnClientDependency = new TestDependencyInfo(
@@ -456,10 +386,8 @@ public class BaseBlueprintProcessorTest {
     final DependencyInfo oozieClientDependency = new TestDependencyInfo(
         "OOZIE/OOZIE_CLIENT");
 
-    mockSupport.replayAll();
-
     // create stack for testing
-    Stack testStack = new Stack("HDP", "2.1", mockMgmtController) {
+    Stack testStack = new Stack(new StackInfo()) {
       @Override
       public Collection<DependencyInfo> getDependenciesForComponent(
           String component) {
@@ -526,23 +454,11 @@ public class BaseBlueprintProcessorTest {
         "OOZIE",
         testStack.getDependencyConditionalServiceMap().get(
             oozieClientDependency));
-
-    mockSupport.verifyAll();
   }
 
   @Test
   public void testStackRegisterConditionalDependenciesNoOozieClient()
       throws Exception {
-    EasyMockSupport mockSupport = new EasyMockSupport();
-    AmbariManagementController mockMgmtController = mockSupport.createMock(AmbariManagementController.class);
-
-    // setup mock expectations
-    expect(mockMgmtController.getStackServices(isA(Set.class))).andReturn(
-        Collections.<StackServiceResponse> emptySet());
-
-    expect(mockMgmtController.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-
     // test dependencies
     final DependencyInfo hCatDependency = new TestDependencyInfo("HIVE/HCAT");
     final DependencyInfo yarnClientDependency = new TestDependencyInfo(
@@ -552,10 +468,8 @@ public class BaseBlueprintProcessorTest {
     final DependencyInfo mapReduceTwoClientDependency = new TestDependencyInfo(
         "YARN/MAPREDUCE2_CLIENT");
 
-    mockSupport.replayAll();
-
     // create stack for testing
-    Stack testStack = new Stack("HDP", "2.1", mockMgmtController) {
+    Stack testStack = new Stack(new StackInfo()) {
       @Override
       public Collection<DependencyInfo> getDependenciesForComponent(
           String component) {
@@ -622,230 +536,7 @@ public class BaseBlueprintProcessorTest {
         "MAPREDUCE2",
         testStack.getDependencyConditionalServiceMap().get(
             mapReduceTwoClientDependency));
-
-    mockSupport.verifyAll();
   }
-
-
- //todo: validate method moved
-//  @Test
-//  public void testValidationOverrideForSecondaryNameNodeWithHA() throws Exception {
-//    EasyMockSupport mockSupport = new EasyMockSupport();
-//
-//    AmbariManagementController mockController =
-//      mockSupport.createMock(AmbariManagementController.class);
-//
-//    AmbariMetaInfo mockMetaInfo =
-//      mockSupport.createMock(AmbariMetaInfo.class);
-//
-//    BaseBlueprintProcessor.stackInfo = mockMetaInfo;
-//
-//    ServiceInfo serviceInfo = new ServiceInfo();
-//    serviceInfo.setName("HDFS");
-//
-//    StackServiceResponse stackServiceResponse =
-//      new StackServiceResponse(serviceInfo);
-//
-//    ComponentInfo componentInfo = new ComponentInfo();
-//    componentInfo.setName("SECONDARY_NAMENODE");
-//    // simulate the stack requirements that there
-//    // always be one SECONDARY_NAMENODE per cluster
-//    componentInfo.setCardinality("1");
-//
-//    StackServiceComponentResponse stackComponentResponse =
-//      new StackServiceComponentResponse(componentInfo);
-//
-//    ComponentInfo componentInfoNameNode = new ComponentInfo();
-//    componentInfoNameNode.setName("NAMENODE");
-//    componentInfo.setCardinality("1-2");
-//    StackServiceComponentResponse stackServiceComponentResponseTwo =
-//      new StackServiceComponentResponse(componentInfoNameNode);
-//
-//    Set<StackServiceComponentResponse> responses =
-//      new HashSet<StackServiceComponentResponse>();
-//    responses.add(stackComponentResponse);
-//    responses.add(stackServiceComponentResponseTwo);
-//
-//    expect(mockController.getStackServices(isA(Set.class))).andReturn(
-//      Collections.singleton(stackServiceResponse));
-//    expect(mockController.getStackComponents(isA(Set.class))).andReturn(
-//      responses);
-//    expect(mockController.getStackConfigurations(isA(Set.class))).andReturn(Collections.<StackConfigurationResponse>emptySet());
-//    expect(mockController.getStackLevelConfigurations(isA(Set.class))).andReturn(Collections.<StackConfigurationResponse>emptySet());
-//
-//    expect(mockMetaInfo.getComponentDependencies("HDP", "2.0.6", "HDFS", "SECONDARY_NAMENODE")).andReturn(Collections.<DependencyInfo>emptyList());
-//    expect(mockMetaInfo.getComponentDependencies("HDP", "2.0.6", "HDFS", "NAMENODE")).andReturn(Collections.<DependencyInfo>emptyList());
-//
-//
-//    mockSupport.replayAll();
-//
-//    BaseBlueprintProcessor baseBlueprintProcessor =
-//      new BaseBlueprintProcessor(Collections.<String>emptySet(), Collections.<Resource.Type, String>emptyMap(), mockController) {
-//        @Override
-//        protected Set<String> getPKPropertyIds() {
-//          return null;
-//        }
-//
-//        @Override
-//        public RequestStatus createResources(Request request) throws SystemException, UnsupportedPropertyException, ResourceAlreadyExistsException, NoSuchParentResourceException {
-//          return null;
-//        }
-//
-//        @Override
-//        public Set<Resource> getResources(Request request, Predicate predicate) throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-//          return null;
-//        }
-//
-//        @Override
-//        public RequestStatus updateResources(Request request, Predicate predicate) throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-//          return null;
-//        }
-//
-//        @Override
-//        public RequestStatus deleteResources(Predicate predicate) throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-//          return null;
-//        }
-//      };
-//
-//    HostGroupComponentEntity hostGroupComponentEntity =
-//      new HostGroupComponentEntity();
-//    // don't include the SECONDARY_NAMENODE in this entity
-//    hostGroupComponentEntity.setName("NAMENODE");
-//
-//    HostGroupEntity hostGroupEntity =
-//      new HostGroupEntity();
-//    hostGroupEntity.setName("host-group-one");
-//    hostGroupEntity.setComponents(Collections.singleton(hostGroupComponentEntity));
-//    hostGroupEntity.setConfigurations(Collections.<HostGroupConfigEntity>emptyList());
-//
-//    // setup config entity to simulate the case of NameNode HA being enabled
-//    BlueprintConfigEntity configEntity =
-//      new BlueprintConfigEntity();
-//    configEntity.setConfigData("{\"dfs.nameservices\":\"mycluster\",\"key4\":\"value4\"}");
-//    configEntity.setType("hdfs-site");
-//
-//    BlueprintEntity testEntity =
-//      new BlueprintEntity();
-//    testEntity.setBlueprintName("test-blueprint");
-//    testEntity.setStackName("HDP");
-//    testEntity.setStackVersion("2.0.6");
-//    testEntity.setHostGroups(Collections.singleton(hostGroupEntity));
-//    testEntity.setConfigurations(Collections.singleton(configEntity));
-//
-//    baseBlueprintProcessor.validateTopology(testEntity);
-//
-//    mockSupport.verifyAll();
-//  }
-
-//  @Test
-//  public void testValidationOverrideForSecondaryNameNodeWithoutHA() throws Exception {
-//    EasyMockSupport mockSupport = new EasyMockSupport();
-//
-//    AmbariManagementController mockController =
-//      mockSupport.createMock(AmbariManagementController.class);
-//
-//    AmbariMetaInfo mockMetaInfo =
-//      mockSupport.createMock(AmbariMetaInfo.class);
-//
-//    BaseBlueprintProcessor.stackInfo = mockMetaInfo;
-//
-//    ServiceInfo serviceInfo = new ServiceInfo();
-//    serviceInfo.setName("HDFS");
-//
-//    StackServiceResponse stackServiceResponse =
-//      new StackServiceResponse(serviceInfo);
-//
-//    ComponentInfo componentInfo = new ComponentInfo();
-//    componentInfo.setName("SECONDARY_NAMENODE");
-//    // simulate the stack requirements that there
-//    // always be one SECONDARY_NAMENODE per cluster
-//    componentInfo.setCardinality("1");
-//
-//    StackServiceComponentResponse stackComponentResponse =
-//      new StackServiceComponentResponse(componentInfo);
-//
-//    ComponentInfo componentInfoNameNode = new ComponentInfo();
-//    componentInfoNameNode.setName("NAMENODE");
-//    componentInfo.setCardinality("1-2");
-//    StackServiceComponentResponse stackServiceComponentResponseTwo =
-//      new StackServiceComponentResponse(componentInfoNameNode);
-//
-//    Set<StackServiceComponentResponse> responses =
-//      new HashSet<StackServiceComponentResponse>();
-//    responses.add(stackComponentResponse);
-//    responses.add(stackServiceComponentResponseTwo);
-//
-//    expect(mockController.getStackServices(isA(Set.class))).andReturn(
-//      Collections.singleton(stackServiceResponse));
-//    expect(mockController.getStackComponents(isA(Set.class))).andReturn(
-//      responses);
-//    expect(mockController.getStackConfigurations(isA(Set.class))).andReturn(Collections.<StackConfigurationResponse>emptySet());
-//    expect(mockController.getStackLevelConfigurations(isA(Set.class))).andReturn(Collections.<StackConfigurationResponse>emptySet());
-//
-//    expect(mockMetaInfo.getComponentDependencies("HDP", "2.0.6", "HDFS", "SECONDARY_NAMENODE")).andReturn(Collections.<DependencyInfo>emptyList());
-//    expect(mockMetaInfo.getComponentDependencies("HDP", "2.0.6", "HDFS", "NAMENODE")).andReturn(Collections.<DependencyInfo>emptyList());
-//
-//
-//    mockSupport.replayAll();
-//
-//    BaseBlueprintProcessor baseBlueprintProcessor =
-//      new BaseBlueprintProcessor(Collections.<String>emptySet(), Collections.<Resource.Type, String>emptyMap(), mockController) {
-//        @Override
-//        protected Set<String> getPKPropertyIds() {
-//          return null;
-//        }
-//
-//        @Override
-//        public RequestStatus createResources(Request request) throws SystemException, UnsupportedPropertyException, ResourceAlreadyExistsException, NoSuchParentResourceException {
-//          return null;
-//        }
-//
-//        @Override
-//        public Set<Resource> getResources(Request request, Predicate predicate) throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-//          return null;
-//        }
-//
-//        @Override
-//        public RequestStatus updateResources(Request request, Predicate predicate) throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-//          return null;
-//        }
-//
-//        @Override
-//        public RequestStatus deleteResources(Predicate predicate) throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-//          return null;
-//        }
-//      };
-//
-//    HostGroupComponentEntity hostGroupComponentEntity =
-//      new HostGroupComponentEntity();
-//    // don't include the SECONDARY_NAMENODE in this entity
-//    hostGroupComponentEntity.setName("NAMENODE");
-//
-//    HostGroupEntity hostGroupEntity =
-//      new HostGroupEntity();
-//    hostGroupEntity.setName("host-group-one");
-//    hostGroupEntity.setComponents(Collections.singleton(hostGroupComponentEntity));
-//    hostGroupEntity.setConfigurations(Collections.<HostGroupConfigEntity>emptyList());
-//
-//
-//
-//    BlueprintEntity testEntity =
-//      new BlueprintEntity();
-//    testEntity.setBlueprintName("test-blueprint");
-//    testEntity.setStackName("HDP");
-//    testEntity.setStackVersion("2.0.6");
-//    testEntity.setHostGroups(Collections.singleton(hostGroupEntity));
-//    testEntity.setConfigurations(Collections.<BlueprintConfigEntity>emptyList());
-//
-//    try {
-//      baseBlueprintProcessor.validateTopology(testEntity);
-//      fail("IllegalArgumentException should have been thrown");
-//    } catch (IllegalArgumentException expectedException) {
-//      // expected exception
-//    }
-//
-//    mockSupport.verifyAll();
-//  }
 
   /**
    * Convenience class for easier setup/initialization of dependencies for unit

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -145,7 +145,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
   @Before
   public void init() throws Exception {
     expect(bp.getStack()).andReturn(stack).anyTimes();
-    expect(bp.getStackId()).andReturn(STACK_ID).anyTimes();
+    expect(bp.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(bp.getName()).andReturn("test-bp").anyTimes();
 
     expect(stack.getName()).andReturn(STACK_NAME).atLeastOnce();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -104,6 +104,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
   private final String STACK_NAME = "testStack";
   private final String STACK_VERSION = "1";
+  private final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -144,6 +145,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
   @Before
   public void init() throws Exception {
     expect(bp.getStack()).andReturn(stack).anyTimes();
+    expect(bp.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(bp.getName()).andReturn("test-bp").anyTimes();
 
     expect(stack.getName()).andReturn(STACK_NAME).atLeastOnce();
@@ -8232,7 +8234,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
       }
 
       //create host group which is set on topology
-      allHostGroups.put(hostGroup.name, new HostGroupImpl(hostGroup.name, "test-bp", Collections.singleton(stack),
+      allHostGroups.put(hostGroup.name, new HostGroupImpl(hostGroup.name, "test-bp", stack,
         componentList, EMPTY_CONFIG, "1"));
 
       hostGroupInfo.put(hostGroup.name, groupInfo);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -104,6 +104,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
   private final String STACK_NAME = "testStack";
   private final String STACK_VERSION = "1";
+  private final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -144,6 +145,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
   @Before
   public void init() throws Exception {
     expect(bp.getStack()).andReturn(stack).anyTimes();
+    expect(bp.getStackId()).andReturn(STACK_ID).anyTimes();
     expect(bp.getName()).andReturn("test-bp").anyTimes();
 
     expect(stack.getName()).andReturn(STACK_NAME).atLeastOnce();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintResourceProviderTest.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.controller.internal;
 
 import static org.easymock.EasyMock.anyBoolean;
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.createStrictMock;
@@ -47,6 +48,7 @@ import java.util.Set;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.ResourceProviderFactory;
 import org.apache.ambari.server.controller.internal.BlueprintResourceProvider.BlueprintConfigPopulationStrategy;
 import org.apache.ambari.server.controller.internal.BlueprintResourceProvider.BlueprintConfigPopulationStrategyV1;
 import org.apache.ambari.server.controller.internal.BlueprintResourceProvider.BlueprintConfigPopulationStrategyV2;
@@ -73,19 +75,17 @@ import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.BlueprintFactory;
+import org.apache.ambari.server.topology.BlueprintValidator;
 import org.apache.ambari.server.topology.InvalidTopologyException;
 import org.apache.ambari.server.topology.SecurityConfiguration;
 import org.apache.ambari.server.topology.SecurityConfigurationFactory;
 import org.apache.ambari.server.topology.Setting;
 import org.apache.ambari.server.utils.StageUtils;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import com.google.gson.Gson;
 
 /**
  * BlueprintResourceProvider unit tests.
@@ -98,18 +98,21 @@ public class BlueprintResourceProviderTest {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  private static final ResourceProviderFactory resourceProviderFactory = createNiceMock(ResourceProviderFactory.class);
   private final static BlueprintDAO dao = createStrictMock(BlueprintDAO.class);
   private final static BlueprintEntity entity = createStrictMock(BlueprintEntity.class);
   private final static Blueprint blueprint = createMock(Blueprint.class);
+  private final static BlueprintValidator blueprintValidator = createMock(BlueprintValidator.class);
   private final static AmbariMetaInfo metaInfo = createMock(AmbariMetaInfo.class);
   private final static BlueprintFactory blueprintFactory = createMock(BlueprintFactory.class);
   private final static SecurityConfigurationFactory securityFactory = createMock(SecurityConfigurationFactory.class);
   private final static BlueprintResourceProvider provider = createProvider();
-  private final static Gson gson = new Gson();
 
   @BeforeClass
   public static void initClass() {
-    BlueprintResourceProvider.init(blueprintFactory, dao, securityFactory, metaInfo);
+    AbstractControllerResourceProvider.init(resourceProviderFactory);
+    expect(resourceProviderFactory.getBlueprintResourceProvider(anyObject())).andReturn(provider).anyTimes();
+    replay(resourceProviderFactory);
   }
 
   private Map<String, Set<HashMap<String, String>>> getSettingProperties() {
@@ -118,7 +121,7 @@ public class BlueprintResourceProviderTest {
 
   @Before
   public void resetGlobalMocks() {
-    reset(dao, metaInfo, blueprintFactory, securityFactory, blueprint, entity);
+    reset(dao, metaInfo, blueprintFactory, securityFactory, blueprint, blueprintValidator, entity);
   }
 
   @Test
@@ -135,8 +138,8 @@ public class BlueprintResourceProviderTest {
     // set expectations
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), null)).andReturn(blueprint).once();
     expect(securityFactory.createSecurityConfigurationFromRequest(null, true)).andReturn(null).anyTimes();
-    blueprint.validateRequiredProperties();
-    blueprint.validateTopology();
+    blueprintValidator.validateRequiredProperties(blueprint);
+    blueprintValidator.validateTopology(blueprint);
     expect(blueprint.getSetting()).andReturn(setting).anyTimes();
     expect(setting.getProperties()).andReturn(settingProperties).anyTimes();
     expect(blueprint.toEntity()).andReturn(entity);
@@ -146,7 +149,7 @@ public class BlueprintResourceProviderTest {
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
     dao.create(entity);
 
-    replay(dao, entity, metaInfo, blueprintFactory, securityFactory, blueprint, setting, request, managementController);
+    replay(dao, entity, metaInfo, blueprintFactory, securityFactory, blueprint, blueprintValidator, setting, request, managementController);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -165,7 +168,7 @@ public class BlueprintResourceProviderTest {
     assertEquals(request, lastEvent.getRequest());
     assertNull(lastEvent.getPredicate());
 
-    verify(dao, entity, blueprintFactory, securityFactory, metaInfo, request, managementController);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, securityFactory, metaInfo, request, managementController);
   }
 
   @Test()
@@ -212,7 +215,7 @@ public class BlueprintResourceProviderTest {
 
     // set expectations
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), null)).andReturn(blueprint).once();
-    blueprint.validateRequiredProperties();
+    blueprintValidator.validateRequiredProperties(blueprint);
     expect(blueprint.getSetting()).andReturn(setting).anyTimes();
     expect(setting.getProperties()).andReturn(settingProperties).anyTimes();
     expect(blueprint.toEntity()).andReturn(entity);
@@ -222,7 +225,7 @@ public class BlueprintResourceProviderTest {
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
     dao.create(entity);
 
-    replay(dao, entity, metaInfo, blueprintFactory, blueprint, setting, request, managementController);
+    replay(dao, entity, metaInfo, blueprintFactory, blueprint, blueprintValidator, setting, request, managementController);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -241,7 +244,7 @@ public class BlueprintResourceProviderTest {
     assertEquals(request, lastEvent.getRequest());
     assertNull(lastEvent.getPredicate());
 
-    verify(dao, entity, blueprintFactory, metaInfo, request, managementController);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request, managementController);
   }
 
   @Test
@@ -253,16 +256,16 @@ public class BlueprintResourceProviderTest {
 
     // set expectations
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), null)).andReturn(blueprint).once();
-    blueprint.validateRequiredProperties();
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).atLeastOnce();
-    blueprint.validateTopology();
-    expectLastCall().andThrow(new InvalidTopologyException("test"));
+    blueprintValidator.validateRequiredProperties(blueprint);
+    blueprintValidator.validateTopology(blueprint);
+    expectLastCall().andThrow(new InvalidTopologyException("test")).once();
 
     expect(request.getProperties()).andReturn(setProperties);
     expect(request.getRequestInfoProperties()).andReturn(requestInfoProperties);
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
 
-    replay(dao, entity, metaInfo, blueprintFactory, blueprint, request);
+    replay(dao, entity, metaInfo, blueprintFactory, blueprint, blueprintValidator, request);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -279,7 +282,7 @@ public class BlueprintResourceProviderTest {
       // expected
     }
 
-    verify(dao, entity, blueprintFactory, metaInfo, request);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request);
   }
 
 
@@ -296,8 +299,8 @@ public class BlueprintResourceProviderTest {
 
     // set expectations
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), null)).andReturn(blueprint).once();
-    blueprint.validateRequiredProperties();
-    blueprint.validateTopology();
+    blueprintValidator.validateRequiredProperties(blueprint);
+    blueprintValidator.validateTopology(blueprint);
     expect(blueprint.getSetting()).andReturn(setting).anyTimes();
     expect(setting.getProperties()).andReturn(settingProperties).anyTimes();
     expect(blueprint.toEntity()).andReturn(entity);
@@ -307,7 +310,7 @@ public class BlueprintResourceProviderTest {
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
     dao.create(entity);
 
-    replay(dao, entity, metaInfo, blueprintFactory, blueprint, setting, request, managementController);
+    replay(dao, entity, metaInfo, blueprintFactory, blueprint, blueprintValidator, setting, request, managementController);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -326,7 +329,7 @@ public class BlueprintResourceProviderTest {
     assertEquals(request, lastEvent.getRequest());
     assertNull(lastEvent.getPredicate());
 
-    verify(dao, entity, blueprintFactory, metaInfo, request, managementController);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request, managementController);
   }
 
   @Test
@@ -346,7 +349,7 @@ public class BlueprintResourceProviderTest {
     expect(request.getProperties()).andReturn(setProperties);
     expect(request.getRequestInfoProperties()).andReturn(requestInfoProperties);
 
-    replay(dao, entity, metaInfo, blueprintFactory, securityFactory, blueprint, request);
+    replay(dao, entity, metaInfo, blueprintFactory, securityFactory, blueprint, blueprintValidator, request);
     // end expectations
 
     try {
@@ -355,7 +358,7 @@ public class BlueprintResourceProviderTest {
     } catch (IllegalArgumentException e) {
       // expected
     }
-    verify(dao, entity, blueprintFactory, metaInfo, request);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request);
   }
 
   @Test
@@ -370,11 +373,11 @@ public class BlueprintResourceProviderTest {
     SecurityConfiguration securityConfiguration = new SecurityConfiguration(SecurityType.KERBEROS, "testRef", null);
 
     // set expectations
-    expect(securityFactory.createSecurityConfigurationFromRequest(EasyMock.anyObject(), anyBoolean())).andReturn
+    expect(securityFactory.createSecurityConfigurationFromRequest(anyObject(), anyBoolean())).andReturn
       (securityConfiguration).once();
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), securityConfiguration)).andReturn(blueprint).once();
-    blueprint.validateRequiredProperties();
-    blueprint.validateTopology();
+    blueprintValidator.validateRequiredProperties(blueprint);
+    blueprintValidator.validateTopology(blueprint);
     expect(blueprint.getSetting()).andReturn(setting).anyTimes();
     expect(setting.getProperties()).andReturn(settingProperties).anyTimes();
     expect(blueprint.toEntity()).andReturn(entity);
@@ -384,7 +387,7 @@ public class BlueprintResourceProviderTest {
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
     dao.create(entity);
 
-    replay(dao, entity, metaInfo, blueprintFactory, securityFactory, blueprint, setting, request, managementController);
+    replay(dao, entity, metaInfo, blueprintFactory, securityFactory, blueprint, blueprintValidator, setting, request, managementController);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -403,7 +406,7 @@ public class BlueprintResourceProviderTest {
     assertEquals(request, lastEvent.getRequest());
     assertNull(lastEvent.getPredicate());
 
-    verify(dao, entity, blueprintFactory, metaInfo, request, managementController);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request, managementController);
   }
 
   @Test
@@ -499,8 +502,8 @@ public class BlueprintResourceProviderTest {
 
     // set expectations
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), null)).andReturn(blueprint).once();
-    blueprint.validateRequiredProperties();
-    blueprint.validateTopology();
+    blueprintValidator.validateRequiredProperties(blueprint);
+    blueprintValidator.validateTopology(blueprint);
     expect(blueprint.getSetting()).andReturn(setting).anyTimes();
     expect(setting.getProperties()).andReturn(settingProperties).anyTimes();
     expect(blueprint.toEntity()).andReturn(entity);
@@ -510,7 +513,7 @@ public class BlueprintResourceProviderTest {
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
     dao.create(entity);
 
-    replay(dao, entity, metaInfo, blueprintFactory, blueprint, setting, request, managementController);
+    replay(dao, entity, metaInfo, blueprintFactory, blueprint, blueprintValidator, setting, request, managementController);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -529,7 +532,7 @@ public class BlueprintResourceProviderTest {
     assertEquals(request, lastEvent.getRequest());
     assertNull(lastEvent.getPredicate());
 
-    verify(dao, entity, blueprintFactory, metaInfo, request, managementController);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request, managementController);
   }
 
   @Test
@@ -546,8 +549,8 @@ public class BlueprintResourceProviderTest {
 
     // set expectations
     expect(blueprintFactory.createBlueprint(setProperties.iterator().next(), null)).andReturn(blueprint).once();
-    blueprint.validateRequiredProperties();
-    blueprint.validateTopology();
+    blueprintValidator.validateRequiredProperties(blueprint);
+    blueprintValidator.validateTopology(blueprint);
     expect(blueprint.getSetting()).andReturn(setting).anyTimes();
     expect(setting.getProperties()).andReturn(settingProperties).anyTimes();
     expect(blueprint.toEntity()).andReturn(entity);
@@ -557,7 +560,7 @@ public class BlueprintResourceProviderTest {
     expect(dao.findByName(BLUEPRINT_NAME)).andReturn(null);
     dao.create(entity);
 
-    replay(dao, entity, metaInfo, blueprintFactory, blueprint, setting, request, managementController);
+    replay(dao, entity, metaInfo, blueprintFactory, blueprint, blueprintValidator, setting, request, managementController);
     // end expectations
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
@@ -576,7 +579,7 @@ public class BlueprintResourceProviderTest {
     assertEquals(request, lastEvent.getRequest());
     assertNull(lastEvent.getPredicate());
 
-    verify(dao, entity, blueprintFactory, metaInfo, request, managementController);
+    verify(dao, entity, blueprintFactory, blueprint, blueprintValidator, metaInfo, request, managementController);
   }
 
   @Test
@@ -795,10 +798,6 @@ public class BlueprintResourceProviderTest {
 
   }
 
-  private static BlueprintResourceProvider createProvider() {
-    return new BlueprintResourceProvider(null);
-  }
-
   private BlueprintEntity createEntity(Map<String, Object> properties) {
     BlueprintEntity entity = new BlueprintEntity();
     entity.setBlueprintName((String) properties.get(BlueprintResourceProvider.BLUEPRINT_NAME_PROPERTY_ID));
@@ -841,7 +840,7 @@ public class BlueprintResourceProviderTest {
 
     Collection<Map<String, String>> configProperties = (Collection<Map<String, String>>) properties.get(
         BlueprintResourceProvider.CONFIGURATION_PROPERTY_ID);
-    createProvider().createBlueprintConfigEntities(configProperties, entity);
+    provider.createBlueprintConfigEntities(configProperties, entity);
     return entity;
   }
 
@@ -1207,6 +1206,10 @@ public class BlueprintResourceProviderTest {
     assertEquals(setting3value.get(1).get("name"), "KAFKA_CLIENT");
     assertTrue(setting3value.get(1).containsKey("recovery_enabled"));
     assertEquals(setting3value.get(1).get("recovery_enabled"), "false");
+  }
+
+  private static BlueprintResourceProvider createProvider() {
+    return new BlueprintResourceProvider(blueprintValidator, blueprintFactory, dao, securityFactory, metaInfo, null);
   }
 }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintResourceProviderTest.java
@@ -108,15 +108,14 @@ public class BlueprintResourceProviderTest {
   private final static AmbariMetaInfo metaInfo = createMock(AmbariMetaInfo.class);
   private final static BlueprintFactory blueprintFactory = createMock(BlueprintFactory.class);
   private final static SecurityConfigurationFactory securityFactory = createMock(SecurityConfigurationFactory.class);
-  private final static BlueprintResourceProvider provider = new BlueprintResourceProvider(blueprintValidator, null);
   private final static Gson gson = new Gson();
+  private final static BlueprintResourceProvider provider = createProvider();
 
   @BeforeClass
   public static void initClass() {
     AbstractControllerResourceProvider.init(resourceProviderFactory);
     expect(resourceProviderFactory.getBlueprintResourceProvider(anyObject())).andReturn(provider).anyTimes();
     replay(resourceProviderFactory);
-    BlueprintResourceProvider.init(blueprintFactory, dao, securityFactory, gson, metaInfo);
   }
 
   private Map<String, Set<HashMap<String, String>>> getSettingProperties() {
@@ -1210,6 +1209,10 @@ public class BlueprintResourceProviderTest {
     assertEquals(setting3value.get(1).get("name"), "KAFKA_CLIENT");
     assertTrue(setting3value.get(1).containsKey("recovery_enabled"));
     assertEquals(setting3value.get(1).get("recovery_enabled"), "false");
+  }
+
+  private static BlueprintResourceProvider createProvider() {
+    return new BlueprintResourceProvider(blueprintValidator, blueprintFactory, dao, securityFactory, gson, metaInfo, null);
   }
 }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompositeStackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompositeStackTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.controller.internal;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.ambari.server.stack.StackManager;
+import org.apache.ambari.server.stack.StackManagerTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CompositeStackTest {
+
+  private static Set<Stack> elements;
+  private static StackDefinition composite;
+
+  @BeforeClass
+  public static void initStack() throws Exception{
+    StackManager stackManager = StackManagerTest.createTestStackManager();
+    elements = stackManager.getStacksByName().values().stream()
+      .flatMap(stacks -> stacks.stream().limit(1))
+      .filter(Objects::nonNull)
+      .map(Stack::new)
+      .collect(toSet());
+    composite = StackDefinition.of(elements);
+  }
+
+  @Test
+  public void getStackIds() {
+    assertEquals(elements.size(), composite.getStackIds().size());
+  }
+
+  @Test
+  public void getServices() {
+    Set<String> services = new HashSet<>(composite.getServices());
+    for (Stack stack : elements) {
+      assertTrue(services.containsAll(stack.getServices()));
+    }
+    for (Stack stack : elements) {
+      services.removeAll(stack.getServices());
+    }
+    assertEquals(emptySet(), services);
+  }
+
+  // TODO add more tests after StackDefinition interface is finalized
+
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompositeStackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompositeStackTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.ambari.server.stack.StackManager;
 import org.apache.ambari.server.stack.StackManagerTest;
+import org.apache.ambari.server.state.StackId;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -62,6 +63,46 @@ public class CompositeStackTest {
       services.removeAll(stack.getServices());
     }
     assertEquals(emptySet(), services);
+  }
+
+  @Test
+  public void getComponents() {
+    Set<String> components = new HashSet<>(composite.getComponents());
+    for (Stack stack : elements) {
+      assertTrue(components.containsAll(stack.getComponents()));
+    }
+    for (Stack stack : elements) {
+      components.removeAll(stack.getComponents());
+    }
+    assertEquals(emptySet(), components);
+  }
+
+  @Test
+  public void getStacksForService() {
+    Set<String> services = new HashSet<>(composite.getServices());
+    for (String service : services) {
+      Set<StackId> stackIds = new HashSet<>();
+      for (Stack stack : elements) {
+        if (stack.getServices().contains(service)) {
+          stackIds.add(stack.getStackId());
+        }
+      }
+      assertEquals(service, stackIds, composite.getStacksForService(service));
+    }
+  }
+
+  @Test
+  public void getStacksForComponent() {
+    Set<String> components = new HashSet<>(composite.getComponents());
+    for (String component : components) {
+      Set<StackId> stackIds = new HashSet<>();
+      for (Stack stack : elements) {
+        if (stack.getComponents().contains(component)) {
+          stackIds.add(stack.getStackId());
+        }
+      }
+      assertEquals(component, stackIds, composite.getStacksForComponent(component));
+    }
   }
 
   // TODO add more tests after StackDefinition interface is finalized

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ExportBlueprintRequestTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
@@ -39,14 +38,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.api.util.TreeNode;
 import org.apache.ambari.server.api.util.TreeNodeImpl;
 import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.StackLevelConfigurationRequest;
-import org.apache.ambari.server.controller.StackServiceRequest;
 import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.HostGroup;
 import org.apache.ambari.server.topology.HostGroupInfo;
@@ -76,11 +74,14 @@ public class ExportBlueprintRequestTest {
     f.setAccessible(true);
     f.set(null, controller);
 
-    expect(controller.getStackServices((Set<StackServiceRequest>)  anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-    expect(controller.getStackLevelConfigurations((Set<StackLevelConfigurationRequest>) anyObject())).andReturn(
-        Collections.emptySet()).anyTimes();
-    replay(controller);
+    AmbariMetaInfo metainfo = createNiceMock(AmbariMetaInfo.class);
+    expect(controller.getAmbariMetaInfo()).andReturn(metainfo).anyTimes();
+    StackInfo stackInfo = createNiceMock(StackInfo.class);
+    expect(metainfo.getStack("TEST", "1.0")).andReturn(stackInfo);
+    expect(stackInfo.getServices()).andReturn(Collections.emptySet()).anyTimes();
+    expect(stackInfo.getProperties()).andReturn(Collections.emptyList()).anyTimes();
+
+    replay(controller, metainfo, stackInfo);
 
     // This can save precious time
     mockStatic(InetAddress.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackTest.java
@@ -18,119 +18,175 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import static org.easymock.EasyMock.capture;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toSet;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.powermock.api.easymock.PowerMock.createNiceMock;
-import static org.powermock.api.easymock.PowerMock.replay;
-import static org.powermock.api.easymock.PowerMock.verifyAll;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import org.apache.ambari.server.api.services.AmbariMetaInfo;
-import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.StackConfigurationRequest;
-//import org.apache.ambari.server.controller.StackConfigurationResponse;
-import org.apache.ambari.server.controller.StackLevelConfigurationRequest;
 import org.apache.ambari.server.controller.StackLevelConfigurationResponse;
-import org.apache.ambari.server.controller.StackServiceComponentRequest;
-import org.apache.ambari.server.controller.StackServiceComponentResponse;
-import org.apache.ambari.server.controller.StackServiceRequest;
-import org.apache.ambari.server.controller.StackServiceResponse;
+import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.PropertyDependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Configuration;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
+import org.apache.commons.lang3.tuple.Pair;
 import org.easymock.EasyMockSupport;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 
 /**
  * Stack unit tests.
  */
 public class StackTest {
 
+  private static final String STACK_CONFIG_TYPE = "cluster-env";
+  private static final String STACK_CONFIG_FILE = STACK_CONFIG_TYPE + ".xml";
+  private static final String SERVICE_CONFIG_TYPE = "test-site";
+  private static final String SERVICE_CONFIG_FILE = SERVICE_CONFIG_TYPE + ".xml";
+
+  private StackInfo stackInfo;
+  private ServiceInfo serviceInfo;
+  private ComponentInfo componentInfo;
+  private PropertyInfo serviceLevelProperty;
+  private PropertyInfo stackLevelProperty;
+  private PropertyInfo optionalServiceLevelProperty;
+  private PropertyInfo passwordProperty;
+
+  @Before
+  public void setUp() {
+    stackInfo = new StackInfo();
+    stackInfo.setName("stack name");
+    stackInfo.setVersion("1.0");
+
+    serviceInfo = new ServiceInfo();
+    serviceInfo.setName("some service");
+    stackInfo.getServices().add(serviceInfo);
+
+    componentInfo = new ComponentInfo();
+    componentInfo.setName("some component");
+    serviceInfo.getComponents().add(componentInfo);
+
+    serviceLevelProperty = new PropertyInfo();
+    serviceLevelProperty.setName("service_level");
+    serviceLevelProperty.setValue("service-level value");
+    serviceLevelProperty.setFilename(SERVICE_CONFIG_FILE);
+    serviceLevelProperty.setRequireInput(true);
+    serviceLevelProperty.getPropertyTypes().add(PropertyInfo.PropertyType.TEXT);
+    serviceInfo.getProperties().add(serviceLevelProperty);
+
+    passwordProperty = new PropertyInfo();
+    passwordProperty.setName("a_password");
+    passwordProperty.setValue("secret");
+    passwordProperty.setFilename(SERVICE_CONFIG_FILE);
+    passwordProperty.setRequireInput(true);
+    passwordProperty.getPropertyTypes().add(PropertyInfo.PropertyType.PASSWORD);
+    serviceInfo.getProperties().add(passwordProperty);
+
+    optionalServiceLevelProperty = new PropertyInfo();
+    optionalServiceLevelProperty.setName("optional_service_level");
+    optionalServiceLevelProperty.setValue("service-level value (optional)");
+    optionalServiceLevelProperty.setFilename(SERVICE_CONFIG_FILE);
+    optionalServiceLevelProperty.setRequireInput(false);
+    optionalServiceLevelProperty.getPropertyTypes().add(PropertyInfo.PropertyType.USER);
+    serviceInfo.getProperties().add(optionalServiceLevelProperty);
+
+    stackLevelProperty = new PropertyInfo();
+    stackLevelProperty.setName("stack_level");
+    stackLevelProperty.setValue("stack-level value");
+    stackLevelProperty.setFilename(STACK_CONFIG_FILE);
+    stackLevelProperty.setRequireInput(true);
+    stackLevelProperty.getPropertyTypes().add(PropertyInfo.PropertyType.TEXT);
+    stackInfo.getProperties().add(stackLevelProperty);
+  }
+
   @Test
-  public void testTestXmlExtensionStrippedOff() throws Exception {
-    AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
-    AmbariMetaInfo metaInfo = createNiceMock(AmbariMetaInfo.class);
-    Capture<Set<StackServiceRequest>> stackServiceRequestCapture = EasyMock.newCapture();
-    StackServiceResponse stackServiceResponse = createNiceMock(StackServiceResponse.class);
-    Capture<Set<StackServiceComponentRequest>> stackComponentRequestCapture = EasyMock.newCapture();
-    StackServiceComponentResponse stackComponentResponse = createNiceMock(StackServiceComponentResponse.class);
-    Capture<Set<StackConfigurationRequest>> stackConfigurationRequestCapture = EasyMock.newCapture();
-    Capture<Set<StackLevelConfigurationRequest>> stackLevelConfigurationRequestCapture = EasyMock.newCapture();
-    StackLevelConfigurationResponse stackConfigurationResponse = EasyMock.createNiceMock(StackLevelConfigurationResponse.class);
+  public void stackHasCorrectNameAndVersion() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
 
-    expect(controller.getStackServices(capture(stackServiceRequestCapture))).
-        andReturn(Collections.singleton(stackServiceResponse)).anyTimes();
+    // THEN
+    assertEquals(stackInfo.getName(), stack.getName());
+    assertEquals(stackInfo.getVersion(), stack.getVersion());
+  }
 
-    expect(controller.getAmbariMetaInfo()).andReturn(metaInfo).anyTimes();
+  @Test
+  public void getServices() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
 
-    expect(stackServiceResponse.getServiceName()).andReturn("service1").anyTimes();
-    expect(stackServiceResponse.getExcludedConfigTypes()).andReturn(Collections.emptySet());
-    expect(stackServiceResponse.getConfigTypes()).andReturn(Collections.emptyMap());
+    // WHEN
+    Collection<String> services = stack.getServices();
 
-    expect(controller.getStackComponents(capture(stackComponentRequestCapture))).
-        andReturn(Collections.singleton(stackComponentResponse)).anyTimes();
+    // THEN
+    assertEquals(ImmutableSet.of(serviceInfo.getName()), ImmutableSet.copyOf(services));
+  }
 
-    expect(stackComponentResponse.getComponentName()).andReturn("component1").anyTimes();
-    expect(stackComponentResponse.getComponentCategory()).andReturn("test-site.xml").anyTimes();
+  @Test
+  public void configTypeOmitsFileExtension() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
 
-    expect(controller.getStackConfigurations(capture(stackConfigurationRequestCapture))).
-        andReturn(Collections.singleton(stackConfigurationResponse)).anyTimes();
+    // WHEN
+    Configuration configuration = stack.getConfiguration(singleton(serviceInfo.getName()));
 
-    // no stack level configs for this test
-    expect(controller.getStackLevelConfigurations(capture(stackLevelConfigurationRequestCapture))).
-        andReturn(Collections.emptySet()).anyTimes();
+    // THEN
+    assertEquals(serviceLevelProperty.getValue(), configuration.getProperties().get(SERVICE_CONFIG_TYPE).get(serviceLevelProperty.getName()));
+  }
 
-    expect(stackConfigurationResponse.getPropertyName()).andReturn("prop1").anyTimes();
-    expect(stackConfigurationResponse.getPropertyValue()).andReturn("prop1Val").anyTimes();
-    expect(stackConfigurationResponse.getType()).andReturn("test-site.xml").anyTimes();
-    expect(stackConfigurationResponse.getPropertyType()).andReturn(
-        Collections.emptySet()).anyTimes();
-    expect(stackConfigurationResponse.getPropertyAttributes()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(stackConfigurationResponse.isRequired()).andReturn(true).anyTimes();
+  @Test
+  public void getRequiredPropertiesForService() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
 
-    expect(metaInfo.getComponentDependencies("test", "1.0", "service1", "component1")).
-        andReturn(Collections.emptyList()).anyTimes();
+    // WHEN
+    Collection<Stack.ConfigProperty> requiredConfigurationProperties = stack.getRequiredConfigurationProperties(serviceInfo.getName());
 
+    // THEN
+    // should include stack-level property
+    // should exclude optional property
+    Set<Pair<String, String>> actualRequiredProperties = convertToPropertySet(requiredConfigurationProperties);
+    Set<Pair<String, String>> expected = ImmutableSet.of(
+      Pair.of(STACK_CONFIG_TYPE, stackLevelProperty.getName()),
+      Pair.of(SERVICE_CONFIG_TYPE, passwordProperty.getName()),
+      Pair.of(SERVICE_CONFIG_TYPE, serviceLevelProperty.getName())
+    );
+    assertEquals(expected, actualRequiredProperties);
+    assertEquals(expected.size(), requiredConfigurationProperties.size());
+  }
 
-    replay(controller, stackServiceResponse, stackComponentResponse, stackConfigurationResponse, metaInfo);
+  @Test
+  public void getRequiredPropertiesForServiceAndType() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
 
+    // WHEN
+    Collection<Stack.ConfigProperty> requiredConfigurationProperties = stack.getRequiredConfigurationProperties(serviceInfo.getName(), PropertyInfo.PropertyType.TEXT);
 
-    Stack stack = new Stack("test", "1.0", controller);
-    Configuration configuration = stack.getConfiguration(Collections.singleton("service1"));
-    assertEquals("prop1Val", configuration.getProperties().get("test-site").get("prop1"));
-
-    assertEquals("test-site", stack.getRequiredConfigurationProperties("service1").iterator().next().getType());
-
-    // assertions
-    StackServiceRequest stackServiceRequest = stackServiceRequestCapture.getValue().iterator().next();
-    assertEquals("test", stackServiceRequest.getStackName());
-    assertEquals("1.0", stackServiceRequest.getStackVersion());
-
-    StackServiceComponentRequest stackComponentRequest = stackComponentRequestCapture.getValue().iterator().next();
-    assertEquals("service1", stackComponentRequest.getServiceName());
-    assertEquals("test", stackComponentRequest.getStackName());
-    assertEquals("1.0", stackComponentRequest.getStackVersion());
-    assertNull(stackComponentRequest.getComponentName());
+    // THEN
+    Set<Pair<String, String>> actualRequiredProperties = convertToPropertySet(requiredConfigurationProperties);
+    Set<Pair<String, String>> expected = ImmutableSet.of(
+      Pair.of(STACK_CONFIG_TYPE, stackLevelProperty.getName()),
+      Pair.of(SERVICE_CONFIG_TYPE, serviceLevelProperty.getName())
+    );
+    assertEquals(expected, actualRequiredProperties);
+    assertEquals(expected.size(), requiredConfigurationProperties.size());
   }
 
   @Test
   public void testConfigPropertyReadsInDependencies() throws Exception {
+    // FIXME get rid of mock
     EasyMockSupport mockSupport = new EasyMockSupport();
 
     Set<PropertyDependencyInfo> setOfDependencyInfo = new HashSet<>();
@@ -158,221 +214,106 @@ public class StackTest {
   }
 
   @Test
-  public void testGetRequiredProperties_serviceAndPropertyType() throws Exception {
-    AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
-    AmbariMetaInfo metaInfo = createNiceMock(AmbariMetaInfo.class);
-    Capture<Set<StackServiceRequest>> stackServiceRequestCapture = EasyMock.newCapture();
-    StackServiceResponse stackServiceResponse = createNiceMock(StackServiceResponse.class);
-    Capture<Set<StackServiceComponentRequest>> stackComponentRequestCapture = EasyMock.newCapture();
-    StackServiceComponentResponse stackComponentResponse = createNiceMock(StackServiceComponentResponse.class);
-    Capture<Set<StackConfigurationRequest>> stackConfigurationRequestCapture = EasyMock.newCapture();
-    Capture<Set<StackLevelConfigurationRequest>> stackLevelConfigurationRequestCapture = EasyMock.newCapture();
-    StackLevelConfigurationResponse stackConfigurationResponse = EasyMock.createNiceMock(StackLevelConfigurationResponse.class);
-    StackLevelConfigurationResponse stackConfigurationResponse2 = EasyMock.createNiceMock(StackLevelConfigurationResponse.class);
+  public void getAllConfigurationTypesReturnsExcludedOnesToo() throws Exception {
+    // GIVEN
+    serviceInfo.setExcludedConfigTypes(ImmutableSet.of(SERVICE_CONFIG_TYPE));
+    Stack stack = new Stack(stackInfo);
 
-    expect(controller.getStackServices(capture(stackServiceRequestCapture))).
-        andReturn(Collections.singleton(stackServiceResponse)).anyTimes();
+    // WHEN
+    Collection<String> allConfigurationTypes = stack.getAllConfigurationTypes(serviceInfo.getName());
 
-    expect(controller.getAmbariMetaInfo()).andReturn(metaInfo).anyTimes();
-
-    expect(stackServiceResponse.getServiceName()).andReturn("service1").anyTimes();
-    expect(stackServiceResponse.getExcludedConfigTypes()).andReturn(Collections.emptySet());
-    expect(stackServiceResponse.getConfigTypes()).andReturn(Collections.emptyMap());
-
-    expect(controller.getStackComponents(capture(stackComponentRequestCapture))).
-        andReturn(Collections.singleton(stackComponentResponse)).anyTimes();
-
-    expect(stackComponentResponse.getComponentName()).andReturn("component1").anyTimes();
-    expect(stackComponentResponse.getComponentCategory()).andReturn("test-site.xml").anyTimes();
-
-    expect(controller.getStackConfigurations(capture(stackConfigurationRequestCapture))).
-        andReturn(new HashSet<>(Arrays.asList(
-          stackConfigurationResponse, stackConfigurationResponse2))).anyTimes();
-
-    // no stack level configs for this test
-    expect(controller.getStackLevelConfigurations(capture(stackLevelConfigurationRequestCapture))).
-        andReturn(Collections.emptySet()).anyTimes();
-
-    expect(stackConfigurationResponse.getPropertyName()).andReturn("prop1").anyTimes();
-    expect(stackConfigurationResponse.getPropertyValue()).andReturn(null).anyTimes();
-    expect(stackConfigurationResponse.getType()).andReturn("test-site.xml").anyTimes();
-    expect(stackConfigurationResponse.getPropertyType()).andReturn(
-        Collections.singleton(PropertyInfo.PropertyType.PASSWORD)).anyTimes();
-    expect(stackConfigurationResponse.getPropertyAttributes()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(stackConfigurationResponse.isRequired()).andReturn(true).anyTimes();
-
-    // not a PASSWORD property type so shouldn't be returned
-    expect(stackConfigurationResponse2.getPropertyName()).andReturn("prop2").anyTimes();
-    expect(stackConfigurationResponse2.getPropertyValue()).andReturn(null).anyTimes();
-    expect(stackConfigurationResponse2.getType()).andReturn("test-site.xml").anyTimes();
-    expect(stackConfigurationResponse2.getPropertyType()).andReturn(
-        Collections.singleton(PropertyInfo.PropertyType.USER)).anyTimes();
-    expect(stackConfigurationResponse2.getPropertyAttributes()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(stackConfigurationResponse2.isRequired()).andReturn(true).anyTimes();
-
-    expect(metaInfo.getComponentDependencies("test", "1.0", "service1", "component1")).
-        andReturn(Collections.emptyList()).anyTimes();
-
-    replay(controller, stackServiceResponse, stackComponentResponse, stackConfigurationResponse,
-        stackConfigurationResponse2, metaInfo);
-
-    // test
-    Stack stack = new Stack("test", "1.0", controller);
-    // get required password properties
-    Collection<Stack.ConfigProperty> requiredPasswordProperties = stack.getRequiredConfigurationProperties(
-        "service1", PropertyInfo.PropertyType.PASSWORD);
-
-    // assertions
-    assertEquals(1, requiredPasswordProperties.size());
-    Stack.ConfigProperty requiredPasswordConfigProperty = requiredPasswordProperties.iterator().next();
-    assertEquals("test-site", requiredPasswordConfigProperty.getType());
-    assertEquals("prop1", requiredPasswordConfigProperty.getName());
-    assertTrue(requiredPasswordConfigProperty.getPropertyTypes().contains(PropertyInfo.PropertyType.PASSWORD));
-
-    StackServiceRequest stackServiceRequest = stackServiceRequestCapture.getValue().iterator().next();
-    assertEquals("test", stackServiceRequest.getStackName());
-    assertEquals("1.0", stackServiceRequest.getStackVersion());
-
-    StackServiceComponentRequest stackComponentRequest = stackComponentRequestCapture.getValue().iterator().next();
-    assertEquals("service1", stackComponentRequest.getServiceName());
-    assertEquals("test", stackComponentRequest.getStackName());
-    assertEquals("1.0", stackComponentRequest.getStackVersion());
-    assertNull(stackComponentRequest.getComponentName());
+    // THEN
+    Set<String> expected = ImmutableSet.of(SERVICE_CONFIG_TYPE, STACK_CONFIG_TYPE);
+    assertEquals(expected, allConfigurationTypes);
   }
 
-  // Test that getAllConfigurationTypes returns beside the configuration types that have
-  // service config properties defined also the empty ones that doesn't have any config
-  // property defined.
   @Test
-  public void testGetAllConfigurationTypesWithEmptyStackServiceConfigType() throws Exception {
-    // Given
-    AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
-    AmbariMetaInfo metaInfo = createNiceMock(AmbariMetaInfo.class);
-    StackServiceResponse stackServiceResponse = createNiceMock(StackServiceResponse.class);
-    StackServiceComponentResponse stackComponentResponse = createNiceMock(StackServiceComponentResponse.class);
-    StackLevelConfigurationResponse stackConfigurationResponse1 = createNiceMock(StackLevelConfigurationResponse.class);
-    StackLevelConfigurationResponse stackConfigurationResponse2 = createNiceMock(StackLevelConfigurationResponse.class);
+  public void getConfigurationTypesOmitsExcludedOnes() throws Exception {
+    // GIVEN
+    serviceInfo.setExcludedConfigTypes(ImmutableSet.of(SERVICE_CONFIG_TYPE));
+    Stack stack = new Stack(stackInfo);
 
-    String testServiceName = "service1";
-    String testEmptyConfigType = "test-empty-config-type";
-    String testSiteConfigFile = "test-site.xml";
-    String testSiteConfigType = "test-site";
+    // WHEN
+    Collection<String> allConfigurationTypes = stack.getConfigurationTypes(serviceInfo.getName());
 
-
-    expect(controller.getAmbariMetaInfo()).andReturn(metaInfo).anyTimes();
-
-    expect(controller.getStackServices(EasyMock.anyObject())).andReturn(Collections.singleton(stackServiceResponse)).anyTimes();
-    expect(stackServiceResponse.getServiceName()).andReturn(testServiceName).anyTimes();
-    expect(stackServiceResponse.getExcludedConfigTypes()).andReturn(Collections.emptySet());
-
-    // stack components
-    expect(stackComponentResponse.getComponentName()).andReturn("component1").anyTimes();
-    expect(stackComponentResponse.getComponentCategory()).andReturn(testSiteConfigFile).anyTimes();
-    expect(controller.getStackComponents(EasyMock.anyObject())).andReturn(Collections.singleton(stackComponentResponse)).anyTimes();
-
-    // stack configurations
-
-    // two properties with config type 'test-site'
-    expect(stackConfigurationResponse1.getPropertyName()).andReturn("prop1").anyTimes();
-    expect(stackConfigurationResponse1.getPropertyValue()).andReturn(null).anyTimes();
-    expect(stackConfigurationResponse1.getType()).andReturn(testSiteConfigFile).anyTimes();
-    expect(stackConfigurationResponse1.getPropertyType()).andReturn(Collections.singleton(PropertyInfo.PropertyType.TEXT)).anyTimes();
-    expect(stackConfigurationResponse1.getPropertyAttributes()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(stackConfigurationResponse1.isRequired()).andReturn(true).anyTimes();
-
-    expect(stackConfigurationResponse2.getPropertyName()).andReturn("prop2").anyTimes();
-    expect(stackConfigurationResponse2.getPropertyValue()).andReturn(null).anyTimes();
-    expect(stackConfigurationResponse2.getType()).andReturn(testSiteConfigFile).anyTimes();
-    expect(stackConfigurationResponse2.getPropertyType()).andReturn(Collections.singleton(PropertyInfo.PropertyType.USER)).anyTimes();
-    expect(stackConfigurationResponse2.getPropertyAttributes()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(stackConfigurationResponse2.isRequired()).andReturn(true).anyTimes();
-
-    expect(controller.getStackConfigurations(EasyMock.anyObject())).andReturn(Sets.newHashSet(stackConfigurationResponse1, stackConfigurationResponse2)).anyTimes();
-
-    // empty stack service config type
-    expect(stackServiceResponse.getConfigTypes()).andReturn(Collections.singletonMap(testEmptyConfigType, Collections.emptyMap()));
-
-    // no stack level configs for this test
-    expect(controller.getStackLevelConfigurations(EasyMock.anyObject())).andReturn(Collections.emptySet()).anyTimes();
-
-    expect(metaInfo.getComponentDependencies("test", "1.0", "service1", "component1")).andReturn(Collections.emptyList()).anyTimes();
-
-    replay(controller, stackServiceResponse, stackComponentResponse, stackConfigurationResponse1, stackConfigurationResponse2, metaInfo);
-
-
-    Stack stack = new Stack("test", "1.0", controller);
-
-    // When
-    Collection<String> allServiceConfigTypes = stack.getAllConfigurationTypes(testServiceName);
-
-    // Then
-
-    assertTrue(allServiceConfigTypes.containsAll(ImmutableSet.of(testSiteConfigType, testEmptyConfigType)));
-    assertEquals(2, allServiceConfigTypes.size());
-
-    verifyAll();
+    // THEN
+    Set<String> expected = ImmutableSet.of(STACK_CONFIG_TYPE);
+    assertEquals(expected, allConfigurationTypes);
   }
 
-  // Test that getServiceForConfigType skips excluded config types.
   @Test
-  public void testGetServiceForConfigTypeWithExcludedConfigs() throws Exception {
-    // Given
-    AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
-    AmbariMetaInfo metaInfo = createNiceMock(AmbariMetaInfo.class);
-    StackServiceResponse stackServiceResponse = createNiceMock(StackServiceResponse.class);
-    StackServiceComponentResponse stackComponentResponse = createNiceMock(StackServiceComponentResponse.class);
-    StackLevelConfigurationResponse stackConfigurationResponse1 = createNiceMock(StackLevelConfigurationResponse.class);
+  public void findsServiceForValidConfigType() {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
 
-    String testServiceName = "service1";
-    String testEmptyConfigType = "test-empty-config-type";
-    String testSiteConfigFile = "test-site.xml";
-    String testSiteConfigType = "test-site";
+    // WHEN
+    String service = stack.getServiceForConfigType(SERVICE_CONFIG_TYPE);
 
-    expect(controller.getAmbariMetaInfo()).andReturn(metaInfo).anyTimes();
-
-    expect(controller.getStackServices(EasyMock.anyObject())).andReturn(Collections.singleton(stackServiceResponse)).anyTimes();
-    expect(stackServiceResponse.getServiceName()).andReturn(testServiceName).anyTimes();
-
-    // Config type test-site is excluded for the service service1
-    expect(stackServiceResponse.getExcludedConfigTypes()).andReturn(Collections.singleton(testSiteConfigType));
-
-    // stack components
-    expect(stackComponentResponse.getComponentName()).andReturn("component1").anyTimes();
-    expect(stackComponentResponse.getComponentCategory()).andReturn(testSiteConfigFile).anyTimes();
-    expect(controller.getStackComponents(EasyMock.anyObject())).andReturn(Collections.singleton(stackComponentResponse)).anyTimes();
-
-    expect(stackConfigurationResponse1.getPropertyName()).andReturn("prop1").anyTimes();
-    expect(stackConfigurationResponse1.getPropertyValue()).andReturn(null).anyTimes();
-    expect(stackConfigurationResponse1.getType()).andReturn(testSiteConfigFile).anyTimes();
-    expect(stackConfigurationResponse1.getPropertyType()).andReturn(Collections.singleton(PropertyInfo.PropertyType.TEXT)).anyTimes();
-    expect(stackConfigurationResponse1.getPropertyAttributes()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(stackConfigurationResponse1.isRequired()).andReturn(true).anyTimes();
-
-    expect(controller.getStackConfigurations(EasyMock.anyObject())).andReturn(Collections.singleton(stackConfigurationResponse1)).anyTimes();
-
-    // empty stack service config type
-    expect(stackServiceResponse.getConfigTypes()).andReturn(Collections.singletonMap(testEmptyConfigType, Collections.emptyMap()));
-
-    // no stack level configs for this test
-    expect(controller.getStackLevelConfigurations(EasyMock.anyObject())).andReturn(Collections.emptySet()).anyTimes();
-    expect(metaInfo.getComponentDependencies("test", "1.0", "service1", "component1")).andReturn(Collections.emptyList()).anyTimes();
-
-    replay(controller, stackServiceResponse, stackComponentResponse, stackConfigurationResponse1, metaInfo);
-
-    Stack stack = new Stack("test", "1.0", controller);
-
-    // When
-    try {
-      stack.getServiceForConfigType(testSiteConfigType);
-      fail("Exception not thrown");
-    } catch (IllegalArgumentException e) {
-      // Expected
-    }
-
-    // Not excluded config type
-    assertEquals(testServiceName, stack.getServiceForConfigType(testEmptyConfigType));
-
-    verifyAll();
+    // THEN
+    assertEquals(serviceInfo.getName(), service);
   }
 
+  @Test(expected = IllegalArgumentException.class) // THEN
+  public void serviceIsNotFoundForExcludedConfigType() {
+    // GIVEN
+    serviceInfo.setExcludedConfigTypes(ImmutableSet.of(SERVICE_CONFIG_TYPE));
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    stack.getServiceForConfigType(SERVICE_CONFIG_TYPE);
+  }
+
+  @Test(expected = IllegalArgumentException.class) // THEN
+  public void serviceIsNotFoundForUnknownConfigType() {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    stack.getServiceForConfigType("no_such_config_type");
+  }
+
+  @Test
+  public void findsAllServicesForValidConfigType() {
+    // GIVEN
+    ServiceInfo otherMatchingService = new ServiceInfo();
+    otherMatchingService.setName("matches");
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    Stream<String> services = stack.getServicesForConfigType(SERVICE_CONFIG_TYPE);
+
+    // THEN
+    Set<String> expected = ImmutableSet.of(serviceInfo.getName());
+    assertEquals(expected, services.collect(toSet()));
+  }
+
+  @Test
+  public void noServiceFoundForExcludedConfigType() {
+    // GIVEN
+    serviceInfo.setExcludedConfigTypes(ImmutableSet.of(SERVICE_CONFIG_TYPE));
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    Stream<String> services = stack.getServicesForConfigType(SERVICE_CONFIG_TYPE);
+
+    // THEN
+    assertEquals(emptySet(), services.collect(toSet()));
+  }
+
+  @Test
+  public void noServiceFoundForUnknownConfigType() {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    Stream<String> services = stack.getServicesForConfigType("no_such_config_type");
+
+    // THEN
+    assertEquals(emptySet(), services.collect(toSet()));
+  }
+
+  private static Set<Pair<String, String>> convertToPropertySet(Collection<Stack.ConfigProperty> requiredConfigurationProperties) {
+    return requiredConfigurationProperties
+      .stream().map(p -> Pair.of(p.getType(), p.getName())).collect(toSet());
+  }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
@@ -97,6 +97,7 @@ public class RoleCommandOrderTest {
     ClusterImpl cluster = createMock(ClusterImpl.class);
     Service service = createMock(Service.class);
     expect(service.getDesiredStackId()).andReturn(stackId);
+    expect(service.getServiceComponents()).andReturn(Collections.emptyMap());
     expect(cluster.getClusterId()).andReturn(1L);
     expect(cluster.getService("GLUSTERFS")).andReturn(service);
     expect(cluster.getService("HDFS")).andReturn(null);
@@ -149,6 +150,7 @@ public class RoleCommandOrderTest {
 
     expect(cluster.getService("HDFS")).andReturn(hdfsService).atLeastOnce();
     expect(cluster.getService("YARN")).andReturn(null).atLeastOnce();
+    expect(hdfsService.getServiceComponents()).andReturn(Collections.emptyMap());
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     expect(hdfsService.getDesiredStackId()).andReturn(new StackId("HDP", "2.0.6"));
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
@@ -196,6 +198,7 @@ public class RoleCommandOrderTest {
 
     expect(cluster.getService("HDFS")).andReturn(hdfsService).atLeastOnce();
     expect(cluster.getService("YARN")).andReturn(null);
+    expect(hdfsService.getServiceComponents()).andReturn(Collections.emptyMap());
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(journalnodeSC);
     expect(hdfsService.getDesiredStackId()).andReturn(new StackId("HDP", "2.0.6"));
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
@@ -245,6 +248,7 @@ public class RoleCommandOrderTest {
 
     expect(cluster.getService("YARN")).andReturn(yarnService).atLeastOnce();
     expect(cluster.getService("HDFS")).andReturn(null);
+    expect(yarnService.getServiceComponents()).andReturn(Collections.emptyMap());
     expect(yarnService.getServiceComponent("RESOURCEMANAGER")).andReturn(resourcemanagerSC).anyTimes();
     expect(resourcemanagerSC.getServiceComponentHosts()).andReturn(hostComponents).anyTimes();
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
@@ -301,6 +305,7 @@ public class RoleCommandOrderTest {
 
     expect(cluster.getService("YARN")).andReturn(yarnService).atLeastOnce();
     expect(cluster.getService("HDFS")).andReturn(null);
+    expect(yarnService.getServiceComponents()).andReturn(Collections.emptyMap());
     expect(yarnService.getServiceComponent("RESOURCEMANAGER")).andReturn(resourcemanagerSC).anyTimes();
     expect(yarnService.getDesiredStackId()).andReturn(new StackId("HDP", "2.0.6")).anyTimes();
     expect(resourcemanagerSC.getServiceComponentHosts()).andReturn(hostComponents).anyTimes();
@@ -398,6 +403,7 @@ public class RoleCommandOrderTest {
 
     expect(cluster.getService("HDFS")).andReturn(hdfsService).atLeastOnce();
     expect(cluster.getService("YARN")).andReturn(null);
+    expect(hdfsService.getServiceComponents()).andReturn(Collections.emptyMap());
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     //There is no rco file in this stack, should use default
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.5"));
@@ -490,6 +496,7 @@ public class RoleCommandOrderTest {
 
     expect(cluster.getService("HDFS")).andReturn(hdfsService).atLeastOnce();
     expect(cluster.getService("YARN")).andReturn(null).atLeastOnce();
+    expect(hdfsService.getServiceComponents()).andReturn(Collections.emptyMap()).anyTimes();
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     expect(hdfsService.getDesiredStackId()).andReturn(new StackId("HDP", "2.2.0")).anyTimes();
     expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -242,7 +242,6 @@ public class AmbariContextTest {
 
     expect(blueprint.getName()).andReturn(BP_NAME).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
     expect(blueprint.getStackIds()).andReturn(Collections.singleton(STACK_ID)).anyTimes();
     expect(blueprint.getServices()).andReturn(blueprintServices).anyTimes();
     expect(blueprint.getComponents("service1")).andReturn(Arrays.asList("s1Component1", "s1Component2")).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -242,6 +242,7 @@ public class AmbariContextTest {
 
     expect(blueprint.getName()).andReturn(BP_NAME).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackId()).andReturn(new StackId(STACK_NAME, STACK_VERSION)).anyTimes();
     expect(blueprint.getServices()).andReturn(blueprintServices).anyTimes();
     expect(blueprint.getComponents("service1")).andReturn(Arrays.asList("s1Component1", "s1Component2")).anyTimes();
     expect(blueprint.getComponents("service2")).andReturn(Collections.singleton("s2Component1")).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -246,6 +246,8 @@ public class AmbariContextTest {
     expect(blueprint.getServices()).andReturn(blueprintServices).anyTimes();
     expect(blueprint.getComponents("service1")).andReturn(Arrays.asList("s1Component1", "s1Component2")).anyTimes();
     expect(blueprint.getComponents("service2")).andReturn(Collections.singleton("s2Component1")).anyTimes();
+    expect(blueprint.getStackIdsForService("service1")).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
+    expect(blueprint.getStackIdsForService("service2")).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.getConfiguration()).andReturn(bpConfiguration).anyTimes();
     expect(blueprint.getCredentialStoreEnabled("service1")).andReturn("true").anyTimes();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ClusterRequest;
@@ -255,7 +256,7 @@ public class AmbariContextTest {
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
 
     for (Map.Entry<String, String> entry : configTypeServiceMapping.entrySet()) {
-      expect(stack.getServicesForConfigType(entry.getKey())).andReturn(singletonList(entry.getValue())).anyTimes();
+      expect(stack.getServicesForConfigType(entry.getKey())).andReturn(Stream.of(entry.getValue())).anyTimes();
     }
 
     expect(controller.getClusters()).andReturn(clusters).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ClusterRequest;
@@ -99,11 +100,11 @@ public class AmbariContextTest {
   private static final long CLUSTER_ID = 1L;
   private static final String STACK_NAME = "testStack";
   private static final String STACK_VERSION = "testVersion";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
   private static final String HOST_GROUP_1 = "group1";
   private static final String HOST_GROUP_2 = "group2";
   private static final String HOST1 = "host1";
   private static final String HOST2 = "host2";
-  StackId stackId = new StackId(STACK_NAME, STACK_VERSION);
 
   private static final AmbariContext context = new AmbariContext();
   private static final AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
@@ -242,9 +243,12 @@ public class AmbariContextTest {
 
     expect(blueprint.getName()).andReturn(BP_NAME).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(Collections.singleton(STACK_ID)).anyTimes();
     expect(blueprint.getServices()).andReturn(blueprintServices).anyTimes();
     expect(blueprint.getComponentNames("service1")).andReturn(Arrays.asList("s1Component1", "s1Component2")).anyTimes();
     expect(blueprint.getComponentNames("service2")).andReturn(Collections.singleton("s2Component1")).anyTimes();
+    expect(blueprint.getStackIdsForService("service1")).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
+    expect(blueprint.getStackIdsForService("service2")).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.getConfiguration()).andReturn(bpConfiguration).anyTimes();
     expect(blueprint.getCredentialStoreEnabled("service1")).andReturn("true").anyTimes();
 
@@ -252,7 +256,7 @@ public class AmbariContextTest {
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
 
     for (Map.Entry<String, String> entry : configTypeServiceMapping.entrySet()) {
-      expect(stack.getServicesForConfigType(entry.getKey())).andReturn(singletonList(entry.getValue())).anyTimes();
+      expect(stack.getServicesForConfigType(entry.getKey())).andReturn(Stream.of(entry.getValue())).anyTimes();
     }
 
     expect(controller.getClusters()).andReturn(clusters).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -99,11 +99,11 @@ public class AmbariContextTest {
   private static final long CLUSTER_ID = 1L;
   private static final String STACK_NAME = "testStack";
   private static final String STACK_VERSION = "testVersion";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
   private static final String HOST_GROUP_1 = "group1";
   private static final String HOST_GROUP_2 = "group2";
   private static final String HOST1 = "host1";
   private static final String HOST2 = "host2";
-  StackId stackId = new StackId(STACK_NAME, STACK_VERSION);
 
   private static final AmbariContext context = new AmbariContext();
   private static final AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
@@ -242,7 +242,8 @@ public class AmbariContextTest {
 
     expect(blueprint.getName()).andReturn(BP_NAME).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(new StackId(STACK_NAME, STACK_VERSION)).anyTimes();
+    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(Collections.singleton(STACK_ID)).anyTimes();
     expect(blueprint.getServices()).andReturn(blueprintServices).anyTimes();
     expect(blueprint.getComponents("service1")).andReturn(Arrays.asList("s1Component1", "s1Component2")).anyTimes();
     expect(blueprint.getComponents("service2")).andReturn(Collections.singleton("s2Component1")).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintFactoryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintFactoryTest.java
@@ -22,7 +22,6 @@ import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.createStrictMock;
 import static org.powermock.api.easymock.PowerMock.replay;
@@ -44,6 +43,7 @@ import org.apache.ambari.server.orm.dao.BlueprintDAO;
 import org.apache.ambari.server.orm.entities.BlueprintConfigEntity;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
 import org.apache.ambari.server.stack.NoSuchStackException;
+import org.apache.ambari.server.state.StackId;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
 import org.junit.Before;
@@ -77,6 +77,7 @@ public class BlueprintFactoryTest {
     componentMap.put("test-service2", components2);
     components2.add("component2");
 
+    expect(stack.getServices()).andReturn(componentMap.keySet()).anyTimes();
     expect(stack.getComponents()).andReturn(componentMap).anyTimes();
     expect(stack.isMasterComponent("component1")).andReturn(true).anyTimes();
     expect(stack.isMasterComponent("component2")).andReturn(false).anyTimes();
@@ -123,7 +124,6 @@ public class BlueprintFactoryTest {
     Blueprint blueprint = testFactory.createBlueprint(props, null);
 
     assertEquals(BLUEPRINT_NAME, blueprint.getName());
-    assertSame(stack, blueprint.getStack());
     assertEquals(2, blueprint.getHostGroups().size());
 
     Map<String, HostGroup> hostGroups = blueprint.getHostGroups();
@@ -176,7 +176,7 @@ public class BlueprintFactoryTest {
 
     BlueprintFactory factoryUnderTest =
       new BlueprintFactory(mockStackFactory);
-    factoryUnderTest.createStack(new HashMap<>());
+    factoryUnderTest.createStack(new StackId("null", "null"));
 
     mockSupport.verifyAll();
   }
@@ -240,7 +240,7 @@ public class BlueprintFactoryTest {
     }
 
     @Override
-    protected Stack createStack(Map<String, Object> properties) throws NoSuchStackException {
+    protected Stack createStack(StackId stackId) throws NoSuchStackException {
       return stack;
     }
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintFactoryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintFactoryTest.java
@@ -170,13 +170,13 @@ public class BlueprintFactoryTest {
       mockSupport.createMock(BlueprintFactory.StackFactory.class);
 
     // setup mock to throw exception, to simulate invalid stack request
-    expect(mockStackFactory.createStack("null", "null", null)).andThrow(new ObjectNotFoundException("Invalid Stack"));
+    expect(mockStackFactory.createStack(new StackId(), null)).andThrow(new ObjectNotFoundException("Invalid Stack"));
 
     mockSupport.replayAll();
 
     BlueprintFactory factoryUnderTest =
       new BlueprintFactory(mockStackFactory);
-    factoryUnderTest.createStack(new StackId("null", "null"));
+    factoryUnderTest.createStack(new StackId());
 
     mockSupport.verifyAll();
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintImplTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.topology;
 
+import static java.util.Collections.emptySet;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
@@ -124,7 +125,7 @@ public class BlueprintImplTest {
     category2Props.put("prop2", "val");
 
     SecurityConfiguration securityConfiguration = new SecurityConfiguration(SecurityType.KERBEROS, "testRef", null);
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, securityConfiguration);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, securityConfiguration, null);
     blueprint.validateRequiredProperties();
     BlueprintEntity entity = blueprint.toEntity();
 
@@ -162,7 +163,7 @@ public class BlueprintImplTest {
     hadoopProps.put("dfs_ha_initial_namenode_active", "%HOSTGROUP:group1%");
     hadoopProps.put("dfs_ha_initial_namenode_standby", "%HOSTGROUP:group2%");
     replay(stack, group1, group2, serverConfig);
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, null);
     blueprint.validateRequiredProperties();
     BlueprintEntity entity = blueprint.toEntity();
     verify(stack, group1, group2, serverConfig);
@@ -202,7 +203,7 @@ public class BlueprintImplTest {
     hadoopProps.put("dfs_ha_initial_namenode_standby", "%HOSTGROUP::group2%");
     replay(stack, group1, group2, serverConfig);
 
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, null);
     blueprint.validateRequiredProperties();
     BlueprintEntity entity = blueprint.toEntity();
 
@@ -243,7 +244,7 @@ public class BlueprintImplTest {
     hadoopProps.put("dfs_ha_initial_namenode_active", "%HOSTGROUP::group2%");
     hadoopProps.put("dfs_ha_initial_namenode_standby", "%HOSTGROUP::group3%");
     replay(stack, group1, group2, serverConfig);
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, null);
     blueprint.validateRequiredProperties();
     verify(stack, group1, group2, serverConfig);
   }
@@ -279,7 +280,7 @@ public class BlueprintImplTest {
     hadoopProps.put("dfs_ha_initial_namenode_active", "%HOSTGROUP::group2%");
     hadoopProps.put("dfs_ha_initial_namenode_standby", "%HOSTGROUP::group2%");
     replay(stack, group1, group2, serverConfig);
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, null);
     blueprint.validateRequiredProperties();
     verify(stack, group1, group2, serverConfig);
   }
@@ -294,7 +295,7 @@ public class BlueprintImplTest {
     hdfsProps.put("secret", "SECRET:hdfs-site:1:test");
     replay(stack, group1, group2, serverConfig);
 
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, null);
     blueprint.validateRequiredProperties();
     verify(stack, group1, group2, serverConfig);
   }
@@ -311,7 +312,7 @@ public class BlueprintImplTest {
     serverConfig = setupConfigurationWithGPLLicense(false);
     replay(stack, group1, group2, serverConfig);
 
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, lzoUsageConfiguration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), lzoUsageConfiguration, null, null);
     blueprint.validateRequiredProperties();
     verify(stack, group1, group2, serverConfig);
   }
@@ -328,7 +329,7 @@ public class BlueprintImplTest {
     serverConfig = setupConfigurationWithGPLLicense(false);
     replay(stack, group1, group2, serverConfig);
 
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, lzoUsageConfiguration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), lzoUsageConfiguration, null, null);
     blueprint.validateRequiredProperties();
     verify(stack, group1, group2, serverConfig);
   }
@@ -346,14 +347,14 @@ public class BlueprintImplTest {
     expect(group2.getConfiguration()).andReturn(EMPTY_CONFIGURATION).atLeastOnce();
     replay(stack, group1, group2, serverConfig);
 
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, lzoUsageConfiguration, null);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), lzoUsageConfiguration, null, null);
     blueprint.validateRequiredProperties();
     verify(stack, group1, group2, serverConfig);
   }
 
   @Test
   public void testAutoSkipFailureEnabled() {
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null, setting);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, setting);
     HashMap<String, String> skipFailureSetting = new HashMap<>();
     skipFailureSetting.put(Setting.SETTING_NAME_SKIP_FAILURE, "true");
     expect(setting.getSettingValue(Setting.SETTING_NAME_DEPLOYMENT_SETTINGS)).andReturn(Collections.singleton(skipFailureSetting));
@@ -365,7 +366,7 @@ public class BlueprintImplTest {
 
   @Test
   public void testAutoSkipFailureDisabled() {
-    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, null, setting);
+    Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, emptySet(), configuration, null, setting);
     HashMap<String, String> skipFailureSetting = new HashMap<>();
     skipFailureSetting.put(Setting.SETTING_NAME_SKIP_FAILURE, "false");
     expect(setting.getSettingValue(Setting.SETTING_NAME_DEPLOYMENT_SETTINGS)).andReturn(Collections.singleton(skipFailureSetting));

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintValidatorImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintValidatorImplTest.java
@@ -37,6 +37,7 @@ import org.apache.ambari.server.state.AutoDeployInfo;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.DependencyConditionInfo;
 import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.StackId;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRule;
 import org.easymock.Mock;
@@ -98,6 +99,7 @@ public class BlueprintValidatorImplTest {
     autoDeploy.setEnabled(true);
     autoDeploy.setCoLocate("service1/component2");
 
+    expect(blueprint.getStackId()).andReturn(new StackId("HDP", "2.2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
     expect(blueprint.getHostGroups()).andReturn(hostGroups).anyTimes();
     expect(blueprint.getServices()).andReturn(services).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintValidatorImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintValidatorImplTest.java
@@ -47,6 +47,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * BlueprintValidatorImpl unit tests.
  */
@@ -99,7 +101,7 @@ public class BlueprintValidatorImplTest {
     autoDeploy.setEnabled(true);
     autoDeploy.setCoLocate("service1/component2");
 
-    expect(blueprint.getStackId()).andReturn(new StackId("HDP", "2.2")).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(new StackId("HDP", "2.2"))).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
     expect(blueprint.getHostGroups()).andReturn(hostGroups).anyTimes();
     expect(blueprint.getServices()).andReturn(services).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintValidatorImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintValidatorImplTest.java
@@ -144,8 +144,8 @@ public class BlueprintValidatorImplTest {
     expect(blueprint.getHostGroupsForComponent("component2")).andReturn(Arrays.asList(group1, group2)).anyTimes();
 
     replay(blueprint, stack, group1, group2, dependency1);
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
   }
 
   @Test(expected = InvalidTopologyException.class)
@@ -160,8 +160,8 @@ public class BlueprintValidatorImplTest {
     expect(blueprint.getHostGroupsForComponent("component2")).andReturn(Arrays.asList(group1, group2)).anyTimes();
 
     replay(blueprint, stack, group1, group2, dependency1);
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
   }
 
   @Test
@@ -178,8 +178,8 @@ public class BlueprintValidatorImplTest {
     expect(group1.addComponent("component1")).andReturn(true).once();
 
     replay(blueprint, stack, group1, group2, dependency1);
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
 
     verify(group1);
   }
@@ -216,64 +216,10 @@ public class BlueprintValidatorImplTest {
 
     replay(blueprint, stack, group1, group2, dependency1, dependencyComponentInfo);
 
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
 
     verify(group1);
-  }
-
-  @Test(expected=InvalidTopologyException.class)
-  public void testValidateRequiredProperties_SqlaInHiveStackHdp22() throws Exception {
-    Map<String, String> hiveEnvConfig = new HashMap<>();
-    hiveEnvConfig.put("hive_database","Existing SQL Anywhere Database");
-    configProperties.put("hive-env", hiveEnvConfig);
-
-    group1Components.add("HIVE_METASTORE");
-
-    services.addAll(Arrays.asList("HIVE"));
-
-    org.apache.ambari.server.configuration.Configuration serverConfig =
-        BlueprintImplTest.setupConfigurationWithGPLLicense(true);
-
-    Configuration config = new Configuration(new HashMap<>(), new HashMap<>());
-    expect(group1.getConfiguration()).andReturn(config).anyTimes();
-
-    expect(stack.getComponents("HIVE")).andReturn(Collections.singleton("HIVE_METASTORE")).anyTimes();
-    expect(stack.getVersion()).andReturn("2.2").once();
-    expect(stack.getName()).andReturn("HDP").once();
-
-    expect(blueprint.getHostGroupsForComponent("HIVE_METASTORE")).andReturn(Collections.singleton(group1)).anyTimes();
-
-    replay(blueprint, stack, group1, group2, dependency1, serverConfig);
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateRequiredProperties();
-  }
-
-  @Test(expected=InvalidTopologyException.class)
-  public void testValidateRequiredProperties_SqlaInOozieStackHdp22() throws Exception {
-    Map<String, String> hiveEnvConfig = new HashMap<>();
-    hiveEnvConfig.put("oozie_database","Existing SQL Anywhere Database");
-    configProperties.put("oozie-env", hiveEnvConfig);
-
-    group1Components.add("OOZIE_SERVER");
-
-    services.addAll(Arrays.asList("OOZIE"));
-
-    org.apache.ambari.server.configuration.Configuration serverConfig =
-        BlueprintImplTest.setupConfigurationWithGPLLicense(true);
-
-    Configuration config = new Configuration(new HashMap<>(), new HashMap<>());
-    expect(group1.getConfiguration()).andReturn(config).anyTimes();
-
-    expect(stack.getComponents("OOZIE")).andReturn(Collections.singleton("OOZIE_SERVER")).anyTimes();
-    expect(stack.getVersion()).andReturn("2.2").once();
-    expect(stack.getName()).andReturn("HDP").once();
-
-    expect(blueprint.getHostGroupsForComponent("OOZIE_SERVER")).andReturn(Collections.singleton(group1)).anyTimes();
-
-    replay(blueprint, stack, group1, group2, dependency1, serverConfig);
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateRequiredProperties();
   }
 
   @Test
@@ -315,8 +261,8 @@ public class BlueprintValidatorImplTest {
     replay(blueprint, stack, group1, group2, dependency1, dependencyComponentInfo);
 
     // WHEN
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
 
     // THEN
     verify(group1);
@@ -358,8 +304,8 @@ public class BlueprintValidatorImplTest {
     replay(blueprint, stack, group1, group2, dependency1, dependencyComponentInfo);
 
     // WHEN
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
 
     // THEN
     verify(group1);
@@ -420,8 +366,8 @@ public class BlueprintValidatorImplTest {
     replay(blueprint, stack, group1, group2, dependency1, dependency2, dependencyComponentInfo,dependencyConditionInfo1,dependencyConditionInfo2);
 
     // WHEN
-    BlueprintValidator validator = new BlueprintValidatorImpl(blueprint);
-    validator.validateTopology();
+    BlueprintValidator validator = new BlueprintValidatorImpl(null);
+    validator.validateTopology(blueprint);
 
     // THEN
     verify(group1);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
@@ -235,6 +235,7 @@ public class ClusterConfigurationRequestTest {
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackId()).andReturn(new StackId(STACK_NAME, STACK_VERSION)).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
     expect(stack.getServiceForConfigType("testConfigType")).andReturn("KERBEROS").anyTimes();
@@ -327,6 +328,7 @@ public class ClusterConfigurationRequestTest {
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackId()).andReturn(new StackId(STACK_NAME, STACK_VERSION)).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
     expect(stack.getAllConfigurationTypes(anyString())).andReturn(Collections.singletonList("testConfigType")).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
@@ -64,6 +64,7 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 /**
@@ -107,8 +108,9 @@ public class ClusterConfigurationRequestTest {
   @Mock(type = MockType.NICE)
   private ConfigHelper configHelper;
 
-  private final String STACK_NAME = "testStack";
-  private final String STACK_VERSION = "1";
+  private static final String STACK_NAME = "testStack";
+  private static final String STACK_VERSION = "1";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
   private final Map<String, Map<String, String>> stackProperties = new HashMap<>();
   private final Map<String, String> defaultClusterEnvProperties = new HashMap<>();
 
@@ -235,7 +237,7 @@ public class ClusterConfigurationRequestTest {
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(new StackId(STACK_NAME, STACK_VERSION)).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
     expect(stack.getServiceForConfigType("testConfigType")).andReturn("KERBEROS").anyTimes();
@@ -279,7 +281,7 @@ public class ClusterConfigurationRequestTest {
       .emptyList()).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     if (kerberosConfig == null) {
       kerberosConfig = new HashMap<>();
@@ -328,7 +330,7 @@ public class ClusterConfigurationRequestTest {
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(new StackId(STACK_NAME, STACK_VERSION)).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
     expect(stack.getAllConfigurationTypes(anyString())).andReturn(Collections.singletonList("testConfigType")).anyTimes();
@@ -365,7 +367,7 @@ public class ClusterConfigurationRequestTest {
       .emptyList()).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     PowerMock.replay(stack, blueprint, topology, controller, clusters, ambariContext,
         AmbariContext.class, configHelper);
@@ -406,7 +408,7 @@ public class ClusterConfigurationRequestTest {
     expect(ambariContext.getConfigHelper()).andReturn(configHelper).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     EasyMock.replay(stack, blueprint, topology, ambariContext, configHelper);
     // WHEN
@@ -454,7 +456,7 @@ public class ClusterConfigurationRequestTest {
     expect(ambariContext.getConfigHelper()).andReturn(configHelper).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     EasyMock.replay(stack, blueprint, topology, ambariContext, configHelper);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
@@ -64,6 +64,7 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 /**
@@ -107,8 +108,9 @@ public class ClusterConfigurationRequestTest {
   @Mock(type = MockType.NICE)
   private ConfigHelper configHelper;
 
-  private final String STACK_NAME = "testStack";
-  private final String STACK_VERSION = "1";
+  private static final String STACK_NAME = "testStack";
+  private static final String STACK_VERSION = "1";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
   private final Map<String, Map<String, String>> stackProperties = new HashMap<>();
   private final Map<String, String> defaultClusterEnvProperties = new HashMap<>();
 
@@ -235,6 +237,7 @@ public class ClusterConfigurationRequestTest {
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
     expect(stack.getServiceForConfigType("testConfigType")).andReturn("KERBEROS").anyTimes();
@@ -278,7 +281,7 @@ public class ClusterConfigurationRequestTest {
       .emptyList()).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     if (kerberosConfig == null) {
       kerberosConfig = new HashMap<>();
@@ -327,6 +330,7 @@ public class ClusterConfigurationRequestTest {
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
     expect(stack.getAllConfigurationTypes(anyString())).andReturn(Collections.singletonList("testConfigType")).anyTimes();
@@ -363,7 +367,7 @@ public class ClusterConfigurationRequestTest {
       .emptyList()).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     PowerMock.replay(stack, blueprint, topology, controller, clusters, ambariContext,
         AmbariContext.class, configHelper);
@@ -404,7 +408,7 @@ public class ClusterConfigurationRequestTest {
     expect(ambariContext.getConfigHelper()).andReturn(configHelper).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     EasyMock.replay(stack, blueprint, topology, ambariContext, configHelper);
     // WHEN
@@ -452,7 +456,7 @@ public class ClusterConfigurationRequestTest {
     expect(ambariContext.getConfigHelper()).andReturn(configHelper).anyTimes();
 
     expect(configHelper.getDefaultStackProperties(
-        EasyMock.eq(new StackId(STACK_NAME, STACK_VERSION)))).andReturn(stackProperties).anyTimes();
+        EasyMock.eq(STACK_ID))).andReturn(stackProperties).anyTimes();
 
     EasyMock.replay(stack, blueprint, topology, ambariContext, configHelper);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
@@ -61,6 +61,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidatorService;
@@ -79,6 +80,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
 public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
@@ -87,6 +90,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -254,6 +258,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
@@ -391,7 +396,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().times(3);
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().once();
 
     expect(configureClusterTaskFactory.createConfigureClusterTask(anyObject(), anyObject(), anyObject())).andReturn(configureClusterTask);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
@@ -61,6 +61,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidatorService;
@@ -87,6 +88,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -254,6 +256,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
@@ -391,7 +394,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().times(3);
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().once();
 
     expect(configureClusterTaskFactory.createConfigureClusterTask(anyObject(), anyObject(), anyObject())).andReturn(configureClusterTask);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
@@ -80,6 +80,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
 public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
@@ -256,7 +258,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
@@ -193,8 +193,6 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
   private Map<String, Collection<String>> group1ServiceComponents = new HashMap<>();
   private Map<String, Collection<String>> group2ServiceComponents = new HashMap<>();
 
-  private Map<String, Collection<String>> serviceComponents = new HashMap<>();
-
   private String predicate = "Hosts/host_name=foo";
 
   private List<TopologyValidator> topologyValidators = new ArrayList<>();
@@ -235,8 +233,9 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
     groupMap.put("group1", group1);
     groupMap.put("group2", group2);
 
-    serviceComponents.put("service1", Arrays.asList("component1", "component3"));
-    serviceComponents.put("service2", Arrays.asList("component2", "component4"));
+    Collection<String> components1 = ImmutableSet.of("component1", "component3");
+    Collection<String> components2 = ImmutableSet.of("component2", "component4");
+    Collection<String> components = ImmutableSet.<String>builder().addAll(components1).addAll(components2).build();
 
     group1ServiceComponents.put("service1", Arrays.asList("component1", "component3"));
     group1ServiceComponents.put("service2", Collections.singleton("component2"));
@@ -282,9 +281,9 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
     expect(stack.getCardinality("component2")).andReturn(new Cardinality("1")).anyTimes();
     expect(stack.getCardinality("component3")).andReturn(new Cardinality("1+")).anyTimes();
     expect(stack.getCardinality("component4")).andReturn(new Cardinality("1+")).anyTimes();
-    expect(stack.getComponents()).andReturn(serviceComponents).anyTimes();
-    expect(stack.getComponents("service1")).andReturn(serviceComponents.get("service1")).anyTimes();
-    expect(stack.getComponents("service2")).andReturn(serviceComponents.get("service2")).anyTimes();
+    expect(stack.getComponents()).andReturn(components).anyTimes();
+    expect(stack.getComponents("service1")).andReturn(components1).anyTimes();
+    expect(stack.getComponents("service2")).andReturn(components2).anyTimes();
     expect(stack.getConfiguration()).andReturn(stackConfig).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
@@ -63,6 +63,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidatorService;
@@ -81,6 +82,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
 public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupport {
@@ -89,6 +92,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -257,6 +261,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
@@ -375,7 +380,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().times(3);
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().once();
 
     expect(configureClusterTaskFactory.createConfigureClusterTask(anyObject(), anyObject(), anyObject())).andReturn(configureClusterTask);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
@@ -18,7 +18,6 @@
 package org.apache.ambari.server.topology;
 
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_AND_START;
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyLong;
@@ -190,9 +189,6 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
   private Map<String, Collection<Component>> group1ServiceComponents = new HashMap<>();
   private Map<String, Collection<Component>> group2ServiceComponents = new HashMap<>();
 
-  private Map<String, Collection<Component>> serviceComponents = new HashMap<>();
-  private Map<String, Collection<String>> serviceComponentNames = new HashMap<>();
-
   private String predicate = "Hosts/host_name=foo";
 
   private List<TopologyValidator> topologyValidators = new ArrayList<>();
@@ -234,12 +230,9 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     groupMap.put("group1", group1);
     groupMap.put("group2", group2);
 
-    serviceComponents.put("service1", Arrays.asList(new Component("component1"), new Component("component3")));
-    serviceComponents.put("service2", Arrays.asList(new Component("component2"), new Component("component4")));
-
-    for(Map.Entry<String, Collection<Component>> entry: serviceComponents.entrySet()) {
-      serviceComponentNames.put(entry.getKey(), entry.getValue().stream().map(Component::getName).collect(toList()));
-    }
+    Collection<String> components1 = ImmutableSet.of("component1", "component3");
+    Collection<String> components2 = ImmutableSet.of("component2", "component4");
+    Collection<String> components = ImmutableSet.<String>builder().addAll(components1).addAll(components2).build();
 
     group1ServiceComponents.put("service1", Arrays.asList(new Component("component1"), new Component("component3")));
     group1ServiceComponents.put("service2", Collections.singleton(new Component("component2")));
@@ -285,9 +278,9 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     expect(stack.getCardinality("component2")).andReturn(new Cardinality("1")).anyTimes();
     expect(stack.getCardinality("component3")).andReturn(new Cardinality("1+")).anyTimes();
     expect(stack.getCardinality("component4")).andReturn(new Cardinality("1+")).anyTimes();
-    expect(stack.getComponents()).andReturn(serviceComponentNames).anyTimes();
-    expect(stack.getComponents("service1")).andReturn(serviceComponentNames.get("service1")).anyTimes();
-    expect(stack.getComponents("service2")).andReturn(serviceComponentNames.get("service2")).anyTimes();
+    expect(stack.getComponents()).andReturn(components).anyTimes();
+    expect(stack.getComponents("service1")).andReturn(components1).anyTimes();
+    expect(stack.getComponents("service2")).andReturn(components2).anyTimes();
     expect(stack.getConfiguration()).andReturn(stackConfig).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
@@ -81,6 +81,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
 public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupport {
@@ -252,7 +254,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
@@ -62,6 +62,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidatorService;
@@ -88,6 +89,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -250,6 +252,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
@@ -368,7 +371,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().times(3);
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().once();
 
     expect(configureClusterTaskFactory.createConfigureClusterTask(anyObject(), anyObject(), anyObject())).andReturn(configureClusterTask);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
@@ -62,6 +62,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidatorService;
@@ -89,6 +90,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -252,6 +254,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
@@ -363,7 +366,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().times(3);
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().once();
 
     expect(configureClusterTaskFactory.createConfigureClusterTask(anyObject(), anyObject(), anyObject())).andReturn(configureClusterTask);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
@@ -62,6 +62,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidatorService;
@@ -80,6 +81,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
 public class ClusterInstallWithoutStartTest extends EasyMockSupport {
@@ -89,6 +92,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
@@ -252,6 +256,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
@@ -363,7 +368,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().times(3);
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().once();
 
     expect(configureClusterTaskFactory.createConfigureClusterTask(anyObject(), anyObject(), anyObject())).andReturn(configureClusterTask);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
@@ -191,8 +191,6 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
   private Map<String, Collection<String>> group1ServiceComponents = new HashMap<>();
   private Map<String, Collection<String>> group2ServiceComponents = new HashMap<>();
 
-  private Map<String, Collection<String>> serviceComponents = new HashMap<>();
-
   private String predicate = "Hosts/host_name=foo";
 
   private List<TopologyValidator> topologyValidators = new ArrayList<>();
@@ -233,8 +231,9 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     groupMap.put("group1", group1);
     groupMap.put("group2", group2);
 
-    serviceComponents.put("service1", Arrays.asList("component1", "component3"));
-    serviceComponents.put("service2", Arrays.asList("component2", "component4"));
+    Collection<String> components1 = ImmutableSet.of("component1", "component3");
+    Collection<String> components2 = ImmutableSet.of("component2", "component4");
+    Collection<String> components = ImmutableSet.<String>builder().addAll(components1).addAll(components2).build();
 
     group1ServiceComponents.put("service1", Arrays.asList("component1", "component3"));
     group1ServiceComponents.put("service2", Collections.singleton("component2"));
@@ -280,9 +279,9 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     expect(stack.getCardinality("component2")).andReturn(new Cardinality("1")).anyTimes();
     expect(stack.getCardinality("component3")).andReturn(new Cardinality("1+")).anyTimes();
     expect(stack.getCardinality("component4")).andReturn(new Cardinality("1+")).anyTimes();
-    expect(stack.getComponents()).andReturn(serviceComponents).anyTimes();
-    expect(stack.getComponents("service1")).andReturn(serviceComponents.get("service1")).anyTimes();
-    expect(stack.getComponents("service2")).andReturn(serviceComponents.get("service2")).anyTimes();
+    expect(stack.getComponents()).andReturn(components).anyTimes();
+    expect(stack.getComponents("service1")).andReturn(components1).anyTimes();
+    expect(stack.getComponents("service2")).andReturn(components2).anyTimes();
     expect(stack.getConfiguration()).andReturn(stackConfig).anyTimes();
     expect(stack.getName()).andReturn(STACK_NAME).anyTimes();
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
@@ -81,6 +81,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariServer.class)
 public class ClusterInstallWithoutStartTest extends EasyMockSupport {
@@ -254,7 +256,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getStackId()).andReturn(STACK_ID).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.isValidConfigType(anyString())).andReturn(true).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -87,6 +87,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * TopologyManager unit tests
  */
@@ -259,6 +261,7 @@ public class TopologyManagerTest {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -196,8 +196,6 @@ public class TopologyManagerTest {
   private Map<String, Collection<String>> group1ServiceComponents = new HashMap<>();
   private Map<String, Collection<String>> group2ServiceComponents = new HashMap<>();
 
-  private Map<String, Collection<String>> serviceComponents = new HashMap<>();
-
   private String predicate = "Hosts/host_name=foo";
 
   private List<TopologyValidator> topologyValidators = new ArrayList<>();
@@ -238,8 +236,9 @@ public class TopologyManagerTest {
     groupMap.put("group1", group1);
     groupMap.put("group2", group2);
 
-    serviceComponents.put("service1", Arrays.asList("component1", "component3"));
-    serviceComponents.put("service2", Arrays.asList("component2", "component4"));
+    Collection<String> components1 = ImmutableSet.of("component1", "component3");
+    Collection<String> components2 = ImmutableSet.of("component2", "component4");
+    Collection<String> components = ImmutableSet.<String>builder().addAll(components1).addAll(components2).build();
 
     group1ServiceComponents.put("service1", Arrays.asList("component1", "component3"));
     group1ServiceComponents.put("service2", Collections.singleton("component2"));
@@ -275,9 +274,9 @@ public class TopologyManagerTest {
     expect(stack.getCardinality("component2")).andReturn(new Cardinality("1")).anyTimes();
     expect(stack.getCardinality("component3")).andReturn(new Cardinality("1+")).anyTimes();
     expect(stack.getCardinality("component4")).andReturn(new Cardinality("1+")).anyTimes();
-    expect(stack.getComponents()).andReturn(serviceComponents).anyTimes();
-    expect(stack.getComponents("service1")).andReturn(serviceComponents.get("service1")).anyTimes();
-    expect(stack.getComponents("service2")).andReturn(serviceComponents.get("service2")).anyTimes();
+    expect(stack.getComponents()).andReturn(components).anyTimes();
+    expect(stack.getComponents("service1")).andReturn(components1).anyTimes();
+    expect(stack.getComponents("service2")).andReturn(components2).anyTimes();
     expect(stack.getServiceForConfigType("service1-site")).andReturn("service1").anyTimes();
     expect(stack.getServiceForConfigType("service2-site")).andReturn("service2").anyTimes();
     expect(stack.getConfiguration()).andReturn(stackConfig).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -65,6 +65,7 @@ import org.apache.ambari.server.security.authorization.AuthorizationHelper;
 import org.apache.ambari.server.security.encryption.CredentialStoreService;
 import org.apache.ambari.server.stack.NoSuchStackException;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfile;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
@@ -86,6 +87,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * TopologyManager unit tests
  */
@@ -98,6 +101,7 @@ public class TopologyManagerTest {
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
   private static final String SAMPLE_QUICKLINKS_PROFILE_1 = "{\"filters\":[{\"visible\":true}],\"services\":[]}";
   private static final String SAMPLE_QUICKLINKS_PROFILE_2 =
       "{\"filters\":[],\"services\":[{\"name\":\"HDFS\",\"components\":[],\"filters\":[{\"visible\":true}]}]}";
@@ -257,6 +261,7 @@ public class TopologyManagerTest {
     expect(blueprint.getName()).andReturn(BLUEPRINT_NAME).anyTimes();
     expect(blueprint.getServices()).andReturn(Arrays.asList("service1", "service2")).anyTimes();
     expect(blueprint.getStack()).andReturn(stack).anyTimes();
+    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(blueprint.getRepositorySettings()).andReturn(new ArrayList<>()).anyTimes();
     // don't expect toEntity()
 
@@ -340,7 +345,7 @@ public class TopologyManagerTest {
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().anyTimes();
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().anyTimes();
 
     expect(clusterController.ensureResourceProvider(anyObject(Resource.Type.class))).andReturn(resourceProvider);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -65,6 +65,7 @@ import org.apache.ambari.server.security.authorization.AuthorizationHelper;
 import org.apache.ambari.server.security.encryption.CredentialStoreService;
 import org.apache.ambari.server.stack.NoSuchStackException;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfile;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
@@ -98,6 +99,7 @@ public class TopologyManagerTest {
   private static final String BLUEPRINT_NAME = "test-bp";
   private static final String STACK_NAME = "test-stack";
   private static final String STACK_VERSION = "test-stack-version";
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
   private static final String SAMPLE_QUICKLINKS_PROFILE_1 = "{\"filters\":[{\"visible\":true}],\"services\":[]}";
   private static final String SAMPLE_QUICKLINKS_PROFILE_2 =
       "{\"filters\":[],\"services\":[{\"name\":\"HDFS\",\"components\":[],\"filters\":[{\"visible\":true}]}]}";
@@ -340,7 +342,7 @@ public class TopologyManagerTest {
 
     ambariContext.setConfigurationOnCluster(capture(updateClusterConfigRequestCapture));
     expectLastCall().anyTimes();
-    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_NAME, STACK_VERSION);
+    ambariContext.persistInstallStateForUI(CLUSTER_NAME, STACK_ID);
     expectLastCall().anyTimes();
 
     expect(clusterController.ensureResourceProvider(anyObject(Resource.Type.class))).andReturn(resourceProvider);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support for creating cluster via blueprint using one or more manually installed mpacks.

Mpacks referenced in the blueprint are combined into a composite stack.  Both single and composite stack implement a common interface, to minimize the change required.

For now it assumes that each service is defined in only one mpack.

## How was this patch tested?

Tested cluster installation using:

 * blueprint with a stack
 * blueprint with 2 mpacks

Tested blueprint validation using:

 * blueprint referencing non-existent stack
 * blueprint referencing non-existent mpack
 * blueprint referencing non-existent component in existing mpack

Related unit tests are OK, no regression in other unit tests:

```
[ERROR] Tests run: 5104, Failures: 39, Errors: 230, Skipped: 37
->
[ERROR] Tests run: 5117, Failures: 39, Errors: 230, Skipped: 37
```

Checkstyle is OK:

```
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
```