### PR TITLE
[AMBARI-22834] Fix Zeppelin service check pid file

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/package/scripts/alert_check_zeppelin.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/package/scripts/alert_check_zeppelin.py
@@ -37,7 +37,7 @@ RESULT_CODE_UNKNOWN = 'UNKNOWN'
 
 def execute(configurations={}, parameters={}, host_name=None):
   try:
-    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-*.pid')[0]
+    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-zeppelin-*.pid')[0]
     check_process_status(pid_file)
   except ComponentIsNotRunning as ex:
     return (RESULT_CODE_CRITICAL, [str(ex)])

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/package/scripts/alert_check_zeppelin.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/package/scripts/alert_check_zeppelin.py
@@ -29,6 +29,7 @@ sys.setdefaultencoding('utf8')
 config = Script.get_config()
 
 zeppelin_pid_dir = config['configurations']['zeppelin-env']['zeppelin_pid_dir']
+zeppelin_user = config['configurations']['zeppelin-env']['zeppelin_user']
 
 RESULT_CODE_OK = 'OK'
 RESULT_CODE_CRITICAL = 'CRITICAL'
@@ -37,7 +38,7 @@ RESULT_CODE_UNKNOWN = 'UNKNOWN'
 
 def execute(configurations={}, parameters={}, host_name=None):
   try:
-    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-zeppelin-*.pid')[0]
+    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-' + zeppelin_user + '-*.pid')[0]
     check_process_status(pid_file)
   except ComponentIsNotRunning as ex:
     return (RESULT_CODE_CRITICAL, [str(ex)])

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/alert_check_zeppelin.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/alert_check_zeppelin.py
@@ -37,7 +37,7 @@ RESULT_CODE_UNKNOWN = 'UNKNOWN'
 
 def execute(configurations={}, parameters={}, host_name=None):
   try:
-    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-*.pid')[0]
+    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-zeppelin-*.pid')[0]
     check_process_status(pid_file)
   except ComponentIsNotRunning as ex:
     return (RESULT_CODE_CRITICAL, [str(ex)])

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/alert_check_zeppelin.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/alert_check_zeppelin.py
@@ -29,6 +29,7 @@ sys.setdefaultencoding('utf8')
 config = Script.get_config()
 
 zeppelin_pid_dir = config['configurations']['zeppelin-env']['zeppelin_pid_dir']
+zeppelin_user = config['configurations']['zeppelin-env']['zeppelin_user']
 
 RESULT_CODE_OK = 'OK'
 RESULT_CODE_CRITICAL = 'CRITICAL'
@@ -37,7 +38,7 @@ RESULT_CODE_UNKNOWN = 'UNKNOWN'
 
 def execute(configurations={}, parameters={}, host_name=None):
   try:
-    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-zeppelin-*.pid')[0]
+    pid_file = glob.glob(zeppelin_pid_dir + '/zeppelin-' + zeppelin_user + '-*.pid')[0]
     check_process_status(pid_file)
   except ComponentIsNotRunning as ex:
     return (RESULT_CODE_CRITICAL, [str(ex)])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #AMBARI-22834  - checking only for the server's pid-file, instead of one random pid-file (may or may not be the servers file).


## How was this patch tested?

Applied the patch and checked alerts for Ambari.
File not covered by automated tests
* Alert still does trigger when Zeppelin is stopped
* Allert does not trigger during normal operation (Zeppelin started - interpreter restarts etc).
