### PR TITLE
AMBARI-22951 Export JAVA_HOME env variable in shell script for Ranger…

### DIFF
--- a/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/setup_ranger_xml.py
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/setup_ranger_xml.py
@@ -120,6 +120,13 @@ def setup_ranger_admin(upgrade_type=None):
     create_parents=True
   )
 
+  File(format('{ranger_conf}/ranger-admin-env.sh'),
+    content = format("export JAVA_HOME={java_home}"),
+    owner = params.unix_user,
+    group = params.unix_group,
+    mode = 0755
+  )
+
   if params.stack_supports_pid:
     File(format('{ranger_conf}/ranger-admin-env-piddir.sh'),
       content = format("export RANGER_PID_DIR_PATH={ranger_pid_dir}\nexport RANGER_USER={unix_user}"),

--- a/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/package/scripts/kms.py
+++ b/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/package/scripts/kms.py
@@ -226,6 +226,13 @@ def kms(upgrade_type=None):
       create_parents=True
     )
 
+    File(format('{kms_conf_dir}/ranger-kms-env.sh'),
+      content = format("export JAVA_HOME={java_home}"),
+      owner = params.kms_user,
+      group = params.kms_group,
+      mode = 0755
+    )
+
     if params.stack_supports_pid:
       File(format('{kms_conf_dir}/ranger-kms-env-piddir.sh'),
         content = format("export RANGER_KMS_PID_DIR_PATH={ranger_kms_pid_dir}\nexport KMS_USER={kms_user}"),

--- a/ambari-server/src/test/python/stacks/2.5/RANGER/test_ranger_admin.py
+++ b/ambari-server/src/test/python/stacks/2.5/RANGER/test_ranger_admin.py
@@ -265,6 +265,13 @@ class TestRangerAdmin(RMFTestCase):
       create_parents=True
     )
 
+    self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env.sh',
+      content = 'export JAVA_HOME=/usr/jdk64/jdk1.7.0_45',
+      owner = 'ranger',
+      group = 'ranger',
+      mode = 0755
+    )
+
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env-piddir.sh',
       content = 'export RANGER_PID_DIR_PATH=/var/run/ranger\nexport RANGER_USER=ranger',
       owner = 'ranger',
@@ -419,6 +426,13 @@ class TestRangerAdmin(RMFTestCase):
       group = 'hadoop',
       cd_access = "a",
       create_parents=True
+    )
+
+    self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env.sh',
+      content = 'export JAVA_HOME=/usr/jdk64/jdk1.7.0_45',
+      owner = 'ranger',
+      group = 'ranger',
+      mode = 0755
     )
 
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env-piddir.sh',

--- a/ambari-server/src/test/python/stacks/2.5/RANGER_KMS/test_kms_server.py
+++ b/ambari-server/src/test/python/stacks/2.5/RANGER_KMS/test_kms_server.py
@@ -357,6 +357,13 @@ class TestRangerKMS(RMFTestCase):
       create_parents=True
     )
 
+    self.assertResourceCalled('File', '/usr/hdp/current/ranger-kms/conf/ranger-kms-env.sh',
+      content = 'export JAVA_HOME=/usr/jdk64/jdk1.7.0_45',
+      owner = 'kms',
+      group = 'kms',
+      mode = 0755
+    )
+
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-kms/conf/ranger-kms-env-piddir.sh',
       content = 'export RANGER_KMS_PID_DIR_PATH=/var/run/ranger_kms\nexport KMS_USER=kms',
       owner = 'kms',
@@ -778,6 +785,13 @@ class TestRangerKMS(RMFTestCase):
       group = 'hadoop',
       cd_access = "a",
       create_parents=True
+    )
+
+    self.assertResourceCalled('File', '/usr/hdp/current/ranger-kms/conf/ranger-kms-env.sh',
+      content = 'export JAVA_HOME=/usr/jdk64/jdk1.7.0_45',
+      owner = 'kms',
+      group = 'kms',
+      mode = 0755
     )
 
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-kms/conf/ranger-kms-env-piddir.sh',

--- a/ambari-server/src/test/python/stacks/2.6/RANGER/test_ranger_admin.py
+++ b/ambari-server/src/test/python/stacks/2.6/RANGER/test_ranger_admin.py
@@ -308,6 +308,13 @@ class TestRangerAdmin(RMFTestCase):
       create_parents=True
     )
 
+    self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env.sh',
+      content = 'export JAVA_HOME=/usr/jdk64/jdk1.7.0_45',
+      owner = 'ranger',
+      group = 'ranger',
+      mode = 0755
+    )
+
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env-piddir.sh',
       content = 'export RANGER_PID_DIR_PATH=/var/run/ranger\nexport RANGER_USER=ranger',
       owner = 'ranger',
@@ -484,6 +491,13 @@ class TestRangerAdmin(RMFTestCase):
       group = 'hadoop',
       cd_access = "a",
       create_parents=True
+    )
+
+    self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env.sh',
+      content = 'export JAVA_HOME=/usr/jdk64/jdk1.7.0_45',
+      owner = 'ranger',
+      group = 'ranger',
+      mode = 0755
     )
 
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-admin/conf/ranger-admin-env-piddir.sh',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Need to export JAVA_HOME variable in [ranger-admin-env.sh](https://github.com/apache/ranger/blob/master/embeddedwebserver/scripts/ranger-admin-services.sh), so that ranger-admin-services.sh knows which java to be used for processing.

## How was this patch tested?

Tested with fresh Installation.

Unit Test Report,
Total run:1201
Total errors:0
Total failures:0

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@vishalsuvagia @jonathan-hurley @swagle 
Request to kindly review and merge the pull request.