### PR TITLE
[AMBARI-23065] Upgrading org.apache.httpcomponents:httpclient dependecy to v4.5.5 and removing commons-httpclient:commons-httpclient dependency due to security reasons

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -104,6 +104,11 @@
         <version>1.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.5</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-servlet</artifactId>
         <version>3.0</version>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1421,7 +1421,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -1474,6 +1473,12 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-common</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -1504,6 +1509,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-auth</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -1525,6 +1536,14 @@
         <exclusion>
           <groupId>org.mortbay.jetty</groupId>
           <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+         <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per [CVE-2014-3577](https://nvd.nist.gov/vuln/detail/CVE-2014-3577)
>org.apache.http.conn.ssl.AbstractVerifier in Apache HttpComponents HttpClient before 4.3.5 and HttpAsyncClient before 4.0.2 does not properly verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a "CN=" string in a field in the distinguished name (DN) of a certificate, as demonstrated by the "foo,CN=www.apache.org" string in the O field.

Per [CVE-2015-5262](https://nvd.nist.gov/vuln/detail/CVE-2015-5262)
>http/conn/ssl/SSLConnectionSocketFactory.java in Apache HttpComponents HttpClient before 4.3.6 ignores the http.socket.timeout configuration setting during an SSL handshake, which allows remote attackers to cause a denial of service (HTTPS call hang) via unspecified vectors.

So that we need to upgrade to a more recent version (>4.3.6); at the time of this issue is being fixed the latest one is 4.5.5

## How was this patch tested?
After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
ambari-server smolnar$ mvn dependency:tree -Dincludes=*:*httpclient*

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building Ambari Server 2.6.1.0.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.6.1.0.0
[INFO] \- org.apache.httpcomponents:httpclient:jar:4.5.5:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.269 s
[INFO] Finished at: 2018-02-23T15:36:27+01:00
[INFO] Final Memory: 25M/446M
[INFO] ------------------------------------------------------------------------
```

2.) I executed `mvn clean install` in `utility` and in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 36:20 min
[INFO] Finished at: 2018-02-23T16:03:24+01:00
[INFO] Final Memory: 77M/1343M
[INFO] ------------------------------------------------------------------------
```

3.) In addition to this; I replaced the content of `usr/lib/ambari-server` in my vagrant host with the content from `ambari-server/target/ambari-server-2.6.0.0.0-dist/usr/lib/ambari-server` (where the relevant JAR(s) were replaced with version 4.5.5) and restarted the server; logged in and did some actions (in this case I used the REST API to get information about my cluster I created before); there were no any issues.
