### PR TITLE
[AMBARI-23001] trunk. HA, Move wizard shows error modal on selection

### DIFF
--- a/ambari-web/app/controllers/global/cluster_controller.js
+++ b/ambari-web/app/controllers/global/cluster_controller.js
@@ -174,6 +174,10 @@ App.ClusterController = Em.Controller.extend(App.ReloadPopupMixin, {
     App.router.get('userSettingsController').getAllUserSettings();
     App.router.get('errorsHandlerController').loadErrorLogs();
 
+    var hostsController = App.router.get('mainHostController');
+    hostsController.set('isCountersUpdating', true);
+    hostsController.updateStatusCounters();
+
     this.loadClusterInfo();
     this.restoreUpgradeState();
     App.router.get('wizardWatcherController').getUser();

--- a/ambari-web/app/controllers/main/service/reassign/step4_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step4_controller.js
@@ -115,10 +115,9 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
         .concat(App.ClientComponent.find().toArray())
         .concat(App.SlaveComponent.find().toArray())
         .filter(function(service){
-          return service.get("installedCount") > 0;
+          return service.get("totalCount") > 0;
         })
         .mapProperty('componentName');
-
     var dependenciesToInstall = App.StackServiceComponent.find(componentName)
         .get('dependencies')
         .filter(function (component) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Move NameNode, Enable HA wizards on HDFS service page throws up an error that at least 2 hosts are to be present even though more than 2 hosts are present.

## How was this patch tested?
manually, unit tests

  21380 passing (30s)
  48 pending


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.