### PR TITLE
AMBARI-23000. Timeline Service V2.0 reader install fails if wget is not installed

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-INSTALL/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-INSTALL/scripts/shared_initialization.py
@@ -28,7 +28,7 @@ def install_packages():
   if params.host_sys_prepped:
     return
 
-  packages = ['unzip', 'curl']
+  packages = ['unzip', 'curl', 'wget']
   if params.stack_version_formatted != "" and compare_versions(params.stack_version_formatted, '2.2') >= 0:
     stack_selector_package = stack_tools.get_stack_tool_package(stack_tools.STACK_SELECTOR_NAME)
     packages.append(stack_selector_package)

--- a/ambari-server/src/test/python/stacks/2.0.6/hooks/before-INSTALL/test_before_install.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/hooks/before-INSTALL/test_before_install.py
@@ -57,6 +57,7 @@ class TestHookBeforeInstall(RMFTestCase):
 
     self.assertResourceCalled('Package', 'unzip', retry_count=5, retry_on_repo_unavailability=False)
     self.assertResourceCalled('Package', 'curl', retry_count=5, retry_on_repo_unavailability=False)
+    self.assertResourceCalled('Package', 'wget', retry_count=5, retry_on_repo_unavailability=False)
     self.assertNoMoreResources()
 
   def test_hook_no_repos(self):
@@ -108,4 +109,5 @@ class TestHookBeforeInstall(RMFTestCase):
 
     self.assertResourceCalled('Package', 'unzip', retry_count=5, retry_on_repo_unavailability=False)
     self.assertResourceCalled('Package', 'curl', retry_count=5, retry_on_repo_unavailability=False)
+    self.assertResourceCalled('Package', 'wget', retry_count=5, retry_on_repo_unavailability=False)
     self.assertNoMoreResources()


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/YARN/3.0.0.3.0/package/scripts/timelinereader.py", line 101, in <module>
    ApplicationTimelineReader().execute()
  File "/usr/lib/python2.6/site-packages/resource_management/libraries/script/script.py", line 376, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/common-services/YARN/3.0.0.3.0/package/scripts/timelinereader.py", line 45, in install
    hbase_service.install_hbase(env)
  File "/var/lib/ambari-agent/cache/common-services/YARN/3.0.0.3.0/package/scripts/hbase_service.py", line 82, in install_hbase
    Execute(hbase_download_cmd, user="root", logoutput=True)
  File "/usr/lib/python2.6/site-packages/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/python2.6/site-packages/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/python2.6/site-packages/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/python2.6/site-packages/resource_management/core/providers/system.py", line 262, in action_run
    tries=self.resource.tries, try_sleep=self.resource.try_sleep)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 72, in inner
    result = function(command, **kwargs)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 102, in checked_call
    tries=tries, try_sleep=try_sleep, timeout_kill_strategy=timeout_kill_strategy)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 150, in _call_wrapper
    result = _call(command, **kwargs_copy)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 303, in _call
    raise ExecutionFailed(err_msg, code, out, err)
resource_management.core.exceptions.ExecutionFailed: Execution of 'umask 0022;wget --no-cookies --no-check-certificate http://public-repo-1.hortonworks.com/ARTIFACTS/dist/hbase/1.2.6/hadoop-2.7.5/hbase-1.2.6-bin.tar.gz && tar -xzf hbase-1.2.6-bin.tar.gz && rm -rf hbase-1.2.6-bin.tar.gz && rm -rf /usr/hdp/3.0.0.0-809/hadoop-yarn-hbase && mv hbase-* /usr/hdp/3.0.0.0-809/hadoop-yarn-hbase' returned 127. -bash: wget: command not found
