### PR TITLE
AMBARI-23010. Make solrIndexHelper.sh script to be able to run index migration against a snapshot

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/src/main/resources/solrIndexHelper.sh
+++ b/ambari-infra/ambari-infra-solr-client/src/main/resources/solrIndexHelper.sh
@@ -162,7 +162,6 @@ function upgrade_index() {
   if [[ "$BACKUP_ENABLED" == "true" ]]; then
     for SNAPSHOT_DIR in $(find $INDEX_DIR -maxdepth 1 -mindepth 1); do
       if $(test -d ${SNAPSHOT_DIR}); then
-        name=$(echo $SNAPSHOT_DIR | sed -e 's/.*\///g')
         abspath=$(cd "$(dirname "$SNAPSHOT_DIR")"; pwd)/$(basename "$SNAPSHOT_DIR")
         echo "--------------------------------"
         echo "Checking snapshot: $abspath"
@@ -179,9 +178,9 @@ function upgrade_index() {
             name=$(echo $c | sed -e 's/.*\///g')
             abspath=$(cd "$(dirname "$c")"; pwd)/$(basename "$c")
             find $c/data -maxdepth 1 -type d -name 'index*' | while read indexDir; do
-            echo "--------------------------------"
-            echo "Checking core $name - $abspath"
-            upgrade_core "$indexDir" "$FORCE_UPDATE" "$SOLR_CORE_FILTERS" "$LUCENE_VERSION" "$BACKUP_ENABLED" "$DEBUG_ENABLED"
+              echo "--------------------------------"
+              echo "Checking core $name - $abspath"
+              upgrade_core "$indexDir" "$FORCE_UPDATE" "$SOLR_CORE_FILTERS" "$LUCENE_VERSION" "$BACKUP_ENABLED" "$DEBUG_ENABLED"
             done
           else
             echo "No index folder found for $name"

--- a/ambari-infra/ambari-infra-solr-client/src/main/resources/solrIndexHelper.sh
+++ b/ambari-infra/ambari-infra-solr-client/src/main/resources/solrIndexHelper.sh
@@ -40,13 +40,9 @@ function print_help() {
    upgrade-index command arguments:
      -d, --index-data-dir <DIRECTORY>        Location of the solr cores (e.g.: /opt/ambari_infra_solr/data)
      -c, --core-filter <FILTER1,FILTER2>     Comma separated name filters of core directoies (default: hadoop_logs,audit_logs,history)
+     -b, --backup-enabled                    Use indexer tool with backup snapshots. (core filter won't be used)
+     -g, --debug                             Enable debug mode, IndexUpgrader output will be verbose.
      -f, --force                             Force to start index upgrade, even is the version is at least 6.
-     -v, --version                           Lucene version to upgrade (default: 6.6.0, available: 6.6.0, 7.2.1)
-
-   run-check-index-tool arguments:
-     -v, --version                           Lucene version to upgrade (default: 6.6.0, available: 6.6.0, 7.2.1)
-
-   run-upgrade-index-tool arguments:
      -v, --version                           Lucene version to upgrade (default: 6.6.0, available: 6.6.0, 7.2.1)
 EOF
 }
@@ -56,24 +52,37 @@ function upgrade_core() {
   local FORCE_UPDATE=${2:?"usage <force_update_flag> e.g.: true"}
   local SOLR_CORE_FILTERS=${3:?"usage: <comma separated core filters> e.g.: hadoop_logs,audit_logs,history"}
   local LUCENE_VERSION=${4:?"usage <lucene_index_version> e.g.: 7.2.1"}
+  local BACKUP_MODE=${5:?"usage <backup_mode_enabled> e.g.: true"}
+  local DEBUG_MODE=${6:?"usage <debug_mode> e.g.: true"}
   SOLR_CORE_FILTER_ARR=$(echo $SOLR_CORE_FILTERS | sed "s/,/ /g")
 
   local version_prefix="$(echo $LUCENE_VERSION | head -c 1)"
 
+  local core_str="Core"
+  if [[ "$BACKUP_MODE" == "true" ]]; then
+    core_str="Snapshot"
+  fi
+
+  local verbose=""
+  if [[ "$DEBUG_MODE" == "true" ]]; then
+    verbose="-verbose"
+  fi
+
   for coll in $SOLR_CORE_FILTER_ARR; do
     if [[ "$1" == *"$coll"* ]]; then
-      echo "Core '$1' dir name contains $coll (core filter)'";
+      echo "$core_str '$1' dir name contains $coll (core filter)'";
       version=$(PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$LUCENE_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$LUCENE_VERSION.jar" org.apache.lucene.index.CheckIndex -fast $1|grep "   version="|sed -e 's/.*=//g'|head -1)
       if [ -z $version ] ; then
-        echo "Core '$1' - Empty index?"
+        echo "$core_str '$1' - Empty index?"
         return
       fi
       majorVersion=$(echo $version|cut -c 1)
       if [ $majorVersion -ge $version_prefix ] && [ $FORCE_UPDATE == "false" ] ; then
-        echo "Core '$1' - Already on version $version, not upgrading. Use -f or --force option to run upgrade anyway."
+        echo "$core_str '$1' - Already on version $version, not upgrading. Use -f or --force option to run upgrade anyway."
       else
-        echo "Core '$1' - Index version is $version, upgrading ..."
-        PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$LUCENE_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$LUCENE_VERSION.jar" org.apache.lucene.index.IndexUpgrader -delete-prior-commits $1
+        echo "$core_str '$1' - Index version is $version, upgrading ..."
+        echo "Run: PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$LUCENE_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$LUCENE_VERSION.jar" org.apache.lucene.index.IndexUpgrader -delete-prior-commits $verbose $1"
+        PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$LUCENE_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$LUCENE_VERSION.jar" org.apache.lucene.index.IndexUpgrader -delete-prior-commits $verbose $1
         echo "Upgrading core '$1' has finished"
       fi
     fi
@@ -91,6 +100,14 @@ function upgrade_index() {
         ;;
         -f|--force)
           local FORCE_UPDATE="true"
+          shift
+        ;;
+        -b|--backup-enabled)
+          local BACKUP_ENABLED="true"
+          shift
+        ;;
+        -g|--debug)
+          local DEBUG_ENABLED="true"
           shift
         ;;
         -d|--index-data-dir)
@@ -112,8 +129,18 @@ function upgrade_index() {
     exit 1
   fi
 
+  if [[ -z "$BACKUP_ENABLED" ]] ; then
+    BACKUP_ENABLED="false"
+  else
+    if [[ -z "$SOLR_CORE_FILTERS" ]]; then
+      SOLR_CORE_FILTERS="snapshot"
+      echo "NOTE: Use 'snapshot' as filter."
+    fi
+  fi
+
   if [[ -z "$SOLR_CORE_FILTERS" ]] ; then
     SOLR_CORE_FILTERS="hadoop_logs,audit_logs,history"
+    echo "NOTE: Use 'hadoop_logs,audit_logs,history' as filte."
   fi
 
   if [[ -z "$LUCENE_VERSION" ]] ; then
@@ -126,63 +153,54 @@ function upgrade_index() {
     echo "NOTE: Forcing index upgrade is set."
   fi
 
-  CORES=$(for replica_dir in `find $INDEX_DIR -name data`; do dirname $replica_dir; done);
-  if [[ -z "$CORES" ]] ; then
-    echo "No indices found on path $INDEX_DIR"
+  if [[ -z "$DEBUG_ENABLED" ]] ; then
+    DEBUG_ENABLED="false"
   else
-      for c in $CORES ; do
-        if find $c/data -maxdepth 1 -type d -name 'index*' 1> /dev/null 2>&1; then
-          name=$(echo $c | sed -e 's/.*\///g')
-          abspath=$(cd "$(dirname "$c")"; pwd)/$(basename "$c")
-          find $c/data -maxdepth 1 -type d -name 'index*' | while read indexDir; do
-          echo "Checking core $name - $abspath"
-          upgrade_core "$indexDir" "$FORCE_UPDATE" "$SOLR_CORE_FILTERS" "$LUCENE_VERSION"
-          done
-        else
-          echo "No index folder found for $name"
-        fi
-      done
-      echo "DONE"
+    echo "NOTE: Debug mode is enabled."
+  fi
+
+  if [[ "$BACKUP_ENABLED" == "true" ]]; then
+    for SNAPSHOT_DIR in $(find $INDEX_DIR -maxdepth 1 -mindepth 1); do
+      if $(test -d ${SNAPSHOT_DIR}); then
+        name=$(echo $SNAPSHOT_DIR | sed -e 's/.*\///g')
+        abspath=$(cd "$(dirname "$SNAPSHOT_DIR")"; pwd)/$(basename "$SNAPSHOT_DIR")
+        echo "--------------------------------"
+        echo "Checking snapshot: $abspath"
+        upgrade_core "$abspath" "$FORCE_UPDATE" "$SOLR_CORE_FILTERS" "$LUCENE_VERSION" "$BACKUP_ENABLED" "$DEBUG_ENABLED"
+      fi;
+    done
+  else
+    CORES=$(for replica_dir in `find $INDEX_DIR -name data`; do dirname $replica_dir; done);
+    if [[ -z "$CORES" ]] ; then
+      echo "No indices found on path $INDEX_DIR"
+    else
+        for c in $CORES ; do
+          if find $c/data -maxdepth 1 -type d -name 'index*' 1> /dev/null 2>&1; then
+            name=$(echo $c | sed -e 's/.*\///g')
+            abspath=$(cd "$(dirname "$c")"; pwd)/$(basename "$c")
+            find $c/data -maxdepth 1 -type d -name 'index*' | while read indexDir; do
+            echo "--------------------------------"
+            echo "Checking core $name - $abspath"
+            upgrade_core "$indexDir" "$FORCE_UPDATE" "$SOLR_CORE_FILTERS" "$LUCENE_VERSION" "$BACKUP_ENABLED" "$DEBUG_ENABLED"
+            done
+          else
+            echo "No index folder found for $name"
+          fi
+        done
+        echo "DONE"
+    fi
   fi
 }
 
 function upgrade_index_tool() {
   # see: https://cwiki.apache.org/confluence/display/solr/IndexUpgrader+Tool
-  luc_version = "6.6.0"
-  while [[ $# -gt 0 ]]
-    do
-     key="$1"
-     case $key in
-        -v|--version)
-          luc_version="$2"
-          shift 2
-        ;;
-        *)
-          echo "Unknown option: $1"
-          exit 1
-        ;;
-     esac
-  done
-  PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$luc_version.jar:$DIR/migrate/lucene-backward-codecs-$luc_version.jar" org.apache.lucene.index.IndexUpgrader ${@}
+  : ${INDEX_VERSION:?"Please set the INDEX_VERSION variable! (6.6.0 or 7.2.1)"}
+  PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$INDEX_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$INDEX_VERSION.jar" org.apache.lucene.index.IndexUpgrader ${@}
 }
 
 function check_index_tool() {
-  luc_version = "6.6.0"
-  while [[ $# -gt 0 ]]
-    do
-     key="$1"
-     case $key in
-        -v|--version)
-          luc_version="$2"
-          shift 2
-        ;;
-        *)
-          echo "Unknown option: $1"
-          exit 1
-        ;;
-     esac
-  done
-  PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$luc_version.jar:$DIR/migrate/lucene-backward-codecs-$luc_version.jar" org.apache.lucene.index.CheckIndex ${@}
+  : ${INDEX_VERSION:?"Please set the INDEX_VERSION variable! (6.6.0 or 7.2.1)"}
+  PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$INDEX_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$INDEX_VERSION.jar" org.apache.lucene.index.CheckIndex ${@}
 }
 
 function main() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
solr index helper should support to work on snapshots as well
also added debug options to make to log verbose if it required

## How was this patch tested?
Manually, create ranger collection (replica) backup, run index migration on that, upgrade solr, then restore the collection

please review @zeroflag @adoroszlai @swagle @kasakrisz 