### PR TITLE
[AMBARI-22998] Wrong user used to execute the Spark/Livy Server service check

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/params.py
@@ -113,6 +113,7 @@ spark_submit_cmd = format("{spark_home}/bin/spark-submit")
 spark_smoke_example = "org.apache.spark.examples.SparkPi"
 spark_service_check_cmd = format(
   "{spark_submit_cmd} --class {spark_smoke_example}  --master yarn-cluster  --num-executors 1 --driver-memory 256m  --executor-memory 256m   --executor-cores 1  {spark_home}/lib/spark-examples*.jar 1")
+smoke_user = config['configurations']['cluster-env']['smokeuser']
 smoke_user_keytab = config['configurations']['cluster-env']['smokeuser_keytab']
 smokeuser_principal = config['configurations']['cluster-env']['smokeuser_principal_name']
 

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/service_check.py
@@ -31,8 +31,8 @@ class SparkServiceCheck(Script):
       spark_kinit_cmd = format("{kinit_path_local} -kt {spark_kerberos_keytab} {spark_principal}; ")
       Execute(spark_kinit_cmd, user=params.spark_user)
       if (params.has_livyserver):
-        livy_kinit_cmd = format("{kinit_path_local} -kt {smoke_user_keytab} {smokeuser_principal}; ")
-        Execute(livy_kinit_cmd, user=params.livy_user)
+        smokeruser_kinit_cmd = format("{kinit_path_local} -kt {smoke_user_keytab} {smokeuser_principal}; ")
+        Execute(smokeruser_kinit_cmd, user=params.smoke_user)
 
     Execute(format("curl -s -o /dev/null -w'%{{http_code}}' --negotiate -u: -k http://{spark_history_server_host}:{spark_history_ui_port} | grep 200"),
       tries=5,

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/service_check.py
@@ -48,7 +48,7 @@ class SparkServiceCheck(Script):
               tries=3,
               try_sleep=1,
               logoutput=True,
-              user=params.livy_user
+              user=params.smoke_user
               )
           live_livyserver_host = livyserver_host
           break

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/params.py
@@ -134,6 +134,7 @@ security_enabled = config['configurations']['cluster-env']['security_enabled']
 kinit_path_local = get_kinit_path(default('/configurations/kerberos-env/executable_search_paths', None))
 spark_kerberos_keytab =  config['configurations']['spark2-defaults']['spark.history.kerberos.keytab']
 spark_kerberos_principal =  config['configurations']['spark2-defaults']['spark.history.kerberos.principal']
+smoke_user = config['configurations']['cluster-env']['smokeuser']
 smoke_user_keytab = config['configurations']['cluster-env']['smokeuser_keytab']
 smokeuser_principal =  config['configurations']['cluster-env']['smokeuser_principal_name']
 

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/service_check.py
@@ -49,7 +49,7 @@ class SparkServiceCheck(Script):
                   tries=3,
                   try_sleep=1,
                   logoutput=True,
-                  user=params.livy2_user
+                  user=params.smoke_user
                   )
           live_livyserver_host = livyserver_host
           break

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/service_check.py
@@ -32,8 +32,8 @@ class SparkServiceCheck(Script):
       spark_kinit_cmd = format("{kinit_path_local} -kt {spark_kerberos_keytab} {spark_principal}; ")
       Execute(spark_kinit_cmd, user=params.spark_user)
       if params.has_livyserver:
-        livy_kinit_cmd = format("{kinit_path_local} -kt {smoke_user_keytab} {smokeuser_principal}; ")
-        Execute(livy_kinit_cmd, user=params.livy2_user)
+        smokeuser_kinit_cmd = format("{kinit_path_local} -kt {smoke_user_keytab} {smokeuser_principal}; ")
+        Execute(smokeuser_kinit_cmd, user=params.smoke_user)
 
     Execute(format("curl -s -o /dev/null -w'%{{http_code}}' --negotiate -u: -k {spark_history_scheme}://{spark_history_server_host}:{spark_history_ui_port} | grep 200"),
             tries=5,


### PR DESCRIPTION
## What changes were proposed in this pull request?

**_common-services/SPARK/1.2.1/package/scripts/service_check.py:36_**
```
 livy_kinit_cmd = format("{kinit_path_local} -kt {smoke_user_keytab} {smokeuser_principal}; ")
 Execute(livy_kinit_cmd, user=params.livy_user)
```
Notice the Kerberos identity is for the smoke user, but the exec is for the livy user. This will replace the livy user's interactive Kerberos ticket cache.

This should be 
```
smoke_user_kinit_cmd = format("{kinit_path_local} -kt {smoke_user_keytab} {smokeuser_principal}; ")
Execute(smoke_user_kinit_cmd, user=params.smoke_user)
```
Where `smoke_user` is
```
smoke_user =  config['configurations']['cluster-env']['smokeuser']
```

**This is similar for SPARK2 as well.** 

## How was this patch tested?

Tested manually with original code to see the issue and then fix the fixed code to see it working properly:

```
2018-02-15 03:15:04,058 - Using hadoop conf dir: /usr/hdp/2.6.5.0-96/hadoop/conf
2018-02-15 03:15:04,061 - Execute['/usr/bin/kinit -kt /etc/security/keytabs/spark.headless.keytab spark-c1@EXAMPLE.COM; '] {'user': 'spark'}
2018-02-15 03:15:04,085 - Execute['/usr/bin/kinit -kt /etc/security/keytabs/smokeuser.headless.keytab ambari-qa-c1@EXAMPLE.COM; '] {'user': 'ambari-qa'}
2018-02-15 03:15:04,109 - Execute['curl -s -o /dev/null -w'%{http_code}' --negotiate -u: -k http://c6403.ambari.apache.org:18081 | grep 200'] {'logoutput': True, 'tries': 5, 'user': 'spark', 'try_sleep': 3}
200
2018-02-15 03:15:04,356 - Execute['curl -s -o /dev/null -w'%{http_code}' --negotiate -u: -k http://c6402.ambari.apache.org:8999/sessions | grep 200'] {'logoutput': True, 'tries': 3, 'user': 'livy', 'try_sleep': 1}
200

Command completed successfully!
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.