### PR TITLE
AMBARI-23013. Disable some failing python unit tests temporarily

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
@@ -45,7 +45,7 @@ import logging
 
 CLUSTER_ID = '0'
 
-class TestActionQueue(TestCase):
+class TestActionQueue:#(TestCase):
   def setUp(self):
     # save original open() method for later use
     self.original_open = open

--- a/ambari-agent/src/test/python/ambari_agent/TestClusterConfigurationCache.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestClusterConfigurationCache.py
@@ -26,7 +26,7 @@ from ambari_agent.ClusterConfigurationCache import ClusterConfigurationCache
 from mock.mock import MagicMock, patch, mock_open, ANY
 from unittest import TestCase
 
-class TestClusterConfigurationCache(TestCase):
+class TestClusterConfigurationCache:#(TestCase):
 
   o_flags = os.O_WRONLY | os.O_CREAT
   perms = 0o600

--- a/ambari-agent/src/test/python/ambari_agent/TestCommandStatusDict.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestCommandStatusDict.py
@@ -25,7 +25,7 @@ import logging
 import json, pprint
 from mock.mock import patch, MagicMock, call
 
-class TestCommandStatusDict(TestCase):
+class TestCommandStatusDict:#(TestCase):
 
   logger = logging.getLogger()
 

--- a/ambari-agent/src/test/python/ambari_agent/TestController.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestController.py
@@ -44,7 +44,7 @@ import ambari_commons
 
 @not_for_platform(PLATFORM_WINDOWS)
 @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
-class TestController(unittest.TestCase):
+class TestController:#(unittest.TestCase):
 
   logger = logging.getLogger()
 

--- a/ambari-agent/src/test/python/ambari_agent/TestCustomServiceOrchestrator.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestCustomServiceOrchestrator.py
@@ -45,7 +45,7 @@ from ambari_agent.PythonExecutor import PythonExecutor
 from ambari_commons import OSCheck
 from only_for_platform import get_platform, os_distro_value, PLATFORM_WINDOWS
 
-class TestCustomServiceOrchestrator(TestCase):
+class TestCustomServiceOrchestrator:#(TestCase):
 
 
   def setUp(self):

--- a/ambari-agent/src/test/python/ambari_agent/TestHeartbeat.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestHeartbeat.py
@@ -39,7 +39,7 @@ with patch("platform.linux_distribution", return_value = ('Suse','11','Final')):
 from only_for_platform import not_for_platform, PLATFORM_WINDOWS
 
 @not_for_platform(PLATFORM_WINDOWS)
-class TestHeartbeat(TestCase):
+class TestHeartbeat:#(TestCase):
 
   def setUp(self):
     # disable stdout

--- a/ambari-agent/src/test/python/ambari_agent/TestHostInfo.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestHostInfo.py
@@ -43,7 +43,7 @@ from resource_management.core.system import System
 
 @not_for_platform(PLATFORM_WINDOWS)
 @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
-class TestHostInfo(TestCase):
+class TestHostInfo:#(TestCase):
 
   @patch('os.path.exists')
   def test_checkFolders(self, path_mock):

--- a/ambari-agent/src/test/python/ambari_agent/TestMain.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestMain.py
@@ -46,7 +46,7 @@ with patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_
   from ambari_agent.ExitHelper import ExitHelper
 
 
-class TestMain(unittest.TestCase):
+class TestMain:#(unittest.TestCase):
 
   def setUp(self):
     # disable stdout

--- a/ambari-agent/src/test/python/ambari_agent/TestNetUtil.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestNetUtil.py
@@ -25,7 +25,7 @@ import threading
 from ambari_commons import OSCheck
 from only_for_platform import not_for_platform, os_distro_value, PLATFORM_WINDOWS
 
-class TestNetUtil(unittest.TestCase):
+class TestNetUtil:#(unittest.TestCase):
 
   @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
   @patch("urlparse.urlparse")

--- a/ambari-agent/src/test/python/ambari_agent/TestRegistration.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestRegistration.py
@@ -30,7 +30,7 @@ from ambari_agent.Hardware import Hardware
 from ambari_agent.Facter import FacterLinux
 
 @not_for_platform(PLATFORM_WINDOWS)
-class TestRegistration(TestCase):
+class TestRegistration:#(TestCase):
 
   @patch("subprocess.Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))


### PR DESCRIPTION
As discussed with Siddharth Wagle for now we should ignore UT failing on branch-3.0-perf as they take up a lot of time rework.

The reason for this is that we need to merge into trunk soon, so the feature code gets enough test cycles.
The tests will be unignored and fixed after the merge is done.