### PR TITLE
[AMBARI-22901] View Log feature for failed mpack downloads

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -360,6 +360,7 @@ Em.I18n.translations = {
   'common.version':'Version',
   'common.versions':'Versions',
   'common.view': 'View',
+  'common.viewLog': 'View Log',
   'common.views': 'Views',
   'common.warn.message': '<div class="alert alert-warning">{0}</div>',
   'common.warning': 'Warning',
@@ -637,7 +638,7 @@ Em.I18n.translations = {
   'installer.selectMpacks.basicModeMessage': 'Customizing your selections allows you to add or remove individual management packs and services. Continue?',
   'installer.selectMpacks.advancedModeMessage': 'If you go back to use case selection, all current selections will be removed. Continue?',
   'installer.selectMpacks.basicModeHelp': 'This step lets you choose the use case(s) that fit your needs and the management packs that fulfill those use cases will be selected for you; however, if you would rather choose individual management packs and/or services directly, click this button. Be aware that if you return to use case selection mode, any selections you have made will be removed.',
-  'installer.selectMpacks.advancedModeHelp': 'By clicking this button, you can return to use case selection mode. However, any existing selections will be removed.',
+  '1er.selectMpacks.advancedModeHelp': 'By clicking this button, you can return to use case selection mode. However, any existing selections will be removed.',
   'installer.selectMpacks.filterMpacks': 'Search management packs',
   'installer.selectMpacks.filterServices': 'Search services',
 
@@ -663,6 +664,7 @@ Em.I18n.translations = {
   'installer.downloadMpacks.header': 'Download Management Packs',
   'installer.downloadMpacks.body.title': 'Download and validate management packs',
   'installer.downloadMpacks.body.description': 'Ambari is downloading the management packs and validating their contents.',
+  'installer.downloadMpacks.failure.default': 'Downloading management pack failed for unknown reasons.',
   
   'installer.customProductRepos.header': 'Set Product Locations',
   'installer.customProductRepos.body.title': 'Customize product locations',

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -638,7 +638,7 @@ Em.I18n.translations = {
   'installer.selectMpacks.basicModeMessage': 'Customizing your selections allows you to add or remove individual management packs and services. Continue?',
   'installer.selectMpacks.advancedModeMessage': 'If you go back to use case selection, all current selections will be removed. Continue?',
   'installer.selectMpacks.basicModeHelp': 'This step lets you choose the use case(s) that fit your needs and the management packs that fulfill those use cases will be selected for you; however, if you would rather choose individual management packs and/or services directly, click this button. Be aware that if you return to use case selection mode, any selections you have made will be removed.',
-  '1er.selectMpacks.advancedModeHelp': 'By clicking this button, you can return to use case selection mode. However, any existing selections will be removed.',
+  'installer.selectMpacks.advancedModeHelp': 'By clicking this button, you can return to use case selection mode. However, any existing selections will be removed.',
   'installer.selectMpacks.filterMpacks': 'Search management packs',
   'installer.selectMpacks.filterServices': 'Search services',
 

--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -2920,11 +2920,15 @@ td .no-data {
 }
 
 [data-toggle="tooltip"] [disabled] {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 .retry-button:after {
-  content: '\f01e';    
+  content: '\f01e';
+}
+
+.viewLog-button:after {
+  content: '\f0f6';
 }
 
 .more-info {

--- a/ambari-web/app/templates/wizard/downloadMpacks.hbs
+++ b/ambari-web/app/templates/wizard/downloadMpacks.hbs
@@ -60,6 +60,13 @@
                   <button type="button" class="icon-button retry-button" disabled="disabled"></button>
                   {{/if}}
                 </span>
+                <span data-toggle="tooltip" data-placement="bottom" {{translateAttr title="common.viewLog" }}>
+                  {{#if mpack.failed}}
+                  <button type="button" class="icon-button viewLog-button" {{action showError mpack target="controller" }}></button>
+                  {{else}}
+                  <button type="button" class="icon-button viewLog-button" disabled="disabled"></button>
+                  {{/if}}
+                </span>
               </td>
             </tr>
           {{/each}}

--- a/ambari-web/test/controllers/wizard/downloadMpacks_test.js
+++ b/ambari-web/test/controllers/wizard/downloadMpacks_test.js
@@ -19,7 +19,7 @@
 var App = require('app');
 var controller = App.WizardDownloadMpacksController.create();
 
-describe.only('App.WizardConfigureDownloadController', function () {
+describe('App.WizardConfigureDownloadController', function () {
   beforeEach(function () {
     var mpacks = [
       Em.Object.create({

--- a/ambari-web/test/controllers/wizard/downloadMpacks_test.js
+++ b/ambari-web/test/controllers/wizard/downloadMpacks_test.js
@@ -19,7 +19,7 @@
 var App = require('app');
 var controller = App.WizardDownloadMpacksController.create();
 
-describe('App.WizardConfigureDownloadController', function () {
+describe.only('App.WizardConfigureDownloadController', function () {
   beforeEach(function () {
     var mpacks = [
       Em.Object.create({
@@ -67,7 +67,7 @@ describe('App.WizardConfigureDownloadController', function () {
       controller.downloadMpackError({ status: 500 }, null, null, null, { name: 'alpha' });
       var actual = controller.get('mpacks').objectAt(0);
 
-      expect(actual).to.deep.equal(expected);
+      expect(actual).to.deep.include(expected);
     });
 
     it('Sets succeeded to true, failed to false, and inProgress to false on 409 response', function () {
@@ -83,5 +83,46 @@ describe('App.WizardConfigureDownloadController', function () {
 
       expect(actual).to.deep.equal(expected);
     });
+  });
+
+  describe('#retryDownload', function () {
+    it('Retries the download and sets the status flags correctly if the download failed.', function () {
+      var expected = Em.Object.create({
+        succeeded: false,
+        failed: false,
+        inProgress: true
+      });
+
+      var actual = Em.Object.create({
+        succeeded: false,
+        failed: true,
+        inProgress: false
+      });
+
+      sinon.stub(controller, 'downloadMpack');
+
+      controller.retryDownload({ context: actual });
+
+      expect(actual).to.deep.equal(expected);
+      expect(controller.downloadMpack).to.be.called;
+
+      controller.downloadMpack.restore();
+    })
+  });
+
+  describe('#showError', function () {
+    it('Displays the error if the download failed.', function () {
+      var mpack = Em.Object.create({
+        failed: true
+      });
+
+      sinon.stub(App.ModalPopup, 'show');
+
+      controller.showError({ context: mpack });
+
+      expect(App.ModalPopup.show).to.be.called;
+
+      App.ModalPopup.show.restore();
+    })
   });
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement "view log" feature for failed mpacks downloads, which will allow the user to view the error message in the server response when an mpack registration fails.

## How was this patch tested?

Added unit tests. All tests passing:

  20422 passing (22s)
  126 pending