### PR TITLE
[AMBARI-23015] Added NaN handling to JSON handling in MetricsRetrievalService

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/services/MetricsRetrievalService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/services/MetricsRetrievalService.java
@@ -39,6 +39,7 @@ import org.apache.ambari.server.controller.jmx.JMXMetricHolder;
 import org.apache.ambari.server.controller.utilities.ScalingThreadPoolExecutor;
 import org.apache.ambari.server.controller.utilities.StreamProvider;
 import org.apache.commons.io.IOUtils;
+import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectReader;
@@ -182,6 +183,7 @@ public class MetricsRetrievalService extends AbstractService {
   public MetricsRetrievalService() {
     ObjectMapper jmxObjectMapper = new ObjectMapper();
     jmxObjectMapper.configure(DeserializationConfig.Feature.USE_ANNOTATIONS, false);
+    jmxObjectMapper.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
     m_jmxObjectReader = jmxObjectMapper.reader(JMXMetricHolder.class);
   }
 


### PR DESCRIPTION
…ervice.java

## What changes were proposed in this pull request?

JSON NaN handling added to MetricsRetrievalService

## How was this patch tested?
mvn -pl ambari-server -DskipPythonTests clean test
[ERROR] Errors: 
[ERROR]   AmbariCustomCommandExecutionHelperTest.testHostsFilterUnhealthyComponent:346 » IllegalState
[INFO] 
[ERROR] Tests run: 5057, Failures: 0, Errors: 1, Skipped: 66
I guess, it is not caused by my changes.

Added a new  test case to  MetricsRetrievalServiceTest

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@swagle Please review.