### PR TITLE
[AMBARI-22491] trunk. Moving Metrics Collector Forces ZooKeeper Server Install on Target Host

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step4_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step4_controller.js
@@ -115,10 +115,9 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
         .concat(App.ClientComponent.find().toArray())
         .concat(App.SlaveComponent.find().toArray())
         .filter(function(service){
-          return service.get("installedCount") > 0;
+          return service.get("totalCount") > 0;
         })
         .mapProperty('componentName');
-
     var dependenciesToInstall = App.StackServiceComponent.find(componentName)
         .get('dependencies')
         .filter(function (component) {


### PR DESCRIPTION
…l on Target Host (alexantonenko)

## What changes were proposed in this pull request?
Moving Metrics Collector Forces ZooKeeper Server Install on Target Host

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.