### PR TITLE
AMBARI-22902. Changed description of Kadmin Host

### DIFF
--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/configuration/kerberos-env.xml
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/configuration/kerberos-env.xml
@@ -165,7 +165,7 @@
     <name>admin_server_host</name>
     <display-name>Kadmin host</display-name>
     <description>
-      The IP address or FQDN for the KDC Kerberos administrative host. Optionally a port number may be included.
+      The FQDN for the KDC Kerberos administrative host. Optionally a port number may be included.
     </description>
     <value/>
     <value-attributes>

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/configuration/kerberos-env.xml
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/configuration/kerberos-env.xml
@@ -165,7 +165,7 @@
     <name>admin_server_host</name>
     <display-name>Kadmin host</display-name>
     <description>
-      The IP address or FQDN for the KDC Kerberos administrative host. Optionally a port number may be included.
+      The FQDN for the KDC Kerberos administrative host. Optionally a port number may be included.
     </description>
     <value/>
     <value-attributes>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to changes in the implementation for the MIT KDC and FreeIPA choices the KDC administration host must be the FQDN of the host (with or without the port). If the FQDN is not used, authentication with the KDC will fail.
So that we needed to change the description of Kadmin Host input field to reflect this implementation change.

## How was this patch tested?

1. changed kerberos-env.xml on the host where my ambari-server is running
2. `ambari-server restart`
3. started Enable Kerberos wizard and navigated to Step 2 (Configure Kerberos)
4. checked if `Kadmin host`'s description is changed

The result is:
<img width="1283" alt="screen shot 2018-02-06 at 2 41 38 pm" src="https://user-images.githubusercontent.com/34065904/35862664-b8a229e4-0b4c-11e8-8dd9-4c805f2a8da8.png">
