### PR TITLE
Git link for Ambari project is broken on Ambari project website

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -604,7 +604,7 @@
           <artifactId>buildnumber-maven-plugin</artifactId>
           <version>${buildnumber-maven-plugin-version}</version>
           <configuration>
-              <urlScm>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-ambari.git</urlScm>
+              <urlScm>scm:git:https://gitbox.apache.org/repos/asf/ambari.git</urlScm>
           </configuration>
           <executions>
               <execution>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -804,7 +804,7 @@
         <artifactId>buildnumber-maven-plugin</artifactId>
         <version>${buildnumber-maven-plugin-version}</version>
         <configuration>
-          <urlScm>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-ambari.git</urlScm>
+          <urlScm>scm:git:https://gitbox.apache.org/repos/asf/ambari.git</urlScm>
         </configuration>
         <executions>
           <execution>

--- a/ambari-web/package.json
+++ b/ambari-web/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://ambari.apache.org/",
   "repository": {
     "type": "git",
-    "url": "https://git-wip-us.apache.org/repos/asf/ambari/repo?p=ambari.git;a=summary"
+    "url": "https://gitbox.apache.org/repos/asf/ambari/repo?p=ambari.git;a=summary"
   },
   "dependencies": {
     "brunch": "1.7.20",

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -83,7 +83,7 @@
 
     <links>
       <item name="JIRA" href="https://issues.apache.org/jira/browse/AMBARI" />
-      <item name="Git" href="https://git-wip-us.apache.org/repos/asf/ambari/repo?p=ambari.git;a=summary" />
+      <item name="Git" href="https://gitbox.apache.org/repos/asf/ambari/repo?p=ambari.git;a=summary" />
       <item name="Wiki" href="https://cwiki.apache.org/confluence/display/AMBARI/Ambari" />
     </links>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <url>http://ambari.apache.org/</url>
   <scm>
     <url>https://github.com/apache/ambari</url>
-    <connection>https://git-wip-us.apache.org/repos/asf/ambari.git</connection>
+    <connection>https://gitbox.apache.org/repos/asf/ambari.git</connection>
   </scm>
   <licenses>
     <license>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update URLs that still reference the old Git repo at `git-wip-us` to point to `gitbox`.

## How was this patch tested?

```
cd docs
mvn site
open target/index.html
```

Verified _External Links > Git_ link (top right corner).