### PR TITLE
[AMBARI-23064] Upgrading jackson-databind (plus jackson-annotations and jackson-core) to 2.9.4 due to security concerns

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -32,6 +32,7 @@
     <jetty.version>8.1.19.v20160209</jetty.version>
     <checkstyle.version>6.19</checkstyle.version> <!-- last version that does not require Java 8 -->
     <checkstyle.skip>false</checkstyle.skip>
+    <fasterxml.jackson.version>2.9.4</fasterxml.jackson.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -XX:MaxPermSize=512m -Xms512m</surefire.argLine>
@@ -486,6 +487,16 @@
         <groupId>com.puppycrawl.tools</groupId>
         <artifactId>checkstyle</artifactId>
         <version>${checkstyle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${fasterxml.jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${fasterxml.jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1446,7 +1446,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.8.0</version>
+    </dependency>
+   <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
@@ -1539,6 +1542,12 @@
       <artifactId>json-schema-validator</artifactId>
       <version>0.1.10</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per [CVE-2018-5968](https://nvd.nist.gov/vuln/detail/CVE-2018-5968)
`FasterXML jackson-databind through 2.8.11 and 2.9.x through 2.9.3 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 and CVE-2017-17485 deserialization flaws. This is exploitable via two different gadgets that bypass a blacklist.`

## How was this patch tested?
After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.6.1.0.0
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.4:compile
[INFO] \- com.fasterxml.jackson.core:jackson-databind:jar:2.9.4:compile
[INFO]    \- com.fasterxml.jackson.core:jackson-core:jar:2.9.4:compile
```

2.) I executed `mvn clean install` in `utility` and in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 33:54 min
[INFO] Finished at: 2018-02-23T13:56:04+01:00
[INFO] Final Memory: 188M/1638M
[INFO] ------------------------------------------------------------------------
```
3.) In addition to this; I replaced the content of `usr/lib/ambari-server` in my vagrant host with the content from `ambari-server/target/ambari-server-2.6.0.0.0-dist/usr/lib/ambari-server` (where the affected JAR were replaced with version 2.9.4) and restarted the server; logged in and did some actions (in this case I created a cluster); there were no any issues.
