### PR TITLE
AMBARI-23028. Fix AMBARI_INFRA_SOLR dependency for the stack code.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
@@ -44,7 +44,7 @@
           </logs>
           <dependencies>
             <dependency>
-              <name>AMBARI_INFRA/INFRA_SOLR_CLIENT</name>
+              <name>AMBARI_INFRA_SOLR/INFRA_SOLR_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.2.5/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.7.0.2.5/metainfo.xml
@@ -30,7 +30,7 @@
           <versionAdvertised>true</versionAdvertised>
           <dependencies>
             <dependency>
-              <name>AMBARI_INFRA/INFRA_SOLR_CLIENT</name>
+              <name>AMBARI_INFRA_SOLR/INFRA_SOLR_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/metainfo.xml
@@ -56,7 +56,7 @@
           </logs>
           <dependencies>
             <dependency>
-              <name>AMBARI_INFRA/INFRA_SOLR_CLIENT</name>
+              <name>AMBARI_INFRA_SOLR/INFRA_SOLR_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>

--- a/ambari-server/src/main/resources/common-services/RANGER/0.6.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.6.0/metainfo.xml
@@ -32,7 +32,7 @@
           <cardinality>1+</cardinality>
           <dependencies>
             <dependency>
-              <name>AMBARI_INFRA/INFRA_SOLR_CLIENT</name>
+              <name>AMBARI_INFRA_SOLR/INFRA_SOLR_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>

--- a/ambari-server/src/test/python/stacks/2.4/AMBARI_INFRA/test_infra_solr.py
+++ b/ambari-server/src/test/python/stacks/2.4/AMBARI_INFRA/test_infra_solr.py
@@ -26,7 +26,7 @@ from mock.mock import MagicMock, call, patch
 @patch("os.listdir", new = MagicMock(return_value=['solr-8886.pid']))
 @patch("os.path.isdir", new = MagicMock(return_value=True))
 class TestInfraSolr(RMFTestCase):
-  COMMON_SERVICES_PACKAGE_DIR = "AMBARI_INFRA/0.1.0/package"
+  COMMON_SERVICES_PACKAGE_DIR = "AMBARI_INFRA_SOLR/0.1.0/package"
   STACK_VERSION = "2.4"
 
   def configureResourcesCalled(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

After renaming AMBARI_INFRA to AMBARI_INFRA_SOLR, the references were not updated properly in metainfo.xml files.

Also update it in a test file (no idea how that can pass before)

## How was this patch tested?

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:16 min
[INFO] Finished at: 2018-02-20T09:25:22+01:00
[INFO] Final Memory: 109M/1721M
[INFO] ------------------------------------------------------------------------

please review @benyoka @kasakrisz 