### PR TITLE
[AMBARI-22991] [trunk] Grafana shows incorrect info for HBase Average Regions per RegionServer

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-home.json
@@ -248,7 +248,7 @@
           },
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "max",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-home.json
@@ -247,7 +247,7 @@
           },
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "max",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor changes to HBase and AMS HBase Grafana dashboards.

## How was this patch tested?

Manually tested.