### PR TITLE
[AMBARI-22884]. LogSearch Integration should call newer API to obtain log file metadata

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ServiceLogsManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ServiceLogsManager.java
@@ -608,7 +608,7 @@ public class ServiceLogsManager extends ManagerBase<ServiceLogData, ServiceLogRe
 
   public HostLogFilesResponse getHostLogFileData(HostLogFilesRequest request) {
     SimpleFacetQuery facetQuery = conversionService.convert(request, SimpleFacetQuery.class);
-    QueryResponse queryResponse = serviceLogsSolrDao.process(facetQuery, "/service/logs/hostlogfiles");
+    QueryResponse queryResponse = serviceLogsSolrDao.process(facetQuery, "/service/logs/files");
     return responseDataGenerator.generateHostLogFilesResponse(queryResponse);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/HostLogFilesResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/HostLogFilesResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.server.controller.logging;
+
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HostLogFilesResponse {
+
+  private Map<String, List<String>> hostLogFiles;
+
+  @JsonProperty("hostLogFiles")
+  public Map<String, List<String>> getHostLogFiles() {
+    return hostLogFiles;
+  }
+
+  public void setHostLogFiles(Map<String, List<String>> hostLogFiles) {
+    this.hostLogFiles = hostLogFiles;
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogSearchDataRetrievalService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogSearchDataRetrievalService.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ambari.server.controller.logging;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -28,7 +30,7 @@ import org.apache.ambari.server.AmbariService;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariServer;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,8 +189,7 @@ public class LogSearchDataRetrievalService extends AbstractService {
     final String key = generateKey(component, host);
 
     // check cache for data
-    Set<String> cacheResult =
-      logFileNameCache.getIfPresent(key);
+    Set<String> cacheResult = logFileNameCache.getIfPresent(key);
 
     if (cacheResult != null) {
       LOG.debug("LogFileNames result for key = {} found in cache", key);
@@ -367,15 +368,15 @@ public class LogSearchDataRetrievalService extends AbstractService {
 
         if (helper != null) {
           // make request to LogSearch service
-          Set<String> logFileNamesResult =
-            helper.sendGetLogFileNamesRequest(component, host);
-
+          HostLogFilesResponse logFilesResponse = helper.sendGetLogFileNamesRequest(host);
           // update the cache if result is available
-          if (CollectionUtils.isNotEmpty(logFileNamesResult)) {
+          if (logFilesResponse != null && MapUtils.isNotEmpty(logFilesResponse.getHostLogFiles())) {
             LOG.debug("LogSearchFileNameRequestRunnable: request was successful, updating cache");
-            final String key = generateKey(component, host);
             // update cache with returned result
-            logFileNameCache.put(key, logFileNamesResult);
+            for (Map.Entry<String, List<String>> componentEntry : logFilesResponse.getHostLogFiles().entrySet()) {
+              final String key = generateKey(componentEntry.getKey(), host);
+              logFileNameCache.put(key, new HashSet<>(componentEntry.getValue()));
+            }
           } else {
             LOG.debug("LogSearchFileNameRequestRunnable: remote request was not successful for component = {} on host ={}", component, host);
             if (!componentRequestFailureCounts.containsKey(component)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingRequestHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingRequestHelper.java
@@ -1,7 +1,6 @@
 package org.apache.ambari.server.controller.logging;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -32,16 +31,14 @@ public interface LoggingRequestHelper {
   LogQueryResponse sendQueryRequest(Map<String, String> queryParameters);
 
   /**
-   * Sends a request to obtain the log file name for a given component, on
-   *   a given host
+   * Sends a request to obtain the log file names for a given host
    *
-   * @param componentName the component name
    * @param hostName the host name
    *
-   * @return a Set of Strings that include the log file names associated
-   *         with this component/host combination
+   * @return a HostLogFilesResponse, containing include the log file names for components associated
+   *         with a hostname
    */
-  Set<String> sendGetLogFileNamesRequest(String componentName, String hostName);
+  HostLogFilesResponse sendGetLogFileNamesRequest(String hostName);
 
   /**
    * Sends a request to obtain the log level counts for a given component on

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogSearchDataRetrievalServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogSearchDataRetrievalServiceTest.java
@@ -26,7 +26,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -378,6 +381,13 @@ public class LogSearchDataRetrievalServiceTest {
     final String expectedClusterName = "clusterone";
     final String expectedComponentAndHostName = expectedComponentName + "+" + expectedHostName;
 
+    final HostLogFilesResponse resp = new HostLogFilesResponse();
+    Map<String, List<String>> componentMap = new HashMap<>();
+    List<String> expectedList = new ArrayList<>();
+    expectedList.add("/this/is/just/a/test/directory");
+    componentMap.put(expectedComponentName, expectedList);
+    resp.setHostLogFiles(componentMap);
+
     EasyMockSupport mockSupport = new EasyMockSupport();
 
     LoggingRequestHelperFactory helperFactoryMock = mockSupport.createMock(LoggingRequestHelperFactory.class);
@@ -389,7 +399,7 @@ public class LogSearchDataRetrievalServiceTest {
     Map<String, AtomicInteger> componentFailureCounts = mockSupport.createMock(Map.class);
 
     expect(helperFactoryMock.getHelper(controllerMock, expectedClusterName)).andReturn(helperMock);
-    expect(helperMock.sendGetLogFileNamesRequest(expectedComponentName, expectedHostName)).andReturn(Collections.singleton("/this/is/just/a/test/directory"));
+    expect(helperMock.sendGetLogFileNamesRequest(expectedHostName)).andReturn(resp);
     // expect that the results will be placed in the cache
     cacheMock.put(expectedComponentAndHostName, Collections.singleton("/this/is/just/a/test/directory"));
     // expect that the completed request is removed from the current request set
@@ -462,7 +472,7 @@ public class LogSearchDataRetrievalServiceTest {
 
     expect(helperFactoryMock.getHelper(controllerMock, expectedClusterName)).andReturn(helperMock);
     // return null to simulate an error occurring during the LogSearch data request
-    expect(helperMock.sendGetLogFileNamesRequest(expectedComponentName, expectedHostName)).andReturn(null);
+    expect(helperMock.sendGetLogFileNamesRequest(expectedHostName)).andReturn(null);
     // expect that the completed request is removed from the current request set,
     // even in the event of a failure to obtain the LogSearch data
     expect(currentRequestsMock.remove(expectedComponentAndHostName)).andReturn(true).once();
@@ -510,7 +520,7 @@ public class LogSearchDataRetrievalServiceTest {
 
     expect(helperFactoryMock.getHelper(controllerMock, expectedClusterName)).andReturn(helperMock);
     // return null to simulate an error occurring during the LogSearch data request
-    expect(helperMock.sendGetLogFileNamesRequest(expectedComponentName, expectedHostName)).andReturn(null);
+    expect(helperMock.sendGetLogFileNamesRequest(expectedHostName)).andReturn(null);
     // expect that the completed request is removed from the current request set,
     // even in the event of a failure to obtain the LogSearch data
     expect(currentRequestsMock.remove(expectedComponentAndHostName)).andReturn(true).once();
@@ -544,6 +554,8 @@ public class LogSearchDataRetrievalServiceTest {
     final String expectedComponentAndHostName = expectedComponentName + "+" + expectedHostName;
     final AtomicInteger testInteger = new AtomicInteger(0);
 
+    final HostLogFilesResponse resp = new HostLogFilesResponse();
+    resp.setHostLogFiles(new HashMap<>());
     EasyMockSupport mockSupport = new EasyMockSupport();
 
     LoggingRequestHelperFactory helperFactoryMock = mockSupport.createMock(LoggingRequestHelperFactory.class);
@@ -558,7 +570,7 @@ public class LogSearchDataRetrievalServiceTest {
 
     expect(helperFactoryMock.getHelper(controllerMock, expectedClusterName)).andReturn(helperMock);
     // return null to simulate an error occurring during the LogSearch data request
-    expect(helperMock.sendGetLogFileNamesRequest(expectedComponentName, expectedHostName)).andReturn(Collections.emptySet());
+    expect(helperMock.sendGetLogFileNamesRequest(expectedHostName)).andReturn(resp);
     // expect that the completed request is removed from the current request set,
     // even in the event of a failure to obtain the LogSearch data
     expect(currentRequestsMock.remove(expectedComponentAndHostName)).andReturn(true).once();
@@ -583,4 +595,5 @@ public class LogSearchDataRetrievalServiceTest {
 
     mockSupport.verifyAll();
   }
+
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperImplTest.java
@@ -22,6 +22,7 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -30,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.ambari.server.security.credential.PrincipalKeyCredential;
 import org.apache.ambari.server.security.encryption.CredentialStoreService;
@@ -99,6 +99,16 @@ public class LoggingRequestHelperImplTest {
       "  }" +
       "]" +
       "}";
+
+  private static final String TEST_JSON_INPUT_LOG_FILES_MAP =
+    "{" +
+    "\"hostLogFiles\":{" +
+    "\"hdfs_namenode\": [" +
+    "\"/var/log/hadoop/hdfs/hadoop-hdfs-namenode-c6401.ambari.apache.org.log\"" +
+    "],\"logsearch_app\": [" +
+    "\"/var/log/ambari-logsearch-portal/logsearch.json\"" +
+    "]" +
+    "}}";
 
   private static final String TEST_JSON_INPUT_LOG_LEVEL_QUERY =
     "{\"pageSize\":\"0\",\"queryTimeMS\":\"1459970731998\",\"resultSize\":\"6\",\"startIndex\":\"0\",\"totalCount\":\"0\"," +
@@ -340,7 +350,7 @@ public class LoggingRequestHelperImplTest {
     expect(clusterMock.getDesiredConfigByType("logsearch-admin-json")).andReturn(adminPropertiesConfigMock).atLeastOnce();
     expect(clusterMock.getClusterName()).andReturn("clusterone").atLeastOnce();
     expect(adminPropertiesConfigMock.getProperties()).andReturn(testConfigProperties).atLeastOnce();
-    expect(networkConnectionMock.readQueryResponseFromServer(capture(captureURLConnection))).andReturn(new StringBuffer(TEST_JSON_INPUT_TWO_LIST_ENTRIES)).atLeastOnce();
+    expect(networkConnectionMock.readQueryResponseFromServer(capture(captureURLConnection))).andReturn(new StringBuffer(TEST_JSON_INPUT_LOG_FILES_MAP)).atLeastOnce();
 
     // expect that basic authentication is setup, with the expected encoded credentials
     networkConnectionMock.setupBasicAuthentication(capture(captureURLConnectionForAuthentication), eq(EXPECTED_ENCODED_CREDENTIALS));
@@ -351,8 +361,8 @@ public class LoggingRequestHelperImplTest {
       new LoggingRequestHelperImpl(EXPECTED_HOST_NAME, EXPECTED_PORT_NUMBER, EXPECTED_PROTOCOL, credentialStoreServiceMock, clusterMock, networkConnectionMock);
 
     // invoke query request
-    Set<String> result =
-      helper.sendGetLogFileNamesRequest(expectedComponentName, EXPECTED_HOST_NAME);
+    HostLogFilesResponse result =
+      helper.sendGetLogFileNamesRequest(EXPECTED_HOST_NAME);
 
     // verify that the HttpURLConnection was created with the propert values
     HttpURLConnection httpURLConnection =
@@ -378,18 +388,14 @@ public class LoggingRequestHelperImplTest {
     // verify that the query contains the three required parameters
     assertTrue("host_name parameter was not included in query",
       resultQuery.contains("host_name=c6401.ambari.apache.org"));
-    assertTrue("component_name parameter was not included in the query",
-      resultQuery.contains("component_name=" + expectedComponentName));
-    assertTrue("pageSize parameter was not included in query",
-      resultQuery.contains("pageSize=1"));
 
     assertNotNull("Response object should not be null",
       result);
     assertEquals("Response Set was not of the expected size",
-      1, result.size());
+      2, result.getHostLogFiles().size());
     assertEquals("Response did not include the expected file name",
       "/var/log/hadoop/hdfs/hadoop-hdfs-namenode-c6401.ambari.apache.org.log",
-      result.iterator().next());
+      result.getHostLogFiles().get(expectedComponentName).get(0));
 
     mockSupport.verifyAll();
   }
@@ -436,8 +442,8 @@ public class LoggingRequestHelperImplTest {
       new LoggingRequestHelperImpl(EXPECTED_HOST_NAME, EXPECTED_PORT_NUMBER, EXPECTED_PROTOCOL, credentialStoreServiceMock, clusterMock, networkConnectionMock);
 
     // invoke query request
-    Set<String> result =
-      helper.sendGetLogFileNamesRequest(expectedComponentName, EXPECTED_HOST_NAME);
+    HostLogFilesResponse result =
+      helper.sendGetLogFileNamesRequest(EXPECTED_HOST_NAME);
 
     // verify that the HttpURLConnection was created with the propert values
     HttpURLConnection httpURLConnection =
@@ -463,15 +469,10 @@ public class LoggingRequestHelperImplTest {
     // verify that the query contains the three required parameters
     assertTrue("host_name parameter was not included in query",
       resultQuery.contains("host_name=c6401.ambari.apache.org"));
-    assertTrue("component_name parameter was not included in the query",
-      resultQuery.contains("component_name=" + expectedComponentName));
-    assertTrue("pageSize parameter was not included in query",
-      resultQuery.contains("pageSize=1"));
 
     assertNotNull("Response object should not be null",
       result);
-    assertEquals("Response Set was not of the expected size, expected an empty set",
-      0, result.size());
+    assertNull("Response Map should be null", result.getHostLogFiles());
 
     mockSupport.verifyAll();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use /api/v1/service/logs/files rest API call inside ambari-server code in order to get the log files path based on components and hostname.

The change: we wont use component parameter for that call, therefore we will get every component + logfile pairs for a host. Although UI will still use multiple calls, because of the cache mechanism, after one (or more - as calls are async), we will just go for the cache from the result. (As no UI changes included -> we still wait for a set of logfiles for one component, instead of a map of component with the set of logfiles) - at least with these change we will use less REST API calls agains Log Search server 

## How was this patch tested?
UT: run related UTs
FT: upload jar to remote machine and try out -> logfiels appeared

please review @rnettleton @swagle @kasakrisz 