### PR TITLE
[AMBARI-22939]. Ambari throws NPE when deleting a service (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1311,7 +1311,7 @@ public class ClusterImpl implements Cluster {
     Map<Long, ConfigGroup> configGroups = service.getCluster().getConfigGroups();
     if (!MapUtils.isEmpty(configGroups)) {
       for (ConfigGroup configGroup : configGroups.values()) {
-        if (configGroup.getServiceName().equalsIgnoreCase(serviceName)) {
+        if (configGroup.getServiceName() != null && configGroup.getServiceName().equalsIgnoreCase(serviceName)) {
           LOG.info("Deleting ConfigGroup {} for service {}", configGroup.getName(), serviceName);
           configGroup.delete();
           clusterConfigGroups.remove(configGroup.getId());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a config group exists with service_name = null, ambari will throw a NullPointerException after removing a service. Ambari tries to remove config groups after deleting a service which causes the NPE

## How was this patch tested?

* created a config group with service_name = null
* successfully deleted a service
