### PR TITLE
[AMBARI-23035] HDFS Balancer via Ambari fails when FIPS mode is activated on the OS

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/alerts/web_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/web_alert.py
@@ -37,17 +37,6 @@ from ambari_commons.inet_utils import resolve_address, ensure_ssl_using_protocol
 from ambari_commons.constants import AGENT_TMP_DIR
 from ambari_agent.AmbariConfig import AmbariConfig
 
-# hashlib is supplied as of Python 2.5 as the replacement interface for md5
-# and other secure hashes.  In 2.6, md5 is deprecated.  Import hashlib if
-# available, avoiding a deprecation warning under 2.6.  Import md5 otherwise,
-# preserving 2.4 compatibility.
-try:
-  import hashlib
-  _md5 = hashlib.md5
-except ImportError:
-  import md5
-  _md5 = md5.new
-
 logger = logging.getLogger(__name__)
 
 # default timeout
@@ -189,9 +178,7 @@ class WebAlert(BaseAlert):
       
       if kerberos_principal is not None and kerberos_keytab is not None \
         and security_enabled is not None and security_enabled.lower() == "true":
-        # Create the kerberos credentials cache (ccache) file and set it in the environment to use
-        # when executing curl. Use the md5 hash of the combination of the principal and keytab file
-        # to generate a (relatively) unique cache filename so that we can use it as needed.
+
         tmp_dir = AGENT_TMP_DIR
         if tmp_dir is None:
           tmp_dir = gettempdir()

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -21,6 +21,7 @@ import sys
 import os
 import json
 import tempfile
+import hashlib
 from datetime import datetime
 import ambari_simplejson as json # simplejson is much faster comparing to Python 2.6 json module and has the same functions set.
 
@@ -51,18 +52,8 @@ from hdfs import hdfs
 import hdfs_rebalance
 from utils import initiate_safe_zkfc_failover, get_hdfs_binary, get_dfsadmin_base_command
 
-
-
-# hashlib is supplied as of Python 2.5 as the replacement interface for md5
-# and other secure hashes.  In 2.6, md5 is deprecated.  Import hashlib if
-# available, avoiding a deprecation warning under 2.6.  Import md5 otherwise,
-# preserving 2.4 compatibility.
-try:
-  import hashlib
-  _md5 = hashlib.md5
-except ImportError:
-  import md5
-  _md5 = md5.new
+# The hash algorithm to use to generate digests/hashes
+HASH_ALGORITHM = hashlib.sha224
 
 class NameNode(Script):
 
@@ -222,11 +213,11 @@ class NameNodeDefault(NameNode):
 
     if params.security_enabled:
       # Create the kerberos credentials cache (ccache) file and set it in the environment to use
-      # when executing HDFS rebalance command. Use the md5 hash of the combination of the principal and keytab file
+      # when executing HDFS rebalance command. Use the sha224 hash of the combination of the principal and keytab file
       # to generate a (relatively) unique cache filename so that we can use it as needed.
       # TODO: params.tmp_dir=/var/lib/ambari-agent/tmp. However hdfs user doesn't have access to this path.
       # TODO: Hence using /tmp
-      ccache_file_name = "hdfs_rebalance_cc_" + _md5(format("{hdfs_principal_name}|{hdfs_user_keytab}")).hexdigest()
+      ccache_file_name = "hdfs_rebalance_cc_" + HASH_ALGORITHM(format("{hdfs_principal_name}|{hdfs_user_keytab}")).hexdigest()
       ccache_file_path = os.path.join(tempfile.gettempdir(), ccache_file_name)
       rebalance_env['KRB5CCNAME'] = ccache_file_path
 

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/service_check.py
@@ -19,19 +19,13 @@ Ambari Agent
 
 """
 
+import hashlib
+
 from kerberos_common import *
 from resource_management import *
 
-# hashlib is supplied as of Python 2.5 as the replacement interface for md5
-# and other secure hashes.  In 2.6, md5 is deprecated.  Import hashlib if
-# available, avoiding a deprecation warning under 2.6.  Import md5 otherwise,
-# preserving 2.4 compatibility.
-try:
-  import hashlib
-  _md5 = hashlib.md5
-except ImportError:
-  import md5
-  _md5 = md5.new
+# The hash algorithm to use to generate digests/hashes
+HASH_ALGORITHM = hashlib.sha224
 
 class KerberosServiceCheck(KerberosScript):
   def service_check(self, env):
@@ -52,7 +46,7 @@ class KerberosServiceCheck(KerberosScript):
           os.path.isfile(params.smoke_test_keytab_file)):
       print "Performing kinit using %s" % params.smoke_test_principal
 
-      ccache_file_name = _md5("{0}|{1}".format(params.smoke_test_principal,params.smoke_test_keytab_file)).hexdigest()
+      ccache_file_name = HASH_ALGORITHM("{0}|{1}".format(params.smoke_test_principal, params.smoke_test_keytab_file)).hexdigest()
       ccache_file_path = "{0}{1}kerberos_service_check_cc_{2}".format(params.tmp_dir, os.sep, ccache_file_name)
 
       kinit_path_local = functions.get_kinit_path(default('/configurations/kerberos-env/executable_search_paths', None))

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1257,7 +1257,7 @@ class TestNamenode(RMFTestCase):
                        call_mocks=[(1, "no kinit")]
     )
     tempdir = tempfile.gettempdir()
-    ccache_path =  os.path.join(tempfile.gettempdir(), "hdfs_rebalance_cc_7add60ca651f1bd1ed909a6668937ba9")
+    ccache_path =  os.path.join(tempfile.gettempdir(), "hdfs_rebalance_cc_676e87466798ee1b4128732da3effe26e7dfc902e2c9ebdfde4331d2")
     kinit_cmd = "/usr/bin/kinit -c {0} -kt /etc/security/keytabs/hdfs.headless.keytab hdfs@EXAMPLE.COM".format(ccache_path)
     rebalance_cmd = "ambari-sudo.sh su hdfs -l -s /bin/bash -c 'export  PATH=/bin:/usr/bin KRB5CCNAME={0} ; hdfs --config /etc/hadoop/conf balancer -threshold -1'".format(ccache_path)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is similar issue as reported on AMBARI-22417, but for service checks.

```
ValueError: error:060800A3:digital envelope routines:EVP_DigestInit_ex:disabled for fips
```

The original issue of ambari check is resolved. But the same issue is seen when running the HDFS balancer via Ambari.

Solution
MD5 is disabled on the OS, Code needs to be updated to use SHA

This is required when FIPS mode is enabled on the RHEL OS

## How was this patch tested?

Manually tested in cluster, ran unit tests:

```
Total run:1051
Total errors:0
Total failures:0
OK
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.