### PR TITLE
[AMBARI-22889] Make sure that the latest configuration is used when populating LDAP data

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/service/AmbariLdapConfigurationProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/service/AmbariLdapConfigurationProvider.java
@@ -74,15 +74,17 @@ public class AmbariLdapConfigurationProvider implements Provider<AmbariLdapConfi
 
   @Override
   public AmbariLdapConfiguration get() {
-    return instance == null || !instance.toMap().isEmpty() ? loadInstance() : instance;
+    LOGGER.debug("Getting LDAP configuration...");
+    if (instance == null || instance.toMap().isEmpty()) {
+      loadInstance();
+    }
+    return instance;
   }
 
   /**
    * Loads the AmbariLdapConfiguration from the database.
-   *
-   * @return the AmbariLdapConfiguration instance
    */
-  private AmbariLdapConfiguration loadInstance() {
+  private void loadInstance() {
     List<AmbariConfigurationEntity> configEntities = null;
 
     LOGGER.info("Loading LDAP configuration ...");
@@ -99,8 +101,6 @@ public class AmbariLdapConfigurationProvider implements Provider<AmbariLdapConfi
     }
 
     LOGGER.info("Loaded LDAP configuration instance: [ {} ]", instance.toMap());
-
-    return instance;
   }
 
   private Map<String, String> toProperties(List<AmbariConfigurationEntity> configEntities) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderForDNWithSpaceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderForDNWithSpaceTest.java
@@ -17,9 +17,12 @@
  */
 package org.apache.ambari.server.security.authorization;
 
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.Properties;
 
 import org.apache.ambari.server.AmbariException;
@@ -28,7 +31,9 @@ import org.apache.ambari.server.audit.AuditLoggerModule;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.ControllerModule;
 import org.apache.ambari.server.ldap.LdapModule;
+import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfigurationKeys;
+import org.apache.ambari.server.ldap.service.AmbariLdapConfigurationProvider;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.dao.UserDAO;
 import org.apache.ambari.server.orm.entities.UserEntity;
@@ -41,8 +46,12 @@ import org.apache.directory.server.core.annotations.ContextEntry;
 import org.apache.directory.server.core.annotations.CreateDS;
 import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.easymock.MockType;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -74,17 +83,27 @@ import com.google.inject.Injector;
 @ApplyLdifFiles("users_for_dn_with_space.ldif")
 public class AmbariLdapAuthenticationProviderForDNWithSpaceTest extends AmbariLdapAuthenticationProviderBaseTest {
 
+  @Rule
+  public EasyMockRule mocks = new EasyMockRule(this);
+
   private static Injector injector;
 
   @Inject
-  private AmbariLdapAuthenticationProvider authenticationProvider;
-  @Inject
   private UserDAO userDAO;
+
   @Inject
   private Users users;
 
   @Inject
   Configuration configuration;
+
+  @Mock(type = MockType.NICE)
+  private AmbariLdapAuthoritiesPopulator authoritiesPopulator;
+
+  @Mock(type = MockType.NICE)
+  private AmbariLdapConfigurationProvider ldapConfigurationProvider;
+
+  private AmbariLdapAuthenticationProvider authenticationProvider;
 
   @Before
   public void setUp() throws Exception {
@@ -93,10 +112,16 @@ public class AmbariLdapAuthenticationProviderForDNWithSpaceTest extends AmbariLd
     injector.injectMembers(this);
 
     configuration.setClientSecurityType(ClientSecurityType.LDAP);
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_HOST, "localhost");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_PORT, String.valueOf(getLdapServer().getPort()));
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.USER_SEARCH_BASE, "dc=ambari,dc=the apache,dc=org");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.GROUP_BASE, "ou=the groups,dc=ambari,dc=the apache,dc=org");
+    final AmbariLdapConfiguration ldapConfiguration = new AmbariLdapConfiguration();
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_HOST, "localhost");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_PORT, String.valueOf(getLdapServer().getPort()));
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.USER_SEARCH_BASE, "dc=ambari,dc=the apache,dc=org");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.GROUP_BASE, "ou=the groups,dc=ambari,dc=the apache,dc=org");
+    expect(ldapConfigurationProvider.get()).andReturn(ldapConfiguration).anyTimes();
+    expect(authoritiesPopulator.getGrantedAuthorities(anyObject(), anyObject())).andReturn(Collections.emptyList()).anyTimes();
+    replayAll();
+
+    authenticationProvider = new AmbariLdapAuthenticationProvider(users, configuration, ldapConfigurationProvider, authoritiesPopulator);
   }
 
   @After

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderForDuplicateUserTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderForDuplicateUserTest.java
@@ -17,11 +17,14 @@
  */
 package org.apache.ambari.server.security.authorization;
 
+import static org.easymock.EasyMock.expect;
+
 import java.util.Properties;
 
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfigurationKeys;
+import org.apache.ambari.server.ldap.service.AmbariLdapConfigurationProvider;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
 import org.apache.directory.server.core.annotations.ApplyLdifFiles;
@@ -74,9 +77,12 @@ public class AmbariLdapAuthenticationProviderForDuplicateUserTest extends Ambari
   @Mock(type = MockType.NICE)
   private Users users;
 
-  private AmbariLdapAuthenticationProvider authenticationProvider;
+  @Mock(type = MockType.NICE)
+  private AmbariLdapConfigurationProvider ldapConfigurationProvider;
 
-  private Configuration configuration;
+  private AmbariLdapConfiguration ldapConfiguration;
+
+  private AmbariLdapAuthenticationProvider authenticationProvider;
 
   @Before
   public void setUp() {
@@ -89,19 +95,21 @@ public class AmbariLdapAuthenticationProviderForDuplicateUserTest extends Ambari
     properties.setProperty(Configuration.SHARED_RESOURCES_DIR.getKey(), "src/test/resources/");
     Configuration configuration = new Configuration(properties);
 
-    final AmbariLdapConfiguration ldapConfiguration = new AmbariLdapConfiguration();
+    ldapConfiguration = new AmbariLdapConfiguration();
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.USER_SEARCH_BASE, "dc=apache,dc=org");
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_HOST, "localhost");
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_PORT, String.valueOf(getLdapServer().getPort()));
+    expect(ldapConfigurationProvider.get()).andReturn(ldapConfiguration).anyTimes();
+    replayAll();
 
-    authenticationProvider = new AmbariLdapAuthenticationProvider(users, configuration, ldapConfiguration, authoritiesPopulator);
+    authenticationProvider = new AmbariLdapAuthenticationProvider(users, configuration, ldapConfigurationProvider, authoritiesPopulator);
   }
 
   @Test
   public void testAuthenticateDuplicateUserAltUserSearchDisabled() throws Exception {
     // Given
     Authentication authentication = new UsernamePasswordAuthenticationToken("user_dup", "password");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "false");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "false");
 
     expectedException.expect(DuplicateLdapUserFoundAuthenticationException.class);
     expectedException.expectMessage("Login Failed: More than one user with that username found, please work with your Ambari Administrator to adjust your LDAP configuration");
@@ -119,7 +127,7 @@ public class AmbariLdapAuthenticationProviderForDuplicateUserTest extends Ambari
   public void testAuthenticateDuplicateUserAltUserSearchEnabled() throws Exception {
     // Given
     Authentication authentication = new UsernamePasswordAuthenticationToken("user_dup", "password");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
 
     expectedException.expect(DuplicateLdapUserFoundAuthenticationException.class);
     expectedException.expectMessage("Login Failed: Please append your domain to your username and try again.  Example: user_dup@domain");

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProviderTest.java
@@ -21,10 +21,13 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.find;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.util.Collections;
 
 import org.apache.ambari.server.H2DatabaseCleaner;
 import org.apache.ambari.server.audit.AuditLoggerModule;
@@ -32,6 +35,7 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.ldap.LdapModule;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfigurationKeys;
+import org.apache.ambari.server.ldap.service.AmbariLdapConfigurationProvider;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.dao.UserDAO;
 import org.apache.ambari.server.orm.entities.UserEntity;
@@ -45,9 +49,13 @@ import org.apache.directory.server.core.annotations.ContextEntry;
 import org.apache.directory.server.core.annotations.CreateDS;
 import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.easymock.EasyMockRule;
 import org.easymock.IAnswer;
+import org.easymock.Mock;
+import org.easymock.MockType;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -82,17 +90,26 @@ import junit.framework.Assert;
 @ApplyLdifFiles("users.ldif")
 public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticationProviderBaseTest {
 
+  @Rule
+  public EasyMockRule mocks = new EasyMockRule(this);
+
   private static Injector injector;
 
-  @Inject
   private AmbariLdapAuthenticationProvider authenticationProvider;
+
   @Inject
   private UserDAO userDAO;
   @Inject
   private Users users;
   @Inject
   private Configuration configuration;
-  @Inject
+
+  @Mock(type = MockType.NICE)
+  private AmbariLdapAuthoritiesPopulator authoritiesPopulator;
+
+  @Mock(type = MockType.NICE)
+  private AmbariLdapConfigurationProvider ldapConfigurationProvider;
+
   private AmbariLdapConfiguration ldapConfiguration;
 
   @Before
@@ -101,10 +118,14 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
     injector.getInstance(GuiceJpaInitializer.class);
     injector.injectMembers(this);
     configuration.setClientSecurityType(ClientSecurityType.LDAP);
+    ldapConfiguration = new AmbariLdapConfiguration();
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "false");
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_FILTER, "(&(mail={0})(objectClass={userObjectClass}))");
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_HOST, "localhost");
     ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.SERVER_PORT, String.valueOf(getLdapServer().getPort()));
+    expect(ldapConfigurationProvider.get()).andReturn(ldapConfiguration).anyTimes();
+
+    authenticationProvider = new AmbariLdapAuthenticationProvider(users, configuration, ldapConfigurationProvider, authoritiesPopulator);
   }
 
   @After
@@ -114,17 +135,17 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
 
   @Test(expected = InvalidUsernamePasswordCombinationException.class)
   public void testBadCredential() throws Exception {
+    replay(ldapConfigurationProvider);
     Authentication authentication = new UsernamePasswordAuthenticationToken("notFound", "wrong");
     authenticationProvider.authenticate(authentication);
   }
 
   @Test
   public void testGoodManagerCredentials() throws Exception {
-    AmbariLdapAuthoritiesPopulator authoritiesPopulator = createMock(AmbariLdapAuthoritiesPopulator.class);
     AmbariLdapAuthenticationProvider provider = createMockBuilder(AmbariLdapAuthenticationProvider.class)
             .addMockedMethod("loadLdapAuthenticationProvider")
             .addMockedMethod("isLdapEnabled")
-            .withConstructor(users, configuration, ldapConfiguration, authoritiesPopulator).createMock();
+            .withConstructor(users, configuration, ldapConfigurationProvider, authoritiesPopulator).createMock();
     // Create the last thrown exception
     org.springframework.security.core.AuthenticationException exception =
             createNiceMock(org.springframework.security.core.AuthenticationException.class);
@@ -156,11 +177,10 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
 
   @Test
   public void testBadManagerCredentials() throws Exception {
-    AmbariLdapAuthoritiesPopulator authoritiesPopulator = createMock(AmbariLdapAuthoritiesPopulator.class);
     AmbariLdapAuthenticationProvider provider = createMockBuilder(AmbariLdapAuthenticationProvider.class)
             .addMockedMethod("loadLdapAuthenticationProvider")
             .addMockedMethod("isLdapEnabled")
-            .withConstructor(users, configuration, ldapConfiguration, authoritiesPopulator).createMock();
+            .withConstructor(users, configuration, ldapConfigurationProvider, authoritiesPopulator).createMock();
     // Create the cause
     org.springframework.ldap.AuthenticationException cause =
             createNiceMock(org.springframework.ldap.AuthenticationException.class);
@@ -195,6 +215,9 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
 
     UserEntity ldapUser = userDAO.findUserByName("allowedUser");
     Authentication authentication = new UsernamePasswordAuthenticationToken("allowedUser", "password");
+    expect(authoritiesPopulator.getGrantedAuthorities(anyObject(), anyObject())).andReturn(Collections.emptyList()).anyTimes();
+
+    replay(ldapConfigurationProvider, authoritiesPopulator);
 
     AmbariUserAuthentication result = (AmbariUserAuthentication)authenticationProvider.authenticate(authentication);
     assertTrue(result.isAuthenticated());
@@ -209,6 +232,7 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
   public void testDisabled() throws Exception {
     configuration.setClientSecurityType(ClientSecurityType.LOCAL);
     Authentication authentication = new UsernamePasswordAuthenticationToken("allowedUser", "password");
+    replay(ldapConfigurationProvider);
     Authentication auth = authenticationProvider.authenticate(authentication);
     Assert.assertTrue(auth == null);
   }
@@ -221,7 +245,9 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
     users.addLdapAuthentication(userEntity, "uid=allowedUser,ou=people,dc=ambari,dc=apache,dc=org");
 
     Authentication authentication = new UsernamePasswordAuthenticationToken("allowedUser@ambari.apache.org", "password");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
+    expect(authoritiesPopulator.getGrantedAuthorities(anyObject(), anyObject())).andReturn(Collections.emptyList()).anyTimes();
+    replay(ldapConfigurationProvider, authoritiesPopulator);
 
     // When
     Authentication result = authenticationProvider.authenticate(authentication);
@@ -235,8 +261,9 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
     // Given
     assertNull("User already exists in DB", userDAO.findUserByName("allowedUser"));
     Authentication authentication = new UsernamePasswordAuthenticationToken("missingloginalias@ambari.apache.org", "password");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
 
+    replay(ldapConfigurationProvider);
 
     // When
     authenticationProvider.authenticate(authentication);
@@ -251,8 +278,9 @@ public class AmbariLdapAuthenticationProviderTest extends AmbariLdapAuthenticati
     // Given
     assertNull("User already exists in DB", userDAO.findUserByName("allowedUser"));
     Authentication authentication = new UsernamePasswordAuthenticationToken("allowedUser@ambari.apache.org", "bad_password");
-    authenticationProvider.ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
+    ldapConfiguration.setValueFor(AmbariLdapConfigurationKeys.ALTERNATE_USER_SEARCH_ENABLED, "true");
 
+    replay(ldapConfigurationProvider);
 
     // When
     authenticationProvider.authenticate(authentication);

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
@@ -83,13 +83,14 @@ import org.springframework.ldap.filter.Filter;
 import org.springframework.ldap.support.LdapUtils;
 
 import com.google.common.collect.Sets;
+import com.google.inject.Provider;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AmbariLdapUtils.class)
 public class AmbariLdapDataPopulatorTest {
   public static class AmbariLdapDataPopulatorTestInstance extends TestAmbariLdapDataPopulator {
-    public AmbariLdapDataPopulatorTestInstance(AmbariLdapConfiguration configuration, Users users) {
-      super(configuration, users);
+    public AmbariLdapDataPopulatorTestInstance(Provider<AmbariLdapConfiguration> configurationProvider, Users users) {
+      super(configurationProvider, users);
     }
 
     @Override
@@ -104,8 +105,8 @@ public class AmbariLdapDataPopulatorTest {
     private LdapContextSource ldapContextSource;
     private PagedResultsDirContextProcessor processor;
 
-    public TestAmbariLdapDataPopulator(AmbariLdapConfiguration configuration, Users users) {
-      super(configuration, users);
+    public TestAmbariLdapDataPopulator(Provider<AmbariLdapConfiguration> configurationProvider, Users users) {
+      super(configurationProvider, users);
     }
 
     @Override
@@ -149,27 +150,32 @@ public class AmbariLdapDataPopulatorTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsLdapEnabled_badConfiguration() {
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     final AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     final Users users = createNiceMock(Users.class);
 
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.ldapEnabled()).andReturn(true);
     expect(ldapTemplate.search(EasyMock.<String>anyObject(), EasyMock.anyObject(), EasyMock.<AttributesMapper>anyObject())).andThrow(new NullPointerException()).once();
-    replay(ldapTemplate, configuration, ldapServerProperties);
+    replay(ldapTemplate, configurationProvider, configuration, ldapServerProperties);
 
-    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
     assertFalse(populator.isLdapEnabled());
-    verify(populator.loadLdapTemplate(), configuration);
+    verify(populator.loadLdapTemplate(), configurationProvider, configuration);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testReferralMethod() {
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     final AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     final Users users = createNiceMock(Users.class);
     LdapContextSource ldapContextSource = createNiceMock(LdapContextSource.class);
@@ -178,66 +184,74 @@ public class AmbariLdapDataPopulatorTest {
 
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getLdapUrls()).andReturn(ldapUrls).anyTimes();
     expect(ldapServerProperties.getReferralMethod()).andReturn("follow");
     ldapContextSource.setReferral("follow");
     ldapTemplate.setIgnorePartialResultException(true);
 
-    replay(ldapTemplate, configuration, ldapServerProperties, ldapContextSource);
+    replay(ldapTemplate, configurationProvider, configuration, ldapServerProperties, ldapContextSource);
 
-    final TestAmbariLdapDataPopulator populator = new TestAmbariLdapDataPopulator(configuration, users);
+    final TestAmbariLdapDataPopulator populator = new TestAmbariLdapDataPopulator(configurationProvider, users);
     populator.setLdapContextSource(ldapContextSource);
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
     populator.loadLdapTemplate();
 
-    verify(ldapTemplate, configuration, ldapServerProperties, ldapContextSource);
+    verify(ldapTemplate, configurationProvider, configuration, ldapServerProperties, ldapContextSource);
   }
 
   @Test
   public void testIsLdapEnabled_reallyEnabled() {
+    @SuppressWarnings("unchecked")
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     final AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     final Users users = createNiceMock(Users.class);
 
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.ldapEnabled()).andReturn(true);
     expect(ldapTemplate.search(EasyMock.<String>anyObject(), EasyMock.anyObject(), EasyMock.<AttributesMapper>anyObject())).andReturn(Collections.emptyList()).once();
-    replay(ldapTemplate, configuration);
+    replay(ldapTemplate, configurationProvider, configuration);
 
-    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
     assertTrue(populator.isLdapEnabled());
-    verify(populator.loadLdapTemplate(), configuration);
+    verify(populator.loadLdapTemplate(), configurationProvider, configuration);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsLdapEnabled_reallyDisabled() {
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     final AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     final Users users = createNiceMock(Users.class);
 
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.ldapEnabled()).andReturn(false);
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties);
-    replay(ldapTemplate, ldapServerProperties, configuration);
+    replay(ldapTemplate, ldapServerProperties, configurationProvider, configuration);
 
-    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
     assertFalse(populator.isLdapEnabled());
-    verify(populator.loadLdapTemplate(), populator.getLdapServerProperties(), configuration);
+    verify(populator.loadLdapTemplate(), populator.getLdapServerProperties(), configurationProvider, configuration);
   }
 
   private <T> Set<T> createSet(T... elements) {
     return new HashSet<>(Arrays.asList(elements));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void synchronizeExistingLdapGroups() throws Exception {
 
@@ -259,20 +273,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4, group5);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4, group5);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapGroups")
         .addMockedMethod("refreshGroupMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     expect(populator.getLdapGroups("group2")).andReturn(Collections.emptySet());
@@ -300,6 +316,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeExistingLdapGroups_removeDuringIteration() throws Exception {
     // GIVEN
@@ -313,7 +330,9 @@ public class AmbariLdapDataPopulatorTest {
     expect(group2.getGroupName()).andReturn("group2").anyTimes();
     expect(group2.isLdapGroup()).andReturn(true).anyTimes();
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     expect(users.getAllGroups()).andReturn(Arrays.asList(group1, group2));
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
@@ -332,9 +351,9 @@ public class AmbariLdapDataPopulatorTest {
     groupDtos2.add(group2Dto);
 
     LdapBatchDto batchInfo = new LdapBatchDto();
-    replay(configuration, users, group1, group2);
+    replay(configurationProvider, configuration, users, group1, group2);
     AmbariLdapDataPopulator dataPopulator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .addMockedMethod("getLdapGroups")
         .addMockedMethod("getLdapUserByMemberAttr")
         .addMockedMethod("getLdapGroupByMemberAttr")
@@ -353,6 +372,7 @@ public class AmbariLdapDataPopulatorTest {
 
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeLdapGroups_allExist() throws Exception {
 
@@ -371,20 +391,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapGroups")
         .addMockedMethod("refreshGroupMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -432,6 +454,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeLdapGroups_add() throws Exception {
 
@@ -450,20 +473,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapGroups")
         .addMockedMethod("refreshGroupMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -507,6 +532,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeLdapGroups_update() throws Exception {
 
@@ -525,20 +551,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapGroups")
         .addMockedMethod("refreshGroupMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -577,6 +605,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test(expected = AmbariException.class)
   public void testSynchronizeLdapGroups_absent() throws Exception {
 
@@ -595,20 +624,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapGroups")
         .addMockedMethod("refreshGroupMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -634,6 +665,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.synchronizeLdapGroups(createSet("x*", "group1", "group2"), batchInfo);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapGroups() throws Exception {
 
@@ -655,20 +687,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4, group5);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4, group5);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getExternalLdapGroupInfo")
         .addMockedMethod("refreshGroupMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -708,6 +742,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapGroups_add() throws Exception {
 
@@ -718,20 +753,22 @@ public class AmbariLdapDataPopulatorTest {
     expect(group1.isLdapGroup()).andReturn(false).anyTimes();
     expect(group2.isLdapGroup()).andReturn(false).anyTimes();
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(Arrays.asList(group1, group2));
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("refreshGroupMembers")
         .addMockedMethod("getExternalLdapGroupInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -765,6 +802,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapGroups_remove() throws Exception {
 
@@ -783,20 +821,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3, group4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3, group4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("refreshGroupMembers")
         .addMockedMethod("getExternalLdapGroupInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -828,6 +868,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapGroups_update() throws Exception {
 
@@ -843,20 +884,22 @@ public class AmbariLdapDataPopulatorTest {
 
     List<Group> groupList = Arrays.asList(group1, group2, group3);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllGroups()).andReturn(groupList);
     expect(users.getAllUsers()).andReturn(Collections.emptyList());
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(group1, group2, group3);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("refreshGroupMembers")
         .addMockedMethod("getExternalLdapGroupInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
@@ -890,6 +933,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapUsers() throws Exception {
 
@@ -908,18 +952,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3, user4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user3, user2, user4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getExternalLdapUserInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser1 = createNiceMock(LdapUserDto.class);
@@ -952,6 +998,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapSkipLocal() throws Exception {
 
@@ -967,19 +1014,21 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.syncCollisionHandlingBehavior()).andReturn(LdapUsernameCollisionHandlingBehavior.SKIP).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user3, user2);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getExternalLdapUserInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser1 = createNiceMock(LdapUserDto.class);
@@ -1009,6 +1058,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapUsers_add() throws Exception {
 
@@ -1021,18 +1071,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getExternalLdapUserInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser1 = createNiceMock(LdapUserDto.class);
@@ -1061,6 +1113,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapUsers_remove() throws Exception {
 
@@ -1076,18 +1129,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getExternalLdapUserInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
 
@@ -1110,6 +1165,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeAllLdapUsers_update() throws Exception {
 
@@ -1125,18 +1181,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getExternalLdapUserInfo")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
 
@@ -1167,6 +1225,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeExistingLdapUsers() throws Exception {
 
@@ -1185,18 +1244,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3, user4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3, user4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapUsers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     expect(populator.getLdapUsers("synced_user1")).andReturn(Collections.emptySet());
@@ -1219,6 +1280,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeLdapUsers_allExist() throws Exception {
 
@@ -1237,18 +1299,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3, user4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3, user4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapUsers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser1 = createNiceMock(LdapUserDto.class);
@@ -1283,6 +1347,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeLdapUsers_add() throws Exception {
 
@@ -1301,18 +1366,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3, user4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3, user4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapUsers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser2 = createNiceMock(LdapUserDto.class);
@@ -1344,6 +1411,7 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testSynchronizeLdapUsers_update() throws Exception {
 
@@ -1362,18 +1430,20 @@ public class AmbariLdapDataPopulatorTest {
 
     List<User> userList = Arrays.asList(user1, user2, user3, user4);
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(users.getAllUsers()).andReturn(userList);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3, user4);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapUsers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser1 = createNiceMock(LdapUserDto.class);
@@ -1406,19 +1476,22 @@ public class AmbariLdapDataPopulatorTest {
     verify(populator.loadLdapTemplate(), populator);
   }
 
+  @SuppressWarnings("unchecked")
   @Test(expected = AmbariException.class)
   public void testSynchronizeLdapUsers_absent() throws Exception {
 
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
 
     AmbariLdapDataPopulatorTestInstance populator = createMockBuilder(AmbariLdapDataPopulatorTestInstance.class)
         .addMockedMethod("getLdapUsers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapUserDto externalUser1 = createNiceMock(LdapUserDto.class);
@@ -1442,6 +1515,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.synchronizeLdapUsers(createSet("user1", "user2", "xuser*"), new LdapBatchDto());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testRefreshGroupMembers() throws Exception {
 
@@ -1464,13 +1538,16 @@ public class AmbariLdapDataPopulatorTest {
     expect(group2.isLdapGroup()).andReturn(true).anyTimes();
     expect(group1.getGroupName()).andReturn("group1").anyTimes();
     expect(group2.getGroupName()).andReturn("group2").anyTimes();
+
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn("cn").anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("uid").anyTimes();
-    replay(ldapTemplate, ldapServerProperties, users, configuration);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration);
     replay(user1, user2, user3, user4);
     replay(group1, group2);
 
@@ -1478,7 +1555,7 @@ public class AmbariLdapDataPopulatorTest {
         .addMockedMethod("getLdapUserByMemberAttr")
         .addMockedMethod("getLdapGroupByMemberAttr")
         .addMockedMethod("getInternalMembers")
-        .withConstructor(configuration, users)
+        .withConstructor(configurationProvider, users)
         .createNiceMock();
 
     LdapGroupDto externalGroup = createNiceMock(LdapGroupDto.class);
@@ -1532,10 +1609,13 @@ public class AmbariLdapDataPopulatorTest {
   }
 
   @Test
-  @SuppressWarnings("serial")
+  @SuppressWarnings({ "serial", "unchecked" })
   public void testCleanUpLdapUsersWithoutGroup() throws AmbariException {
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     final AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     final Users users = createNiceMock(Users.class);
+
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
 
     final GroupEntity ldapGroup = new GroupEntity();
     ldapGroup.setGroupId(1);
@@ -1570,9 +1650,9 @@ public class AmbariLdapDataPopulatorTest {
       }
     });
 
-    replay(users);
+    replay(users, configurationProvider, configuration);
 
-    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     populator.setLdapTemplate(createNiceMock(LdapTemplate.class));
     populator.setLdapServerProperties(createNiceMock(LdapServerProperties.class));
     populator.cleanUpLdapUsersWithoutGroup();
@@ -1587,15 +1667,15 @@ public class AmbariLdapDataPopulatorTest {
     verify(users);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetLdapUserByMemberAttr() throws Exception {
-
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     Capture<ContextMapper> contextMapperCapture = EasyMock.newCapture();
-    Capture<SearchControls> searchControlsCapture = EasyMock.newCapture();
     PagedResultsDirContextProcessor processor = createNiceMock(PagedResultsDirContextProcessor.class);
     PagedResultsCookie cookie = createNiceMock(PagedResultsCookie.class);
     LdapUserDto dto = new LdapUserDto();
@@ -1603,6 +1683,7 @@ public class AmbariLdapDataPopulatorTest {
     List<LdapUserDto> list = new LinkedList<>();
     list.add(dto);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.isPaginationEnabled()).andReturn(true).anyTimes();
     expect(ldapServerProperties.getUserObjectClass()).andReturn("objectClass").anyTimes();
@@ -1614,27 +1695,27 @@ public class AmbariLdapDataPopulatorTest {
 
     expect(ldapTemplate.search(eq(LdapUtils.newLdapName("cn=testUser,ou=Ambari,dc=SME,dc=support,dc=com")), eq("(&(objectClass=objectClass)(uid=foo))"), anyObject(SearchControls.class), capture(contextMapperCapture), eq(processor))).andReturn(list);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration, processor, cookie);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration, processor, cookie);
 
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
 
     populator.setLdapTemplate(ldapTemplate);
     populator.setProcessor(processor);
 
     assertEquals(dto, populator.getLdapUserByMemberAttr("foo"));
 
-    verify(ldapTemplate, ldapServerProperties, users, configuration, processor, cookie);
+    verify(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration, processor, cookie);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetLdapUserByMemberAttrNoPagination() throws Exception {
-
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapTemplate ldapTemplate = createNiceMock(LdapTemplate.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     Capture<ContextMapper> contextMapperCapture = EasyMock.newCapture();
-    Capture<SearchControls> searchControlsCapture = EasyMock.newCapture();
     PagedResultsDirContextProcessor processor = createNiceMock(PagedResultsDirContextProcessor.class);
     PagedResultsCookie cookie = createNiceMock(PagedResultsCookie.class);
     LdapUserDto dto = new LdapUserDto();
@@ -1642,6 +1723,7 @@ public class AmbariLdapDataPopulatorTest {
     List<LdapUserDto> list = new LinkedList<>();
     list.add(dto);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.isPaginationEnabled()).andReturn(false).anyTimes();
     expect(ldapServerProperties.getUserObjectClass()).andReturn("objectClass").anyTimes();
@@ -1651,16 +1733,16 @@ public class AmbariLdapDataPopulatorTest {
 
     expect(ldapTemplate.search(eq(LdapUtils.newLdapName("cn=testUser,ou=Ambari,dc=SME,dc=support,dc=com")), eq("(&(objectClass=objectClass)(uid=foo))"), anyObject(SearchControls.class), capture(contextMapperCapture))).andReturn(list);
 
-    replay(ldapTemplate, ldapServerProperties, users, configuration, processor, cookie);
+    replay(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration, processor, cookie);
 
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
 
     populator.setLdapTemplate(ldapTemplate);
     populator.setProcessor(processor);
 
     assertEquals(dto, populator.getLdapUserByMemberAttr("foo"));
 
-    verify(ldapTemplate, ldapServerProperties, users, configuration, processor, cookie);
+    verify(ldapTemplate, ldapServerProperties, users, configurationProvider, configuration, processor, cookie);
   }
 
   @Test
@@ -1730,186 +1812,225 @@ public class AmbariLdapDataPopulatorTest {
     assertEquals("cn=testuser,ou=ambari,dc=sme,dc=support,dc=com", userDto.getDn());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsMemberAttributeBaseDn() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("UID");
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn("CN");
 
-    replay(configuration, users, ldapServerProperties);
+    replay(configurationProvider, configuration, users, ldapServerProperties);
 
     // WHEN
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     boolean result = populator.isMemberAttributeBaseDn("CN=mygroupname,OU=myOrganizationUnit,DC=apache,DC=org");
     // THEN
     assertTrue(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsMemberAttributeBaseDn_withUidMatch() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("UID");
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn("CN");
 
-    replay(configuration, users, ldapServerProperties);
+    replay(configurationProvider, configuration, users, ldapServerProperties);
 
     // WHEN
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     boolean result = populator.isMemberAttributeBaseDn("uid=myuid,OU=myOrganizationUnit,DC=apache,DC=org");
     // THEN
     assertTrue(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsMemberAttributeBaseDn_withLowerAndUpperCaseValue() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("uid");
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn("CN");
 
-    replay(configuration, users, ldapServerProperties);
+    replay(configurationProvider, configuration, users, ldapServerProperties);
 
     // WHEN
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     boolean result = populator.isMemberAttributeBaseDn("cn=mygroupname,OU=myOrganizationUnit,DC=apache,DC=org");
     // THEN
     assertTrue(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsMemberAttributeBaseDn_withWrongAttribute() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("uid");
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn("CN");
 
-    replay(configuration, users, ldapServerProperties);
+    replay(configurationProvider, configuration, users, ldapServerProperties);
 
     // WHEN
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     boolean result = populator.isMemberAttributeBaseDn("cnn=mygroupname,OU=myOrganizationUnit,DC=apache,DC=org");
     // THEN
     assertFalse(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsMemberAttributeBaseDn_withEmptyValues() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
 
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("");
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn(null);
 
-    replay(configuration, users, ldapServerProperties);
+    replay(configurationProvider, configuration, users, ldapServerProperties);
 
     // WHEN
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     boolean result = populator.isMemberAttributeBaseDn("cnn=mygroupname,OU=myOrganizationUnit,DC=apache,DC=org");
     // THEN
     assertFalse(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testIsMemberAttributeBaseDn_withDifferentUserAndGroupNameAttribute() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
     Users users = createNiceMock(Users.class);
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
+
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties).anyTimes();
     expect(ldapServerProperties.getUsernameAttribute()).andReturn("sAMAccountName");
     expect(ldapServerProperties.getGroupNamingAttr()).andReturn("groupOfNames");
 
-    replay(configuration, users, ldapServerProperties);
+    replay(configurationProvider, configuration, users, ldapServerProperties);
 
     // WHEN
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     boolean result = populator.isMemberAttributeBaseDn("cn=mygroupname,OU=myOrganizationUnit,DC=apache,DC=org");
     // THEN
     assertTrue(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetUniqueIdMemberPattern() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     String syncUserMemberPattern = "(?<sid>.*);(?<guid>.*);(?<member>.*)";
     String memberAttribute = "<SID=...>;<GUID=...>;cn=member,dc=apache,dc=org";
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    replay(configurationProvider, configuration);
     // WHEN
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     String result = populator.getUniqueIdByMemberPattern(memberAttribute, syncUserMemberPattern);
     // THEN
     assertEquals("cn=member,dc=apache,dc=org", result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetUniqueIdByMemberPatternWhenPatternIsWrong() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     String syncUserMemberPattern = "(?<sid>.*);(?<guid>.*);(?<mem>.*)";
     String memberAttribute = "<SID=...>;<GUID=...>;cn=member,dc=apache,dc=org";
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    replay(configurationProvider, configuration);
     // WHEN
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     String result = populator.getUniqueIdByMemberPattern(memberAttribute, syncUserMemberPattern);
     // THEN
     assertEquals(memberAttribute, result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetUniqueIdByMemberPatternWhenPatternIsEmpty() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     String memberAttribute = "<SID=...>;<GUID=...>;cn=member,dc=apache,dc=org";
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    replay(configurationProvider, configuration);
     // WHEN
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     String result = populator.getUniqueIdByMemberPattern(memberAttribute, "");
     // THEN
     assertEquals(memberAttribute, result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testGetUniqueIdByMemberPatternWhenMembershipAttributeIsNull() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
     String syncUserMemberPattern = "(?<sid>.*);(?<guid>.*);(?<member>.*)";
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    replay(configurationProvider, configuration);
     // WHEN
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     String result = populator.getUniqueIdByMemberPattern(null, syncUserMemberPattern);
     // THEN
     assertNull(result);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testCreateCustomMemberFilter() {
     // GIVEN
+    final Provider<AmbariLdapConfiguration> configurationProvider = createNiceMock(Provider.class);
     AmbariLdapConfiguration configuration = createNiceMock(AmbariLdapConfiguration.class);
+    expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     Users users = createNiceMock(Users.class);
-    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configuration, users);
+    replay(configurationProvider, configuration);
     // WHEN
+    AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);
     Filter result = populator.createCustomMemberFilter("myUid", "(&(objectclass=posixaccount)(uid={member}))");
     // THEN
     assertEquals("(&(objectclass=posixaccount)(uid=myUid))", result.encode());

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7650,16 +7650,18 @@ class TestAmbariServer(TestCase):
 
   @patch("urllib2.urlopen")
   @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
   @patch("ambari_server.setupSecurity.is_ldap_enabled")
   @patch("ambari_server.setupSecurity.is_server_runing")
   @patch("ambari_server.setupSecurity.is_root")
   @patch("ambari_server.setupSecurity.logger")
-  def test_ldap_sync_existing(self, logger_mock, is_root_method, is_server_runing_mock, is_ldap_enabled_mock,
+  def test_ldap_sync_existing(self, logger_mock, is_root_method, is_server_runing_mock, is_ldap_enabled_mock, get_ambari_properties_mock,
                          get_validated_string_input_mock, urlopen_mock):
 
     is_root_method.return_value = True
     is_server_runing_mock.return_value = (True, 0)
     is_ldap_enabled_mock.return_value = 'true'
+    get_ambari_properties_mock.return_value = Properties()
     get_validated_string_input_mock.side_effect = ['admin', 'admin']
 
     response = MagicMock()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`AmbariLdapDataPopulator` did not use the latest LDAP configuration when created LDAP template. To solve this issue we should inject the Provider instance instead of the configuration itself and use its get method to retrieve the (up-to-date) configuration.

## How was this patch tested?

Updated JUnit tests; latest results in ambari-server:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:13 min
[INFO] Finished at: 2018-02-01T12:18:13+01:00
[INFO] Final Memory: 213M/1796M
[INFO] ------------------------------------------------------------------------
```

I ran integration tests manually as described in [AMBARI-22889](https://issues.apache.org/jira/browse/AMBARI-22889)
