### PR TITLE
AMBARI-23002 Cancel Button in Upload table doesnt works in Hive views 2.0

### DIFF
--- a/contrib/views/hive20/src/main/resources/ui/app/components/upload-table.js
+++ b/contrib/views/hive20/src/main/resources/ui/app/components/upload-table.js
@@ -53,6 +53,9 @@ export default Ember.Component.extend({
       tableData.set("fileInfo", this.get("fileInfo"));
       tableData.set("tableMeta", this.get("tableMeta"));
       this.sendAction("createAndUpload", tableData);
+    },
+    cancel: function() {
+      this.sendAction("cancel");
     }
   }
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

BUG FIX : AMBARI-23002 Cancel Button in Upload table doesnt works in Hive views 2.0
Issue :

Open Hive Views 2.0
navigate to Tables Tab
click on + button
click on Upload Table button
Click on cancel button that appears along with create button , its throws a script error and no action is performed

## How was this patch tested?

The issue is tested as per reproducible steps .
when click on cancel button the intended function is meet .
No UT errors