### PR TITLE
AMBARI-22864. Agent commands hang even after freeing up disk space

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -145,8 +145,8 @@ class ActionQueue(threading.Thread):
       self.customServiceOrchestrator.cancel_command(task_id, reason)
 
   def run(self):
-    try:
-      while not self.stopped():
+    while not self.stopped():
+      try:
         self.processBackgroundQueueSafeEmpty()
         self.controller.get_status_commands_executor().process_results() # process status commands
         try:
@@ -177,9 +177,8 @@ class ActionQueue(threading.Thread):
             pass
         except (Queue.Empty):
           pass
-    except:
-      logger.exception("ActionQueue thread failed with exception:")
-      raise
+      except:
+        logger.exception("ActionQueue thread failed with exception. Re-running it")
     
     logger.info("ActionQueue thread has successfully finished")
 


### PR DESCRIPTION
STR
Install a cluster with Ambari-2.6.2 and HDP-2.6.4.0
Go to the host (say host1) running Nimbus component and restart Nimbus
Fill up the disk space on host1 (in my test, the disk space was filled up on the host running Nimbus component)
Try to restart Nimbus. Nimbus restart expectedly fails with error:
Caught an exception while executing custom service command: <type 'exceptions.IOError'>: [Errno 28] No space left on device; [Errno 28] No space left on device
Now free up the disk space on host1 and try to restart Nimbus