### PR TITLE
AMBARI-22941. Debian stackdeploys failing with "ambari-agent: command not found"

### DIFF
--- a/ambari-agent/conf/unix/install-helper.sh
+++ b/ambari-agent/conf/unix/install-helper.sh
@@ -59,6 +59,10 @@ do_install(){
     mv /etc/ambari-agent/conf.save /etc/ambari-agent/conf_$(date '+%d_%m_%y_%H_%M').save
   fi
 
+  # setting up /usr/sbin/ambari-agent symlink
+  rm -f "$AMBARI_AGENT_BINARY_SYMLINK"
+  ln -s "$AMBARI_AGENT_BINARY" "$AMBARI_AGENT_BINARY_SYMLINK"
+
   # these symlinks (or directories) where created in ambari releases prior to ambari-2.6.2. Do clean up.   
   rm -rf "$OLD_COMMON_DIR" "$OLD_RESOURCE_MANAGEMENT_DIR" "$OLD_JINJA_DIR" "$OLD_SIMPLEJSON_DIR" "$OLD_COMMON_DIR" "$OLD_AMBARI_AGENT_DIR"
   


### PR DESCRIPTION
Debian stackdeploys failing with "ambari-agent: command not found" errors even though ambari-agent is installed.

From a debian cluster:

root@ctr-e137-1514896590304-63273-01-000006:~# dpkg-query -l | grep ambari
ii  ambari-agent                                  2.6.2.0-45                        amd64        Ambari Agent
root@ctr-e137-1514896590304-63273-01-000006:~# find / -name ambari-agent
/run/ambari-agent
/usr/lib/ambari-agent
/var/log/ambari-agent
/var/lib/ambari-agent
/var/lib/ambari-agent/bin/ambari-agent
/etc/init.d/ambari-agent
/etc/ambari-agent
/grid/0/log/ambari-agent