### PR TITLE
AMBARI-22759 [Hive Views 2.0] Deleting a Saved query is Buggy

### DIFF
--- a/contrib/views/hive20/src/main/resources/ui/app/routes/savedqueries.js
+++ b/contrib/views/hive20/src/main/resources/ui/app/routes/savedqueries.js
@@ -52,12 +52,10 @@ export default Ember.Route.extend(UILoggerMixin, {
       let self = this;
 
       console.log('deleteSavedQuery', queryId);
-
-      this.get('store').queryRecord('saved-query', { filter: { id: queryId } }, {reload: true}).then(function(record) {
-        record.destroyRecord().then(function(data) {
-          self.send('deleteSavedQueryDeclined');
-          self.send('refreshSavedQueryList');
-        });
+      let recordToDelete = this.get('store').peekRecord('saved-query', queryId);
+      recordToDelete.destroyRecord().then(function (data) {
+        self.send('deleteSavedQueryDeclined');
+        self.send('refreshSavedQueryList');
       }, (error) => {
         console.log('error', error);
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?
**AMBARI-22759**
[Hive Views 2.0] Deleting a Saved query is Buggy when Mutliple Queries exist in same Name
## How was this patch tested?
Tested in UI when a duplicate name saved query is deleted , exactly the same sved query is deleted than randon
NO UT Failures
[INFO] Results:
[INFO]
[INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:20 min
[INFO] Finished at: 2018-02-21T19:07:31+05:30
[INFO] Final Memory: 69M/908M
[INFO] ------------------------------------------------------------------------