### PR TITLE
[AMBARI-22649] settings library should convert true/false to boolean

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/settings.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/settings.py
@@ -55,7 +55,7 @@ def get_setting_type_entries(setting_type, setting_names=None):
         return None
 
     if setting_names is None: # Return all settings
-        return settings
+        setting_names = settings.keys()
 
     if not isinstance(setting_names, (set, frozenset, tuple, list)):
         Logger.error("'setting_names' type expected to be either a : set, frozenset, tuple, or list. "
@@ -66,7 +66,7 @@ def get_setting_type_entries(setting_type, setting_names=None):
         Logger.error("Passed-in settings set is EMPTY")
         return None
     else:
-        result = dict((setting, settings[setting]) for setting in setting_names if setting in settings)
+        result = dict((setting, convert_value(settings[setting])) for setting in setting_names if setting in settings)
         if not result:
             Logger.error("Passed-in setting(s) in set not present.")
             return {}
@@ -100,7 +100,7 @@ def get_setting_value(setting_type, setting_name):
         Logger.info("Couldn't retrieve '"+setting_type+"'.")
         return None
 
-    return settings.get(setting_name)
+    return convert_value(settings.get(setting_name))
 
 
 def is_setting_type_supported(setting_type):
@@ -110,3 +110,16 @@ def is_setting_type_supported(setting_type):
     :return: True or False
     """
     return setting_type in (STACK_SETTINGS_TYPE, CLUSTER_SETTINGS_TYPE)
+
+
+def convert_value(value):
+    """
+    Converts some values for easier consumption.
+    Currently only strings corresponding to true/false are converted to actual boolean values.
+    """
+
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return value

--- a/ambari-server/src/test/python/TestSettings.py
+++ b/ambari-server/src/test/python/TestSettings.py
@@ -51,26 +51,35 @@ class TestSettings(TestCase):
     Script.config = TestSettings._get_simple_command()
 
     # For stackSettings
-    self.assertEquals(Script.config['stackSettings'], settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE, None))
-    self.assertEquals(Script.config['stackSettings'], settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE))
+    stackSettings = dict((k, settings.convert_value(v)) for k, v in Script.config['stackSettings'].items())
+    self.assertEquals(stackSettings, settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE, None))
+    self.assertEquals(stackSettings, settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE))
 
     # For clusterSettings
-    self.assertEquals(Script.config['clusterSettings'], settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE, None))
-    self.assertEquals(Script.config['clusterSettings'], settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE))
+    clusterSettings = dict((k, settings.convert_value(v)) for k, v in Script.config['clusterSettings'].items())
+    self.assertEquals(clusterSettings, settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE, None))
+    self.assertEquals(clusterSettings, settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE))
+
+
+  def test_boolean_values_are_converted(self):
+    Script.config = TestSettings._get_simple_command()
+
+    self.assertEquals(settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, 'manage_dirs_on_root'), True)
+    self.assertEquals(settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, 'recovery_enabled'), False)
 
 
   def test_full_subset_of_entries_for_supported_type(self):
     Script.config = TestSettings._get_simple_command()
 
     # For stackSettings
-    stackSettings = Script.config['stackSettings']
+    stackSettings = dict((k, settings.convert_value(v)) for k, v in Script.config['stackSettings'].items())
     self.assertEquals(stackSettings, settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE, set(stackSettings.keys())))
     self.assertEquals(stackSettings, settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE, frozenset(stackSettings.keys())))
     self.assertEquals(stackSettings, settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE, tuple(stackSettings.keys())))
     self.assertEquals(stackSettings, settings.get_setting_type_entries(settings.STACK_SETTINGS_TYPE, list(stackSettings.keys())))
 
     # For clusterSettings
-    clusterSettings = Script.config['clusterSettings']
+    clusterSettings = dict((k, settings.convert_value(v)) for k, v in Script.config['clusterSettings'].items())
     self.assertEquals(clusterSettings, settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE, set(clusterSettings.keys())))
     self.assertEquals(clusterSettings, settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE, frozenset(clusterSettings.keys())))
     self.assertEquals(clusterSettings, settings.get_setting_type_entries(settings.CLUSTER_SETTINGS_TYPE, tuple(clusterSettings.keys())))
@@ -155,7 +164,7 @@ class TestSettings(TestCase):
     # For clusterSettings
     self.assertTrue(settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, 'non_existing_key') is None)
 
-  def test_value_of_supported_setting_type_empy_string_name(self):
+  def test_value_of_supported_setting_type_empty_string_name(self):
     Script.config = TestSettings._get_simple_command()
 
     # For stackSettings
@@ -179,12 +188,12 @@ class TestSettings(TestCase):
     # For stackSettings
     stack_settings = Script.config['stackSettings']
     for k in stack_settings.keys():
-      self.assertEquals(stack_settings[k], settings.get_setting_value(settings.STACK_SETTINGS_TYPE, k))
+      self.assertEquals(settings.convert_value(stack_settings[k]), settings.get_setting_value(settings.STACK_SETTINGS_TYPE, k))
 
     # For clusterSettings
     cluster_settings = Script.config['clusterSettings']
     for k in cluster_settings.keys():
-      self.assertEquals(cluster_settings[k], settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, k))
+      self.assertEquals(settings.convert_value(cluster_settings[k]), settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, k))
 
 
   @staticmethod
@@ -199,6 +208,7 @@ class TestSettings(TestCase):
       },
       "clusterSettings": {
         "recovery_enabled": "false",
+        "manage_dirs_on_root": "true",
         "smokeuser": "ambari-qa",
         "recovery_type": "AUTO_START",
         "user_group": "hadoop",


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `settings` library for getting `clusterSettings` and `stackSettings` should convert literal `"true"` and `"false"` values to the Python boolean type to retain backward compatibility with `ConfigDictionary`:

https://github.com/apache/ambari/blob/40e5585b08fe563e061ecd19823e609ee47817e6/ambari-common/src/main/python/resource_management/libraries/script/config_dictionary.py#L57-L62

Stack scripts rely on this behavior in a lot of places.  One of the most widely used is the `security_enabled` flag.  Without this conversion, scripts would execute the "secure" code path for both `"true"` and `"false"` values, since only the empty string is treated as `False`.

https://github.com/apache/ambari/blob/40e5585b08fe563e061ecd19823e609ee47817e6/ambari-server/src/main/resources/common-services/ZOOKEEPER/3.4.5/package/scripts/params_linux.py#L96

https://github.com/apache/ambari/blob/40e5585b08fe563e061ecd19823e609ee47817e6/ambari-server/src/main/resources/common-services/ZOOKEEPER/3.4.5/package/scripts/zookeeper.py#L99

## How was this patch tested?

Deployed cluster using blueprint.

Unit test tweaked, passing:

```
$ mvn -am -pl ambari-server -Del.log=WARN -DfailIfNoTests=false -DskipSurefireTests -Dcheckstyle.skip -Drat.skip -Dpython.test.mask=TestSettings.py test
...
Total run:14
Total errors:0
Total failures:0
OK
```