### PR TITLE
AMBARI-23040. Deploy fails during Atlas Client installation

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -559,7 +559,6 @@ class Script(object):
     if package_version is None:
       package_version = default("hostLevelParams/package_version", None)
 
-    package_version = None
     if (package_version is None or '-' not in package_version) and default('/repositoryFile', None):
       self.load_available_packages()
       package_name = self.get_package_from_available(name, self.available_packages_in_repos)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/ATLAS/package/scripts/atlas_client.py", line 53, in 
    AtlasClient().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 377, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/ATLAS/package/scripts/atlas_client.py", line 41, in install
    self.install_packages(env)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 823, in install_packages
    name = self.format_package_name(package['name'])
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 567, in format_package_name
    raise Fail("Cannot match package for regexp name {0}. Available packages: {1}".format(name, self.available_packages_in_repos))
resource_management.core.exceptions.Fail: Cannot match package for regexp name atlas-metadata_${stack_version}. Available packages: ['openblas', 'openblas-Rblas', 'openblas-devel', 'openblas-openmp', 'openblas-openmp64', 'openblas-openmp64_', 'openblas-serial64', 'openblas-serial64_', 'openblas-static', 'openblas-threads', 'openblas-threads64', 'openblas-threads64_', 'snappy', 'snappy', 'snappy-devel', 'snappy-devel']