### PR TITLE
[AMBARI-22914] Oracle DDL is broken at trunk

### DIFF
--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -1176,7 +1176,7 @@ insert into adminprincipal (principal_id, principal_type_id)
   select 13, 8 from dual;
 
 -- Insert the default administrator user.
-insert into users(user_id, principal_id, user_name, display_name, local_username, create_timestamp)
+insert into users(user_id, principal_id, user_name, display_name, local_username, create_time)
   SELECT 1, 1, 'admin', 'Administrator', 'admin', CURRENT_TIMESTAMP from dual;
 
 -- Insert the LOCAL authentication data for the default administrator user.


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Oracle DDL is broken
```
ERROR at line 1:
ORA-00904: "CREATE_TIMESTAMP": invalid identifier


insert into user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
*
ERROR at line 1:
ORA-02291: integrity constraint (AMBARI.FK_USER_AUTHENTICATION_USERS) violated
- parent key not found
```

The error is in the following insert statement found at https://github.com/apache/ambari/blob/ef801acbb290657760ced9917055fbb6250c95d4/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql#L1179-L1180

This is fixed by using the correct column name for the create timestamp, `create_time`, rather than `create_timestamp`.

```
insert into users(user_id, principal_id, user_name, display_name, local_username, create_time)
  SELECT 1, 1, 'admin', 'Administrator', 'admin', CURRENT_TIMESTAMP from dual;
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.