### PR TITLE
[AMBARI-22988] master-key option is missing from ambari-server setup action

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -494,6 +494,9 @@ def init_setup_parser_options(parser):
                                                                "Name sid|sname", dest="sid_or_sname")
   other_group.add_option('--enable-lzo-under-gpl-license', action="store_true", default=False, help="Automatically accepts GPL license", dest="accept_gpl")
 
+  # the --master-key option is needed in the event passwords in the ambari.properties file are encrypted
+  other_group.add_option('--master-key', default=None, help="Master key for encrypting passwords", dest="master_key")
+
   parser.add_option_group(other_group)
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ambari-server setup --enable-lzo-under-gpl-license` failing with `Unexpected AttibuteError`

```
# ambari-server setup --enable-lzo-under-gpl-license -s
Using python /usr/bin/python
Setup ambari-server
Checking SELinux...
SELinux status is 'disabled'
Customize user account for ambari-server daemon [y/n] (n)?
Adjusting ambari-server permissions and ownership...
Checking firewall status...
Checking JDK...
Do you want to change Oracle JDK [y/n] (n)?
Check JDK version for Ambari Server...
JDK version found: 8
Minimum JDK version is 8 for Ambari. Skipping to setup different JDK for Ambari Server.
Checking GPL software agreement...
Completing setup...
Configuring database...
Enter advanced database configuration [y/n] (n)?
Configuring database...
ERROR: Unexpected AttributeError: Values instance has no attribute 'master_key'
For more info run ambari-server with -v or --verbose option
```
**Note**: This occurs after encrypting passwords in the ambari_server.properties file:

```
# ambari-server setup-security
Using python  /usr/bin/python
Security setup options...
===========================================================================
Choose one of the following options:
  [1] Enable HTTPS for Ambari server.
  [2] Encrypt passwords stored in ambari.properties file.
  [3] Setup Ambari kerberos JAAS configuration.
  [4] Setup truststore.
  [5] Import certificate to truststore.
===========================================================================
Enter choice, (1-5): 2
Please provide master key for locking the credential store:
Re-enter master key:
Do you want to persist master key. If you choose not to persist, you need to provide the Master Key while starting the ambari server as an env variable named AMBARI_SECURITY_MASTER_KEY or the start will prompt for the master key. Persist [y/n] (y)? y
Adjusting ambari-server permissions and ownership...
Ambari Server 'setup-security' completed successfully.
```

**The solution is to add the missing master_key property to the parser options.** 

## How was this patch tested?

After making the proposed change, the failing command now succeeds:

```
# ambari-server setup --enable-lzo-under-gpl-license -s
Using python  /usr/bin/python
Setup ambari-server
Checking SELinux...
SELinux status is 'enabled'
SELinux mode is 'permissive'
WARNING: SELinux is set to 'permissive' mode and temporarily disabled.
OK to continue [y/n] (y)?
Customize user account for ambari-server daemon [y/n] (n)?
Adjusting ambari-server permissions and ownership...
Checking firewall status...
Checking JDK...
Do you want to change Oracle JDK [y/n] (n)?
Check JDK version for Ambari Server...
JDK version found: 8
Minimum JDK version is 8 for Ambari. Skipping to setup different JDK for Ambari Server.
Checking GPL software agreement...
Completing setup...
Configuring database...
Enter advanced database configuration [y/n] (n)?
Configuring database...
Configuring ambari database...
Configuring remote database connection properties...
WARNING: Before starting Ambari Server, you must run the following DDL against the database to create the schema: /var/lib/ambari-server/resources/Ambari-DDL-MySQL-CREATE.sql
Proceed with configuring remote database connection properties [y/n] (y)?
Extracting system views...
...........
Adjusting ambari-server permissions and ownership...
Ambari Server 'setup' completed successfully.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.