### PR TITLE
[AMBARI-22996] ViewInstanceResourceProviderTest, ViewPermissionResourceProviderTest, and ViewURLResourceProviderTest fail unexpectedly

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProviderTest.java
@@ -71,6 +71,7 @@ public class ViewInstanceResourceProviderTest {
 
   @Before
   public void before() {
+    ViewRegistry.initInstance(viewregistry);
     reset(viewregistry);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProviderTest.java
@@ -65,10 +65,6 @@ public class ViewInstanceResourceProviderTest {
 
   private static final ViewRegistry viewregistry = createMock(ViewRegistry.class);
 
-  static {
-    ViewRegistry.initInstance(viewregistry);
-  }
-
   @Before
   public void before() {
     ViewRegistry.initInstance(viewregistry);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewPermissionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewPermissionResourceProviderTest.java
@@ -50,10 +50,6 @@ public class ViewPermissionResourceProviderTest {
   private final static PermissionDAO dao = createStrictMock(PermissionDAO.class);
   private static final ViewRegistry viewRegistry = createMock(ViewRegistry.class);
 
-  static {
-    ViewRegistry.initInstance(viewRegistry);
-  }
-
   @BeforeClass
   public static void initClass() {
     ViewPermissionResourceProvider.init(dao);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewPermissionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewPermissionResourceProviderTest.java
@@ -61,6 +61,7 @@ public class ViewPermissionResourceProviderTest {
 
   @Before
   public void resetGlobalMocks() {
+    ViewRegistry.initInstance(viewRegistry);
     reset(dao, viewRegistry);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewURLResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewURLResourceProviderTest.java
@@ -59,10 +59,6 @@ public class ViewURLResourceProviderTest {
 
   private static final ViewRegistry viewregistry = createMock(ViewRegistry.class);
 
-  static {
-    ViewRegistry.initInstance(viewregistry);
-  }
-
   @Before
   public void before() throws Exception {
     ViewRegistry.initInstance(viewregistry);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewURLResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewURLResourceProviderTest.java
@@ -65,6 +65,7 @@ public class ViewURLResourceProviderTest {
 
   @Before
   public void before() throws Exception {
+    ViewRegistry.initInstance(viewregistry);
     reset(viewregistry);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

These tests require that a mocked ViewRegistry be used, which is set in a static initializer block. If the ViewRegistry is set after that, for example, but running a test in one of these classes, then the tests will no longer be using the correct ViewRegistry. Therefore, I have changed the set up methods of these test classes to set the ViewRegistry to the mocked version from that class.

## How was this patch tested?

Patch was tested manually.

@adoroszlai @rlevas This pull request fixes an issue similar to others I have submitted in the past (https://github.com/apache/ambari/pull/176 and https://github.com/apache/ambari/pull/133).