### PR TITLE
[AMBARI-22957] Stack Metainfo.xml should contain the osSpecifics tag

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +47,7 @@ import org.apache.ambari.server.orm.entities.MpackEntity;
 import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.state.Module;
 import org.apache.ambari.server.state.Mpack;
+import org.apache.ambari.server.state.OsSpecific;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.stack.StackMetainfoXml;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -327,6 +329,17 @@ public class MpackManager {
     StackMetainfoXml.Version version = new StackMetainfoXml.Version();
     version.setActive(true);
     generatedMetainfo.setVersion(version);
+
+    //Add osSpecifics to the metainfo.xml
+    OsSpecific osSpecific = new OsSpecific("any");
+    OsSpecific.Package pkg = new OsSpecific.Package();
+    pkg.setName(mpack.getName().toLowerCase());
+    ArrayList<OsSpecific.Package> packageArrayList = new ArrayList<>();
+    packageArrayList.add(pkg);
+    ArrayList<OsSpecific> osSpecificArrayList = new ArrayList<>();
+    osSpecificArrayList.add(osSpecific);
+    osSpecific.addPackages(packageArrayList);
+    generatedMetainfo.setOsSpecifics(osSpecificArrayList);
 
     Map<String, String> prerequisites = mpack.getPrerequisites();
     if (prerequisites != null && prerequisites.containsKey(MIN_JDK_PROPERTY)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/StackMetainfoXml.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/StackMetainfoXml.java
@@ -130,6 +130,10 @@ public class StackMetainfoXml implements Validable{
   public void setVersion(Version version) {
     this.version = version;
   }
+  
+  public void setOsSpecifics(List<OsSpecific> osSpecifics) {
+    this.osSpecifics = osSpecifics;
+  }
 
   /**
    * Internal list of os-specific details (loaded from xml). Added at schema ver 2


### PR DESCRIPTION
osSpecifics tag should be added to mpacks at time of metainfo generation. 

POST /mpacks
Verify osSpecifics tag in the generated metainfo.xml
