### PR TITLE
[AMBARI-22992] Update error handling during mpack installation

### DIFF
--- a/ambari-server/src/main/assemblies/server.xml
+++ b/ambari-server/src/main/assemblies/server.xml
@@ -316,6 +316,11 @@
     </file>
     <file>
       <fileMode>755</fileMode>
+      <source>target/classes/cluster-settings.xml</source>
+      <outputDirectory>/var/lib/ambari-server/resources</outputDirectory>
+    </file>
+    <file>
+      <fileMode>755</fileMode>
       <source>target/classes/Ambari-DDL-Postgres-CREATE.sql</source>
       <outputDirectory>/var/lib/ambari-server/resources</outputDirectory>
     </file>

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -433,17 +433,8 @@ public class MpackManager {
    */
   private void createSymLinks(Mpack mpack) throws IOException {
 
-    String stackId = mpack.getStackId();
-    String stackName = "";
-    String stackVersion = "";
-    if (stackId == null) {
-      stackName = mpack.getName();
-      stackVersion = mpack.getVersion();
-    } else {
-      StackId id = new StackId(stackId);
-      stackName = id.getStackName();
-      stackVersion = id.getStackVersion();
-    }
+    String stackName = mpack.getName();
+    String stackVersion = mpack.getVersion();
     File stack = new File(stackRoot + "/" + stackName);
     Path stackPath = Paths.get(stackRoot + "/" + stackName + "/" + stackVersion);
     Path mpackPath = Paths.get(mpacksStaging + "/" + mpack.getName() + "/" + mpack.getVersion());
@@ -542,18 +533,8 @@ public class MpackManager {
    */
   protected void populateStackDB(Mpack mpack) throws IOException {
 
-    String stackId = mpack.getStackId();
-    String stackName = "";
-    String stackVersion = "";
-    if (stackId == null) {
-      stackName = mpack.getName();
-      stackVersion = mpack.getVersion();
-    } else {
-      StackId id = new StackId(stackId);
-      stackName = id.getStackName();
-      stackVersion = id.getStackVersion();
-    }
-
+    String stackName = mpack.getName();
+    String stackVersion = mpack.getVersion();
     StackEntity stackEntity = stackDAO.find(stackName, stackVersion);
     if (stackEntity == null) {
       LOG.info("Adding stack {}-{} to the database", stackName, stackVersion);
@@ -564,10 +545,7 @@ public class MpackManager {
       stackEntity.setMpackId(mpack.getMpackId());
       stackDAO.create(stackEntity);
     } else {
-      LOG.info("Updating stack {}-{} to the database", stackName, stackVersion);
-
-      stackEntity.setMpackId(mpack.getMpackId());
-      stackDAO.merge(stackEntity);
+      LOG.error("Stack {}-{} already exists in the database", stackName, stackVersion);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -48,7 +48,6 @@ import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.state.Module;
 import org.apache.ambari.server.state.Mpack;
 import org.apache.ambari.server.state.OsSpecific;
-import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.stack.StackMetainfoXml;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;


### PR DESCRIPTION
Remove stale code and update error handling in MpackManager. At present the code supports refreshing a stack definition when an mpack is installed. Given we are will map stack to mpack 1:1, we need to remove this stale code and replace with error handling. Also the old mpack json schema used to contain stack-id that we no longer need.

Will be tested with multi-mpack scenario.
Ran unit tests and build check.

