### PR TITLE
[AMBARI-22985] Quick links should be grouped by namespace

### DIFF
--- a/ambari-web/app/templates/main/dashboard/widgets/hbase_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/hbase_links.hbs
@@ -75,15 +75,17 @@
                   {{#if view.isLoaded}}
                     {{#if view.quickLinksArray}}
                       <!--there are multiple masters eg, HBase multiple masters or HDFS HA enabled-->
-                      {{#each quickLinks in view.quickLinksArray}}
-                        <li class="dropdown-submenu">
-                          <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
-                          <ul class="dropdown-menu">
-                            {{#each quickLinks}}
-                              <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
-                            {{/each}}
-                          </ul>
-                        </li>
+                      {{#each group in view.quickLinksArray}}
+                        {{#each quickLinks in group.links}}
+                          <li class="dropdown-submenu">
+                            <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
+                            <ul class="dropdown-menu">
+                              {{#each quickLinks}}
+                                <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        {{/each}}
                       {{/each}}
                     {{else}}
                       {{#each view.quickLinks}}

--- a/ambari-web/app/templates/main/dashboard/widgets/hdfs_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/hdfs_links.hbs
@@ -94,15 +94,17 @@
                 {{#if view.isLoaded}}
                   {{#if view.quickLinksArray}}
                     <!--there are multiple masters eg, HBase multiple masters or HDFS HA enabled-->
-                    {{#each quickLinks in view.quickLinksArray}}
-                      <li class="dropdown-submenu">
-                        <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
-                        <ul class="dropdown-menu">
-                          {{#each quickLinks}}
-                            <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
-                          {{/each}}
-                        </ul>
-                      </li>
+                    {{#each group in view.quickLinksArray}}
+                      {{#each quickLinks in group.links}}
+                        <li class="dropdown-submenu">
+                          <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
+                          <ul class="dropdown-menu">
+                            {{#each quickLinks}}
+                              <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                            {{/each}}
+                          </ul>
+                        </li>
+                      {{/each}}
                     {{/each}}
                   {{else}}
                     {{#each view.quickLinks}}

--- a/ambari-web/app/templates/main/dashboard/widgets/yarn_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/yarn_links.hbs
@@ -60,15 +60,17 @@
                   {{#if view.isLoaded}}
                     {{#if view.quickLinksArray}}
                       <!--there are multiple masters eg, HBase multiple masters or HDFS HA enabled-->
-                      {{#each quickLinks in view.quickLinksArray}}
-                        <li class="dropdown-submenu">
-                          <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
-                          <ul class="dropdown-menu">
-                            {{#each quickLinks}}
-                              <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
-                            {{/each}}
-                          </ul>
-                        </li>
+                      {{#each group in view.quickLinksArray}}
+                        {{#each quickLinks in group.links}}
+                          <li class="dropdown-submenu">
+                            <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
+                            <ul class="dropdown-menu">
+                              {{#each quickLinks}}
+                                <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                              {{/each}}
+                            </ul>
+                          </li>
+                        {{/each}}
                       {{/each}}
                     {{else}}
                       {{#each view.quickLinks}}

--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -88,7 +88,7 @@
     </div>
 
     <div class="panel panel-default quick-links-block">
-      {{#view App.QuickLinksView contentBinding="view.svc"}}
+      {{#view App.QuickLinksView contentBinding="view.svc" masterGroupsBinding="view.mastersObj"}}
         <div class="panel-heading">
           <div class="row col-md-8 col-lg-12">
             <h4 class="panel-title">{{t common.quickLinks}}</h4>
@@ -99,10 +99,15 @@
             {{#if view.isLoaded}}
               {{#if view.quickLinksArray}}
                 <!--there are multiple masters eg, HBase multiple masters or HDFS HA enabled-->
-                {{#each quickLinks in view.quickLinksArray}}
-                  <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
-                  {{#each quickLinks}}
-                    <a {{bindAttr href="url"}} target="_blank">{{label}}</a>
+                {{#each group in view.quickLinksArray}}
+                  {{#if group.title}}
+                    <h5>{{group.title}}</h5>
+                  {{/if}}
+                  {{#each quickLinks in group.links}}
+                    <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
+                    {{#each quickLinks}}
+                      <a {{bindAttr href="url"}} target="_blank">{{label}}</a>
+                    {{/each}}
                   {{/each}}
                 {{/each}}
               {{else}}

--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -79,6 +79,8 @@ App.QuickLinksView = Em.View.extend({
    */
   servicesSupportsHttps: ["HDFS", "HBASE"],
 
+  masterGroups: [],
+
   /**
    * @type {object}
    */
@@ -287,6 +289,8 @@ App.QuickLinksView = Em.View.extend({
       this.setEmptyLinks();
     } else if (hosts.length === 1 || isMultipleComponentsInLinks || this.hasOverriddenHost()) {
       this.setSingleHostLinks(hosts, response);
+    } else if (this.get('masterGroups.length') > 1) {
+      this.setMultipleGroupLinks(hosts);
     } else {
       this.setMultipleHostLinks(hosts);
     }
@@ -480,17 +484,9 @@ App.QuickLinksView = Em.View.extend({
     }
   },
 
-  /**
-   * set links that contain multiple hosts
-   *
-   * @param {hostForQuickLink[]} hosts
-   * @method setMultipleHostLinks
-   */
-  setMultipleHostLinks: function (hosts) {
+  getMultipleHostLinks: function (hosts) {
     var quickLinksConfig = this.getQuickLinksConfiguration();
     if (Em.isNone(quickLinksConfig)) {
-      this.set('quickLinksArray', []);
-      this.set('isLoaded', false);
       return;
     }
 
@@ -544,8 +540,50 @@ App.QuickLinksView = Em.View.extend({
       }
       quickLinksArray.push(quickLinks);
     }, this);
-    this.set('quickLinksArray', quickLinksArray);
-    this.set('isLoaded', true);
+    return quickLinksArray;
+  },
+
+  /**
+   * set links that contain multiple hosts
+   *
+   * @param {hostForQuickLink[]} hosts
+   * @method setMultipleHostLinks
+   */
+  setMultipleHostLinks: function (hosts) {
+    const quickLinks = this.getMultipleHostLinks(hosts);
+    this.setProperties({
+      quickLinksArray: [
+        {
+          links: quickLinks || []
+        }
+      ],
+      isLoaded: !!quickLinks
+    });
+  },
+
+  /**
+   * set links that contain for multiple grouped hosts
+   *
+   * @param {hostForQuickLink[]} hosts
+   * @method setMultipleGroupLinks
+   */
+  setMultipleGroupLinks: function (hosts) {
+    let isLoaded = true;
+    const quickLinksArray = this.get('masterGroups').map(group => {
+      const groupHosts = hosts.filter(host => group.hosts.contains(host.hostName)),
+        links = this.getMultipleHostLinks(groupHosts);
+      if (!links) {
+        isLoaded = false;
+      }
+      return {
+        title: group.title,
+        links: links || []
+      };
+    });
+    this.setProperties({
+      quickLinksArray,
+      isLoaded
+    });
   },
 
   /**

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -446,7 +446,7 @@ App.MainServiceInfoSummaryView = Em.View.extend({
                     title,
                     isActive: title === this.get('activeMasterComponentGroup'),
                     components: [],
-                    hosts: [hostName]
+                    hosts: []
                   };
               if (!existingGroup) {
                 groups.push(currentGroup);

--- a/ambari-web/test/views/common/quick_link_view_test.js
+++ b/ambari-web/test/views/common/quick_link_view_test.js
@@ -258,6 +258,7 @@ describe('App.QuickViewLinks', function () {
       sinon.stub(quickViewLinks, 'setEmptyLinks');
       sinon.stub(quickViewLinks, 'setSingleHostLinks');
       sinon.stub(quickViewLinks, 'setMultipleHostLinks');
+      sinon.stub(quickViewLinks, 'setMultipleGroupLinks');
       quickViewLinks.set('content.quickLinks', []);
     });
     afterEach(function () {
@@ -266,6 +267,8 @@ describe('App.QuickViewLinks', function () {
       quickViewLinks.setEmptyLinks.restore();
       quickViewLinks.setSingleHostLinks.restore();
       quickViewLinks.setMultipleHostLinks.restore();
+      quickViewLinks.setMultipleGroupLinks.restore();
+      quickViewLinks.get('masterGroups').clear();
     });
     it("no hosts", function () {
       this.mock.returns([]);
@@ -292,6 +295,14 @@ describe('App.QuickViewLinks', function () {
       this.mock.returns([{hostName: 'host1'}, {hostName: 'host2'}]);
       quickViewLinks.setQuickLinksSuccessCallback();
       expect(quickViewLinks.setMultipleHostLinks.calledWith(
+        [{hostName: 'host1'}, {hostName: 'host2'}]
+      )).to.be.true;
+    });
+    it("multiple grouped hosts", function () {
+      this.mock.returns([{hostName: 'host1'}, {hostName: 'host2'}]);
+      quickViewLinks.set('masterGroups', [{}, {}]);
+      quickViewLinks.setQuickLinksSuccessCallback();
+      expect(quickViewLinks.setMultipleGroupLinks.calledWith(
         [{hostName: 'host1'}, {hostName: 'host2'}]
       )).to.be.true;
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently quick links are grouped by host. These groups in their part should be grouped by namespace (if any).

## How was this patch tested?

Tested on real clusters with and without NameNode Federation.
UI unit tests:
  21380 passing (23s)
  48 pending