### PR TITLE
AMBARI-22971: Remove current_mpack_id to mpack_id in stacks table

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackResourceDefinition.java
@@ -95,13 +95,13 @@ public class MpackResourceDefinition extends BaseResourceDefinition {
   }
 
   /***
-   * Post processing to change the name of the result node to current_mpack
+   * Post processing to change the name of the result node to mpack
    */
   private class MpackPostProcessor implements PostProcessor {
     @Override
     public void process(Request request, TreeNode<Resource> resultNode, String href) {
       if (href.contains("/stacks/")) {
-        resultNode.setName("current_mpack");
+        resultNode.setName("mpack");
 
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/StackVersionResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/StackVersionResourceDefinition.java
@@ -92,14 +92,13 @@ public class StackVersionResourceDefinition extends BaseResourceDefinition {
   }
 
   /***
-   * Post processing to change the name of the result node to current_mpack
+   * Post processing to change the name of the result node to stack
    */
   private class StackVersionPostProcessor implements PostProcessor {
     @Override
     public void process(Request request, TreeNode<Resource> resultNode, String href) {
       if (href.contains("/mpacks/")) {
         resultNode.setName("stack");
-
       }
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
@@ -264,7 +264,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
         String stackName = (String) propertyMap.get(STACK_NAME_PROPERTY_ID);
         String stackVersion = (String) propertyMap.get(STACK_VERSION_PROPERTY_ID);
         StackEntity stackEntity = stackDAO.find(stackName, stackVersion);
-        mpackId = stackEntity.getCurrentMpackId();
+        mpackId = stackEntity.getMpackId();
         if (mpackId != null) {
           MpackResponse response = getManagementController().getMpack(mpackId);
           Resource resource = new ResourceImpl(Resource.Type.Mpack);

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -548,12 +548,12 @@ public class MpackManager {
 
       stackEntity.setStackName(stackName);
       stackEntity.setStackVersion(stackVersion);
-      stackEntity.setCurrentMpackId(mpack.getMpackId());
+      stackEntity.setMpackId(mpack.getMpackId());
       stackDAO.create(stackEntity);
     } else {
-      LOG.info("Updating stack {}-{} to the database", stackName, stackVersion);
+      LOG.error("Updating stack {}-{} to the database", stackName, stackVersion);
 
-      stackEntity.setCurrentMpackId(mpack.getMpackId());
+      stackEntity.setMpackId(mpack.getMpackId());
       stackDAO.merge(stackEntity);
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -551,7 +551,7 @@ public class MpackManager {
       stackEntity.setMpackId(mpack.getMpackId());
       stackDAO.create(stackEntity);
     } else {
-      LOG.error("Updating stack {}-{} to the database", stackName, stackVersion);
+      LOG.info("Updating stack {}-{} to the database", stackName, stackVersion);
 
       stackEntity.setMpackId(mpack.getMpackId());
       stackDAO.merge(stackEntity);

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/StackDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/StackDAO.java
@@ -196,7 +196,7 @@ public class StackDAO {
   public StackEntity findByMpack(Long mpackId) {
     TypedQuery<StackEntity> query = entityManagerProvider.get().createNamedQuery(
             "StackEntity.findByMpack", StackEntity.class);
-    query.setParameter("currentMpackId", mpackId);
+    query.setParameter("mpackId", mpackId);
 
     return daoUtils.selectOne(query);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/StackEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/StackEntity.java
@@ -40,7 +40,7 @@ import javax.persistence.UniqueConstraint;
 @TableGenerator(name = "stack_id_generator", table = "ambari_sequences", pkColumnName = "sequence_name", valueColumnName = "sequence_value", pkColumnValue = "stack_id_seq", initialValue = 0)
 @NamedQueries({
     @NamedQuery(name = "StackEntity.findAll", query = "SELECT stack FROM StackEntity stack"),
-    @NamedQuery(name = "StackEntity.findByMpack", query = "SELECT stack FROM StackEntity stack where stack.currentMpackId = :currentMpackId"),
+    @NamedQuery(name = "StackEntity.findByMpack", query = "SELECT stack FROM StackEntity stack where stack.mpackId = :mpackId"),
     @NamedQuery(name = "StackEntity.findByNameAndVersion", query = "SELECT stack FROM StackEntity stack WHERE stack.stackName = :stackName AND stack.stackVersion = :stackVersion",
                 hints = {
                   @QueryHint(name = "eclipselink.query-results-cache", value = "true"),
@@ -60,15 +60,15 @@ public class StackEntity {
   @Column(name = "stack_version", length = 255, nullable = false)
   private String stackVersion;
 
-  @Column(name = "current_mpack_id")
-  private Long currentMpackId;
+  @Column(name = "mpack_id")
+  private Long mpackId;
 
-  public Long getCurrentMpackId() {
-    return currentMpackId;
+  public Long getMpackId() {
+    return mpackId;
   }
 
-  public void setCurrentMpackId(Long currentMpackId) {
-    this.currentMpackId = currentMpackId;
+  public void setMpackId(Long mpackId) {
+    this.mpackId = mpackId;
   }
 
 
@@ -167,7 +167,7 @@ public class StackEntity {
     buffer.append("id=").append(stackId);
     buffer.append(", name=").append(stackName);
     buffer.append(", version=").append(stackVersion);
-    buffer.append(", current_mpack_id=").append(currentMpackId);
+    buffer.append(", mpack_id=").append(mpackId);
     buffer.append("}");
     return buffer.toString();
   }

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -39,9 +39,9 @@ CREATE TABLE stack (
   stack_id BIGINT NOT NULL,
   stack_name VARCHAR(255) NOT NULL,
   stack_version VARCHAR(255) NOT NULL,
-  current_mpack_id BIGINT,
+  mpack_id BIGINT,
   CONSTRAINT PK_stack PRIMARY KEY (stack_id),
-  CONSTRAINT FK_mpacks FOREIGN KEY (current_mpack_id) REFERENCES mpacks(id),
+  CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
 CREATE TABLE extension(

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -58,9 +58,9 @@ CREATE TABLE stack (
   stack_id BIGINT NOT NULL,
   stack_name VARCHAR(100) NOT NULL,
   stack_version VARCHAR(100) NOT NULL,
-  current_mpack_id BIGINT,
+  mpack_id BIGINT,
   CONSTRAINT PK_stack PRIMARY KEY (stack_id),
-  CONSTRAINT FK_mpacks FOREIGN KEY (current_mpack_id) REFERENCES mpacks(id),
+  CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
 CREATE TABLE extension(

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -39,9 +39,9 @@ CREATE TABLE stack (
   stack_id NUMBER(19) NOT NULL,
   stack_name VARCHAR2(255) NOT NULL,
   stack_version VARCHAR2(255) NOT NULL,
-  current_mpack_id NUMBER(19),
+  mpack_id NUMBER(19),
   CONSTRAINT PK_stack PRIMARY KEY (stack_id),
-  CONSTRAINT FK_mpacks FOREIGN KEY (current_mpack_id) REFERENCES mpacks(id),
+  CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
 CREATE TABLE extension(

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -39,9 +39,9 @@ CREATE TABLE stack (
   stack_id BIGINT NOT NULL,
   stack_name VARCHAR(255) NOT NULL,
   stack_version VARCHAR(255) NOT NULL,
-  current_mpack_id BIGINT,
+  mpack_id BIGINT,
   CONSTRAINT PK_stack PRIMARY KEY (stack_id),
-  CONSTRAINT FK_mpacks FOREIGN KEY (current_mpack_id) REFERENCES mpacks(id),
+  CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
 CREATE TABLE extension(

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -38,9 +38,9 @@ CREATE TABLE stack (
   stack_id NUMERIC(19) NOT NULL,
   stack_name VARCHAR(255) NOT NULL,
   stack_version VARCHAR(255) NOT NULL,
-  current_mpack_id BIGINT,
+  mpack_id BIGINT,
   CONSTRAINT PK_stack PRIMARY KEY (stack_id),
-  CONSTRAINT FK_mpacks FOREIGN KEY (current_mpack_id) REFERENCES mpacks(id),
+  CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
 CREATE TABLE extension(

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -51,9 +51,9 @@ CREATE TABLE stack (
   stack_id BIGINT NOT NULL,
   stack_name VARCHAR(255) NOT NULL,
   stack_version VARCHAR(255) NOT NULL,
-  current_mpack_id BIGINT,
+  mpack_id BIGINT,
   CONSTRAINT PK_stack PRIMARY KEY CLUSTERED (stack_id),
-  CONSTRAINT FK_mpacks FOREIGN KEY (current_mpack_id) REFERENCES mpacks(id),
+  CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
 CREATE TABLE extension(
@@ -137,6 +137,7 @@ CREATE TABLE servicegroups (
   id BIGINT NOT NULL,
   service_group_name VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
+  stack_id BIGINT NOT NULL,
   CONSTRAINT PK_servicegroups PRIMARY KEY (id, cluster_id),
   CONSTRAINT FK_servicegroups_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters (cluster_id));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename current_mpack_id to mpack_id

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
mvn clean install

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.