### PR TITLE
AMBARI-23027. Add backup/copy znode command for infra-solr-client.

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
@@ -338,7 +338,7 @@ public class AmbariSolrCloudCLI {
       .longOpt("transfer-mode")
       .desc("Transfer mode, if not used copy znode to znode.")
       .numberOfArgs(1)
-      .argName("copyToLocal|copyToLocal")
+      .argName("copyFromLocal|copyToLocal")
       .build();
 
     final Option securityJsonLocationOption = Option.builder("sjl")

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
@@ -63,7 +63,7 @@ public class AmbariSolrCloudCLI {
       + "\n./solrCloudCli.sh --remove-admin-handlers -z host1:2181,host2:2181/ambari-solr -c collection"
       + "\n./solrCloudCli.sh --create-znode -z host1:2181,host2:2181 -zn /ambari-solr"
       + "\n./solrCloudCli.sh --check-znode -z host1:2181,host2:2181 -zn /ambari-solr"
-      + "\n./solrCloudCli.sh --transfer-znode -z host1:2181,host2:2181 -tz -cps /ambari-solr -cpd /ambari-solr-backup"
+      + "\n./solrCloudCli.sh --transfer-znode -z host1:2181,host2:2181 -cps /ambari-solr -cpd /ambari-solr-backup"
       + "\n./solrCloudCli.sh --cluster-prop -z host1:2181,host2:2181/ambari-solr -cpn urlScheme -cpn http"
       + "\n./solrCloudCli.sh --secure-znode -z host1:2181,host2:2181 -zn /ambari-solr -su logsearch,atlas,ranger --jaas-file /etc/myconf/jaas_file"
       + "\n./solrCloudCli.sh --unsecure-znode -z host1:2181,host2:2181 -zn /ambari-solr --jaas-file /etc/myconf/jaas_file"

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
@@ -448,7 +448,7 @@ public class AmbariSolrCloudCLI {
       } else if (cli.hasOption("rah")) {
         command = REMOVE_ADMIN_HANDLERS;
         validateRequiredOptions(cli, command, zkConnectStringOption, collectionOption);
-      } else if (cli.hasOption("tf")) {
+      } else if (cli.hasOption("tz")) {
         command = TRANSFER_ZNODE_COMMAND;
         validateRequiredOptions(cli, command, zkConnectStringOption, copyScrOption, copyDestOption);
       }else {

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
@@ -322,23 +322,24 @@ public class AmbariSolrCloudCLI {
       .build();
 
     final Option copyScrOption = Option.builder("cps")
-      .longOpt("copy-scr")
-      .desc("")
-      .argName("/myznode")
+      .longOpt("copy-src")
+      .desc("ZNode or local source (used for ZNode transfer)")
+      .numberOfArgs(1)
+      .argName("/myznode | /my/path")
       .build();
 
     final Option copyDestOption = Option.builder("cpd")
       .longOpt("copy-dist")
-      .desc("")
+      .desc("ZNode or local destination (used for ZNode transfer)")
       .numberOfArgs(1)
-      .argName("/myznode")
+      .argName("/myznode | /my/path")
       .build();
 
     final Option transferModeOption = Option.builder("tm")
       .longOpt("transfer-mode")
       .desc("Transfer mode, if not used copy znode to znode.")
       .numberOfArgs(1)
-      .argName("copyFromLocal|copyToLocal")
+      .argName("copyFromLocal | copyToLocal")
       .build();
 
     final Option securityJsonLocationOption = Option.builder("sjl")

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
@@ -53,6 +53,7 @@ public class AmbariSolrCloudCLI {
   private static final String SECURE_SOLR_ZNODE_COMMAND = "secure-solr-znode";
   private static final String SECURITY_JSON_LOCATION = "security-json-location";
   private static final String REMOVE_ADMIN_HANDLERS = "remove-admin-handlers";
+  private static final String TRANSFER_ZNODE_COMMAND = "transfer-znode";
   private static final String CMD_LINE_SYNTAX =
     "\n./solrCloudCli.sh --create-collection -z host1:2181,host2:2181/ambari-solr -c collection -cs conf_set"
       + "\n./solrCloudCli.sh --upload-config -z host1:2181,host2:2181/ambari-solr -d /tmp/myconfig_dir -cs config_set"
@@ -62,6 +63,7 @@ public class AmbariSolrCloudCLI {
       + "\n./solrCloudCli.sh --remove-admin-handlers -z host1:2181,host2:2181/ambari-solr -c collection"
       + "\n./solrCloudCli.sh --create-znode -z host1:2181,host2:2181 -zn /ambari-solr"
       + "\n./solrCloudCli.sh --check-znode -z host1:2181,host2:2181 -zn /ambari-solr"
+      + "\n./solrCloudCli.sh --transfer-znode -z host1:2181,host2:2181 -tz -cps /ambari-solr -cpd /ambari-solr-backup"
       + "\n./solrCloudCli.sh --cluster-prop -z host1:2181,host2:2181/ambari-solr -cpn urlScheme -cpn http"
       + "\n./solrCloudCli.sh --secure-znode -z host1:2181,host2:2181 -zn /ambari-solr -su logsearch,atlas,ranger --jaas-file /etc/myconf/jaas_file"
       + "\n./solrCloudCli.sh --unsecure-znode -z host1:2181,host2:2181 -zn /ambari-solr --jaas-file /etc/myconf/jaas_file"
@@ -142,6 +144,11 @@ public class AmbariSolrCloudCLI {
     final Option removeAdminHandlerOption = Option.builder("rah")
       .longOpt(REMOVE_ADMIN_HANDLERS)
       .desc("Remove AdminHandlers request handler from solrconfig.xml (command)")
+      .build();
+
+    final Option transferZnodeOption = Option.builder("tz")
+      .longOpt(TRANSFER_ZNODE_COMMAND)
+      .desc("Transfer znode (copy from/to local or to another znode)")
       .build();
 
     final Option shardNameOption = Option.builder("sn")
@@ -307,18 +314,31 @@ public class AmbariSolrCloudCLI {
       .argName("cluster prop value")
       .build();
 
-    final Option copyFromZnodeOption = Option.builder("cfz")
-      .longOpt("copy-from-znode")
-      .desc("Copy-from-znode")
-      .numberOfArgs(1)
-      .argName("/ambari-solr-secure")
-      .build();
-
     final Option saslUsersOption = Option.builder("su")
       .longOpt("sasl-users")
       .desc("Sasl users (comma separated list)")
       .numberOfArgs(1)
       .argName("atlas,ranger,logsearch-solr")
+      .build();
+
+    final Option copyScrOption = Option.builder("cps")
+      .longOpt("copy-scr")
+      .desc("")
+      .argName("/myznode")
+      .build();
+
+    final Option copyDestOption = Option.builder("cpd")
+      .longOpt("copy-dist")
+      .desc("")
+      .numberOfArgs(1)
+      .argName("/myznode")
+      .build();
+
+    final Option transferModeOption = Option.builder("tm")
+      .longOpt("transfer-mode")
+      .desc("Transfer mode, if not used copy znode to znode.")
+      .numberOfArgs(1)
+      .argName("copyToLocal|copyToLocal")
       .build();
 
     final Option securityJsonLocationOption = Option.builder("sjl")
@@ -344,6 +364,7 @@ public class AmbariSolrCloudCLI {
     options.addOption(secureZnodeOption);
     options.addOption(unsecureZnodeOption);
     options.addOption(secureSolrZnodeOption);
+    options.addOption(transferZnodeOption);
     options.addOption(shardsOption);
     options.addOption(replicationOption);
     options.addOption(maxShardsOption);
@@ -369,7 +390,9 @@ public class AmbariSolrCloudCLI {
     options.addOption(createZnodeOption);
     options.addOption(znodeOption);
     options.addOption(secureOption);
-    options.addOption(copyFromZnodeOption);
+    options.addOption(transferModeOption);
+    options.addOption(copyScrOption);
+    options.addOption(copyDestOption);
     options.addOption(saslUsersOption);
     options.addOption(checkZnodeOption);
     options.addOption(setupKerberosPluginOption);
@@ -425,10 +448,13 @@ public class AmbariSolrCloudCLI {
       } else if (cli.hasOption("rah")) {
         command = REMOVE_ADMIN_HANDLERS;
         validateRequiredOptions(cli, command, zkConnectStringOption, collectionOption);
-      } else {
+      } else if (cli.hasOption("tf")) {
+        command = TRANSFER_ZNODE_COMMAND;
+        validateRequiredOptions(cli, command, zkConnectStringOption, copyScrOption, copyDestOption);
+      }else {
         List<String> commands = Arrays.asList(CREATE_COLLECTION_COMMAND, CREATE_SHARD_COMMAND, UPLOAD_CONFIG_COMMAND,
           DOWNLOAD_CONFIG_COMMAND, CONFIG_CHECK_COMMAND, SET_CLUSTER_PROP, CREATE_ZNODE, SECURE_ZNODE_COMMAND, UNSECURE_ZNODE_COMMAND,
-          SECURE_SOLR_ZNODE_COMMAND, CHECK_ZNODE, SETUP_KERBEROS_PLUGIN, REMOVE_ADMIN_HANDLERS);
+          SECURE_SOLR_ZNODE_COMMAND, CHECK_ZNODE, SETUP_KERBEROS_PLUGIN, REMOVE_ADMIN_HANDLERS, TRANSFER_ZNODE_COMMAND);
         helpFormatter.printHelp(CMD_LINE_SYNTAX, options);
         exit(1, String.format("One of the supported commands is required (%s)", StringUtils.join(commands, "|")));
       }
@@ -459,6 +485,9 @@ public class AmbariSolrCloudCLI {
       boolean isSecure = cli.hasOption("sec");
       String saslUsers = cli.hasOption("su") ? cli.getOptionValue("su") : "";
       String securityJsonLocation = cli.hasOption("sjl") ? cli.getOptionValue("sjl") : "";
+      String copySrc = cli.hasOption("cps") ? cli.getOptionValue("cps") : null;
+      String copyDest = cli.hasOption("cpd") ? cli.getOptionValue("cpd") : null;
+      String transferMode = cli.hasOption("tm") ? cli.getOptionValue("tm") : "NONE";
 
       AmbariSolrCloudClientBuilder clientBuilder = new AmbariSolrCloudClientBuilder()
         .withZkConnectString(zkConnectString)
@@ -482,6 +511,9 @@ public class AmbariSolrCloudCLI {
         .withTrustStoreType(trustStoreType)
         .withClusterPropName(clusterPropName)
         .withClusterPropValue(clusterPropValue)
+        .withTransferMode(transferMode)
+        .withCopySrc(copySrc)
+        .withCopyDest(copyDest)
         .withSecurityJsonLocation(securityJsonLocation)
         .withZnode(znode)
         .withSecure(isSecure)
@@ -553,6 +585,10 @@ public class AmbariSolrCloudCLI {
         case REMOVE_ADMIN_HANDLERS:
           solrCloudClient = clientBuilder.build();
           solrCloudClient.removeAdminHandlerFromCollectionConfig();
+          break;
+        case TRANSFER_ZNODE_COMMAND:
+          solrCloudClient = clientBuilder.build();
+          solrCloudClient.transferZnode();
           break;
         default:
           throw new AmbariSolrCloudClientException(String.format("Not found command: '%s'", command));

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudClient.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudClient.java
@@ -18,22 +18,7 @@
  */
 package org.apache.ambari.infra.solr;
 
-import org.apache.ambari.infra.solr.commands.CheckConfigZkCommand;
-import org.apache.ambari.infra.solr.commands.CreateCollectionCommand;
-import org.apache.ambari.infra.solr.commands.CreateShardCommand;
-import org.apache.ambari.infra.solr.commands.CreateSolrZnodeZkCommand;
-import org.apache.ambari.infra.solr.commands.DownloadConfigZkCommand;
-import org.apache.ambari.infra.solr.commands.EnableKerberosPluginSolrZkCommand;
-import org.apache.ambari.infra.solr.commands.GetShardsCommand;
-import org.apache.ambari.infra.solr.commands.GetSolrHostsCommand;
-import org.apache.ambari.infra.solr.commands.ListCollectionCommand;
-import org.apache.ambari.infra.solr.commands.RemoveAdminHandlersCommand;
-import org.apache.ambari.infra.solr.commands.SecureSolrZNodeZkCommand;
-import org.apache.ambari.infra.solr.commands.SecureZNodeZkCommand;
-import org.apache.ambari.infra.solr.commands.SetClusterPropertyZkCommand;
-import org.apache.ambari.infra.solr.commands.UnsecureZNodeZkCommand;
-import org.apache.ambari.infra.solr.commands.UploadConfigZkCommand;
-import org.apache.ambari.infra.solr.commands.CheckZnodeZkCommand;
+import org.apache.ambari.infra.solr.commands.*;
 import org.apache.ambari.infra.solr.util.ShardUtils;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.common.cloud.Slice;
@@ -72,6 +57,9 @@ public class AmbariSolrCloudClient {
   private final String propValue;
   private final String securityJsonLocation;
   private final boolean secure;
+  private final String transferMode;
+  private final String copySrc;
+  private final String copyDest;
 
   public AmbariSolrCloudClient(AmbariSolrCloudClientBuilder builder) {
     this.zkConnectString = builder.zkConnectString;
@@ -95,6 +83,9 @@ public class AmbariSolrCloudClient {
     this.propValue = builder.propValue;
     this.securityJsonLocation = builder.securityJsonLocation;
     this.secure = builder.secure;
+    this.transferMode = builder.transferMode;
+    this.copySrc = builder.copySrc;
+    this.copyDest = builder.copyDest;
   }
 
   /**
@@ -265,6 +256,13 @@ public class AmbariSolrCloudClient {
     return new RemoveAdminHandlersCommand(getRetryTimes(), getInterval()).run(this);
   }
 
+  /**
+   * Transfer znode data (cannot be both scr and dest local)
+   */
+  public boolean transferZnode() throws Exception {
+    return new TransferZnodeZkCommand(getRetryTimes(), getInterval()).run(this);
+  }
+
   public String getZkConnectString() {
     return zkConnectString;
   }
@@ -347,5 +345,17 @@ public class AmbariSolrCloudClient {
 
   public String getSecurityJsonLocation() {
     return securityJsonLocation;
+  }
+
+  public String getTransferMode() {
+    return transferMode;
+  }
+
+  public String getCopySrc() {
+    return copySrc;
+  }
+
+  public String getCopyDest() {
+    return copyDest;
   }
 }

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudClient.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudClient.java
@@ -18,7 +18,23 @@
  */
 package org.apache.ambari.infra.solr;
 
-import org.apache.ambari.infra.solr.commands.*;
+import org.apache.ambari.infra.solr.commands.CheckConfigZkCommand;
+import org.apache.ambari.infra.solr.commands.CreateCollectionCommand;
+import org.apache.ambari.infra.solr.commands.CreateShardCommand;
+import org.apache.ambari.infra.solr.commands.CreateSolrZnodeZkCommand;
+import org.apache.ambari.infra.solr.commands.DownloadConfigZkCommand;
+import org.apache.ambari.infra.solr.commands.EnableKerberosPluginSolrZkCommand;
+import org.apache.ambari.infra.solr.commands.GetShardsCommand;
+import org.apache.ambari.infra.solr.commands.GetSolrHostsCommand;
+import org.apache.ambari.infra.solr.commands.ListCollectionCommand;
+import org.apache.ambari.infra.solr.commands.RemoveAdminHandlersCommand;
+import org.apache.ambari.infra.solr.commands.SecureSolrZNodeZkCommand;
+import org.apache.ambari.infra.solr.commands.SecureZNodeZkCommand;
+import org.apache.ambari.infra.solr.commands.SetClusterPropertyZkCommand;
+import org.apache.ambari.infra.solr.commands.TransferZnodeZkCommand;
+import org.apache.ambari.infra.solr.commands.UnsecureZNodeZkCommand;
+import org.apache.ambari.infra.solr.commands.UploadConfigZkCommand;
+import org.apache.ambari.infra.solr.commands.CheckZnodeZkCommand;
 import org.apache.ambari.infra.solr.util.ShardUtils;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.common.cloud.Slice;

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudClientBuilder.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudClientBuilder.java
@@ -54,6 +54,9 @@ public class AmbariSolrCloudClientBuilder {
   String propValue;
   String securityJsonLocation;
   boolean secure;
+  String transferMode;
+  String copySrc;
+  String copyDest;
 
   public AmbariSolrCloudClient build() {
     return new AmbariSolrCloudClient(this);
@@ -194,6 +197,21 @@ public class AmbariSolrCloudClientBuilder {
 
   public AmbariSolrCloudClientBuilder withClusterPropValue(String clusterPropValue) {
     this.propValue = clusterPropValue;
+    return this;
+  }
+
+  public AmbariSolrCloudClientBuilder withTransferMode(String transferMode) {
+    this.transferMode = transferMode;
+    return this;
+  }
+
+  public AmbariSolrCloudClientBuilder withCopySrc(String copySrc) {
+    this.copySrc = copySrc;
+    return this;
+  }
+
+  public AmbariSolrCloudClientBuilder withCopyDest(String copyDest) {
+    this.copyDest = copyDest;
     return this;
   }
 

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/commands/TransferZnodeZkCommand.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/commands/TransferZnodeZkCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.ambari.infra.solr.commands;
 
 import org.apache.ambari.infra.solr.AmbariSolrCloudClient;

--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/commands/TransferZnodeZkCommand.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/commands/TransferZnodeZkCommand.java
@@ -1,0 +1,27 @@
+package org.apache.ambari.infra.solr.commands;
+
+import org.apache.ambari.infra.solr.AmbariSolrCloudClient;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.SolrZooKeeper;
+
+public class TransferZnodeZkCommand extends AbstractZookeeperRetryCommand<Boolean> {
+
+  public TransferZnodeZkCommand(int maxRetries, int interval) {
+    super(maxRetries, interval);
+  }
+
+  @Override
+  protected Boolean executeZkCommand(AmbariSolrCloudClient client, SolrZkClient zkClient, SolrZooKeeper solrZooKeeper) throws Exception {
+    boolean isSrcZk = true;
+    boolean isDestZk = true;
+    if ("copyToLocal".equals(client.getTransferMode())) {
+      isDestZk = false;
+    } else if ("copyFromLocal".equals(client.getTransferMode())) {
+      isSrcZk = false;
+    }
+    zkClient.zkTransfer(client.getCopySrc(), isSrcZk, client.getCopyDest(), isDestZk, true);
+    return true;
+  }
+
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new transfer znode (recursive) command in order to backup znodes (to locally or other znodes)
It can be useful during solr index migration

## How was this patch tested?

FT: Done, manually

please review @zeroflag @adoroszlai @kasakrisz @swagle 