### PR TITLE
[AMBARI-22975] Add namespace-specific layout for service summary page

### DIFF
--- a/ambari-web/app/app.js
+++ b/ambari-web/app/app.js
@@ -239,6 +239,10 @@ module.exports = Em.Application.create({
     return App.Service.find('HDFS').get('isLoaded') && !App.HostComponent.find().someProperty('componentName', 'SECONDARY_NAMENODE');
   }.property('router.clusterController.dataLoadList.services', 'router.clusterController.isServiceContentFullyLoaded'),
 
+  hasNameNodeFederation: function () {
+    return App.HostComponent.find().filterProperty('componentName', 'NAMENODE').length > 2;
+  }.property('router.clusterController.dataLoadList.services', 'router.clusterController.isServiceContentFullyLoaded'),
+
   /**
    * If ResourceManager High Availability is enabled
    * Based on number of ResourceManager host components installed

--- a/ambari-web/app/mappers/service_metrics_mapper.js
+++ b/ambari-web/app/mappers/service_metrics_mapper.js
@@ -165,6 +165,8 @@ App.serviceMetricsMapper = App.QuickDataMapper.create({
     ha_status: 'HostRoles.ha_state',
     display_name_advanced: 'display_name_advanced',
     admin_state: 'HostRoles.desired_admin_state'
+    // TODO add mapping for namespace property
+    // ha_name_space:
   },
 
   /**

--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -32,6 +32,7 @@ App.HostComponent = DS.Model.extend({
   publicHostName: DS.attr('string'),
   service: DS.belongsTo('App.Service'),
   adminState: DS.attr('string'),
+  haNameSpace: DS.attr('string'),
 
   serviceDisplayName: Em.computed.truncate('service.displayName', 14, 11),
 

--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -46,6 +46,16 @@
   {{/isAuthorized}}
 {{/if}}
 
+{{#if view.hasMultipleMasterGroups}}
+  <ul class="nav nav-tabs">
+    {{#each group in view.mastersObj}}
+      <li {{bindAttr class="group.isActive:active"}}>
+        <a href="#" {{action setActiveComponentGroup group.title target="view"}}>{{group.title}}</a>
+      </li>
+    {{/each}}
+  </ul>
+{{/if}}
+
 <div class="service-block">
   <div class="summary-links-block">
     <div class="panel panel-default summary-block">

--- a/ambari-web/app/templates/main/service/info/summary/base.hbs
+++ b/ambari-web/app/templates/main/service/info/summary/base.hbs
@@ -16,11 +16,15 @@
 * limitations under the License.
 }}
 
-<div class="row">
-  <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
+<div class="row component-summary">
+  {{view App.SummaryMasterComponentsView mastersCompBinding="view.parentView.mastersObj"}}
+  <div class="col-md-12">
+    <div class="col-md-2">
+      {{#if view.parentView.showComponentsTitleForNonMasters}}
+        {{t dashboard.services.hdfs.summary.components}}
+      {{/if}}
+    </div>
     <div class="col-md-10">
-      {{view App.SummaryMasterComponentsView mastersCompBinding="view.parentView.mastersObj"}}
       {{view App.SummarySlaveComponentsView slavesObjBinding="view.parentView.slavesObj"}}
       {{view App.SummaryClientComponentsView clientsObjBinding="view.parentView.clientObj"}}
     </div>

--- a/ambari-web/app/templates/main/service/info/summary/master_components.hbs
+++ b/ambari-web/app/templates/main/service/info/summary/master_components.hbs
@@ -16,25 +16,45 @@
 * limitations under the License.
 }}
 
-{{#each comp in view.mastersComp}}
-  <div {{bindAttr class="comp.isSubComponent:component-small :component :col-md-3 comp.componentName :row"}}>
-    <div {{bindAttr class=":summary-value comp.summaryValueClassName"}}>
-      <span rel='SummaryComponentHealthTooltip' {{bindAttr class="comp.statusClass comp.statusIconClass" data-original-title="comp.passiveTooltip"}}></span>
-      <span class="main-info">{{comp.componentTextStatus}}</span>
-      {{#if comp.alertsCount}}
-        <span {{action "showServiceAlertsPopup" comp target="controller"}} {{bindAttr class=":label comp.hasCriticalAlerts:alerts-crit-count:alerts-warn-count"}}>
-          {{comp.alertsCount}}
-        </span>
-      {{/if}}
-    </div>
-    <div {{bindAttr class=":summary-label comp.summaryLabelClassName"}}>
-      <a href="#" {{action showDetails comp.host}} data-original-title="{{unbound comp.publicHostName}}" rel="UsageTooltip">
-        {{#if comp.displayNameAdvanced}}
-          {{comp.displayNameAdvanced}}
-        {{else}}
-          {{comp.displayName}}
-        {{/if}}
-      </a>
-    </div>
-  </div>
-{{/each}}
+{{#if view.activeMastersComp.length}}
+  {{#each group in view.activeMastersComp}}
+    {{#if group.components.length}}
+      <div class="col-md-12">
+        <div class="col-md-2">
+          {{#if group.title}}
+            {{group.title}}
+          {{else}}
+            {{t dashboard.services.hdfs.summary.components}}
+          {{/if}}
+        </div>
+        <div class="col-md-10">
+          {{#each comp in group.components}}
+            <div {{bindAttr class="comp.isSubComponent:component-small :component :col-md-3 comp.componentName :row"}}>
+              <div {{bindAttr class=":summary-value comp.summaryValueClassName"}}>
+        <span rel='SummaryComponentHealthTooltip'
+          {{bindAttr class="comp.statusClass comp.statusIconClass" data-original-title="comp.passiveTooltip"}}></span>
+                <span class="main-info">{{comp.componentTextStatus}}</span>
+                {{#if comp.alertsCount}}
+                  <span {{action "showServiceAlertsPopup" comp target="controller"}}
+                    {{bindAttr class=":label comp.hasCriticalAlerts:alerts-crit-count:alerts-warn-count"}}>
+                    {{comp.alertsCount}}
+                  </span>
+                {{/if}}
+              </div>
+              <div {{bindAttr class=":summary-label comp.summaryLabelClassName"}}>
+                <a href="#" {{action showDetails comp.host}} data-original-title="{{unbound comp.publicHostName}}"
+                   rel="UsageTooltip">
+                  {{#if comp.displayNameAdvanced}}
+                    {{comp.displayNameAdvanced}}
+                  {{else}}
+                    {{comp.displayName}}
+                  {{/if}}
+                </a>
+              </div>
+            </div>
+          {{/each}}
+        </div>
+      </div>
+    {{/if}}
+  {{/each}}
+{{/if}}

--- a/ambari-web/app/templates/main/service/services/hbase.hbs
+++ b/ambari-web/app/templates/main/service/services/hbase.hbs
@@ -17,35 +17,41 @@
 }}
 
 <div class="row">
-  <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
-    <div class="col-md-10">
-      {{! HBase Master Server }}
-      {{view view.dashboardMasterComponentView}}
-      {{! RegionServers }}
-      {{#if view.isRegionServerCreated}}
-        <div {{bindAttr class=":row :component :col-md-3 view.regionServerComponent.componentName"}}>
-          <div class="summary-value main-info">
-            {{#if App.router.clusterController.isServiceContentFullyLoaded}}
-              <span>
-                {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.regionServersStarted" totalComponentsBinding="view.service.regionServersTotal"}}
-                  {{view.liveComponents}}/{{view.totalComponents}}
-                {{/view}}
-              </span>
-              {{t common.live}}
-            {{else}}
-              {{t common.loading.eclipses}}
-            {{/if}}
+  <div class="component-summary">
+    {{! HBase Master Server }}
+    {{view view.dashboardMasterComponentView}}
+    <div class="col-md-12">
+      <div class="col-md-2">
+        {{#if view.hasMultipleMasterGroups}}
+          {{t dashboard.services.hdfs.summary.components}}
+        {{/if}}
+      </div>
+      <div class="col-md-10">
+        {{! RegionServers }}
+        {{#if view.isRegionServerCreated}}
+          <div {{bindAttr class=":row :component :col-md-3 view.regionServerComponent.componentName"}}>
+            <div class="summary-value main-info">
+              {{#if App.router.clusterController.isServiceContentFullyLoaded}}
+                <span>
+                  {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.regionServersStarted" totalComponentsBinding="view.service.regionServersTotal"}}
+                    {{view.liveComponents}}/{{view.totalComponents}}
+                  {{/view}}
+                </span>
+                {{t common.live}}
+              {{else}}
+                {{t common.loading.eclipses}}
+              {{/if}}
+            </div>
+            <div class="summary-label">
+              <a
+                href="#" {{action filterHosts view.regionServerComponent}}>{{t dashboard.services.hbase.regionServers}}</a>
+            </div>
           </div>
-          <div class="summary-label">
-            <a href="#" {{action filterHosts view.regionServerComponent}}>{{t dashboard.services.hbase.regionServers}}</a>
-          </div>
-        </div>
-      {{/if}}
-      {{! PhoenixServers }}
-      {{#if view.isPhoenixQueryServerCreated}}
-        <div {{bindAttr class=":row :component :col-md-3 view.phoenixServerComponent.componentName"}}>
-          <div class="summary-value main-info">
+        {{/if}}
+        {{! PhoenixServers }}
+        {{#if view.isPhoenixQueryServerCreated}}
+          <div {{bindAttr class=":row :component :col-md-3 view.phoenixServerComponent.componentName"}}>
+            <div class="summary-value main-info">
             <span>
               {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.phoenixServersStarted" totalComponentsBinding="view.service.phoenixServersTotal"}}
                 {{#if App.router.clusterController.isServiceContentFullyLoaded}}
@@ -53,17 +59,19 @@
                 {{/if}}
               {{/view}}
             </span>
-            {{t common.live}}
+              {{t common.live}}
+            </div>
+            <div class="summary-label">
+              <a
+                href="#" {{action filterHosts view.phoenixServerComponent}}>{{t dashboard.services.hbase.phoenixServers}}</a>
+            </div>
           </div>
-          <div class="summary-label">
-            <a href="#" {{action filterHosts view.phoenixServerComponent}}>{{t dashboard.services.hbase.phoenixServers}}</a>
-          </div>
+        {{/if}}
+        {{! Regions in Transition }}
+        <div class="row col-md-3 regions-in-trnasition">
+          <div class="summary-value main-info">{{view.service.regionsInTransition}}</div>
+          <div class="summary-label">{{t dashboard.services.hbase.regions.transition}}</div>
         </div>
-      {{/if}}
-      {{! Regions in Transition }}
-      <div class="row col-md-3 regions-in-trnasition">
-        <div class="summary-value main-info">{{view.service.regionsInTransition}}</div>
-        <div class="summary-label">{{t dashboard.services.hbase.regions.transition}}</div>
       </div>
     </div>
   </div>

--- a/ambari-web/app/templates/main/service/services/hdfs.hbs
+++ b/ambari-web/app/templates/main/service/services/hdfs.hbs
@@ -18,135 +18,147 @@
 
 <div class="row">
   {{! Component Section }}
-  <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
-    <div class="col-md-10">
-      {{view view.dashboardMasterComponentView}}
-      {{! NameNode Uptime }}
-      <div class="row namenode-uptime col-md-3">
-        <div class="summary-value main-info">{{view.nodeUptime}}</div>
-        <div class="summary-label">{{t dashboard.services.hdfs.nodes.uptime}}</div>
+  <div class="component-summary">
+    {{view view.dashboardMasterComponentView}}
+    <div class="col-md-12">
+      <div class="col-md-10 col-md-offset-2">
+        {{! TODO add NameNode uptime and heap for each namespace}}
+        {{! NameNode Uptime }}
+        <div class="row namenode-uptime col-md-3">
+          <div class="summary-value main-info">{{view.nodeUptime}}</div>
+          <div class="summary-label">{{t dashboard.services.hdfs.nodes.uptime}}</div>
+        </div>
+        {{! NameNode Heap }}
+        <div class="row namenode-heap col-md-3">
+          <div class="summary-value">
+            <div class="main-info"> {{view.nodeHeapPercent}} </div>
+            <div class="info-desc"> {{view.nodeHeap}} </div>
+          </div>
+          <div class="summary-label">{{t dashboard.services.hdfs.nodes.heap}}</div>
+        </div>
       </div>
-      {{! NameNode Heap }}
-      <div class="row namenode-heap col-md-3">
-        <div class="summary-value">
-          <div class="main-info"> {{view.nodeHeapPercent}} </div>
-          <div class="info-desc"> {{view.nodeHeap}} </div>
-        </div>
-        <div class="summary-label">{{t dashboard.services.hdfs.nodes.heap}}</div>
+    </div>
+    <div class="col-md-12">
+      <div class="col-md-2">
+        {{#if view.hasMultipleMasterGroups}}
+          {{t dashboard.services.hdfs.summary.components}}
+        {{/if}}
       </div>
-      {{! Data Nodes }}
-      {{#if view.isDataNodeCreated}}
-        <div {{bindAttr class=":row :component :col-md-3 view.dataNodeComponent.componentName"}}>
-          <div class="summary-value main-info">
-            {{#if App.router.clusterController.isServiceContentFullyLoaded}}
-              <span>
-                {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.dataNodesStarted" totalComponentsBinding="view.service.dataNodesTotal"}}
-                  {{view.liveComponents}}/{{view.totalComponents}}
-                {{/view}}
-              </span>
-              {{t common.started}}
-            {{else}}
-              {{t common.loading.eclipses}}
-            {{/if}}
-          </div>
-          <div class="summary-label">
-            <a href="#" {{action filterHosts view.dataNodeComponent}}>{{t dashboard.services.hdfs.datanodes}}</a>
-          </div>
-        </div>
-      {{/if}}
-      {{! JournalNodes }}
-      {{#if view.isJournalNodeCreated}}
-        <div {{bindAttr class=":row :component :col-md-3 view.journalNodeComponent.componentName"}}>
-          <div class="summary-value main-info">
-            {{#if App.router.clusterController.isComponentsStateLoaded}}
-              <span>
-                {{#view App.ComponentLiveTextView liveComponentsBinding="view.journalNodesLive" totalComponentsBinding="view.journalNodesTotal"}}
-                  {{view.liveComponents}}/{{view.totalComponents}}
-                {{/view}}
-              </span>
-              <span> {{t common.live}} </span>
-            {{else}}
-              {{t common.loading.eclipses}}
-            {{/if}}
-          </div>
-          <div class="summary-label">
-            <a href="#" {{action filterHosts view.journalNodeComponent}}>{{t dashboard.services.hdfs.journalnodes}}</a>
-          </div>
-        </div>
-      {{/if}}
-      {{! NFS Gateway }}
-      {{#if view.isNfsInStack}}
-        <div {{bindAttr class=":row :component :col-md-3 view.nfsGatewayComponent.componentName"}}>
-          <div class="summary-value main-info">
-            {{#if App.router.clusterController.isServiceContentFullyLoaded}}
-              <span>
-                {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.nfsGatewaysStarted" totalComponentsBinding="view.service.nfsGatewaysTotal"}}
-                  {{view.liveComponents}}/{{view.totalComponents}}
-                {{/view}}
-              </span>
-              {{t common.started}}
-            {{else}}
-              {{t common.loading.eclipses}}
-            {{/if}}
-          </div>
-          <div class="summary-label">
-            <a href="#" {{action filterHosts view.nfsGatewayComponent}}>{{t dashboard.services.hdfs.nfsgateways}}</a>
-          </div>
-        </div>
-      {{/if}}
-      {{! indent next row}}
-      <div class="row"></div>
-      {{! Data Node Counts live }}
-      <div class="row datanode-count-live col-md-3">
-        <div class="summary-value">
-          {{#if view.service.metricsNotAvailable}}
-            <div class="main-info">
-              {{t services.service.summary.notAvailable}}
+      <div class="col-md-10">
+        {{! Data Nodes }}
+        {{#if view.isDataNodeCreated}}
+          <div {{bindAttr class=":row :component :col-md-3 view.dataNodeComponent.componentName"}}>
+            <div class="summary-value main-info">
+              {{#if App.router.clusterController.isServiceContentFullyLoaded}}
+                <span>
+                  {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.dataNodesStarted" totalComponentsBinding="view.service.dataNodesTotal"}}
+                    {{view.liveComponents}}/{{view.totalComponents}}
+                  {{/view}}
+                </span>
+                {{t common.started}}
+              {{else}}
+                {{t common.loading.eclipses}}
+              {{/if}}
             </div>
-          {{else}}
-            <span class="main-info" rel="tooltip"
-              {{translateAttr data-original-title="dashboard.services.hdfs.datanode.status.tooltip.live" }}>
-              {{view.service.liveDataNodes.length}}
-            </span>
-            <div class="info-desc">{{t dashboard.services.hdfs.nodes.live}}</div>
+            <div class="summary-label">
+              <a href="#" {{action filterHosts view.dataNodeComponent}}>{{t dashboard.services.hdfs.datanodes}}</a>
+            </div>
+          </div>
+        {{/if}}
+        {{! JournalNodes }}
+        {{#if view.isJournalNodeCreated}}
+          <div {{bindAttr class=":row :component :col-md-3 view.journalNodeComponent.componentName"}}>
+            <div class="summary-value main-info">
+              {{#if App.router.clusterController.isComponentsStateLoaded}}
+                <span>
+                  {{#view App.ComponentLiveTextView liveComponentsBinding="view.journalNodesLive" totalComponentsBinding="view.journalNodesTotal"}}
+                    {{view.liveComponents}}/{{view.totalComponents}}
+                  {{/view}}
+                </span>
+                <span> {{t common.live}} </span>
+              {{else}}
+                {{t common.loading.eclipses}}
+              {{/if}}
+            </div>
+            <div class="summary-label">
+              <a
+                href="#" {{action filterHosts view.journalNodeComponent}}>{{t dashboard.services.hdfs.journalnodes}}</a>
+            </div>
+          </div>
+        {{/if}}
+        {{! NFS Gateway }}
+        {{#if view.isNfsInStack}}
+          <div {{bindAttr class=":row :component :col-md-3 view.nfsGatewayComponent.componentName"}}>
+            <div class="summary-value main-info">
+              {{#if App.router.clusterController.isServiceContentFullyLoaded}}
+                <span>
+                  {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.nfsGatewaysStarted" totalComponentsBinding="view.service.nfsGatewaysTotal"}}
+                    {{view.liveComponents}}/{{view.totalComponents}}
+                  {{/view}}
+                </span>
+                {{t common.started}}
+              {{else}}
+                {{t common.loading.eclipses}}
+              {{/if}}
+            </div>
+            <div class="summary-label">
+              <a href="#" {{action filterHosts view.nfsGatewayComponent}}>{{t dashboard.services.hdfs.nfsgateways}}</a>
+            </div>
+          </div>
+        {{/if}}
+        {{! indent next row}}
+        <div class="row"></div>
+        {{! Data Node Counts live }}
+        <div class="row datanode-count-live col-md-3">
+          <div class="summary-value">
+            {{#if view.service.metricsNotAvailable}}
+              <div class="main-info">
+                {{t services.service.summary.notAvailable}}
+              </div>
+            {{else}}
+              <span class="main-info" rel="tooltip"
+                {{translateAttr data-original-title="dashboard.services.hdfs.datanode.status.tooltip.live" }}>
+                {{view.service.liveDataNodes.length}}
+              </span>
+              <div class="info-desc">{{t dashboard.services.hdfs.nodes.live}}</div>
             {{/if}}
+          </div>
+          <div class="summary-label">{{t dashboard.services.hdfs.datanodecounts}}</div>
         </div>
-        <div class="summary-label">{{t dashboard.services.hdfs.datanodecounts}}</div>
-      </div>
-      {{! Data Node Counts dead }}
-      <div class="row datanode-count-dead col-md-3">
-        <div class="summary-value">
-          {{#if view.service.metricsNotAvailable}}
-            <div class="main-info">
-              {{t services.service.summary.notAvailable}}
-            </div>
-          {{else}}
-            <span class="main-info" rel="tooltip"
-              {{translateAttr data-original-title="dashboard.services.hdfs.datanode.status.tooltip.dead" }}>
-              {{view.service.deadDataNodes.length}}
-            </span>
-            <div class="info-desc">{{t dashboard.services.hdfs.nodes.dead}}</div>
-          {{/if}}
+        {{! Data Node Counts dead }}
+        <div class="row datanode-count-dead col-md-3">
+          <div class="summary-value">
+            {{#if view.service.metricsNotAvailable}}
+              <div class="main-info">
+                {{t services.service.summary.notAvailable}}
+              </div>
+            {{else}}
+              <span class="main-info" rel="tooltip"
+                {{translateAttr data-original-title="dashboard.services.hdfs.datanode.status.tooltip.dead" }}>
+                {{view.service.deadDataNodes.length}}
+              </span>
+              <div class="info-desc">{{t dashboard.services.hdfs.nodes.dead}}</div>
+            {{/if}}
+          </div>
+          <div class="summary-label">{{t dashboard.services.hdfs.datanodecounts}}</div>
         </div>
-        <div class="summary-label">{{t dashboard.services.hdfs.datanodecounts}}</div>
-      </div>
-      {{! Data Node Counts decommission }}
-      <div class="row datanode-count-decommission col-md-3">
-        <div class="summary-value">
-          {{#if view.service.metricsNotAvailable}}
-            <div class="main-info">
-              {{t services.service.summary.notAvailable}}
-            </div>
-          {{else}}
-            <span class="main-info" rel="tooltip"
-              {{translateAttr data-original-title="dashboard.services.hdfs.datanode.status.tooltip.decommission" }}>
-              {{view.service.decommissionDataNodes.length}}
-            </span>
-            <div class="info-desc">{{t dashboard.services.hdfs.nodes.decom}}</div>
-          {{/if}}
+        {{! Data Node Counts decommission }}
+        <div class="row datanode-count-decommission col-md-3">
+          <div class="summary-value">
+            {{#if view.service.metricsNotAvailable}}
+              <div class="main-info">
+                {{t services.service.summary.notAvailable}}
+              </div>
+            {{else}}
+              <span class="main-info" rel="tooltip"
+                {{translateAttr data-original-title="dashboard.services.hdfs.datanode.status.tooltip.decommission" }}>
+                {{view.service.decommissionDataNodes.length}}
+              </span>
+              <div class="info-desc">{{t dashboard.services.hdfs.nodes.decom}}</div>
+            {{/if}}
+          </div>
+          <div class="summary-label">{{t dashboard.services.hdfs.datanodecounts}}</div>
         </div>
-        <div class="summary-label">{{t dashboard.services.hdfs.datanodecounts}}</div>
       </div>
     </div>
   </div>

--- a/ambari-web/app/templates/main/service/services/hive.hbs
+++ b/ambari-web/app/templates/main/service/services/hive.hbs
@@ -16,11 +16,15 @@
 * limitations under the License.
 }}
 
-<div class="row">
-  <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
+<div class="row component-summary">
+  {{view view.dashboardMasterComponentView}}
+  <div class="col-md-12">
+    <div class="col-md-2">
+      {{#if view.hasMultipleMasterGroups}}
+        {{t dashboard.services.hdfs.summary.components}}
+      {{/if}}
+    </div>
     <div class="col-md-10">
-      {{view App.SummaryMasterComponentsView mastersCompBinding="view.parentView.mastersObj"}}
       {{view App.SummaryClientComponentsView clientsObjBinding="view.parentView.clientObj"}}
     </div>
   </div>

--- a/ambari-web/app/templates/main/service/services/ranger.hbs
+++ b/ambari-web/app/templates/main/service/services/ranger.hbs
@@ -16,12 +16,15 @@
 * limitations under the License.
 }}
 
-<div class="row">
-  <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
+<div class="row component-summary">
+  {{view view.dashboardMasterComponentView}}
+  <div class="col-md-12">
+    <div class="col-md-2">
+      {{#if view.hasMultipleMasterGroups}}
+        {{t dashboard.services.hdfs.summary.components}}
+      {{/if}}
+    </div>
     <div class="col-md-10">
-      {{view view.dashboardMasterComponentView}}
-
       {{! Ranger Tagsyncs }}
       {{#if view.isRangerTagsyncCreated}}
         <div {{bindAttr class=":row :component :col-md-3 view.rangerTagsyncComponent.componentName"}}>

--- a/ambari-web/app/templates/main/service/services/storm.hbs
+++ b/ambari-web/app/templates/main/service/services/storm.hbs
@@ -18,28 +18,34 @@
 
 <div class="row">
   <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
-    <div class="col-md-10">
-      {{view App.SummaryMasterComponentsView mastersCompBinding="view.parentView.mastersObj"}}
-      {{#if view.isSupervisorCreated}}
-        <div class="row col-md-3 component SUPERVISOR">
-          <div class="summary-value main-info">
-            {{#if App.router.clusterController.isServiceContentFullyLoaded}}
-              {{#view App.ComponentLiveTextView liveComponentsBinding="view.superVisorsLive" totalComponentsBinding="view.superVisorsTotal" tagName="span"}}
-                {{view.liveComponents}}/{{view.totalComponents}}
-              {{/view}}
-              {{t common.live}}
-            {{else}}
-              {{t common.loading.eclipses}}
-            {{/if}}
+    {{view view.dashboardMasterComponentView}}
+    <div class="col-md-12">
+      <div class="col-md-2">
+        {{#if view.hasMultipleMasterGroups}}
+          {{t dashboard.services.hdfs.summary.components}}
+        {{/if}}
+      </div>
+      <div class="col-md-10">
+        {{#if view.isSupervisorCreated}}
+          <div class="row col-md-3 component SUPERVISOR">
+            <div class="summary-value main-info">
+              {{#if App.router.clusterController.isServiceContentFullyLoaded}}
+                {{#view App.ComponentLiveTextView liveComponentsBinding="view.superVisorsLive" totalComponentsBinding="view.superVisorsTotal" tagName="span"}}
+                  {{view.liveComponents}}/{{view.totalComponents}}
+                {{/view}}
+                {{t common.live}}
+              {{else}}
+                {{t common.loading.eclipses}}
+              {{/if}}
+            </div>
+            <div class="summary-label">
+              <a href="#" {{action filterHosts view.filterComponent}}>
+                {{t dashboard.services.storm.supervisors}}
+              </a>
+            </div>
           </div>
-          <div class="summary-label">
-            <a href="#" {{action filterHosts view.filterComponent}}>
-              {{t dashboard.services.storm.supervisors}}
-            </a>
-          </div>
-        </div>
-      {{/if}}
+        {{/if}}
+      </div>
     </div>
   </div>
   <div class="col-md-12 metrics-summary">

--- a/ambari-web/app/templates/main/service/services/yarn.hbs
+++ b/ambari-web/app/templates/main/service/services/yarn.hbs
@@ -18,105 +18,111 @@
 
 <div class="row">
   {{! Component Section }}
-  <div class="col-md-12 component-summary">
-    <div class="col-md-2">{{t dashboard.services.hdfs.summary.components}}</div>
-    <div class="col-md-10">
-      {{view view.dashboardMasterComponentView}}
-
-      {{! NodeManagers }}
-      {{#if view.isNodeManagerCreated}}
-        <div {{bindAttr class=":row :component :col-md-3 view.nodeManagerComponent.componentName"}}>
+  <div class="component-summary">
+    {{view view.dashboardMasterComponentView}}
+    <div class="col-md-12">
+      <div class="col-md-2">
+        {{#if view.hasMultipleMasterGroups}}
+          {{t dashboard.services.hdfs.summary.components}}
+        {{/if}}
+      </div>
+      <div class="col-md-10">
+        {{! NodeManagers }}
+        {{#if view.isNodeManagerCreated}}
+          <div {{bindAttr class=":row :component :col-md-3 view.nodeManagerComponent.componentName"}}>
+            <div class="summary-value main-info">
+              {{#if App.router.clusterController.isServiceContentFullyLoaded}}
+                {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.nodeManagersStarted" totalComponentsBinding="view.service.nodeManagersTotal" tagName="span"}}
+                  {{view.liveComponents}}/{{view.totalComponents}}
+                {{/view}}
+                {{t common.started}}
+              {{else}}
+                {{t common.loading.eclipses}}
+              {{/if}}
+            </div>
+            <div class="summary-label">
+              <a
+                href="#" {{action filterHosts view.nodeManagerComponent}}>{{t dashboard.services.yarn.nodeManagers}}</a>
+            </div>
+          </div>
+        {{/if}}
+        {{! YARN Clients }}
+        <div {{bindAttr class=":row :component :col-md-3 view.yarnClientComponent.componentName"}}>
           <div class="summary-value main-info">
-            {{#if App.router.clusterController.isServiceContentFullyLoaded}}
-              {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.nodeManagersStarted" totalComponentsBinding="view.service.nodeManagersTotal" tagName="span"}}
-                {{view.liveComponents}}/{{view.totalComponents}}
-              {{/view}}
-              {{t common.started}}
-            {{else}}
-              {{t common.loading.eclipses}}
-            {{/if}}
+            <span>{{view.service.installedClients}} {{t common.installed}} </span>
           </div>
           <div class="summary-label">
-            <a href="#" {{action filterHosts view.nodeManagerComponent}}>{{t dashboard.services.yarn.nodeManagers}}</a>
+            <a {{action filterHosts view.yarnClientComponent}} href="javascript:void(null)">
+              {{pluralize view.service.installedClients singular="t:dashboard.services.yarn.client" plural="t:dashboard.services.yarn.clients"}}
+            </a>
           </div>
         </div>
-      {{/if}}
-      {{! YARN Clients }}
-      <div {{bindAttr class=":row :component :col-md-3 view.yarnClientComponent.componentName"}}>
-        <div class="summary-value main-info">
-          <span>{{view.service.installedClients}} {{t common.installed}} </span>
+        {{! indent next row}}
+        <div class="row"></div>
+        {{! ResourceManager Uptime }}
+        <div class="row col-md-3 resourcemanager-uptime">
+          <div class="summary-value main-info">{{view.nodeUptime}}</div>
+          <div class="summary-label">{{t dashboard.services.yarn.resourceManager.uptime}}</div>
         </div>
-        <div class="summary-label">
-          <a {{action filterHosts view.yarnClientComponent}} href="javascript:void(null)">
-            {{pluralize view.service.installedClients singular="t:dashboard.services.yarn.client" plural="t:dashboard.services.yarn.clients"}}
-          </a>
-        </div>
-      </div>
-      {{! indent next row}}
-      <div class="row"></div>
-      {{! ResourceManager Uptime }}
-      <div class="row col-md-3 resourcemanager-uptime">
-        <div class="summary-value main-info">{{view.nodeUptime}}</div>
-        <div class="summary-label">{{t dashboard.services.yarn.resourceManager.uptime}}</div>
-      </div>
-      {{! indent next row}}
-      <div class="row"></div>
-      {{! NodeManagers active }}
-      <div class="row col-md-3 nodemanager-active">
+        {{! indent next row}}
+        <div class="row"></div>
+        {{! NodeManagers active }}
+        <div class="row col-md-3 nodemanager-active">
         <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.active"}}
-          rel="tooltip">
+              rel="tooltip">
           {{view._nmActive}}
         </span>
-        <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.active}}</div>
-        <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
-      </div>
-      {{! NodeManagers lost }}
-      <div class="row col-md-3 nodemanager-lost">
+          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.active}}</div>
+          <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
+        </div>
+        {{! NodeManagers lost }}
+        <div class="row col-md-3 nodemanager-lost">
         <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.lost"}}
-          rel="tooltip">
+              rel="tooltip">
           {{view._nmLost}}
         </span>
-        <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.lost}}</div>
-        <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
-      </div>
-      {{! NodeManagers unhealthy }}
-      <div class="row col-md-3 nodemanager-unhealthy">
+          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.lost}}</div>
+          <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
+        </div>
+        {{! NodeManagers unhealthy }}
+        <div class="row col-md-3 nodemanager-unhealthy">
         <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.unhealthy"}}
-          rel="tooltip">
+              rel="tooltip">
           {{view._nmUnhealthy}}
         </span>
-        <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.unhealthy}}</div>
-        <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
-      </div>
-      {{! NodeManagers rebooted }}
-      <div class="row col-md-3 nodemanager-rebooted">
+          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.unhealthy}}</div>
+          <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
+        </div>
+        {{! NodeManagers rebooted }}
+        <div class="row col-md-3 nodemanager-rebooted">
         <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.rebooted"}}
-          rel="tooltip">
+              rel="tooltip">
           {{view._nmRebooted}}
         </span>
-        <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.rebooted}}</div>
-        <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
-      </div>
-      {{! NodeManagers decommissioned }}
-      <div class="row col-md-3 nodemanager-decommissioned">
+          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.rebooted}}</div>
+          <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
+        </div>
+        {{! NodeManagers decommissioned }}
+        <div class="row col-md-3 nodemanager-decommissioned">
         <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.decommissioned"}}
-          rel="tooltip">
+              rel="tooltip">
           {{view._nmDecom}}
         </span>
-        <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.decommissioned}}</div>
-        <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
-      </div>
-      {{! indent next row}}
-      <div class="row"></div>
-      {{! ResourceManager Heap }}
-      <div class="row col-md-3 resourcemanager-heap">
-        <div class="summary-value main-info">{{view.nodeHeap}}</div>
-        <div class="summary-label">{{t dashboard.services.resourceManager.nodes.heap}}</div>
+          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.decommissioned}}</div>
+          <div class="summary-label">{{t dashboard.services.yarn.nodeManagers.status}}</div>
+        </div>
+        {{! indent next row}}
+        <div class="row"></div>
+        {{! ResourceManager Heap }}
+        <div class="row col-md-3 resourcemanager-heap">
+          <div class="summary-value main-info">{{view.nodeHeap}}</div>
+          <div class="summary-label">{{t dashboard.services.resourceManager.nodes.heap}}</div>
+        </div>
       </div>
     </div>
   </div>

--- a/ambari-web/app/views/main/service/info/components_list_view.js
+++ b/ambari-web/app/views/main/service/info/components_list_view.js
@@ -21,15 +21,25 @@ var App = require('app');
 App.SummaryMasterComponentsView = Em.View.extend({
   templateName: require('templates/main/service/info/summary/master_components'),
 
-  mastersComp: [],
+  mastersComp: [
+    {
+      components: []
+    }
+  ],
+
+  activeMastersComp: function () {
+    const mastersComp = this.get('mastersComp'),
+      activeGroup = mastersComp.findProperty('isActive');
+    return activeGroup ? [activeGroup] : mastersComp;
+  }.property('mastersComp.length', 'mastersComp.@each.isActive', 'mastersComp.@each.components.length'),
 
   mastersCompWillChange: function() {
     Em.run.next(() => this.removeTooltips());
-  }.observesBefore('mastersComp.length'),
+  }.observesBefore('mastersComp.length', 'mastersComp.@each.components.length'),
 
   mastersCompDidChange: function() {
     Em.run.next(() => this.attachTooltip());
-  }.observes('mastersComp.length'),
+  }.observes('mastersComp.length', 'mastersComp.@each.components.length'),
 
   removeTooltips: function() {
     $('.tooltip').remove();

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -27,11 +27,15 @@ App.MainServiceInfoSummaryView = Em.View.extend({
   attributes: null,
 
   /**
-   * Contain array with list of master components from <code>App.Service.hostComponets</code> which are
+   * Contain array with list of groups of master components from <code>App.Service.hostComponets</code> which are
    * <code>App.HostComponent</code> models.
-   * @type {App.HostComponent[]}
+   * @type {{title: String, isActive: Boolean, hosts: String[], components: App.HostComponent[]}[]}
    */
-  mastersObj: [],
+  mastersObj: [
+    {
+      components: []
+    }
+  ],
   mastersLength: 0,
 
   /**
@@ -155,6 +159,7 @@ App.MainServiceInfoSummaryView = Em.View.extend({
     return {};
   }.property('controller.content'),
 
+  showComponentsTitleForNonMasters: Em.computed.or('!mastersLength', 'hasMultipleMasterGroups'),
 
   componentsLengthDidChange: function() {
     var self = this;
@@ -213,7 +218,11 @@ App.MainServiceInfoSummaryView = Em.View.extend({
       var clients = this.get('service.clientComponents').toArray();
 
       if (this.get('mastersLength') !== masters.length) {
-        this.updateComponentList(this.get('mastersObj'), masters);
+        const mastersInit = this.get('mastersObj').mapProperty('components').reduce((acc, group) => {
+          return [...acc, ...group];
+        }, []);
+        this.updateComponentList(mastersInit, masters);
+        this.set('mastersObj', this.getGroupedMasterComponents(mastersInit));
         this.set('mastersLength', masters.length);
       }
       if (this.get('slavesLength') !== slaves.length) {
@@ -410,5 +419,71 @@ App.MainServiceInfoSummaryView = Em.View.extend({
 
   rollingRestartStaleConfigSlaveComponents: function (componentName) {
     batchUtils.launchHostComponentRollingRestart(componentName.context, this.get('service.displayName'), this.get('service.passiveState') === "ON", true);
+  },
+
+  hasMultipleMasterGroups: Em.computed.gt('mastersObj.length', 1),
+
+  activeMasterComponentGroup: function () {
+    const activeGroup = this.get('mastersObj').findProperty('isActive');
+    return activeGroup ? activeGroup.title : '';
+  }.property('mastersObj.@each.isActive'),
+
+  getGroupedMasterComponents: function (components) {
+    switch (this.get('serviceName')) {
+      case 'HDFS':
+        const hostComponents = this.get('service.hostComponents'),
+          zkfcs = hostComponents.filterProperty('componentName', 'ZKFC'),
+          hasNameNodeFederation = App.get('hasNameNodeFederation');
+        let groups = [];
+        hostComponents.forEach(component => {
+          if (component.get('isMaster') && component.get('componentName') !== 'JOURNALNODE') {
+            const hostName = component.get('hostName'),
+              zkfc = zkfcs.findProperty('hostName', hostName);
+            if (hasNameNodeFederation) {
+              const title = component.get('haNameSpace'),
+                existingGroup = groups.findProperty('title', title),
+                currentGroup = existingGroup || {
+                    title,
+                    isActive: title === this.get('activeMasterComponentGroup'),
+                    components: [],
+                    hosts: [hostName]
+                  };
+              if (!existingGroup) {
+                groups.push(currentGroup);
+              }
+              currentGroup.components.push(component);
+              currentGroup.hosts.push(hostName);
+              if (zkfc) {
+                zkfc.set('isSubComponent', true);
+                currentGroup.components.push(zkfc);
+              }
+            } else {
+              if (!groups.length) {
+                groups.push({
+                  components: []
+                });
+              }
+              const defaultGroupComponents = groups[0].components;
+              defaultGroupComponents.push(component);
+              if (zkfc) {
+                zkfc.set('isSubComponent', true);
+                defaultGroupComponents.push(zkfc);
+              }
+            }
+          }
+        });
+        return groups;
+      default:
+        return [
+          {
+            components
+          }
+        ];
+    }
+  },
+
+  setActiveComponentGroup: function (event) {
+    const groupName = event.context;
+    this.get('mastersObj').forEach(group => Em.set(group, 'isActive', group.title === groupName));
   }
 });

--- a/ambari-web/app/views/main/service/service.js
+++ b/ambari-web/app/views/main/service/service.js
@@ -157,6 +157,8 @@ App.MainDashboardServiceView = Em.View.extend(App.MainDashboardServiceViewWrappe
     };
   }.property('service'),
 
+  hasMultipleMasterGroups: Em.computed.gt('parentView.mastersObj.length', 1),
+
   /**
    * Check if service component is created
    * @param componentName

--- a/ambari-web/app/views/main/service/services/hdfs.js
+++ b/ambari-web/app/views/main/service/services/hdfs.js
@@ -62,27 +62,6 @@ App.MainDashboardServiceHdfsView = App.MainDashboardServiceView.extend({
     }.property('service.capacityUsed', 'service.capacityTotal')
   }),
 
-  dashboardMasterComponentView: App.SummaryMasterComponentsView.extend({
-    mastersComp: function() {
-      var masterComponents = [];
-      var hostComponents = this.get('parentView.service.hostComponents');
-      var zkfcs = hostComponents.filterProperty('componentName', 'ZKFC');
-
-      hostComponents.forEach(function (comp) {
-        if (comp.get('isMaster') && comp.get('componentName') !== 'JOURNALNODE') {
-          masterComponents.push(comp);
-          var zkfc = zkfcs.findProperty('hostName', comp.get('hostName'));
-          if (zkfc) {
-            zkfc.set('isSubComponent', true);
-            masterComponents.push(zkfc);
-          }
-        }
-      });
-      return masterComponents;
-    }.property('parentView.service.hostComponents.length')
-
-  }),
-  
   metricsNotAvailableObserver: function () {
     if(!this.get("service.metricsNotAvailable")) {
       App.tooltip($("[rel='tooltip']"));

--- a/ambari-web/test/views/main/service/info/summary_test.js
+++ b/ambari-web/test/views/main/service/info/summary_test.js
@@ -279,7 +279,11 @@ describe('App.MainServiceInfoSummaryView', function() {
         mastersLength: 0,
         slavesLength: 0,
         clientsLength: 0,
-        mastersObj: ['master'],
+        mastersObj: [
+          {
+            components: ['master']
+          }
+        ],
         slavesObj: ['slave'],
         clientObj: ['client']
       });
@@ -521,4 +525,8 @@ describe('App.MainServiceInfoSummaryView', function() {
       )).to.be.true;
     });
   });
+
+  App.TestAliases.testAsComputedOr(view, 'showComponentsTitleForNonMasters', ['!mastersLength', 'hasMultipleMasterGroups']);
+
+  App.TestAliases.testAsComputedGt(view, 'hasMultipleMasterGroups', 'mastersObj.length', 1);
 });

--- a/ambari-web/test/views/main/service/service_test.js
+++ b/ambari-web/test/views/main/service/service_test.js
@@ -200,11 +200,15 @@ describe('App.ComponentLiveTextView', function () {
 describe('App.MainDashboardServiceView', function () {
   var view;
 
-  beforeEach(function() {
-    view = App.MainDashboardServiceView.create({
+  function getView() {
+    return App.MainDashboardServiceView.create({
       controller: Em.Object.create(),
       service: Em.Object.create()
     });
+  }
+
+  beforeEach(function() {
+    view = getView();
   });
 
   describe('#data', function() {
@@ -261,4 +265,6 @@ describe('App.MainDashboardServiceView', function () {
       expect(view.isServiceComponentCreated('S1')).to.be.true;
     });
   });
+
+  App.TestAliases.testAsComputedGt(getView(), 'hasMultipleMasterGroups', 'parentView.mastersObj.length', 1);
 });

--- a/ambari-web/test/views/main/service/services/hdfs_test.js
+++ b/ambari-web/test/views/main/service/services/hdfs_test.js
@@ -55,45 +55,6 @@ describe('App.MainDashboardServiceHdfsView', function () {
     });
   });
 
-  describe("#dashboardMasterComponentView", function() {
-    var dashboardMasterComponentView;
-
-    beforeEach(function() {
-      dashboardMasterComponentView = view.get('dashboardMasterComponentView').create({
-        parentView: Em.Object.create({
-          service: Em.Object.create({
-            hostComponents: []
-          })
-        })
-      });
-    });
-
-    describe("#mastersComp", function () {
-
-      it("should return master components", function () {
-        dashboardMasterComponentView.set('parentView.service', Em.Object.create({
-          hostComponents: [
-            Em.Object.create({
-              componentName: 'ZKFC'
-            }),
-            Em.Object.create({
-              componentName: 'JOURNALNODE'
-            }),
-            Em.Object.create({
-              componentName: 'NAMENODE',
-              isMaster: true
-            })
-          ]
-        }));
-        dashboardMasterComponentView.propertyDidChange('mastersComp');
-        expect(dashboardMasterComponentView.get('mastersComp').mapProperty('componentName')).to.be.eql(['NAMENODE', 'ZKFC']);
-        expect(dashboardMasterComponentView.get('mastersComp')[0].get('isMaster')).to.be.true;
-        expect(dashboardMasterComponentView.get('mastersComp')[1].get('isSubComponent')).to.be.true;
-      });
-    });
-
-  });
-
   describe("#metricsNotAvailableObserver()", function() {
 
     beforeEach(function() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- HDFS components should be grouped by namespace
- Service summary page should have separate tab for each namespace

## How was this patch tested?

Tested on real clusters with and without enabled federation
UI unit tests:
  21379 passing (26s)
  48 pending