### PR TITLE
[AMBARI-22944] Using the proper variable when checking emptiness

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosKeytabDescriptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosKeytabDescriptor.java
@@ -463,7 +463,7 @@ public class KerberosKeytabDescriptor extends AbstractKerberosDescriptor {
       group.put(KEY_ACL_ACCESS, data);
     }
 
-    if (!owner.isEmpty()) {
+    if (!group.isEmpty()) {
       map.put(KEY_GROUP, group);
     }
     // Build file owner map (end)


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should check if 'group' is empty (instead of 'owner') when putting its value into the result map with key 'group'

## How was this patch tested?

Latest unit test results:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Main ........................................ SUCCESS [  5.557 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.030 s]
[INFO] Ambari Views ....................................... SUCCESS [  2.126 s]
[INFO] ambari-utility ..................................... SUCCESS [  2.834 s]
[INFO] ambari-metrics ..................................... SUCCESS [  0.325 s]
[INFO] Ambari Metrics Common .............................. SUCCESS [  4.322 s]
[INFO] Ambari Service Advisor ............................. SUCCESS [  0.427 s]
[INFO] Ambari Server ...................................... SUCCESS [21:49 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 22:05 min
[INFO] Finished at: 2018-02-19T13:58:39+01:00
[INFO] Final Memory: 137M/1305M
[INFO] ------------------------------------------------------------------------
```