### PR TITLE
[AMBARI-23022] Ambari UI deploy fails during startup of Ambari Metrics.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
@@ -36,44 +36,47 @@
 
 # HBase-specific configuration to reset long-running stats (e.g. compactions)
 # If this variable is left out, then the default is no expiration.
-hbase.extendedperiod = 3600
 
-hbase.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
-hbase.period=30
-hbase.collector.hosts={{ams_collector_hosts}}
-hbase.port={{metric_collector_port}}
-hbase.protocol={{metric_collector_protocol}}
+# Disable metrics since AMS 2.X doesn't work with Hadoop 3.x sink
 
-jvm.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
-jvm.period=30
-jvm.collector.hosts={{ams_collector_hosts}}
-jvm.port={{metric_collector_port}}
-jvm.protocol={{metric_collector_protocol}}
-
-rpc.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
-rpc.period=30
-rpc.collector.hosts={{ams_collector_hosts}}
-rpc.port={{metric_collector_port}}
-rpc.protocol={{metric_collector_protocol}}
-
-*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
-*.sink.timeline.slave.host.name={{hostname}}
-*.host_in_memory_aggregation = {{host_in_memory_aggregation}}
-*.host_in_memory_aggregation_port = {{host_in_memory_aggregation_port}}
-
-hbase.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
-hbase.sink.timeline.period={{metrics_collection_period}}
-hbase.sink.timeline.sendInterval={{metrics_report_interval}}000
-hbase.sink.timeline.collector.hosts={{ams_collector_hosts}}
-hbase.sink.timeline.port={{metric_collector_port}}
-hbase.sink.timeline.protocol={{metric_collector_protocol}}
-hbase.sink.timeline.serviceName-prefix=ams
-
-# HTTPS properties
-hbase.sink.timeline.truststore.path = {{metric_truststore_path}}
-hbase.sink.timeline.truststore.type = {{metric_truststore_type}}
-hbase.sink.timeline.truststore.password = {{metric_truststore_password}}
-
-# Switch off metrics generation on a per region basis
-*.source.filter.class=org.apache.hadoop.metrics2.filter.RegexFilter
-hbase.*.source.filter.exclude=.*(Regions|Users|Tables).*
+#hbase.extendedperiod = 3600
+#
+#hbase.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
+#hbase.period=30
+#hbase.collector.hosts={{ams_collector_hosts}}
+#hbase.port={{metric_collector_port}}
+#hbase.protocol={{metric_collector_protocol}}
+#
+#jvm.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
+#jvm.period=30
+#jvm.collector.hosts={{ams_collector_hosts}}
+#jvm.port={{metric_collector_port}}
+#jvm.protocol={{metric_collector_protocol}}
+#
+#rpc.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
+#rpc.period=30
+#rpc.collector.hosts={{ams_collector_hosts}}
+#rpc.port={{metric_collector_port}}
+#rpc.protocol={{metric_collector_protocol}}
+#
+#*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+#*.sink.timeline.slave.host.name={{hostname}}
+#*.host_in_memory_aggregation = {{host_in_memory_aggregation}}
+#*.host_in_memory_aggregation_port = {{host_in_memory_aggregation_port}}
+#
+#hbase.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
+#hbase.sink.timeline.period={{metrics_collection_period}}
+#hbase.sink.timeline.sendInterval={{metrics_report_interval}}000
+#hbase.sink.timeline.collector.hosts={{ams_collector_hosts}}
+#hbase.sink.timeline.port={{metric_collector_port}}
+#hbase.sink.timeline.protocol={{metric_collector_protocol}}
+#hbase.sink.timeline.serviceName-prefix=ams
+#
+## HTTPS properties
+#hbase.sink.timeline.truststore.path = {{metric_truststore_path}}
+#hbase.sink.timeline.truststore.type = {{metric_truststore_type}}
+#hbase.sink.timeline.truststore.password = {{metric_truststore_password}}
+#
+## Switch off metrics generation on a per region basis
+#*.source.filter.class=org.apache.hadoop.metrics2.filter.RegexFilter
+#hbase.*.source.filter.exclude=.*(Regions|Users|Tables).*


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently AMS sink is incompatible with HDP 3.0 deployments. Disabling AMS sink until branch-3.0-ams changes are pulled in.

## How was this patch tested?
Minor change. 