### PR TITLE
AMBARI-23045. Default Solr operator is not working anymore for history collection

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/configsets/history/conf/managed-schema
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/configsets/history/conf/managed-schema
@@ -79,8 +79,6 @@
   <fieldType name="tlong" class="solr.TrieLongField" positionIncrementGap="0" precisionStep="8"/>
   <fieldType name="tlongs" class="solr.TrieLongField" positionIncrementGap="0" multiValued="true" precisionStep="8"/>
 
-  <solrQueryParser defaultOperator="OR"/>
-
   <field name="_version_" type="long" indexed="true" stored="true"/>
   <field name="filtername" type="key_lower_case" indexed="true" required="true" stored="true"/>
   <field name="id" type="string" required="true"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?
With using Solr 7.2.1, history collection is not created, as default operator cannot be used in the Solr schema (and anyway, OR is the default operator)

## How was this patch tested?
with docker env, it created the collection after the change

please review @swagle @adoroszlai @kasakrisz 