### PR TITLE
[AMBARI-22911] Log Search UI: move Capture button to top menu

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.html
@@ -25,6 +25,10 @@
              additionalLabelComponentSetter="getHistoryItemIcons"></menu-button>
 <menu-button label="{{'topMenu.filter' | translate}}" iconClass="fa fa-filter"
              (buttonClick)="openLogIndexFilter()"></menu-button>
+<menu-button *ngIf="!captureSeconds" label="{{'filter.capture' | translate}}" iconClass="fa fa-caret-right"
+             (buttonClick)="startCapture()"></menu-button>
+<menu-button *ngIf="captureSeconds" label="{{captureSeconds | timerSeconds}}" iconClass="fa fa-stop stop-icon"
+             (buttonClick)="stopCapture()"></menu-button>
 <menu-button label="{{'topMenu.refresh' | translate}}" iconClass="fa fa-refresh"
              (buttonClick)="refresh()"></menu-button>
 <modal *ngIf="isLogIndexFilterDisplayed" (submit)="saveLogIndexFilter()" (cancel)="closeLogIndexFilter()"

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.less
@@ -15,10 +15,15 @@
  * limitations under the License.
  */
 
+@import '../variables';
+
 :host {
   display: block;
   margin-left: auto;
   menu-button {
     margin: 0 1em;
+    /deep/ .stop-icon {
+      color: @exclude-color;
+    }
   }
 }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.spec.ts
@@ -42,6 +42,7 @@ import {LogsContainerService} from '@app/services/logs-container.service';
 import {UserSettingsService} from '@app/services/user-settings.service';
 import {UtilsService} from '@app/services/utils.service';
 import {ModalComponent} from '@app/components/modal/modal.component';
+import {TimerSecondsPipe} from '@app/pipes/timer-seconds.pipe';
 
 import {ActionMenuComponent} from './action-menu.component';
 
@@ -81,7 +82,8 @@ describe('ActionMenuComponent', () => {
       ],
       declarations: [
         ActionMenuComponent,
-        ModalComponent
+        ModalComponent,
+        TimerSecondsPipe
       ],
       providers: [
         {

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.ts
@@ -48,6 +48,10 @@ export class ActionMenuComponent {
     return this.historyManager.activeHistory;
   }
 
+  get captureSeconds(): number {
+    return this.logsContainer.captureSeconds;
+  }
+
   isLogIndexFilterDisplayed: boolean = false;
 
   settingsForm: FormGroup = this.settings.settingsFormGroup;
@@ -89,6 +93,14 @@ export class ActionMenuComponent {
   saveLogIndexFilter(): void {
     this.isLogIndexFilterDisplayed = false;
     this.settings.saveIndexFilterConfig();
+  }
+
+  startCapture(): void {
+    this.logsContainer.startCaptureTimer();
+  }
+
+  stopCapture(): void {
+    this.logsContainer.stopCaptureTimer();
   }
 
 }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.html
@@ -46,9 +46,5 @@
     <filter-button *ngIf="isFilterConditionDisplayed('levels')" formControlName="levels"
                    label="{{filters.levels.label | translate}}" [iconClass]="filters.levels.iconClass"
                    [subItems]="filters.levels.options" [isMultipleChoice]="true" [isRightAlign]="true"></filter-button>
-    <menu-button *ngIf="!captureSeconds" label="{{'filter.capture' | translate}}" iconClass="fa fa-caret-right"
-                 (buttonClick)="startCapture()"></menu-button>
-    <menu-button *ngIf="captureSeconds" label="{{captureSeconds | timerSeconds}}" iconClass="fa fa-stop stop-icon"
-                 (buttonClick)="stopCapture()"></menu-button>
   </div>
 </form>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.less
@@ -68,10 +68,6 @@
     }
   }
 
-  /deep/ .stop-icon {
-    color: @exclude-color;
-  }
-
   .filter-buttons {
     .default-flex;
   }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.spec.ts
@@ -39,7 +39,6 @@ import {TabsService, tabs} from '@app/services/storage/tabs.service';
 import {HttpClientService} from '@app/services/http-client.service';
 import {UtilsService} from '@app/services/utils.service';
 import {LogsContainerService} from '@app/services/logs-container.service';
-import {TimerSecondsPipe} from '@app/pipes/timer-seconds.pipe';
 
 import {FiltersPanelComponent} from './filters-panel.component';
 
@@ -58,8 +57,7 @@ describe('FiltersPanelComponent', () => {
     };
     TestBed.configureTestingModule({
       declarations: [
-        FiltersPanelComponent,
-        TimerSecondsPipe
+        FiltersPanelComponent
       ],
       imports: [
         StoreModule.provideStore({

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.ts
@@ -95,10 +95,6 @@ export class FiltersPanelComponent implements OnChanges {
     return this.logsContainer.queryParameterAdd;
   }
 
-  get captureSeconds(): number {
-    return this.logsContainer.captureSeconds;
-  }
-
   searchBoxValueUpdate: Subject<void> = new Subject();
 
   isFilterConditionDisplayed(key: string): boolean {
@@ -107,14 +103,6 @@ export class FiltersPanelComponent implements OnChanges {
 
   updateSearchBoxValue(): void {
     this.searchBoxValueUpdate.next();
-  }
-
-  startCapture(): void {
-    this.logsContainer.startCaptureTimer();
-  }
-
-  stopCapture(): void {
-    this.logsContainer.stopCaptureTimer();
   }
 
   proceedWithExclude(item: string): void {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Move 'Capture' button from filters panel to top menu
- Buttons order: Undo, Redo, History, Filter, Capture, Refresh

## How was this patch tested?

Tested on mock and real data
Unit tests:
Executed 255 of 255 SUCCESS (6.414 secs / 6.295 secs)