### PR TITLE
[AMBARI-22877] Ambari does not show all cluster hosts to select for assigning HiveServer2 Interactive.

### DIFF
--- a/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
+++ b/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
@@ -65,6 +65,7 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
     
     switch (action) {
       case 'ADD':
+        this.clearRecommendations();
         if (hostComponent.componentName === "HIVE_SERVER_INTERACTIVE") {
           this.getPendingBatchRequests(hostComponent);  
         } else {
@@ -290,34 +291,32 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
   },
 
   /**
-   * Load active host list to <code>hosts</code> variable
+   * Success callback after loading active host list
    * @override
-   * @method renderHostInfo
+   * @method loadWizardHostsSuccessCallback
    */
-  renderHostInfo: function () {
+   loadWizardHostsSuccessCallback: function (data) {
     var parentController = this.get('content.controllerName');
     if (parentController) {
-      return this._super();
+      this._super(data);
     } else {
-      var dfd = $.Deferred();
-      var hosts = App.Host.find().toArray();
       var result = [];
-      for (var p = 0; p < hosts.length; p++) {
+      data.items.forEach(function (host) {
+        var hostName = host.Hosts.host_name,
+          cpu = host.Hosts.cpu_count,
+          memory = host.Hosts.total_mem.toFixed(2);
         result.push(Em.Object.create({
-          host_name: hosts[p].get('hostName'),
-          cpu: hosts[p].get('cpu'),
-          memory: hosts[p].get('memory'),
-          maintenance_state: hosts[p].get('maintenance_state'),
-          disk_info: hosts[p].get('diskInfo'),
-          host_info: Em.I18n.t('installer.step5.hostInfo').fmt(hosts[p].get('hostName'), numberUtils.bytesToSize(hosts[p].get('memory'), 1, 'parseFloat', 1024), hosts[p].get('cpu'))
+          host_name: hostName,
+          cpu: cpu,
+          memory: memory,
+          disk_info: host.Hosts.disk_info,
+          maintenance_state: host.Hosts.maintenance_state,
+          host_info: Em.I18n.t('installer.step5.hostInfo').fmt(hostName, numberUtils.bytesToSize(memory, 1, 'parseFloat', 1024), cpu)
         }));
-      }
-
-      this.set("hosts", result);
-      this.sortHosts(result);
+      }, this);
+      this.set('hosts', result);
+      this.sortHosts(this.get('hosts'));
       this.set('isHostsLoaded', true);
-      dfd.resolve();
-      return dfd.promise();
     }
   },
 

--- a/ambari-web/app/mixins/wizard/assign_master_components.js
+++ b/ambari-web/app/mixins/wizard/assign_master_components.js
@@ -309,6 +309,8 @@ App.AssignMasterComponents = Em.Mixin.create(App.HostComponentValidationMixin, A
   clearRecommendations: function() {
     if (this.get('content.recommendations')) {
       this.set('content.recommendations', null);
+    }
+    if (this.get('recommendations')) {
       this.set('recommendations', null);
     }
   },
@@ -597,14 +599,16 @@ App.AssignMasterComponents = Em.Mixin.create(App.HostComponentValidationMixin, A
    * @method renderHostInfo
    */
   renderHostInfo: function () {
+    var self = this;
     var isInstaller = (this.get('wizardController.name') === 'installerController' || this.get('content.controllerName') === 'installerController');
     return App.ajax.send({
       name: isInstaller ? 'hosts.info.install' : 'hosts.high_availability.wizard',
       sender: this,
       data: {
         hostNames: isInstaller ? this.getHosts().join() : null
-      },
-      success: 'loadWizardHostsSuccessCallback'
+      }
+    }).success(function(data) {
+      self.loadWizardHostsSuccessCallback(data)
     });
   },
 

--- a/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
+++ b/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
@@ -241,46 +241,11 @@ describe('App.AssignMasterOnStep7Controller', function () {
   describe("#renderHostInfo()", function () {
 
     beforeEach(function() {
-      sinon.stub(App.Host, 'find').returns([
-        Em.Object.create({
-          hostName: 'host1',
-          cpu: 1,
-          memory: 1,
-          diskInfo: {}
-        })
-      ]);
-      sinon.stub(view, 'sortHosts');
       sinon.stub(view, 'getHosts').returns([]);
-      sinon.stub(numberUtils, 'bytesToSize').returns(1);
     });
 
     afterEach(function() {
-      App.Host.find.restore();
-      view.sortHosts.restore();
-      numberUtils.bytesToSize.restore();
-    });
-
-    it("should set hosts", function() {
-      view.reopen({
-        content: Em.Object.create({
-          controllerName: null
-        })
-      });
-      view.renderHostInfo();
-      expect(view.get('hosts')).to.be.eql([Em.Object.create({
-        host_name: 'host1',
-        cpu: 1,
-        memory: 1,
-        disk_info: {},
-        host_info: Em.I18n.t('installer.step5.hostInfo').fmt('host1', 1, 1)
-      })]);
-      expect(view.sortHosts.calledWith([Em.Object.create({
-        host_name: 'host1',
-        cpu: 1,
-        memory: 1,
-        disk_info: {},
-        host_info: Em.I18n.t('installer.step5.hostInfo').fmt('host1', 1, 1)
-      })])).to.be.true;
+      view.getHosts.restore();
     });
 
     it("should make general request to get hosts", function() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Get all host information using Ajax call when "Add HSI" modal is opened.  

## How was this patch tested?

Tested and fixed ambari-web unit tests. Tested manually on cluster