### PR TITLE
AMBARI-22935. Update HttpClient version in Log Search (use 4.4.1 with Solr 6)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -220,6 +220,12 @@
       <groupId>org.springframework.security.kerberos</groupId>
       <artifactId>spring-security-kerberos-client</artifactId>
       <version>1.0.1.RELEASE</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Solr client is not working properly on secure env. It tries to use methods for SPNego that are not exist. Reason for that spring-kerberos-client override the httpclient version and uses an older one. Spring kerberos client has not used yet, so that is a safe change. (Solr-clientr dependency has multiple dependency on different http components ... when we will upgrade to Solr 7, with that fix we will use those that Solr client provides for us)

## How was this patch tested?
Manually, and validated with mvn dependency:tree command

please review @zeroflag @adoroszlai @swagle @kasakrisz 