### PR TITLE
AMBARI-22921. Unable to enable hive interactive, LLAP, on our Ambari

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive_server_interactive.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive_server_interactive.py
@@ -243,8 +243,9 @@ class HiveServerInteractiveDefault(HiveServerInteractive):
       if params.security_enabled:
         llap_keytab_splits = params.hive_llap_keytab_file.split("/")
         Logger.debug("llap_keytab_splits : {0}".format(llap_keytab_splits))
+        slider_keytab = llap_keytab_splits[-1]
         cmd += format(" --slider-keytab-dir .slider/keytabs/{params.hive_user}/ --slider-keytab "
-                      "{llap_keytab_splits[4]} --slider-principal {params.hive_llap_principal}")
+                      "{slider_keytab} --slider-principal {params.hive_llap_principal}")
 
       # Add the aux jars if they are specified. If empty, dont need to add this param.
       if params.hive_aux_jars:


### PR DESCRIPTION
While trying to enable the hive interactive plugin, we identified that Ambari was looking in the incorrect directory when trying to locate the users keytab.

