### PR TITLE
[AMBARI-22883] NPE in HostResourceDefinition

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/DetachedHostResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/DetachedHostResourceDefinition.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.api.resources;
 
 import org.apache.ambari.server.api.query.render.HostSummaryRenderer;
 import org.apache.ambari.server.api.query.render.Renderer;
+import org.apache.ambari.server.controller.internal.HostResourceProvider;
 import org.apache.ambari.server.controller.spi.Resource;
 
 
@@ -45,7 +46,7 @@ public class DetachedHostResourceDefinition extends BaseResourceDefinition {
 
   @Override
   public Renderer getRenderer(String name) {
-    if (name.equals("summary")) {
+    if (HostResourceProvider.SUMMARY_PROPERTY_ID.equals(name)) {
       return new HostSummaryRenderer();
     }
     return super.getRenderer(name);

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/HostResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/HostResourceDefinition.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.ambari.server.api.query.render.HostSummaryRenderer;
 import org.apache.ambari.server.api.query.render.Renderer;
+import org.apache.ambari.server.controller.internal.HostResourceProvider;
 import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.Resource;
 
@@ -58,7 +59,7 @@ public class HostResourceDefinition extends BaseResourceDefinition {
 
   @Override
   public Renderer getRenderer(String name) {
-    if (name.equals("summary")) {
+    if (HostResourceProvider.SUMMARY_PROPERTY_ID.equals(name)) {
       return new HostSummaryRenderer();
     }
     return super.getRenderer(name);

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/HostResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/HostResourceDefinitionTest.java
@@ -19,10 +19,13 @@
 package org.apache.ambari.server.api.resources;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
+import org.apache.ambari.server.api.query.render.DefaultRenderer;
+import org.apache.ambari.server.api.query.render.HostSummaryRenderer;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.junit.Test;
 
@@ -51,6 +54,13 @@ public class HostResourceDefinitionTest {
     assertTrue(includesType(subResources, Resource.Type.Alert));
     assertTrue(includesType(subResources, Resource.Type.HostStackVersion));
     assertTrue(includesType(subResources, Resource.Type.HostKerberosIdentity));
+  }
+
+  @Test
+  public void getRenderer() {
+    ResourceDefinition resource = new HostResourceDefinition();
+    assertSame(HostSummaryRenderer.class, resource.getRenderer("summary").getClass());
+    assertSame(DefaultRenderer.class, resource.getRenderer(null).getClass());
   }
 
   private boolean includesType(Set<SubResourceDefinition> resources, Resource.Type type) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following errors:

```
$ curl http://$AMBARI_SERVER:8080/api/v1/clusters/TEST/hosts
HTTP/1.1 500 Server Error
$ curl http://$AMBARI_SERVER:8080/api/v1/hosts
HTTP/1.1 500 Server Error
```

The corresponding exceptions in `ambari-server.log`:

```
java.lang.NullPointerException
        at org.apache.ambari.server.api.resources.HostResourceDefinition.getRenderer(HostResourceDefinition.java:61)
        at org.apache.ambari.server.api.services.BaseRequest.parseRenderer(BaseRequest.java:361)
        at org.apache.ambari.server.api.services.BaseRequest.process(BaseRequest.java:142)
        at org.apache.ambari.server.api.services.BaseService.handleRequest(BaseService.java:162)
        at org.apache.ambari.server.api.services.BaseService.handleRequest(BaseService.java:126)
        at org.apache.ambari.server.api.services.HostService.getHosts(HostService.java:139)

java.lang.NullPointerException
        at org.apache.ambari.server.api.resources.DetachedHostResourceDefinition.getRenderer(DetachedHostResourceDefinition.java:48)
        at org.apache.ambari.server.api.services.BaseRequest.parseRenderer(BaseRequest.java:361)
        at org.apache.ambari.server.api.services.BaseRequest.process(BaseRequest.java:142)
        at org.apache.ambari.server.api.services.BaseService.handleRequest(BaseService.java:162)
        at org.apache.ambari.server.api.services.BaseService.handleRequest(BaseService.java:126)
        at org.apache.ambari.server.api.services.HostService.getHosts(HostService.java:139)
```

Apparently `null` renderer name is valid use case:

https://github.com/apache/ambari/blob/396e488c5493e906db1d8d49a1fc08e18cd8d5d7/ambari-server/src/main/java/org/apache/ambari/server/api/resources/BaseResourceDefinition.java#L125-L127

## How was this patch tested?

Tested API requests on live cluster.  Also verified `?format=summary` request to avoid regression.

Added unit test case for `HostResourceDefinition.getRenderer` based on similar test in `ClusterResourceDefinitionTest`.