### PR TITLE
AMBARI-22906. Not able to register new HDP version after upgrading

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -1142,6 +1142,19 @@ def update_ambari_env():
     return -1
 
   return 0
+
+def set_property(key, value, rewrite=True):
+  properties = get_ambari_properties()
+  if properties == -1:
+    err = "Error getting ambari properties"
+    raise FatalException(-1, err)
+
+  if not rewrite and key in properties.keys():
+    return
+
+  properties.process_pair(key, value)
+  update_properties(properties)
+
  
 # default should be false / not accepted 
 def write_gpl_license_accepted(default_prompt_value = False, text = GPL_LICENSE_PROMPT_TEXT):
@@ -1155,9 +1168,7 @@ def write_gpl_license_accepted(default_prompt_value = False, text = GPL_LICENSE_
     return True
 
   result = get_YN_input(text, default_prompt_value)
-
-  properties.process_pair(GPL_LICENSE_ACCEPTED_PROPERTY, str(result).lower())
-  update_properties(properties)
+  set_property(GPL_LICENSE_ACCEPTED_PROPERTY, str(result).lower())
 
   return result
 

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -40,9 +40,9 @@ from ambari_server.serverConfiguration import configDefaults, get_resources_loca
   check_database_name_property, get_ambari_properties, get_ambari_version, \
   get_java_exe_path, get_stack_location, parse_properties_file, read_ambari_user, update_ambari_properties, \
   update_database_name_property, get_admin_views_dir, get_views_dir, get_views_jars, \
-  AMBARI_PROPERTIES_FILE, CLIENT_SECURITY, RESOURCES_DIR_PROPERTY, \
+  AMBARI_PROPERTIES_FILE, CLIENT_SECURITY, RESOURCES_DIR_PROPERTY, GPL_LICENSE_ACCEPTED_PROPERTY, \
   SETUP_OR_UPGRADE_MSG, update_krb_jaas_login_properties, AMBARI_KRB_JAAS_LOGIN_FILE, get_db_type, update_ambari_env, \
-  AMBARI_ENV_FILE, JDBC_DATABASE_PROPERTY, get_default_views_dir, write_gpl_license_accepted
+  AMBARI_ENV_FILE, JDBC_DATABASE_PROPERTY, get_default_views_dir, write_gpl_license_accepted, set_property
 from ambari_server.setupSecurity import adjust_directory_permissions, \
   generate_env, ensure_can_start_under_current_user
 from ambari_server.utils import compare_versions
@@ -177,6 +177,7 @@ def run_schema_upgrade(args):
 
 def check_gpl_license_approved(upgrade_response):
   if 'lzo_enabled' not in upgrade_response or upgrade_response['lzo_enabled'].lower() != "true":
+    set_property(GPL_LICENSE_ACCEPTED_PROPERTY, "false", rewrite=False)
     return
 
   while not write_gpl_license_accepted(text = LZO_ENABLED_GPL_TEXT) and not get_YN_input(INSTALLED_LZO_WITHOUT_GPL_TEXT, False):


### PR DESCRIPTION
Steps to reproduce the issue

1. Install Ambari2.5.x and install HDP on that.

2. Now Upgrade ambari to 2.6.1 version.

3. Now try to register HDP version with VDF file - Save button is not enabled (also UI does not load repo URLs and)

4. In JS it fails with below error

Cannot read property 'gpl.license.accepted' of undefined
What is expected: UI should properly show the message that gpl license needs to be enabled. also Upgrade should take care of adding this property if it is needed.

Workaround for this is : add "gpl.license.accepted=true" to ambari.proeprties and then restart should fix the problem