### PR TITLE
Incorrect rendering due to missing space in Markdown headers

### DIFF
--- a/ambari-server/docs/api/v1/authentication-source-resources.md
+++ b/ambari-server/docs/api/v1/authentication-source-resources.md
@@ -26,7 +26,7 @@ view and update all authentication source resources.  Any other user can only vi
 update their own authentication source resources. For example a user may change their own password
 by updating the relevant authentication source resource.  
 
-###API Summary
+### API Summary
 
 - [List authentication sources](authentication-source-list.md)
 - [Get authentication source](authentication-source-get.md)
@@ -34,7 +34,7 @@ by updating the relevant authentication source resource.
 - [Update authentication source](authentication-source-update.md)
 - [Delete authentication source](authenticationsource-delete.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/cluster-resources.md
+++ b/ambari-server/docs/api/v1/cluster-resources.md
@@ -18,14 +18,14 @@ limitations under the License.
 # Cluster Resources
 Cluster resources represent named Hadoop clusters.  Clusters are top level resources.
 
-###API Summary
+### API Summary
 
 - [List clusters](clusters.md)
 - [View cluster information](clusters-cluster.md)
 - [Create cluster](create-cluster.md)
 - [Delete cluster](delete-cluster.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/component-resources.md
+++ b/ambari-server/docs/api/v1/component-resources.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Component Resources
 Component resources are the individual components of a service (e.g. HDFS/NameNode and MapReduce/JobTracker).  Components are sub-resources of services.
 
-###API Summary 
+### API Summary
 
 - [List service components](components.md)
 - [View component information](components-component.md)
@@ -26,7 +26,7 @@ Component resources are the individual components of a service (e.g. HDFS/NameNo
 
 
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/configuration.md
+++ b/ambari-server/docs/api/v1/configuration.md
@@ -172,7 +172,7 @@ To list the desired configs for a host:
 
 Notice overrides for a configuration type are listed with the key as the config group id and value is the tag identifying the configuration resource.
 
-##Actual Configuration
+## Actual Configuration
 Actual configuration represents the set of `tag`s that identify the cluster's current configuration.  When configurations are changed, they are saved into the backing database, even if the host has not yet received the change.  When a 
 host receives the desired configuration changes AND applies them, it will respond with the applied tags. This is called the actual configuration.
 

--- a/ambari-server/docs/api/v1/credential-resources.md
+++ b/ambari-server/docs/api/v1/credential-resources.md
@@ -20,7 +20,7 @@ Credential resources represent named principal/key pairs related to a particular
 
 Credential resources may be stored in the persisted credential store or the temporary credential store. If stored in the persisted credential store, the credential will be stored until deleted. If stored in the temporary credential store, the credential will be stored until a timeout is met (default 90 minutes) or Ambari is restarted. 
 
-###API Summary
+### API Summary
 
 - [List credentials](credential-list.md)
 - [Get credential](credential-get.md)
@@ -28,7 +28,7 @@ Credential resources may be stored in the persisted credential store or the temp
 - [Update credential](credential-update.md)
 - [Delete credential](credential-delete.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/host-component-resources.md
+++ b/ambari-server/docs/api/v1/host-component-resources.md
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 # Host Component Resources
-###API Summary
+### API Summary
 
 
 - [List host components](host-components.md)
@@ -24,7 +24,7 @@ limitations under the License.
 - [Create host component](create-hostcomponent.md)
 - [Update host component](update-hostcomponent.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -67,7 +67,7 @@ limitations under the License.
 
 
 
-###States
+### States
 
 The current state of a host component resource can be determined by looking at the ServiceComponentInfo/state property.
 
@@ -147,13 +147,13 @@ The following table lists the possible values of the service resource ServiceCom
 </table>
 
 
-###Starting a Host Component
+### Starting a Host Component
 A component can be started through the API by setting its state to be STARTED (see [update host component](update-hostcomponent.md)).
 
-###Stopping a Host Component
+### Stopping a Host Component
 A component can be stopped through the API by setting its state to be INSTALLED (see [update host component](update-hostcomponent.md)).
 
-###Maintenance
+### Maintenance
 
 The user can update the desired state of a host component through the API to be MAINTENANCE (see [update host component](update-hostcomponent.md)).  When a host component is into maintenance state it is basically taken off line. This state can be used, for example, to move a component like NameNode.  The NameNode component can be put in MAINTENANCE mode and then a new NameNode can be created for the service. 
 

--- a/ambari-server/docs/api/v1/host-resources.md
+++ b/ambari-server/docs/api/v1/host-resources.md
@@ -18,13 +18,13 @@ limitations under the License.
 # Host Resources
  
  
-###API Summary 
+### API Summary
 
 - [List hosts](hosts.md)
 - [View host information](hosts-host.md)
 - [Create host](create-host.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -97,7 +97,7 @@ limitations under the License.
   </tr>
 </table>
 
-###States
+### States
 
 The current state of a host resource can be determined by looking at the Hosts/host_state property.
 

--- a/ambari-server/docs/api/v1/permission-resources.md
+++ b/ambari-server/docs/api/v1/permission-resources.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Permission Resources
 Permission resources help to determine access control for a user upon a resource (Ambari, a cluster, a view, etc...).
 
-###API Summary
+### API Summary
 
 - [List permissions](permission-list.md)
 - [Get permission](permission-get.md)
@@ -26,7 +26,7 @@ Permission resources help to determine access control for a user upon a resource
 - [Update permission](permission-update.md)
 - [Delete permission](permission-delete.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/repository-version-resources.md
+++ b/ambari-server/docs/api/v1/repository-version-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Repository Version Resources
 
-#####Create Instance
+##### Create Instance
 New repository versions may be created through the API. At least one set of base repository URLs should be provided.
 
     POST http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/
@@ -51,7 +51,7 @@ New repository versions may be created through the API. At least one set of base
       ]
     }
 
-#####Get Repository Versions
+##### Get Repository Versions
 The user may query for all repository versions of a particular stack.
 
     GET http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/
@@ -78,7 +78,7 @@ The user may query for all repository versions of a particular stack.
       ]
     }
 
-#####Get Repository Version
+##### Get Repository Version
 Returns single repository version.
 
     GET http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/1
@@ -115,12 +115,12 @@ Returns single repository version.
       ]
     }
     
-#####Delete Repository Version
+##### Delete Repository Version
 Deregisters repository version. It won't be possible to remove repository version which is installed on any of the clusters.
 
     DELETE http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/1
 
-#####Update Repository Version
+##### Update Repository Version
 Updates repository version. It is possible to change display name and base URLs. 
 
     PUT http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/repository_versions/1
@@ -161,7 +161,7 @@ Updates repository version. It is possible to change display name and base URLs.
       ]
     }
     
-#####Validate Base URL
+##### Validate Base URL
 User may validate URLs of repositories before persisting.
 
     POST http://<server>:8080/api/v1/stacks/<stack_name>/versions/<stack_version>/operating_systems/redhat5/repositories/HDP-UTILS-1.1.0.20?validate_only=true

--- a/ambari-server/docs/api/v1/request-resources.md
+++ b/ambari-server/docs/api/v1/request-resources.md
@@ -18,11 +18,11 @@ limitations under the License.
 # Request Resources
  
  
-###API Summary 
+### API Summary
 
 - [List requests](requests.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/rolling-upgrade-check-resources.md
+++ b/ambari-server/docs/api/v1/rolling-upgrade-check-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Rolling Upgrade Check Resources
 
-#####Get Check Results
+##### Get Check Results
 Retrieves results of rolling upgrade checks. All checks should have status PASS before running rolling upgrade.
 
     GET http://<server>:8080/api/v1/clusters/<cluster_name>/rolling_upgrades_check/
@@ -42,7 +42,7 @@ Retrieves results of rolling upgrade checks. All checks should have status PASS 
       ]
     }
 
-#####Example of checks execution
+##### Example of checks execution
 Successful and unsuccessful check.
 
     {

--- a/ambari-server/docs/api/v1/service-resources.md
+++ b/ambari-server/docs/api/v1/service-resources.md
@@ -18,7 +18,7 @@ limitations under the License.
 # Service Resources
 Service resources are services of a Hadoop cluster (e.g. HDFS, MapReduce and Ganglia).  Service resources are sub-resources of clusters. 
 
-###API Summary
+### API Summary
 
 - [List services](services.md)
 - [View service information](services-service.md)
@@ -26,7 +26,7 @@ Service resources are services of a Hadoop cluster (e.g. HDFS, MapReduce and Gan
 - [Update services](update-services.md)
 - [Update service](update-service.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -53,7 +53,7 @@ Service resources are services of a Hadoop cluster (e.g. HDFS, MapReduce and Gan
 
 
 
-###States
+### States
 
 The current state of a service resource can be determined by looking at the ServiceInfo/state property.
 
@@ -131,10 +131,10 @@ The following table lists the possible values of the service resource ServiceInf
   </tr>
 </table>
 
-###Starting a Service
+### Starting a Service
 A service can be started through the API by setting its state to be STARTED (see [update service](update-service.md)).
 
-###Stopping a Service
+### Stopping a Service
 A service can be stopped through the API by setting its state to be INSTALLED (see [update service](update-service.md)).
 
 

--- a/ambari-server/docs/api/v1/stack-version-resources.md
+++ b/ambari-server/docs/api/v1/stack-version-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Stack Version Resources
 
-#####Get Stack Versions
+##### Get Stack Versions
 Retrieves all stack versions.
 
 For cluster:
@@ -60,7 +60,7 @@ For host:
       ]
     }
     
-#####Get Stack Version
+##### Get Stack Version
 Retrieves single stack version.
 
 For cluster:
@@ -141,7 +141,7 @@ For host:
       ]
     }
     
-#####Install Repository Version
+##### Install Repository Version
 Performs install of given repository version on the resource.
 
 For cluster:

--- a/ambari-server/docs/api/v1/task-resources.md
+++ b/ambari-server/docs/api/v1/task-resources.md
@@ -18,11 +18,11 @@ limitations under the License.
 # Task Resources
  
  
-###API Summary 
+### API Summary
 
 - [List tasks](tasks.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>
@@ -84,7 +84,7 @@ limitations under the License.
 </table>
 
 
-###Status
+### Status
 
 The current status of a task resource can be determined by looking at the Tasks/status property.
 

--- a/ambari-server/docs/api/v1/user-resources.md
+++ b/ambari-server/docs/api/v1/user-resources.md
@@ -23,7 +23,7 @@ Users with the <code>AMBARI.MANAGE_USERS</code> privilege (currently, Ambari Adm
 view and update all user resources.  Any other user can only view and (partially) update their own 
 user resource.
 
-###API Summary
+### API Summary
 
 - [List users](user-list.md)
 - [Get user](user-get.md)
@@ -31,7 +31,7 @@ user resource.
 - [Update user](user-update.md)
 - [Delete user](user-delete.md)
 
-###Properties
+### Properties
 
 <table>
   <tr>

--- a/ambari-server/docs/api/v1/view-resources.md
+++ b/ambari-server/docs/api/v1/view-resources.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # View Resources
 
-#####Get Views
+##### Get Views
 The user may query for all of the deployed views.  Note that views are a top level resources (they are not sub-resources of a cluster).
 
     GET http://<server>:8080/api/v1/views/
@@ -40,7 +40,7 @@ The user may query for all of the deployed views.  Note that views are a top lev
       ]
     }
 
-#####Get View
+##### Get View
 To get a specific view, request it by name.  Note that the response shows all of the versions of the view as sub-resources.
 
     GET http://<server>:8080/api/v1/views/FILES/
@@ -62,7 +62,7 @@ To get a specific view, request it by name.  Note that the response shows all of
     }
 
 
-#####Get Versions
+##### Get Versions
 The user may request all of the versions of a named view.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/
@@ -80,7 +80,7 @@ The user may request all of the versions of a named view.
       ]
     }
 
-#####Get Version
+##### Get Version
 A specific version can be requested.  Note that all of the instances of the view version are included in the response.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/
@@ -117,7 +117,7 @@ A specific version can be requested.  Note that all of the instances of the view
       ]
     }
 
-#####Get Instances
+##### Get Instances
 The user may request all of the instances of a view.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/
@@ -137,7 +137,7 @@ The user may request all of the instances of a view.
     }
 
 
-#####Get Instance
+##### Get Instance
 A specific view instance may be requested by specifying its name.  Note that the instance resources are listed as sub-resources.
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_1
@@ -165,12 +165,12 @@ A specific view instance may be requested by specifying its name.  Note that the
       ]
     }
     
-#####Create Instance
+##### Create Instance
 New view instances may be created through the API.
 
     POST http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
     
-#####Update Instance
+##### Update Instance
 The properties of a view instance may be updated through the API.
 
     PUT http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
@@ -182,20 +182,20 @@ The properties of a view instance may be updated through the API.
         }
     }]
 
-#####Delete Instance
+##### Delete Instance
 A view instances may be deleted through the API.
 
     DELETE http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_2
     
 
-#####Resources
+##### Resources
 A view resource may be accessed through the REST API.  The href for each view resource can be found in a request for the parent view instance.  The resource endpoints and behavior depends on the implementation of the JAX-RS annotated service class specified for the resource element in the view.xml. 
 
     GET http://<server>:8080/api/v1/views/FILES/versions/0.1.0/instances/FILES_1/resources/files/fileops/listdir?path=%2F
     
     [{"path":"/app-logs","replication":0,"isDirectory":true,"len":0,"owner":"yarn","group":"hadoop","permission":"-rwxrwxrwx","accessTime":0,"modificationTime":1400006792122,"blockSize":0},{"path":"/mapred","replication":0,"isDirectory":true,"len":0,"owner":"mapred","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006653817,"blockSize":0},{"path":"/mr-history","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006653822,"blockSize":0},{"path":"/tmp","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxrwxrwx","accessTime":0,"modificationTime":1400006720415,"blockSize":0},{"path":"/user","replication":0,"isDirectory":true,"len":0,"owner":"hdfs","group":"hdfs","permission":"-rwxr-xr-x","accessTime":0,"modificationTime":1400006610050,"blockSize":0}]
 
-#####Managed Resources
+##### Managed Resources
 Any managed resources for a view may also be accessed through the REST API.  Note that instances of a managed resource appear as sub-resources of an instance under the plural name specified for the resource in the view.xml.  In this example, a list of managed resources named **'scripts'** is included in the response for the view instance … 
  
     GET http://<server>:8080/api/v1/views/PIG/versions/0.1.0/instances/INSTANCE_1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Markdown headers (eg. "API Summary") are not rendered correctly due to missing space between `##` and title.  (Thanks @csomaati for noticing this.)

## How was this patch tested?

Visual comparison of pages on GitHub, eg.

https://github.com/apache/ambari/blob/f430ba7c67d7ccda76c18cdd386d67cf746eebe9/ambari-server/docs/api/v1/service-resources.md#service-resources

vs

https://github.com/adoroszlai/ambari/blob/0816c33af2c9f1594b982ed9f55ef7f3a4cdad9b/ambari-server/docs/api/v1/service-resources.md#service-resources