### PR TITLE
[AMBARI-23020] Decreasing the log level from WARN to DEBUG in case we use the default value of an undefined LDAP configuration element

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfiguration.java
@@ -44,7 +44,7 @@ public class AmbariLdapConfiguration {
     if (configurationMap.containsKey(ambariLdapConfigurationKeys.key())) {
       value = configurationMap.get(ambariLdapConfigurationKeys.key());
     } else {
-      LOGGER.warn("Ldap configuration property [{}] hasn't been set; using default value", ambariLdapConfigurationKeys.key());
+      LOGGER.debug("Ldap configuration property [{}] hasn't been set; using default value", ambariLdapConfigurationKeys.key());
       value = ambariLdapConfigurationKeys.getDefaultValue();
     }
     return value;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Lowering the log level to DEBUG when an LDAP configuration element's default value is used (i.e. it's not stored in the DB).

## How was this patch tested?

Latest JUnit test results in ambari-server:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25:41 min
[INFO] Finished at: 2018-02-19T14:35:33+01:00
[INFO] Final Memory: 214M/832M
[INFO] ------------------------------------------------------------------------
```

Besides this I re-deployed my `ambari-server` using the new JAR I built locally and queried a previously saved LDAP configuration;  checking the log files I found that the "...using default value" log entries are no longer there.