### PR TITLE
[AMBARI-22961] Blacklist by default /boot/efi path as mount point reported by Ambari Agent (dgrinenko)

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/Hardware.py
+++ b/ambari-agent/src/main/python/ambari_agent/Hardware.py
@@ -40,7 +40,7 @@ class Hardware:
   CHECK_REMOTE_MOUNTS_KEY = 'agent.check.remote.mounts'
   CHECK_REMOTE_MOUNTS_TIMEOUT_KEY = 'agent.check.mounts.timeout'
   CHECK_REMOTE_MOUNTS_TIMEOUT_DEFAULT = '10'
-  IGNORE_ROOT_MOUNTS = ["proc", "dev", "sys"]
+  IGNORE_ROOT_MOUNTS = ["proc", "dev", "sys", "boot"]
   IGNORE_DEVICES = ["proc", "tmpfs", "cgroup", "mqueue", "shm"]
   LINUX_PATH_SEP = "/"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude `/boot/efi` mount point from the list of auto-suggested by stack adviser. `/boot` partition is small, dedicated for system boot purpose and shouldn't be proposed for any other purpose

## How was this patch tested?

In docker with faked boot mount 