### PR TITLE
[AMBARI-23043] Table or view not found error' with livy/livy2 interpreter on upgraded cluster to Fenton-M30

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
@@ -292,6 +292,39 @@ class Master(Script):
       if setting_key not in interpreter_settings:
         interpreter_settings[setting_key] = interpreter_json_template[
           setting_key]
+      else:
+        templateGroups = interpreter_json_template[setting_key]['interpreterGroup']
+        groups = interpreter_settings[setting_key]['interpreterGroup']
+
+        templateProperties = interpreter_json_template[setting_key]['properties']
+        properties = interpreter_settings[setting_key]['properties']
+
+        templateOptions = interpreter_json_template[setting_key]['option']
+        options = interpreter_settings[setting_key]['option']
+
+        # search for difference in groups from current interpreter and template interpreter
+        # if any group exists in template but doesn't exist in current interpreter, it will be added
+        group_names = []
+        for group in groups:
+          group_names.append(group['name'])
+
+        for template_group in templateGroups:
+          if not template_group['name'] in group_names:
+            groups.append(template_group)
+
+
+        # search for difference in properties from current interpreter and template interpreter
+        # if any property exists in template but doesn't exist in current interpreter, it will be added
+        for template_property in templateProperties:
+          if not template_property in properties:
+            properties[template_property] = templateProperties[template_property]
+
+
+        # search for difference in options from current interpreter and template interpreter
+        # if any option exists in template but doesn't exist in current interpreter, it will be added
+        for template_option in templateOptions:
+          if not template_option in options:
+            options[template_option] = templateOptions[template_option]
 
     self.set_interpreter_settings(config_data)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I've added chnages to reset_interpreter_settings() method. After my cahnges during reset interpreter.json config, we also will add new properties/groups/options. Earlier we added only new setting_key section.

## How was this patch tested?

On upgraded (RU/EU) cluster added my changes and restart zeppelin. Changes were successfully added and zeppelin start work fine. Tested interpreters to check new chenges in interpreter.json.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.