### PR TITLE
[AMBARI-23046]. Remove unsecure dependencies from Ambari Groovy Client …

### DIFF
--- a/ambari-client/groovy-client/pom.xml
+++ b/ambari-client/groovy-client/pom.xml
@@ -41,6 +41,27 @@
     <dependency>
       <groupId>org.codehaus.groovy.modules.http-builder</groupId>
       <artifactId>http-builder</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.6</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.2</version>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>

--- a/ambari-client/groovy-client/src/test/groovy/org/apache/ambari/groovy/client/AmbariHostsTest.groovy
+++ b/ambari-client/groovy-client/src/test/groovy/org/apache/ambari/groovy/client/AmbariHostsTest.groovy
@@ -28,7 +28,7 @@ class AmbariHostsTest extends AbstractAmbariClientTest {
 
   def "test get host components as map when there is no cluster yet"() {
     given:
-    ambari.metaClass.getHostComponenets = { return null }
+    ambari.metaClass.getHostComponents = { return null }
 
     when:
     def result = ambari.getHostComponentsMap("host")


### PR DESCRIPTION
…(amagyar)

## What changes were proposed in this pull request?

Remove dependency on xerces:xercesImpl before version 2.11.2 for Ambari Groovy Client

* Remove dependency on org.apache.httpcomponents:httpclient before version 4.3.5.1 for Ambari Groovy Client
* Remove dependency on commons-collections:commons-collections:jar before version 3.2.2 for Ambari Groovy Client
* Remove dependency on commons-beanutils:commons-beanutils-core before version 1.9.2 for Ambari Groovy Client

## How was this patch tested?

Manually using a the groovy client and a real cluster.
