### PR TITLE
[AMBARI-23053] Rename NON-ROLLING to EXPRESS

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/constants.py
+++ b/ambari-common/src/main/python/ambari_commons/constants.py
@@ -21,7 +21,7 @@ limitations under the License.
 AMBARI_SUDO_BINARY = "ambari-sudo.sh"
 
 UPGRADE_TYPE_ROLLING = "rolling"
-UPGRADE_TYPE_NON_ROLLING = "nonrolling"
+UPGRADE_TYPE_EXPRESS = "express"
 UPGRADE_TYPE_HOST_ORDERED = "host_ordered"
 
 

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -32,7 +32,7 @@ import time
 from optparse import OptionParser
 import resource_management
 from ambari_commons import OSCheck, OSConst
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS
 from ambari_commons.constants import UPGRADE_TYPE_ROLLING
 from ambari_commons.constants import UPGRADE_TYPE_HOST_ORDERED
 from ambari_commons.network import reconfigure_urllib2_opener
@@ -1130,8 +1130,8 @@ class Script(object):
     upgrade_type = None
     if upgrade_type_command_param.lower() == "rolling_upgrade":
       upgrade_type = UPGRADE_TYPE_ROLLING
-    elif upgrade_type_command_param.lower() == "nonrolling_upgrade":
-      upgrade_type = UPGRADE_TYPE_NON_ROLLING
+    elif upgrade_type_command_param.lower() == "express_upgrade":
+      upgrade_type = UPGRADE_TYPE_EXPRESS
     elif upgrade_type_command_param.lower() == "host_ordered_upgrade":
       upgrade_type = UPGRADE_TYPE_HOST_ORDERED
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/AutoStartDisabledCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/AutoStartDisabledCheck.java
@@ -36,7 +36,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     group = UpgradeCheckGroup.CONFIGURATION_WARNING,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class AutoStartDisabledCheck extends AbstractCheckDescriptor {
 
   static final String CLUSTER_ENV_TYPE = "cluster-env";

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ClientRetryPropertyCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ClientRetryPropertyCheck.java
@@ -41,7 +41,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     group = UpgradeCheckGroup.CLIENT_RETRY_PROPERTY,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ClientRetryPropertyCheck extends AbstractCheckDescriptor {
 
   static final String HDFS_CLIENT_RETRY_DISABLED_KEY = "hdfs.client.retry.enabled.key";

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ComponentsExistInRepoCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ComponentsExistInRepoCheck.java
@@ -48,7 +48,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     group = UpgradeCheckGroup.TOPOLOGY,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ComponentsExistInRepoCheck extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ComponentsInstallationCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ComponentsInstallationCheck.java
@@ -47,7 +47,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.LIVELINESS,
     order = 2.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ComponentsInstallationCheck extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ConfigurationMergeCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ConfigurationMergeCheck.java
@@ -41,7 +41,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     order = 99.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ConfigurationMergeCheck extends AbstractCheckDescriptor {
 
   @Inject

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HardcodedStackVersionPropertiesCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HardcodedStackVersionPropertiesCheck.java
@@ -46,7 +46,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     order = 98.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class HardcodedStackVersionPropertiesCheck extends AbstractCheckDescriptor {
 
   public HardcodedStackVersionPropertiesCheck() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HealthCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HealthCheck.java
@@ -49,7 +49,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     group = UpgradeCheckGroup.DEFAULT,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class HealthCheck extends AbstractCheckDescriptor {
 
   private static final List<AlertState> ALERT_STATES = asList(WARNING, CRITICAL);

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HiveDynamicServiceDiscoveryCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HiveDynamicServiceDiscoveryCheck.java
@@ -44,7 +44,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.DEFAULT,
     order = 20.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS })
 public class HiveDynamicServiceDiscoveryCheck extends AbstractCheckDescriptor {
 
   static final String HIVE_DYNAMIC_SERVICE_DISCOVERY_ENABLED_KEY = "hive.dynamic-service.discovery.enabled.key";

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HostMaintenanceModeCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HostMaintenanceModeCheck.java
@@ -43,7 +43,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.MAINTENANCE_MODE,
     order = 7.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class HostMaintenanceModeCheck extends AbstractCheckDescriptor {
 
   public static final String KEY_CANNOT_START_HOST_ORDERED = "cannot_upgrade_mm_hosts";

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsHeartbeatCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsHeartbeatCheck.java
@@ -45,7 +45,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.LIVELINESS,
     order = 1.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class HostsHeartbeatCheck extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheck.java
@@ -45,7 +45,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.MAINTENANCE_MODE,
     order = 5.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class HostsMasterMaintenanceCheck extends AbstractCheckDescriptor {
 
   static final String KEY_NO_UPGRADE_NAME = "no_upgrade_name";

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheck.java
@@ -45,7 +45,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     group = UpgradeCheckGroup.REPOSITORY_VERSION,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class HostsRepositoryVersionCheck extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/InstallPackagesCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/InstallPackagesCheck.java
@@ -45,7 +45,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.DEFAULT,
     order = 3.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class InstallPackagesCheck extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/PreviousUpgradeCompleted.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/PreviousUpgradeCompleted.java
@@ -40,7 +40,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.DEFAULT,
     order = 4.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class PreviousUpgradeCompleted extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/RangerPasswordCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/RangerPasswordCheck.java
@@ -53,7 +53,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.CONFIGURATION_WARNING,
     order = 23.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class RangerPasswordCheck extends AbstractCheckDescriptor {
 
   private static final Logger LOG = LoggerFactory.getLogger(RangerPasswordCheck.class);

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheck.java
@@ -45,7 +45,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.REPOSITORY_VERSION,
     order = 1.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED },
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED },
     orchestration = { RepositoryType.PATCH, RepositoryType.MAINT, RepositoryType.SERVICE })
 public class RequiredServicesInRepositoryCheck extends AbstractCheckDescriptor {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServiceCheckValidityCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServiceCheckValidityCheck.java
@@ -57,7 +57,7 @@ import com.google.inject.Singleton;
 @Singleton
 @UpgradeCheck(
     group = UpgradeCheckGroup.DEFAULT,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ServiceCheckValidityCheck extends AbstractCheckDescriptor {
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceCheckValidityCheck.class);

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheck.java
@@ -37,7 +37,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.MAINTENANCE_MODE,
     order = 6.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ServicesMaintenanceModeCheck extends AbstractCheckDescriptor {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesUpCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesUpCheck.java
@@ -67,7 +67,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.LIVELINESS,
     order = 2.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class ServicesUpCheck extends AbstractCheckDescriptor {
 
   private static final float SLAVE_THRESHOLD = 0.5f;

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/VersionMismatchCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/VersionMismatchCheck.java
@@ -43,7 +43,7 @@ import com.google.inject.Singleton;
 @UpgradeCheck(
     group = UpgradeCheckGroup.COMPONENT_VERSION,
     order = 7.0f,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+    required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
 public class VersionMismatchCheck extends AbstractCheckDescriptor {
 
   public VersionMismatchCheck() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -720,7 +720,7 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
 
     // Non Rolling Upgrades require a group with name "UPDATE_DESIRED_REPOSITORY_ID".
     // This is needed as a marker to indicate which version to use when an upgrade is paused.
-    if (pack.getType() == UpgradeType.NON_ROLLING) {
+    if (pack.getType() == UpgradeType.EXPRESS) {
       boolean foundUpdateDesiredRepositoryIdGrouping = false;
       for (UpgradeGroupHolder group : groups) {
         if (group.groupClass == UpdateStackGrouping.class) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/UpdateDesiredRepositoryAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/UpdateDesiredRepositoryAction.java
@@ -47,7 +47,7 @@ import com.google.inject.persist.Transactional;
 
 /**
  * Action that represents updating the Desired Stack Id during the middle of a stack upgrade (typically NonRolling).
- * In a {@link org.apache.ambari.server.state.stack.upgrade.UpgradeType#NON_ROLLING}, the effective Stack Id is
+ * In a {@link org.apache.ambari.server.state.stack.upgrade.UpgradeType#EXPRESS}, the effective Stack Id is
  * actually changed half-way through calculating the Actions, and this serves to update the database to make it
  * evident to the user at which point it changed.
  */

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -1069,7 +1069,7 @@ public class UpgradeContext {
       case HOST_ORDERED:
         upgradeTypeValidator = new HostOrderedUpgradeValidator();
         break;
-      case NON_ROLLING:
+      case EXPRESS:
       case ROLLING:
       default:
         upgradeTypeValidator = null;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -338,7 +338,7 @@ public class UpgradeHelper {
 
       // NonRolling defaults to not performing service checks on a group.
       // Of course, a Service Check Group does indeed run them.
-      if (upgradePack.getType() == UpgradeType.NON_ROLLING) {
+      if (upgradePack.getType() == UpgradeType.EXPRESS) {
         group.performServiceCheck = false;
       }
 
@@ -449,7 +449,7 @@ public class UpgradeHelper {
                       StringUtils.join(hostsType.getHosts(), ','), hostsType.getMasters(), hostsType.getSecondaries());
                 }
                 break;
-              case NON_ROLLING:
+              case EXPRESS:
                 boolean isNameNodeHA = mhr.isNameNodeHA();
                 if (isNameNodeHA && hostsType.hasMastersAndSecondaries()) {
                   // This could be any order, but the NameNodes have to know what role they are going to take.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
@@ -318,7 +318,7 @@ public class UpgradePack {
       list = groups;
     } else {
       switch (this.type) {
-        case NON_ROLLING:
+        case EXPRESS:
           list = getDowngradeGroupsForNonrolling(groups);
           break;
         case HOST_ORDERED:

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/UpdateStackGrouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/UpdateStackGrouping.java
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Used to represent operations that update the Stack.
- * This is primarily needed during a {@link UpgradeType#NON_ROLLING} upgrade.
+ * This is primarily needed during a {@link UpgradeType#EXPRESS} upgrade.
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/UpgradeType.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/UpgradeType.java
@@ -28,21 +28,21 @@ public enum UpgradeType {
   /**
    * Services are up the entire time
    */
-  @XmlEnumValue("ROLLING")
+  @XmlEnumValue("rolling")
   @SerializedName("rolling_upgrade")
   ROLLING,
 
   /**
    * All services are stopped, then started
    */
-  @XmlEnumValue("NON_ROLLING")
-  @SerializedName("nonrolling_upgrade")
-  NON_ROLLING,
+  @XmlEnumValue("express")
+  @SerializedName("express_upgrade")
+  EXPRESS,
 
   /**
    * Host-ordered upgrade.
    */
-  @XmlEnumValue("HOST_ORDERED")
+  @XmlEnumValue("host_ordered")
   @SerializedName("host_ordered_upgrade")
   HOST_ORDERED;
 }

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/hdfs_namenode.py
@@ -143,7 +143,7 @@ def namenode(action=None, hdfs_binary=None, do_format=True, upgrade_type=None,
         options = "-rollingUpgrade started"
       elif params.upgrade_direction == Direction.DOWNGRADE:
         options = "-rollingUpgrade downgrade"
-    elif upgrade_type == constants.UPGRADE_TYPE_NON_ROLLING:
+    elif upgrade_type == constants.UPGRADE_TYPE_EXPRESS:
       is_previous_image_dir = is_previous_fs_image()
       Logger.info("Previous file system image dir present is {0}".format(str(is_previous_image_dir)))
 
@@ -209,7 +209,7 @@ def namenode(action=None, hdfs_binary=None, do_format=True, upgrade_type=None,
 
     # During an Express Upgrade, NameNode will not leave SafeMode until the DataNodes are started,
     # so always disable the Safemode check
-    if upgrade_type == constants.UPGRADE_TYPE_NON_ROLLING:
+    if upgrade_type == constants.UPGRADE_TYPE_EXPRESS:
       ensure_safemode_off = False
 
     # some informative logging separate from the above logic to keep things a little cleaner

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/journalnode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/journalnode.py
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS
 
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions import stack_select
@@ -64,7 +64,7 @@ class JournalNodeDefault(JournalNode):
 
   def post_upgrade_restart(self, env, upgrade_type=None):
     # express upgrade cannot determine if the JN quorum is established
-    if upgrade_type == UPGRADE_TYPE_NON_ROLLING:
+    if upgrade_type == UPGRADE_TYPE_EXPRESS:
       return
 
     Logger.info("Executing Stack Upgrade post-restart")

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -117,7 +117,7 @@ class NameNode(Script):
 
     # after starting NN in an upgrade, touch the marker file - but only do this for certain
     # upgrade types - not all upgrades actually tell NN about the upgrade (like HOU)
-    if upgrade_type in (constants.UPGRADE_TYPE_ROLLING, constants.UPGRADE_TYPE_NON_ROLLING):
+    if upgrade_type in (constants.UPGRADE_TYPE_ROLLING, constants.UPGRADE_TYPE_EXPRESS):
       # place a file on the system indicating that we've submitting the command that
       # instructs NN that it is now part of an upgrade
       namenode_upgrade.create_upgrade_marker()
@@ -200,7 +200,7 @@ class NameNodeDefault(NameNode):
 
   def finalize_non_rolling_upgrade(self, env):
     hfds_binary = self.get_hdfs_binary()
-    namenode_upgrade.finalize_upgrade(constants.UPGRADE_TYPE_NON_ROLLING, hfds_binary)
+    namenode_upgrade.finalize_upgrade(constants.UPGRADE_TYPE_EXPRESS, hfds_binary)
 
   def finalize_rolling_upgrade(self, env):
     hfds_binary = self.get_hdfs_binary()

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka_broker.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka_broker.py
@@ -1,4 +1,4 @@
-"""
+  """
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie.py
@@ -43,7 +43,7 @@ from resource_management.core.shell import as_user, as_sudo, call, checked_call
 from resource_management.core.exceptions import Fail
 
 from resource_management.libraries.functions.setup_atlas_hook import has_atlas_in_cluster, setup_atlas_hook
-from ambari_commons.constants import SERVICE, UPGRADE_TYPE_NON_ROLLING, UPGRADE_TYPE_ROLLING
+from ambari_commons.constants import SERVICE, UPGRADE_TYPE_EXPRESS, UPGRADE_TYPE_ROLLING
 from resource_management.libraries.functions.constants import Direction
 
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
@@ -397,7 +397,7 @@ def copy_atlas_hive_hook_to_dfs_share_lib(upgrade_type=None, upgrade_direction=N
   then copy the entire contents of that directory to the Oozie Sharelib in DFS, e.g.,
   /usr/$stack/$current_version/atlas/hook/hive/ -> hdfs:///user/oozie/share/lib/lib_$timetamp/hive
 
-  :param upgrade_type: If in the middle of a stack upgrade, the type as UPGRADE_TYPE_ROLLING or UPGRADE_TYPE_NON_ROLLING
+  :param upgrade_type: If in the middle of a stack upgrade, the type as UPGRADE_TYPE_ROLLING or UPGRADE_TYPE_EXPRESS
   :param upgrade_direction: If in the middle of a stack upgrade, the direction as Direction.UPGRADE or Direction.DOWNGRADE.
   """
   import params

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_server.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_server.py
@@ -34,7 +34,7 @@ from resource_management.libraries.functions.security_commons import FILE_TYPE_X
 
 from ambari_commons import OSConst
 from ambari_commons.os_family_impl import OsFamilyImpl
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING, UPGRADE_TYPE_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS, UPGRADE_TYPE_ROLLING
 
 from oozie import oozie
 from oozie_service import oozie_service

--- a/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/ranger_admin.py
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/ranger_admin.py
@@ -29,7 +29,7 @@ from resource_management.core.logger import Logger
 from resource_management.core import shell
 from ranger_service import ranger_service
 from resource_management.libraries.functions import solr_cloud_util
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS
 from resource_management.libraries.functions.constants import Direction
 
 import setup_ranger_xml
@@ -58,7 +58,7 @@ class RangerAdmin(Script):
     import params
     env.set_params(params)
 
-    if upgrade_type == UPGRADE_TYPE_NON_ROLLING and params.upgrade_direction == Direction.UPGRADE:
+    if upgrade_type == UPGRADE_TYPE_EXPRESS and params.upgrade_direction == Direction.UPGRADE:
       if params.stack_supports_rolling_upgrade and not params.stack_supports_config_versioning and os.path.isfile(format('{ranger_home}/ews/stop-ranger-admin.sh')):
         File(format('{ranger_home}/ews/stop-ranger-admin.sh'),
           owner=params.unix_user,

--- a/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/ranger_usersync.py
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/ranger_usersync.py
@@ -26,7 +26,7 @@ from resource_management.libraries.functions import stack_select
 from resource_management.core.logger import Logger
 from resource_management.core import shell
 from ranger_service import ranger_service
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING, UPGRADE_TYPE_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS, UPGRADE_TYPE_ROLLING
 from resource_management.libraries.functions.constants import Direction
 import os
 
@@ -71,7 +71,7 @@ class RangerUsersync(Script):
     import params
     env.set_params(params)
 
-    if upgrade_type == UPGRADE_TYPE_NON_ROLLING and params.upgrade_direction == Direction.UPGRADE:
+    if upgrade_type == UPGRADE_TYPE_EXPRESS and params.upgrade_direction == Direction.UPGRADE:
       if params.stack_supports_usersync_non_root and os.path.isfile(params.usersync_services_file):
         File(params.usersync_services_file,
           mode = 0755

--- a/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/setup_ranger_xml.py
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/setup_ranger_xml.py
@@ -34,7 +34,7 @@ from resource_management.libraries.functions.is_empty import is_empty
 from resource_management.core.utils import PasswordString
 from resource_management.core.shell import as_sudo
 from resource_management.libraries.functions import solr_cloud_util
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING, UPGRADE_TYPE_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS, UPGRADE_TYPE_ROLLING
 from resource_management.core.exceptions import ExecutionFailed
 
 # This file contains functions used for setup/configure of Ranger Admin and Ranger Usersync.

--- a/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/package/scripts/kms_service.py
+++ b/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/package/scripts/kms_service.py
@@ -24,7 +24,7 @@ from resource_management.libraries.functions.format import format
 from resource_management.core.exceptions import ComponentIsNotRunning
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.show_logs import show_logs
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING, UPGRADE_TYPE_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS, UPGRADE_TYPE_ROLLING
 from resource_management.libraries.functions.constants import Direction
 import os
 
@@ -44,7 +44,7 @@ def kms_service(action='start', upgrade_type=None):
       show_logs(params.kms_log_dir, params.kms_user)
       raise
   elif action == 'stop':
-    if upgrade_type == UPGRADE_TYPE_NON_ROLLING and params.upgrade_direction == Direction.UPGRADE:
+    if upgrade_type == UPGRADE_TYPE_EXPRESS and params.upgrade_direction == Direction.UPGRADE:
       if os.path.isfile(format('{kms_home}/ranger-kms')):
         File(format('{kms_home}/ranger-kms'),
           owner=params.kms_user,

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/setup_spark.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/setup_spark.py
@@ -35,7 +35,7 @@ def setup_spark(env, type, upgrade_type=None, action=None, config_dir=None):
   """
   :param env: Python environment
   :param type: Spark component type
-  :param upgrade_type: If in a stack upgrade, either UPGRADE_TYPE_ROLLING or UPGRADE_TYPE_NON_ROLLING
+  :param upgrade_type: If in a stack upgrade, either UPGRADE_TYPE_ROLLING or UPGRADE_TYPE_EXPRESS
   :param action: Action to perform, such as generate configs
   :param config_dir: Optional config directory to write configs to.
   """

--- a/ambari-server/src/main/resources/common-services/ZOOKEEPER/3.4.5/package/scripts/zookeeper_server.py
+++ b/ambari-server/src/main/resources/common-services/ZOOKEEPER/3.4.5/package/scripts/zookeeper_server.py
@@ -20,7 +20,7 @@ Ambari Agent
 """
 import random
 
-from ambari_commons.constants import UPGRADE_TYPE_NON_ROLLING
+from ambari_commons.constants import UPGRADE_TYPE_EXPRESS
 
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions import get_unique_id_and_date
@@ -77,7 +77,7 @@ class ZookeeperServerLinux(ZookeeperServer):
 
   def post_upgrade_restart(self, env, upgrade_type=None):
     # during an express upgrade, there is no quorum, so don't try to perform the check
-    if upgrade_type == UPGRADE_TYPE_NON_ROLLING:
+    if upgrade_type == UPGRADE_TYPE_EXPRESS:
       return
 
     Logger.info("Executing Stack Upgrade post-restart")

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -39,9 +39,9 @@
   <!-- FIXME case sensitivity -->
   <xs:simpleType name="upgrade-kind-type">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="ROLLING" />
-      <xs:enumeration value="NON_ROLLING" />
-      <xs:enumeration value="HOST_ORDERED" />
+      <xs:enumeration value="rolling" />
+      <xs:enumeration value="express" />
+      <xs:enumeration value="host_ordered" />
     </xs:restriction>
   </xs:simpleType>
   

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AbstractCheckDescriptorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AbstractCheckDescriptorTest.java
@@ -207,23 +207,23 @@ public class AbstractCheckDescriptorTest extends EasyMockSupport {
   public void testRequired() throws Exception {
     RollingTestCheckImpl rollingCheck = new RollingTestCheckImpl(PrereqCheckType.SERVICE);
     Assert.assertTrue(rollingCheck.isRequired(UpgradeType.ROLLING));
-    Assert.assertFalse(rollingCheck.isRequired(UpgradeType.NON_ROLLING));
+    Assert.assertFalse(rollingCheck.isRequired(UpgradeType.EXPRESS));
 
     NotRequiredCheckTest notRequiredCheck = new NotRequiredCheckTest(PrereqCheckType.SERVICE);
     Assert.assertFalse(notRequiredCheck.isRequired(UpgradeType.ROLLING));
-    Assert.assertFalse(notRequiredCheck.isRequired(UpgradeType.NON_ROLLING));
+    Assert.assertFalse(notRequiredCheck.isRequired(UpgradeType.EXPRESS));
     Assert.assertFalse(notRequiredCheck.isRequired(UpgradeType.HOST_ORDERED));
 
     TestCheckImpl requiredCheck = new TestCheckImpl(PrereqCheckType.SERVICE);
     Assert.assertTrue(requiredCheck.isRequired(UpgradeType.ROLLING));
-    Assert.assertTrue(requiredCheck.isRequired(UpgradeType.NON_ROLLING));
+    Assert.assertTrue(requiredCheck.isRequired(UpgradeType.EXPRESS));
     Assert.assertTrue(requiredCheck.isRequired(UpgradeType.HOST_ORDERED));
   }
 
   @UpgradeCheck(
       group = UpgradeCheckGroup.DEFAULT,
       order = 1.0f,
-      required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+      required = { UpgradeType.ROLLING, UpgradeType.EXPRESS, UpgradeType.HOST_ORDERED })
   private class TestCheckImpl extends AbstractCheckDescriptor {
     private PrereqCheckType m_type;
     private Set<String> m_applicableServices = Sets.newHashSet();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompatibleRepositoryVersionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompatibleRepositoryVersionResourceProviderTest.java
@@ -161,7 +161,7 @@ public class CompatibleRepositoryVersionResourceProviderTest {
 
           @Override
           public UpgradeType getType() {
-            return UpgradeType.NON_ROLLING;
+            return UpgradeType.EXPRESS;
           }
         };
 
@@ -212,7 +212,7 @@ public class CompatibleRepositoryVersionResourceProviderTest {
 
           @Override
           public UpgradeType getType() {
-            return UpgradeType.NON_ROLLING;
+            return UpgradeType.EXPRESS;
           }
         };
 
@@ -300,7 +300,7 @@ public class CompatibleRepositoryVersionResourceProviderTest {
     // Test For Upgrade Types
     Map<String, List<UpgradeType>> versionToUpgradeTypesMap = new HashMap<>();
     versionToUpgradeTypesMap.put("1.1", Arrays.asList(UpgradeType.ROLLING));
-    versionToUpgradeTypesMap.put("2.2", Arrays.asList(UpgradeType.NON_ROLLING, UpgradeType.ROLLING));
+    versionToUpgradeTypesMap.put("2.2", Arrays.asList(UpgradeType.EXPRESS, UpgradeType.ROLLING));
     assertEquals(versionToUpgradeTypesMap.size(), checkUpgradeTypes(resources, versionToUpgradeTypesMap));
 
     // !!! verify we can get services
@@ -382,7 +382,7 @@ public class CompatibleRepositoryVersionResourceProviderTest {
     // Test For Upgrade Types
     Map<String, List<UpgradeType>> versionToUpgradeTypesMap = new HashMap<>();
     versionToUpgradeTypesMap.put("1.1", Arrays.asList(UpgradeType.ROLLING));
-    versionToUpgradeTypesMap.put("2.2", Arrays.asList(UpgradeType.NON_ROLLING, UpgradeType.ROLLING));
+    versionToUpgradeTypesMap.put("2.2", Arrays.asList(UpgradeType.EXPRESS, UpgradeType.ROLLING));
     assertEquals(versionToUpgradeTypesMap.size(), checkUpgradeTypes(resources, versionToUpgradeTypesMap));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -123,7 +123,7 @@ public class PreUpgradeCheckResourceProviderTest {
 
     expect(repoDao.findByPK(1L)).andReturn(repo).anyTimes();
     expect(repo.getStackId()).andReturn(targetStackId).atLeastOnce();
-    expect(upgradeHelper.suggestUpgradePack("Cluster100", currentStackId, targetStackId, Direction.UPGRADE, UpgradeType.NON_ROLLING, "upgrade_pack11")).andReturn(upgradePack);
+    expect(upgradeHelper.suggestUpgradePack("Cluster100", currentStackId, targetStackId, Direction.UPGRADE, UpgradeType.EXPRESS, "upgrade_pack11")).andReturn(upgradePack);
 
     List<AbstractCheckDescriptor> upgradeChecksToRun = new LinkedList<>();
     List<String> prerequisiteChecks = new LinkedList<>();
@@ -146,7 +146,7 @@ public class PreUpgradeCheckResourceProviderTest {
     PredicateBuilder builder = new PredicateBuilder();
     Predicate predicate = builder.property(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
         .property(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_UPGRADE_PACK_PROPERTY_ID).equals("upgrade_pack11").and()
-        .property(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_UPGRADE_TYPE_PROPERTY_ID).equals(UpgradeType.NON_ROLLING).and()
+        .property(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_UPGRADE_TYPE_PROPERTY_ID).equals(UpgradeType.EXPRESS).and()
         .property(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_TARGET_REPOSITORY_VERSION_ID_ID).equals("1").toPredicate();
 
 
@@ -174,7 +174,7 @@ public class PreUpgradeCheckResourceProviderTest {
       String clusterName = (String) resource.getPropertyValue(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_CLUSTER_NAME_PROPERTY_ID);
       Assert.assertEquals("Cluster100", clusterName);
       UpgradeType upgradeType = (UpgradeType) resource.getPropertyValue(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_UPGRADE_TYPE_PROPERTY_ID);
-      Assert.assertEquals(UpgradeType.NON_ROLLING, upgradeType);
+      Assert.assertEquals(UpgradeType.EXPRESS, upgradeType);
     }
 
     // verify

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
@@ -211,7 +211,7 @@ public class ComponentVersionCheckActionTest {
     upgradeEntity.setRequestEntity(requestEntity);
     upgradeEntity.setUpgradePackage("");
     upgradeEntity.setRepositoryVersion(toRepositoryVersion);
-    upgradeEntity.setUpgradeType(UpgradeType.NON_ROLLING);
+    upgradeEntity.setUpgradeType(UpgradeType.EXPRESS);
     upgradeDAO.create(upgradeEntity);
 
     c.setUpgradeEntity(upgradeEntity);
@@ -276,7 +276,7 @@ public class ComponentVersionCheckActionTest {
     upgradeEntity.setRequestEntity(requestEntity);
     upgradeEntity.setUpgradePackage("");
     upgradeEntity.setRepositoryVersion(toRepositoryVersion);
-    upgradeEntity.setUpgradeType(UpgradeType.NON_ROLLING);
+    upgradeEntity.setUpgradeType(UpgradeType.EXPRESS);
     upgradeDAO.create(upgradeEntity);
 
     c.setUpgradeEntity(upgradeEntity);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
@@ -312,7 +312,7 @@ public class CreateAndConfigureActionTest {
     upgradeEntity.setRequestEntity(requestEntity);
     upgradeEntity.setUpgradePackage("");
     upgradeEntity.setRepositoryVersion(repositoryVersion);
-    upgradeEntity.setUpgradeType(UpgradeType.NON_ROLLING);
+    upgradeEntity.setUpgradeType(UpgradeType.EXPRESS);
 
     Map<String, Service> services = cluster.getServices();
     for (String serviceName : services.keySet()) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeContextTest.java
@@ -236,7 +236,7 @@ public class UpgradeContextTest extends EasyMockSupport {
     replayAll();
 
     Map<String, Object> requestMap = new HashMap<>();
-    requestMap.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.NON_ROLLING.name());
+    requestMap.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.EXPRESS.name());
     requestMap.put(UpgradeResourceProvider.UPGRADE_DIRECTION, Direction.UPGRADE.name());
     requestMap.put(UpgradeResourceProvider.UPGRADE_REPO_VERSION_ID, m_targetRepositoryVersion.getId().toString());
     requestMap.put(UpgradeResourceProvider.UPGRADE_SKIP_PREREQUISITE_CHECKS, "true");
@@ -284,7 +284,7 @@ public class UpgradeContextTest extends EasyMockSupport {
     replayAll();
 
     Map<String, Object> requestMap = new HashMap<>();
-    requestMap.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.NON_ROLLING.name());
+    requestMap.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.EXPRESS.name());
     requestMap.put(UpgradeResourceProvider.UPGRADE_DIRECTION, Direction.UPGRADE.name());
     requestMap.put(UpgradeResourceProvider.UPGRADE_REPO_VERSION_ID, m_targetRepositoryVersion.getId().toString());
     requestMap.put(UpgradeResourceProvider.UPGRADE_SKIP_PREREQUISITE_CHECKS, "true");
@@ -354,7 +354,7 @@ public class UpgradeContextTest extends EasyMockSupport {
       EasyMock.anyObject(UpgradeType.class), EasyMock.anyString())).andReturn(upgradePack).once();
 
     expect(m_upgradeDAO.findRevertable(1L)).andReturn(m_completedRevertableUpgrade).once();
-    expect(m_completedRevertableUpgrade.getUpgradeType()).andReturn(UpgradeType.NON_ROLLING);
+    expect(m_completedRevertableUpgrade.getUpgradeType()).andReturn(UpgradeType.EXPRESS);
 
     Map<String, Object> requestMap = new HashMap<>();
     requestMap.put(UpgradeResourceProvider.UPGRADE_REVERT_UPGRADE_ID, "1");
@@ -366,7 +366,7 @@ public class UpgradeContextTest extends EasyMockSupport {
 
     assertEquals(Direction.DOWNGRADE, context.getDirection());
     assertEquals(RepositoryType.PATCH, context.getOrchestrationType());
-    assertEquals(UpgradeType.NON_ROLLING, context.getType());
+    assertEquals(UpgradeType.EXPRESS, context.getType());
     assertEquals(1, context.getSupportedServices().size());
     assertTrue(context.isPatchRevert());
 
@@ -486,7 +486,7 @@ public class UpgradeContextTest extends EasyMockSupport {
 
 
     Map<String, Object> requestMap = new HashMap<>();
-    requestMap.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.NON_ROLLING.name());
+    requestMap.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.EXPRESS.name());
     requestMap.put(UpgradeResourceProvider.UPGRADE_DIRECTION, Direction.DOWNGRADE.name());
 
     replayAll();

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/stack/UpgradePackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/stack/UpgradePackTest.java
@@ -30,6 +30,7 @@ import org.apache.ambari.server.stack.ModuleFileUnmarshaller;
 import org.apache.ambari.server.state.stack.upgrade.Grouping;
 import org.apache.ambari.server.state.stack.upgrade.Lifecycle;
 import org.apache.ambari.server.state.stack.upgrade.Lifecycle.LifecycleType;
+import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.junit.Test;
 
 /**
@@ -55,6 +56,7 @@ public class UpgradePackTest {
 
     UpgradePack upgradepack = unmarshaller.unmarshal(UpgradePack.class, f, true);
 
+    assertEquals(UpgradeType.ROLLING, upgradepack.getType());
     assertEquals(6, upgradepack.lifecycles.size());
 
     Optional<Lifecycle> upgradeLifecycle = upgradepack.lifecycles.stream()

--- a/ambari-server/src/test/python/stacks/2.1/HIVE/test_hive_metastore.py
+++ b/ambari-server/src/test/python/stacks/2.1/HIVE/test_hive_metastore.py
@@ -553,7 +553,7 @@ class TestHiveMetastore(RMFTestCase):
         }
       },
       "direction":"UPGRADE",
-      "type":"nonrolling_upgrade",
+      "type":"express_upgrade",
       "isRevert":False,
       "orchestration":"STANDARD"
     }

--- a/ambari-server/src/test/python/stacks/2.2/KNOX/test_knox_gateway.py
+++ b/ambari-server/src/test/python/stacks/2.2/KNOX/test_knox_gateway.py
@@ -225,7 +225,7 @@ class TestKnoxGateway(RMFTestCase):
         }
       },
       "direction":"UPGRADE",
-      "type":"nonrolling_upgrade",
+      "type":"express_upgrade",
       "isRevert":False,
       "orchestration":"STANDARD"
     }

--- a/ambari-server/src/test/resources/mpacks-v2/upgrade-packs/upgrade-basic.xml
+++ b/ambari-server/src/test/resources/mpacks-v2/upgrade-packs/upgrade-basic.xml
@@ -21,7 +21,7 @@
   <target-stack>HDP-2.6</target-stack>
   <skip-failures>false</skip-failures>
   <skip-service-check-failures>false</skip-service-check-failures>
-  <type>ROLLING</type>
+  <type>rolling</type>
   <prerequisite-checks>
     <!-- List of additional pre-req checks to run in addition to the required pre-reqs -->
     <check>org.apache.ambari.server.checks.HiveMultipleMetastoreCheck</check>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The term "non-rolling" was coined before we used "Express". The enum should be called EXPRESS.

I also changed the XSD to be more consistent since we had a mix of enums that were all uppercase or all lowercase.  I'll do others as I get to those parts of the Upgrade Pack

## How was this patch tested?

Unit tests.  No new tests are broken:

```
[ERROR] Tests run: 5029, Failures: 25, Errors: 19, Skipped: 37
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31:28 min
[INFO] Finished at: 2018-02-22T12:05:52-05:00
[INFO] Final Memory: 102M/1913M
[INFO] ------------------------------------------------------------------------
```