### PR TITLE
[AMBARI-22905] Supporting old CLI option names in setup-ldap tool

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -26,6 +26,7 @@ import logging
 import logging.handlers
 import logging.config
 
+from optparse import OptionValueError
 from ambari_commons.exceptions import FatalException, NonFatalException
 from ambari_commons.logging_utils import set_verbose, set_silent, \
   print_info_msg, print_warning_msg, print_error_msg, set_debug_mode_from_options
@@ -522,12 +523,22 @@ def init_ldap_sync_parser_options(parser):
   parser.add_option('--ldap-sync-admin-name', default=None, help="Username for LDAP sync", dest="ldap_sync_admin_name")
   parser.add_option('--ldap-sync-admin-password', default=None, help="Password for LDAP sync", dest="ldap_sync_admin_password")
 
+def check_ldap_url_options(option, opt_str, value, parser):
+  setattr(parser.values, option.dest, value)
+  if parser.values.ldap_url and (parser.values.ldap_primary_host or parser.values.ldap_primary_port):
+    raise OptionValueError("You must use either [--ldap-url] or [--ldap-primary-host and --ldap-primary-port] but not both at the same time!")
+
+  if parser.values.ldap_secondary_url and (parser.values.ldap_secondary_host or parser.values.ldap_secondary_port):
+    raise OptionValueError("You must use either [--ldap-secondary-url] or [--ldap-secondary-host and --ldap-secondary-port] but not both at the same time!")
+
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_ldap_setup_parser_options(parser):
-  parser.add_option('--ldap-primary-host', default=None, help="Primary Host for LDAP", dest="ldap_primary_host")
-  parser.add_option('--ldap-primary-port', default=None, help="Primary Port for LDAP", dest="ldap_primary_port")
-  parser.add_option('--ldap-secondary-host', default=None, help="Secondary Host for LDAP", dest="ldap_secondary_host")
-  parser.add_option('--ldap-secondary-port', default=None, help="Secondary Port for LDAP", dest="ldap_secondary_port")
+  parser.add_option('--ldap-url', action="callback", callback=check_ldap_url_options, type='str', default=None, help="Primary URL for LDAP (must not be used together with --ldap-primary-host and --ldap-primary-port)", dest="ldap_url")
+  parser.add_option('--ldap-primary-host', action="callback", callback=check_ldap_url_options, type='str', default=None, help="Primary Host for LDAP (must not be used together with --ldap-url)", dest="ldap_primary_host")
+  parser.add_option('--ldap-primary-port', action="callback", callback=check_ldap_url_options, type='int', default=None, help="Primary Port for LDAP (must not be used together with --ldap-url)", dest="ldap_primary_port")
+  parser.add_option('--ldap-secondary-url', action="callback", callback=check_ldap_url_options, type='str', default=None, help="Secondary URL for LDAP (must not be used together with --ldap-secondary-host and --ldap-secondary-port)", dest="ldap_secondary_url")
+  parser.add_option('--ldap-secondary-host', action="callback", callback=check_ldap_url_options, type='str', default=None, help="Secondary Host for LDAP (must not be used together with --ldap-secondary-url)", dest="ldap_secondary_host")
+  parser.add_option('--ldap-secondary-port', action="callback", callback=check_ldap_url_options, type='int', default=None, help="Secondary Port for LDAP (must not be used together with --ldap-secondary-url)", dest="ldap_secondary_port")
   parser.add_option('--ldap-ssl', default=None, help="Use SSL [true/false] for LDAP", dest="ldap_ssl")
   parser.add_option('--ldap-user-class', default=None, help="User Attribute Object Class for LDAP", dest="ldap_user_class")
   parser.add_option('--ldap-user-attr', default=None, help="User Attribute Name for LDAP", dest="ldap_user_attr")


### PR DESCRIPTION
## What changes were proposed in this pull request?

While working on [AMBARI-22797](https://issues.apache.org/jira/browse/AMBARI-22797) we modified the following option names for the `setup-ldap` tool in AMBARI server:

1. `ldap-url` became `ldap-primary-host` and `ldap-primary-port`
2. `ldap-secondary-ur`l became `ldap-secondary-host` and `ldap-secondary-port`

To support backward compatibility we need to support old option names too.

## How was this patch tested?

New unit test has been added to cover this use case; latest Python test results in `ambari-server`:
```
Total run:123
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:02 min
[INFO] Finished at: 2018-02-05T10:53:30+01:00
[INFO] Final Memory: 99M/1690M
[INFO] ------------------------------------------------------------------------
```
In addition to unit testing I executed manual integration tests by running the setup-ldap tool with the following options and outcomes:

1. `--ldap-url`=myHost:1 and `--ldap-primary-host=myHost`: failed; either ldap-url or ldap-primary-host should be defined at a time
2. `--ldap-url=myHost:1` and `--ldap-primary-port=1`: failed; either ldap-url or ldap-primary-port should be defined at a time
3. `--ldap-secondary-url=myHost:1` and `--ldap-secondary-host=myHost`: failed; either ldap-url or ldap-secondary-host should be defined at a time
4. `--ldap-secondary-url=myHost:1` and `--ldap-secondary-port=1`: failed; either ldap-url or ldap-secondary-port should be defined at a time
5. `--ldap-url=myHost:1` and entered the rest of the parameters as usual: setup-ldap succeeded; `ambari.ldap.connectivity.server.host=myHost` and `ambari.ldap.connectivity.server.port=1` have been set in the DB (checked via browser using the API)
6. `--ldap-primary-host=myOtherHost`, `--ldap-primary-port=2` and entered the rest of the parameters as usual: setup-ldap succeeded; `ambari.ldap.connectivity.server.host=myOtherHost` and `ambari.ldap.connectivity.server.port=2` have been set in the DB (checked via browser using the API)
7. `--ldap-secondary-url=myHost:1` and entered the rest of the parameters as usual: setup-ldap succeeded; `ambari.ldap.connectivity.server.host=myHost` and `ambari.ldap.connectivity.server.port=1` have been set in the DB (checked via browser using the API)
8. `--ldap-secondary-host=myOtherHost`, `--ldap-secondary-port=2` and entered the rest of the parameters as usual: setup-ldap succeeded; `ambari.ldap.connectivity.secondary.server.host=myOtherHost` and `ambari.ldap.connectivity.secondary.server.port=2` have been added in the DB (checked via browser using the API)
