### PR TITLE
[AMBARI-22958] Upgrade Apache Rat to 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .idea/
 .iml/
 .DS_Store
-target
+**/target/
 /ambari-server/derby.log
 /ambari-server/pass.txt
 /ambari-web/npm-debug.log
@@ -13,7 +13,7 @@ target
 /ambari-web/node/
 *.pyc
 *.py~
-*.iml
+**/*.iml
 .hg
 .hgignore
 .hgtags

--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -208,7 +208,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.11</version>
+        <version>0.12</version>
         <configuration>
           <excludes>
             <exclude>README.md</exclude>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -212,7 +212,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.11</version>
+        <version>0.12</version>
         <configuration>
           <excludes>
             <exclude>**/README.md</exclude>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -272,7 +272,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.11</version>
+        <version>0.12</version>
         <configuration>
           <excludes>
             <exclude>pass.txt</exclude>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -367,7 +367,6 @@
             <exclude>conf/unix/krb5JAASLogin.conf</exclude>
             <exclude>conf/windows/ca.config</exclude>
             <exclude>conf/windows/krb5JAASLogin.conf</exclude>
-            <exclude>**/*.iml</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/*.sql</exclude>
             <exclude>**/repo_suse_rhel.j2</exclude>

--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -118,6 +134,11 @@
           <description>Maven Recipe: RPM Package.</description>
           <mappings/>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.12</version>
       </plugin>
     </plugins>
   </build>

--- a/contrib/management-packs/pom.xml
+++ b/contrib/management-packs/pom.xml
@@ -36,17 +36,9 @@
   <modules>
     <module>microsoft-r_mpack</module>
     <module>hdf-ambari-mpack</module>
+    <module>isilon-onefs-mpack</module>
   </modules>
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <version>0.11</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.rat</groupId>
@@ -55,7 +47,6 @@
           <excludes>
             <!--GIT files-->
             <exclude>.git/</exclude>
-            <exclude>**/.gitignore</exclude>
             <exclude>**/.gitattributes</exclude>
             <!--gitignore content-->
             <exclude>.idea/</exclude>
@@ -65,7 +56,6 @@
             <exclude>.classpath</exclude>
             <exclude>.project</exclude>
             <exclude>.settings</exclude>
-            <exclude>**/target/**</exclude>
             <exclude>**/.gitkeep</exclude>
             <exclude>**/.bowerrc</exclude>
             <exclude>**/.editorconfig</exclude>

--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -53,15 +53,6 @@
     <module>ambari-views-package</module>
   </modules>
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <version>0.11</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.rat</groupId>
@@ -77,11 +68,9 @@
             <exclude>pass.txt</exclude>
             <exclude>.DS_Store</exclude>
             <exclude>.iml/</exclude>
-            <exclude>**/*.iml</exclude>
             <exclude>.classpath</exclude>
             <exclude>.project</exclude>
             <exclude>.settings</exclude>
-            <exclude>**/target/**</exclude>
             <exclude>**/.gitkeep</exclude>
             <exclude>**/.ember-cli</exclude>
             <exclude>**/.travis.yml</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
@@ -137,7 +137,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.11</version>
+          <version>0.12</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -263,17 +263,11 @@
             <exclude>derby.log</exclude>
             <exclude>CHANGES.txt</exclude>
             <exclude>pass.txt</exclude>
-            <exclude>ambari-metrics/ambari-metrics-host-monitoring/conf/unix/metric_groups.conf</exclude>
-            <exclude>ambari-metrics/ambari-metrics-host-monitoring/conf/windows/metric_groups.conf</exclude>
-            <exclude>ambari-metrics/ambari-metrics-host-monitoring/conf/unix/metric_groups.conf</exclude>
-            <exclude>stack-advisor/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst</exclude>
-            <exclude>stack-advisor/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst</exclude>
             <exclude>contrib/ambari-scom/msi/src/GUI_Ambari.sln</exclude>
             <exclude>contrib/fast-hdfs-resource/dependency-reduced-pom.xml</exclude>
             <exclude>contrib/agent-simulator/docker_image/package_list.txt</exclude>
             <exclude>contrib/agent-simulator/config/cluster.txt</exclude>
             <exclude>version</exclude>
-            <exclude>**/target/surefire-reports/</exclude>
             <!--IDE and GIT files-->
             <exclude>**/.idea/</exclude>
             <exclude>**/.classpath/</exclude>
@@ -281,14 +275,12 @@
             <exclude>**/.settings/</exclude>
             <exclude>.git/</exclude>
             <exclude>.pydevproject</exclude>
-            <exclude>**/.gitignore</exclude>
             <exclude>**/.gitattributes</exclude>
             <exclude>**/.gitkeep</exclude>
             <exclude>**/.jshintrc</exclude>
             <exclude>**/.editorconfig</exclude>
             <!--gitignore content-->
             <exclude>.DS_Store</exclude>
-            <exclude>**/*.iml</exclude>
             <exclude>*.pyc</exclude>
             <exclude>*.py~</exclude>
             <exclude>.hg</exclude>
@@ -308,7 +300,7 @@
             <!--Subprocess32 library (PSF license)-->
             <exclude>ambari-common/src/main/python/ambari_commons/subprocess32.py</exclude>
             <exclude>ambari-common/src/main/python/ambari_commons/_posixsubprocess.so</exclude>
-            
+
             <exclude>ambari-web/node_modules/**</exclude>
 
             <!--Contributions-->
@@ -318,8 +310,6 @@
             <exclude>contrib/ambari-scom/msi/src/GUI_Ambari.sln</exclude>
             <exclude>contrib/ambari-scom/ambari-scom-server/pass.txt</exclude>
             <exclude>contrib/ambari-scom/*/rat.txt</exclude>
-            <exclude>contrib/ambari-scom/metrics-sink/target/**</exclude>
-            <exclude>contrib/views/*/target/**</exclude>
             <exclude>contrib/views/commons/src/main/resources/ui/*/.bowerrc</exclude>
             <exclude>contrib/views/commons/src/main/resources/ui/*/bower_components/**</exclude>
             <exclude>contrib/views/commons/src/main/resources/ui/*/node/**</exclude>
@@ -385,29 +375,14 @@
             <exclude>contrib/views/hueambarimigration/src/main/resources/ui/hueambarimigration-view/app/assets/javascripts/**</exclude>
 
             <exclude>contrib/ambari-scom/ambari-scom-server/pass.txt</exclude>
-            <exclude>contrib/ambari-scom/ambari-scom-server/target/**</exclude>
             <exclude>contrib/ambari-scom/*/rat.txt</exclude>
-            <exclude>contrib/ambari-scom/metrics-sink/target/**</exclude>
 
             <!--Velocity log -->
             <exclude>**/velocity.log*</exclude>
 
-            <!-- Metrics module -->
-            <!-- grafana -->
-            <exclude>ambari-metrics/ambari-metrics-grafana/conf/unix/ams-grafana.ini</exclude>
-            <!-- psutil : external lib, Apache 2.0 license included as a source file -->
-            <exclude>ambari-metrics/target/**</exclude>
-            <exclude>ambari-metrics/ambari-metrics-host-monitoring/src/main/python/psutil/**</exclude>
-            <exclude>ambari-metrics/target/rpm/ambari-metrics/SPECS/ambari-metrics.spec</exclude>
-            <exclude>ambari-metrics/ambari-metrics-timelineservice/src/test/resources/lib/org/apache/phoenix/phoenix-core-tests/4.2.0/phoenix-core-tests-4.2.0.pom</exclude>
-            <exclude>ambari-metrics/ambari-metrics-timelineservice/src/test/resources/lib/org/apache/phoenix/phoenix-core-tests/maven-metadata-local.xml</exclude>
-            <exclude>ambari-metrics/*/target/**</exclude>
-            <!-- ignore .settings and .project  -->
-            <exclude>ambari-metrics/**/.*/**</exclude>
             <!-- generated DDL-->
             <exclude>**/createDDL.jdbc</exclude>
             <exclude>**/yarn.lock</exclude>
-            <exclude>ambari-utility/target/**</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * [Upgrade](https://issues.apache.org/jira/browse/AMBARI-22958) Apache Rat to 0.12.
 * Add missing check and license to `ambari-serviceadvisor/pom.xml`
 * Add `isilon-onefs-mpack` to `management-packs` aggregator
 * Remove some (but not all) unnecessary excludes

## How was this patch tested?

```
for d in contrib/management-packs contrib/views .; do
  cd $d
  mvn apache-rat:check
  cd -
done
```