### PR TITLE
AMBARI-23019. Use lucene version 6.6.2 instead of 6.6.0 in index migration script

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/pom.xml
+++ b/ambari-infra/ambari-infra-solr-client/pom.xml
@@ -30,7 +30,7 @@
   <artifactId>ambari-infra-solr-client</artifactId>
 
   <properties>
-    <lucene6.version>6.6.0</lucene6.version>
+    <lucene6.version>6.6.2</lucene6.version>
     <lucene6-core-jar.name>lucene-core-${lucene6.version}.jar</lucene6-core-jar.name>
     <lucene6-core.url>http://central.maven.org/maven2/org/apache/lucene/lucene-core/${lucene6.version}/${lucene6-core-jar.name}</lucene6-core.url>
     <lucene6-backward-codecs-jar.name>lucene-backward-codecs-${lucene6.version}.jar</lucene6-backward-codecs-jar.name>

--- a/ambari-infra/ambari-infra-solr-client/src/main/resources/solrIndexHelper.sh
+++ b/ambari-infra/ambari-infra-solr-client/src/main/resources/solrIndexHelper.sh
@@ -43,7 +43,7 @@ function print_help() {
      -b, --backup-enabled                    Use indexer tool with backup snapshots. (core filter won't be used)
      -g, --debug                             Enable debug mode, IndexUpgrader output will be verbose.
      -f, --force                             Force to start index upgrade, even is the version is at least 6.
-     -v, --version                           Lucene version to upgrade (default: 6.6.0, available: 6.6.0, 7.2.1)
+     -v, --version                           Lucene version to upgrade (default: 6.6.2, available: 6.6.2, 7.2.1)
 EOF
 }
 
@@ -144,7 +144,7 @@ function upgrade_index() {
   fi
 
   if [[ -z "$LUCENE_VERSION" ]] ; then
-    LUCENE_VERSION="6.6.0"
+    LUCENE_VERSION="6.6.2"
   fi
 
   if [[ -z "$FORCE_UPDATE" ]] ; then
@@ -193,12 +193,12 @@ function upgrade_index() {
 
 function upgrade_index_tool() {
   # see: https://cwiki.apache.org/confluence/display/solr/IndexUpgrader+Tool
-  : ${INDEX_VERSION:?"Please set the INDEX_VERSION variable! (6.6.0 or 7.2.1)"}
+  : ${INDEX_VERSION:?"Please set the INDEX_VERSION variable! (6.6.2 or 7.2.1)"}
   PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$INDEX_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$INDEX_VERSION.jar" org.apache.lucene.index.IndexUpgrader ${@}
 }
 
 function check_index_tool() {
-  : ${INDEX_VERSION:?"Please set the INDEX_VERSION variable! (6.6.0 or 7.2.1)"}
+  : ${INDEX_VERSION:?"Please set the INDEX_VERSION variable! (6.6.2 or 7.2.1)"}
   PATH=$JAVA_HOME/bin:$PATH $JVM -classpath "$DIR/migrate/lucene-core-$INDEX_VERSION.jar:$DIR/migrate/lucene-backward-codecs-$INDEX_VERSION.jar" org.apache.lucene.index.CheckIndex ${@}
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use lucene 6.6.2 version instead of 6.6.0 in solrIndexHelper.sh

## How was this patch tested?

[INFO] ambari-infra ....................................... SUCCESS [  1.376 s]
[INFO] Ambari Infra Solr Client ........................... SUCCESS [  8.501 s]
[INFO] Ambari Infra Solr Plugin ........................... SUCCESS [  1.252 s]
[INFO] Ambari Infra Manager ............................... SUCCESS [ 14.008 s]
[INFO] Ambari Infra Assembly .............................. SUCCESS [01:17 min]
[INFO] Ambari Infra Manager Integration Tests ............. SUCCESS [  0.459 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:42 min
[INFO] Finished at: 2018-02-19T12:24:59+01:00
[INFO] Final Memory: 75M/488M
[INFO] ------------------------------------------------------------------------

please review @kasakrisz @zeroflag @adoroszlai 