### PR TITLE
[AMBARI-22910] Supporting Ambari admin user/pw CLI options in setup-ldap tool

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -555,6 +555,8 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-sync-username-collisions-behavior', default=None, help="Handling behavior for username collisions [convert/skip] for LDAP sync", dest="ldap_sync_username_collisions_behavior")
   parser.add_option('--ldap-force-lowercase-usernames', default=None, help="Declares whether to force the ldap user name to be lowercase or leave as-is", dest="ldap_force_lowercase_usernames")
   parser.add_option('--ldap-pagination-enabled', default=None, help="Determines whether results from LDAP are paginated when requested", dest="ldap_pagination_enabled")
+  parser.add_option('--ldap-setup-admin-name', default=None, help="Ambari username for LDAP setup", dest="ldap_setup_admin_name")
+  parser.add_option('--ldap-setup-admin-password', default=None, help="Ambari password for LDAP setup", dest="ldap_setup_admin_password")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_pam_setup_parser_options(parser):

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -555,8 +555,8 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-sync-username-collisions-behavior', default=None, help="Handling behavior for username collisions [convert/skip] for LDAP sync", dest="ldap_sync_username_collisions_behavior")
   parser.add_option('--ldap-force-lowercase-usernames', default=None, help="Declares whether to force the ldap user name to be lowercase or leave as-is", dest="ldap_force_lowercase_usernames")
   parser.add_option('--ldap-pagination-enabled', default=None, help="Determines whether results from LDAP are paginated when requested", dest="ldap_pagination_enabled")
-  parser.add_option('--ldap-setup-admin-name', default=None, help="Ambari username for LDAP setup", dest="ldap_setup_admin_name")
-  parser.add_option('--ldap-setup-admin-password', default=None, help="Ambari password for LDAP setup", dest="ldap_setup_admin_password")
+  parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
+  parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_pam_setup_parser_options(parser):

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -672,9 +672,14 @@ def init_ldap_properties_list_reqd(properties, options):
   ]
   return ldap_properties
 
+def get_ambari_admin_username_password_pair(options):
+  admin_login = options.ambari_admin_username if options.ambari_admin_username is not None else get_validated_string_input("Enter Ambari Admin login: ", None, None, None, False, False)
+  admin_password = options.ambari_admin_password if options.ambari_admin_password is not None else get_validated_string_input("Enter Ambari Admin password: ", None, None, None, True, False)
+
+  return admin_login, admin_password
+
 def update_ldap_configuration(options, properties, ldap_property_value_map):
-  admin_login = options.ldap_setup_admin_name if options.ldap_setup_admin_name is not None else get_validated_string_input("Enter Ambari Admin login: ", None, None, None, False, False)
-  admin_password = options.ldap_setup_admin_password if options.ldap_setup_admin_password is not None else get_validated_string_input("Enter Ambari Admin password: ", None, None, None, True, False)
+  admin_login, admin_password = get_ambari_admin_username_password_pair(options)
   url = get_ambari_server_api_base(properties) + SETUP_LDAP_CONFIG_URL
   admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
   request = urllib2.Request(url)

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -672,9 +672,9 @@ def init_ldap_properties_list_reqd(properties, options):
   ]
   return ldap_properties
 
-def update_ldap_configuration(properties, ldap_property_value_map):
-  admin_login = get_validated_string_input("Enter Ambari Admin login: ", None, None, None, False, False)
-  admin_password = get_validated_string_input("Enter Ambari Admin password: ", None, None, None, True, False)
+def update_ldap_configuration(options, properties, ldap_property_value_map):
+  admin_login = options.ldap_setup_admin_name if options.ldap_setup_admin_name is not None else get_validated_string_input("Enter Ambari Admin login: ", None, None, None, False, False)
+  admin_password = options.ldap_setup_admin_password if options.ldap_setup_admin_password is not None else get_validated_string_input("Enter Ambari Admin password: ", None, None, None, True, False)
   url = get_ambari_server_api_base(properties) + SETUP_LDAP_CONFIG_URL
   admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
   request = urllib2.Request(url)
@@ -850,7 +850,7 @@ def setup_ldap(options):
 
     ldap_property_value_map[IS_LDAP_CONFIGURED] = "true"
     #Saving LDAP configuration in Ambari DB using the REST API
-    update_ldap_configuration(properties, ldap_property_value_map)
+    update_ldap_configuration(options, properties, ldap_property_value_map)
 
     #The only property we want to write out in Ambari.properties is the client.security type being LDAP
     ldap_property_value_map.clear()

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7535,6 +7535,60 @@ class TestAmbariServer(TestCase):
     sys.stdout = sys.__stdout__
     pass
 
+  @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSecurity.get_YN_input")
+  @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
+  @patch("ambari_server.setupSecurity.is_server_runing")
+  def test_setup_ldap_with_admin_username_and_password_options(self, is_server_runing_method, get_ambari_properties_method,
+                                                                get_validated_string_input_method, get_YN_input_method, urlopen_method):
+
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_server_runing_method.return_value = (True, 0)
+
+    def yn_input_side_effect(*args, **kwargs):
+      return False if 'TrustStore' in args[0] else True
+
+    get_YN_input_method.side_effect = yn_input_side_effect
+    get_ambari_properties_method.return_value = Properties()
+
+    def valid_input_side_effect(*args, **kwargs):
+      if 'lower-case' in args[0] or 'paginated' in args[0]:
+        return 'false'
+      if 'Bind anonymously' in args[0]:
+        return 'true'
+      if 'username collisions' in args[0]:
+        return 'skip'
+      if 'URL Port' in args[0]:
+        return '1'
+      if 'Ambari Admin' in args[0]:
+        raise Exception("ShouldNotBeInvoked") # no user name/password should be read by the mock
+      if 'Primary URL' in args[0]:
+        return kwargs['answer']
+      if args[1] == "true" or args[1] == "false":
+        return args[1]
+      else:
+        return "test"
+
+    get_validated_string_input_method.side_effect = valid_input_side_effect
+
+    response = MagicMock()
+    response.getcode.return_value = 200
+    urlopen_method.return_value = response
+    options = self._create_empty_options_mock()
+    options.ldap_setup_admin_name = 'admin'
+    options.ldap_setup_admin_password = 'admin'
+
+    setup_ldap(options)
+
+    self.assertTrue(urlopen_method.called)
+
+    sys.stdout = sys.__stdout__
+    pass
+
   @patch("urllib2.urlopen")
   @patch("ambari_server.setupSecurity.get_validated_string_input")
   @patch("ambari_server.setupSecurity.get_ambari_properties")
@@ -8619,6 +8673,8 @@ class TestAmbariServer(TestCase):
     options.ldap_save_settings = None
     options.ldap_referral = None
     options.ldap_bind_anonym = None
+    options.ldap_setup_admin_name = None
+    options.ldap_setup_admin_password = None
     options.ldap_sync_admin_name = None
     options.ldap_sync_username_collisions_behavior = None
     options.ldap_force_lowercase_usernames = None

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7541,7 +7541,7 @@ class TestAmbariServer(TestCase):
   @patch("ambari_server.setupSecurity.get_validated_string_input")
   @patch("ambari_server.setupSecurity.get_ambari_properties")
   @patch("ambari_server.setupSecurity.is_server_runing")
-  def test_setup_ldap_with_admin_username_and_password_options(self, is_server_runing_method, get_ambari_properties_method,
+  def test_setup_ldap_with_ambari_admin_username_and_password_options(self, is_server_runing_method, get_ambari_properties_method,
                                                                 get_validated_string_input_method, get_YN_input_method, urlopen_method):
 
     out = StringIO.StringIO()
@@ -7579,8 +7579,8 @@ class TestAmbariServer(TestCase):
     response.getcode.return_value = 200
     urlopen_method.return_value = response
     options = self._create_empty_options_mock()
-    options.ldap_setup_admin_name = 'admin'
-    options.ldap_setup_admin_password = 'admin'
+    options.ambari_admin_username = 'admin'
+    options.ambari_admin_password = 'admin'
 
     setup_ldap(options)
 
@@ -8673,8 +8673,8 @@ class TestAmbariServer(TestCase):
     options.ldap_save_settings = None
     options.ldap_referral = None
     options.ldap_bind_anonym = None
-    options.ldap_setup_admin_name = None
-    options.ldap_setup_admin_password = None
+    options.ambari_admin_username = None
+    options.ambari_admin_password = None
     options.ldap_sync_admin_name = None
     options.ldap_sync_username_collisions_behavior = None
     options.ldap_force_lowercase_usernames = None


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since we use Ambari's REST API in the `setup-ldap` tool to persists its outcome into the DB we require the end-user to type his/her Ambari username and password during the user input phase. This makes automated integration tests very hard to implement.

The solution is to add two new CLI option names for `setup-ldap` (similarly to the `sync-ldap` tool):
```
--ldap-setup-admin-name
--ldap-setup-admin-password
```

## How was this patch tested?
A new unit test case has been added to cover this use case; latest Python test results in `ambari-server`:
```
Ran 124 tests in 6.109s

OK
----------------------------------------------------------------------
Total run:124
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:08 min
[INFO] Finished at: 2018-02-05T14:59:39+01:00
[INFO] Final Memory: 99M/1605M
[INFO] ------------------------------------------------------------------------
```
In addition to unit testing I executed the following integration test manually:

1. copied `ambari-server.py` and `setupSecurity.py` into the appropriate folders in my cluster (I use vagrant)
2. ran `ambari-server setup-ldap --ldap-setup-admin-name=admin --ldap-setup-admin-password=****` (pw is masked for security reasons)
3. entered the required properties (host, port, etc...)
4. no Ambari username/pw has been requested
5. the `setup-ldap` tool succeeded; the outcome has been saved in the DB
