### PR TITLE
Dockerfiles for building Ambari (CentOS, Ubuntu)

### DIFF
--- a/dev-support/docker/centos6/Dockerfile
+++ b/dev-support/docker/centos6/Dockerfile
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for installing the necessary dependencies for building Ambari on CentOS6
+
+FROM centos:6
+
+RUN yum -y install \
+    gcc \
+    gcc-c++ \
+    git \
+    java-1.8.0-openjdk-devel \
+    python-devel \
+    python-setuptools \
+    rpm-build \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+RUN curl -LSs -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+  && chmod 755 /usr/local/bin/jq

--- a/dev-support/docker/centos7/Dockerfile
+++ b/dev-support/docker/centos7/Dockerfile
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for installing the necessary dependencies for building Ambari on CentOS7
+
+FROM centos:7
+
+RUN yum -q -y install \
+    curl \
+    gcc \
+    gcc-c++ \
+    git \
+    java-1.8.0-openjdk-devel \
+    make \
+    python \
+    python-devel \
+    python-setuptools \
+    rpm-build \
+    which \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+RUN curl -LSs -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+  && chmod 755 /usr/local/bin/jq

--- a/dev-support/docker/common/.bashrc
+++ b/dev-support/docker/common/.bashrc
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PS1='\h:\w \$ '

--- a/dev-support/docker/common/Dockerfile
+++ b/dev-support/docker/common/Dockerfile
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for installing the necessary dependencies for building Ambari
+
+ARG BUILD_OS
+FROM ambari-build-base:${BUILD_OS}
+
+ARG MAVEN_VERSION=3.3.9
+ENV MAVEN_HOME /opt/maven
+RUN mkdir -p $MAVEN_HOME \
+  && maven_url=$(curl -L -s -S http://www.apache.org/dyn/closer.cgi/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz?as_json=1 \
+      | jq --raw-output '.preferred,.path_info' \
+      | sed -e '1N' -e 's/\n//') \
+  && : ${maven_url:="http://www.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"} \
+  && echo "Downloading Maven from ${maven_url}" \
+  && curl -L -s -S "${maven_url}" \
+    | tar -xzf - --strip-components 1 -C $MAVEN_HOME
+ENV PATH "$PATH:$MAVEN_HOME/bin"
+
+COPY .bashrc /root/

--- a/dev-support/docker/ubuntu16/Dockerfile
+++ b/dev-support/docker/ubuntu16/Dockerfile
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for installing the necessary dependencies for building Ambari on Ubuntu 16.04
+
+FROM ubuntu:16.04
+
+RUN apt-get update -q -y \
+  && apt-get install -y --no-install-recommends \
+    bzip2 \
+    curl \
+    g++ \
+    gcc \
+    git \
+    jq \
+    make \
+    openjdk-8-jdk \
+    python-setuptools \
+    python2.7 \
+    python2.7-dev \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start a Docker-based build environment
+
+set -e -u
+
+cd "$(dirname "$0")"
+
+# OS to build on
+: ${BUILD_OS:=centos7}
+
+# Directory with Ambari source
+: ${AMBARI_DIR:=$(pwd -P)}
+
+# Maven version
+: ${MAVEN_VERSION:=3.3.9}
+
+docker build -t ambari-build-base:${BUILD_OS} dev-support/docker/${BUILD_OS}
+docker build -t ambari-build:${BUILD_OS} --build-arg BUILD_OS="${BUILD_OS}" --build-arg MAVEN_VERSION="${MAVEN_VERSION}" dev-support/docker/common
+
+USER_NAME=${SUDO_USER:=$USER}
+USER_ID=$(id -u "${USER_NAME}")
+GROUP_ID=$(id -g "${USER_NAME}")
+USER_TAG="ambari-build-${USER_NAME}-${USER_ID}:${BUILD_OS}"
+
+docker build -t "$USER_TAG" - <<UserSpecificDocker
+FROM ambari-build:${BUILD_OS}
+RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME}
+RUN useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+ENV HOME /home/${USER_NAME}
+UserSpecificDocker
+
+TTY_MODE="-t -i"
+if [ "$#" -gt 0 ]; then
+  TTY_MODE=""
+fi
+
+# By mapping the .m2 directory you can do an mvn install from
+# within the container and use the result on your normal
+# system.  This also allows a significant speedup in subsequent
+# builds, because the dependencies are downloaded only once.
+docker run --rm=true $TTY_MODE \
+  -u "${USER_NAME}" \
+  -h "${BUILD_OS}" \
+  -v "${AMBARI_DIR}:/home/${USER_NAME}/src:delegated" \
+  -v "${HOME}/.m2:/home/${USER_NAME}/.m2:cached" \
+  -w "/home/${USER_NAME}/src" \
+  "$USER_TAG" \
+  "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a Docker-based environment for building Ambari on various OSes.  This grew out of a bug report that [RPM for Ambari cannot be built on CentOS 7](https://issues.apache.org/jira/browse/AMBARI-22516).

The patch has:

 * Dockerfiles for building CentOS 6, CentOS 7 and Ubuntu 16.04 base images
 * Dockerfile with common additional steps (install specific Maven version)
 * a shell script to build and run any of those images (`start-build-env.sh`)

The script was slightly customized from Hadoop's [similar script](https://github.com/apache/hadoop/blob/71bbb86d69ac474596f5619d22718e9f7ff5f9dc/start-build-env.sh).  It runs the given command (eg. `mvn package`) in a non-root container, or just drops you into the container's shell if none given.  It takes advantage of the host's local Maven repository (`~/.m2`) via volume mount.



(Note: Ambari already has a Dockerfile, but it's CentOS 6-only, has a lot of excess baggage, and is outdated in many respects.)

## How was this patch tested?

Built a few modules:

```
$ BUILD_OS=centos6 ./start-build-env.sh mvn -am -pl ambari-admin,ambari-agent,ambari-server,ambari-web -B -fae -DskipTests -Dcheckstyle.skip -Drat.skip -Dfindbugs.skip -Del.log=WARN clean install
...
[INFO] BUILD SUCCESS
```

Built Agent and Server `.rpm`s on both CentOS 6 and 7, installed them on similar VirtualBox:

```
$ BUILD_OS=centos6 ./start-build-env.sh mvn -pl ambari-agent,ambari-server -B -fae -DskipTests -Dcheckstyle.skip -Drat.skip -Dfindbugs.skip -Del.log=WARN package rpm:rpm
...
[INFO] BUILD SUCCESS
...
$ find ambari-{agent,server}/target -name '*.rpm' | xargs -I FILE scp -q FILE c6401:
$ ssh c6401 'yum install -y ambari*rpm'
...
Installed:
  ambari-agent.x86_64 0:2.0.0.0-SNAPSHOT
  ambari-server.x86_64 0:2.0.0.0-SNAPSHOT
```

```
$ BUILD_OS=centos7 ./start-build-env.sh mvn -pl ambari-agent,ambari-server -B -fae -DskipTests -Dcheckstyle.skip -Drat.skip -Dfindbugs.skip -Del.log=WARN package rpm:rpm
...
[INFO] BUILD SUCCESS
...
$ find ambari-{agent,server}/target -name '*.rpm' | xargs -I FILE scp -q FILE c7301:
$ ssh c7301 'yum install -y ambari*rpm'
...
Installed:
  ambari-agent.x86_64 0:2.0.0.0-SNAPSHOT
  ambari-server.x86_64 0:2.0.0.0-SNAPSHOT
```

Built `.deb` packages, installed them on Ubuntu 16.04 VirtualBox:

```
$ BUILD_OS=ubuntu16 ./start-build-env.sh mvn -pl ambari-agent,ambari-server -B -fae -DskipTests -Dcheckstyle.skip -Drat.skip -Dfindbugs.skip -Del.log=WARN -Dpackage-version=2.0.0.0 -Dpackage-release=SNAPSHOT package jdeb:jdeb
...
[INFO] BUILD SUCCESS
...
$ find ambari-{agent,server}/target -name '*.deb' | xargs -I FILE scp -q FILE u1601:
$ ssh u1601 'dpkg -i ambari-agent_2.0.0.0-SNAPSHOT.deb ambari-server_2.0.0.0-SNAPSHOT-dist.deb'
...
Setting up ambari-agent (2.0.0.0-SNAPSHOT) ...
Setting up ambari-server (2.0.0.0-SNAPSHOT) ...
...
```

Tested with custom `MAVEN_VERSION`:

```
$ BUILD_OS=centos6 MAVEN_VERSION=3.5.2 ./start-build-env.sh
...
centos6:~/src $ mvn --version
Apache Maven 3.5.2 (138edd61fd100ec658bfa2d307c43b76940a5d7d; 2017-10-18T07:58:13Z)
```