### PR TITLE
AMBARI-22934. [API] Updating current stack repo without GPL repos in …

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -189,7 +189,6 @@ import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfile;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.scheduler.RequestExecutionFactory;
 import org.apache.ambari.server.state.stack.OsFamily;
-import org.apache.ambari.server.state.stack.RepoTag;
 import org.apache.ambari.server.state.stack.RepositoryXml;
 import org.apache.ambari.server.state.stack.WidgetLayout;
 import org.apache.ambari.server.state.stack.WidgetLayoutInfo;
@@ -4258,7 +4257,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         for (RepositoryXml.Repo repo : os.getRepos()) {
           RepositoryResponse resp = new RepositoryResponse(repo.getBaseUrl(), os.getFamily(),
               repo.getRepoId(), repo.getRepoName(), repo.getDistribution(), repo.getComponents(), repo.getMirrorsList(),
-              repo.getBaseUrl(), Collections.<RepoTag>emptySet());
+              repo.getBaseUrl(), repo.getTags());
 
           resp.setVersionDefinitionId(versionDefinitionId);
           resp.setStackName(stackId.getStackName());

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProvider.java
@@ -63,6 +63,7 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.repository.ManifestServiceInfo;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
+import org.apache.ambari.server.state.stack.RepoTag;
 import org.apache.ambari.server.state.stack.upgrade.RepositoryVersionHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
@@ -494,9 +495,38 @@ public class RepositoryVersionResourceProvider extends AbstractAuthorizedResourc
       }
     }
 
+    if (RepositoryVersionHelper.shouldContainGPLRepo(repositoryVersion.getStackId(), repositoryVersion.getVersion())) {
+      validateGPLRepoPresence(repositoryVersion);
+    }
+
     if (!RepositoryVersionEntity.isVersionInStack(repositoryVersion.getStackId(), repositoryVersion.getVersion())) {
       throw new AmbariException(MessageFormat.format("Version {0} needs to belong to stack {1}",
           repositoryVersion.getVersion(), repositoryVersion.getStackName() + "-" + repositoryVersion.getStackVersion()));
+    }
+  }
+
+  /**
+   * Checks HDP repository version contains GPL repo for each os.
+   * @param repositoryVersion repository version to check.
+   * @throws AmbariException in case repository version id HDP and should contain GPL repo, bug shouldn't.
+   */
+  private static void validateGPLRepoPresence(RepositoryVersionEntity repositoryVersion) throws AmbariException {
+    if (!repositoryVersion.getStackName().equals("HDP")) {
+      return;
+    }
+    for (RepoOsEntity os : repositoryVersion.getRepoOsEntities()) {
+      boolean hasGPLRepo = false;
+      for (RepoDefinitionEntity repositoryEntity : os.getRepoDefinitionEntities()) {
+        if (repositoryEntity.getTags().contains(RepoTag.GPL)) {
+          hasGPLRepo = true;
+        }
+      }
+      if (!hasGPLRepo) {
+        throw new AmbariException("Operating system type " + os.getFamily()
+            + " for repository with id " + repositoryVersion.getId()
+            + " should contain GPL repo for HDP repository version greater than "
+            + RepositoryVersionHelper.GPL_MINIMAL_VERSION);
+      }
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -95,6 +95,9 @@ public class RepositoryVersionHelper {
 
   @Inject Provider<Clusters> clusters;
 
+  public static final String GPL_MINIMAL_VERSION = "2.6.4.0";
+  private static final String ZERO_VERSION = "0.0.0.0";
+  private static final String VERSION_SPLITTER = "\\.";
 
   /**
    * Checks repo URLs against the current version for the cluster and make
@@ -621,5 +624,36 @@ public class RepositoryVersionHelper {
     });
   }
 
+  /**
+   * Checks repository version is HDP and should contain repo with GPL tag.
+   * @param stackId stack id
+   * @param version repository version as x.x.x.x, x.x.x.x-x, x.x-x, x.x
+   * @return true if stack is HDP and version is younger than {@value #GPL_MINIMAL_VERSION}
+   */
+  public static boolean shouldContainGPLRepo(StackId stackId, String version) {
+    if (!stackId.getStackName().equals("HDP")) {
+      return false;
+    }
+    if (version.contains("-")) {
+      version = version.split("-")[0];
+    }
+    String[] versionItems = ZERO_VERSION.split(VERSION_SPLITTER);
+    int versionIndex = 0;
+    for (String versionItem : version.split(VERSION_SPLITTER)) {
+      versionItems[versionIndex++] = versionItem;
+    }
+    String[] gplMinimalItems = GPL_MINIMAL_VERSION.split(VERSION_SPLITTER);
+
+    for (versionIndex = 0; versionIndex < versionItems.length; versionIndex++) {
+      Integer versionItem = Integer.parseInt(versionItems[versionIndex]);
+      Integer gplMinimalItem = Integer.parseInt(gplMinimalItems[versionIndex]);
+      if (versionItem < gplMinimalItem) {
+        return false;
+      } else if (versionItem > gplMinimalItem) {
+        return true;
+      }
+    }
+    return true;
+  }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelperTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.state.stack.upgrade;
+
+import org.apache.ambari.server.state.StackId;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the {@link RepositoryVersionHelper} class
+ */
+public class RepositoryVersionHelperTest {
+
+  @Test
+  public void testGPLRepoIsRequired(){
+    String versionGreater1 = "2.7.0.3-75";
+    String versionGreater2 = "2.7.0.3";
+    String versionGreater3 = "2.7";
+    String versionEquals1 = "2.6.4.0-75";
+    String versionEquals2 = "2.6.4.0";
+    String versionEquals3 = "2.6.4";
+    String versionLower1 = "2.1.0.3-75";
+    String versionLower2 = "2.1.0.3";
+    String versionLower3 = "2.1";
+    StackId hdpStackId = new StackId();
+    hdpStackId.setStackId("HDP-x.x");
+
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionGreater1));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionGreater2));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionGreater3));
+
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionEquals1));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionEquals2));
+    Assert.assertEquals(true, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionEquals3));
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionLower1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionLower2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(hdpStackId, versionLower3));
+
+    StackId nonHDPStackId = new StackId();
+    hdpStackId.setStackId("NOTHDP-x.x");
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionGreater1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionGreater2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionGreater3));
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionEquals1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionEquals2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionEquals3));
+
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionLower1));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionLower2));
+    Assert.assertEquals(false, RepositoryVersionHelper.shouldContainGPLRepo(nonHDPStackId, versionLower3));
+  }
+}


### PR DESCRIPTION
…the body does not throw any error. (mpapirkovkyy)

## What changes were proposed in this pull request?

Restrict importing VSF without GPL repositories from HDP stack with version greater than 2.6.4.0

## How was this patch tested?

mvn clean test
manual check