### PR TITLE
[AMBARI-23048]. Remove unsecure dependencies from Ambari Groovy Shell (amagyar)

### DIFF
--- a/ambari-shell/ambari-groovy-shell/pom.xml
+++ b/ambari-shell/ambari-groovy-shell/pom.xml
@@ -69,12 +69,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.4.1</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
+      <version>4.5.5</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Remove dependency on org.apache.zookeeper:zookeeper before version 3.4.6.2.0.0.0-579 for Ambari Groovy Shell
* Remove dependency on xerces:xercesImpl before version 2.11.2 for Ambari Groovy Shell
* Remove dependency on tomcat:jasper-compiler and tomcat:jasper-runtime before version 6.0.20.0 for Ambari Groovy Shell
* Remove dependency on org.apache.httpcomponents:httpclient before version 4.3.5.1 for Ambari Groovy Shell
* Remove dependency on commons-httpclient:commons-httpclient before version 3.1.0 for Ambari Groovy Shell
* Remove dependency on commons-collections:commons-collections:jar before version 3.2.2 for Ambari Groovy Shell
* Remove dependency on commons-beanutils:commons-beanutils-core before version 1.9.2 for Ambari Groovy Shell

Most of these were eliminated by updating the version hadoop-common. Some of these were the dependencies of groovy-client. This was fixed in AMBARI-23046.

## How was this patch tested?

* mvn dependency:tree
* java -jar ambari-groovy-shell-2.6.1.0.0.jar --ambari.host=c6401 

