### PR TITLE
[AMBARI-23054] Upgrading commons-beanutils dependency in ambari-server to 1.9.3

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -77,6 +77,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.3</version>
+      </dependency>
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.1</version>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1486,6 +1486,10 @@
       <version>${hadoop.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -33,6 +33,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>    <!-- has to be compile-time dependency on junit -->
@@ -45,6 +49,10 @@
           <groupId>com.sun</groupId>
           <artifactId>tools</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -53,6 +61,12 @@
       <type>test-jar</type>
       <version>${checkstyle.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Per [CVE-2014-0114](https://nvd.nist.gov/vuln/detail/CVE-2014-0114):

> Apache Commons BeanUtils, as distributed in lib/commons-beanutils-1.8.0.jar in Apache Struts 1.x through 1.3.10 and in other products requiring commons-beanutils through 1.9.2, does not suppress the class property, which allows remote attackers to "manipulate" the ClassLoader and execute arbitrary code via the class parameter, as demonstrated by the passing of this parameter to the getClass method of the ActionForm object in Struts 1.

To avoid this in Ambari server we upgarded to 1.9.3.

## How was this patch tested?

After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.6.0.0.0
[INFO] \- org.apache.hadoop:hadoop-common:jar:2.7.2:compile
[INFO]    \- commons-configuration:commons-configuration:jar:1.6:compile
[INFO]       +- commons-digester:commons-digester:jar:1.8:compile
[INFO]       |  \- commons-beanutils:commons-beanutils:jar:1.9.3:compile
[INFO]       \- commons-beanutils:commons-beanutils-core:jar:1.8.0:compile
```

2.) I executed `mvn clean install` in `utility` and in `ambari-server`:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 40:01 min
[INFO] Finished at: 2018-02-22T17:51:54+01:00
[INFO] Final Memory: 186M/1678M
[INFO] ------------------------------------------------------------------------
```

3.) In addition to this; I replaced the content of `usr/lib/ambari-server` in my vagrant host with the content from `mbari-server/target/ambari-server-2.6.0.0.0-dist/usr/lib/ambari-server` (where I found `commons-beanutils-1.9.3.jar`) and restarted the server then logged in; there were no any issues.