### PR TITLE
[AMBARI-22895] Mysql connection fails for Ranger Admin configuration during service installation

### DIFF
--- a/ambari-web/app/views/common/configs/widgets/test_db_connection_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/test_db_connection_widget_view.js
@@ -157,14 +157,13 @@ App.TestDbConnectionWidgetView = App.ConfigWidgetView.extend({
       ambari_server_host: location.hostname,
       check_execute_list: "db_connection_check"
     };
-    var properties = App.permit(properties, ['jdk.name', 'jdk_location', 'java.home']);
+    var properties = App.permit(properties, ['jdk.name', 'jdk_location']);
     var renameKey = function (oldKey, newKey) {
       if (properties[oldKey]) {
         defaults[newKey] = properties[oldKey];
         delete properties[oldKey];
       }
     };
-    renameKey('java.home', 'java_home');
     renameKey('jdk.name', 'jdk_name');
     $.extend(properties, defaults);
     App.db.set('tmp', 'ambariProperties', properties);


### PR DESCRIPTION


## What changes were proposed in this pull request?

Remove default java home from API for check_host action and populate OS family specific java home from server side.

## How was this patch tested?

Tests were successful in ambari-web.

@ncole 