### PR TITLE
[AMBARI-22918] Decommission RegionServer fails when kerberos is enabled

### DIFF
--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/hbase_decommission.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/hbase_decommission.py
@@ -64,7 +64,7 @@ def hbase_decommission(env):
     for host in hosts:
       if host:
         regiondrainer_cmd = format(
-          "{kinit_cmd} {hbase_cmd} --config {hbase_conf_dir} {master_security_config} org.jruby.Main {region_drainer} remove {host}")
+          "{kinit_cmd} HBASE_OPTS=\"$HBASE_OPTS {master_security_config}\" {hbase_cmd} --config {hbase_conf_dir} org.jruby.Main {region_drainer} remove {host}")
         Execute(regiondrainer_cmd,
                 user=params.hbase_user,
                 logoutput=True
@@ -76,9 +76,9 @@ def hbase_decommission(env):
     for host in hosts:
       if host:
         regiondrainer_cmd = format(
-          "{kinit_cmd} {hbase_cmd} --config {hbase_conf_dir} {master_security_config} org.jruby.Main {region_drainer} add {host}")
+          "{kinit_cmd} HBASE_OPTS=\"$HBASE_OPTS {master_security_config}\" {hbase_cmd} --config {hbase_conf_dir} org.jruby.Main {region_drainer} add {host}")
         regionmover_cmd = format(
-          "{kinit_cmd} {hbase_cmd} --config {hbase_conf_dir} {master_security_config} org.jruby.Main {region_mover} unload {host}")
+          "{kinit_cmd} HBASE_OPTS=\"$HBASE_OPTS {master_security_config}\" {hbase_cmd} --config {hbase_conf_dir} org.jruby.Main {region_mover} unload {host}")
 
         Execute(regiondrainer_cmd,
                 user=params.hbase_user,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change the hbase_decommission.py to make it work when kerberos is enabled.
- Move {master_security_config} into the environment variable HBASE_OPTS.

## How was this patch tested?

I manually tested it my local env, but I didn't make a unit test for this. Could anyone advise me how to make a unit test for the python code?

