### PR TITLE
[AMBARI-22888] Cancel operation during package deployment causing repository manager to be broken (dgrinenko)

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestShell.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestShell.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-'''
+"""
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
@@ -17,66 +17,128 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-'''
+"""
+from contextlib import contextmanager
 
-from ambari_agent import main
-main.MEMORY_LEAK_DEBUG_FILEPATH = "/tmp/memory_leak_debug.out"
-import os
 import unittest
-import tempfile
+import signal
 from mock.mock import patch, MagicMock, call
-from ambari_agent.AmbariConfig import AmbariConfig
 from ambari_commons import shell
-from ambari_commons.shell import shellRunner
-from sys import platform as _platform
-from only_for_platform import not_for_platform, PLATFORM_WINDOWS
-import subprocess, time
+from ambari_commons import OSCheck
+from StringIO import StringIO
 
-@not_for_platform(PLATFORM_WINDOWS)
+ROOT_PID = 10
+ROOT_PID_CHILDRENS = [10, 11, 12, 13]
+shell.logger = MagicMock()  # suppress any log output
+
+__proc_fs = {
+  "/proc/10/task/10/children": "11 12",
+  "/proc/10/comm": "a",
+  "/proc/10/cmdline": "",
+
+  "/proc/11/task/11/children": "13",
+  "/proc/11/comm": "b",
+  "/proc/11/cmdline": "",
+
+  "/proc/12/task/12/children": "",
+  "/proc/12/comm": "c",
+  "/proc/12/cmdline": "",
+
+  "/proc/13/task/13/children": "",
+  "/proc/13/comm": "d",
+  "/proc/13/cmdline": ""
+}
+
+__proc_fs_yum = {
+  "/proc/10/task/10/children": "11",
+  "/proc/10/comm": "a",
+  "/proc/10/cmdline": "",
+
+  "/proc/11/task/11/children": "",
+  "/proc/11/comm": "yum",
+  "/proc/11/cmdline": "yum install something"
+}
+
+
+class FakeSignals(object):
+  SIGTERM = signal.SIG_IGN
+  SIGKILL = signal.SIG_IGN
+
+
+@contextmanager
+def _open_mock(path, open_mode):
+  if path in __proc_fs:
+    yield StringIO(__proc_fs[path])
+  else:
+    yield StringIO("")
+
+
+@contextmanager
+def _open_mock_yum(path, open_mode):
+  if path in __proc_fs:
+    yield StringIO(__proc_fs_yum[path])
+  else:
+    yield StringIO("")
+
+
 class TestShell(unittest.TestCase):
 
+  @patch("__builtin__.open", new=MagicMock(side_effect=_open_mock))
+  def test_get_all_children(self):
 
-  @patch("os.setuid")
-  def test_changeUid(self, os_setUIDMock):
-    shell.threadLocal.uid = 9999
-    shell.changeUid()
-    self.assertTrue(os_setUIDMock.called)
+    pid_list = [item[0] for item in shell.get_all_childrens(ROOT_PID)]
 
+    self.assertEquals(len(ROOT_PID_CHILDRENS), len(pid_list))
+    self.assertEquals(ROOT_PID, pid_list[0])
 
-  @patch("pwd.getpwnam")
-  def test_shellRunner_run(self, getpwnamMock):
-    sh = shellRunner()
-    result = sh.run(['echo'])
-    self.assertEquals(result['exitCode'], 0)
-    self.assertEquals(result['error'], '')
+    for i in ROOT_PID_CHILDRENS:
+      self.assertEquals(True, i in pid_list)
 
-    getpwnamMock.return_value = [os.getuid(), os.getuid(), os.getuid()]
-    result = sh.run(['echo'], 'non_exist_user_name')
-    self.assertEquals(result['exitCode'], 0)
-    self.assertEquals(result['error'], '')
+  @patch("__builtin__.open", new=MagicMock(side_effect=_open_mock))
+  @patch.object(OSCheck, "get_os_family", new=MagicMock(return_value="redhat"))
+  @patch.object(shell, "signal", new_callable=FakeSignals)
+  @patch.object(shell, "is_pid_life")
+  @patch("os.kill")
+  def test_kill_process_with_children(self, os_kill_mock, is_pid_life_mock, fake_signals):
+    pid_list = [item[0] for item in shell.get_all_childrens(ROOT_PID)]
+    reverse_pid_list = sorted(pid_list, reverse=True)
+    shell.gracefull_kill_delay = 0.1
+    is_pid_life_clean_kill = [True] * len(pid_list) + [False] * len(pid_list)
+    is_pid_life_not_clean_kill = [True] * (len(pid_list) * 2)
 
-  def test_kill_process_with_children(self):
-    if _platform == "linux" or _platform == "linux2": # Test is Linux-specific
-      gracefull_kill_delay_old = shell.gracefull_kill_delay
-      shell.gracefull_kill_delay = 0.1
-      sleep_cmd = "sleep 314159265"
-      test_cmd = """ (({0}) & ({0} & {0})) """.format(sleep_cmd)
-      # Starting process tree (multiple process groups)
-      test_process = subprocess.Popen(test_cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
-      time.sleep(0.3) # Delay to allow subprocess to start
-      # Check if processes are running
-      ps_cmd = """ps auxww """
-      ps_process = subprocess.Popen(ps_cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
-      (out, err) = ps_process.communicate()
-      self.assertTrue(sleep_cmd in out)
-      # Kill test process
-      shell.kill_process_with_children(test_process.pid)
-      test_process.communicate()
-      # Now test process should not be running
-      ps_process = subprocess.Popen(ps_cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
-      (out, err) = ps_process.communicate()
-      self.assertFalse(sleep_cmd in out)
-      shell.gracefull_kill_delay = gracefull_kill_delay_old
-    else:
-      # Do not run under other systems
-      pass
+    is_pid_life_mock.side_effect = is_pid_life_clean_kill
+    shell.kill_process_with_children(ROOT_PID)
+
+    # test clean pid by SIGTERM
+    os_kill_pids = [item[0][0] for item in os_kill_mock.call_args_list]
+    self.assertEquals(len(os_kill_pids), len(pid_list))
+    self.assertEquals(reverse_pid_list, os_kill_pids)
+
+    os_kill_mock.reset_mock()
+    is_pid_life_mock.reset_mock()
+
+    is_pid_life_mock.side_effect = is_pid_life_not_clean_kill
+    shell.kill_process_with_children(ROOT_PID)
+
+    # test clean pid by SIGKILL
+    os_kill_pids = [item[0][0] for item in os_kill_mock.call_args_list]
+    self.assertEquals(len(os_kill_pids), len(pid_list)*2)
+    self.assertEquals(reverse_pid_list + reverse_pid_list, os_kill_pids)
+
+  @patch("__builtin__.open", new=MagicMock(side_effect=_open_mock_yum))
+  @patch.object(OSCheck, "get_os_family", new=MagicMock(return_value="redhat"))
+  @patch.object(shell, "signal", new_callable=FakeSignals)
+  @patch.object(shell, "is_pid_life")
+  @patch("os.kill")
+  def test_kill_process_with_children_except_yum(self, os_kill_mock, is_pid_life_mock, fake_signals):
+    shell.gracefull_kill_delay = 0.1
+    is_pid_life_clean_kill = [True, False, True, False]  # used here only first pair
+
+    is_pid_life_mock.side_effect = is_pid_life_clean_kill
+    shell.kill_process_with_children(ROOT_PID)
+
+    # test clean pid by SIGTERM
+    os_kill_pids = [item[0][0] for item in os_kill_mock.call_args_list]
+    self.assertEquals(len(os_kill_pids), 1)
+    self.assertEquals([10], os_kill_pids)
+


### PR DESCRIPTION
Ambari 2.x Implementation

## What changes were proposed in this pull request?
Rework of the way how we killing process and it children. Rather of usage Popen and bash scriptlets, which r hardly manageable, switching to native python `os.kill` with using `/proc` FS to extract system information (same as ps, pgrep util doing).

Additionally, such implementation allow to add several required limits to tree killer:
- exclusion list, currently contains package managers (main goal of the task)
- exclude caller PID from being killed by occasion

## How was this patch tested?
Tested using Unit Tests and on selected cluster node

```
[09:32:47] :	 [Step 2/2] [INFO] ------------------------------------------------------------------------
[09:32:47] :	 [Step 2/2] [INFO] Reactor Summary:
[09:32:47] :	 [Step 2/2] [INFO] 
[09:32:47] :	 [Step 2/2] [INFO] Ambari Views ....................................... SUCCESS [  1.936 s]
[09:32:47] :	 [Step 2/2] [INFO] utility ............................................ SUCCESS [  1.935 s]
[09:32:47] :	 [Step 2/2] [INFO] Ambari Metrics Common .............................. SUCCESS [  3.578 s]
[09:32:47] :	 [Step 2/2] [INFO] Ambari Server ...................................... SUCCESS [22:30 min]
[09:32:47] :	 [Step 2/2] [INFO] Ambari Agent ....................................... SUCCESS [ 35.743 s]
[09:32:47] :	 [Step 2/2] [INFO] ------------------------------------------------------------------------
[09:32:47] :	 [Step 2/2] [INFO] BUILD SUCCESS
[09:32:47] :	 [Step 2/2] [INFO] ------------------------------------------------------------------------
[09:32:47] :	 [Step 2/2] [INFO] Total time: 22:36 min (Wall Clock)
[09:32:47] :	 [Step 2/2] [INFO] Finished at: 2018-02-01T09:32:47Z
[09:32:47] :	 [Step 2/2] [INFO] Final Memory: 87M/2743M
[09:32:47] :	 [Step 2/2] [INFO] ------------------------------------------------------------------------
```