### PR TITLE
[AMBARI-22882] Long cannot be cast to String error when changing a user's password

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ambari.server.controller.internal;
 
+import java.text.NumberFormat;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -550,7 +551,7 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
             .toPredicate();
         Predicate predicate2 = new PredicateBuilder()
             .property(UserAuthenticationSourceResourceProvider.AUTHENTICATION_AUTHENTICATION_SOURCE_ID_PROPERTY_ID)
-            .equals(userAuthenticationEntity.getUserAuthenticationId())
+            .equals(convertIdToString(userAuthenticationEntity.getUserAuthenticationId()))
             .toPredicate();
 
         try {
@@ -559,6 +560,22 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
           throw new AmbariException(e.getMessage(), e);
         }
       }
+    }
+  }
+
+  /**
+   * Safely converts an id value to a string
+   *
+   * @param id the value to convert
+   * @return a string representation of the id
+   */
+  private String convertIdToString(Long id) {
+    if (id == null) {
+      return null;
+    } else {
+      NumberFormat format = NumberFormat.getIntegerInstance();
+      format.setGroupingUsed(false);
+      return format.format(id);
     }
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserResourceProviderTest.java
@@ -813,7 +813,7 @@ public class UserResourceProviderTest extends EasyMockSupport {
           if (UserAuthenticationSourceResourceProvider.AUTHENTICATION_USER_NAME_PROPERTY_ID.equals(equalsPredicate.getPropertyId())) {
             Assert.assertEquals(requestedUsername, equalsPredicate.getValue());
           } else if (UserAuthenticationSourceResourceProvider.AUTHENTICATION_AUTHENTICATION_SOURCE_ID_PROPERTY_ID.equals(equalsPredicate.getPropertyId())) {
-            Assert.assertEquals(100L, equalsPredicate.getValue());
+            Assert.assertEquals("100", equalsPredicate.getValue());
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Long cannot be cast to String error when changing a user's password:
```
30 Jan 2018 18:21:11,308 ERROR [ambari-client-thread-38] AbstractResourceProvider:353 - Caught AmbariException when modifying a resource
org.apache.ambari.server.AmbariException: java.lang.Long cannot be cast to java.lang.String
at org.apache.ambari.server.controller.internal.UserResourceProvider.addOrUpdateLocalAuthenticationSource(UserResourceProvider.java:559)
at org.apache.ambari.server.controller.internal.UserResourceProvider.updateUsers(UserResourceProvider.java:486)
at org.apache.ambari.server.controller.internal.UserResourceProvider.access$200(UserResourceProvider.java:69)
at org.apache.ambari.server.controller.internal.UserResourceProvider$3.invoke(UserResourceProvider.java:264)
at org.apache.ambari.server.controller.internal.UserResourceProvider$3.invoke(UserResourceProvider.java:261)
at org.apache.ambari.server.controller.internal.AbstractResourceProvider.invokeWithRetry(AbstractResourceProvider.java:465)
at org.apache.ambari.server.controller.internal.AbstractResourceProvider.modifyResources(AbstractResourceProvider.java:346)
at org.apache.ambari.server.controller.internal.UserResourceProvider.updateResources(UserResourceProvider.java:261)
at org.apache.ambari.server.controller.internal.ClusterControllerImpl.updateResources(ClusterControllerImpl.java:317)
...
```
### Steps to reproduce
 1. Create a {{LOCAL}} user account (using either the Ambari UI or REST API)
```
POST /api/v1/users
```
``` Payload
{ 
  "Users" : {
    "user_name" : "myuser",
    "password" : "hadoop"
  }
}
```
 2. Change the user's password (using either the Ambari UI or REST API via the users entry point)
```
PUT /api/v1/users/myuser
```
```
{ 
  "Users" : {
    "old_password" : "hadoop"
    "password" : "hadoop1234"
  }
}
```
```
{
  "status" : 500,
  "message" : "org.apache.ambari.server.controller.spi.SystemException: An internal system exception occurred: java.lang.Long cannot be cast to java.lang.String"
}
```

### Cause
When building the internal request to set the user's password via the UserAuthenticationSource resource provider, the authentication source key is set as a `Long`. The UserAuthenticationSource resource provider expects this value to be a `String`.


### Solution 
The User resource provider should set the `AuthenticationSourceInfo/source_id` as a `String` value.

## How was this patch tested?

Manually tested using the REST API and UI. 

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31:41 min
[INFO] Finished at: 2018-01-30T15:34:11-05:00
[INFO] Final Memory: 105M/1900M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.