### PR TITLE
[AMBARI-22955] Bulk operation to turn on Maintanance Mode on hosts do…

### DIFF
--- a/ambari-web/app/models/stack_version/version.js
+++ b/ambari-web/app/models/stack_version/version.js
@@ -43,7 +43,9 @@ App.StackVersion = DS.Model.extend({
 
   noInitHosts: Em.computed.empty('notInstalledHosts'),
 
-  isCurrent: Em.computed.equal('state', 'CURRENT')
+  isCurrent: Em.computed.equal('state', 'CURRENT'),
+
+  isOutOfSync: Em.computed.equal('state', 'OUT_OF_SYNC')
 });
 
 App.StackVersion.FIXTURES = [];


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is possible in some circumstances for a single-repository cluster to be OUT_OF_SYNC and not CURRENT, so the web client should be able to handle this situation if it arises.

## How was this patch tested?

  21367 passing (22s)
  48 pending