### PR TITLE
AMBARI-22983. Add Hosts is Failing with Error while bootstrapping

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -1200,6 +1200,7 @@ def update_ambari_properties():
       new_properties.load(hfNew)
 
     for prop_key, prop_value in old_properties.getPropertyDict().items():
+      prop_value = prop_value.replace("/usr/lib/python2.6/site-packages", "/usr/lib/ambari-server/lib")
       if "agent.fqdn.service.url" == prop_key:
         # what is agent.fqdn property in ambari.props?
         new_properties.process_pair(GET_FQDN_SERVICE_URL, prop_value)


### PR DESCRIPTION
Add Hosts(UI/API) is broken after upgrade and the following error is seen:

Error while bootstrapping:
Cannot run program "/usr/lib/python2.6/site-packages/ambari_server/bootstrap.py": error=2, No such file or directory