### PR TITLE
[AMBARI-23005]  Failed to Add Big SQL to HDP 3.0 due to a stack advisor error on calculating slave component dependencies

### DIFF
--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -935,8 +935,8 @@ class DefaultStackAdvisor(StackAdvisor):
           if scope == "host":
             for host, hostComponents in hostsComponentsMap.iteritems():
               isRequiredIncluded = False
-              for component in hostComponents:
-                currentComponentName = None if "name" not in component else component["name"]
+              for hostComponent in hostComponents:
+                currentComponentName = None if "name" not in hostComponent else hostComponent["name"]
                 if requiredComponentName == currentComponentName:
                   isRequiredIncluded = True
               if not isRequiredIncluded:


### PR DESCRIPTION
AMBARI-23005: Failed to Add Big SQL to HDP 3.0 due to a stack advisor error (dili)

## What changes were proposed in this pull request?

Original code re-init "component" variable with incorrect information that caused the advisor to throw a keyerror

## How was this patch tested?

unit tests, manually patch an Ambari 2.7.0/HDP 3.0 cluster with the change and verify after the patch, I could add Big SQL without seeing the keyerror exception anymore.
