### PR TITLE
[AMBARI-22930] Restart failure due to Library scripts not able to handle multiple nameservices

### DIFF
--- a/ambari-agent/src/test/python/resource_management/TestNamenodeHaUtils.py
+++ b/ambari-agent/src/test/python/resource_management/TestNamenodeHaUtils.py
@@ -62,6 +62,7 @@ class TestNamenodeHaUtils(TestCase):
     # federated config dfs.internal.nameservices in hdfs-site
     hdfs_site = {
       "dfs.internal.nameservices": "ns1,ns2",
+      "dfs.nameservices": "ns1,ns2,exns1,exns2"
     }
 
     self.assertEqual(["ns1","ns2"], get_nameservices(hdfs_site))

--- a/ambari-agent/src/test/python/resource_management/TestNamenodeHaUtils.py
+++ b/ambari-agent/src/test/python/resource_management/TestNamenodeHaUtils.py
@@ -19,7 +19,7 @@ limitations under the License.
 '''
 from unittest import TestCase
 from resource_management.libraries.functions.namenode_ha_utils import \
-  get_nameservice
+  get_nameservices
 
 
 class TestNamenodeHaUtils(TestCase):
@@ -39,7 +39,7 @@ class TestNamenodeHaUtils(TestCase):
       "dfs.namenode.rpc-address.HAB.nn2": "hostb2:8020",
     }
 
-    self.assertEqual("HAA", get_nameservice(hdfs_site))
+    self.assertEqual(["HAA"], get_nameservices(hdfs_site))
 
     # dfs.internal.nameservices not in hdfs-site
     hdfs_site = {
@@ -52,9 +52,16 @@ class TestNamenodeHaUtils(TestCase):
       "dfs.namenode.rpc-address.HAB.nn2": "hostb2:8020",
     }
 
-    self.assertEqual("HAA", get_nameservice(hdfs_site))
+    self.assertEqual(["HAA"], get_nameservices(hdfs_site))
 
     # Non HA
     hdfs_site = {}
 
-    self.assertEqual(None, get_nameservice(hdfs_site))
+    self.assertEqual([], get_nameservices(hdfs_site))
+
+    # federated config dfs.internal.nameservices in hdfs-site
+    hdfs_site = {
+      "dfs.internal.nameservices": "ns1,ns2",
+    }
+
+    self.assertEqual(["ns1","ns2"], get_nameservices(hdfs_site))


### PR DESCRIPTION
So far the code could  handle only a single name service. Added support for multiple name services.

## What changes were proposed in this pull request?

Multiple name service handling added.

## How was this patch tested?

mvn -pl ambari-server,ambari-agent -DskipSurefireTests test

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.