### PR TITLE
[AMBARI-22934] [API] Updating current stack repo without GPL repos in …

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -190,7 +190,6 @@ import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfile;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.scheduler.RequestExecutionFactory;
 import org.apache.ambari.server.state.stack.OsFamily;
-import org.apache.ambari.server.state.stack.RepoTag;
 import org.apache.ambari.server.state.stack.RepositoryXml;
 import org.apache.ambari.server.state.stack.WidgetLayout;
 import org.apache.ambari.server.state.stack.WidgetLayoutInfo;
@@ -4506,7 +4505,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         for (RepositoryXml.Repo repo : os.getRepos()) {
           RepositoryResponse resp = new RepositoryResponse(repo.getBaseUrl(), os.getFamily(),
               repo.getRepoId(), repo.getRepoName(), repo.getDistribution(), repo.getComponents(), repo.getMirrorsList(),
-              repo.getBaseUrl(), repo.getLatestUri(), Collections.<String>emptyList(), Collections.<RepoTag>emptySet());
+              repo.getBaseUrl(), repo.getLatestUri(), Collections.<String>emptyList(), repo.getTags());
 
           resp.setVersionDefinitionId(versionDefinitionId);
           resp.setStackName(stackId.getStackName());

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -100,6 +100,9 @@ public class RepositoryVersionHelper {
 
   @Inject Provider<Clusters> clusters;
 
+  public static final String GPL_MINIMAL_VERSION = "2.6.4.0";
+  private static final String ZERO_VERSION = "0.0.0.0";
+  private static final String VERSION_SPLITTER = "\\.";
 
   /**
    * Checks repo URLs against the current version for the cluster and make
@@ -716,5 +719,36 @@ public class RepositoryVersionHelper {
     });
   }
 
+  /**
+   * Checks repository version is HDP and should contain repo with GPL tag.
+   * @param stackId stack id
+   * @param version repository version as x.x.x.x, x.x.x.x-x, x.x-x, x.x
+   * @return true if stack is HDP and version is younger than {@value #GPL_MINIMAL_VERSION}
+   */
+  public static boolean shouldContainGPLRepo(StackId stackId, String version) {
+    if (!stackId.getStackName().equals("HDP")) {
+      return false;
+    }
+    if (version.contains("-")) {
+      version = version.split("-")[0];
+    }
+    String[] versionItems = ZERO_VERSION.split(VERSION_SPLITTER);
+    int versionIndex = 0;
+    for (String versionItem : version.split(VERSION_SPLITTER)) {
+      versionItems[versionIndex++] = versionItem;
+    }
+    String[] gplMinimalItems = GPL_MINIMAL_VERSION.split(VERSION_SPLITTER);
+
+    for (versionIndex = 0; versionIndex < versionItems.length; versionIndex++) {
+      Integer versionItem = Integer.parseInt(versionItems[versionIndex]);
+      Integer gplMinimalItem = Integer.parseInt(gplMinimalItems[versionIndex]);
+      if (versionItem < gplMinimalItem) {
+        return false;
+      } else if (versionItem > gplMinimalItem) {
+        return true;
+      }
+    }
+    return true;
+  }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProviderTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.controller.internal;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -563,6 +565,53 @@ public class RepositoryVersionResourceProviderTest {
     Assert.assertEquals(false, RepositoryVersionEntity.isVersionInStack(sid3, "HDF-2.1"));
   }
 
+  private void testGPLRepoCheck(RepositoryVersionEntity repositoryVersionEntity) throws NoSuchMethodException,
+      InvocationTargetException, IllegalAccessException {
+    final ResourceProvider provider = injector.getInstance(ResourceProviderFactory.class)
+        .getRepositoryVersionResourceProvider();
+
+    Method validateGPLRepoMethod = RepositoryVersionResourceProvider.class.getDeclaredMethod("validateGPLRepoPresence",
+        RepositoryVersionEntity.class);
+    validateGPLRepoMethod.setAccessible(true);
+    validateGPLRepoMethod.invoke(provider, repositoryVersionEntity);
+  }
+
+  @Test
+  public void testGPLRepoCheckWithUnsatisfiedGPLRepoRequirement() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    RepositoryVersionEntity repositoryVersionEntity = new RepositoryVersionEntity();
+    repositoryVersionEntity.setOperatingSystems("[{\"repositories\":[],\"OperatingSystems/os_type\":\"debian7\"}]");
+
+    // check should not be failed for no-HDP stack
+    StackEntity hdpStackEntity = new StackEntity();
+    hdpStackEntity.setStackName("NOTHDP");
+    repositoryVersionEntity.setStack(hdpStackEntity);
+    testGPLRepoCheck(repositoryVersionEntity);
+
+    // should be failed for HDP only
+    hdpStackEntity.setStackName("HDP");
+    try {
+      testGPLRepoCheck(repositoryVersionEntity);
+    } catch (InvocationTargetException e) {
+      Assert.assertTrue(e.getTargetException() instanceof AmbariException);
+    }
+  }
+
+  @Test
+  public void testGPLRepoCheckWithSatisfiedGPLRepoRequirement() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    RepositoryVersionEntity newRepositoryVersion = new RepositoryVersionEntity();
+    StackEntity hdpStackEntity = new StackEntity();
+    hdpStackEntity.setStackName("HDP");
+    newRepositoryVersion.setStack(hdpStackEntity);
+    newRepositoryVersion.setOperatingSystems("[{\"repositories\":[{\"Repositories/repo_id\":\"\"" +
+        ",\"Repositories/tags\":[\"GPL\"],\"Repositories/base_url\":\"\",\"Repositories/repo_name\":\"\"}" +
+        ",{\"Repositories/repo_id\":\"\",\"Repositories/tags\":[],\"Repositories/base_url\":\"\"" +
+        ",\"Repositories/repo_name\":\"\"}],\"OperatingSystems/os_type\":\"debian7\"}]");
+
+    testGPLRepoCheck(newRepositoryVersion);
+
+    hdpStackEntity.setStackName("NOTHDP");
+    testGPLRepoCheck(newRepositoryVersion);
+  }
 
   @After
   public void after() throws AmbariException, SQLException {

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelperTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.ambari.server.state.RepositoryInfo;
+import org.apache.ambari.server.state.StackId;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,5 +55,47 @@ public class RepositoryVersionHelperTest {
 
     final String serialized = helper.serializeOperatingSystems(repositories);
     Assert.assertEquals("[{\"OperatingSystems/ambari_managed_repositories\":true,\"repositories\":[{\"Repositories/base_url\":\"baseurl\",\"Repositories/repo_id\":\"repoId\",\"Repositories/unique\":true,\"Repositories/tags\":[],\"Repositories/applicable_services\":[]}],\"OperatingSystems/os_type\":\"os\"}]", serialized);
+  }
+
+  @Test
+  public void testGPLRepoIsRequired(){
+    String versionGreater1 = "2.7.0.3-75";
+    String versionGreater2 = "2.7.0.3";
+    String versionGreater3 = "2.7";
+    String versionEquals1 = "2.6.4.0-75";
+    String versionEquals2 = "2.6.4.0";
+    String versionEquals3 = "2.6.4";
+    String versionLower1 = "2.1.0.3-75";
+    String versionLower2 = "2.1.0.3";
+    String versionLower3 = "2.1";
+    StackId hdpStackId = new StackId();
+    hdpStackId.setStackId("HDP-x.x");
+
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionGreater1));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionGreater2));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionGreater3));
+
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionEquals1));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionEquals2));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionEquals3));
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionLower1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionLower2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionLower3));
+
+    StackId nonHDPStackId = new StackId();
+    hdpStackId.setStackId("NOTHDP-x.x");
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionGreater1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionGreater2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionGreater3));
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionEquals1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionEquals2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionEquals3));
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionLower1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionLower2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionLower3));
   }
 }


### PR DESCRIPTION
…the body does not throw any error. (mpapirkovkyy)

## What changes were proposed in this pull request?

Restrict importing VSF without GPL repositories from HDP stack with version greater than 2.6.4.0

## How was this patch tested?

mvn clean test
manual check