### PR TITLE
[AMBARI-22881] Added user_authentication_id_seq into ambari_sequences upon upgrade to 2.7

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
@@ -208,6 +208,28 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
     }
   }
 
+  /**
+   * Fetches the maximum value of the given ID column from the given table.
+   *
+   * @param tableName
+   *          the name of the table to query the data from
+   * @param idColumnName
+   *          the name of the ID column you want to query the maximum value for.
+   *          This MUST refer an existing numeric type column
+   * @return the maximum value of the given column in the given table if any;
+   *         <code>0L</code> otherwise.
+   * @throws SQLException
+   */
+  protected final long fetchMaxId(String tableName, String idColumnName) throws SQLException {
+    try (Statement stmt = dbAccessor.getConnection().createStatement();
+        ResultSet rs = stmt.executeQuery(String.format("SELECT MAX(%s) FROM %s", idColumnName, tableName))) {
+      if (rs.next()) {
+        return rs.getLong(1);
+      }
+      return 0L;
+    }
+  }
+
   @Override
   public String getSourceVersion() {
     return null;

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
@@ -19,7 +19,9 @@ package org.apache.ambari.server.upgrade;
 
 
 import java.sql.Clob;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +57,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.support.JdbcUtils;
 
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
@@ -561,6 +564,32 @@ public class UpgradeCatalog300 extends AbstractUpgradeCatalog {
     updateKerberosConfigurations();
     upgradeLdapConfiguration();
     createRoleAuthorizations();
+    addUserAuthenticationSequence();
+  }
+
+  protected void addUserAuthenticationSequence() throws SQLException {
+    final long maxUserAuthenticationId = fetchMaxUserAuthenticationId();
+    LOG.info("Maximum user authentication ID = " + maxUserAuthenticationId);
+    addSequence("user_authentication_id_seq", maxUserAuthenticationId + 1, false);
+  }
+
+  private long fetchMaxUserAuthenticationId() throws SQLException {
+    Statement statement = null;
+    ResultSet rs = null;
+    try {
+      statement = dbAccessor.getConnection().createStatement();
+      if (statement != null) {
+        rs = statement.executeQuery(String.format("SELECT MAX(user_authentication_id) FROM %s", USER_AUTHENTICATION_TABLE));
+
+        if (rs.next()) {
+          return rs.getLong(1);
+        }
+      }
+    } finally {
+      JdbcUtils.closeResultSet(rs);
+      JdbcUtils.closeStatement(statement);
+    }
+    return 0L;
   }
 
   protected void createRoleAuthorizations() throws SQLException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
@@ -19,9 +19,7 @@ package org.apache.ambari.server.upgrade;
 
 
 import java.sql.Clob;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,7 +55,6 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.jdbc.support.JdbcUtils;
 
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
@@ -568,28 +565,9 @@ public class UpgradeCatalog300 extends AbstractUpgradeCatalog {
   }
 
   protected void addUserAuthenticationSequence() throws SQLException {
-    final long maxUserAuthenticationId = fetchMaxUserAuthenticationId();
+    final long maxUserAuthenticationId = fetchMaxId(USER_AUTHENTICATION_TABLE, "user_authentication_id");
     LOG.info("Maximum user authentication ID = " + maxUserAuthenticationId);
     addSequence("user_authentication_id_seq", maxUserAuthenticationId + 1, false);
-  }
-
-  private long fetchMaxUserAuthenticationId() throws SQLException {
-    Statement statement = null;
-    ResultSet rs = null;
-    try {
-      statement = dbAccessor.getConnection().createStatement();
-      if (statement != null) {
-        rs = statement.executeQuery(String.format("SELECT MAX(user_authentication_id) FROM %s", USER_AUTHENTICATION_TABLE));
-
-        if (rs.next()) {
-          return rs.getLong(1);
-        }
-      }
-    } finally {
-      JdbcUtils.closeResultSet(rs);
-      JdbcUtils.closeStatement(statement);
-    }
-    return 0L;
   }
 
   protected void createRoleAuthorizations() throws SQLException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog300.java
@@ -565,7 +565,7 @@ public class UpgradeCatalog300 extends AbstractUpgradeCatalog {
   }
 
   protected void addUserAuthenticationSequence() throws SQLException {
-    final long maxUserAuthenticationId = fetchMaxId(USER_AUTHENTICATION_TABLE, "user_authentication_id");
+    final long maxUserAuthenticationId = fetchMaxId(USER_AUTHENTICATION_TABLE, USER_AUTHENTICATION_USER_AUTHENTICATION_ID_COLUMN);
     LOG.info("Maximum user authentication ID = " + maxUserAuthenticationId);
     addSequence("user_authentication_id_seq", maxUserAuthenticationId + 1, false);
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog300Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog300Test.java
@@ -196,6 +196,7 @@ public class UpgradeCatalog300Test {
     Method updateKerberosConfigurations = UpgradeCatalog300.class.getDeclaredMethod("updateKerberosConfigurations");
     Method upgradeLdapConfiguration = UpgradeCatalog300.class.getDeclaredMethod("upgradeLdapConfiguration");
     Method createRoleAuthorizations = UpgradeCatalog300.class.getDeclaredMethod("createRoleAuthorizations");
+    Method addUserAuthenticationSequence = UpgradeCatalog300.class.getDeclaredMethod("addUserAuthenticationSequence");
 
     UpgradeCatalog300 upgradeCatalog300 = createMockBuilder(UpgradeCatalog300.class)
         .addMockedMethod(showHcatDeletedUserMessage)
@@ -205,6 +206,7 @@ public class UpgradeCatalog300Test {
         .addMockedMethod(updateKerberosConfigurations)
         .addMockedMethod(upgradeLdapConfiguration)
         .addMockedMethod(createRoleAuthorizations)
+        .addMockedMethod(addUserAuthenticationSequence)
         .createMock();
 
 
@@ -227,6 +229,9 @@ public class UpgradeCatalog300Test {
     expectLastCall().once();
 
     upgradeCatalog300.upgradeLdapConfiguration();
+    expectLastCall().once();
+
+    upgradeCatalog300.addUserAuthenticationSequence();
     expectLastCall().once();
 
     replay(upgradeCatalog300);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Missing `user_authentication_id_seq` in `ambari_sequences` table should be added upon upgrade.

Please note that we have no JPA at upgrade time so that pure JDBC+SQL should be used.

## How was this patch tested?

I adapted UpgradeCatalog300 (soon to be UpgradeCatalog270) JUnit test; local test results in ambari-server:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:17 min
[INFO] Finished at: 2018-01-30T20:39:52+01:00
[INFO] Final Memory: 213M/1711M
[INFO] ------------------------------------------------------------------------
```

Besides unit testing I executed integration testing manually:

1. deployed AMBARI 2.6
2. upgraded to 3.0 (soon to be 2.7); before ambari-server upgrade I replaced the ambari-server JAR in /usr/lib/ambari-server

Result:
```
[root@c6401 ambari-server]# ambari-server upgrade
Using python  /usr/bin/python
Upgrading ambari-server
INFO: Upgrade Ambari Server
INFO: Updating Ambari Server properties in ambari.properties ...
INFO: Updating Ambari Server properties in ambari-env.sh ...
INFO: Original file ambari-env.sh kept
INFO: Fixing database objects owner
Ambari Server configured for Embedded Postgres. Confirm you have made a backup of the Ambari Server database [y/n] (y)? y
INFO: Upgrading database schema
INFO: Return code from schema upgrade command, retcode = 0
INFO: Console output from schema upgrade command:
INFO: {"lzo_enabled":"false"}

INFO: Schema upgrade completed
Adjusting ambari-server permissions and ownership...
Ambari Server 'upgrade' completed successfully.
```

In the log I found these lines:
```
30 Jan 2018 19:34:25,330  INFO [main] UpgradeCatalog300:572 - Maximum user authentication ID = 1
30 Jan 2018 19:34:25,331  INFO [main] DBAccessorImpl:874 - Executing query: INSERT INTO ambari_sequences(sequence_name, sequence_value) VALUES('user_authentication_id_seq', 2)
```

I also checked if the expected record appears in the DB:
```
ambari=> SELECT * FROM ambari_sequences WHERE LOWER(sequence_name) = 'user_authentication_id_seq';
       sequence_name        | sequence_value 
----------------------------+----------------
 user_authentication_id_seq |              2
(1 row)
```

