### PR TITLE
[AMBARI-22868] Expose Done Flag for Coordinator Datasets in Workflow Manager View

### DIFF
--- a/contrib/views/wfmanager/src/main/resources/ui/app/components/dataset-config.js
+++ b/contrib/views/wfmanager/src/main/resources/ui/app/components/dataset-config.js
@@ -62,6 +62,12 @@ export default Ember.Component.extend(Validations, {
     this.get('timeUnitOptions').pushObject({value:'cron',displayName:'Cron'});
     this.set('childComponents', new Map());
     this.set('timezoneList', Ember.copy(Constants.timezoneList));
+    if(!this.get('dataset.doneFlag')){
+      this.set('dataset.doneFlag', {
+        type : 'default',
+        value : ''
+      });
+    }
   }.on('init'),
   validateChildComponents(){
     var isChildComponentsValid = true;
@@ -98,6 +104,10 @@ export default Ember.Component.extend(Validations, {
     },
     cancelDatasetOperation(){
       this.sendAction('cancel');
+    },
+    clearDoneFlag(){
+      this.set('dataset.doneFlag.value', '');
+      this.set('dataset.doneFlag.type', 'default');
     }
   }
 });

--- a/contrib/views/wfmanager/src/main/resources/ui/app/domain/coordinator/coordinator-xml-generator.js
+++ b/contrib/views/wfmanager/src/main/resources/ui/app/domain/coordinator/coordinator-xml-generator.js
@@ -71,8 +71,8 @@ var CoordinatorGenerator= Ember.Object.extend({
           dataSetJson._frequency = dataset.frequency.value;
         }
         dataSetJson["uri-template"]=dataset.uriTemplate;
-        if (dataset.doneFlag){
-          dataSetJson["done-flag"]=dataset.doneFlag;
+        if (dataset.doneFlag.type !== 'default'){
+          dataSetJson["done-flag"]=dataset.doneFlag.value;
         }
         datasets.push(dataSetJson);
       });

--- a/contrib/views/wfmanager/src/main/resources/ui/app/templates/components/dataset-config.hbs
+++ b/contrib/views/wfmanager/src/main/resources/ui/app/templates/components/dataset-config.hbs
@@ -58,6 +58,26 @@
     </div>
   </div>
   <div class="form-group">
+    <label for="" class="control-label col-xs-2">Done Flag
+      {{#if required}}
+        <span class="requiredField">&nbsp;*</span>
+      {{/if}}
+    </label>
+    <div class="col-xs-7">
+      <div class="input-group">
+        <div class="input-group-btn">
+          <button onclick={{action 'clearDoneFlag'}} type="button" class="btn btn-default {{if (eq dataset.doneFlag.type 'default') 'btn-secondary' ''}} scope-btn">
+            Default
+          </button>
+          <button onclick={{action (mut dataset.doneFlag.type) "custom"}} type="button" class="btn btn-default {{if (eq dataset.doneFlag.type 'custom') 'btn-secondary' ''}} scope-btn">
+            Custom
+          </button>
+        </div>
+        {{input type="text" class="form-control" name="done-flag" value=dataset.doneFlag.value placeholder='Done Flag' disabled=(eq dataset.doneFlag.type 'default')}}
+      </div>
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-xs-7 pull-right">
       <button id="dataset-add-btn" {{action 'cancelDatasetOperation'}} type="button" class="btn btn-default">Cancel</button>
       {{#if createMode}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expose the Coordinator Dataset element "done-flag" in the UI. This is an optional field with the following possible values:

- absent
- present, but empty
- present with text value

In the UI, this condenses to two options:

- "Default" = absent
- "Custom" = present, with optional text value

## How was this patch tested?

Manual testing as no mvn tests are defined. After each of the test cases listed below, the xml preview was inspected for correctness:

1. Create coordinator dataset entity with Done Flag as "Default"
2. Create coordinator dataset entity with Done Flag as "Custom" and text box empty
3. Create coordinator dataset entity with Done Flag as "Custom" and non-empty text value
4. Modify existing coordinator dataset entity with Done Flag as "Default" changed to "Custom"
5. Modify existing coordinator dataset entity with Done Flag as "Custom" changed to "Default"

For each of the test cases below, the xml file generated in HDFS was inspected for correctness and run against oozie validate

1. Coordinator with dataset entity containing "Default" done flag
2. Coordinator with dataset entity containing "Custom" done flag with empty text
3. Coordinator with dataset entity containing "Custom" done flag with non-empty text

<img width="1403" alt="ambari-22868" src="https://user-images.githubusercontent.com/28899694/35841818-b95a7e24-0ac3-11e8-80e2-77646554c507.png">
