### PR TITLE
Upgrade Ambari to Guice 4.1

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -36,7 +36,7 @@
     <swagger.version>1.5.10</swagger.version>
     <swagger.maven.plugin.version>3.1.4</swagger.maven.plugin.version>
     <slf4j.version>1.7.20</slf4j.version>
-    <guice.version>3.0</guice.version>
+    <guice.version>4.1.0</guice.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -36,6 +36,7 @@
     <swagger.version>1.5.10</swagger.version>
     <swagger.maven.plugin.version>3.1.4</swagger.maven.plugin.version>
     <slf4j.version>1.7.20</slf4j.version>
+    <guice.version>3.0</guice.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
@@ -91,11 +92,6 @@
         <version>1.1</version>
       </dependency>
       <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-servlet</artifactId>
-        <version>3.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
         <version>1.1</version>
@@ -103,17 +99,27 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>3.0</version>
+        <version>${guice.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>3.0</version>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-multibindings</artifactId>
+        <version>${guice.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-persist</artifactId>
-        <version>3.0</version>
+        <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-servlet</artifactId>
+        <version>${guice.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1168,8 +1168,16 @@
       <version>1.9.2</version>
     </dependency>
     <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
@@ -1178,11 +1186,6 @@
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
@@ -1465,11 +1468,6 @@
       <groupId>asm</groupId>
       <artifactId>asm</artifactId>
       <version>3.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/ambari-server/src/main/java/com/google/inject/persist/jpa/AmbariJpaPersistModule.java
+++ b/ambari-server/src/main/java/com/google/inject/persist/jpa/AmbariJpaPersistModule.java
@@ -25,7 +25,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -38,13 +38,13 @@ import org.apache.ambari.server.orm.RequiresSession;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.persist.PersistModule;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.UnitOfWork;
 import com.google.inject.persist.finder.DynamicFinder;
 import com.google.inject.persist.finder.Finder;
-import com.google.inject.util.Providers;
 
 /**
  * Copy of guice persist module for local modifications
@@ -60,17 +60,11 @@ public class AmbariJpaPersistModule extends PersistModule {
     }
   }
 
-  private Properties properties;
+  private Map<?, ?> properties;
   private MethodInterceptor transactionInterceptor;
 
   @Override protected void configurePersistence() {
     bindConstant().annotatedWith(Jpa.class).to(jpaUnit);
-
-    if (null != properties) {
-      bind(Properties.class).annotatedWith(Jpa.class).toInstance(properties);
-    } else {
-      bind(Properties.class).annotatedWith(Jpa.class).toProvider(Providers.of(null));
-    }
 
     bind(AmbariJpaPersistService.class).in(Singleton.class);
 
@@ -100,13 +94,17 @@ public class AmbariJpaPersistModule extends PersistModule {
     return transactionInterceptor;
   }
 
+  @Provides @Jpa Map<?, ?> provideProperties() {
+    return properties;
+  }
+
   /**
    * Configures the JPA persistence provider with a set of properties.
    *
    * @param properties A set of name value pairs that configure a JPA persistence
    * provider as per the specification.
    */
-  public AmbariJpaPersistModule properties(Properties properties) {
+  public AmbariJpaPersistModule properties(Map<?, ?> properties) {
     this.properties = properties;
     return this;
   }

--- a/ambari-server/src/main/java/com/google/inject/persist/jpa/AmbariJpaPersistService.java
+++ b/ambari-server/src/main/java/com/google/inject/persist/jpa/AmbariJpaPersistService.java
@@ -17,11 +17,9 @@
  */
 package com.google.inject.persist.jpa;
 
-
-import java.util.Properties;
+import java.util.Map;
 
 import com.google.inject.Inject;
-import com.google.inject.internal.util.$Nullable;
 
 /**
  * Override non-public class limitations as we need non-interface method
@@ -29,7 +27,7 @@ import com.google.inject.internal.util.$Nullable;
 public class AmbariJpaPersistService extends JpaPersistService {
 
   @Inject
-  public AmbariJpaPersistService(@Jpa String persistenceUnitName, @$Nullable @Jpa Properties persistenceProperties) {
+  public AmbariJpaPersistService(@Jpa String persistenceUnitName, @Jpa Map<?, ?> persistenceProperties) {
     super(persistenceUnitName, persistenceProperties);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/StaticallyInject.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/StaticallyInject.java
@@ -22,13 +22,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.google.inject.ScopeAnnotation;
-
 /**
- * Annotation indicating there are static members that should be injected 
+ * Annotation indicating there are static members that should be injected
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })
-@ScopeAnnotation
 public @interface StaticallyInject {
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/users/CsvFilePersisterService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/users/CsvFilePersisterService.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -42,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 
-@Singleton
 public class CsvFilePersisterService implements CollectionPersisterService<String, List<String>> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CsvFilePersisterService.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

As more Java 8 code is added in Ambari, it becomes ever harder to find the root cause of problems that come up during Injector creation (eg. missing bindings or [JPA/DB issues](https://issues.apache.org/jira/browse/AMBARI-22938)).  Guice 3 usually shows an [ArrayIndexOutBoundsException](https://stackoverflow.com/questions/28244342/why-is-a-lambda-expression-breaking-guice-error-handling-when-i-try-to-start-jet/) instead of the actual problem.

Guice 4.0 added [Java8 runtime compatibility](https://github.com/google/guice/wiki/Guice40#some-highlights).  Current version is [4.1](https://github.com/google/guice/wiki/Guice41), released June 17, 2016.

## How was this patch tested?

Built RPMs, installed them on CentOS6 and deployed a minimal kerberized ZooKeeper cluster.

Unit tests:

```
[WARNING] Tests run: 5067, Failures: 0, Errors: 0, Skipped: 35
...
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 5665 licenses.
...
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
```