### PR TITLE
AMBARI-21158. Eliminate Maven warnings

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -37,6 +37,7 @@
     <swagger.maven.plugin.version>3.1.4</swagger.maven.plugin.version>
     <slf4j.version>1.7.20</slf4j.version>
     <guice.version>4.1.0</guice.version>
+    <spring.version>4.3.7.RELEASE</spring.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
@@ -153,13 +154,8 @@
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
-        <version>3.2.10.RELEASE</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>4.2.2.RELEASE</version>
+        <version>${spring.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -423,48 +419,48 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context-support</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-websocket</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>4.3.7.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey.contribs</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1184,10 +1184,6 @@
       <artifactId>guice-persist</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
     </dependency>
@@ -1424,10 +1420,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get rid of Maven warnings introduced on trunk with the recent `branch-3.0-perf` merge:

```
[WARNING] Some problems were encountered while building the effective model for org.apache.ambari:ambari-web:pom:2.0.0.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework:spring-jdbc:jar -> version 3.2.10.RELEASE vs 4.3.7.RELEASE @ org.apache.ambari:ambari-project:2.0.0.0-SNAPSHOT, /Users/adoroszlai/src/review-ambari/ambari-project/pom.xml, line 428, column 19
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.ambari:ambari-project:pom:2.0.0.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework:spring-jdbc:jar -> version 3.2.10.RELEASE vs 4.3.7.RELEASE @ line 428, column 19
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.ambari:ambari-server:jar:2.0.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.google.inject:guice:jar -> duplicate declaration of version (?) @ line 1186, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework:spring-jdbc:jar -> duplicate declaration of version (?) @ line 1428, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
```

## How was this patch tested?

```
$ mvn -am -pl ambari-admin,ambari-agent,ambari-client,ambari-server,ambari-web -DskipTests -Del.log=WARN -Drat.skip test
...
[INFO] BUILD SUCCESS
```