### PR TITLE
AMBARI-22950. SPNEGO service keytab is getting deleted upon deleting component from host

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/AbstractKerberosDescriptorContainer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/AbstractKerberosDescriptorContainer.java
@@ -789,7 +789,7 @@ public abstract class AbstractKerberosDescriptorContainer extends AbstractKerber
   public List<KerberosIdentityDescriptor> getIdentitiesSkipReferences() {
     return nullToEmpty(getIdentities())
       .stream()
-      .filter(identity -> !identity.getReferencedServiceName().isPresent() && identity.getName() != null && !identity.getName().startsWith("/"))
+      .filter(identity -> !identity.getReferencedServiceName().isPresent() && !identity.isReference())
       .collect(toList());
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

spnego.service.keytab is getting deleted upon deleting components.

Steps to reproduce :
1. Add additional "livy" component to some host in the cluster
2. Delete added "livy" component
3. Deletion of livy is deleting /etc/security/keytabs/spnego.service.keytab as well

The cause of this is due to an invalid check to determine if a Kerberos identity is a reference or no at 
`org.apache.ambari.server.state.kerberos.AbstractKerberosDescriptorContainer#getIdentitiesSkipReferences`:
```
  public List<KerberosIdentityDescriptor> getIdentitiesSkipReferences() {
    return nullToEmpty(getIdentities())
      .stream()
      .filter(identity -> !identity.getReferencedServiceName().isPresent() && identity.getName() != null && !identity.getName().startsWith("/"))
      .collect(toList());
  }
```

The fixed code should be

```
  public List<KerberosIdentityDescriptor> getIdentitiesSkipReferences() {
    return nullToEmpty(getIdentities())
      .stream()
.filter(identity -> !identity.getReferencedServiceName().isPresent() && !identity.isReference())      .collect(toList());
  }
```
## How was this patch tested?

Manually tested to ensure the SPENGO Kerberos identity was not removed when component was removed. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.