### PR TITLE
[AMBARI-22980] Commenting out stack_features and stack_select calls u…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py
@@ -21,6 +21,7 @@ from ambari_commons.os_check import OSCheck
 from resource_management.core.exceptions import Fail
 from resource_management.core.logger import Logger
 from resource_management.libraries.resources.repository import Repository
+from resource_management.libraries.functions.cluster_settings import get_cluster_setting_value
 from resource_management.libraries.functions.is_empty import is_empty
 import ambari_simplejson as json
 
@@ -36,8 +37,8 @@ class RepositoryUtil:
 
     # repo templates
     repo_file = config['repositoryFile']
-    repo_rhel_suse =  config['configurations']['cluster-env']['repo_suse_rhel_template']
-    repo_ubuntu =  config['configurations']['cluster-env']['repo_ubuntu_template']
+    repo_rhel_suse =  get_cluster_setting_value('repo_rhel_suse_template')
+    repo_ubuntu =  get_cluster_setting_value('repo_ubuntu_template')
 
     if is_empty(repo_file):
       return

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
@@ -82,8 +82,8 @@ def check_stack_feature(stack_feature, stack_version):
           if compare_versions(stack_version, max_version, format = True) >= 0:
             return False
         return True
-  #else:
-    #raise Fail("Stack features not defined by stack")
+  else:
+    Logger.warning("Stack features not defined by stack")
         
   return False
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
@@ -82,8 +82,8 @@ def check_stack_feature(stack_feature, stack_version):
           if compare_versions(stack_version, max_version, format = True) >= 0:
             return False
         return True
-  else:
-    raise Fail("Stack features not defined by stack")
+  #else:
+    #raise Fail("Stack features not defined by stack")
         
   return False
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_select.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_select.py
@@ -129,6 +129,9 @@ def is_package_supported(package, supported_packages = None):
   """
   if supported_packages is None:
     supported_packages = get_supported_packages()
+    if supported_packages is None:
+       Logger.warning('No stack tool available, all packages are assumed to be supported by this stack')
+       return True
 
   if package in supported_packages:
     return True
@@ -142,6 +145,9 @@ def get_supported_packages():
   :return: and array of packages support by <stack-select>
   """
   stack_selector_path = stack_tools.get_stack_tool_path(stack_tools.STACK_SELECTOR_NAME)
+  if not os.path.exists(stack_selector_path):
+    Logger.warning('This stack does not have a stack select tool')
+    return
   command = (STACK_SELECT_PREFIX, stack_selector_path, "packages")
   code, stdout = shell.call(command, sudo = True,  quiet = True)
 

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
@@ -50,9 +50,9 @@ def setup_stack_symlinks(struct_out_file):
     return
 
   # get the packages which the stack-select tool should be used on
-  stack_packages = stack_select.get_packages(stack_select.PACKAGE_SCOPE_INSTALL)
-  if stack_packages is None:
-    return
+  #stack_packages = stack_select.get_packages(stack_select.PACKAGE_SCOPE_INSTALL)
+  #if stack_packages is None:
+    #return
 
   json_version = load_version(struct_out_file)
 

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
@@ -50,9 +50,9 @@ def setup_stack_symlinks(struct_out_file):
     return
 
   # get the packages which the stack-select tool should be used on
-  #stack_packages = stack_select.get_packages(stack_select.PACKAGE_SCOPE_INSTALL)
-  #if stack_packages is None:
-    #return
+  stack_packages = stack_select.get_packages(stack_select.PACKAGE_SCOPE_INSTALL)
+  if stack_packages is None:
+    return
 
   json_version = load_version(struct_out_file)
 


### PR DESCRIPTION
…ntil instance_manager is ready

stack_select and stack_features will most likely be replaced with the new instance manager. These calls will then become redundant. It will be required that we revisit the cleanup code at the time of instance manager usage.

## How was this patch tested?
Deploy Zookeeper & Zookeeper Clients