### PR TITLE
[AMBARI-22966] ambari-agent fails to start (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/shell.py
+++ b/ambari-common/src/main/python/ambari_commons/shell.py
@@ -27,7 +27,6 @@ from contextlib import contextmanager
 
 from ambari_commons import OSConst
 from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl
-from resource_management.core import sudo
 
 logger = logging.getLogger()
 
@@ -353,6 +352,8 @@ def kill_process_with_children(base_pid):
   Process tree killer
   :type base_pid int
   """
+  from resource_management.core import sudo  # to avoid circular dependency
+
   exception_list = ["apt-get", "apt", "yum", "zypper", "zypp"]
   signals_to_post = {
     "SIGTERM": signal.SIGTERM,
@@ -401,7 +402,7 @@ class shellRunnerLinux(shellRunner):
     import pwd
 
     try:
-      if user != None:
+      if user is not None:
         user = pwd.getpwnam(user)[2]
       else:
         user = os.getuid()


### PR DESCRIPTION
## What changes were proposed in this pull request?

RM wildcard module resolving cased `sudo` module to be imported twice, causing circular import issue. Moving `sudo` import inside function will help to broke  circular import chain.

## How was this patch tested?
Before:
```
# ambari-agent start
Verifying Python version compatibility...
Using python  /usr/bin/python
Checking for previously running Ambari Agent...
Checking ambari-common dir...
Starting ambari-agent
Verifying ambari-agent process status...
ERROR: ambari-agent start failed. For more details, see /var/log/ambari-agent/ambari-agent.out:
====================
  File "/usr/lib/ambari-agent/lib/resource_management/__init__.py", line 23, in <module>
    from resource_management.libraries import *
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/__init__.py", line 23, in <module>
    from resource_management.libraries.functions import *
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/__init__.py", line 48, in <module>
    from resource_management.libraries.functions.log_process_information import *
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/log_process_information.py", line 22, in <module>
    from ambari_commons.shell import shellRunner
ImportError: cannot import name shellRunner
====================
Agent out at: /var/log/ambari-agent/ambari-agent.out
Agent log at: /var/log/ambari-agent/ambari-agent.log
```

After: 

```
# ambari-agent start
Verifying Python version compatibility...
Using python  /usr/bin/python
Checking for previously running Ambari Agent...
Checking ambari-common dir...
Starting ambari-agent
Verifying ambari-agent process status...
Ambari Agent successfully started
Agent PID at: /var/run/ambari-agent/ambari-agent.pid
Agent out at: /var/log/ambari-agent/ambari-agent.out
Agent log at: /var/log/ambari-agent/ambari-agent.log
```