### PR TITLE
AMBARI-22945. Enhance host components API to support multiple host component instances.

### DIFF
--- a/AMBARI-22945.002.patch
+++ b/AMBARI-22945.002.patch
@@ -1,0 +1,6975 @@
+commit cf2e86cce52b1e8a4d4b4442aa0d94f74efabb12
+Author: Swapan Shridhar <sshridhar@hortonworks.com>
+Date:   Mon Feb 26 22:27:19 2018 -0800
+
+    AMBARI-22945. Enhance host components API to support multiple host component instances.
+
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
+index c870b65..af1cd69 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
+@@ -31,4 +31,13 @@ public class ServiceComponentHostNotFoundException
+         + ", hostName=" + hostName);
+   }
+ 
++  public ServiceComponentHostNotFoundException(String clusterName,
++      String serviceName, Long serviceComponentId, String hostName) {
++    super("ServiceComponentHost not found"
++            + ", clusterName=" + clusterName
++            + ", serviceName=" + serviceName
++            + ", serviceComponentId=" + serviceComponentId
++            + ", hostName=" + hostName);
++  }
++
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentNotFoundException.java b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentNotFoundException.java
+index b570287..edc8942 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentNotFoundException.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentNotFoundException.java
+@@ -32,4 +32,14 @@ public class ServiceComponentNotFoundException
+         + ", serviceComponentName=" + serviceComponentName);
+   }
+ 
++  public ServiceComponentNotFoundException (String clusterName,
++      String serviceName, String serviceType, String serviceGroupName, Long serviceComponentId) {
++    super("ServiceComponent not found"
++            + ", clusterName=" + clusterName
++            + ", serviceGroupName=" + serviceGroupName
++            + ", serviceName=" + serviceName
++            + ", serviceType=" + serviceType
++            + ", serviceComponentId=" + serviceComponentId);
++  }
++
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java b/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
+index a5e9aec..8af09ff 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
+@@ -71,19 +71,19 @@ public class HostComponentService extends BaseService {
+   }
+ 
+   /**
+-   * Handles GET /clusters/{clusterID}/hosts/{hostID}/host_components/{hostComponentID}
++   * Handles GET /clusters/{clusterName}/hosts/{hostID}/host_components/{hostComponentID}
+    * Get a specific host_component.
+    *
+    * @param headers           http headers
+    * @param ui                uri info
+-   * @param hostComponentName host_component id
+-   * @return host_component resource representation
++   * @param hostComponentId   host_component id
++   * @return host_component   resource representation
+    */
+   @GET @ApiIgnore // until documented
+-  @Path("{hostComponentName}")
++  @Path("{hostComponentId}")
+   @Produces("text/plain")
+   public Response getHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
+-                                   @PathParam("hostComponentName") String hostComponentName, @QueryParam("format") String format) {
++                                   @PathParam("hostComponentId") String hostComponentId, @QueryParam("format") String format) {
+ 
+     //todo: needs to be refactored when properly handling exceptions
+     if (m_hostName == null) {
+@@ -93,11 +93,11 @@ public class HostComponentService extends BaseService {
+     }
+ 
+     if (format != null && format.equals("client_config_tar")) {
+-      return createClientConfigResource(body, headers, ui, hostComponentName);
++      return createClientConfigResource(body, headers, ui, hostComponentId);
+     }
+ 
+     return handleRequest(headers, body, ui, Request.Type.GET,
+-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
++        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
+   }
+ 
+   /**
+@@ -144,18 +144,18 @@ public class HostComponentService extends BaseService {
+    * @param body              http body
+    * @param headers           http headers
+    * @param ui                uri info
+-   * @param hostComponentName host_component id
++   * @param hostComponentId   host_component id
+    *
+    * @return host_component resource representation
+    */
+   @POST @ApiIgnore // until documented
+-  @Path("{hostComponentName}")
++  @Path("{hostComponentId}")
+   @Produces("text/plain")
+   public Response createHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
+-                                   @PathParam("hostComponentName") String hostComponentName) {
++                                   @PathParam("hostComponentId") String hostComponentId) {
+ 
+     return handleRequest(headers, body, ui, Request.Type.POST,
+-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
++        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
+   }
+ 
+   /**
+@@ -165,18 +165,18 @@ public class HostComponentService extends BaseService {
+    * @param body              http body
+    * @param headers           http headers
+    * @param ui                uri info
+-   * @param hostComponentName host_component id
++   * @param hostComponentId   host_component id
+    *
+    * @return information regarding updated host_component
+    */
+   @PUT @ApiIgnore // until documented
+-  @Path("{hostComponentName}")
++  @Path("{hostComponentId}")
+   @Produces("text/plain")
+   public Response updateHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
+-                                      @PathParam("hostComponentName") String hostComponentName) {
++                                      @PathParam("hostComponentId") String hostComponentId) {
+ 
+     return handleRequest(headers, body, ui, Request.Type.PUT,
+-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
++        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
+   }
+ 
+   /**
+@@ -203,18 +203,18 @@ public class HostComponentService extends BaseService {
+    *
+    * @param headers           http headers
+    * @param ui                uri info
+-   * @param hostComponentName host_component id
++   * @param hostComponentId   host_component id
+    *
+    * @return host_component resource representation
+    */
+   @DELETE @ApiIgnore // until documented
+-  @Path("{hostComponentName}")
++  @Path("{hostComponentId}")
+   @Produces("text/plain")
+   public Response deleteHostComponent(@Context HttpHeaders headers, @Context UriInfo ui,
+-                                   @PathParam("hostComponentName") String hostComponentName) {
++                                   @PathParam("hostComponentId") String hostComponentId) {
+ 
+     return handleRequest(headers, null, ui, Request.Type.DELETE,
+-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
++        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
+   }
+ 
+   /**
+@@ -235,14 +235,14 @@ public class HostComponentService extends BaseService {
+   }
+ 
+   @GET @ApiIgnore // until documented
+-  @Path("{hostComponentName}/processes")
++  @Path("{hostComponentId}/processes")
+   @Produces("text/plain")
+   public Response getProcesses(@Context HttpHeaders headers, @Context UriInfo ui,
+-      @PathParam("hostComponentName") String hostComponentName) {
++      @PathParam("hostComponentId") String hostComponentId) {
+     Map<Resource.Type,String> mapIds = new HashMap<>();
+     mapIds.put(Resource.Type.Cluster, m_clusterName);
+     mapIds.put(Resource.Type.Host, m_hostName);
+-    mapIds.put(Resource.Type.HostComponent, hostComponentName);
++    mapIds.put(Resource.Type.HostComponent, hostComponentId);
+ 
+     ResourceInstance ri = createResource(Resource.Type.HostComponentProcess, mapIds);
+ 
+@@ -254,25 +254,25 @@ public class HostComponentService extends BaseService {
+    *
+    * @param clusterName       cluster name
+    * @param hostName          host name
+-   * @param hostComponentName host_component name
++   * @param hostComponentId   host_component id
+    *
+    * @return a host resource instance
+    */
+-  ResourceInstance createHostComponentResource(String clusterName, String hostName, String hostComponentName) {
++  ResourceInstance createHostComponentResource(String clusterName, String hostName, String hostComponentId) {
+     Map<Resource.Type,String> mapIds = new HashMap<>();
+     mapIds.put(Resource.Type.Cluster, clusterName);
+     mapIds.put(Resource.Type.Host, hostName);
+-    mapIds.put(Resource.Type.HostComponent, hostComponentName);
++    mapIds.put(Resource.Type.HostComponent, hostComponentId);
+ 
+     return createResource(Resource.Type.HostComponent, mapIds);
+   }
+ 
+   private Response createClientConfigResource(String body, HttpHeaders headers, UriInfo ui,
+-                                              String hostComponentName) {
++                                              String hostComponentId) {
+     Map<Resource.Type,String> mapIds = new HashMap<>();
+     mapIds.put(Resource.Type.Cluster, m_clusterName);
+     mapIds.put(Resource.Type.Host, m_hostName);
+-    mapIds.put(Resource.Type.Component, hostComponentName);
++    mapIds.put(Resource.Type.Component, hostComponentId);
+ 
+     Response response = handleRequest(headers, body, ui, Request.Type.GET,
+             createResource(Resource.Type.ClientConfig, mapIds));
+@@ -284,10 +284,10 @@ public class HostComponentService extends BaseService {
+ 
+     String filePrefixName;
+ 
+-    if (StringUtils.isEmpty(hostComponentName)) {
++    if (StringUtils.isEmpty(hostComponentId)) {
+       filePrefixName = m_hostName + "(" + Resource.InternalType.Host.toString().toUpperCase()+")";
+     } else {
+-      filePrefixName = hostComponentName;
++      filePrefixName = hostComponentId;
+     }
+ 
+     Validate.notNull(filePrefixName, "compressed config file name should not be null");
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+index 9a1bb92..c34bc98 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+@@ -510,6 +510,19 @@ public interface AmbariManagementController {
+   String findService(Cluster cluster, String componentName) throws AmbariException;
+ 
+   /**
++   * Get service name by cluster instance and component id
++   *
++   * @param cluster the cluster instance
++   * @param componentId the component id in Long type
++   *
++   * @return a service name
++   *
++   * @throws  AmbariException if service name is null or empty
++   */
++
++  String findService(Cluster cluster, Long componentId) throws AmbariException;
++
++  /**
+    * Get the clusters for this management controller.
+    *
+    * @return the clusters
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+index 9f5acbf..1b94dd4 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+@@ -624,6 +624,13 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+     for (ServiceComponentHostRequest request : requests) {
+       validateServiceComponentHostRequest(request);
+ 
++      // TODO: Multi_Component_Instance. When we go into multiple component instance mode, we will need make
++      // component_type as manadatory field. As of now, we are just copying component_name into component_type,
++      // if not provided. Further, need to add validation check too.
++      if(StringUtils.isBlank(request.getComponentType())) {
++        request.setComponentType(request.getComponentName());
++      }
++
+       Cluster cluster;
+       try {
+         cluster = clusters.getCluster(request.getClusterName());
+@@ -647,8 +654,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+       }
+ 
+       if (LOG.isDebugEnabled()) {
+-        LOG.debug("Received a createHostComponent request, clusterName={}, serviceGroupName={}, serviceName={}, componentName={}, hostname={}, request={}",
+-          request.getClusterName(), request.getServiceGroupName(), request.getServiceName(), request.getComponentName(), request.getHostname(), request);
++        LOG.debug("Received a createHostComponent request, clusterName={}, serviceGroupName={}, serviceName={}, " +
++                  "componentName={}, componentType={}, hostname={}, request={}", request.getClusterName(),
++                  request.getServiceGroupName(), request.getServiceName(), request.getComponentName(),
++                  request.getComponentType(), request.getHostname(), request);
+       }
+ 
+       if (!hostComponentNames.containsKey(request.getClusterName())) {
+@@ -1254,7 +1263,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+       }
+     }
+ 
+-    if (request.getComponentName() != null) {
++    if (request.getComponentName() != null ) {
+       if (StringUtils.isBlank(request.getServiceName())) {
+ 
+         // !!! FIXME the assumption that a component is unique across all stacks is a ticking
+@@ -1267,7 +1276,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+         }
+ 
+         if (StringUtils.isBlank(serviceName)) {
+-          LOG.error("Unable to find service for component {}", request.getComponentName());
++          LOG.error("Unable to find service for component Name : {}", request.getComponentName());
+           throw new ServiceComponentHostNotFoundException(
+               cluster.getClusterName(), null, request.getComponentName(), request.getHostname());
+         }
+@@ -1323,11 +1332,15 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+       Set<ServiceComponent> components = new HashSet<>();
+       if (request.getComponentName() != null) {
+         components.add(s.getServiceComponent(request.getComponentName()));
+-      } else {
++      }else {
+         components.addAll(s.getServiceComponents().values());
+       }
+       for (ServiceComponent sc : components) {
+-        if (request.getComponentName() != null) {
++        if (request.getComponentId() != null && sc.getId() != null) {
++          if (sc.getId() != request.getComponentId()) {
++            continue;
++          }
++        } else if (request.getComponentName() != null && sc.getName() != null) {
+           if (!sc.getName().equals(request.getComponentName())) {
+             continue;
+           }
+@@ -1388,7 +1401,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+ 
+             response.add(r);
+           } catch (ServiceComponentHostNotFoundException e) {
+-            if (request.getServiceName() == null || request.getComponentName() == null) {
++            if (request.getServiceName() == null || request.getComponentId() == null) {
+               // Ignore the exception if either the service name or component name are not specified.
+               // This is an artifact of how we get host_components and can happen in the case where
+               // we get all host_components for a host, for example.
+@@ -1400,7 +1413,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+               // condition.
+               LOG.debug("ServiceComponentHost not found ", e);
+               throw new ServiceComponentHostNotFoundException(cluster.getClusterName(),
+-                  request.getServiceName(), request.getComponentName(), request.getHostname());
++                  request.getServiceName(), request.getComponentId(), request.getHostname());
+             }
+           }
+         } else {
+@@ -3562,10 +3575,14 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+         || request.getClusterName().isEmpty()
+         || request.getComponentName() == null
+         || request.getComponentName().isEmpty()
++        || request.getServiceName() == null
++        || request.getServiceName().isEmpty()
++        || request.getServiceGroupName() == null
++        || request.getServiceGroupName().isEmpty()
+         || request.getHostname() == null
+         || request.getHostname().isEmpty()) {
+       throw new IllegalArgumentException("Invalid arguments"
+-          + ", cluster name, component name and host name should be"
++          + ", cluster name, component name, service name, service group name and host name should be"
+           + " provided");
+     }
+ 
+@@ -3596,6 +3613,11 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+   }
+ 
+   @Override
++  public String findService(Cluster cluster, Long componentId) throws AmbariException {
++    return cluster.getServiceByComponentId(componentId).getName();
++  }
++
++  @Override
+   public synchronized void deleteCluster(ClusterRequest request)
+       throws AmbariException {
+ 
+@@ -3635,8 +3657,8 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+ 
+         for (ServiceComponentHost sch : cluster.getServiceComponentHosts(request.getHostname())) {
+           ServiceComponentHostRequest schr = new ServiceComponentHostRequest(request.getClusterName(),
+-                  request.getServiceGroupName(), sch.getServiceName(), sch.getServiceComponentName(),
+-                  sch.getHostName(), null);
++                  request.getServiceGroupName(), sch.getServiceName(), sch.getServiceComponentId(), sch.getServiceComponentName(),
++                  sch.getServiceComponentType(), sch.getHostName(), null);
+           expanded.add(schr);
+         }
+       }
+@@ -3662,6 +3684,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
+         + ", clusterName=" + request.getClusterName()
+         + ", serviceName=" + request.getServiceName()
+         + ", componentName=" + request.getComponentName()
++        + ", componentType=" + request.getComponentType()
+         + ", hostname=" + request.getHostname()
+         + ", request=" + request);
+ 
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
+index 0824d53..f9d5c57 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
+@@ -26,7 +26,9 @@ public class ServiceComponentHostRequest {
+   private String clusterName; // REF
+   private String serviceGroupName;
+   private String serviceName;
++  private Long componentId;
+   private String componentName;
++  private String componentType;
+   private String hostname;
+   private String publicHostname;
+   private String state;
+@@ -39,17 +41,31 @@ public class ServiceComponentHostRequest {
+   public ServiceComponentHostRequest(String clusterName,
+                                      String serviceGroupName,
+                                      String serviceName,
++                                     Long componentId,
+                                      String componentName,
++                                     String componentType,
+                                      String hostname,
+                                      String desiredState) {
+     this.clusterName = clusterName;
+     this.serviceGroupName = serviceGroupName;
+     this.serviceName = serviceName;
++    this.componentId = componentId;
+     this.componentName = componentName;
++    this.componentType = componentType;
+     this.hostname = hostname;
+     this.desiredState = desiredState;
+   }
+ 
++  public ServiceComponentHostRequest(String clusterName,
++                                     String serviceGroupName,
++                                     String serviceName,
++                                     String componentName,
++                                     String componentType,
++                                     String hostname,
++                                     String desiredState) {
++    this(clusterName, serviceGroupName, serviceName, null, componentName, componentType, hostname, desiredState);
++  }
++
+   /**
+    * @return the service group Name
+    */
+@@ -75,6 +91,13 @@ public class ServiceComponentHostRequest {
+   }
+ 
+   /**
++   * @return the componentd
++   */
++  public Long getComponentId() {
++    return componentId;
++  }
++
++  /**
+    * @return the componentName
+    */
+   public String getComponentName() {
+@@ -89,6 +112,22 @@ public class ServiceComponentHostRequest {
+   }
+ 
+   /**
++   * @param componentId the componentId to set
++   */
++  public void setComponentId(Long componentId) {
++    this.componentId = componentId;
++  }
++
++  /**
++   * @return the componentType
++   */
++  public String getComponentType() { return componentType; }
++
++  /**
++   * @param componentType the componenType to set
++   */
++  public void setComponentType(String componentType) { this.componentType = componentType; }
++  /**
+    * @return the hostname
+    */
+   public String getHostname() {
+@@ -162,7 +201,9 @@ public class ServiceComponentHostRequest {
+     sb.append("{" + " clusterName=").append(clusterName)
+       .append(", serviceGroupName=").append(serviceGroupName)
+       .append(", serviceName=").append(serviceName)
++      .append(", componentId=").append(componentId)
+       .append(", componentName=").append(componentName)
++      .append(", componentType=").append(componentType)
+       .append(", hostname=").append(hostname)
+       .append(", publicHostname=").append(publicHostname)
+       .append(", desiredState=").append(desiredState)
+@@ -203,7 +244,9 @@ public class ServiceComponentHostRequest {
+     return Objects.equals(clusterName, other.clusterName) &&
+       Objects.equals(serviceGroupName, other.serviceGroupName) &&
+       Objects.equals(serviceName, other.serviceName) &&
++      Objects.equals(componentId, other.componentId) &&
+       Objects.equals(componentName, other.componentName) &&
++      Objects.equals(componentType, other.componentType) &&
+       Objects.equals(hostname, other.hostname) &&
+       Objects.equals(publicHostname, other.publicHostname) &&
+       Objects.equals(desiredState, other.desiredState) &&
+@@ -216,7 +259,7 @@ public class ServiceComponentHostRequest {
+ 
+   @Override
+   public int hashCode() {
+-    return Objects.hash(clusterName, serviceGroupName, serviceName, componentName, hostname, publicHostname,
+-      desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
++    return Objects.hash(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType, hostname,
++      publicHostname, desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
+   }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
+index 14f1d47..91d5dd9 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
+@@ -35,6 +35,7 @@ public class ServiceComponentHostResponse {
+   private String serviceType;
+   private Long hostComponentId;
+   private String componentName;
++  private String componentType;
+   private String displayName;
+   private String publicHostname;
+   private String hostname;
+@@ -53,9 +54,10 @@ public class ServiceComponentHostResponse {
+ 
+   public ServiceComponentHostResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName,
+                                       Long serviceId, String serviceName, String serviceType, Long hostComponentId,
+-                                      String componentName, String displayName, String hostname, String publicHostname,
+-                                      String liveState, String version, String desiredState, String desiredStackVersion,
+-                                      String desiredRepositoryVersion, HostComponentAdminState adminState) {
++                                      String componentName, String componentType, String displayName, String hostname,
++                                      String publicHostname, String liveState, String version, String desiredState,
++                                      String desiredStackVersion, String desiredRepositoryVersion,
++                                      HostComponentAdminState adminState) {
+     this.clusterId = clusterId;
+     this.serviceGroupId = serviceGroupId;
+     this.serviceGroupName = serviceGroupName;
+@@ -65,6 +67,7 @@ public class ServiceComponentHostResponse {
+     this.serviceType = serviceType;
+     this.hostComponentId = hostComponentId;
+     this.componentName = componentName;
++    this.componentType = componentType;
+     this.displayName = displayName;
+     this.hostname = hostname;
+     this.publicHostname = publicHostname;
+@@ -150,6 +153,13 @@ public class ServiceComponentHostResponse {
+   }
+ 
+   /**
++   * @return the componentType
++   */
++  public String getComponentType() {
++    return componentType;
++  }
++
++  /**
+    * @param componentName the componentName to set
+    */
+   public void setComponentName(String componentName) {
+@@ -157,6 +167,13 @@ public class ServiceComponentHostResponse {
+   }
+ 
+   /**
++   * @param componentType the componentType to set
++   */
++  public void setComponentType(String componentType) {
++    this.componentType = componentType;
++  }
++
++  /**
+    * @return the displayName
+    */
+   public String getDisplayName() {
+@@ -339,6 +356,11 @@ public class ServiceComponentHostResponse {
+       return false;
+     }
+ 
++    if (componentType != null ?
++            !componentType.equals(that.componentType) : that.componentType != null) {
++      return false;
++    }
++
+     if (displayName != null ?
+             !displayName.equals(that.displayName) : that.displayName != null) {
+       return false;
+@@ -362,6 +384,7 @@ public class ServiceComponentHostResponse {
+     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
+     result = 71 * result + (serviceType != null ? serviceType.hashCode() : 0);
+     result = 71 * result + (componentName != null ? componentName.hashCode() : 0);
++    result = 71 * result + (componentType != null ? componentType.hashCode() : 0);
+     result = 71 * result + (displayName != null ? displayName.hashCode() : 0);
+     result = 71 * result + (hostname != null ? hostname.hashCode() : 0);
+     return result;
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
+index f59eb98..998f077 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
+@@ -25,28 +25,30 @@ public class ServiceComponentRequest {
+   private String serviceGroupName;
+   private String serviceName; // GET/CREATE/UPDATE/DELETE
+   private String componentName; // GET/CREATE/UPDATE/DELETE
++  private String componentType;
+   private String desiredState; // CREATE/UPDATE
+   private String componentCategory;
+   private String recoveryEnabled; // CREATE/UPDATE
+ 
+   public ServiceComponentRequest(String clusterName, String serviceGroupName, String serviceName,
+-                                 String componentName, String desiredState) {
+-    this(clusterName, serviceGroupName, serviceName, componentName, desiredState, null, null);
++                                 String componentName, String componentType, String desiredState) {
++    this(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState, null, null);
+   }
+ 
+   public ServiceComponentRequest(String clusterName, String serviceGroupName, String serviceName, String componentName,
+-                                 String desiredState, String recoveryEnabled) {
+-    this(clusterName, serviceGroupName, serviceName, componentName, desiredState, recoveryEnabled, null);
++                                 String componentType, String desiredState, String recoveryEnabled) {
++    this(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState, recoveryEnabled, null);
+   }
+ 
+   public ServiceComponentRequest(String clusterName, String serviceGroupName,
+-                                 String serviceName, String componentName,
++                                 String serviceName, String componentName, String componentType,
+                                  String desiredState, String recoveryEnabled,
+                                  String componentCategory) {
+     this.clusterName = clusterName;
+     this.serviceGroupName = serviceGroupName;
+     this.serviceName = serviceName;
+     this.componentName = componentName;
++    this.componentType = componentType;
+     this.desiredState = desiredState;
+     this.recoveryEnabled = recoveryEnabled;
+     this.componentCategory = componentCategory;
+@@ -90,6 +92,18 @@ public class ServiceComponentRequest {
+   }
+ 
+   /**
++   * @return the componentType
++   */
++  public String getComponentType() { return componentType; }
++
++  /**
++   * @param componentType the componentType to set
++   */
++  public void setComponentType(String componentType) {
++    this.componentType = componentType;
++  }
++
++  /**
+    * @return the desiredState
+    */
+   public String getDesiredState() {
+@@ -141,8 +155,8 @@ public class ServiceComponentRequest {
+ 
+   @Override
+   public String toString() {
+-    return String.format("[clusterName=%s, serviceGroupName=%s, serviceName=%s, componentName=%s, " +
++    return String.format("[clusterName=%s, serviceGroupName=%s, serviceName=%s, componentName=%s, componentType=%s, " +
+       "desiredState=%s, recoveryEnabled=%s, componentCategory=%s]", clusterName, serviceGroupName,
+-      serviceName, clusterName, desiredState, recoveryEnabled, componentCategory);
++      serviceName, componentName, componentType, desiredState, recoveryEnabled, componentCategory);
+   }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
+index d63b33c..85dc55f 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
+@@ -33,7 +33,9 @@ public class ServiceComponentResponse {
+   private Long serviceId; // REF
+   private String serviceName;
+   private String serviceType;
++  private Long componentId;
+   private String componentName;
++  private String componentType;
+   private String displayName;
+   private String desiredStackId;
+   private String desiredState;
+@@ -44,10 +46,10 @@ public class ServiceComponentResponse {
+   private RepositoryVersionState repoState;
+ 
+   public ServiceComponentResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName,
+-                                  Long serviceId, String serviceName, String serviceType, String componentName,
+-                                  StackId desiredStackId, String desiredState, Map<String, Integer> serviceComponentStateCount,
+-                                  boolean recoveryEnabled, String displayName, String desiredVersion,
+-                                  RepositoryVersionState repoState) {
++                                  Long serviceId, String serviceName, String serviceType, Long componentId, String componentName,
++                                  String componentType, StackId desiredStackId, String desiredState,
++                                  Map<String, Integer> serviceComponentStateCount, boolean recoveryEnabled,
++                                  String displayName, String desiredVersion, RepositoryVersionState repoState) {
+     this.clusterId = clusterId;
+     this.clusterName = clusterName;
+     this.serviceGroupId = serviceGroupId;
+@@ -55,7 +57,9 @@ public class ServiceComponentResponse {
+     this.serviceId = serviceId;
+     this.serviceName = serviceName;
+     this.serviceType = serviceType;
++    this.componentId = componentId;
+     this.componentName = componentName;
++    this.componentType = componentType;
+     this.displayName = displayName;
+     this.desiredStackId = desiredStackId.getStackId();
+     this.desiredState = desiredState;
+@@ -134,6 +138,34 @@ public class ServiceComponentResponse {
+   }
+ 
+   /**
++   * @param componentId the componentId to set
++   */
++  public void setComponentName(Long componentId) {
++    this.componentId = componentId;
++  }
++
++  /**
++   * @return the componentType
++   */
++  public String getComponentType() {
++    return componentType;
++  }
++
++  /**
++   * @param componentType the componentType to set
++   */
++  public void setComponentType(String componentType) {
++    this.componentType = componentType;
++  }
++
++  /**
++   * @return the componentId
++   */
++  public Long getComponentId() {
++    return componentId;
++  }
++
++  /**
+    * @return the displayName
+    */
+   public String getDisplayName() {
+@@ -293,11 +325,21 @@ public class ServiceComponentResponse {
+       return false;
+     }
+ 
++    if (componentId != null ?
++            !componentId.equals(that.componentId) : that.componentId != null) {
++      return false;
++    }
++
+     if (componentName != null ?
+         !componentName.equals(that.componentName) : that.componentName != null){
+       return false;
+     }
+ 
++    if (componentType != null ?
++            !componentType.equals(that.componentType) : that.componentType != null){
++      return false;
++    }
++
+     if (displayName != null ?
+             !displayName.equals(that.displayName) : that.displayName != null) {
+       return false;
+@@ -315,7 +357,9 @@ public class ServiceComponentResponse {
+     result = 71 * result + (serviceId != null ? serviceId.hashCode() : 0);
+     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
+     result = 71 * result + (serviceType != null ? serviceType.hashCode() : 0);
++    result = 71 * result + (componentId != null ? componentId.hashCode() : 0);
+     result = 71 * result + (componentName != null ? componentName.hashCode():0);
++    result = 71 * result + (componentType != null ? componentType.hashCode():0);
+     result = 71 * result + (displayName != null ? displayName.hashCode():0);
+     return result;
+   }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractPropertyProvider.java
+index 05b0eaa..7d17ca8 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractPropertyProvider.java
+@@ -97,7 +97,6 @@ public abstract class AbstractPropertyProvider extends BaseProvider implements P
+     this.componentMetrics = componentMetrics;
+   }
+ 
+-
+   // ----- accessors ---------------------------------------------------------
+ 
+   /**
+@@ -477,7 +476,7 @@ public abstract class AbstractPropertyProvider extends BaseProvider implements P
+ 
+   /**
+    * Verify that the component metrics contains the property id.
+-   * @param componentName Name of the component
++   * @param componentName  Name of the component
+    * @param propertyId Property Id
+    * @return true/false
+    */
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
+index f385f7e..41b21db 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
+@@ -505,10 +505,17 @@ public abstract class AbstractProviderModule implements ProviderModule,
+   public boolean isCollectorComponentLive(String clusterName, MetricsService service) throws SystemException {
+ 
+     final String collectorHostName = getCollectorHostName(clusterName, service);
++    Long componentId = null;
++    AmbariManagementController managementController = AmbariServer.getController();
++    try {
++      componentId = managementController.getClusters().getCluster(clusterName).getComponentId(Role.METRICS_COLLECTOR.name());
++    } catch (AmbariException e) {
++      e.printStackTrace();
++    }
+ 
+     if (service.equals(GANGLIA)) {
+       return HostStatusHelper.isHostComponentLive(managementController, clusterName, collectorHostName, "GANGLIA",
+-        Role.GANGLIA_SERVER.name());
++        componentId, Role.GANGLIA_SERVER.name(), Role.GANGLIA_SERVER.name());
+     } else if (service.equals(TIMELINE_METRICS)) {
+       return metricsCollectorHAManager.isCollectorComponentLive(clusterName);
+     }
+@@ -1112,7 +1119,6 @@ public abstract class AbstractProviderModule implements ProviderModule,
+                                                                       String clusterNamePropertyId,
+                                                                       String hostNamePropertyId,
+                                                                       String componentNamePropertyId) {
+-
+     return MetricsPropertyProvider.createInstance(type,
+       PropertyHelper.getMetricPropertyIds(type), streamProvider, configuration,
+       metricCacheProvider, hostProvider, serviceProvider, clusterNamePropertyId,
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+index fdbb034..cd057fe 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+@@ -119,7 +119,9 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
+   protected static final String COMPONENT_CLUSTER_NAME_PROPERTY_ID = "ServiceComponentInfo/cluster_name";
+   protected static final String COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID = "ServiceComponentInfo/service_group_name";
+   protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID = "ServiceComponentInfo/service_name";
++  protected static final String COMPONENT_COMPONENT_ID_PROPERTY_ID = "ServiceComponentInfo/id";
+   protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID = "ServiceComponentInfo/component_name";
++  protected static final String COMPONENT_COMPONENT_TYPE_PROPERTY_ID = "ServiceComponentInfo/component_type";
+   protected static final String HOST_COMPONENT_HOST_NAME_PROPERTY_ID =
+           PropertyHelper.getPropertyId("HostRoles", "host_name");
+ 
+@@ -141,6 +143,7 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
+   private static Set<String> propertyIds = Sets.newHashSet(
+       COMPONENT_CLUSTER_NAME_PROPERTY_ID,
+       COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
++      COMPONENT_COMPONENT_ID_PROPERTY_ID,
+       COMPONENT_SERVICE_NAME_PROPERTY_ID,
+       COMPONENT_COMPONENT_NAME_PROPERTY_ID,
+       HOST_COMPONENT_HOST_NAME_PROPERTY_ID);
+@@ -914,7 +917,9 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
+             (String) properties.get(COMPONENT_CLUSTER_NAME_PROPERTY_ID),
+             (String) properties.get(COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
+             (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
++            (Long) properties.get(COMPONENT_COMPONENT_ID_PROPERTY_ID),
+             (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
++            (String) properties.get(COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
+             (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
+             null);
+   }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+index e679e50..73675f1 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+@@ -94,7 +94,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+   protected static final String COMPONENT_SERVICE_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_id";
+   protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_name";
+   protected static final String COMPONENT_SERVICE_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_type";
++  protected static final String COMPONENT_COMPONENT_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "id";
+   protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_name";
++  protected static final String COMPONENT_COMPONENT_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_type";
+   protected static final String COMPONENT_DISPLAY_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "display_name";
+   protected static final String COMPONENT_STATE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "state";
+   protected static final String COMPONENT_CATEGORY_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "category";
+@@ -120,7 +122,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+           COMPONENT_CLUSTER_NAME_PROPERTY_ID,
+           COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
+           COMPONENT_SERVICE_NAME_PROPERTY_ID,
+-          COMPONENT_COMPONENT_NAME_PROPERTY_ID);
++          COMPONENT_COMPONENT_ID_PROPERTY_ID,
++          COMPONENT_COMPONENT_NAME_PROPERTY_ID,
++          COMPONENT_COMPONENT_TYPE_PROPERTY_ID);
+ 
+   /**
+    * The property ids for an servce resource.
+@@ -141,7 +145,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+     PROPERTY_IDS.add(COMPONENT_SERVICE_ID_PROPERTY_ID);
+     PROPERTY_IDS.add(COMPONENT_SERVICE_NAME_PROPERTY_ID);
+     PROPERTY_IDS.add(COMPONENT_SERVICE_TYPE_PROPERTY_ID);
++    PROPERTY_IDS.add(COMPONENT_COMPONENT_ID_PROPERTY_ID);
+     PROPERTY_IDS.add(COMPONENT_COMPONENT_NAME_PROPERTY_ID);
++    PROPERTY_IDS.add(COMPONENT_COMPONENT_TYPE_PROPERTY_ID);
+     PROPERTY_IDS.add(COMPONENT_DISPLAY_NAME_PROPERTY_ID);
+     PROPERTY_IDS.add(COMPONENT_STATE_PROPERTY_ID);
+     PROPERTY_IDS.add(COMPONENT_CATEGORY_PROPERTY_ID);
+@@ -223,7 +229,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+         resource.setProperty(COMPONENT_SERVICE_ID_PROPERTY_ID, response.getServiceId());
+         resource.setProperty(COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName());
+         resource.setProperty(COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType());
++        resource.setProperty(COMPONENT_COMPONENT_ID_PROPERTY_ID, response.getComponentId());
+         resource.setProperty(COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName());
++        resource.setProperty(COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType());
+         resource.setProperty(COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName());
+         resource.setProperty(COMPONENT_STATE_PROPERTY_ID, response.getDesiredState());
+         resource.setProperty(COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory());
+@@ -270,7 +278,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+       setResourceProperty(resource, COMPONENT_SERVICE_ID_PROPERTY_ID, response.getServiceId(), requestedIds);
+       setResourceProperty(resource, COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName(), requestedIds);
+       setResourceProperty(resource, COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType(), requestedIds);
++      setResourceProperty(resource, COMPONENT_COMPONENT_ID_PROPERTY_ID, response.getComponentId(), requestedIds);
+       setResourceProperty(resource, COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName(), requestedIds);
++      setResourceProperty(resource, COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType(), requestedIds);
+       setResourceProperty(resource, COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName(), requestedIds);
+       setResourceProperty(resource, COMPONENT_STATE_PROPERTY_ID, response.getDesiredState(), requestedIds);
+       setResourceProperty(resource, COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory(), requestedIds);
+@@ -363,6 +373,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+         (String) properties.get(COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
+         (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
+         (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
++        (String) properties.get(COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
+         (String) properties.get(COMPONENT_STATE_PROPERTY_ID),
+         (String) properties.get(COMPONENT_RECOVERY_ENABLED_ID),
+         (String) properties.get(COMPONENT_CATEGORY_PROPERTY_ID));
+@@ -392,6 +403,13 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+       Validate.notEmpty(request.getServiceName(), "service name should be non-empty");
+       Cluster cluster = getClusterForRequest(request, clusters);
+ 
++      // TODO: Multi_Component_Instance. When we go into multiple component instance mode, we will need make
++      // component_type as manadatory field. As of now, we are just copying component_name into component_type,
++      // if not provided. Further, need to add validation check too.
++      if(StringUtils.isBlank(request.getComponentType())) {
++        request.setComponentType(request.getComponentName());
++      }
++
+       isAuthorized(cluster, getRequiredCreateAuthorizations());
+ 
+       debug("Received a createComponent request: {}", request);
+@@ -454,7 +472,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+     for (ServiceComponentRequest request : requests) {
+       Cluster cluster = clusters.getCluster(request.getClusterName());
+       Service s = cluster.getService(request.getServiceName());
+-      ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName());
++      ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName(), request.getComponentType());
+       sc.setDesiredRepositoryVersion(s.getDesiredRepositoryVersion());
+ 
+       if (StringUtils.isNotEmpty(request.getDesiredState())) {
+@@ -475,10 +493,10 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+       } else {
+         StackId stackId = s.getDesiredStackId();
+         ComponentInfo componentInfo = ambariMetaInfo.getComponent(stackId.getStackName(),
+-                stackId.getStackVersion(), s.getServiceType(), request.getComponentName());
++                stackId.getStackVersion(), s.getServiceType(), request.getComponentType());
+         if (componentInfo == null) {
+             throw new AmbariException("Could not get component information from stack definition: Stack=" +
+-              stackId + ", Service=" + s.getServiceType() + ", Component=" + request.getComponentName());
++              stackId + ", Service=" + s.getServiceType() + ", Component type =" + request.getComponentType());
+         }
+         sc.setRecoveryEnabled(componentInfo.isRecoveryEnabled());
+         LOG.info("Component: {}, recovery_enabled from stack definition:{}", componentInfo.getName(),
+@@ -631,6 +649,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+       final String serviceGroupName = request.getServiceGroupName();
+       final String serviceName = request.getServiceName();
+       final String componentName = request.getComponentName();
++      final String componentType = request.getComponentType();
+ 
+       LOG.info("Received a updateComponent request: {}", request);
+ 
+@@ -659,7 +678,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+       State newState = getValidDesiredState(request);
+ 
+       if (! maintenanceStateHelper.isOperationAllowed(reqOpLvl, s)) {
+-        LOG.info("Operations cannot be applied to component " + componentName
++        LOG.info("Operations cannot be applied to component name : " + componentName + " with type : " + componentType
+                 + " because service " + serviceName +
+                 " is in the maintenance state of " + s.getMaintenanceState());
+         continue;
+@@ -674,8 +693,8 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+ 
+         boolean newRecoveryEnabled = Boolean.parseBoolean(request.getRecoveryEnabled());
+         boolean oldRecoveryEnabled = sc.isRecoveryEnabled();
+-        LOG.info("Component: {}, oldRecoveryEnabled: {}, newRecoveryEnabled {}",
+-                componentName, oldRecoveryEnabled, newRecoveryEnabled);
++        LOG.info("ComponentName: {}, componentType: {}, oldRecoveryEnabled: {}, newRecoveryEnabled {}",
++                componentName, componentType, oldRecoveryEnabled, newRecoveryEnabled);
+         if (newRecoveryEnabled != oldRecoveryEnabled) {
+           if (newRecoveryEnabled) {
+             recoveryEnabledComponents.add(sc);
+@@ -712,6 +731,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+               + ", serviceGroupName=" + serviceGroupName
+               + ", serviceName=" + sc.getServiceName()
+               + ", componentName=" + sc.getName()
++              + ", componentType=" + sc.getType()
+               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+               + ", currentDesiredState=" + oldScState
+               + ", newDesiredState=" + newState);
+@@ -725,6 +745,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+               + ", serviceGroupName=" + serviceGroupName
+               + ", serviceName=" + serviceName
+               + ", componentName=" + sc.getName()
++              + ", componentType=" + sc.getType()
+               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+               + ", currentDesiredState=" + oldScState
+               + ", newDesiredState=" + newState);
+@@ -740,6 +761,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+                 + ", serviceGroupName=" + serviceGroupName
+                 + ", serviceName=" + serviceName
+                 + ", componentName=" + sc.getName()
++                + ", componentType=" + sc.getType()
+                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+                 + ", hostname=" + sch.getHostName()
+                 + ", currentState=" + oldSchState
+@@ -754,6 +776,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+                 + ", serviceGroupName=" + serviceGroupName
+                 + ", serviceName=" + serviceName
+                 + ", componentName=" + sc.getName()
++                + ", componentType=" + sc.getType()
+                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+                 + ", hostname=" + sch.getHostName()
+                 + ", currentState=" + oldSchState
+@@ -769,6 +792,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+                 + ", serviceGroupName=" + serviceGroupName
+                 + ", serviceName=" + serviceName
+                 + ", componentName=" + sc.getName()
++                + ", componentType=" + sc.getType()
+                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+                 + ", hostname=" + sch.getHostName());
+ 
+@@ -784,6 +808,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+               + ", serviceGroupName=" + serviceGroupName
+               + ", serviceName=" + sch.getServiceName()
+               + ", componentName=" + sch.getServiceComponentName()
++              + ", componentType=" + sch.getServiceComponentType()
+               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+               + ", hostname=" + sch.getHostName()
+               + ", currentState=" + oldSchState
+@@ -801,6 +826,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+               + ", serviceGroupName=" + serviceGroupName
+               + ", serviceName=" + serviceName
+               + ", componentName=" + sc.getName()
++              + ", componentType=" + sc.getType()
+               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
+               + ", hostname=" + sch.getHostName()
+               + ", currentState=" + oldSchState
+@@ -914,14 +940,15 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
+     if (StringUtils.isEmpty(request.getServiceName())) {
+ 
+       String componentName = request.getComponentName();
++      String componentType = request.getComponentType();
+ 
+-      String serviceName = getManagementController().findService(cluster, componentName);
++      String serviceName = getManagementController().findService(cluster, componentType);
+ 
+-      debug("Looking up service name for component, componentName={}, serviceName={}", componentName, serviceName);
++      debug("Looking up service name for component, componentType={}, serviceName={}", componentType, serviceName);
+ 
+       if (StringUtils.isEmpty(serviceName)) {
+         throw new AmbariException("Could not find service for component"
+-                + ", componentName=" + request.getComponentName()
++                + ", componentType=" + request.getComponentType()
+                 + ", clusterName=" + cluster.getClusterName());
+       }
+       request.setServiceName(serviceName);
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+index 8facd21..4d58784 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+@@ -97,6 +97,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+   public static final String HOST_COMPONENT_SERVICE_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_type";
+   public static final String HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "id";
+   public static final String HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_name";
++  public static final String HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_type";
+   public static final String HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "display_name";
+   public static final String HOST_COMPONENT_HOST_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "host_name";
+   public static final String HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "public_host_name";
+@@ -123,8 +124,10 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+   public static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
+       .put(Resource.Type.Cluster, HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID)
+       .put(Resource.Type.Host, HOST_COMPONENT_HOST_NAME_PROPERTY_ID)
+-      .put(Resource.Type.HostComponent, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)
++      .put(Resource.Type.HostComponent, HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID)
+       .put(Resource.Type.Component, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)
++      .put(Resource.Type.Service, HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID)
++      .put(Resource.Type.ServiceGroup, HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID)
+       .build();
+ 
+   /**
+@@ -135,7 +138,9 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+       HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID,
+       HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
+       HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID,
++      HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID,
+       HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID,
++      HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID,
+       HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID,
+       HOST_COMPONENT_HOST_NAME_PROPERTY_ID,
+       HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID,
+@@ -215,6 +220,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+         resource.setProperty(HOST_COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType());
+         resource.setProperty(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID, response.getHostComponentId());
+         resource.setProperty(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName());
++        resource.setProperty(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType());
+         resource.setProperty(HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName());
+         resource.setProperty(HOST_COMPONENT_HOST_NAME_PROPERTY_ID, response.getHostname());
+         resource.setProperty(HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID, response.getPublicHostname());
+@@ -287,6 +293,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+       setResourceProperty(resource, HOST_COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType(), requestedIds);
+       setResourceProperty(resource, HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID, response.getHostComponentId(), requestedIds);
+       setResourceProperty(resource, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName(), requestedIds);
++      setResourceProperty(resource, HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType(), requestedIds);
+       setResourceProperty(resource, HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName(), requestedIds);
+       setResourceProperty(resource, HOST_COMPONENT_HOST_NAME_PROPERTY_ID, response.getHostname(), requestedIds);
+       setResourceProperty(resource, HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID, response.getPublicHostname(), requestedIds);
+@@ -677,6 +684,8 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+             + ", clusterId=" + cluster.getClusterId()
+             + ", serviceName=" + sch.getServiceName()
+             + ", componentName=" + sch.getServiceComponentName()
++            + ", componentType=" + sch.getServiceComponentType()
++            + ", componentType=" + sch.getServiceComponentType()
+             + ", hostname=" + sch.getHostName()
+             + ", currentState=" + oldSchState
+             + ", newDesiredState=" + newState);
+@@ -722,13 +731,33 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+    * @return the component request object
+    */
+   private ServiceComponentHostRequest getRequest(Map<String, Object> properties) {
+-    ServiceComponentHostRequest serviceComponentHostRequest = new ServiceComponentHostRequest(
+-        (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
+-        (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
+-        (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
+-        (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+-        (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
+-        (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
++    ServiceComponentHostRequest serviceComponentHostRequest = null;
++    if (properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID) != null) {
++      Long hostComponentId = properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID) instanceof String ?
++              Long.parseLong((String) properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID)) :
++              (Long) properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID);
++
++      serviceComponentHostRequest = new ServiceComponentHostRequest(
++              (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
++              hostComponentId,
++              (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
++    } else {
++      serviceComponentHostRequest = new ServiceComponentHostRequest(
++              (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
++              (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
++
++    }
++
+     serviceComponentHostRequest.setState((String) properties.get(HOST_COMPONENT_STATE_PROPERTY_ID));
+     if (properties.get(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID) != null) {
+       serviceComponentHostRequest.setStaleConfig(
+@@ -765,6 +794,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+             (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
+             (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
+             (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
++            (String) properties.get(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
+             (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
+             (String) properties.get(HOST_COMPONENT_STATE_PROPERTY_ID));
+     if (properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID) != null) {
+@@ -967,12 +997,13 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+    * @param request  the request to log
+    */
+   private void logRequestInfo(String msg, ServiceComponentHostRequest request) {
+-    LOG.info("{}, clusterName={}, serviceGroupName={}, serviceName={}, componentName={}, hostname={}, request={}",
++    LOG.info("{}, clusterName={}, serviceGroupName={}, serviceName={}, componentName={}, componentType={}, hostname={}, request={}",
+         msg,
+         request.getClusterName(),
+         request.getServiceGroupName(),
+         request.getServiceName(),
+         request.getComponentName(),
++        request.getComponentType(),
+         request.getHostname(),
+         request);
+   }
+@@ -992,6 +1023,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+       .append(", serviceGroupName=").append(request.getServiceGroupName())
+       .append(", serviceName=").append(request.getServiceName())
+       .append(", componentName=").append(request.getComponentName())
++      .append(", componentType=").append(request.getComponentType())
+       .append(", hostname=").append(request.getHostname())
+       .append(", currentState=").append(oldState == null ? "null" : oldState)
+       .append(", newDesiredState=").append(newDesiredState == null ? "null" : newDesiredState);
+@@ -1031,10 +1063,14 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
+         || request.getClusterName().isEmpty()
+         || request.getComponentName() == null
+         || request.getComponentName().isEmpty()
++        || request.getServiceName() == null
++        || request.getServiceName().isEmpty()
++        || request.getServiceGroupName() == null
++        || request.getServiceGroupName().isEmpty()
+         || request.getHostname() == null
+         || request.getHostname().isEmpty()) {
+       throw new IllegalArgumentException("Invalid arguments"
+-          + ", cluster name, component name and host name should be"
++          + ", cluster name, component name, service name, service group name and host name should be"
+           + " provided");
+     }
+ 
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+index 79f4233..1d993a5 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+@@ -958,7 +958,9 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
+           ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster.getClusterName(),
+                                                                              sch.getServiceGroupName(),
+                                                                              sch.getServiceName(),
++                                                                             sch.getHostComponentId(),
+                                                                              sch.getServiceComponentName(),
++                                                                             sch.getServiceComponentType(),
+                                                                              sch.getHostName(),
+                                                                              null);
+           schrs.add(schr);
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
+index 9c38bff..a62a7bf 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
+@@ -38,11 +38,11 @@ import org.slf4j.LoggerFactory;
+ public class HostStatusHelper {
+ 
+   private static final Logger LOG =
+-    LoggerFactory.getLogger(HostStatusHelper.class);
++          LoggerFactory.getLogger(HostStatusHelper.class);
+ 
+   public static boolean isHostComponentLive(AmbariManagementController managementController,
+-                                             String clusterName, String hostName,
+-                                      String serviceName, String componentName) {
++                                            String clusterName, String hostName, String serviceName,
++                                            Long componentId, String componentName, String componentType) {
+     if (clusterName == null) {
+       return false;
+     }
+@@ -54,11 +54,11 @@ public class HostStatusHelper {
+       Cluster cluster = clusters.getCluster(clusterName);
+       Service s = cluster.getService(serviceName);
+       ServiceComponentHostRequest componentRequest =
+-        new ServiceComponentHostRequest(clusterName, s.getServiceGroupName(), serviceName, componentName, hostName,
+-                null);
++              new ServiceComponentHostRequest(clusterName, s.getServiceGroupName(), serviceName, componentId, componentName, componentType,
++                      hostName, null);
+ 
+       Set<ServiceComponentHostResponse> hostComponents =
+-        managementController.getHostComponents(Collections.singleton(componentRequest));
++              managementController.getHostComponents(Collections.singleton(componentRequest));
+ 
+       componentHostResponse = hostComponents.size() == 1 ? hostComponents.iterator().next() : null;
+     } catch (AmbariException e) {
+@@ -68,7 +68,7 @@ public class HostStatusHelper {
+ 
+     //Cluster without SCH
+     return componentHostResponse != null &&
+-      componentHostResponse.getLiveState().equals(State.STARTED.name());
++            componentHostResponse.getLiveState().equals(State.STARTED.name());
+   }
+ 
+   public static boolean isHostLive(AmbariManagementController managementController, String clusterName, String hostName) {
+@@ -88,6 +88,6 @@ public class HostStatusHelper {
+     }
+     //Cluster without host
+     return hostResponse != null &&
+-      !hostResponse.getHostState().equals(HostState.HEARTBEAT_LOST);
++            !hostResponse.getHostState().equals(HostState.HEARTBEAT_LOST);
+   }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProvider.java
+index 7e95ac2..4684a6c 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProvider.java
+@@ -162,21 +162,24 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
+       for (Resource r : resources) {
+         String clusterName = r.getPropertyValue(clusterNamePropertyId).toString();
+         String componentName = r.getPropertyValue(componentNamePropertyId).toString();
+-
+         Cluster cluster = clusters.getCluster(clusterName);
+         Service service = null;
+ 
++        Long componentId = null;
++        String componentType = null;
+         try {
+-          service = cluster.getServiceByComponentName(componentName);
++          componentId = cluster.getComponentId(componentName);
++          componentType = cluster.getComponentType(componentId);
++          service = cluster.getServiceByComponentId(componentId);
+         } catch (ServiceNotFoundException e) {
+-          LOG.debug("Could not load component {}", componentName);
++          LOG.debug("Could not load componentName {}", componentName);
+           continue;
+         }
+ 
+         StackId stack = service.getDesiredStackId();
+ 
+         List<MetricDefinition> defs = metaInfo.getMetrics(
+-            stack.getStackName(), stack.getStackVersion(), service.getServiceType(), componentName, type.name());
++            stack.getStackName(), stack.getStackVersion(), service.getServiceType(), componentType, type.name());
+ 
+         if (null == defs || 0 == defs.size()) {
+           continue;
+@@ -191,7 +194,7 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
+           } else {
+             PropertyProvider pp = getDelegate(m,
+                 streamProvider, metricHostProvider,
+-                clusterNamePropertyId, hostNamePropertyId,
++                clusterNamePropertyId, clusterName, hostNamePropertyId,
+                 componentNamePropertyId, resourceStatePropertyId,
+                 componentName);
+             if (pp == null) {
+@@ -221,10 +224,10 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
+ 
+       if (jmxMap.size() > 0) {
+         JMXPropertyProvider jpp = metricPropertyProviderFactory.createJMXPropertyProvider(jmxMap,
+-            streamProvider,
+-            jmxHostProvider, metricHostProvider,
+-            clusterNamePropertyId, hostNamePropertyId,
+-            componentNamePropertyId, resourceStatePropertyId);
++                streamProvider,
++                jmxHostProvider, metricHostProvider,
++                clusterNamePropertyId, hostNamePropertyId,
++                componentNamePropertyId, resourceStatePropertyId);
+ 
+         jpp.populateResources(resources, request, predicate);
+       } else {
+@@ -320,7 +323,7 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
+    * @param definition the metric definition for a component
+    * @param streamProvider the stream provider
+    * @param metricsHostProvider the metrics host provider
+-   * @param clusterNamePropertyId the cluster name property id
++   * @param clusterNamePropertyId the cluster id property id
+    * @param hostNamePropertyId the host name property id
+    * @param componentNamePropertyId the component name property id
+    * @param statePropertyId the state property id
+@@ -331,24 +334,26 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
+                                        StreamProvider streamProvider,
+                                        MetricHostProvider metricsHostProvider,
+                                        String clusterNamePropertyId,
++                                       String clusterName,
+                                        String hostNamePropertyId,
+                                        String componentNamePropertyId,
+                                        String statePropertyId,
+                                        String componentName) {
+     Map<String, PropertyInfo> metrics = getPropertyInfo(definition);
+-    HashMap<String, Map<String, PropertyInfo>> componentMetrics =
+-      new HashMap<>();
++    HashMap<String, Map<String, PropertyInfo>> componentMetrics = new HashMap<>();
+     componentMetrics.put(WRAPPED_METRICS_KEY, metrics);
+ 
+     try {
+       Class<?> clz = Class.forName(definition.getType());
+ 
+       // use a Factory for the REST provider
++
+       if (clz.equals(RestMetricsPropertyProvider.class)) {
++        // TODO : Multi_Metrics_Changes. We need to pass UniqueComponentName like :
++        // {SG_instance_name}_{service_instance_name}_component_name instead of just 'componentName'.
+         return metricPropertyProviderFactory.createRESTMetricsPropertyProvider(
+             definition.getProperties(), componentMetrics, streamProvider, metricsHostProvider,
+-            clusterNamePropertyId, hostNamePropertyId, componentNamePropertyId, statePropertyId,
+-            componentName);
++            clusterNamePropertyId, hostNamePropertyId, clusterNamePropertyId, statePropertyId, componentName);
+       }
+ 
+       try {
+@@ -359,6 +364,8 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
+         Constructor<?> ct = clz.getConstructor(Map.class,
+             Map.class, StreamProvider.class, MetricHostProvider.class,
+             String.class, String.class, String.class, String.class, String.class);
++        // TODO : Multi_Metrics_Changes. Check if we need to pass UniqueComponentName like :
++        // {SG_instance_name}_{service_instance_name}_component_name instead of just 'componentId'.
+         Object o = ct.newInstance(
+             injector,
+             definition.getProperties(), componentMetrics,
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
+index c22f90e..35ee308 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
+@@ -151,7 +151,7 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
+    * @param componentMetrics         the map of supported metrics
+    * @param streamProvider           the stream provider
+    * @param jmxHostProvider          the JMX host mapping
+-   * @param metricHostProvider      the host mapping
++   * @param metricHostProvider       the host mapping
+    * @param clusterNamePropertyId    the cluster name property id
+    * @param hostNamePropertyId       the host name property id
+    * @param componentNamePropertyId  the component name property id
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricPropertyProviderFactory.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricPropertyProviderFactory.java
+index 1ccbe23..6f84581 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricPropertyProviderFactory.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricPropertyProviderFactory.java
+@@ -51,7 +51,7 @@ public interface MetricPropertyProviderFactory {
+    * @param hostNamePropertyId
+    *          the host name property id
+    * @param componentNamePropertyId
+-   *          the component name property id
++   *          the component Name property id
+    * @param statePropertyId
+    *          the state property id
+    * @return the instantiated and injected {@link JMXPropertyProvider}.
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsCollectorHAClusterState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsCollectorHAClusterState.java
+index 231d103..80811d2 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsCollectorHAClusterState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsCollectorHAClusterState.java
+@@ -23,6 +23,7 @@ import java.util.Set;
+ import java.util.concurrent.CopyOnWriteArraySet;
+ import java.util.concurrent.atomic.AtomicInteger;
+ 
++import org.apache.ambari.server.AmbariException;
+ import org.apache.ambari.server.Role;
+ import org.apache.ambari.server.controller.AmbariManagementController;
+ import org.apache.ambari.server.controller.AmbariServer;
+@@ -60,11 +61,23 @@ public class MetricsCollectorHAClusterState {
+     this.liveCollectorHosts = new CopyOnWriteArraySet<>();
+     this.deadCollectorHosts = new CopyOnWriteArraySet<>();
+     collectorDownRefreshCounter = new AtomicInteger(0);
++
++  }
++
++  private Long getComponentId(String componentName) {
++    Long componentId = null;
++    try {
++      componentId = managementController.getClusters().getCluster(clusterName).getComponentId(componentName);
++    } catch (AmbariException e) {
++      e.printStackTrace();
++    }
++    return componentId;
+   }
+ 
+   public void addMetricsCollectorHost(String collectorHost) {
++    Long componentId = getComponentId(Role.METRICS_COLLECTOR.name());
+     if (HostStatusHelper.isHostComponentLive(managementController, clusterName, collectorHost, "AMBARI_METRICS",
+-      Role.METRICS_COLLECTOR.name())) {
++            componentId, Role.METRICS_COLLECTOR.name(), Role.METRICS_COLLECTOR.name())) {
+       liveCollectorHosts.add(collectorHost);
+       deadCollectorHosts.remove(collectorHost);
+     } else {
+@@ -73,9 +86,9 @@ public class MetricsCollectorHAClusterState {
+     }
+ 
+     //If there is no current collector host or the current host is down, this will be a proactive switch.
++    // TODO : Multi_Metrics_Changes. componentName=Role.METRICS_COLLECTOR.name() may or may not be unique if there are multiple instances.
+     if (currentCollectorHost == null || !HostStatusHelper.isHostComponentLive(managementController, clusterName,
+-      currentCollectorHost, "AMBARI_METRICS",
+-      Role.METRICS_COLLECTOR.name())) {
++      currentCollectorHost, "AMBARI_METRICS", componentId, Role.METRICS_COLLECTOR.name(), Role.METRICS_COLLECTOR.name())) {
+       refreshCollectorHost(currentCollectorHost);
+     }
+   }
+@@ -142,11 +155,12 @@ public class MetricsCollectorHAClusterState {
+   }
+ 
+   private boolean isValidAliveCollectorHost(String clusterName, String collectorHost) {
+-
++    Long componentId = getComponentId(Role.METRICS_COLLECTOR.name());
++    // TODO : Multi_Metrics_Changes. componentName=Role.METRICS_COLLECTOR.name() may or may not be unique if there are multiple instances.
+     return ((collectorHost != null) &&
+       HostStatusHelper.isHostLive(managementController, clusterName, collectorHost) &&
+-      HostStatusHelper.isHostComponentLive(managementController, clusterName, collectorHost, "AMBARI_METRICS",
+-        Role.METRICS_COLLECTOR.name()));
++      HostStatusHelper.isHostComponentLive(managementController, clusterName, collectorHost,
++              "AMBARI_METRICS", componentId, Role.METRICS_COLLECTOR.name(), Role.METRICS_COLLECTOR.name()));
+   }
+ 
+   /*
+@@ -182,19 +196,21 @@ public class MetricsCollectorHAClusterState {
+     }
+ 
+   public boolean isCollectorComponentAlive() {
+-
++    Long componentId = getComponentId(Role.METRICS_COLLECTOR.name());
+     //Check in live hosts
++    // TODO : Multi_Metrics_Changes. componentName=Role.METRICS_COLLECTOR.name() may or may not be unique if there are multiple instances.
+     for (String host : liveCollectorHosts) {
+       if (HostStatusHelper.isHostComponentLive(managementController, clusterName, host, "AMBARI_METRICS",
+-        Role.METRICS_COLLECTOR.name())) {
++              componentId, Role.METRICS_COLLECTOR.name(), Role.METRICS_COLLECTOR.name())) {
+         return true;
+       }
+     }
+ 
+     //Check in dead hosts. Don't update live and dead lists. Can be done on refresh call.
++    // TODO : Multi_Metrics_Changes. componentName=Role.METRICS_COLLECTOR.name() may or may not be unique if there are multiple instances.
+     for (String host : deadCollectorHosts) {
+       if (HostStatusHelper.isHostComponentLive(managementController, clusterName, host, "AMBARI_METRICS",
+-        Role.METRICS_COLLECTOR.name())) {
++              componentId, Role.METRICS_COLLECTOR.name(), Role.METRICS_COLLECTOR.name())) {
+         return true;
+       }
+     }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProvider.java
+index d5d4368..cec2e3d 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProvider.java
+@@ -23,7 +23,10 @@ import java.util.Map;
+ import java.util.Set;
+ import java.util.regex.Pattern;
+ 
++import org.apache.ambari.server.AmbariException;
+ import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
++import org.apache.ambari.server.controller.AmbariManagementController;
++import org.apache.ambari.server.controller.AmbariServer;
+ import org.apache.ambari.server.controller.internal.AbstractPropertyProvider;
+ import org.apache.ambari.server.controller.internal.PropertyInfo;
+ import org.apache.ambari.server.controller.internal.URLStreamProvider;
+@@ -35,6 +38,8 @@ import org.apache.ambari.server.controller.spi.SystemException;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
++import com.google.inject.Inject;
++
+ public abstract class MetricsPropertyProvider extends AbstractPropertyProvider {
+   private static final Logger LOG =
+     LoggerFactory.getLogger(MetricsPropertyProvider.class);
+@@ -49,12 +54,15 @@ public abstract class MetricsPropertyProvider extends AbstractPropertyProvider {
+ 
+   protected final String hostNamePropertyId;
+ 
+-  protected final String componentNamePropertyId;
++  protected final String componentIdPropertyId;
+ 
+   protected final ComponentSSLConfiguration configuration;
+ 
+   protected MetricsPaddingMethod metricsPaddingMethod;
+ 
++  @Inject
++  AmbariManagementController managementController;
++
+   private static final MetricsPaddingMethod DEFAULT_PADDING_METHOD =
+     new MetricsPaddingMethod(MetricsPaddingMethod.PADDING_STRATEGY.ZEROS);
+ 
+@@ -65,7 +73,7 @@ public abstract class MetricsPropertyProvider extends AbstractPropertyProvider {
+        MetricHostProvider hostProvider,
+        String clusterNamePropertyId,
+        String hostNamePropertyId,
+-       String componentNamePropertyId) {
++       String componentIdPropertyId) {
+ 
+     super(componentPropertyInfoMap);
+ 
+@@ -74,7 +82,11 @@ public abstract class MetricsPropertyProvider extends AbstractPropertyProvider {
+     this.hostProvider             = hostProvider;
+     this.clusterNamePropertyId    = clusterNamePropertyId;
+     this.hostNamePropertyId       = hostNamePropertyId;
+-    this.componentNamePropertyId  = componentNamePropertyId;
++    this.componentIdPropertyId    = componentIdPropertyId;
++
++    if (managementController == null) {
++      managementController = AmbariServer.getController();
++    }
+   }
+ 
+   public static MetricsPropertyProviderProxy createInstance(
+@@ -116,6 +128,38 @@ public abstract class MetricsPropertyProvider extends AbstractPropertyProvider {
+    */
+   protected abstract String getHostName(Resource resource);
+ 
++
++  /**
++   * Get the component id for the given resource.
++   *
++   * @param resource  the resource
++   *
++   * @return the component id
++   */
++  protected Long getComponentId(Resource resource) {
++    return (Long) resource.getPropertyValue(getComponentIdPropertyId());
++  }
++
++  /**
++   * Get the component type for the given resource.
++   *
++   * @param resource  the resource
++   *
++   * @return the component type
++   */
++  protected String getComponentType(Resource resource) {
++    String componentType = null;
++    Long componentId = getComponentId(resource);
++    String clusterName = (String) resource.getPropertyValue(clusterNamePropertyId);
++
++    try {
++      componentType = managementController.getClusters().getCluster(clusterName).getComponentType(componentId);
++    } catch (AmbariException e) {
++      e.printStackTrace();
++    }
++    return componentType;
++  }
++
+   /**
+    * Get the component name for the given resource.
+    *
+@@ -123,7 +167,28 @@ public abstract class MetricsPropertyProvider extends AbstractPropertyProvider {
+    *
+    * @return the component name
+    */
+-  protected abstract String getComponentName(Resource resource);
++  protected String getComponentName(Resource resource) {
++    AmbariManagementController managementController = AmbariServer.getController();
++    String componentName = null;
++    Long componentId = getComponentId(resource);
++    String clusterName = (String) resource.getPropertyValue(clusterNamePropertyId);
++
++    try {
++      componentName = managementController.getClusters().getCluster(clusterName).getComponentName(componentId);
++    } catch (AmbariException e) {
++      e.printStackTrace();
++    }
++    return componentName;
++  }
++
++  /**
++   * Get the component id property id.
++   *
++   * @return the component Id property id
++   */
++  protected String getComponentIdPropertyId() {
++    return componentIdPropertyId;
++  }
+ 
+   @Override
+   public Set<Resource> populateResources(Set<Resource> resources,
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProviderProxy.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProviderProxy.java
+index 9237960..3adf71a 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProviderProxy.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProviderProxy.java
+@@ -51,16 +51,16 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+   private String clusterNamePropertyId;
+ 
+   public MetricsPropertyProviderProxy(
+-    InternalType type,
+-    Map<String, Map<String, PropertyInfo>> componentPropertyInfoMap,
+-    URLStreamProvider streamProvider,
+-    ComponentSSLConfiguration configuration,
+-    TimelineMetricCacheProvider cacheProvider,
+-    MetricHostProvider hostProvider,
+-    MetricsServiceProvider serviceProvider,
+-    String clusterNamePropertyId,
+-    String hostNamePropertyId,
+-    String componentNamePropertyId) {
++        InternalType type,
++        Map<String, Map<String, PropertyInfo>> componentPropertyInfoMap,
++        URLStreamProvider streamProvider,
++        ComponentSSLConfiguration configuration,
++        TimelineMetricCacheProvider cacheProvider,
++        MetricHostProvider hostProvider,
++        MetricsServiceProvider serviceProvider,
++        String clusterNamePropertyId,
++        String hostNamePropertyId,
++        String componentNamePropertyId) {
+ 
+     super(componentPropertyInfoMap);
+     this.metricsServiceProvider = serviceProvider;
+@@ -133,7 +133,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+                                             MetricHostProvider hostProvider,
+                                             String clusterNamePropertyId,
+                                             String hostNamePropertyId,
+-                                            String componentNamePropertyId) {
++                                            String componentIdPropertyId) {
+ 
+     this.amsPropertyProvider = new AMSHostComponentPropertyProvider(
+                                             componentPropertyInfoMap,
+@@ -143,7 +143,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+                                             hostProvider,
+                                             clusterNamePropertyId,
+                                             hostNamePropertyId,
+-                                            componentNamePropertyId);
++                                            componentIdPropertyId);
+ 
+     this.gangliaPropertyProvider = new GangliaHostComponentPropertyProvider(
+                                             componentPropertyInfoMap,
+@@ -152,7 +152,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+                                             hostProvider,
+                                             clusterNamePropertyId,
+                                             hostNamePropertyId,
+-                                            componentNamePropertyId);
++                                            componentIdPropertyId);
+   }
+ 
+   private void createComponentPropertyProviders(Map<String, Map<String, PropertyInfo>> componentPropertyInfoMap,
+@@ -160,7 +160,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+                                                 ComponentSSLConfiguration configuration,
+                                                 MetricHostProvider hostProvider,
+                                                 String clusterNamePropertyId,
+-                                                String componentNamePropertyId) {
++                                                String componentIdPropertyId) {
+ 
+     this.amsPropertyProvider = new AMSComponentPropertyProvider(
+                                             componentPropertyInfoMap,
+@@ -169,7 +169,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+                                             cacheProvider,
+                                             hostProvider,
+                                             clusterNamePropertyId,
+-                                            componentNamePropertyId);
++                                            componentIdPropertyId);
+ 
+     this.gangliaPropertyProvider = new GangliaComponentPropertyProvider(
+                                             componentPropertyInfoMap,
+@@ -177,7 +177,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
+                                             configuration,
+                                             hostProvider,
+                                             clusterNamePropertyId,
+-                                            componentNamePropertyId);
++                                            componentIdPropertyId);
+   }
+ 
+   @Override
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/RestMetricsPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/RestMetricsPropertyProvider.java
+index e2f0906..442c107 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/RestMetricsPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/RestMetricsPropertyProvider.java
+@@ -130,7 +130,7 @@ public class RestMetricsPropertyProvider extends ThreadPoolEnabledPropertyProvid
+    * @param metricsProperties       the map of per-component metrics properties
+    * @param componentMetrics        the map of supported metrics for component
+    * @param streamProvider          the stream provider
+-   * @param metricHostProvider     metricsHostProvider instance
++   * @param metricHostProvider      metricsHostProvider instance
+    * @param clusterNamePropertyId   the cluster name property id
+    * @param hostNamePropertyId      the host name property id
+    * @param componentNamePropertyId the component name property id
+@@ -215,7 +215,7 @@ public class RestMetricsPropertyProvider extends ThreadPoolEnabledPropertyProvid
+     try {
+       String clusterName = (String) resource.getPropertyValue(clusterNamePropertyId);
+       Cluster cluster = clusters.getCluster(clusterName);
+-      hostname = getHost(resource, clusterName, resourceComponentName);
++      hostname = getHost(resource, clusterName, componentName);
+       if (hostname == null) {
+         String msg = String.format("Unable to get component REST metrics. " +
+             "No host name for %s.", resourceComponentName);
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaComponentPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaComponentPropertyProvider.java
+index aa46412..516735b 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaComponentPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaComponentPropertyProvider.java
+@@ -14,6 +14,9 @@
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
++ *
++ *
++ *
+  */
+ 
+ package org.apache.ambari.server.controller.metrics.ganglia;
+@@ -57,16 +60,11 @@ public class GangliaComponentPropertyProvider extends GangliaPropertyProvider {
+   }
+ 
+   @Override
+-  protected String getComponentName(Resource resource) {
+-    return (String) resource.getPropertyValue(getComponentNamePropertyId());
+-  }
+-
+-  @Override
+   protected Set<String> getGangliaClusterNames(Resource resource, String clusterName) {
+-    String component = getComponentName(resource);
++    Long componentId = getComponentId(resource);
+     
+-    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(component) ?
+-      GANGLIA_CLUSTER_NAME_MAP.get(component) :
++    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(componentId) ?
++      GANGLIA_CLUSTER_NAME_MAP.get(componentId) :
+       Collections.emptyList());
+   }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostComponentPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostComponentPropertyProvider.java
+index 3a5d4e2..c63542c 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostComponentPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostComponentPropertyProvider.java
+@@ -41,10 +41,10 @@ public class GangliaHostComponentPropertyProvider extends GangliaPropertyProvide
+                                               MetricHostProvider hostProvider,
+                                               String clusterNamePropertyId,
+                                               String hostNamePropertyId,
+-                                              String componentNamePropertyId) {
++                                              String componentIdPropertyId) {
+ 
+     super(componentPropertyInfoMap, streamProvider, configuration, hostProvider,
+-        clusterNamePropertyId, hostNamePropertyId, componentNamePropertyId);
++        clusterNamePropertyId, hostNamePropertyId, componentIdPropertyId);
+   }
+ 
+ 
+@@ -56,16 +56,11 @@ public class GangliaHostComponentPropertyProvider extends GangliaPropertyProvide
+   }
+ 
+   @Override
+-  protected String getComponentName(Resource resource) {
+-    return (String) resource.getPropertyValue(getComponentNamePropertyId());
+-  }
+-
+-  @Override
+   protected Set<String> getGangliaClusterNames(Resource resource, String clusterName) {
+-    String component = getComponentName(resource);
++    Long componentId = getComponentId(resource);
+     
+-    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(component) ?
+-      GANGLIA_CLUSTER_NAME_MAP.get(component) :
++    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(componentId) ?
++      GANGLIA_CLUSTER_NAME_MAP.get(componentId) :
+       Collections.emptyList());
+   }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostPropertyProvider.java
+index 7abf7a8..314ad62 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostPropertyProvider.java
+@@ -73,6 +73,17 @@ public class GangliaHostPropertyProvider extends GangliaPropertyProvider {
+     return (String) resource.getPropertyValue(getHostNamePropertyId());
+   }
+ 
++  // TODO : Multi_Metrics_Changes. Confirm that getComponentId is correct, as we are passing '*' in Name and Type below.
++  @Override
++  protected Long getComponentId(Resource resource) {
++    return getComponentId(resource);
++  }
++
++  @Override
++  protected String getComponentType(Resource resource) {
++    return "*";
++  }
++
+   @Override
+   protected String getComponentName(Resource resource) {
+     return "*";
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
+index ac0c590..ae04718 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
+@@ -60,7 +60,6 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
+    */
+   static final Map<String, List<String>> GANGLIA_CLUSTER_NAME_MAP = new HashMap<>();
+ 
+-  
+   static {
+     GANGLIA_CLUSTER_NAME_MAP.put("NAMENODE",           Collections.singletonList("HDPNameNode"));
+     GANGLIA_CLUSTER_NAME_MAP.put("DATANODE",           Arrays.asList("HDPDataNode", "HDPSlaves"));
+@@ -88,11 +87,12 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
+                                  MetricHostProvider hostProvider,
+                                  String clusterNamePropertyId,
+                                  String hostNamePropertyId,
+-                                 String componentNamePropertyId) {
++                                 String componentIdPropertyId) {
+ 
+     super(componentPropertyInfoMap, streamProvider,configuration,
+       hostProvider, clusterNamePropertyId, hostNamePropertyId,
+-      componentNamePropertyId);
++            componentIdPropertyId);
++
+   }
+ 
+ 
+@@ -131,15 +131,6 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
+ 
+ 
+   /**
+-   * Get the component name property id.
+-   *
+-   * @return the component name property id
+-   */
+-  protected String getComponentNamePropertyId() {
+-    return componentNamePropertyId;
+-  }
+-
+-  /**
+    * Get the host name property id.
+    *
+    * @return the host name property id
+@@ -160,6 +151,7 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
+ 
+   // ----- helper methods ----------------------------------------------------
+ 
++
+   /**
+    * Get the request objects containing all the information required to
+    * make single requests to the Ganglia rrd script.
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSComponentPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSComponentPropertyProvider.java
+index efc0f4f..61ff807 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSComponentPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSComponentPropertyProvider.java
+@@ -34,21 +34,16 @@ public class AMSComponentPropertyProvider extends AMSPropertyProvider {
+                                           TimelineMetricCacheProvider cacheProvider,
+                                           MetricHostProvider hostProvider,
+                                           String clusterNamePropertyId,
+-                                          String componentNamePropertyId) {
++                                          String componentIdPropertyId) {
+ 
+     super(componentPropertyInfoMap, streamProvider, configuration,
+-      cacheProvider, hostProvider, clusterNamePropertyId, null, componentNamePropertyId);
++      cacheProvider, hostProvider, clusterNamePropertyId, null, componentIdPropertyId);
+   }
+ 
+   @Override
+   protected String getHostName(Resource resource) {
+       return hostProvider
+-        .getExternalHostName((String) resource.getPropertyValue(clusterNamePropertyId), (String) resource.getPropertyValue(componentNamePropertyId))
++        .getExternalHostName((String) resource.getPropertyValue(clusterNamePropertyId), (String) resource.getPropertyValue(componentIdPropertyId))
+         .orElse(null);
+   }
+-
+-  @Override
+-  protected String getComponentName(Resource resource) {
+-    return (String) resource.getPropertyValue(componentNamePropertyId);
+-  }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostComponentPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostComponentPropertyProvider.java
+index fee8104..c2ec721 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostComponentPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostComponentPropertyProvider.java
+@@ -35,22 +35,15 @@ public class AMSHostComponentPropertyProvider extends AMSPropertyProvider {
+                                  MetricHostProvider hostProvider,
+                                  String clusterNamePropertyId,
+                                  String hostNamePropertyId,
+-                                 String componentNamePropertyId) {
++                                 String componentIdPropertyId) {
+ 
+     super(componentPropertyInfoMap, streamProvider, configuration,
+       cacheProvider, hostProvider, clusterNamePropertyId, hostNamePropertyId,
+-      componentNamePropertyId);
++            componentIdPropertyId);
+   }
+ 
+   @Override
+   protected String getHostName(Resource resource) {
+     return (String) resource.getPropertyValue(hostNamePropertyId);
+   }
+-
+-  @Override
+-  protected String getComponentName(Resource resource) {
+-    String componentName = (String) resource.getPropertyValue(componentNamePropertyId);
+-
+-    return componentName;
+-  }
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostPropertyProvider.java
+index f70fbe0..8dd2f1b 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostPropertyProvider.java
+@@ -46,6 +46,17 @@ public class AMSHostPropertyProvider extends AMSPropertyProvider {
+   }
+ 
+   @Override
++  protected Long getComponentId(Resource resource) {
++    return (Long) resource.getPropertyValue(componentIdPropertyId);
++  }
++
++  @Override
++  protected String getComponentType(Resource resource) {
++    return "HOST";
++  }
++
++  // TODO : Multi_Metrics_Changes. Confirm if its always going to be HOST ?
++  @Override
+   protected String getComponentName(Resource resource) {
+     return "HOST";
+   }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSPropertyProvider.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSPropertyProvider.java
+index e137477..26ee089 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSPropertyProvider.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSPropertyProvider.java
+@@ -246,7 +246,7 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
+               setQueryParams(hostComponentHostMetricParams, hostNamesBatch, true, componentName);
+               TimelineMetrics metricsResponse = getTimelineMetricsFromCache(
+                 getTimelineAppMetricCacheKey(hostComponentHostMetrics,
+-                  componentName, hostNamesBatch, uriBuilder.toString()), componentName);
++                  hostNamesBatch, componentName, uriBuilder.toString()), componentName);
+ 
+               if (metricsResponse != null) {
+                 timelineMetrics.getMetrics().addAll(metricsResponse.getMetrics());
+@@ -258,7 +258,7 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
+               setQueryParams(nonHostComponentHostMetricParams, hostNamesBatch, false, componentName);
+               TimelineMetrics metricsResponse = getTimelineMetricsFromCache(
+                 getTimelineAppMetricCacheKey(nonHostComponentMetrics,
+-                  componentName, hostNamesBatch, uriBuilder.toString()), componentName);
++                        hostNamesBatch, componentName, uriBuilder.toString()), componentName);
+ 
+               if (metricsResponse != null) {
+                 timelineMetrics.getMetrics().addAll(metricsResponse.getMetrics());
+@@ -576,9 +576,6 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
+     if (metricPropertyIds.containsKey(HBASE_REGIONSERVER.name())) {
+       amsMetrics.putAll(metricPropertyIds.get(HBASE_REGIONSERVER.name()));
+     }
+-    if (!amsMetrics.isEmpty()) {
+-      super.getComponentMetrics().putAll(Collections.singletonMap(METRICS_COLLECTOR.name(), amsMetrics));
+-    }
+ 
+     return super.getComponentMetrics();
+   }
+@@ -666,7 +663,7 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
+       for (String id : ids) {
+         Map<String, PropertyInfo> propertyInfoMap = new HashMap<>();
+ 
+-        String componentName = getOverridenComponentName(resource);
++        String componentName  = getOverridenComponentName(resource);
+ 
+         Map<String, PropertyInfo> componentMetricMap = getComponentMetrics().get(componentName);
+ 
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
+index 9045230..0a352b0 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
+@@ -89,7 +89,7 @@ public class DefaultServiceCalculatedState implements ServiceCalculatedState {
+           StackId stackId = service.getDesiredStackId();
+ 
+           ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-            serviceName, null, null, null);
++            serviceName, null, null, null, null, null);
+ 
+           Set<ServiceComponentHostResponse> hostComponentResponses =
+             managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
+index b34b926..63a01dc 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
+@@ -52,7 +52,7 @@ public final class FlumeServiceCalculatedState extends DefaultServiceCalculatedS
+       if (cluster != null && managementControllerProvider != null) {
+         Service service = cluster.getService(serviceName);
+         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-          serviceName, null, null, null);
++          serviceName, null, null, null, null, null);
+ 
+         Set<ServiceComponentHostResponse> hostComponentResponses =
+           managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
+index 63456e8..51dd6c3 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
+@@ -54,7 +54,7 @@ public final class HBaseServiceCalculatedState extends DefaultServiceCalculatedS
+         StackId stackId = service.getDesiredStackId();
+ 
+         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-          serviceName, null, null, null);
++          serviceName, null, null, null, null, null);
+ 
+         Set<ServiceComponentHostResponse> hostComponentResponses =
+           managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
+index 05e8904..6c17113 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
+@@ -54,7 +54,7 @@ public final class HDFSServiceCalculatedState extends DefaultServiceCalculatedSt
+         StackId stackId = service.getDesiredStackId();
+ 
+         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-          serviceName, null, null, null);
++          serviceName, null,null, null, null, null);
+ 
+         Set<ServiceComponentHostResponse> hostComponentResponses =
+           managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
+index 83d26f0..6881a1f 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
+@@ -55,7 +55,7 @@ public final class HiveServiceCalculatedState extends DefaultServiceCalculatedSt
+ 
+ 
+         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-          serviceName, null, null, null);
++          serviceName, null, null, null, null, null);
+ 
+         Set<ServiceComponentHostResponse> hostComponentResponses =
+           managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
+index 5cd0319..db2318d 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
+@@ -54,7 +54,7 @@ public final class OozieServiceCalculatedState extends DefaultServiceCalculatedS
+         StackId stackId = service.getDesiredStackId();
+ 
+         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-          serviceName, null, null, null);
++          serviceName, null, null, null, null, null);
+ 
+         Set<ServiceComponentHostResponse> hostComponentResponses =
+           managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
+index 2530068..adeb740 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
+@@ -55,7 +55,7 @@ public final class YARNServiceCalculatedState extends DefaultServiceCalculatedSt
+ 
+ 
+         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
+-          serviceName, null, null, null);
++          serviceName, null, null, null, null, null);
+ 
+         Set<ServiceComponentHostResponse> hostComponentResponses =
+           managementControllerProvider.get().getHostComponents(Collections.singleton(request));
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
+index 6f6fa43..6cd7d05 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
+@@ -89,21 +89,17 @@ public class HostComponentDesiredStateDAO {
+    * @param clusterId Cluster ID
+    * @param serviceGroupId Service Group ID
+    * @param serviceId Service ID
+-   * @param componentName Component Name
++   * @param componentId Component Id
+    * @param hostId Host ID
+    * @return Return the Host Component Desired State entity that match the criteria.
+    */
+   @RequiresSession
+   public HostComponentDesiredStateEntity findByIndex(Long clusterId, Long serviceGroupId, Long serviceId,
+-                                                     String componentName, Long hostId) {
++                                                     Long componentId, Long hostId) {
+     final TypedQuery<HostComponentDesiredStateEntity> query = entityManagerProvider.get()
+       .createNamedQuery("HostComponentDesiredStateEntity.findByIndex", HostComponentDesiredStateEntity.class);
+ 
+-    query.setParameter("clusterId", clusterId);
+-    query.setParameter("serviceGroupId", serviceGroupId);
+-    query.setParameter("serviceId", serviceId);
+-    query.setParameter("componentName", componentName);
+-    query.setParameter("hostId", hostId);
++    query.setParameter("id", componentId);
+ 
+     return daoUtils.selectSingle(query);
+   }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
+index 7115b28..dd2e9d0 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
+@@ -42,6 +42,9 @@ public class HostComponentStateDAO {
+   @Inject
+   HostDAO hostDAO;
+ 
++  @Inject
++  HostComponentDesiredStateDAO hostComponentDesiredStateDAO;
++
+   @RequiresSession
+   public HostComponentStateEntity findById(long id) {
+     return entityManagerProvider.get().find(HostComponentStateEntity.class, id);
+@@ -120,22 +123,18 @@ public class HostComponentStateDAO {
+    *          Service Group ID
+    * @param serviceId
+    *          Service ID
+-   * @param componentName
+-   *          Component Name
++   * @param componentId
++   *          Component ID
+    * @param hostId
+    *          Host ID
+    * @return Return all of the Host Component States that match the criteria.
+    */
+   @RequiresSession
+   public HostComponentStateEntity findByIndex(Long clusterId, Long serviceGroupId, Long serviceId,
+-                                              String componentName, Long hostId) {
++                                              Long componentId, Long hostId) {
+     final TypedQuery<HostComponentStateEntity> query = entityManagerProvider.get().createNamedQuery(
+         "HostComponentStateEntity.findByIndex", HostComponentStateEntity.class);
+-    query.setParameter("clusterId", clusterId);
+-    query.setParameter("serviceGroupId", serviceGroupId);
+-    query.setParameter("serviceId", serviceId);
+-    query.setParameter("componentName", componentName);
+-    query.setParameter("hostId", hostId);
++    query.setParameter("id", componentId);
+ 
+     return daoUtils.selectSingle(query);
+   }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
+index 61bc9ae..7cc4beb 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
+@@ -83,7 +83,7 @@ public class ServiceComponentDesiredStateDAO {
+    */
+   @RequiresSession
+   public ServiceComponentDesiredStateEntity findByName(long clusterId, long serviceGroupId, long serviceId,
+-       String componentName) {
++       String componentName, String componentType) {
+     EntityManager entityManager = entityManagerProvider.get();
+     TypedQuery<ServiceComponentDesiredStateEntity> query = entityManager.createNamedQuery(
+         "ServiceComponentDesiredStateEntity.findByName", ServiceComponentDesiredStateEntity.class);
+@@ -92,6 +92,41 @@ public class ServiceComponentDesiredStateDAO {
+     query.setParameter("serviceGroupId", serviceGroupId);
+     query.setParameter("serviceId", serviceId);
+     query.setParameter("componentName", componentName);
++    query.setParameter("componentType", componentType);
++
++    ServiceComponentDesiredStateEntity entity = null;
++    List<ServiceComponentDesiredStateEntity> entities = daoUtils.selectList(query);
++    if (null != entities && !entities.isEmpty()) {
++      entity = entities.get(0);
++    }
++
++    return entity;
++  }
++
++  /**
++   * Finds a {@link ServiceComponentDesiredStateEntity} by a combination of
++   * cluster, service, and component.
++   *
++   * @param clusterId
++   *          the cluster ID
++   * @param serviceGroupId
++   *          the service group ID
++   * @param serviceId
++   *          the service ID
++   * @param componentId
++   *          the component id (not {@code null})
++   */
++  @RequiresSession
++  public ServiceComponentDesiredStateEntity findById(long clusterId, long serviceGroupId, long serviceId,
++                                                       Long componentId) {
++    EntityManager entityManager = entityManagerProvider.get();
++    TypedQuery<ServiceComponentDesiredStateEntity> query = entityManager.createNamedQuery(
++            "ServiceComponentDesiredStateEntity.findById", ServiceComponentDesiredStateEntity.class);
++
++    query.setParameter("clusterId", clusterId);
++    query.setParameter("serviceGroupId", serviceGroupId);
++    query.setParameter("serviceId", serviceId);
++    query.setParameter("id", componentId);
+ 
+     ServiceComponentDesiredStateEntity entity = null;
+     List<ServiceComponentDesiredStateEntity> entities = daoUtils.selectList(query);
+@@ -123,8 +158,8 @@ public class ServiceComponentDesiredStateDAO {
+   }
+ 
+   @Transactional
+-  public void removeByName(long clusterId, long serviceGroupId, long serviceId, String componentName) {
+-    ServiceComponentDesiredStateEntity entity = findByName(clusterId, serviceGroupId, serviceId, componentName);
++  public void removeByName(long clusterId, long serviceGroupId, long serviceId, String componentName, String componentType) {
++    ServiceComponentDesiredStateEntity entity = findByName(clusterId, serviceGroupId, serviceId, componentName, componentType);
+     if (null != entity) {
+       entityManagerProvider.get().remove(entity);
+     }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
+index fafec3d..1030572 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
+@@ -48,7 +48,7 @@ import com.google.common.base.Objects;
+   name = "hostcomponentdesiredstate",
+   uniqueConstraints = @UniqueConstraint(
+     name = "UQ_hcdesiredstate_name",
+-    columnNames = { "component_name", "service_id", "host_id", "service_group_id", "cluster_id" }) )
++    columnNames = { "component_name", "service_id", "service_group_id", "cluster_id" }) )
+ @TableGenerator(
+   name = "hostcomponentdesiredstate_id_generator",
+   table = "ambari_sequences",
+@@ -66,7 +66,7 @@ import com.google.common.base.Objects;
+     "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.clusterId=:clusterId AND hcds.serviceGroupId=:serviceGroupId AND hcds.serviceId=:serviceId AND hcds.componentName=:componentName AND hcds.hostEntity.hostName=:hostName"),
+ 
+   @NamedQuery(name = "HostComponentDesiredStateEntity.findByIndex", query =
+-    "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.clusterId=:clusterId AND hcds.serviceGroupId=:serviceGroupId AND hcds.serviceId=:serviceId AND hcds.componentName=:componentName AND hcds.hostId=:hostId"),
++    "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.id=:id")
+ })
+ public class HostComponentDesiredStateEntity {
+ 
+@@ -91,6 +91,9 @@ public class HostComponentDesiredStateEntity {
+   @Column(name = "component_name", insertable = false, updatable = false)
+   private String componentName = "";
+ 
++  @Column(name = "component_type", insertable = false, updatable = false)
++  private String componentType = "";
++
+   @Basic
+   @Column(name = "desired_state", nullable = false, insertable = true, updatable = true)
+   @Enumerated(value = EnumType.STRING)
+@@ -105,7 +108,8 @@ public class HostComponentDesiredStateEntity {
+     @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false),
+     @JoinColumn(name = "service_group_id", referencedColumnName = "service_group_id", nullable = false),
+     @JoinColumn(name = "service_id", referencedColumnName = "service_id", nullable = false),
+-    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false)})
++    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false),
++    @JoinColumn(name = "component_type", referencedColumnName = "component_type", nullable = false) })
+   private ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity;
+ 
+   @ManyToOne
+@@ -154,6 +158,14 @@ public class HostComponentDesiredStateEntity {
+     this.componentName = componentName;
+   }
+ 
++  public String getComponentType() {
++    return defaultString(componentType);
++  }
++
++  public void setComponentType(String componentType) {
++    this.componentType = componentType;
++  }
++
+   public State getDesiredState() {
+     return desiredState;
+   }
+@@ -209,6 +221,10 @@ public class HostComponentDesiredStateEntity {
+       return false;
+     }
+ 
++    if (!Objects.equal(componentType, that.componentType)) {
++      return false;
++    }
++
+     if (!Objects.equal(desiredState, that.desiredState)) {
+       return false;
+     }
+@@ -228,6 +244,7 @@ public class HostComponentDesiredStateEntity {
+     result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
+     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
+     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
++    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
+     result = 31 * result + (desiredState != null ? desiredState.hashCode() : 0);
+     return result;
+   }
+@@ -264,6 +281,7 @@ public class HostComponentDesiredStateEntity {
+   public String toString() {
+     return Objects.toStringHelper(this).add("clusterId", clusterId).add(
+       "serviceGroupId", serviceGroupId).add("serviceId", serviceId).add("componentName",
+-      componentName).add("hostId", hostId).add("desiredState", desiredState).toString();
++      componentName).add("componentType", componentType).add("hostId", hostId).add("desiredState",
++      desiredState).toString();
+   }
+ }
+\ No newline at end of file
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+index f56df9d..6c590eb 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+@@ -30,16 +30,23 @@ import javax.persistence.JoinColumns;
+ import javax.persistence.ManyToOne;
+ import javax.persistence.NamedQueries;
+ import javax.persistence.NamedQuery;
++import javax.persistence.OneToOne;
+ import javax.persistence.Table;
+ import javax.persistence.TableGenerator;
+ 
++import javax.persistence.UniqueConstraint;
++
+ import org.apache.ambari.server.state.State;
+ import org.apache.ambari.server.state.UpgradeState;
+ 
+ import com.google.common.base.Objects;
+ 
+ @Entity
+-@Table(name = "hostcomponentstate")
++@Table(
++    name = "hostcomponentstate",
++    uniqueConstraints = @UniqueConstraint(
++                name = "unq_scdesiredstate_name",
++                columnNames = { "component_name", "service_id" , "service_group_id", "cluster_id" }) )
+ @TableGenerator(
+     name = "hostcomponentstate_id_generator",
+     table = "ambari_sequences",
+@@ -76,9 +83,7 @@ import com.google.common.base.Objects;
+                 "AND hcs.version != :version"),
+     @NamedQuery(
+         name = "HostComponentStateEntity.findByIndex",
+-        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.clusterId=:clusterId " +
+-                "AND hcs.serviceGroupId=:serviceGroupId AND hcs.serviceId=:serviceId AND hcs.componentName=:componentName AND hcs.hostId=:hostId") })
+-
++        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.id=:id") })
+ public class HostComponentStateEntity {
+ 
+   @Id
+@@ -86,6 +91,9 @@ public class HostComponentStateEntity {
+   @Column(name = "id", nullable = false, insertable = true, updatable = false)
+   private Long id;
+ 
++  @Column(name = "host_component_desired_state_id", nullable = false, insertable = false, updatable = false)
++  private Long hostComponentDesiredStateId;
++
+   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
+   private Long clusterId;
+ 
+@@ -101,6 +109,9 @@ public class HostComponentStateEntity {
+   @Column(name = "component_name", nullable = false, insertable = false, updatable = false)
+   private String componentName;
+ 
++  @Column(name = "component_type", nullable = false, insertable = false, updatable = false)
++  private String componentType;
++
+   /**
+    * Version reported by host component during last status update.
+    */
+@@ -117,16 +128,23 @@ public class HostComponentStateEntity {
+ 
+   @ManyToOne
+   @JoinColumns({
++    //@JoinColumn(name = "id", referencedColumnName = "id", nullable = false),
+     @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false),
+     @JoinColumn(name = "service_group_id", referencedColumnName = "service_group_id", nullable = false),
+     @JoinColumn(name = "service_id", referencedColumnName = "service_id", nullable = false),
+-    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false) })
++    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false),
++    @JoinColumn(name = "component_type", referencedColumnName = "component_type", nullable = false) })
+   private ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity;
+ 
+   @ManyToOne
+   @JoinColumn(name = "host_id", referencedColumnName = "host_id", nullable = false)
+   private HostEntity hostEntity;
+ 
++  @OneToOne
++  @JoinColumn(name = "host_component_desired_state_id", referencedColumnName = "id", nullable = false)
++  private HostComponentDesiredStateEntity hostComponentDesiredStateEntity;
++
++
+   public Long getId() {
+     return id;
+   }
+@@ -171,6 +189,26 @@ public class HostComponentStateEntity {
+     this.componentName = componentName;
+   }
+ 
++  public Long getHostComponentDesiredStateId() {
++    return hostComponentDesiredStateEntity != null ? hostComponentDesiredStateEntity.getId() : null;
++  }
++
++  public void setComponentId(Long componentId) {
++    this.id = componentId;
++  }
++
++  public Long getComponentId() {
++    return id;
++  }
++
++  public void setComponentType(String componentType) {
++    this.componentType = componentType;
++  }
++
++  public String getComponentType() {
++    return componentType;
++  }
++
+   public State getCurrentState() {
+     return currentState;
+   }
+@@ -228,6 +266,11 @@ public class HostComponentStateEntity {
+       return false;
+     }
+ 
++    if (componentType != null ? !componentType.equals(that.componentType)
++            : that.componentType != null) {
++      return false;
++    }
++
+     if (currentState != null ? !currentState.equals(that.currentState)
+         : that.currentState != null) {
+       return false;
+@@ -242,6 +285,10 @@ public class HostComponentStateEntity {
+       return false;
+     }
+ 
++    if (hostComponentDesiredStateEntity != null ? !hostComponentDesiredStateEntity.equals(that.hostComponentDesiredStateEntity) : that.hostComponentDesiredStateEntity != null) {
++      return false;
++    }
++
+     if (version != null ? !version.equals(that.version) : that.version != null) {
+       return false;
+     }
+@@ -256,7 +303,9 @@ public class HostComponentStateEntity {
+     result = 31 * result + (serviceGroupId != null ? serviceGroupId.intValue() : 0);
+     result = 31 * result + (serviceId != null ? serviceId.intValue() : 0);
+     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
++    result = 31 * result + (hostComponentDesiredStateEntity != null ? hostComponentDesiredStateEntity.hashCode() : 0);
+     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
++    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
+     result = 31 * result + (currentState != null ? currentState.hashCode() : 0);
+     result = 31 * result + (upgradeState != null ? upgradeState.hashCode() : 0);
+     result = 31 * result + (version != null ? version.hashCode() : 0);
+@@ -267,8 +316,7 @@ public class HostComponentStateEntity {
+     return serviceComponentDesiredStateEntity;
+   }
+ 
+-  public void setServiceComponentDesiredStateEntity(
+-      ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity) {
++  public void setServiceComponentDesiredStateEntity(ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity) {
+     this.serviceComponentDesiredStateEntity = serviceComponentDesiredStateEntity;
+   }
+ 
+@@ -280,14 +328,22 @@ public class HostComponentStateEntity {
+     this.hostEntity = hostEntity;
+   }
+ 
++  public HostComponentDesiredStateEntity getHostComponentDesiredStateEntity() {
++    return hostComponentDesiredStateEntity;
++  }
++
++  public void setHostComponentDesiredStateEntity(HostComponentDesiredStateEntity hostComponentDesiredStateEntity) {
++    this.hostComponentDesiredStateEntity = hostComponentDesiredStateEntity;
++  }
++
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String toString() {
+     return Objects.toStringHelper(this).add("clusterId", clusterId).add("serviceGroupId", serviceGroupId).add(
+-      "serviceId", serviceId).add("componentName", componentName).add(
+-      "hostId", hostId).add("state", currentState).toString();
++      "serviceId", serviceId).add("componentId", id).add("componentName", componentName).add
++            ("componentType", componentType).add("hostId", hostId).add("state", currentState).toString();
+   }
+ 
+ }
+\ No newline at end of file
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
+index 8a8b380..c3f9531 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
+@@ -43,6 +43,7 @@ import javax.persistence.UniqueConstraint;
+ import org.apache.ambari.server.state.RepositoryVersionState;
+ import org.apache.ambari.server.state.State;
+ 
++
+ @Entity
+ @Table(
+     name = "servicecomponentdesiredstate",
+@@ -62,7 +63,15 @@ import org.apache.ambari.server.state.State;
+     query = "SELECT scds FROM ServiceComponentDesiredStateEntity scds WHERE scds.clusterId = :clusterId " +
+       "AND scds.serviceGroupId = :serviceGroupId " +
+       "AND scds.serviceId = :serviceId " +
+-      "AND scds.componentName = :componentName") })
++      "AND scds.componentName = :componentName " +
++      "AND scds.componentType = :componentType" ),
++  @NamedQuery(
++    name = "ServiceComponentDesiredStateEntity.findById",
++    query = "SELECT scds FROM ServiceComponentDesiredStateEntity scds WHERE scds.clusterId = :clusterId " +
++      "AND scds.serviceGroupId = :serviceGroupId " +
++      "AND scds.serviceId = :serviceId " +
++      "AND scds.id = :id" )})
++
+ public class ServiceComponentDesiredStateEntity {
+ 
+   @Id
+@@ -75,6 +84,9 @@ public class ServiceComponentDesiredStateEntity {
+   @Column(name = "component_name", nullable = false, insertable = true, updatable = true)
+   private String componentName;
+ 
++  @Column(name = "component_type", nullable = false, insertable = true, updatable = true)
++  private String componentType;
++
+   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
+   private Long clusterId;
+ 
+@@ -155,6 +167,22 @@ public class ServiceComponentDesiredStateEntity {
+     this.componentName = componentName;
+   }
+ 
++  public void setComponentId(Long componentId) {
++    this.id = componentId;
++  }
++
++  public Long getComponentId() {
++    return id;
++  }
++
++  public String getComponentType() {
++    return componentType;
++  }
++
++  public void setComponentType(String componentType) {
++    this.componentType = componentType;
++  }
++
+   public State getDesiredState() {
+     return desiredState;
+   }
+@@ -237,6 +265,9 @@ public class ServiceComponentDesiredStateEntity {
+     if (componentName != null ? !componentName.equals(that.componentName) : that.componentName != null) {
+       return false;
+     }
++    if (componentType != null ? !componentType.equals(that.componentType) : that.componentType != null) {
++      return false;
++    }
+     if (desiredState != null ? !desiredState.equals(that.desiredState) : that.desiredState != null) {
+       return false;
+     }
+@@ -254,6 +285,7 @@ public class ServiceComponentDesiredStateEntity {
+     result = 31 * result + (serviceGroupId != null ? serviceGroupId.hashCode() : 0);
+     result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
+     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
++    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
+     result = 31 * result + (desiredState != null ? desiredState.hashCode() : 0);
+     result = 31 * result + (desiredRepositoryVersion != null ? desiredRepositoryVersion.hashCode() : 0);
+ 
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+index 79d5844..c708ec1 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+@@ -162,6 +162,22 @@ public interface Cluster {
+   Service getServiceByComponentName(String componentName) throws AmbariException;
+ 
+   /**
++   * Gets a service from the given component Id.
++   *
++   * @param componentId
++   * @return
++   * @throws AmbariException
++   */
++
++  Service getServiceByComponentId(Long componentId) throws AmbariException;
++
++  Long getComponentId(String componentName) throws AmbariException;
++
++  String getComponentName(Long componentId) throws AmbariException;
++
++  String getComponentType(Long componentId) throws AmbariException;
++
++  /**
+    * Get all services
+    *
+    * @return
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java b/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
+index 0ba80cc..bb59110 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
+@@ -54,6 +54,8 @@ public interface Service {
+   ServiceComponent getServiceComponent(String componentName)
+       throws AmbariException;
+ 
++  ServiceComponent getServiceComponent(Long componentId) throws AmbariException;
++
+   Map<String, ServiceComponent> getServiceComponents();
+ 
+   void addServiceComponents(Map<String, ServiceComponent> components)
+@@ -72,7 +74,7 @@ public interface Service {
+ 
+   void debugDump(StringBuilder sb);
+ 
+-  ServiceComponent addServiceComponent(String serviceComponentName)
++  ServiceComponent addServiceComponent(String serviceComponentName, String serviceComponentType)
+       throws AmbariException;
+ 
+   /**
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
+index 3c44fdf..059ad37 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
+@@ -28,6 +28,10 @@ public interface ServiceComponent {
+ 
+   String getName();
+ 
++  String getType();
++
++  Long getId();
++
+   /**
+    * Get a true or false value specifying
+    * if auto start was enabled for this component.
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
+index 9c692d6..4c36e7c 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
+@@ -19,9 +19,12 @@ package org.apache.ambari.server.state;
+ 
+ import org.apache.ambari.server.orm.entities.ServiceComponentDesiredStateEntity;
+ 
++import com.google.inject.assistedinject.Assisted;
++
+ public interface ServiceComponentFactory {
+ 
+-  ServiceComponent createNew(Service service, String componentName);
++  ServiceComponent createNew(Service service, @Assisted("componentName") String componentName,
++                             @Assisted("componentType") String componentType);
+ 
+   ServiceComponent createExisting(Service service, ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity);
+ }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
+index 54c378d..46c704f 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
+@@ -71,12 +71,24 @@ public interface ServiceComponentHost {
+   String getServiceType();
+ 
+   /**
+-   * Get the ServiceComponent this object maps to
++   * Get the ServiceComponent's Id this object maps to
++   * @return Id of the ServiceComponent
++   */
++  public Long getServiceComponentId();
++
++  /**
++   * Get the ServiceComponent's Name this object maps to
+    * @return Name of the ServiceComponent
+    */
+   String getServiceComponentName();
+ 
+   /**
++   * Get the ServiceComponent's Type this object maps to
++   * @return Type of the ServiceComponent
++   */
++  String getServiceComponentType();
++
++  /**
+    * Get the Host this object maps to
+    * @return Host's hostname
+    */
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+index b4b4ea1..913d0c2 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+@@ -70,7 +70,9 @@ public class ServiceComponentImpl implements ServiceComponent {
+       LoggerFactory.getLogger(ServiceComponentImpl.class);
+   private final Service service;
+   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
++  private Long componentId;
+   private final String componentName;
++  private final String componentType;
+   private String displayName;
+   private boolean isClientComponent;
+   private boolean isMasterComponent;
+@@ -103,8 +105,8 @@ public class ServiceComponentImpl implements ServiceComponent {
+   private MaintenanceStateHelper maintenanceStateHelper;
+ 
+   @AssistedInject
+-  public ServiceComponentImpl(@Assisted Service service, @Assisted String componentName,
+-      AmbariMetaInfo ambariMetaInfo,
++  public ServiceComponentImpl(@Assisted Service service, @Assisted("componentName") String componentName,
++      @Assisted("componentType") String componentType, AmbariMetaInfo ambariMetaInfo,
+       ServiceComponentDesiredStateDAO serviceComponentDesiredStateDAO,
+       ClusterServiceDAO clusterServiceDAO, ServiceComponentHostFactory serviceComponentHostFactory,
+       AmbariEventPublisher eventPublisher)
+@@ -113,6 +115,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+     this.ambariMetaInfo = ambariMetaInfo;
+     this.service = service;
+     this.componentName = componentName;
++    this.componentType = componentType;
+     this.serviceComponentDesiredStateDAO = serviceComponentDesiredStateDAO;
+     this.clusterServiceDAO = clusterServiceDAO;
+     this.serviceComponentHostFactory = serviceComponentHostFactory;
+@@ -120,6 +123,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+ 
+     ServiceComponentDesiredStateEntity desiredStateEntity = new ServiceComponentDesiredStateEntity();
+     desiredStateEntity.setComponentName(componentName);
++    desiredStateEntity.setComponentType(componentType);
+     desiredStateEntity.setDesiredState(State.INIT);
+     desiredStateEntity.setServiceGroupId(service.getServiceGroupId());
+     desiredStateEntity.setServiceId(service.getServiceId());
+@@ -138,7 +142,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+     StackId stackId = service.getDesiredStackId();
+     try {
+       ComponentInfo compInfo = ambariMetaInfo.getComponent(stackId.getStackName(),
+-          stackId.getStackVersion(), service.getServiceType(), componentName);
++          stackId.getStackVersion(), service.getServiceType(), componentType);
+       isClientComponent = compInfo.isClient();
+       isMasterComponent = compInfo.isMaster();
+       isVersionAdvertised = compInfo.isVersionAdvertised();
+@@ -149,6 +153,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+           + ", clusterName=" + service.getCluster().getClusterName()
+           + ", serviceName=" + service.getServiceType()
+           + ", componentName=" + componentName
++          + ", componentType=" + componentType
+           + ", stackInfo=" + stackId.getStackId());
+     }
+   }
+@@ -172,6 +177,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+ 
+     desiredStateEntityId = serviceComponentDesiredStateEntity.getId();
+     componentName = serviceComponentDesiredStateEntity.getComponentName();
++    componentType = serviceComponentDesiredStateEntity.getComponentType();
+ 
+     updateComponentInfo();
+ 
+@@ -181,7 +187,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+         hostComponentStateEntity.getClusterId(),
+         hostComponentStateEntity.getServiceGroupId(),
+         hostComponentStateEntity.getServiceId(),
+-        hostComponentStateEntity.getComponentName(),
++        hostComponentStateEntity.getHostComponentDesiredStateId(),
+         hostComponentStateEntity.getHostId()
+       );
+ 
+@@ -191,9 +197,11 @@ public class ServiceComponentImpl implements ServiceComponent {
+             hostComponentStateEntity, hostComponentDesiredStateEntity));
+       } catch(ProvisionException ex) {
+         StackId currentStackId = getDesiredStackId();
+-        LOG.error(String.format("Can not get host component info: stackName=%s, stackVersion=%s, serviceName=%s, componentName=%s, hostname=%s",
+-          currentStackId.getStackName(), currentStackId.getStackVersion(),
+-          service.getName(),serviceComponentDesiredStateEntity.getComponentName(), hostComponentStateEntity.getHostName()));
++        LOG.error(String.format("Cannot get host component info: stackName=%s, stackVersion=%s, serviceName=%s, componentName=%s, " +
++                        "componentType=%s, hostname=%s",
++          currentStackId.getStackName(), currentStackId.getStackVersion(), service.getName(),
++          serviceComponentDesiredStateEntity.getComponentName(), serviceComponentDesiredStateEntity.getComponentType(),
++          hostComponentStateEntity.getHostName()));
+         ex.printStackTrace();
+       }
+     }
+@@ -204,6 +212,16 @@ public class ServiceComponentImpl implements ServiceComponent {
+     return componentName;
+   }
+ 
++  @Override
++  public String getType() {
++    return componentType;
++  }
++
++  @Override
++  public Long getId() {
++    return desiredStateEntityId;
++  }
++
+   /**
+    * Get the recoveryEnabled value.
+    *
+@@ -219,7 +237,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+     } else {
+       LOG.warn("Trying to fetch a member from an entity object that may " +
+               "have been previously deleted, serviceName = " + service.getName() + ", " +
+-              "componentName = " + componentName);
++              "componentName = " + componentName + ", componentType = " + componentType);
+     }
+     return false;
+   }
+@@ -232,8 +250,8 @@ public class ServiceComponentImpl implements ServiceComponent {
+   @Override
+   public void setRecoveryEnabled(boolean recoveryEnabled) {
+     if (LOG.isDebugEnabled()) {
+-      LOG.debug("Setting RecoveryEnabled of Component, clusterName={}, clusterId={}, serviceName={}, componentName={}, oldRecoveryEnabled={}, newRecoveryEnabled={}",
+-        service.getCluster().getClusterName(), service.getCluster().getClusterId(), service.getName(), getName(), isRecoveryEnabled(), recoveryEnabled);
++      LOG.debug("Setting RecoveryEnabled of Component, clusterName={}, clusterId={}, serviceName={}, componentName={}, componentType={}, oldRecoveryEnabled={}, newRecoveryEnabled={}",
++        service.getCluster().getClusterName(), service.getCluster().getClusterId(), service.getName(), getName(), getType(), isRecoveryEnabled(), recoveryEnabled);
+     }
+ 
+     ServiceComponentDesiredStateEntity desiredStateEntity = serviceComponentDesiredStateDAO.findById(
+@@ -346,7 +364,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+       } else {
+         LOG.warn("Trying to fetch a member from an entity object that may " +
+           "have been previously deleted, serviceName = " + getServiceName() + ", " +
+-          "componentName = " + componentName);
++          "componentName = " + componentName + ", componentType = " + componentType);
+       }
+ 
+     return null;
+@@ -439,7 +457,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+     }
+     ServiceComponentResponse r = new ServiceComponentResponse(getClusterId(),
+         cluster.getClusterName(), sg.getServiceGroupId(), sg.getServiceGroupName(), service.getServiceId(),
+-        service.getName(), service.getServiceType(), getName(), desiredStackId, getDesiredState().toString(),
++        service.getName(), service.getServiceType(), getId(), getName(), getType(), desiredStackId, getDesiredState().toString(),
+         getServiceComponentStateCount(), isRecoveryEnabled(), displayName, repositoryVersionEntity.getVersion(),
+         getRepositoryState());
+ 
+@@ -514,7 +532,7 @@ public class ServiceComponentImpl implements ServiceComponent {
+       if (!sch.canBeRemoved()) {
+         LOG.warn("Found non removable hostcomponent when trying to" + " delete service component"
+             + ", clusterName=" + getClusterName() + ", serviceName=" + getServiceName()
+-            + ", componentName=" + getName() + ", state=" + sch.getState() + ", hostname="
++            + ", componentName=" + getName() + ", componentType=" + getType() + ", state=" + sch.getState() + ", hostname="
+             + sch.getHostName());
+         return false;
+       }
+@@ -529,12 +547,12 @@ public class ServiceComponentImpl implements ServiceComponent {
+     try {
+       LOG.info("Deleting all servicecomponenthosts for component" + ", clusterName="
+           + getClusterName() + ", serviceName=" + getServiceName() + ", componentName=" + getName()
+-          + ", recoveryEnabled=" + isRecoveryEnabled());
++          + ", componentType=" + getType() + ", recoveryEnabled=" + isRecoveryEnabled());
+       for (ServiceComponentHost sch : hostComponents.values()) {
+         if (!sch.canBeRemoved()) {
+           throw new AmbariException("Found non removable hostcomponent " + " when trying to delete"
+               + " all hostcomponents from servicecomponent" + ", clusterName=" + getClusterName()
+-              + ", serviceName=" + getServiceName() + ", componentName=" + getName()
++              + ", serviceName=" + getServiceName() + ", componentName=" + getName() + ", componentType=" + getType()
+               + ", recoveryEnabled=" + isRecoveryEnabled() + ", hostname=" + sch.getHostName());
+         }
+       }
+@@ -555,13 +573,14 @@ public class ServiceComponentImpl implements ServiceComponent {
+     try {
+       ServiceComponentHost sch = getServiceComponentHost(hostname);
+       LOG.info("Deleting servicecomponenthost for cluster" + ", clusterName=" + getClusterName()
+-          + ", serviceName=" + getServiceName() + ", componentName=" + getName()
++          + ", serviceName=" + getServiceName() + ", componentName=" + getName() + ", componentType=" + getType()
+           + ", recoveryEnabled=" + isRecoveryEnabled() + ", hostname=" + sch.getHostName());
+       if (!sch.canBeRemoved()) {
+         throw new AmbariException("Could not delete hostcomponent from cluster"
+             + ", clusterName=" + getClusterName()
+             + ", serviceName=" + getServiceName()
+             + ", componentName=" + getName()
++            + ", componentType=" + getType()
+             + ", recoveryEnabled=" + isRecoveryEnabled()
+             + ", hostname=" + sch.getHostName());
+       }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+index 7f1daa7..4c622f9 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+@@ -78,7 +78,8 @@ public class ServiceImpl implements Service {
+ 
+   private final Cluster cluster;
+   private final ServiceGroup serviceGroup;
+-  private final ConcurrentMap<String, ServiceComponent> components = new ConcurrentHashMap<>();
++  private final ConcurrentMap<String, ServiceComponent> componentsByName = new ConcurrentHashMap<>();
++  private final ConcurrentMap<Long, ServiceComponent> componentsById = new ConcurrentHashMap<>();
+   private List<ServiceKey> serviceDependencies = new ArrayList<>();
+   private boolean isClientOnlyService;
+   private boolean isCredentialStoreSupported;
+@@ -224,10 +225,12 @@ public class ServiceImpl implements Service {
+       for (ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity
+           : serviceEntity.getServiceComponentDesiredStateEntities()) {
+         try {
+-            components.put(serviceComponentDesiredStateEntity.getComponentName(),
+-                serviceComponentFactory.createExisting(this,
+-                    serviceComponentDesiredStateEntity));
+-          } catch(ProvisionException ex) {
++            ServiceComponent svcComponent = serviceComponentFactory.createExisting(this,
++                    serviceComponentDesiredStateEntity);
++            componentsByName.put(serviceComponentDesiredStateEntity.getComponentName(), svcComponent);
++            componentsById.put(serviceComponentDesiredStateEntity.getId(), svcComponent);
++
++        } catch(ProvisionException ex) {
+             StackId stackId = new StackId(serviceComponentDesiredStateEntity.getDesiredStack());
+             LOG.error(String.format("Can not get component info: stackName=%s, stackVersion=%s, serviceName=%s, componentName=%s",
+               stackId.getStackName(), stackId.getStackVersion(),
+@@ -302,13 +305,13 @@ public class ServiceImpl implements Service {
+ 
+   @Override
+   public Map<String, ServiceComponent> getServiceComponents() {
+-    return new HashMap<>(components);
++    return new HashMap<>(componentsByName);
+   }
+ 
+   @Override
+   public void addServiceComponents(
+-      Map<String, ServiceComponent> components) throws AmbariException {
+-    for (ServiceComponent sc : components.values()) {
++      Map<String, ServiceComponent> componentsByName) throws AmbariException {
++    for (ServiceComponent sc : componentsByName.values()) {
+       addServiceComponent(sc);
+     }
+   }
+@@ -324,7 +327,7 @@ public class ServiceImpl implements Service {
+ 
+   @Override
+   public void addServiceComponent(ServiceComponent component) throws AmbariException {
+-    if (components.containsKey(component.getName())) {
++    if (componentsByName.containsKey(component.getName())) {
+       throw new AmbariException("Cannot add duplicate ServiceComponent"
+           + ", clusterName=" + cluster.getClusterName()
+           + ", clusterId=" + cluster.getClusterId()
+@@ -333,13 +336,13 @@ public class ServiceImpl implements Service {
+           + ", serviceComponentName=" + component.getName());
+     }
+ 
+-    components.put(component.getName(), component);
++    componentsByName.put(component.getName(), component);
+   }
+ 
+   @Override
+-  public ServiceComponent addServiceComponent(String serviceComponentName)
++  public ServiceComponent addServiceComponent(String serviceComponentName, String serviceComponentType)
+       throws AmbariException {
+-    ServiceComponent component = serviceComponentFactory.createNew(this, serviceComponentName);
++    ServiceComponent component = serviceComponentFactory.createNew(this, serviceComponentName, serviceComponentType);
+     addServiceComponent(component);
+     return component;
+   }
+@@ -347,7 +350,7 @@ public class ServiceImpl implements Service {
+   @Override
+   public ServiceComponent getServiceComponent(String componentName)
+       throws AmbariException {
+-    ServiceComponent serviceComponent = components.get(componentName);
++    ServiceComponent serviceComponent = componentsByName.get(componentName);
+     if (null == serviceComponent) {
+       throw new ServiceComponentNotFoundException(cluster.getClusterName(),
+           getName(), getServiceType(), serviceGroup.getServiceGroupName(), componentName);
+@@ -357,6 +360,17 @@ public class ServiceImpl implements Service {
+   }
+ 
+   @Override
++  public ServiceComponent getServiceComponent(Long componentId) throws AmbariException {
++    ServiceComponent serviceComponent = componentsById.get(componentId);
++    if (null == serviceComponent) {
++      throw new ServiceComponentNotFoundException(cluster.getClusterName(),
++              getName(), getServiceType(), serviceGroup.getServiceGroupName(), componentId);
++    }
++
++    return serviceComponent;
++  }
++
++  @Override
+   public Set<ServiceDependencyResponse> getServiceDependencyResponses() {
+     Set<ServiceDependencyResponse> responses = new HashSet<>();
+     if (getServiceDependencies() != null) {
+@@ -462,8 +476,8 @@ public class ServiceImpl implements Service {
+     serviceDesiredStateEntity.setDesiredRepositoryVersion(repositoryVersionEntity);
+     serviceDesiredStateDAO.merge(serviceDesiredStateEntity);
+ 
+-    Collection<ServiceComponent> components = getServiceComponents().values();
+-    for (ServiceComponent component : components) {
++    Collection<ServiceComponent> componentsByName = getServiceComponents().values();
++    for (ServiceComponent component : componentsByName) {
+       component.setDesiredRepositoryVersion(repositoryVersionEntity);
+     }
+   }
+@@ -473,12 +487,12 @@ public class ServiceImpl implements Service {
+    */
+   @Override
+   public RepositoryVersionState getRepositoryState() {
+-    if (components.isEmpty()) {
++    if (componentsByName.isEmpty()) {
+       return RepositoryVersionState.NOT_REQUIRED;
+     }
+ 
+     List<RepositoryVersionState> states = new ArrayList<>();
+-    for( ServiceComponent component : components.values() ){
++    for( ServiceComponent component : componentsByName.values() ){
+       states.add(component.getRepositoryState());
+     }
+ 
+@@ -649,9 +663,9 @@ public class ServiceImpl implements Service {
+       .append(", clusterId=").append(cluster.getClusterId())
+       .append(", desiredStackVersion=").append(getDesiredStackId())
+       .append(", desiredState=").append(getDesiredState())
+-      .append(", components=[ ");
++      .append(", componentsByName=[ ");
+     boolean first = true;
+-    for (ServiceComponent sc : components.values()) {
++    for (ServiceComponent sc : componentsByName.values()) {
+       if (!first) {
+         sb.append(" , ");
+       }
+@@ -702,11 +716,11 @@ public class ServiceImpl implements Service {
+   @Override
+   public boolean canBeRemoved() {
+     //
+-    // A service can be deleted if all it's components
++    // A service can be deleted if all it's componentsByName
+     // can be removed, irrespective of the state of
+     // the service itself.
+     //
+-    for (ServiceComponent sc : components.values()) {
++    for (ServiceComponent sc : componentsByName.values()) {
+       if (!sc.canBeRemoved()) {
+         LOG.warn("Found non-removable component when trying to delete service" + ", clusterName="
+             + cluster.getClusterName() + ", serviceName=" + getName() + ", serviceType="
+@@ -748,22 +762,22 @@ public class ServiceImpl implements Service {
+   public void deleteAllComponents() throws AmbariException {
+     lock.lock();
+     try {
+-      LOG.info("Deleting all components for service" + ", clusterName=" + cluster.getClusterName()
++      LOG.info("Deleting all componentsByName for service" + ", clusterName=" + cluster.getClusterName()
+           + ", serviceName=" + getName());
+       // FIXME check dependencies from meta layer
+-      for (ServiceComponent component : components.values()) {
++      for (ServiceComponent component : componentsByName.values()) {
+         if (!component.canBeRemoved()) {
+           throw new AmbariException("Found non removable component when trying to"
+-              + " delete all components from service" + ", clusterName=" + cluster.getClusterName()
++              + " delete all componentsByName from service" + ", clusterName=" + cluster.getClusterName()
+               + ", serviceName=" + getName() + ", componentName=" + component.getName());
+         }
+       }
+ 
+-      for (ServiceComponent serviceComponent : components.values()) {
++      for (ServiceComponent serviceComponent : componentsByName.values()) {
+         serviceComponent.delete();
+       }
+ 
+-      components.clear();
++      componentsByName.clear();
+     } finally {
+       lock.unlock();
+     }
+@@ -786,7 +800,7 @@ public class ServiceImpl implements Service {
+       }
+ 
+       component.delete();
+-      components.remove(componentName);
++      componentsByName.remove(componentName);
+     } finally {
+       lock.unlock();
+     }
+@@ -800,7 +814,7 @@ public class ServiceImpl implements Service {
+   @Override
+   @Transactional
+   public void delete() throws AmbariException {
+-    List<Component> components = getComponents(); // XXX temporal coupling, need to call this BEFORE deletingAllComponents
++    List<Component> componentsByName = getComponents(); // XXX temporal coupling, need to call this BEFORE deletingAllComponents
+     deleteAllComponents();
+     deleteAllServiceConfigs();
+ 
+@@ -815,7 +829,7 @@ public class ServiceImpl implements Service {
+ 
+     ServiceRemovedEvent event = new ServiceRemovedEvent(getClusterId(), stackId.getStackName(), stackId.getStackVersion(),
+                                                         getName(), getServiceType(),
+-                                                        serviceGroup.getServiceGroupName(), components);
++                                                        serviceGroup.getServiceGroupName(), componentsByName);
+ 
+     eventPublisher.publish(event);
+   }
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+index 9b0390f..3b83971 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+@@ -1187,6 +1187,58 @@ public class ClusterImpl implements Cluster {
+     throw new ServiceNotFoundException(getClusterName(), "component: " + componentName);
+   }
+ 
++  @Override
++  public Service getServiceByComponentId(Long componentId) throws AmbariException {
++    for (Service service : services.values()) {
++      for (ServiceComponent component : service.getServiceComponents().values()) {
++        if (component.getId().equals(componentId)) {
++          return service;
++        }
++      }
++    }
++
++    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
++  }
++
++  @Override
++  public String getComponentName(Long componentId) throws AmbariException {
++    for (Service service : services.values()) {
++      for (ServiceComponent component : service.getServiceComponents().values()) {
++        if (component.getId() == componentId) {
++          return component.getName();
++        }
++      }
++    }
++
++    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
++  }
++
++
++  @Override
++  public String getComponentType(Long componentId) throws AmbariException {
++    for (Service service : services.values()) {
++      for (ServiceComponent component : service.getServiceComponents().values()) {
++        if (component.getId() == componentId) {
++          return component.getType();
++        }
++      }
++    }
++
++    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
++  }
++
++  @Override
++  public Long getComponentId(String componentName) throws AmbariException {
++    for (Service service : services.values()) {
++      for (ServiceComponent component : service.getServiceComponents().values()) {
++        if (component.getName().equals(componentName)) {
++          return component.getId();
++        }
++      }
++    }
++
++    throw new ServiceNotFoundException(getClusterName(), "component Name: " + componentName);
++  }
+ 
+   @Override
+   public ServiceGroup getServiceGroup(String serviceGroupName) throws ServiceGroupNotFoundException {
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+index 519bcc6..fed7c7e 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+@@ -789,7 +789,9 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+     stateEntity.setClusterId(serviceComponent.getClusterId());
+     stateEntity.setServiceGroupId(serviceComponent.getServiceGroupId());
+     stateEntity.setServiceId(serviceComponent.getServiceId());
++    stateEntity.setComponentId(serviceComponent.getId());
+     stateEntity.setComponentName(serviceComponent.getName());
++    stateEntity.setComponentType(serviceComponent.getType());
+     stateEntity.setVersion(State.UNKNOWN.toString());
+     stateEntity.setHostEntity(hostEntity);
+     stateEntity.setCurrentState(stateMachine.getCurrentState());
+@@ -996,11 +998,21 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+   }
+ 
+   @Override
++  public Long getServiceComponentId() {
++    return serviceComponent.getId();
++  }
++
++  @Override
+   public String getServiceComponentName() {
+     return serviceComponent.getName();
+   }
+ 
+   @Override
++  public String getServiceComponentType() {
++    return serviceComponent.getType();
++  }
++
++  @Override
+   public String getHostName() {
+     return host.getHostName();
+   }
+@@ -1185,6 +1197,8 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+       e.printStackTrace();
+     }
+     String serviceComponentName = serviceComponent.getName();
++    String serviceComponentType = serviceComponent.getType();
++
+     Long hostComponentId = getHostComponentId();
+     String hostName = getHostName();
+     String publicHostName = hostEntity.getPublicHostName();
+@@ -1212,8 +1226,8 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+ 
+     ServiceComponentHostResponse r = new ServiceComponentHostResponse(clusterId, clusterName, service.getServiceGroupId(),
+             service.getServiceGroupName(), service.getServiceId(), service.getName(), service.getServiceType(),
+-            hostComponentId, serviceComponentName, displayName, hostName, publicHostName, state, getVersion(),
+-            desiredState, desiredStackId, desiredRepositoryVersion, componentAdminState);
++            hostComponentId, serviceComponentName, serviceComponentType, displayName, hostName, publicHostName, state,
++            getVersion(), desiredState, desiredStackId, desiredRepositoryVersion, componentAdminState);
+ 
+     r.setActualConfigs(actualConfigs);
+     r.setUpgradeState(upgradeState);
+@@ -1246,6 +1260,8 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+     sb.append("ServiceComponentHost={ hostname=").append(getHostName())
+     .append(", serviceComponentName=")
+     .append(serviceComponent.getName())
++    .append(", serviceComponentType=")
++    .append(serviceComponent.getType())
+     .append(", clusterName=")
+     .append(serviceComponent.getClusterName())
+     .append(", serviceName=")
+@@ -1264,9 +1280,10 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+   @Transactional
+   void persistEntities(HostEntity hostEntity, HostComponentStateEntity stateEntity,
+       HostComponentDesiredStateEntity desiredStateEntity) {
+-    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        serviceComponent.getClusterId(), serviceComponent.getServiceGroupId(), serviceComponent.getServiceId(),
+-        serviceComponent.getName());
++    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = null;
++    serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
++            serviceComponent.getClusterId(), serviceComponent.getServiceGroupId(), serviceComponent.getServiceId(),
++            serviceComponent.getName(), serviceComponent.getType());
+ 
+     desiredStateEntity.setServiceComponentDesiredStateEntity(serviceComponentDesiredStateEntity);
+     desiredStateEntity.setHostEntity(hostEntity);
+@@ -1274,8 +1291,9 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
+     stateEntity.setServiceComponentDesiredStateEntity(serviceComponentDesiredStateEntity);
+     stateEntity.setHostEntity(hostEntity);
+ 
+-    hostComponentStateDAO.create(stateEntity);
+     hostComponentDesiredStateDAO.create(desiredStateEntity);
++    stateEntity.setHostComponentDesiredStateEntity(desiredStateEntity);
++    hostComponentStateDAO.create(stateEntity);
+ 
+     serviceComponentDesiredStateEntity.getHostComponentDesiredStateEntities().add(
+         desiredStateEntity);
+diff --git a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+index 6fbb59e..5eb8175 100644
+--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
++++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+@@ -370,7 +370,7 @@ public class AmbariContext {
+ 
+       for (String component : topology.getBlueprint().getComponentNames(service)) {
+         String recoveryEnabled = topology.getBlueprint().getRecoveryEnabled(service, component);
+-        componentRequests.add(new ServiceComponentRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, component, null, recoveryEnabled));
++        componentRequests.add(new ServiceComponentRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, component, component, recoveryEnabled));
+       }
+     }
+ 
+@@ -446,7 +446,7 @@ public class AmbariContext {
+         //todo: handle this in a generic manner.  These checks are all over the code
+         try {
+           if (cluster.getService(service) != null && !component.equals(RootComponent.AMBARI_SERVER.name())) {
+-            requests.add(new ServiceComponentHostRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, component, hostName, null));
++            requests.add(new ServiceComponentHostRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, null, component, component, hostName, null));
+           }
+         } catch(AmbariException se) {
+           LOG.warn("Service already deleted from cluster: {}", service);
+diff --git a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+index c2f83e6..656aaa4 100644
+--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
++++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+@@ -270,6 +270,7 @@ CREATE TABLE repo_tags (
+ CREATE TABLE servicecomponentdesiredstate (
+   id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+   service_id BIGINT NOT NULL,
+@@ -286,6 +287,7 @@ CREATE TABLE hostcomponentdesiredstate (
+   id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   desired_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+@@ -294,15 +296,17 @@ CREATE TABLE hostcomponentdesiredstate (
+   maintenance_state VARCHAR(32) NOT NULL,
+   restart_required SMALLINT NOT NULL DEFAULT 0,
+   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
+-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
++  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ 
+ CREATE TABLE hostcomponentstate (
+   id BIGINT NOT NULL,
++  host_component_desired_state_id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+   current_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+@@ -310,7 +314,9 @@ CREATE TABLE hostcomponentstate (
+   service_id BIGINT NOT NULL,
+   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
+   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
++  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
++  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);
+diff --git a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+index c420286..17ef99b 100644
+--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
++++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+@@ -289,6 +289,7 @@ CREATE TABLE repo_tags (
+ CREATE TABLE servicecomponentdesiredstate (
+   id BIGINT NOT NULL,
+   component_name VARCHAR(100) NOT NULL,
++  component_type VARCHAR(100) NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+   service_id BIGINT NOT NULL,
+@@ -305,6 +306,7 @@ CREATE TABLE hostcomponentdesiredstate (
+   id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(100) NOT NULL,
++  component_type VARCHAR(100) NOT NULL,
+   desired_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+@@ -313,15 +315,17 @@ CREATE TABLE hostcomponentdesiredstate (
+   maintenance_state VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
+   restart_required TINYINT(1) NOT NULL DEFAULT 0,
+   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
+-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
++  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ 
+ CREATE TABLE hostcomponentstate (
+   id BIGINT NOT NULL,
++  host_component_desired_state_id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(100) NOT NULL,
++  component_type VARCHAR(100) NOT NULL,
+   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+   current_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+@@ -329,7 +333,9 @@ CREATE TABLE hostcomponentstate (
+   service_id BIGINT NOT NULL,
+   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
+   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
++  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
++  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);
+diff --git a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+index 3bcba3f..136b2a2 100644
+--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
++++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+@@ -269,6 +269,7 @@ CREATE TABLE repo_tags (
+ CREATE TABLE servicecomponentdesiredstate (
+   id NUMBER(19) NOT NULL,
+   component_name VARCHAR2(255) NOT NULL,
++  component_type VARCHAR2(255) NOT NULL,
+   cluster_id NUMBER(19) NOT NULL,
+   service_group_id NUMBER(19) NOT NULL,
+   service_id NUMBER(19) NOT NULL,
+@@ -285,6 +286,7 @@ CREATE TABLE hostcomponentdesiredstate (
+   id NUMBER(19) NOT NULL,
+   cluster_id NUMBER(19) NOT NULL,
+   component_name VARCHAR2(255) NOT NULL,
++  component_type VARCHAR2(255) NOT NULL,
+   desired_state VARCHAR2(255) NOT NULL,
+   host_id NUMBER(19) NOT NULL,
+   service_group_id NUMBER(19) NOT NULL,
+@@ -293,14 +295,16 @@ CREATE TABLE hostcomponentdesiredstate (
+   maintenance_state VARCHAR2(32) NOT NULL,
+   restart_required NUMBER(1) DEFAULT 0 NOT NULL,
+   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
+-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, host_id, cluster_id),
++  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, host_id, cluster_id),
+   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE TABLE hostcomponentstate (
+   id NUMBER(19) NOT NULL,
++  host_component_desired_state_id NUMBER(19) NOT NULL,
+   cluster_id NUMBER(19) NOT NULL,
+   component_name VARCHAR2(255) NOT NULL,
++  component_type VARCHAR2(255) NOT NULL,
+   version VARCHAR2(32) DEFAULT 'UNKNOWN' NOT NULL,
+   current_state VARCHAR2(255) NOT NULL,
+   host_id NUMBER(19) NOT NULL,
+@@ -308,7 +312,9 @@ CREATE TABLE hostcomponentstate (
+   service_id NUMBER(19) NOT NULL,
+   upgrade_state VARCHAR2(32) DEFAULT 'NONE' NOT NULL,
+   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
++  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
++  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);
+diff --git a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+index b3c5007..88b0933 100644
+--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
++++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+@@ -271,6 +271,7 @@ CREATE TABLE repo_tags (
+ CREATE TABLE servicecomponentdesiredstate (
+   id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+   service_id BIGINT NOT NULL,
+@@ -287,6 +288,7 @@ CREATE TABLE hostcomponentdesiredstate (
+   id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   desired_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+@@ -295,14 +297,16 @@ CREATE TABLE hostcomponentdesiredstate (
+   maintenance_state VARCHAR(32) NOT NULL,
+   restart_required SMALLINT NOT NULL DEFAULT 0,
+   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
+-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
++  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE TABLE hostcomponentstate (
+   id BIGINT NOT NULL,
++  host_component_desired_state_id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+   current_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+@@ -310,7 +314,9 @@ CREATE TABLE hostcomponentstate (
+   service_id BIGINT NOT NULL,
+   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
+   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
++  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
++  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);
+diff --git a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+index e9897b1..25c76a1 100644
+--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
++++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+@@ -268,6 +268,7 @@ CREATE TABLE repo_tags (
+ CREATE TABLE servicecomponentdesiredstate (
+   id NUMERIC(19) NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   cluster_id NUMERIC(19) NOT NULL,
+   service_group_id NUMERIC(19) NOT NULL,
+   service_id NUMERIC(19) NOT NULL,
+@@ -284,6 +285,7 @@ CREATE TABLE hostcomponentdesiredstate (
+   id NUMERIC(19) NOT NULL,
+   cluster_id NUMERIC(19) NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   desired_state VARCHAR(255) NOT NULL,
+   host_id NUMERIC(19) NOT NULL,
+   service_group_id BIGINT NOT NULL,
+@@ -292,14 +294,16 @@ CREATE TABLE hostcomponentdesiredstate (
+   maintenance_state VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
+   restart_required BIT NOT NULL DEFAULT 0,
+   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
+-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
++  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE TABLE hostcomponentstate (
+   id NUMERIC(19) NOT NULL,
++  host_component_desired_state_id NUMERIC(19) NOT NULL,
+   cluster_id NUMERIC(19) NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+   current_state VARCHAR(255) NOT NULL,
+   host_id NUMERIC(19) NOT NULL,
+@@ -307,7 +311,9 @@ CREATE TABLE hostcomponentstate (
+   service_id BIGINT NOT NULL,
+   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
+   CONSTRAINT PK_hostcomponentstate PRIMARY KEY (id),
++  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
++  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);
+diff --git a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+index 94f00f0..e90078d 100644
+--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
++++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+@@ -282,6 +282,7 @@ CREATE TABLE repo_tags (
+ CREATE TABLE servicecomponentdesiredstate (
+   id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+   service_id BIGINT NOT NULL,
+@@ -298,6 +299,7 @@ CREATE TABLE hostcomponentdesiredstate (
+   id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   desired_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+   service_group_id BIGINT NOT NULL,
+@@ -306,14 +308,16 @@ CREATE TABLE hostcomponentdesiredstate (
+   maintenance_state VARCHAR(32) NOT NULL,
+   restart_required BIT NOT NULL DEFAULT 0,
+   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY CLUSTERED (id),
+-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
++  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE TABLE hostcomponentstate (
+   id BIGINT NOT NULL,
++  host_component_desired_state_id BIGINT NOT NULL,
+   cluster_id BIGINT NOT NULL,
+   component_name VARCHAR(255) NOT NULL,
++  component_type VARCHAR(255) NOT NULL,
+   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
+   current_state VARCHAR(255) NOT NULL,
+   host_id BIGINT NOT NULL,
+@@ -321,7 +325,9 @@ CREATE TABLE hostcomponentstate (
+   service_id BIGINT NOT NULL,
+   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
+   CONSTRAINT PK_hostcomponentstate PRIMARY KEY CLUSTERED (id),
++  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
+   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
++  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
+ 
+ CREATE NONCLUSTERED INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);
+diff --git a/ambari-server/src/main/resources/key_properties.json b/ambari-server/src/main/resources/key_properties.json
+index 6e2463b..c45136c 100644
+--- a/ambari-server/src/main/resources/key_properties.json
++++ b/ambari-server/src/main/resources/key_properties.json
+@@ -11,7 +11,7 @@
+     "ServiceGroup": "HostRoles/service_group_name",
+     "Host": "HostRoles/host_name",
+     "Service": "HostRoles/service_name",
+-    "HostComponent": "HostRoles/component_name",
++    "HostComponent": "HostRoles/id",
+     "Component": "HostRoles/component_name"
+   },
+   "Action": {
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java b/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
+index 53e0984..e5a7fbd 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
+@@ -155,11 +155,11 @@ public class HeartbeatProcessorTest {
+   public void testHeartbeatWithConfigs() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -223,7 +223,7 @@ public class HeartbeatProcessorTest {
+   public void testRestartRequiredAfterInstallClient() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(HDFS_CLIENT);
++    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
+     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -287,11 +287,11 @@ public class HeartbeatProcessorTest {
+   public void testHeartbeatCustomCommandWithConfigs() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -370,11 +370,11 @@ public class HeartbeatProcessorTest {
+   public void testHeartbeatCustomStartStop() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -453,11 +453,11 @@ public class HeartbeatProcessorTest {
+   public void testStatusHeartbeat() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -574,7 +574,7 @@ public class HeartbeatProcessorTest {
+       throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -692,7 +692,7 @@ public class HeartbeatProcessorTest {
+   public void testUpgradeSpecificHandling() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -785,7 +785,7 @@ public class HeartbeatProcessorTest {
+   public void testCommandStatusProcesses() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
+ 
+@@ -863,11 +863,11 @@ public class HeartbeatProcessorTest {
+   public void testComponentUpgradeFailReport() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(HDFS_CLIENT);
++    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
+     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
+ 
+     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
+@@ -974,11 +974,11 @@ public class HeartbeatProcessorTest {
+   public void testComponentUpgradeInProgressReport() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(HDFS_CLIENT);
++    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
+     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
+ 
+     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
+@@ -1230,10 +1230,10 @@ public class HeartbeatProcessorTest {
+   public void testComponentInProgressStatusSafeAfterStatusReport() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).
+         addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).
+         addServiceComponentHost(DummyHostname1);
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+index 3e48ba9..afbb370 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+@@ -186,9 +186,9 @@ public class TestHeartbeatHandler {
+ 
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
+-    hdfs.addServiceComponent(NAMENODE);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     Collection<Host> hosts = cluster.getHosts();
+     assertEquals(hosts.size(), 1);
+ 
+@@ -237,9 +237,9 @@ public class TestHeartbeatHandler {
+   public void testStatusHeartbeatWithAnnotation() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
+-    hdfs.addServiceComponent(NAMENODE);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+ 
+     ActionQueue aq = new ActionQueue();
+ 
+@@ -287,10 +287,10 @@ public class TestHeartbeatHandler {
+   public void testLiveStatusUpdateAfterStopFailed() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).
+         addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, DATANODE);
+     hdfs.getServiceComponent(NAMENODE).
+         addServiceComponentHost(DummyHostname1);
+ 
+@@ -391,15 +391,15 @@ public class TestHeartbeatHandler {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+-    hdfs.addServiceComponent(HDFS_CLIENT);
++    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
+     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
+ 
+     // Create helper after creating service to avoid race condition caused by asynchronous recovery configs
+@@ -467,15 +467,15 @@ public class TestHeartbeatHandler {
+     /*
+      * Add three service components enabled for auto start.
+      */
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+-    hdfs.addServiceComponent(HDFS_CLIENT).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(HDFS_CLIENT);
+     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
+ 
+@@ -796,11 +796,11 @@ public class TestHeartbeatHandler {
+   public void testTaskInProgressHandling() throws Exception, InvalidStateTransitionException {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -852,11 +852,11 @@ public class TestHeartbeatHandler {
+   public void testOPFailedEventForAbortedTask() throws Exception, InvalidStateTransitionException {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
++    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
+     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -922,11 +922,11 @@ public class TestHeartbeatHandler {
+   public void testStatusHeartbeat() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(HDFS_CLIENT);
++    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
+     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
+ 
+     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
+@@ -982,9 +982,9 @@ public class TestHeartbeatHandler {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Host hostObject = clusters.getHost(DummyHostname1);
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+     hdfs.getServiceComponent(NAMENODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
+     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
+@@ -1062,9 +1062,9 @@ public class TestHeartbeatHandler {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Host hostObject = clusters.getHost(DummyHostname1);
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+-    hdfs.addServiceComponent(NAMENODE);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+     hdfs.getServiceComponent(NAMENODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
+     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
+@@ -1388,7 +1388,7 @@ public class TestHeartbeatHandler {
+   public void testCommandStatusProcesses_empty() throws Exception {
+     Cluster cluster = heartbeatTestHelper.getDummyCluster();
+     Service hdfs = addService(cluster, HDFS);
+-    hdfs.addServiceComponent(DATANODE);
++    hdfs.addServiceComponent(DATANODE, DATANODE);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
+index 5c96ece..e4b8b2d 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
+@@ -176,11 +176,11 @@ public class TestHeartbeatMonitor {
+     clusters.mapAndPublishHostsToCluster(hostNames, clusterName);
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
++    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
+     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
+ 
+     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
+@@ -279,16 +279,16 @@ public class TestHeartbeatMonitor {
+     clusters.mapAndPublishHostsToCluster(hostNames, clusterName);
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost
+     (hostname1);
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost
+     (hostname1);
+-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
++    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
+     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).
+         addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost
+     (hostname1);
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost
+@@ -387,11 +387,11 @@ public class TestHeartbeatMonitor {
+ 
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
++    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
+     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
+ 
+     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
+@@ -469,13 +469,13 @@ public class TestHeartbeatMonitor {
+ 
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
++    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
+     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(hostname1);
+ 
+     ActionQueue aq = new ActionQueue();
+@@ -589,11 +589,11 @@ public class TestHeartbeatMonitor {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
+-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
++    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
+     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
+ 
+     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java b/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
+index ff3a109..44befba 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
+@@ -151,7 +151,7 @@ public class RecoveryConfigHelperTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion());
+     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+     // Get the recovery configuration
+@@ -159,7 +159,7 @@ public class RecoveryConfigHelperTest {
+     assertEquals(recoveryConfig.getEnabledComponents(), "DATANODE");
+ 
+     // Install HDFS::NAMENODE to trigger a component installed event
+-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     // Verify that the config is stale now
+@@ -186,10 +186,10 @@ public class RecoveryConfigHelperTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
+     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     // Get the recovery configuration
+@@ -223,7 +223,7 @@ public class RecoveryConfigHelperTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
+     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setDesiredState(State.INSTALLED);
+ 
+@@ -264,10 +264,10 @@ public class RecoveryConfigHelperTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
+     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
+ 
+     // Get the recovery configuration
+@@ -300,7 +300,7 @@ public class RecoveryConfigHelperTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
+     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
+ 
+     // Get the recovery configuration
+@@ -344,7 +344,7 @@ public class RecoveryConfigHelperTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
+     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
+ 
+-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
++    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
+ 
+     // Add SCH to Host1 and Host2
+     hdfs.getServiceComponent(DATANODE).addServiceComponentHost("Host1");
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+index 8fb34c0..15f3134 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+@@ -581,8 +581,8 @@ public class AmbariCustomCommandExecutionHelperTest {
+     OrmTestHelper ormTestHelper = injector.getInstance(OrmTestHelper.class);
+     RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.6"), "2.0.6-1234");
+     createService("c1", "CORE", "HADOOP_CLIENTS", repositoryVersion);
+-    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
+-    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
++    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
++    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", 1L, "SOME_CLIENT_FOR_SERVICE_CHECK", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
+ 
+     //make sure there are no HDFS_CLIENT components from HDFS service
+     Cluster c1 = clusters.getCluster("c1");
+@@ -745,7 +745,7 @@ public class AmbariCustomCommandExecutionHelperTest {
+ 
+     // add a repo version associated with a component
+     ServiceComponentDesiredStateEntity componentEntity = componentDAO.findByName(cluster.getClusterId(), serviceYARN.getServiceGroupId(),
+-        serviceYARN.getServiceId(), componentRM.getName());
++        serviceYARN.getServiceId(), componentRM.getName(), componentRM.getType());
+ 
+     ServiceComponentVersionEntity componentVersionEntity = new ServiceComponentVersionEntity();
+     componentVersionEntity.setRepositoryVersion(repositoryVersion);
+@@ -794,29 +794,30 @@ public class AmbariCustomCommandExecutionHelperTest {
+     createService(clusterName, serviceGroupName, "ZOOKEEPER", repositoryVersion);
+     createService(clusterName, serviceGroupName, "FLUME", repositoryVersion);
+ 
+-    createServiceComponent(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", State.INIT);
+-    createServiceComponent(clusterName, serviceGroupName, "YARN", "NODEMANAGER", State.INIT);
+-    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", State.INIT);
+-    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", State.INIT);
+-    createServiceComponent(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", State.INIT);
++    createServiceComponent(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", State.INIT);
++    createServiceComponent(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", State.INIT);
++    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", "GANGLIA_SERVER", State.INIT);
++    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", "GANGLIA_MONITOR", State.INIT);
++    createServiceComponent(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", State.INIT);
+ 
+     // this component should be not installed on any host
+-    createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", State.INIT);
++    createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", "FLUME_HANDLER", State.INIT);
+   }
+ 
+ 
+   private void createServiceComponentHosts(String clusterName, String serviceGroupName, String hostPrefix) throws AmbariException, AuthorizationException {
+     String hostC6401 = hostPrefix + "-c6401";
+     String hostC6402 = hostPrefix + "-c6402";
+-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", hostC6401, null);
+-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6401, null);
+-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", hostC6401, State.INIT);
+-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", hostC6401, State.INIT);
+-    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostC6401, State.INIT);
+-
+-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6402, null);
+-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", hostC6402, State.INIT);
+-    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostC6402, State.INIT);
++    // TODO : Numbers for component Id may not be correct.
++    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 1L, "RESOURCEMANAGER", "RESOURCEMANAGER", hostC6401, null);
++    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 2L, "NODEMANAGER", "NODEMANAGER", hostC6401, null);
++    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 3L, "GANGLIA_SERVER", "GANGLIA_SERVER", hostC6401, State.INIT);
++    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 4L, "GANGLIA_MONITOR", "GANGLIA_MONITOR", hostC6401, State.INIT);
++    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", 5L, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", hostC6401, State.INIT);
++
++    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 6L,"NODEMANAGER", "NODEMANAGER", hostC6402, null);
++    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 7L,"GANGLIA_MONITOR", "GANGLIA_MONITOR", hostC6402, State.INIT);
++    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", 8L, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", hostC6402, State.INIT);
+   }
+   private void addHost(String hostname, String clusterName) throws AmbariException {
+     clusters.addHost(hostname);
+@@ -849,16 +850,17 @@ public class AmbariCustomCommandExecutionHelperTest {
+   }
+ 
+   private void createServiceComponent(
+-    String clusterName, String serviceGroupName, String serviceName, String componentName, State desiredState
++    String clusterName, String serviceGroupName, String serviceName, String componentName, String componentType, State desiredState
+   ) throws AmbariException, AuthorizationException {
+-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
++    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState != null ? desiredState.name() : null);
+     ComponentResourceProviderTest.createComponents(ambariManagementController, Collections.singleton(r));
+   }
+ 
+   private void createServiceComponentHost(
+-    String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState
++    String clusterName, String serviceGroupName, String serviceName, Long componentId, String componentName, String componentType, String hostname, State desiredState
+   ) throws AmbariException, AuthorizationException {
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType,
++            hostname, desiredState != null ? desiredState.name() : null);
+     ambariManagementController.createHostComponents(Collections.singleton(r));
+   }
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+index 4b996e5..aa6f5c5 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+@@ -846,7 +846,7 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+     setRequests.add(request1);
+@@ -913,7 +913,7 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -978,7 +978,7 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+     request1.setState("INSTALLED");
+ 
+ 
+@@ -1055,7 +1055,7 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+     request1.setMaintenanceState("ON");
+ 
+ 
+@@ -1139,13 +1139,13 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component2", "host1", null);
++        "cluster1", "CORE", "service1", "component2", "component2","host1", null);
+ 
+     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component3", "host1", null);
++        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1238,13 +1238,13 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service2", "component2", "host1", null);
++        "cluster1", "CORE", "service2", "component2", "component2", "host1", null);
+ 
+     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component3", "host1", null);
++        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1344,13 +1344,13 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service2", "component2", "host1", null);
++        "cluster1", "CORE", "service2", "component2", "component2", "host1", null);
+ 
+     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component3", "host1", null);
++        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1452,13 +1452,13 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", null, null);
++        "cluster1", "CORE", "service1", "component1", "component1", null, null);
+ 
+     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component2", "host2", null);
++        "cluster1", "CORE", "service1", "component2", "component2", "host2", null);
+ 
+     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component3", null, null);
++        "cluster1", "CORE", "service1", "component3", "component3", null, null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1537,13 +1537,13 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component2", "host1", null);
++        "cluster1", "CORE", "service1", "component2", "component2", "host1", null);
+ 
+     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component3", "host1", null);
++        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1592,13 +1592,13 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", "host1", null);
++        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
+ 
+     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component2", "host2", null);
++        "cluster1", "CORE", "service1", "component2", "component2", "host2", null);
+ 
+     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component3", "host1", null);
++        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1657,7 +1657,7 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", "service1", "component1", null, null);
++        "cluster1", "CORE", "service1", "component1", "component1", null, null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+@@ -1737,7 +1737,7 @@ public class AmbariManagementControllerImplTest {
+ 
+     // requests
+     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
+-        "cluster1", "CORE", null, null, null, null);
++        "cluster1", "CORE", null, null, null, null, null);
+ 
+ 
+     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+index 3c6ec16..ca97eb0 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+@@ -410,7 +410,7 @@ public class AmbariManagementControllerTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
+-        serviceName, componentName, dStateStr);
++        serviceName, componentName, componentName, dStateStr);
+     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
+   }
+ 
+@@ -423,7 +423,7 @@ public class AmbariManagementControllerTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
+-        serviceName, componentName, hostname, dStateStr);
++        serviceName, componentName, componentName, hostname, dStateStr);
+     controller.createHostComponents(Collections.singleton(r));
+   }
+ 
+@@ -436,7 +436,7 @@ public class AmbariManagementControllerTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
+-        serviceName, componentName, hostname, dStateStr);
++        serviceName, componentName, componentName, hostname, dStateStr);
+     controller.deleteHostComponents(Collections.singleton(r));
+   }
+ 
+@@ -506,7 +506,7 @@ public class AmbariManagementControllerTest {
+     for (ServiceComponent sc : s.getServiceComponents().values()) {
+       for (ServiceComponentHost sch : sc.getServiceComponentHosts().values()) {
+         ServiceComponentHostRequest schr = new ServiceComponentHostRequest
+-          (clusterName, serviceGroupName, serviceName, sc.getName(),
++          (clusterName, serviceGroupName, serviceName, sc.getName(), sc.getType(),
+             sch.getHostName(), State.INSTALLED.name());
+         requests.add(schr);
+       }
+@@ -952,7 +952,7 @@ public class AmbariManagementControllerTest {
+         .getService(serviceName).getServiceComponent(componentName));
+ 
+     ServiceComponentRequest r =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, null, null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, null, null, null);
+     Set<ServiceComponentResponse> response = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(1, response.size());
+ 
+@@ -991,7 +991,7 @@ public class AmbariManagementControllerTest {
+     try {
+       set1.clear();
+       ServiceComponentRequest rInvalid =
+-          new ServiceComponentRequest(cluster1, null, null, null, null);
++          new ServiceComponentRequest(cluster1, null, null, null, null, null);
+       set1.add(rInvalid);
+       ComponentResourceProviderTest.createComponents(controller, set1);
+       fail("Expected failure for invalid requests");
+@@ -1002,7 +1002,7 @@ public class AmbariManagementControllerTest {
+     try {
+       set1.clear();
+       ServiceComponentRequest rInvalid =
+-          new ServiceComponentRequest(cluster1, "s1", null, null, null);
++          new ServiceComponentRequest(cluster1, "s1", null, null, null, null);
+       set1.add(rInvalid);
+       ComponentResourceProviderTest.createComponents(controller, set1);
+       fail("Expected failure for invalid requests");
+@@ -1052,11 +1052,11 @@ public class AmbariManagementControllerTest {
+ 
+     set1.clear();
+     ServiceComponentRequest valid1 =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null);
+     ServiceComponentRequest valid2 =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", "JOBTRACKER", null);
+     ServiceComponentRequest valid3 =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", "TASKTRACKER", null);
+     set1.add(valid1);
+     set1.add(valid2);
+     set1.add(valid3);
+@@ -1065,9 +1065,9 @@ public class AmbariManagementControllerTest {
+     try {
+       set1.clear();
+       ServiceComponentRequest rInvalid1 =
+-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
++          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
+       ServiceComponentRequest rInvalid2 =
+-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
++          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
+       set1.add(rInvalid1);
+       set1.add(rInvalid2);
+       ComponentResourceProviderTest.createComponents(controller, set1);
+@@ -1079,9 +1079,9 @@ public class AmbariManagementControllerTest {
+     try {
+       set1.clear();
+       ServiceComponentRequest rInvalid1 =
+-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
++          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
+       ServiceComponentRequest rInvalid2 =
+-          new ServiceComponentRequest(cluster2, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
++          new ServiceComponentRequest(cluster2, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
+       set1.add(rInvalid1);
+       set1.add(rInvalid2);
+       ComponentResourceProviderTest.createComponents(controller, set1);
+@@ -1093,7 +1093,7 @@ public class AmbariManagementControllerTest {
+     try {
+       set1.clear();
+       ServiceComponentRequest rInvalid =
+-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", null);
++          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null);
+       set1.add(rInvalid);
+       ComponentResourceProviderTest.createComponents(controller, set1);
+       fail("Expected failure for already existing component");
+@@ -1164,7 +1164,7 @@ public class AmbariManagementControllerTest {
+     // issue an install command, expect retry is enabled
+     ServiceComponentHostRequest
+         schr =
+-        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "INSTALLED");
++        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "INSTALLED");
+     Map<String, String> requestProps = new HashMap<>();
+     requestProps.put("phase", "INITIAL_INSTALL");
+     RequestStatusResponse rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
+@@ -1190,7 +1190,7 @@ public class AmbariManagementControllerTest {
+     }
+ 
+     // issue an start command but no retry as phase is only INITIAL_INSTALL
+-    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "STARTED");
++    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "STARTED");
+     rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
+     stages = actionDB.getAllStages(rsr.getRequestId());
+     Assert.assertEquals(1, stages.size());
+@@ -1220,7 +1220,7 @@ public class AmbariManagementControllerTest {
+ 
+     // issue an start command and retry is expected
+     requestProps.put("phase", "INITIAL_START");
+-    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "STARTED");
++    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "STARTED");
+     rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
+     stages = actionDB.getAllStages(rsr.getRequestId());
+     Assert.assertEquals(1, stages.size());
+@@ -1250,7 +1250,7 @@ public class AmbariManagementControllerTest {
+     controller.updateClusters(Collections.singleton(crReq), null);
+ 
+     requestProps.put("phase", "INITIAL_START");
+-    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "STARTED");
++    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "STARTED");
+     rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
+     stages = actionDB.getAllStages(rsr.getRequestId());
+     Assert.assertEquals(1, stages.size());
+@@ -1373,11 +1373,11 @@ public class AmbariManagementControllerTest {
+ 
+     Set<ServiceComponentRequest> set1 = new HashSet<>();
+     ServiceComponentRequest valid1 =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null);
+     ServiceComponentRequest valid2 =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", "JOBTRACKER", null);
+     ServiceComponentRequest valid3 =
+-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", null);
++        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", "TASKTRACKER", null);
+     set1.add(valid1);
+     set1.add(valid2);
+     set1.add(valid3);
+@@ -1481,7 +1481,7 @@ public class AmbariManagementControllerTest {
+ 
+     ServiceComponentHostRequest r =
+         new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName,
+-            componentName2, null, null);
++            componentName2, componentName2, null, null);
+ 
+     Set<ServiceComponentHostResponse> response =
+         controller.getHostComponents(Collections.singleton(r));
+@@ -1511,16 +1511,16 @@ public class AmbariManagementControllerTest {
+       new HashSet<>();
+     ServiceComponentHostRequest r1 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-            componentName1, host1, State.INIT.toString());
++            componentName1, componentName1, host1, State.INIT.toString());
+     ServiceComponentHostRequest r2 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-            componentName2, host1, State.INIT.toString());
++            componentName2, componentName2, host1, State.INIT.toString());
+     ServiceComponentHostRequest r3 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-            componentName1, host2, State.INIT.toString());
++            componentName1, componentName1, host2, State.INIT.toString());
+     ServiceComponentHostRequest r4 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-            componentName2, host2, State.INIT.toString());
++            componentName2, componentName2, host2, State.INIT.toString());
+ 
+     set1.add(r1);
+     set1.add(r2);
+@@ -1550,7 +1550,7 @@ public class AmbariManagementControllerTest {
+   @Test(expected = IllegalArgumentException.class)
+   public void createHostComponentsRequestRejectedWithoutClusterName() throws Exception {
+     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-      new ServiceComponentHostRequest(null, "CORE", "HDFS", "NAMENODE", "host1", null)
++      new ServiceComponentHostRequest(null, "CORE", "HDFS", "NAMENODE", "NAMENODE", "host1", null)
+     );
+     controller.createHostComponents(requests);
+   }
+@@ -1558,7 +1558,7 @@ public class AmbariManagementControllerTest {
+   @Test(expected = IllegalArgumentException.class)
+   public void createHostComponentsRequestRejectedWithoutComponentName() throws Exception {
+     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-      new ServiceComponentHostRequest("foo", "CORE", "HDFS", null, "host1", null)
++      new ServiceComponentHostRequest("foo", "CORE", "HDFS", null, null, "host1", null)
+     );
+     controller.createHostComponents(requests);
+   }
+@@ -1566,7 +1566,7 @@ public class AmbariManagementControllerTest {
+   @Test(expected = IllegalArgumentException.class)
+   public void createHostComponentsRequestRejectedWithoutHostname() throws Exception {
+     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", null, null)
++      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", "NAMENODE",null, null)
+     );
+     controller.createHostComponents(requests);
+   }
+@@ -1574,7 +1574,7 @@ public class AmbariManagementControllerTest {
+   @Test(expected = ParentObjectNotFoundException.class)
+   public void createHostComponentsRequestRejectedForNonexistentCluster() throws Exception {
+     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", "host1", null)
++      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", "NAMENODE", "host1", null)
+     );
+     controller.createHostComponents(requests);
+   }
+@@ -1619,7 +1619,7 @@ public class AmbariManagementControllerTest {
+ 
+     try {
+       ServiceComponentHostRequest rInvalid =
+-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+       controller.createHostComponents(Collections.singleton(rInvalid));
+       fail("Expected failure for invalid service");
+     } catch (IllegalArgumentException e) {
+@@ -1636,24 +1636,24 @@ public class AmbariManagementControllerTest {
+ 
+     try {
+       ServiceComponentHostRequest rInvalid =
+-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+       controller.createHostComponents(Collections.singleton(rInvalid));
+       fail("Expected failure for invalid service");
+     } catch (Exception e) {
+       // Expected
+     }
+ 
+-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "NAMENODE");
++    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
+     s1.addServiceComponent(sc1);
+-    ServiceComponent sc2 = serviceComponentFactory.createNew(s2, "NAMENODE");
++    ServiceComponent sc2 = serviceComponentFactory.createNew(s2, "NAMENODE", "NAMENODE");
+     s2.addServiceComponent(sc2);
+-    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "NAMENODE");
++    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "NAMENODE", "NAMENODE");
+     s3.addServiceComponent(sc3);
+ 
+ 
+     try {
+       ServiceComponentHostRequest rInvalid =
+-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+       controller.createHostComponents(Collections.singleton(rInvalid));
+       fail("Expected failure for invalid host");
+     } catch (Exception e) {
+@@ -1678,7 +1678,7 @@ public class AmbariManagementControllerTest {
+ 
+     try {
+       ServiceComponentHostRequest rInvalid =
+-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+       controller.createHostComponents(Collections.singleton(rInvalid));
+       fail("Expected failure for invalid host cluster mapping");
+     } catch (Exception e) {
+@@ -1691,13 +1691,13 @@ public class AmbariManagementControllerTest {
+     clusters.mapAndPublishHostsToCluster(hostnames, cluster2);
+ 
+     ServiceComponentHostRequest valid =
+-        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+     controller.createHostComponents(Collections.singleton(valid));
+ 
+     try {
+       Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-        new ServiceComponentHostRequest(clusterFoo, "SG1", "HDFS", "NAMENODE", host2, null),
+-        new ServiceComponentHostRequest(clusterFoo, "SG2", "HDFS", "NAMENODE", host2, null)
++        new ServiceComponentHostRequest(clusterFoo, "SG1", "HDFS", "NAMENODE", "NAMENODE", host2, null),
++        new ServiceComponentHostRequest(clusterFoo, "SG2", "HDFS", "NAMENODE", "NAMENODE", host2, null)
+       );
+       controller.createHostComponents(requests);
+       fail("Expected failure for wrong service requests as the SG1 service group doesn't exist on cluster");
+@@ -1707,8 +1707,8 @@ public class AmbariManagementControllerTest {
+ 
+     try {
+       Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", host2, null),
+-        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", host3, null)
++        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host2, null),
++        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host3, null)
+       );
+       controller.createHostComponents(requests);
+       fail("Expected failure for multiple clusters");
+@@ -1718,8 +1718,8 @@ public class AmbariManagementControllerTest {
+ 
+     try {
+       Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
+-        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null),
+-        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host2, null)
++        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null),
++        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host2, null)
+       );
+       controller.createHostComponents(requests);
+       fail("Expected failure for already existing");
+@@ -1732,11 +1732,11 @@ public class AmbariManagementControllerTest {
+     Assert.assertEquals(0, foo.getServiceComponentHosts(host3).size());
+ 
+     ServiceComponentHostRequest valid1 =
+-        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+     controller.createHostComponents(Collections.singleton(valid1));
+ 
+     ServiceComponentHostRequest valid2 =
+-        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", host1, null);
++        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
+     controller.createHostComponents(Collections.singleton(valid2));
+ 
+     Assert.assertEquals(1, foo.getServiceComponentHosts(host1).size());
+@@ -2333,12 +2333,12 @@ public class AmbariManagementControllerTest {
+     Service s1 = serviceFactory.createNew(c1, c1.addServiceGroup(serviceGroupName, "HDP-0.2"), new ArrayList<>(), "HDFS", "HDFS", repositoryVersion);
+     c1.addService(s1);
+     s1.setDesiredState(State.INSTALLED);
+-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
++    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
+     s1.addServiceComponent(sc1);
+     sc1.setDesiredState(State.UNINSTALLED);
+ 
+     ServiceComponentRequest r = new ServiceComponentRequest(cluster1, serviceGroupName,
+-       s1.getName(), sc1.getName(), null);
++       s1.getName(), sc1.getName(), sc1.getType(), null);
+ 
+     Set<ServiceComponentResponse> resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+@@ -2388,14 +2388,14 @@ public class AmbariManagementControllerTest {
+     s2.setDesiredState(State.INSTALLED);
+     s4.setDesiredState(State.INSTALLED);
+ 
+-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
+-    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE");
+-    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER");
+-    ServiceComponent sc4 = serviceComponentFactory.createNew(s4, "HIVE_SERVER");
+-    ServiceComponent sc5 = serviceComponentFactory.createNew(s4, "HIVE_CLIENT");
+-    ServiceComponent sc6 = serviceComponentFactory.createNew(s4, "MYSQL_SERVER");
+-    ServiceComponent sc7 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_SERVER");
+-    ServiceComponent sc8 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_CLIENT");
++    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
++    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
++    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
++    ServiceComponent sc4 = serviceComponentFactory.createNew(s4, "HIVE_SERVER", "HIVE_SERVER");
++    ServiceComponent sc5 = serviceComponentFactory.createNew(s4, "HIVE_CLIENT", "HIVE_CLIENT");
++    ServiceComponent sc6 = serviceComponentFactory.createNew(s4, "MYSQL_SERVER", "MYSQL_SERVER");
++    ServiceComponent sc7 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
++    ServiceComponent sc8 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
+ 
+     s1.addServiceComponent(sc1);
+     s1.addServiceComponent(sc2);
+@@ -2414,7 +2414,7 @@ public class AmbariManagementControllerTest {
+     sc8.setDesiredState(State.UNINSTALLED);
+ 
+     ServiceComponentRequest r = new ServiceComponentRequest(null, null, null,
+-        null, null);
++        null, null, null);
+ 
+     try {
+       ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+@@ -2425,25 +2425,25 @@ public class AmbariManagementControllerTest {
+ 
+     // all comps per cluster
+     r = new ServiceComponentRequest(c1.getClusterName(), null,
+-        null, null, null);
++        null, null, null, null);
+     Set<ServiceComponentResponse> resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(3, resps.size());
+ 
+     // all comps per cluster filter on state
+     r = new ServiceComponentRequest(c2.getClusterName(), null,
+-        null, null, State.UNINSTALLED.toString());
++        null, null, null, State.UNINSTALLED.toString());
+     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(4, resps.size());
+ 
+     // all comps for given service
+     r = new ServiceComponentRequest(c2.getClusterName(), null,
+-        s5.getName(), null, null);
++        s5.getName(), null, null, null);
+     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     // all comps for given service filter by state
+     r = new ServiceComponentRequest(c2.getClusterName(), null,
+-        s4.getName(), null, State.INIT.toString());
++        s4.getName(), null, null, State.INIT.toString());
+     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+     Assert.assertEquals(sc4.getName(),
+@@ -2451,7 +2451,7 @@ public class AmbariManagementControllerTest {
+ 
+     // get single given comp
+     r = new ServiceComponentRequest(c2.getClusterName(), null,
+-        null, sc5.getName(), State.INIT.toString());
++        null, sc5.getName(), sc5.getType(), State.INIT.toString());
+     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+     Assert.assertEquals(sc5.getName(),
+@@ -2459,7 +2459,7 @@ public class AmbariManagementControllerTest {
+ 
+     // get single given comp and given svc
+     r = new ServiceComponentRequest(c2.getClusterName(), null,
+-        s4.getName(), sc5.getName(), State.INIT.toString());
++        s4.getName(), sc5.getName(), sc5.getType(), State.INIT.toString());
+     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+     Assert.assertEquals(sc5.getName(),
+@@ -2469,11 +2469,11 @@ public class AmbariManagementControllerTest {
+     ServiceComponentRequest r1, r2, r3;
+     Set<ServiceComponentRequest> reqs = new HashSet<>();
+     r1 = new ServiceComponentRequest(c2.getClusterName(), null,
+-        null, null, State.UNINSTALLED.toString());
++        null, null, null, State.UNINSTALLED.toString());
+     r2 = new ServiceComponentRequest(c1.getClusterName(), null,
+-        null, null, null);
++        null, null, null, null);
+     r3 = new ServiceComponentRequest(c1.getClusterName(), null,
+-        null, null, State.INIT.toString());
++        null, null, null, State.INIT.toString());
+     reqs.addAll(Arrays.asList(r1, r2, r3));
+     resps = ComponentResourceProviderTest.getComponents(controller, reqs);
+     Assert.assertEquals(7, resps.size());
+@@ -2490,7 +2490,7 @@ public class AmbariManagementControllerTest {
+     ServiceGroup serviceGroup = c1.addServiceGroup("CORE", HDP_0_1);
+     Service s1 = serviceFactory.createNew(c1, serviceGroup, new ArrayList<>(), "HDFS", "HDFS", repositoryVersion);
+     c1.addService(s1);
+-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
++    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
+     s1.addServiceComponent(sc1);
+     sc1.setDesiredState(State.UNINSTALLED);
+     ServiceComponentHost sch1 = serviceComponentHostFactory.createNew(sc1, host1);
+@@ -2505,7 +2505,7 @@ public class AmbariManagementControllerTest {
+ 
+     ServiceComponentHostRequest r =
+         new ServiceComponentHostRequest(c1.getClusterName(), null,
+-            null, null, null, null);
++            null, null, null, null, null);
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+@@ -2591,30 +2591,30 @@ public class AmbariManagementControllerTest {
+     s1.getServiceComponent(componentName3).getServiceComponentHost(host2).updateActualConfigs(actualConfig);
+ 
+     ServiceComponentHostRequest r =
+-        new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++        new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(5, resps.size());
+ 
+     //Get all host components with stale config = true
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setStaleConfig("true");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     //Get all host components with stale config = false
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setStaleConfig("false");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(3, resps.size());
+ 
+     //Get all host components with stale config = false and hostname filter
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host1, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host1, null);
+     r.setStaleConfig("false");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     //Get all host components with stale config = false and hostname filter
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host2, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host2, null);
+     r.setStaleConfig("true");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+@@ -2659,30 +2659,30 @@ public class AmbariManagementControllerTest {
+         setComponentAdminState(HostComponentAdminState.INSERVICE);
+ 
+     ServiceComponentHostRequest r =
+-        new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++        new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(5, resps.size());
+ 
+     //Get all host components with decommissiond = true
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setAdminState("DECOMMISSIONED");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+     //Get all host components with decommissioned = false
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setAdminState("INSERVICE");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+     //Get all host components with decommissioned = some random string
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setAdminState("INSTALLED");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(0, resps.size());
+ 
+     //Update adminState
+-    r = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, null);
++    r = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, null);
+     r.setAdminState("DECOMMISSIONED");
+     try {
+       updateHostComponents(Collections.singleton(r), new HashMap<>(), false);
+@@ -2871,9 +2871,9 @@ public class AmbariManagementControllerTest {
+     s1.setDesiredState(State.INSTALLED);
+     s2.setDesiredState(State.INSTALLED);
+ 
+-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
+-    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE");
+-    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER");
++    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
++    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
++    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
+ 
+     s1.addServiceComponent(sc1);
+     s1.addServiceComponent(sc2);
+@@ -2902,7 +2902,7 @@ public class AmbariManagementControllerTest {
+     sch5.setDesiredState(State.UNINSTALLED);
+ 
+     ServiceComponentHostRequest r =
+-        new ServiceComponentHostRequest(null, null, null, null, null, null);
++        new ServiceComponentHostRequest(null, null, null, null, null, null, null);
+ 
+     try {
+       controller.getHostComponents(Collections.singleton(r));
+@@ -2912,14 +2912,14 @@ public class AmbariManagementControllerTest {
+     }
+ 
+     // all across cluster
+-    r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
++    r = new ServiceComponentHostRequest(c1.getClusterName(), null, null, null,
+         null, null, null);
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(6, resps.size());
+ 
+     // all for service
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s1.getName(),
+-        null, null, null);
++        null, null, null, null);
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Set<String> actual = resps.stream()
+       .map(AmbariManagementControllerTest::serviceComponentHostToString)
+@@ -2932,65 +2932,65 @@ public class AmbariManagementControllerTest {
+ 
+     // all for component
+     r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
+-        sc3.getName(), null, null);
++        sc3.getName(), sc3.getType(), null, null);
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+     // all for host
+     r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
+-        null, host2, null);
++        null, null, host2, null);
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     // all across cluster with state filter
+     r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
+-        null, null, State.UNINSTALLED.toString());
++        null, null, null, State.UNINSTALLED.toString());
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+     // all for service with state filter
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s1.getName(),
+-        null, null, State.INIT.toString());
++        null, null, null, State.INIT.toString());
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     // all for component with state filter
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
+-        sc3.getName(), null, State.INSTALLED.toString());
++        sc3.getName(), sc3.getType(), null, State.INSTALLED.toString());
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(0, resps.size());
+ 
+     // all for host with state filter
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
+-        null, host2, State.INIT.toString());
++        null, null, host2, State.INIT.toString());
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+     // for service and host
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
+-        null, host1, null);
++        null, null, host1, null);
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(0, resps.size());
+ 
+     // single sch - given service and host and component
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
+-        sc3.getName(), host3, State.INSTALLED.toString());
++        sc3.getName(), sc3.getType(), host3, State.INSTALLED.toString());
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(0, resps.size());
+ 
+     // single sch - given service and host and component
+     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
+-        sc3.getName(), host3, null);
++        sc3.getName(), sc3.getType(), host3, null);
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+ 
+     ServiceComponentHostRequest r1, r2, r3;
+     r1 = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
+-        null, host3, null);
++        null, null, host3, null);
+     r2 = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
+-        sc3.getName(), host2, null);
++        sc3.getName(), sc3.getType(), host2, null);
+     r3 = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
+-        null, host2, null);
++        null, null, host2, null);
+     Set<ServiceComponentHostRequest> reqs =
+       new HashSet<>();
+     reqs.addAll(Arrays.asList(r1, r2, r3));
+@@ -3237,22 +3237,22 @@ public class AmbariManagementControllerTest {
+       new HashSet<>();
+     ServiceComponentHostRequest r1 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName1, host1, State.INIT.toString());
++            componentName1, componentName1, host1, State.INIT.toString());
+     ServiceComponentHostRequest r2 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName2, host1, State.INIT.toString());
++            componentName2, componentName2, host1, State.INIT.toString());
+     ServiceComponentHostRequest r3 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName1, host2, State.INIT.toString());
++            componentName1, componentName1, host2, State.INIT.toString());
+     ServiceComponentHostRequest r4 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName2, host2, State.INIT.toString());
++            componentName2, componentName2, host2, State.INIT.toString());
+     ServiceComponentHostRequest r5 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName2,
+-            componentName3, host1, State.INIT.toString());
++            componentName3, componentName3, host1, State.INIT.toString());
+     ServiceComponentHostRequest r6 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName4, host2, State.INIT.toString());
++            componentName4, componentName4, host2, State.INIT.toString());
+ 
+     set1.add(r1);
+     set1.add(r2);
+@@ -3480,19 +3480,19 @@ public class AmbariManagementControllerTest {
+       new HashSet<>();
+     ServiceComponentHostRequest r1 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName1, host1, State.INIT.toString());
++            componentName1, componentName1, host1, State.INIT.toString());
+     ServiceComponentHostRequest r2 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName2, host1, State.INIT.toString());
++            componentName2, componentName2, host1, State.INIT.toString());
+     ServiceComponentHostRequest r3 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName1, host2, State.INIT.toString());
++            componentName1, componentName1, host2, State.INIT.toString());
+     ServiceComponentHostRequest r4 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName2, host2, State.INIT.toString());
++            componentName2, componentName2, host2, State.INIT.toString());
+     ServiceComponentHostRequest r5 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName3, host1, State.INIT.toString());
++            componentName3, componentName3, host1, State.INIT.toString());
+ 
+     set1.add(r1);
+     set1.add(r2);
+@@ -3533,13 +3533,13 @@ public class AmbariManagementControllerTest {
+ 
+     // confirm an UNKOWN doesn't fail
+     req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-        sc3.getName(), State.INSTALLED.toString());
++        sc3.getName(), sc3.getType(), State.INSTALLED.toString());
+     reqs.add(req1);
+     ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
+     try {
+       reqs.clear();
+       req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-          sc1.getName(), State.INIT.toString());
++          sc1.getName(), sc1.getType(), State.INIT.toString());
+       reqs.add(req1);
+       ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
+       fail("Expected failure for invalid state update");
+@@ -3565,7 +3565,7 @@ public class AmbariManagementControllerTest {
+     try {
+       reqs.clear();
+       req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-          sc1.getName(), State.STARTED.toString());
++          sc1.getName(), sc1.getType(), State.STARTED.toString());
+       reqs.add(req1);
+       ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
+       fail("Expected failure for invalid state update");
+@@ -3590,11 +3590,11 @@ public class AmbariManagementControllerTest {
+ 
+     reqs.clear();
+     req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-        sc1.getName(), State.INSTALLED.toString());
++        sc1.getName(), sc1.getType(), State.INSTALLED.toString());
+     req2 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-        sc2.getName(), State.INSTALLED.toString());
++        sc2.getName(), sc2.getType(), State.INSTALLED.toString());
+     req3 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-        sc3.getName(), State.INSTALLED.toString());
++        sc3.getName(), sc3.getType(), State.INSTALLED.toString());
+     reqs.add(req1);
+     reqs.add(req2);
+     reqs.add(req3);
+@@ -3637,9 +3637,9 @@ public class AmbariManagementControllerTest {
+     // test no-op
+     reqs.clear();
+     req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-        sc1.getName(), State.INSTALLED.toString());
++        sc1.getName(), sc1.getType(), State.INSTALLED.toString());
+     req2 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
+-        sc2.getName(), State.INSTALLED.toString());
++        sc2.getName(), sc2.getType(), State.INSTALLED.toString());
+     reqs.add(req1);
+     reqs.add(req2);
+     trackAction = ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
+@@ -3670,19 +3670,19 @@ public class AmbariManagementControllerTest {
+       new HashSet<>();
+     ServiceComponentHostRequest r1 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName1, host1, State.INIT.toString());
++            componentName1, componentName1, host1, State.INIT.toString());
+     ServiceComponentHostRequest r2 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName2, host1, State.INIT.toString());
++            componentName2, componentName2, host1, State.INIT.toString());
+     ServiceComponentHostRequest r3 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName1, host2, State.INIT.toString());
++            componentName1, componentName1, host2, State.INIT.toString());
+     ServiceComponentHostRequest r4 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName2, host2, State.INIT.toString());
++            componentName2, componentName2, host2, State.INIT.toString());
+     ServiceComponentHostRequest r5 =
+         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-            componentName3, host1, State.INIT.toString());
++            componentName3, componentName3, host1, State.INIT.toString());
+ 
+     set1.add(r1);
+     set1.add(r2);
+@@ -3739,19 +3739,19 @@ public class AmbariManagementControllerTest {
+     try {
+       reqs.clear();
+       req1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-          componentName1, host1,
++          componentName1, componentName1, host1,
+           State.INSTALLED.toString());
+       req2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-          componentName1, host2,
++          componentName1, componentName2, host2,
+           State.INSTALLED.toString());
+       req3 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-          componentName2, host1,
++          componentName2, componentName2, host1,
+           State.INSTALLED.toString());
+       req4 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-          componentName2, host2,
++          componentName2, componentName2, host2,
+           State.INSTALLED.toString());
+       req5 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-          componentName3, host1,
++          componentName3, componentName3, host1,
+           State.STARTED.toString());
+       reqs.add(req1);
+       reqs.add(req2);
+@@ -3766,15 +3766,15 @@ public class AmbariManagementControllerTest {
+ 
+     reqs.clear();
+     req1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, null,
+-        componentName1, host1, State.INSTALLED.toString());
++        componentName1, componentName1, host1, State.INSTALLED.toString());
+     req2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName1, host2, State.INSTALLED.toString());
++        componentName1, componentName1, host2, State.INSTALLED.toString());
+     req3 = new ServiceComponentHostRequest(cluster1, serviceGroupName, null,
+-        componentName2, host1, State.INSTALLED.toString());
++        componentName2, componentName2, host1, State.INSTALLED.toString());
+     req4 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName2, host2, State.INSTALLED.toString());
++        componentName2, componentName2, host2, State.INSTALLED.toString());
+     req5 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName3, host1, State.INSTALLED.toString());
++        componentName3, componentName3, host1, State.INSTALLED.toString());
+     reqs.add(req1);
+     reqs.add(req2);
+     reqs.add(req3);
+@@ -3806,10 +3806,10 @@ public class AmbariManagementControllerTest {
+     // test no-op
+     reqs.clear();
+     req1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName1, host1,
++        componentName1, componentName1, host1,
+         State.INSTALLED.toString());
+     req2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName1, host2,
++        componentName1, componentName1, host2,
+         State.INSTALLED.toString());
+     reqs.add(req1);
+     reqs.add(req2);
+@@ -3854,11 +3854,11 @@ public class AmbariManagementControllerTest {
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+     Service mapred = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+ 
+-    mapred.addServiceComponent(Role.RESOURCEMANAGER.name());
++    mapred.addServiceComponent(Role.RESOURCEMANAGER.name(), Role.RESOURCEMANAGER.name());
+ 
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
+@@ -4011,9 +4011,9 @@ public class AmbariManagementControllerTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup(serviceGroupName, "HDP-2.0.7");
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+ 
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
+@@ -4118,11 +4118,11 @@ public class AmbariManagementControllerTest {
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+     Service hive = cluster.addService(serviceGroup, "HIVE", "HIVE", repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+ 
+-    hive.addServiceComponent(Role.HIVE_SERVER.name());
++    hive.addServiceComponent(Role.HIVE_SERVER.name(), Role.HIVE_SERVER.name());
+ 
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
+@@ -4386,8 +4386,8 @@ public class AmbariManagementControllerTest {
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+     Service mapReduce = cluster.addService(serviceGroup, "MAPREDUCE", "MAPREDUCE", repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+-    mapReduce.addServiceComponent(Role.MAPREDUCE_CLIENT.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
++    mapReduce.addServiceComponent(Role.MAPREDUCE_CLIENT.name(), Role.MAPREDUCE_CLIENT.name());
+ 
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
+     mapReduce.getServiceComponent(Role.MAPREDUCE_CLIENT.name()).addServiceComponentHost(host2);
+@@ -4620,14 +4620,14 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeC", "v1");
+     schReqs.clear();
+     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-            componentName1, host1, null));
++            componentName1, componentName1, host1, null));
+     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
+ 
+     configVersions.clear();
+     configVersions.put("typeC", "v1");
+     configVersions.put("typeD", "v1");
+     scReqs.clear();
+-    scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, componentName2, null));
++    scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, componentName2, componentName2, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+     // update configs at service level
+@@ -4647,7 +4647,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeC", "v1");
+     schReqs.clear();
+     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-            componentName1, host1, null));
++            componentName1, componentName1, host1, null));
+     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
+ 
+     // update configs at SC level
+@@ -4656,7 +4656,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeD", "v1");
+     scReqs.clear();
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-            componentName1, null));
++            componentName1, componentName1, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+   }
+@@ -4762,7 +4762,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeC", "v1");
+     schReqs.clear();
+     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-        componentName1, host1, null));
++        componentName1, componentName1, host1, null));
+     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
+ 
+     configVersions.clear();
+@@ -4770,7 +4770,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeD", "v1");
+     scReqs.clear();
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-        componentName2, null));
++        componentName2, componentName2, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+     // update configs at service level
+@@ -4789,7 +4789,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeC", "v1");
+     schReqs.clear();
+     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-        componentName1, host1, null));
++        componentName1, componentName1, host1, null));
+     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
+ 
+     // update configs at SC level
+@@ -4798,7 +4798,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("typeD", "v1");
+     scReqs.clear();
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-        componentName1, null));
++        componentName1, componentName1, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+   }
+@@ -4892,7 +4892,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("hdfs-site", "version1");
+     schReqs.clear();
+     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-      componentName1, host1, null));
++      componentName1, componentName1, host1, null));
+     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
+ 
+     // Reconfigure SCH level
+@@ -4900,7 +4900,7 @@ public class AmbariManagementControllerTest {
+     configVersions.put("core-site", "version122");
+     schReqs.clear();
+     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-      componentName1, host1, null));
++      componentName1, componentName1, host1, null));
+     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
+ 
+     // Clear Entity Manager
+@@ -4911,11 +4911,11 @@ public class AmbariManagementControllerTest {
+     configVersions.put("core-site", "version1");
+     configVersions.put("hdfs-site", "version1");
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-      componentName2, null));
++      componentName2, componentName2, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-      componentName1, null));
++      componentName1, componentName1, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+     // Reconfigure SC level
+@@ -4924,12 +4924,12 @@ public class AmbariManagementControllerTest {
+ 
+     scReqs.clear();
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-      componentName2, null));
++      componentName2, componentName2, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+     scReqs.clear();
+     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
+-      componentName1, null));
++      componentName1, componentName1, null));
+     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
+ 
+     entityManager.clear();
+@@ -5638,7 +5638,7 @@ public class AmbariManagementControllerTest {
+ 
+     // Reinstall SCH
+     ServiceComponentHostRequest schr = new ServiceComponentHostRequest
+-      (cluster1, serviceGroupName, serviceName, componentName3, host3, State.INSTALLED.name());
++      (cluster1, serviceGroupName, serviceName, componentName3, componentName3, host3, State.INSTALLED.name());
+     Set<ServiceComponentHostRequest> setReqs = new
+       HashSet<>();
+     setReqs.add(schr);
+@@ -5836,13 +5836,13 @@ public class AmbariManagementControllerTest {
+     createServiceComponentHost(cluster1, serviceGroupName, serviceName, componentName1,
+         host2, null);
+     ServiceComponentHostRequest r = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-        componentName1, host2, State.INSTALLED.toString());
++        componentName1, componentName1, host2, State.INSTALLED.toString());
+     Set<ServiceComponentHostRequest> requests = new HashSet<>();
+     requests.add(r);
+     updateHostComponents(requests, Collections.emptyMap(), true);
+     s.getServiceComponent(componentName1).getServiceComponentHost(host2).setState(State.INSTALLED);
+     r = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-        componentName1, host2, State.STARTED.toString());
++        componentName1, componentName1, host2, State.STARTED.toString());
+     requests.clear();
+     requests.add(r);
+     updateHostComponents(requests, Collections.emptyMap(), true);
+@@ -5921,11 +5921,11 @@ public class AmbariManagementControllerTest {
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+     Service mapred = cluster.addService(serviceGroup, "YARN", "YARN",  repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+ 
+-    mapred.addServiceComponent(Role.RESOURCEMANAGER.name());
++    mapred.addServiceComponent(Role.RESOURCEMANAGER.name(), Role.RESOURCEMANAGER.name());
+ 
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
+@@ -6019,11 +6019,11 @@ public class AmbariManagementControllerTest {
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+     Service mapred = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
+ 
+-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+-    hdfs.addServiceComponent(Role.NAMENODE.name());
+-    hdfs.addServiceComponent(Role.DATANODE.name());
++    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
++    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
++    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
+ 
+-    mapred.addServiceComponent(Role.RESOURCEMANAGER.name());
++    mapred.addServiceComponent(Role.RESOURCEMANAGER.name(), Role.RESOURCEMANAGER.name());
+ 
+     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
+     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
+@@ -7291,7 +7291,7 @@ public class AmbariManagementControllerTest {
+           sch.setState(State.STOPPING);
+         } else if (sch.getServiceComponentName().equals("DATANODE")) {
+           ServiceComponentHostRequest r1 = new ServiceComponentHostRequest
+-            (cluster1, serviceGroupName, serviceName, sch.getServiceComponentName(),
++            (cluster1, serviceGroupName, serviceName, sch.getServiceComponentName(), sch.getServiceComponentType(),
+               sch.getHostName(), State.INSTALLED.name());
+           Set<ServiceComponentHostRequest> reqs1 = new
+             HashSet<>();
+@@ -7522,7 +7522,7 @@ public class AmbariManagementControllerTest {
+     }
+ 
+     // issue an installed state request without failure
+-    ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "INSTALLED");
++    ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "INSTALLED");
+     Map<String, String> requestProps = new HashMap<>();
+     requestProps.put("datanode", "dn_value");
+     requestProps.put("namenode", "nn_value");
+@@ -7569,11 +7569,11 @@ public class AmbariManagementControllerTest {
+ 
+     Set<ServiceComponentHostRequest> set1 = new HashSet<>();
+     ServiceComponentHostRequest r1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName1, host1, State.INIT.toString());
++        componentName1, componentName1, host1, State.INIT.toString());
+     ServiceComponentHostRequest r2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName2, host1, State.INIT.toString());
++        componentName2, componentName2, host1, State.INIT.toString());
+     ServiceComponentHostRequest r3 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
+-        componentName3, host1, State.INIT.toString());
++        componentName3, componentName3, host1, State.INIT.toString());
+ 
+     set1.add(r1);
+     set1.add(r2);
+@@ -7678,7 +7678,7 @@ public class AmbariManagementControllerTest {
+     Set<ServiceComponentHostRequest> schRequests = new HashSet<>();
+     // delete HC
+     schRequests.clear();
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, componentName1, host1, null));
+     try {
+       controller.deleteHostComponents(schRequests);
+       Assert.fail("Expect failure while deleting.");
+@@ -7702,12 +7702,12 @@ public class AmbariManagementControllerTest {
+     sc6.getServiceComponentHosts().values().iterator().next().setState(State.INIT);
+ 
+     schRequests.clear();
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName2, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName3, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName4, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName5, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName6, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, componentName1, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName2, componentName2, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName3, componentName3, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName4, componentName4, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName5, componentName5, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName6, componentName6, host1, null));
+     DeleteStatusMetaData deleteStatusMetaData = controller.deleteHostComponents(schRequests);
+     Assert.assertEquals(0, deleteStatusMetaData.getExceptionForKeys().size());
+   }
+@@ -7865,15 +7865,15 @@ public class AmbariManagementControllerTest {
+     // Case 1: Delete host that is still part of cluster, but do not specify the cluster_name in the request
+     Set<ServiceComponentHostRequest> schRequests = new HashSet<>();
+     // Disable HC for non-clients
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, host1, "DISABLED"));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, host1, "DISABLED"));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, componentName1, host1, "DISABLED"));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, componentName2, host1, "DISABLED"));
+     updateHostComponents(schRequests, new HashMap<>(), false);
+ 
+     // Delete HC
+     schRequests.clear();
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, host1, null));
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName3, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, componentName1, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, componentName2, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName3, componentName3, host1, null));
+     controller.deleteHostComponents(schRequests);
+ 
+     Assert.assertEquals(0, cluster.getServiceComponentHosts(host1).size());
+@@ -8042,7 +8042,7 @@ public class AmbariManagementControllerTest {
+     sch.handleEvent(new ServiceComponentHostStartedEvent (sch.getServiceComponentName(), sch.getHostName(), System.currentTimeMillis()));
+ 
+     Set<ServiceComponentHostRequest> schRequests = new HashSet<>();
+-    schRequests.add(new ServiceComponentHostRequest(cluster1, null, null, null, host1, null));
++    schRequests.add(new ServiceComponentHostRequest(cluster1, null, null, null, null, host1, null));
+ 
+     DeleteStatusMetaData deleteStatusMetaData = controller.deleteHostComponents(schRequests);
+     Assert.assertEquals(1, deleteStatusMetaData.getExceptionForKeys().size());
+@@ -8194,24 +8194,24 @@ public class AmbariManagementControllerTest {
+     ServiceResourceProviderTest.createServices(amc, repositoryVersionDAO, serviceRequests);
+ 
+     Set<ServiceComponentRequest> serviceComponentRequests = new HashSet<>();
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", "DATANODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", "HISTORYSERVER", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null));
+ 
+     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
+ 
+     Set<ServiceComponentHostRequest> componentHostRequests = new HashSet<>();
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", "HISTORYSERVER", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", host1, null));
+ 
+     amc.createHostComponents(componentHostRequests);
+ 
+@@ -8295,10 +8295,10 @@ public class AmbariManagementControllerTest {
+     ServiceResourceProviderTest.updateServices(amc, serviceRequests, mapRequestProps, true, false);
+ 
+     Set<ServiceComponentRequest> serviceComponentRequests = new HashSet<>();
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", "NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", "DATANODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", "HDFS_CLIENT", null));
+ 
+     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
+ 
+@@ -8310,11 +8310,11 @@ public class AmbariManagementControllerTest {
+     HostResourceProviderTest.createHosts(amc, hostRequests);
+ 
+     Set<ServiceComponentHostRequest> componentHostRequests = new HashSet<>();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host2, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host3, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host2, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host3, null));
+ 
+ 
+     amc.createHostComponents(componentHostRequests);
+@@ -8349,33 +8349,33 @@ public class AmbariManagementControllerTest {
+     }
+ 
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "DISABLED"));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "DISABLED"));
+ 
+     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
+ 
+     Assert.assertEquals(State.DISABLED, componentHost.getState());
+ 
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "INSTALLED"));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "INSTALLED"));
+ 
+     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
+ 
+     Assert.assertEquals(State.INSTALLED, componentHost.getState());
+ 
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "DISABLED"));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "DISABLED"));
+ 
+     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
+ 
+     Assert.assertEquals(State.DISABLED, componentHost.getState());
+ 
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host2, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host2, null));
+ 
+     amc.createHostComponents(componentHostRequests);
+ 
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host2, "INSTALLED"));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host2, "INSTALLED"));
+ 
+     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
+ 
+@@ -8396,7 +8396,7 @@ public class AmbariManagementControllerTest {
+     }
+ 
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, null));
+ 
+     amc.deleteHostComponents(componentHostRequests);
+ 
+@@ -8409,7 +8409,7 @@ public class AmbariManagementControllerTest {
+ 
+     // should be able to add the host component back
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, null));
+     amc.createHostComponents(componentHostRequests);
+     namenodes = cluster.getService(serviceName).getServiceComponent("NAMENODE").getServiceComponentHosts();
+     assertEquals(2, namenodes.size());
+@@ -8419,7 +8419,7 @@ public class AmbariManagementControllerTest {
+     componentHost.handleEvent(new ServiceComponentHostInstallEvent(componentHost.getServiceComponentName(), componentHost.getHostName(), System.currentTimeMillis(), version));
+     componentHost.handleEvent(new ServiceComponentHostOpSucceededEvent(componentHost.getServiceComponentName(), componentHost.getHostName(), System.currentTimeMillis()));
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "INSTALLED"));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "INSTALLED"));
+     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
+     assertEquals(State.INSTALLED, namenodes.get(host1).getState());
+ 
+@@ -8435,7 +8435,7 @@ public class AmbariManagementControllerTest {
+ 
+     // make disabled
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host2, "DISABLED"));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host2, "DISABLED"));
+     updateHostComponents(amc, componentHostRequests, mapRequestProps, false);
+     org.junit.Assert.assertEquals(State.DISABLED, sch.getState());
+ 
+@@ -8463,7 +8463,7 @@ public class AmbariManagementControllerTest {
+ 
+     // confirm delete
+     componentHostRequests.clear();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host2, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host2, null));
+     amc.deleteHostComponents(componentHostRequests);
+ 
+     sch = null;
+@@ -8516,19 +8516,19 @@ public class AmbariManagementControllerTest {
+     ServiceResourceProviderTest.updateServices(amc, serviceRequests, mapRequestProps, true, false);
+     //Crate service components
+     serviceComponentRequests = new HashSet<>();
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", "NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", "DATANODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", "HDFS_CLIENT", null));
+     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
+ 
+     //Create ServiceComponentHosts
+     componentHostRequests = new HashSet<>();
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "host1", null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "host1", null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", host1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "host2", null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "host3", null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", "host1", null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", "host1", null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", host1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", "host2", null));
++    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", "host3", null));
+     amc.createHostComponents(componentHostRequests);
+ 
+ 
+@@ -8577,12 +8577,12 @@ public class AmbariManagementControllerTest {
+     ServiceResourceProviderTest.createServices(amc, repositoryVersionDAO, serviceRequests);
+ 
+     Set<ServiceComponentRequest> serviceComponentRequests = new HashSet<>();
+-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "DATANODE", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "RESOURCEMANAGER", null));
+-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "NODEMANAGER", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "DATANODE", "DATANODE", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", "HISTORYSERVER", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", null));
++    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", null));
+ 
+     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
+ 
+@@ -8592,12 +8592,12 @@ public class AmbariManagementControllerTest {
+     HostResourceProviderTest.createHosts(amc, hostRequests);
+ 
+     Set<ServiceComponentHostRequest> componentHostRequests = new HashSet<>();
+-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "DATANODE", HOST1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NAMENODE", HOST1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "SECONDARY_NAMENODE", HOST1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "HISTORYSERVER", HOST1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "RESOURCEMANAGER", HOST1, null));
+-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NODEMANAGER", HOST1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "DATANODE", "DATANODE", HOST1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NAMENODE", "NAMENODE", HOST1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", HOST1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "HISTORYSERVER", "HISTORYSERVER", HOST1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "RESOURCEMANAGER", "RESOURCEMANAGER", HOST1, null));
++    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NODEMANAGER", "NODEMANAGER", HOST1, null));
+ 
+     amc.createHostComponents(componentHostRequests);
+ 
+@@ -9792,30 +9792,30 @@ public class AmbariManagementControllerTest {
+     s1.getServiceComponent(componentName2).getServiceComponentHost(host2).updateActualConfigs(actualConfigOld);
+     s1.getServiceComponent(componentName3).getServiceComponentHost(host2).updateActualConfigs(actualConfig);
+ 
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(5, resps.size());
+ 
+     // Get all host components with stale config = true
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setStaleConfig("true");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     // Get all host components with stale config = false
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
+     r.setStaleConfig("false");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(3, resps.size());
+ 
+     // Get all host components with stale config = false and hostname filter
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host1, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host1, null);
+     r.setStaleConfig("false");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(2, resps.size());
+ 
+     // Get all host components with stale config = false and hostname filter
+-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host2, null);
++    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host2, null);
+     r.setStaleConfig("true");
+     resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+@@ -10010,7 +10010,7 @@ public class AmbariManagementControllerTest {
+     startService(cluster1, serviceGroupName, serviceName, false, false);
+ 
+     ServiceComponentHostRequest req = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
+-        componentName1, host1, "INSTALLED");
++        componentName1, componentName1, host1, "INSTALLED");
+ 
+     Map<String, String> requestProperties = new HashMap<>();
+     requestProperties.put("namenode", "p1");
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
+index 4bce571..d192c43 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
+@@ -224,13 +224,13 @@ public class BackgroundCustomCommandExecutionTest {
+   private void createServiceComponent(String clusterName, String serviceGroupName,
+       String serviceName, String componentName, State desiredState)
+       throws AmbariException, AuthorizationException {
+-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
++    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
+     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
+   }
+ 
+   private void createServiceComponentHost(String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState)
+       throws AmbariException, AuthorizationException {
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+     controller.createHostComponents(Collections.singleton(r));
+   }
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
+index 5a2faa0..d705d6a 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
+@@ -106,7 +106,7 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
+     controller.updateClusters(Collections.singleton(cr) , null);
+ 
+ 
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null, null);
+     r.setStaleConfig("true");
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(1, resps.size());
+@@ -127,7 +127,7 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
+     controller.updateClusters(Collections.singleton(cr) , null);
+ 
+ 
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null, null);
+     r.setStaleConfig("true");
+     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
+     Assert.assertEquals(4, resps.size());
+@@ -215,13 +215,13 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
+   private void createServiceComponent(String clusterName, String serviceGroupName,
+       String serviceName, String componentName, State desiredState)
+       throws AmbariException, AuthorizationException {
+-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
++    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
+     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
+   }
+ 
+   private void createServiceComponentHost(String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState)
+       throws AmbariException, AuthorizationException {
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+     controller.createHostComponents(Collections.singleton(r));
+ 
+     //set actual config
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
+index a17e94f..eea6b5c 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
+@@ -245,7 +245,7 @@ public class ClientConfigResourceProviderTest {
+     serviceOsSpecificHashMap.put("key", osSpecific);
+ 
+     ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, clusterName, 1L, "CORE", 1L, serviceName, serviceName, 1L,
+-        componentName, displayName, hostName, publicHostname, desiredState, "", null, null, null,
++        componentName, componentName, displayName, hostName, publicHostname, desiredState, "", null, null, null,
+         null);
+ 
+     Set<ServiceComponentHostResponse> responses = new LinkedHashSet<>();
+@@ -502,7 +502,7 @@ public class ClientConfigResourceProviderTest {
+     serviceOsSpecificHashMap.put("key", osSpecific);
+ 
+     ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, clusterName, 1L, "CORE", 1L, serviceName, serviceName, 1L,
+-        componentName, displayName, hostName, publicHostName, desiredState, "", null, null, null,
++        componentName, componentName, displayName, hostName, publicHostName, desiredState, "", null, null, null,
+         null);
+ 
+     Set<ServiceComponentHostResponse> responses = new LinkedHashSet<>();
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+index 642c97b..26c5729 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+@@ -152,7 +152,7 @@ public class ComponentResourceProviderTest {
+     expect(componentInfo.isRecoveryEnabled()).andReturn(true).anyTimes();
+     expect(ambariMetaInfo.getComponent("HDP", "99", "Service100", "Component100")).andReturn(componentInfo).anyTimes();
+ 
+-    expect(serviceComponentFactory.createNew(service, "Component100")).andReturn(serviceComponent);
++    expect(serviceComponentFactory.createNew(service, "Component100", "Component100")).andReturn(serviceComponent);
+ 
+     ServiceComponentResponse componentResponse = createNiceMock(ServiceComponentResponse.class);
+     expect(serviceComponent.convertToResponse()).andReturn(componentResponse);
+@@ -251,13 +251,13 @@ public class ComponentResourceProviderTest {
+     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
+ 
+     expect(serviceComponent1.convertToResponse()).andReturn(
+-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component100", stackId, "", serviceComponentStateCountMap,
++      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 1L, "Component100", "Component100", stackId, "", serviceComponentStateCountMap,
+               true /* recovery enabled */, "Component100 Client", null, null));
+     expect(serviceComponent2.convertToResponse()).andReturn(
+-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component101", stackId, "", serviceComponentStateCountMap,
++      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 2L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
+               false /* recovery not enabled */, "Component101 Client", null, null));
+     expect(serviceComponent3.convertToResponse()).andReturn(
+-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component102", stackId, "", serviceComponentStateCountMap,
++      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 3L, "Component102", "Component102", stackId, "", serviceComponentStateCountMap,
+               true /* recovery enabled */, "Component102 Client", "1.1", RepositoryVersionState.CURRENT));
+ 
+     expect(ambariMetaInfo.getComponent("FOO", "1.0", null, "Component100")).andReturn(
+@@ -431,13 +431,13 @@ public class ComponentResourceProviderTest {
+     expect(component3Info.getCategory()).andReturn(null);
+ 
+     expect(serviceComponent1.convertToResponse()).andReturn(
+-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component101", stackId, "", serviceComponentStateCountMap,
++      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
+               false /* recovery not enabled */, "Component101 Client", null, null));
+     expect(serviceComponent2.convertToResponse()).andReturn(
+-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component102", stackId, "", serviceComponentStateCountMap,
++      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 2L, "Component102", "Component102",stackId, "", serviceComponentStateCountMap,
+               false /* recovery not enabled */, "Component102 Client", null, null));
+     expect(serviceComponent3.convertToResponse()).andReturn(
+-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component103", stackId, "", serviceComponentStateCountMap,
++      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 3L, "Component103", "Component103", stackId, "", serviceComponentStateCountMap,
+               false /* recovery not enabled */, "Component103 Client", null, null));
+     expect(serviceComponent1.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
+     expect(serviceComponent2.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
+@@ -740,7 +740,7 @@ public class ComponentResourceProviderTest {
+     expect(component1Info.getCategory()).andReturn(null);
+ 
+     expect(serviceComponent1.convertToResponse()).andReturn(
+-        new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component101", stackId, "", serviceComponentStateCountMap,
++        new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
+             false /* recovery not enabled */, "Component101 Client", null, null));
+     expect(serviceComponent1.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+index f0337bb..fece707 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+@@ -112,7 +112,7 @@ public class HostComponentResourceProviderTest {
+ 
+     AbstractControllerResourceProvider.init(resourceProviderFactory);
+ 
+-    ServiceComponentHostRequest request = new ServiceComponentHostRequest("Cluster100", SERVICE_GROUP_NAME, "Service100", "Component100", "Host100", null);
++    ServiceComponentHostRequest request = new ServiceComponentHostRequest("Cluster100", SERVICE_GROUP_NAME, "Service100", "Component100", "Component100", "Host100", null);
+     Set<ServiceComponentHostRequest> expectedRequests = Collections.singleton(request);
+     expect(managementController.createHostComponents(eq(expectedRequests))).andReturn(null).once();
+ 
+@@ -183,17 +183,17 @@ public class HostComponentResourceProviderTest {
+     String repositoryVersion2 = "0.2-1234";
+ 
+     allResponse.add(new ServiceComponentHostResponse(
+-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
++        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100", "Host100", "Host100",
+         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
+         stackId2.getStackId(), repositoryVersion2, null));
+ 
+     allResponse.add(new ServiceComponentHostResponse(
+-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component 101", "Host100", "Host100",
++        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", "Component 101", "Host100", "Host100",
+         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
+         stackId2.getStackId(), repositoryVersion2, null));
+ 
+     allResponse.add(new ServiceComponentHostResponse(
+-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102", "Host100", "Host100",
++        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102", "Host100", "Host100",
+         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
+         stackId2.getStackId(), repositoryVersion2, null));
+ 
+@@ -350,7 +350,7 @@ public class HostComponentResourceProviderTest {
+ 
+     Set<ServiceComponentHostResponse> nameResponse = new HashSet<>();
+     nameResponse.add(new ServiceComponentHostResponse(
+-        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
++        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100","Component 100", "Host100", "Host100",
+         "INSTALLED", "", "", "", "", null));
+ 
+     // set expectations
+@@ -450,7 +450,7 @@ public class HostComponentResourceProviderTest {
+         new HostComponentResourceProvider(managementController, injector);
+ 
+     // set expectations
+-    ServiceComponentHostRequest request = new ServiceComponentHostRequest(null, null, null, "Component100", "Host100", null);
++    ServiceComponentHostRequest request = new ServiceComponentHostRequest(null, null, null, "Component100", "Component100", "Host100", null);
+     expect(managementController.deleteHostComponents(Collections.singleton(request))).andReturn(deleteStatusMetaData);
+ 
+     // replay
+@@ -535,7 +535,7 @@ public class HostComponentResourceProviderTest {
+ 
+     Set<ServiceComponentHostResponse> nameResponse = new HashSet<>();
+     nameResponse.add(new ServiceComponentHostResponse(
+-        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
++        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100", "Host100", "Host100",
+         "INSTALLED", "", "", "", "", null));
+ 
+     // set expectations
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+index e68ff2e..1334e26 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+@@ -314,11 +314,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
+     Set<Cluster> clusterSet = new HashSet<>();
+     clusterSet.add(cluster);
+ 
+-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
++    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100","Component 100",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
++    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
++    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+ 
+     Set<ServiceComponentHostResponse> responses = new HashSet<>();
+@@ -409,11 +409,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
+     Set<Cluster> clusterSet = new HashSet<>();
+     clusterSet.add(cluster);
+ 
+-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
++    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
++    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
++    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+ 
+     Set<ServiceComponentHostResponse> responses = new HashSet<>();
+@@ -501,11 +501,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
+     Set<Cluster> clusterSet = new HashSet<>();
+     clusterSet.add(cluster);
+ 
+-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
++    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100",  "Component100","Component 100",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
++    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
+         "Host100", "Host100", "INSTALLED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
++    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103",  "Component 103",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+ 
+     Set<ServiceComponentHostResponse> responses = new HashSet<>();
+@@ -688,7 +688,7 @@ public class HostResourceProviderTest extends EasyMockSupport {
+     Set<Cluster> clusterSet = new HashSet<>();
+     clusterSet.add(cluster);
+ 
+-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
++    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+ 
+     Set<ServiceComponentHostResponse> responses = new HashSet<>();
+@@ -772,11 +772,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
+     Set<Cluster> clusterSet = new HashSet<>();
+     clusterSet.add(cluster);
+ 
+-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
++    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
++    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
+         "Host100", "Host100", "INSTALLED", "", null, null, null, null);
+-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
++    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
+         "Host100", "Host100", "STARTED", "", null, null, null, null);
+ 
+     Set<ServiceComponentHostResponse> responses = new HashSet<>();
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
+index cee3a52..25317ce 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
+@@ -123,14 +123,14 @@ public class JMXHostProviderTest {
+   private void createServiceComponent(String clusterName, String serviceGroupName,
+                                       String serviceName, String componentName, State desiredState)
+       throws AmbariException, AuthorizationException {
+-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
++    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
+     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
+   }
+ 
+   private void createServiceComponentHost(String clusterName, String serviceGroupName,
+                                           String serviceName, String componentName, String hostname,
+                                           State desiredState) throws AmbariException, AuthorizationException {
+-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
++    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+     controller.createHostComponents(Collections.singleton(r));
+   }
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
+index b309930..dbf3cae 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
+@@ -256,7 +256,7 @@ public class ServiceDependencyResourceProviderTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
+-            serviceName, componentName, dStateStr);
++            serviceName, componentName, componentName, dStateStr);
+     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
+   }
+ 
+@@ -269,7 +269,7 @@ public class ServiceDependencyResourceProviderTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
+-            serviceName, componentName, hostname, dStateStr);
++            serviceName, componentName, componentName, hostname, dStateStr);
+     controller.createHostComponents(Collections.singleton(r));
+   }
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
+index 9f1910e..f0e98ca 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
+@@ -251,7 +251,7 @@ public class ServiceGroupDependencyResourceProviderTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
+-            serviceName, componentName, dStateStr);
++            serviceName, componentName, componentName, dStateStr);
+     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
+   }
+ 
+@@ -264,7 +264,7 @@ public class ServiceGroupDependencyResourceProviderTest {
+       dStateStr = desiredState.toString();
+     }
+     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
+-            serviceName, componentName, hostname, dStateStr);
++            serviceName, componentName, componentName, hostname, dStateStr);
+     controller.createHostComponents(Collections.singleton(r));
+   }
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
+index c946406..fe26a82 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
+@@ -142,22 +142,22 @@ public class StackDefinedPropertyProviderTest {
+     RepositoryVersionEntity repositoryVersion = helper.getOrCreateRepositoryVersion(stackId, stackId.getStackVersion());
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service service = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+-    service.addServiceComponent("NAMENODE");
+-    service.addServiceComponent("DATANODE");
+-    service.addServiceComponent("JOURNALNODE");
++    service.addServiceComponent("NAMENODE", "NAMENODE");
++    service.addServiceComponent("DATANODE", "DATANODE");
++    service.addServiceComponent("JOURNALNODE", "JOURNALNODE");
+ 
+     service = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
+-    service.addServiceComponent("RESOURCEMANAGER");
++    service.addServiceComponent("RESOURCEMANAGER", "RESOURCEMANAGER");
+ 
+     service = cluster.addService(serviceGroup, "HBASE", "HBASE", repositoryVersion);
+-    service.addServiceComponent("HBASE_MASTER");
+-    service.addServiceComponent("HBASE_REGIONSERVER");
++    service.addServiceComponent("HBASE_MASTER", "HBASE_MASTER");
++    service.addServiceComponent("HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
+ 
+     stackId = new StackId("HDP-2.1.1");
+     repositoryVersion = helper.getOrCreateRepositoryVersion(stackId, stackId.getStackVersion());
+ 
+     service = cluster.addService(serviceGroup, "STORM", "STORM", repositoryVersion);
+-    service.addServiceComponent("STORM_REST_API");
++    service.addServiceComponent("STORM_REST_API", "STORM_REST_API");
+ 
+     clusters.addHost("h1");
+     Host host = clusters.getHost("h1");
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
+index 473a7dd..549e1c1 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
+@@ -177,11 +177,11 @@ public class UpgradeSummaryResourceProviderTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service service = cluster.addService(serviceGroup, "ZOOKEEPER", "ZOOKEEPER", repoVersionEntity);
+ 
+-    ServiceComponent component = service.addServiceComponent("ZOOKEEPER_SERVER");
++    ServiceComponent component = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+     ServiceComponentHost sch = component.addServiceComponentHost("h1");
+     sch.setVersion("2.2.0.0");
+ 
+-    component = service.addServiceComponent("ZOOKEEPER_CLIENT");
++    component = service.addServiceComponent("ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
+     sch = component.addServiceComponentHost("h1");
+     sch.setVersion("2.2.0.0");
+   }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
+index 9b998e5..14db57a 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
+@@ -43,8 +43,8 @@ public final class DefaultServiceCalculatedStateTest extends GeneralServiceCalcu
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception{
+-    ServiceComponent masterComponent = service.addServiceComponent("ZOOKEEPER_SERVER");
+-    ServiceComponent clientComponent = service.addServiceComponent("ZOOKEEPER_CLIENT");
++    ServiceComponent masterComponent = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
++    ServiceComponent clientComponent = service.addServiceComponent("ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
+ 
+     for (String hostName: hosts){
+       clusters.addHost(hostName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
+index f88a442..35ec2d2 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
+@@ -41,7 +41,7 @@ public class FlumeServiceCalculatedStateTest extends GeneralServiceCalculatedSta
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception {
+-    ServiceComponent masterComponent = service.addServiceComponent("FLUME_HANDLER");
++    ServiceComponent masterComponent = service.addServiceComponent("FLUME_HANDLER", "FLUME_HANDLER");
+ 
+ 
+     for (String hostName: hosts){
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
+index be814e3..5b97220 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
+@@ -41,9 +41,9 @@ public class HBaseServiceCalculatedStateTest extends GeneralServiceCalculatedSta
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception {
+-    ServiceComponent masterComponent = service.addServiceComponent("HBASE_MASTER");
+-    ServiceComponent secondMasterComponent = service.addServiceComponent("HBASE_REGIONSERVER");
+-    ServiceComponent clientComponent = service.addServiceComponent("HBASE_CLIENT");
++    ServiceComponent masterComponent = service.addServiceComponent("HBASE_MASTER", "HBASE_MASTER");
++    ServiceComponent secondMasterComponent = service.addServiceComponent("HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
++    ServiceComponent clientComponent = service.addServiceComponent("HBASE_CLIENT", "HBASE_CLIENT");
+ 
+     for (String hostName: hosts){
+       clusters.addHost(hostName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
+index cfae64f..6c317cd 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
+@@ -42,9 +42,9 @@ public class HDFSServiceCalculatedStateTest extends GeneralServiceCalculatedStat
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception {
+-    ServiceComponent masterComponent = service.addServiceComponent("NAMENODE");
+-    ServiceComponent masterComponent1 = service.addServiceComponent("SECONDARY_NAMENODE");
+-    ServiceComponent clientComponent = service.addServiceComponent("HDFS_CLIENT");
++    ServiceComponent masterComponent = service.addServiceComponent("NAMENODE", "NAMENODE");
++    ServiceComponent masterComponent1 = service.addServiceComponent("SECONDARY_NAMENODE", "SECONDARY_NAMENODE");
++    ServiceComponent clientComponent = service.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
+ 
+     for (String hostName: hosts){
+       clusters.addHost(hostName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
+index 511c165..fb598d6 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
+@@ -42,11 +42,11 @@ public class HiveServiceCalculatedStateTest extends GeneralServiceCalculatedStat
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception {
+-    ServiceComponent masterComponent = service.addServiceComponent("HIVE_METASTORE");
+-    ServiceComponent secondMasterComponent = service.addServiceComponent("HIVE_SERVER");
+-    ServiceComponent thirdMasterComponent = service.addServiceComponent("WEBHCAT_SERVER");
+-    ServiceComponent fourMasterComponent = service.addServiceComponent("MYSQL_SERVER");
+-    ServiceComponent clientComponent = service.addServiceComponent("HIVE_CLIENT");
++    ServiceComponent masterComponent = service.addServiceComponent("HIVE_METASTORE", "HIVE_METASTORE");
++    ServiceComponent secondMasterComponent = service.addServiceComponent("HIVE_SERVER", "HIVE_SERVER");
++    ServiceComponent thirdMasterComponent = service.addServiceComponent("WEBHCAT_SERVER", "WEBHCAT_SERVER");
++    ServiceComponent fourMasterComponent = service.addServiceComponent("MYSQL_SERVER", "MYSQL_SERVER");
++    ServiceComponent clientComponent = service.addServiceComponent("HIVE_CLIENT", "HIVE_CLIENT");
+ 
+     for (String hostName: hosts){
+       clusters.addHost(hostName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
+index 3d959ea..6e3a1c8 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
+@@ -41,8 +41,8 @@ public class OozieServiceCalculatedStateTest extends GeneralServiceCalculatedSta
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception {
+-    ServiceComponent masterComponent = service.addServiceComponent("OOZIE_SERVER");
+-    ServiceComponent clientComponent = service.addServiceComponent("OOZIE_CLIENT");
++    ServiceComponent masterComponent = service.addServiceComponent("OOZIE_SERVER", "OOZIE_SERVER");
++    ServiceComponent clientComponent = service.addServiceComponent("OOZIE_CLIENT", "OOZIE_CLIENT");
+ 
+     for (String hostName: hosts){
+       clusters.addHost(hostName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
+index 2de3ea6..cf23f31 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
+@@ -42,9 +42,9 @@ public class YarnServiceCalculatedStateTest extends GeneralServiceCalculatedStat
+ 
+   @Override
+   protected void createComponentsAndHosts() throws Exception {
+-    ServiceComponent masterComponent = service.addServiceComponent("RESOURCEMANAGER");
+-    ServiceComponent secondMasterComponent = service.addServiceComponent("NODEMANAGER");
+-    ServiceComponent clientComponent = service.addServiceComponent("YARN_CLIENT");
++    ServiceComponent masterComponent = service.addServiceComponent("RESOURCEMANAGER", "RESOURCEMANAGER");
++    ServiceComponent secondMasterComponent = service.addServiceComponent("NODEMANAGER", "NODEMANAGER");
++    ServiceComponent clientComponent = service.addServiceComponent("YARN_CLIENT", "YARN_CLIENT");
+ 
+     for (String hostName: hosts){
+       clusters.addHost(hostName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java b/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
+index a312f8e..f939ce0 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
+@@ -366,7 +366,7 @@ public class EventsTest {
+     Service service = m_cluster.getService(serviceName);
+     Assert.assertNotNull(service);
+ 
+-    ServiceComponent component = m_componentFactory.createNew(service, "DATANODE");
++    ServiceComponent component = m_componentFactory.createNew(service, "DATANODE", "DATANODE");
+     service.addServiceComponent(component);
+     component.setDesiredState(State.INSTALLED);
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java b/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
+index c4bd1de..7a180dc 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
+@@ -558,7 +558,7 @@ public class HostVersionOutOfSyncListenerTest {
+     for (Map.Entry<String, List<Integer>> component : topology.entrySet()) {
+ 
+       String componentName = component.getKey();
+-      cl.getService(serviceName).addServiceComponent(componentName);
++      cl.getService(serviceName).addServiceComponent(componentName, componentName);
+ 
+       for (Integer hostIndex : component.getValue()) {
+         cl.getService(serviceName)
+@@ -580,7 +580,7 @@ public class HostVersionOutOfSyncListenerTest {
+     Service service = cl.getService(serviceName);
+ 
+     if (!service.getServiceComponents().containsKey(componentName)) {
+-      service.addServiceComponent(componentName);
++      service.addServiceComponent(componentName, componentName);
+     }
+ 
+     ServiceComponent component = service.getServiceComponent(componentName);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java b/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
+index a1f6a0f..9756bda 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
+@@ -468,7 +468,7 @@ public class OrmTestHelper {
+     Service service = cluster.getService(serviceName);
+     assertNotNull(service);
+ 
+-    ServiceComponent datanode = componentFactory.createNew(service, "DATANODE");
++    ServiceComponent datanode = componentFactory.createNew(service, "DATANODE", "DATANODE");
+ 
+     service.addServiceComponent(datanode);
+     datanode.setDesiredState(State.INSTALLED);
+@@ -479,7 +479,7 @@ public class OrmTestHelper {
+     sch.setDesiredState(State.INSTALLED);
+     sch.setState(State.INSTALLED);
+ 
+-    ServiceComponent namenode = componentFactory.createNew(service, "NAMENODE");
++    ServiceComponent namenode = componentFactory.createNew(service, "NAMENODE", "NAMENODE");
+ 
+     service.addServiceComponent(namenode);
+     namenode.setDesiredState(State.INSTALLED);
+@@ -503,7 +503,7 @@ public class OrmTestHelper {
+     assertNotNull(service);
+ 
+     ServiceComponent resourceManager = componentFactory.createNew(service,
+-        "RESOURCEMANAGER");
++        "RESOURCEMANAGER", "RESOURCEMANAGER");
+ 
+     service.addServiceComponent(resourceManager);
+     resourceManager.setDesiredState(State.INSTALLED);
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
+index 40ca119..f27d9eb 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
+@@ -511,7 +511,7 @@ public class ComponentVersionCheckActionTest {
+     try {
+       serviceComponent = service.getServiceComponent(componentName);
+     } catch (ServiceComponentNotFoundException e) {
+-      serviceComponent = serviceComponentFactory.createNew(service, componentName);
++      serviceComponent = serviceComponentFactory.createNew(service, componentName, componentName);
+       service.addServiceComponent(serviceComponent);
+       serviceComponent.setDesiredState(State.INSTALLED);
+     }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+index 21c43b4..f6bc2d2 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+@@ -269,7 +269,7 @@ public class CreateAndConfigureActionTest {
+     try {
+       serviceComponent = service.getServiceComponent(componentName);
+     } catch (ServiceComponentNotFoundException e) {
+-      serviceComponent = serviceComponentFactory.createNew(service, componentName);
++      serviceComponent = serviceComponentFactory.createNew(service, componentName, componentName);
+       service.addServiceComponent(serviceComponent);
+       serviceComponent.setDesiredState(State.INSTALLED);
+     }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
+index 4a4541d..7a1412c 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
+@@ -116,7 +116,7 @@ public class ServiceComponentTest {
+   public void testCreateServiceComponent() throws AmbariException {
+     String componentName = "DATANODE2";
+     ServiceComponent component = serviceComponentFactory.createNew(service,
+-        componentName);
++        componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     ServiceComponent sc = service.getServiceComponent(componentName);
+@@ -138,7 +138,7 @@ public class ServiceComponentTest {
+   public void testGetAndSetServiceComponentInfo() throws AmbariException {
+     String componentName = "NAMENODE";
+     ServiceComponent component = serviceComponentFactory.createNew(service,
+-        componentName);
++        componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     ServiceComponent sc = service.getServiceComponent(componentName);
+@@ -162,7 +162,7 @@ public class ServiceComponentTest {
+     long serviceId = 1;
+ 
+     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     ServiceComponent sc1 = serviceComponentFactory.createExisting(service,
+         serviceComponentDesiredStateEntity);
+@@ -200,7 +200,7 @@ public class ServiceComponentTest {
+   @Test
+   public void testAddAndGetServiceComponentHosts() throws AmbariException {
+     String componentName = "NAMENODE";
+-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
++    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     ServiceComponent sc = service.getServiceComponent(componentName);
+@@ -253,18 +253,19 @@ public class ServiceComponentTest {
+ 
+     long serviceGroupId = 1;
+     long serviceId = 1;
++    long componentId = 1;
+ 
+     HostComponentDesiredStateEntity desiredStateEntity =
+         desiredStateDAO.findByIndex(
+           cluster.getClusterId(),
+           serviceGroupId,
+-                serviceId,
+-          componentName,
++          serviceId,
++          componentId,
+           hostEntity1.getHostId()
+         );
+ 
+     HostComponentStateEntity stateEntity = liveStateDAO.findByIndex(cluster.getClusterId(),
+-            serviceGroupId, serviceId, componentName, hostEntity1.getHostId());
++            serviceGroupId, serviceId, componentId, hostEntity1.getHostId());
+ 
+     ServiceComponentHost sch = serviceComponentHostFactory.createExisting(sc,
+         stateEntity, desiredStateEntity);
+@@ -278,7 +279,7 @@ public class ServiceComponentTest {
+   @Test
+   public void testConvertToResponse() throws AmbariException {
+     String componentName = "NAMENODE";
+-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
++    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     addHostToCluster("h1", service.getCluster().getClusterName());
+@@ -339,7 +340,7 @@ public class ServiceComponentTest {
+   public void testCanBeRemoved() throws Exception {
+     String componentName = "NAMENODE";
+     ServiceComponent component = serviceComponentFactory.createNew(service,
+-                                                                   componentName);
++                                                                   componentName, componentName);
+     addHostToCluster("h1", service.getCluster().getClusterName());
+     ServiceComponentHost sch = serviceComponentHostFactory.createNew(component, "h1");
+     component.addServiceComponentHost(sch);
+@@ -367,7 +368,7 @@ public class ServiceComponentTest {
+         ServiceComponentDesiredStateDAO.class);
+ 
+     String componentName = "NAMENODE";
+-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
++    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     ServiceComponent sc = service.getServiceComponent(componentName);
+@@ -380,7 +381,7 @@ public class ServiceComponentTest {
+     long serviceId = 1;
+ 
+     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     Assert.assertNotNull(serviceComponentDesiredStateEntity);
+ 
+@@ -420,7 +421,7 @@ public class ServiceComponentTest {
+ 
+     // verify history is gone, too
+     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     Assert.assertNull(serviceComponentDesiredStateEntity);
+  }
+@@ -431,7 +432,7 @@ public class ServiceComponentTest {
+         ServiceComponentDesiredStateDAO.class);
+ 
+     String componentName = "NAMENODE";
+-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
++    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     ServiceComponent sc = service.getServiceComponent(componentName);
+@@ -444,7 +445,7 @@ public class ServiceComponentTest {
+     long serviceId = 1;
+ 
+     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     StackDAO stackDAO = injector.getInstance(StackDAO.class);
+     StackEntity stackEntity = stackDAO.find("HDP", "2.2.0");
+@@ -475,7 +476,7 @@ public class ServiceComponentTest {
+         serviceComponentDesiredStateEntity);
+ 
+     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     assertEquals(1, serviceComponentDesiredStateEntity.getVersions().size());
+     ServiceComponentVersionEntity persistedVersion = serviceComponentDesiredStateEntity.getVersions().iterator().next();
+@@ -489,7 +490,7 @@ public class ServiceComponentTest {
+         ServiceComponentDesiredStateDAO.class);
+ 
+     String componentName = "NAMENODE";
+-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
++    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
+     service.addServiceComponent(component);
+ 
+     ServiceComponent sc = service.getServiceComponent(componentName);
+@@ -502,7 +503,7 @@ public class ServiceComponentTest {
+     long serviceId = 1;
+ 
+     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     StackDAO stackDAO = injector.getInstance(StackDAO.class);
+     StackEntity stackEntity = stackDAO.find("HDP", "2.2.0");
+@@ -532,7 +533,7 @@ public class ServiceComponentTest {
+         serviceComponentDesiredStateEntity);
+ 
+     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+ 
+     assertEquals(1, serviceComponentDesiredStateEntity.getVersions().size());
+     ServiceComponentVersionEntity persistedVersion = serviceComponentDesiredStateEntity.getVersions().iterator().next();
+@@ -542,7 +543,7 @@ public class ServiceComponentTest {
+     sc.delete();
+ 
+     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
+-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+     Assert.assertNull(serviceComponentDesiredStateEntity);
+ 
+ 
+@@ -559,7 +560,7 @@ public class ServiceComponentTest {
+ 
+     String componentName = "NAMENODE";
+ 
+-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
++    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
+ 
+     StackId newStackId = new StackId("HDP-2.2.0");
+     RepositoryVersionEntity repositoryVersion = helper.getOrCreateRepositoryVersion(newStackId,
+@@ -575,7 +576,8 @@ public class ServiceComponentTest {
+     long serviceGroupId = 1;
+     long serviceId = 1;
+ 
+-    ServiceComponentDesiredStateEntity entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++    ServiceComponentDesiredStateEntity entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(),
++            serviceGroupId, serviceId, componentName, componentName);
+ 
+     RepositoryVersionEntity repoVersion2201 = helper.getOrCreateRepositoryVersion(
+         component.getDesiredStackId(), "2.2.0.1");
+@@ -597,7 +599,7 @@ public class ServiceComponentTest {
+     sch1.setVersion("2.2.0.1");
+     sch2.setVersion("2.2.0.2");
+     sc.updateRepositoryState("2.2.0.2");
+-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
+ 
+     // !!! case 2: component desired is UNKNOWN, all h-c same version
+@@ -605,7 +607,7 @@ public class ServiceComponentTest {
+     sch1.setVersion("2.2.0.1");
+     sch2.setVersion("2.2.0.1");
+     sc.updateRepositoryState("2.2.0.1");
+-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
+ 
+     // !!! case 3: component desired is known, any component reports different version
+@@ -613,7 +615,7 @@ public class ServiceComponentTest {
+     sch1.setVersion("2.2.0.1");
+     sch2.setVersion("2.2.0.2");
+     sc.updateRepositoryState("2.2.0.2");
+-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
+ 
+     // !!! case 4: component desired is known, component reports same as desired, mix of h-c versions
+@@ -621,7 +623,7 @@ public class ServiceComponentTest {
+     sch1.setVersion("2.2.0.1");
+     sch2.setVersion("2.2.0.2");
+     sc.updateRepositoryState("2.2.0.1");
+-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
+ 
+     // !!! case 5: component desired is known, component reports same as desired, all h-c the same
+@@ -629,7 +631,7 @@ public class ServiceComponentTest {
+     sch1.setVersion("2.2.0.1");
+     sch2.setVersion("2.2.0.1");
+     sc.updateRepositoryState("2.2.0.1");
+-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
++    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
+     assertEquals(RepositoryVersionState.CURRENT, entity.getRepositoryState());
+   }
+ }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
+index 3c38c5b..5b8f6fd 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
+@@ -100,7 +100,7 @@ public class ServiceTest {
+       org.junit.Assert.assertTrue(service.canBeRemoved());
+     }
+ 
+-    ServiceComponent component = service.addServiceComponent("NAMENODE");
++    ServiceComponent component = service.addServiceComponent("NAMENODE", "NAMENODE");
+ 
+     // component can be removed
+     component.setDesiredState(State.INSTALLED);
+@@ -179,11 +179,11 @@ public class ServiceTest {
+     Assert.assertTrue(s.getServiceComponents().isEmpty());
+ 
+     ServiceComponent sc1 =
+-        serviceComponentFactory.createNew(s, "NAMENODE");
++        serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
+     ServiceComponent sc2 =
+-        serviceComponentFactory.createNew(s, "DATANODE1");
++        serviceComponentFactory.createNew(s, "DATANODE1", "DATANODE1");
+     ServiceComponent sc3 =
+-        serviceComponentFactory.createNew(s, "DATANODE2");
++        serviceComponentFactory.createNew(s, "DATANODE2", "DATANODE2");
+ 
+     Map<String, ServiceComponent> comps = new
+       HashMap<>();
+@@ -205,7 +205,7 @@ public class ServiceTest {
+ 
+     s.addServiceComponent(sc3);
+ 
+-    ServiceComponent sc4 = s.addServiceComponent("HDFS_CLIENT");
++    ServiceComponent sc4 = s.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
+     Assert.assertNotNull(s.getServiceComponent(sc4.getName()));
+     Assert.assertEquals(State.INIT,
+         s.getServiceComponent("HDFS_CLIENT").getDesiredState());
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
+index 11464dd..06ecdc2 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
+@@ -595,7 +595,7 @@ public class ClusterDeadlockTest {
+       serviceComponent = service.getServiceComponent(componentName);
+     } catch (ServiceComponentNotFoundException e) {
+       serviceComponent = serviceComponentFactory.createNew(service,
+-          componentName);
++          componentName, componentName);
+       service.addServiceComponent(serviceComponent);
+       serviceComponent.setDesiredState(State.INSTALLED);
+     }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
+index 7fbaf6f..c4d0a76 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
+@@ -237,20 +237,20 @@ public class ClusterImplTest {
+     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
+     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+ 
+-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
++    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
+     nameNode.addServiceComponentHost(hostName1);
+ 
+-    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE");
++    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE", "DATANODE");
+     dataNode.addServiceComponentHost(hostName1);
+     dataNode.addServiceComponentHost(hostName2);
+ 
+-    ServiceComponent hdfsClient = hdfs.addServiceComponent("HDFS_CLIENT");
++    ServiceComponent hdfsClient = hdfs.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
+     hdfsClient.addServiceComponentHost(hostName1);
+     hdfsClient.addServiceComponentHost(hostName2);
+ 
+     Service tez = cluster.addService(serviceGroup, serviceToDelete, serviceToDelete, repositoryVersion);
+ 
+-    ServiceComponent tezClient = tez.addServiceComponent("TEZ_CLIENT");
++    ServiceComponent tezClient = tez.addServiceComponent("TEZ_CLIENT", "TEZ_CLIENT");
+     ServiceComponentHost tezClientHost1 =  tezClient.addServiceComponentHost(hostName1);
+     ServiceComponentHost tezClientHost2 = tezClient.addServiceComponentHost(hostName2);
+ 
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+index 9a7deb6..4e85214 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+@@ -343,22 +343,22 @@ public class ClusterTest {
+     cluster.addService(s3);
+ 
+     // Add HDFS components
+-    ServiceComponent sc1CompA = serviceComponentFactory.createNew(s1, "NAMENODE");
+-    ServiceComponent sc1CompB = serviceComponentFactory.createNew(s1, "DATANODE");
+-    ServiceComponent sc1CompC = serviceComponentFactory.createNew(s1, "HDFS_CLIENT");
++    ServiceComponent sc1CompA = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
++    ServiceComponent sc1CompB = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
++    ServiceComponent sc1CompC = serviceComponentFactory.createNew(s1, "HDFS_CLIENT", "HDFS_CLIENT");
+     s1.addServiceComponent(sc1CompA);
+     s1.addServiceComponent(sc1CompB);
+     s1.addServiceComponent(sc1CompC);
+ 
+     // Add ZK
+-    ServiceComponent sc2CompA = serviceComponentFactory.createNew(s2, "ZOOKEEPER_SERVER");
+-    ServiceComponent sc2CompB = serviceComponentFactory.createNew(s2, "ZOOKEEPER_CLIENT");
++    ServiceComponent sc2CompA = serviceComponentFactory.createNew(s2, "ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
++    ServiceComponent sc2CompB = serviceComponentFactory.createNew(s2, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
+     s2.addServiceComponent(sc2CompA);
+     s2.addServiceComponent(sc2CompB);
+ 
+     // Add Ganglia
+-    ServiceComponent sc3CompA = serviceComponentFactory.createNew(s3, "GANGLIA_SERVER");
+-    ServiceComponent sc3CompB = serviceComponentFactory.createNew(s3, "GANGLIA_MONITOR");
++    ServiceComponent sc3CompA = serviceComponentFactory.createNew(s3, "GANGLIA_SERVER", "GANGLIA_SERVER");
++    ServiceComponent sc3CompB = serviceComponentFactory.createNew(s3, "GANGLIA_MONITOR", "GANGLIA_MONITOR");
+     s3.addServiceComponent(sc3CompA);
+     s3.addServiceComponent(sc3CompB);
+ 
+@@ -633,7 +633,7 @@ public class ClusterTest {
+ 
+     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
+     c1.addService(s);
+-    ServiceComponent sc = serviceComponentFactory.createNew(s, "NAMENODE");
++    ServiceComponent sc = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
+     s.addServiceComponent(sc);
+ 
+     ServiceComponentHost sch =
+@@ -651,7 +651,7 @@ public class ClusterTest {
+         iterator.next();
+         Service s1 = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "PIG", "PIG", repositoryVersion);
+         c1.addService(s1);
+-        ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "PIG");
++        ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "PIG", "PIG");
+         s1.addServiceComponent(sc1);
+         ServiceComponentHost sch1 = serviceComponentHostFactory.createNew(sc1, "h1");
+         sc1.addServiceComponentHost(sch1);
+@@ -673,12 +673,12 @@ public class ClusterTest {
+     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
+     c1.addService(s);
+ 
+-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
++    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
+     s.addServiceComponent(scNN);
+     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
+     scNN.addServiceComponentHost(schNNH1);
+ 
+-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
++    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
+     s.addServiceComponent(scDN);
+     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
+     scDN.addServiceComponentHost(scDNH1);
+@@ -703,12 +703,12 @@ public class ClusterTest {
+     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
+     c1.addService(s);
+ 
+-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
++    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
+     s.addServiceComponent(scNN);
+     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
+     scNN.addServiceComponentHost(schNNH1);
+ 
+-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
++    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
+     s.addServiceComponent(scDN);
+     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
+     scDN.addServiceComponentHost(scDNH1);
+@@ -739,12 +739,12 @@ public class ClusterTest {
+     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(),  "HDFS",  "HDFS", repositoryVersion);
+     c1.addService(s);
+ 
+-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
++    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
+     s.addServiceComponent(scNN);
+     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
+     scNN.addServiceComponentHost(schNNH1);
+ 
+-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
++    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
+     s.addServiceComponent(scDN);
+     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
+     scDN.addServiceComponentHost(scDNH1);
+@@ -776,19 +776,19 @@ public class ClusterTest {
+     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
+     c1.addService(sfMR);
+ 
+-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
++    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
+     sfHDFS.addServiceComponent(scNN);
+     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
+     scNN.addServiceComponentHost(schNNH1);
+ 
+-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
++    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
+     sfHDFS.addServiceComponent(scDN);
+     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
+     scDN.addServiceComponentHost(scDNH1);
+     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
+     scDN.addServiceComponentHost(scDNH2);
+ 
+-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
++    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
+     sfMR.addServiceComponent(scJT);
+     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
+     scJT.addServiceComponentHost(schJTH1);
+@@ -834,19 +834,19 @@ public class ClusterTest {
+     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
+     c1.addService(sfMR);
+ 
+-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
++    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
+     sfHDFS.addServiceComponent(scNN);
+     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
+     scNN.addServiceComponentHost(schNNH1);
+ 
+-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
++    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
+     sfHDFS.addServiceComponent(scDN);
+     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
+     scDN.addServiceComponentHost(scDNH1);
+     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
+     scDN.addServiceComponentHost(scDNH2);
+ 
+-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
++    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
+     sfMR.addServiceComponent(scJT);
+     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
+     scJT.addServiceComponentHost(schJTH1);
+@@ -893,19 +893,19 @@ public class ClusterTest {
+     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
+     c1.addService(sfMR);
+ 
+-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
++    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
+     sfHDFS.addServiceComponent(scNN);
+     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
+     scNN.addServiceComponentHost(schNNH1);
+ 
+-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
++    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
+     sfHDFS.addServiceComponent(scDN);
+     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
+     scDN.addServiceComponentHost(scDNH1);
+     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
+     scDN.addServiceComponentHost(scDNH2);
+ 
+-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
++    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
+     sfMR.addServiceComponent(scJT);
+     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
+     scJT.addServiceComponentHost(schJTH1);
+@@ -1076,7 +1076,7 @@ public class ClusterTest {
+     c1.addService(serviceGroup, "MAPREDUCE", "MAPREDUCE", repositoryVersion);
+ 
+     Service hdfs = c1.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
+-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
++    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
+ 
+     assertEquals(2, c1.getServices().size());
+     assertEquals(2, injector.getProvider(EntityManager.class).get().
+@@ -1541,8 +1541,8 @@ public class ClusterTest {
+     c1.addService(hdfs);
+ 
+     // Add HDFS components
+-    ServiceComponent datanode = serviceComponentFactory.createNew(hdfs, "NAMENODE");
+-    ServiceComponent namenode = serviceComponentFactory.createNew(hdfs, "DATANODE");
++    ServiceComponent datanode = serviceComponentFactory.createNew(hdfs, "NAMENODE", "NAMENODE");
++    ServiceComponent namenode = serviceComponentFactory.createNew(hdfs, "DATANODE", "DATANODE");
+     hdfs.addServiceComponent(datanode);
+     hdfs.addServiceComponent(namenode);
+ 
+@@ -1874,12 +1874,12 @@ public class ClusterTest {
+ 
+     ServiceGroup serviceGroup = c1.addServiceGroup("CORE", stackId.getStackId());
+     Service service = c1.addService(serviceGroup, "ZOOKEEPER", "ZOOKEEPER", repositoryVersion);
+-    ServiceComponent sc = service.addServiceComponent("ZOOKEEPER_SERVER");
++    ServiceComponent sc = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+     sc.addServiceComponentHost("h-1");
+     sc.addServiceComponentHost("h-2");
+ 
+     service = c1.addService(serviceGroup, "SQOOP", "SQOOP", repositoryVersion);
+-    sc = service.addServiceComponent("SQOOP");
++    sc = service.addServiceComponent("SQOOP", "SQOOP");
+     sc.addServiceComponentHost("h-3");
+ 
+     HostEntity hostEntity = hostDAO.findByName("h-3");
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
+index 1121668..8988645 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
+@@ -374,7 +374,7 @@ public class ClustersDeadlockTest {
+       serviceComponent = service.getServiceComponent(componentName);
+     } catch (ServiceComponentNotFoundException e) {
+       serviceComponent = serviceComponentFactory.createNew(service,
+-          componentName);
++          componentName, componentName);
+       service.addServiceComponent(serviceComponent);
+       serviceComponent.setDesiredState(State.INSTALLED);
+     }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+index 438079a..e6790c1 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+@@ -432,10 +432,10 @@ public class ClustersTest {
+ 
+     //Assert.assertNotNull(injector.getInstance(ClusterServiceDAO.class).findByClusterAndServiceNames(c1, "HDFS"));
+ 
+-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
+-    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE");
++    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
++    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE", "DATANODE");
+ 
+-    ServiceComponent serviceCheckNode = hdfs.addServiceComponent("HDFS_CLIENT");
++    ServiceComponent serviceCheckNode = hdfs.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
+ 
+     ServiceComponentHost nameNodeHost = nameNode.addServiceComponentHost(h1);
+     HostEntity nameNodeHostEntity = hostDAO.findByName(nameNodeHost.getHostName());
+@@ -448,13 +448,13 @@ public class ClustersTest {
+ 
+     Assert.assertNotNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
+       nameNodeHost.getClusterId(), 1L, 1L,
+-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()));
++      nameNodeHost.getServiceComponentId(),  nameNodeHostEntity.getHostId()));
+ 
+     Assert.assertNotNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(
+       nameNodeHost.getClusterId(),
+       1L,
+       1L,
+-      nameNodeHost.getServiceComponentName(),
++      nameNodeHost.getServiceComponentId(),
+       nameNodeHostEntity.getHostId()
+     ));
+     Assert.assertEquals(2, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config").getResultList().size());
+@@ -492,11 +492,11 @@ public class ClustersTest {
+     Assert.assertEquals(2, hostDAO.findAll().size());
+     Assert.assertNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
+       nameNodeHost.getClusterId(), 1L, 1L,
+-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()));
++      nameNodeHost.getServiceComponentId(), nameNodeHostEntity.getHostId()));
+ 
+     Assert.assertNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(
+       nameNodeHost.getClusterId(), 1L, 1L,
+-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()
++      nameNodeHost.getServiceComponentId(), nameNodeHostEntity.getHostId()
+     ));
+     Assert.assertEquals(0, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config").getResultList().size());
+     Assert.assertEquals(0, injector.getProvider(EntityManager.class).get().createQuery("SELECT state FROM ClusterStateEntity state").getResultList().size());
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
+index e3d76b3..c65b029 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
+@@ -243,7 +243,7 @@ public class ConcurrentServiceConfigVersionTest {
+       serviceComponent = service.getServiceComponent(componentName);
+     } catch (ServiceComponentNotFoundException e) {
+       serviceComponent = serviceComponentFactory.createNew(service,
+-          componentName);
++          componentName, componentName);
+       service.addServiceComponent(serviceComponent);
+       serviceComponent.setDesiredState(State.INSTALLED);
+     }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
+index 8289a0d..b3afd65 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
+@@ -139,7 +139,7 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
+     clusters.mapHostToCluster(hostName, "c1");
+ 
+     Service service = installService("HDFS");
+-    addServiceComponent(service, "NAMENODE");
++    addServiceComponent(service, "NAMENODE", "NAMENODE");
+   }
+ 
+   @After
+@@ -151,8 +151,8 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
+    */
+   @Test()
+   public void testConcurrentWriteDeadlock() throws Exception {
+-    ServiceComponentHost nameNodeSCH = createNewServiceComponentHost("HDFS", "NAMENODE", "c6401");
+-    ServiceComponentHost dataNodeSCH = createNewServiceComponentHost("HDFS", "DATANODE", "c6401");
++    ServiceComponentHost nameNodeSCH = createNewServiceComponentHost("HDFS", "NAMENODE", "NAMENODE", "c6401");
++    ServiceComponentHost dataNodeSCH = createNewServiceComponentHost("HDFS", "DATANODE", "DATANODE", "c6401");
+ 
+     List<ServiceComponentHost> serviceComponentHosts = new ArrayList<>();
+     serviceComponentHosts.add(nameNodeSCH);
+@@ -229,10 +229,10 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
+   }
+ 
+   private ServiceComponentHost createNewServiceComponentHost(String svc,
+-      String svcComponent, String hostName) throws AmbariException {
++      String svcComponentName, String svcComponentType, String hostName) throws AmbariException {
+     Assert.assertNotNull(cluster.getConfigGroups());
+     Service s = installService(svc);
+-    ServiceComponent sc = addServiceComponent(s, svcComponent);
++    ServiceComponent sc = addServiceComponent(s, svcComponentName, svcComponentType);
+ 
+     ServiceComponentHost sch = serviceComponentHostFactory.createNew(sc, hostName);
+ 
+@@ -258,13 +258,13 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
+   }
+ 
+   private ServiceComponent addServiceComponent(Service service,
+-      String componentName) throws AmbariException {
++      String componentName, String svcComponentType) throws AmbariException {
+     ServiceComponent serviceComponent = null;
+     try {
+       serviceComponent = service.getServiceComponent(componentName);
+     } catch (ServiceComponentNotFoundException e) {
+       serviceComponent = serviceComponentFactory.createNew(service,
+-          componentName);
++          componentName, svcComponentType);
+       service.addServiceComponent(serviceComponent);
+       serviceComponent.setDesiredState(State.INSTALLED);
+     }
+diff --git a/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java b/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
+index 7a17ccc..7a3b1a3 100644
+--- a/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
++++ b/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
+@@ -202,7 +202,7 @@ public class ServiceComponentHostTest {
+     try {
+       sc = s.getServiceComponent(svcComponent);
+     } catch (ServiceComponentNotFoundException e) {
+-      sc = serviceComponentFactory.createNew(s, svcComponent);
++      sc = serviceComponentFactory.createNew(s, svcComponent, svcComponent);
+       s.addServiceComponent(sc);
+     }
+ 
+@@ -1057,7 +1057,7 @@ public class ServiceComponentHostTest {
+       cluster.getClusterId(),
+       customServiceGroup.getServiceGroupId(),
+       sch1.getServiceId(),
+-      sch1.getServiceComponentName(),
++      sch1.getServiceComponentId(),
+       hostEntity.getHostId()
+     );
+     Assert.assertEquals(MaintenanceState.OFF, entity.getMaintenanceState());
+@@ -1070,7 +1070,7 @@ public class ServiceComponentHostTest {
+       cluster.getClusterId(),
+       customServiceGroup.getServiceGroupId(),
+       sch1.getServiceId(),
+-      sch1.getServiceComponentName(),
++      sch1.getServiceComponentId(),
+       hostEntity.getHostId()
+     );
+     Assert.assertEquals(MaintenanceState.ON, entity.getMaintenanceState());
+diff --git a/ambari-web/app/controllers/wizard/step8_controller.js b/ambari-web/app/controllers/wizard/step8_controller.js
+index 444981e..3076aac 100644
+--- a/ambari-web/app/controllers/wizard/step8_controller.js
++++ b/ambari-web/app/controllers/wizard/step8_controller.js
+@@ -1051,7 +1051,7 @@ App.WizardStep8Controller = Em.Controller.extend(App.AddSecurityConfigs, App.wiz
+     this.get('selectedServices').forEach(function (_service) {
+       var serviceName = _service.get('serviceName');
+       var componentsData = serviceComponents.filterProperty('serviceName', serviceName).map(function (_component) {
+-        return { "ServiceComponentInfo": { "component_name": _component.get('componentName') } };
++        return { "ServiceComponentInfo": { "component_name": _component.get('componentName'), "component_type": _component.get('componentName') } };
+       });
+ 
+       // Service must be specified in terms of a query for creating multiple components at the same time.
+@@ -1459,7 +1459,8 @@ App.WizardStep8Controller = Em.Controller.extend(App.AddSecurityConfigs, App.wiz
+         "host_components": [
+           {
+             "HostRoles": {
+-              "component_name": componentName
++              "component_name": componentName,
++              "component_type": componentName
+             }
+           }
+         ]
+diff --git a/ambari-web/app/utils/ajax/ajax.js b/ambari-web/app/utils/ajax/ajax.js
+index 706116c..03c1ad1 100644
+--- a/ambari-web/app/utils/ajax/ajax.js
++++ b/ambari-web/app/utils/ajax/ajax.js
+@@ -1432,7 +1432,8 @@ var urls = {
+           "components": [
+             {
+               "ServiceComponentInfo": {
+-                "component_name": data.componentName
++                "component_name": data.componentName,
++                "component_type": data.componentName
+               }
+             }
+           ]

--- a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
@@ -31,4 +31,13 @@ public class ServiceComponentHostNotFoundException
         + ", hostName=" + hostName);
   }
 
+  public ServiceComponentHostNotFoundException(String clusterName,
+      String serviceName, Long serviceComponentId, String hostName) {
+    super("ServiceComponentHost not found"
+            + ", clusterName=" + clusterName
+            + ", serviceName=" + serviceName
+            + ", serviceComponentId=" + serviceComponentId
+            + ", hostName=" + hostName);
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentNotFoundException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentNotFoundException.java
@@ -32,4 +32,14 @@ public class ServiceComponentNotFoundException
         + ", serviceComponentName=" + serviceComponentName);
   }
 
+  public ServiceComponentNotFoundException (String clusterName,
+      String serviceName, String serviceType, String serviceGroupName, Long serviceComponentId) {
+    super("ServiceComponent not found"
+            + ", clusterName=" + clusterName
+            + ", serviceGroupName=" + serviceGroupName
+            + ", serviceName=" + serviceName
+            + ", serviceType=" + serviceType
+            + ", serviceComponentId=" + serviceComponentId);
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
@@ -71,19 +71,19 @@ public class HostComponentService extends BaseService {
   }
 
   /**
-   * Handles GET /clusters/{clusterID}/hosts/{hostID}/host_components/{hostComponentID}
+   * Handles GET /clusters/{clusterName}/hosts/{hostID}/host_components/{hostComponentID}
    * Get a specific host_component.
    *
    * @param headers           http headers
    * @param ui                uri info
-   * @param hostComponentName host_component id
-   * @return host_component resource representation
+   * @param hostComponentId   host_component id
+   * @return host_component   resource representation
    */
   @GET @ApiIgnore // until documented
-  @Path("{hostComponentName}")
+  @Path("{hostComponentId}")
   @Produces("text/plain")
   public Response getHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
-                                   @PathParam("hostComponentName") String hostComponentName, @QueryParam("format") String format) {
+                                   @PathParam("hostComponentId") String hostComponentId, @QueryParam("format") String format) {
 
     //todo: needs to be refactored when properly handling exceptions
     if (m_hostName == null) {
@@ -93,11 +93,11 @@ public class HostComponentService extends BaseService {
     }
 
     if (format != null && format.equals("client_config_tar")) {
-      return createClientConfigResource(body, headers, ui, hostComponentName);
+      return createClientConfigResource(body, headers, ui, hostComponentId);
     }
 
     return handleRequest(headers, body, ui, Request.Type.GET,
-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
+        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
   }
 
   /**
@@ -144,18 +144,18 @@ public class HostComponentService extends BaseService {
    * @param body              http body
    * @param headers           http headers
    * @param ui                uri info
-   * @param hostComponentName host_component id
+   * @param hostComponentId   host_component id
    *
    * @return host_component resource representation
    */
   @POST @ApiIgnore // until documented
-  @Path("{hostComponentName}")
+  @Path("{hostComponentId}")
   @Produces("text/plain")
   public Response createHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
-                                   @PathParam("hostComponentName") String hostComponentName) {
+                                   @PathParam("hostComponentId") String hostComponentId) {
 
     return handleRequest(headers, body, ui, Request.Type.POST,
-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
+        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
   }
 
   /**
@@ -165,18 +165,18 @@ public class HostComponentService extends BaseService {
    * @param body              http body
    * @param headers           http headers
    * @param ui                uri info
-   * @param hostComponentName host_component id
+   * @param hostComponentId   host_component id
    *
    * @return information regarding updated host_component
    */
   @PUT @ApiIgnore // until documented
-  @Path("{hostComponentName}")
+  @Path("{hostComponentId}")
   @Produces("text/plain")
   public Response updateHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
-                                      @PathParam("hostComponentName") String hostComponentName) {
+                                      @PathParam("hostComponentId") String hostComponentId) {
 
     return handleRequest(headers, body, ui, Request.Type.PUT,
-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
+        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
   }
 
   /**
@@ -203,18 +203,18 @@ public class HostComponentService extends BaseService {
    *
    * @param headers           http headers
    * @param ui                uri info
-   * @param hostComponentName host_component id
+   * @param hostComponentId   host_component id
    *
    * @return host_component resource representation
    */
   @DELETE @ApiIgnore // until documented
-  @Path("{hostComponentName}")
+  @Path("{hostComponentId}")
   @Produces("text/plain")
   public Response deleteHostComponent(@Context HttpHeaders headers, @Context UriInfo ui,
-                                   @PathParam("hostComponentName") String hostComponentName) {
+                                   @PathParam("hostComponentId") String hostComponentId) {
 
     return handleRequest(headers, null, ui, Request.Type.DELETE,
-        createHostComponentResource(m_clusterName, m_hostName, hostComponentName));
+        createHostComponentResource(m_clusterName, m_hostName, hostComponentId));
   }
 
   /**
@@ -235,14 +235,14 @@ public class HostComponentService extends BaseService {
   }
 
   @GET @ApiIgnore // until documented
-  @Path("{hostComponentName}/processes")
+  @Path("{hostComponentId}/processes")
   @Produces("text/plain")
   public Response getProcesses(@Context HttpHeaders headers, @Context UriInfo ui,
-      @PathParam("hostComponentName") String hostComponentName) {
+      @PathParam("hostComponentId") String hostComponentId) {
     Map<Resource.Type,String> mapIds = new HashMap<>();
     mapIds.put(Resource.Type.Cluster, m_clusterName);
     mapIds.put(Resource.Type.Host, m_hostName);
-    mapIds.put(Resource.Type.HostComponent, hostComponentName);
+    mapIds.put(Resource.Type.HostComponent, hostComponentId);
 
     ResourceInstance ri = createResource(Resource.Type.HostComponentProcess, mapIds);
 
@@ -254,25 +254,25 @@ public class HostComponentService extends BaseService {
    *
    * @param clusterName       cluster name
    * @param hostName          host name
-   * @param hostComponentName host_component name
+   * @param hostComponentId   host_component id
    *
    * @return a host resource instance
    */
-  ResourceInstance createHostComponentResource(String clusterName, String hostName, String hostComponentName) {
+  ResourceInstance createHostComponentResource(String clusterName, String hostName, String hostComponentId) {
     Map<Resource.Type,String> mapIds = new HashMap<>();
     mapIds.put(Resource.Type.Cluster, clusterName);
     mapIds.put(Resource.Type.Host, hostName);
-    mapIds.put(Resource.Type.HostComponent, hostComponentName);
+    mapIds.put(Resource.Type.HostComponent, hostComponentId);
 
     return createResource(Resource.Type.HostComponent, mapIds);
   }
 
   private Response createClientConfigResource(String body, HttpHeaders headers, UriInfo ui,
-                                              String hostComponentName) {
+                                              String hostComponentId) {
     Map<Resource.Type,String> mapIds = new HashMap<>();
     mapIds.put(Resource.Type.Cluster, m_clusterName);
     mapIds.put(Resource.Type.Host, m_hostName);
-    mapIds.put(Resource.Type.Component, hostComponentName);
+    mapIds.put(Resource.Type.Component, hostComponentId);
 
     Response response = handleRequest(headers, body, ui, Request.Type.GET,
             createResource(Resource.Type.ClientConfig, mapIds));
@@ -284,10 +284,10 @@ public class HostComponentService extends BaseService {
 
     String filePrefixName;
 
-    if (StringUtils.isEmpty(hostComponentName)) {
+    if (StringUtils.isEmpty(hostComponentId)) {
       filePrefixName = m_hostName + "(" + Resource.InternalType.Host.toString().toUpperCase()+")";
     } else {
-      filePrefixName = hostComponentName;
+      filePrefixName = hostComponentId;
     }
 
     Validate.notNull(filePrefixName, "compressed config file name should not be null");

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
@@ -510,6 +510,19 @@ public interface AmbariManagementController {
   String findService(Cluster cluster, String componentName) throws AmbariException;
 
   /**
+   * Get service name by cluster instance and component id
+   *
+   * @param cluster the cluster instance
+   * @param componentId the component id in Long type
+   *
+   * @return a service name
+   *
+   * @throws  AmbariException if service name is null or empty
+   */
+
+  String findService(Cluster cluster, Long componentId) throws AmbariException;
+
+  /**
    * Get the clusters for this management controller.
    *
    * @return the clusters

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -624,6 +624,13 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     for (ServiceComponentHostRequest request : requests) {
       validateServiceComponentHostRequest(request);
 
+      // TODO: Multi_Component_Instance. When we go into multiple component instance mode, we will need make
+      // component_type as manadatory field. As of now, we are just copying component_name into component_type,
+      // if not provided. Further, need to add validation check too.
+      if(StringUtils.isBlank(request.getComponentType())) {
+        request.setComponentType(request.getComponentName());
+      }
+
       Cluster cluster;
       try {
         cluster = clusters.getCluster(request.getClusterName());
@@ -647,8 +654,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       }
 
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Received a createHostComponent request, clusterName={}, serviceGroupName={}, serviceName={}, componentName={}, hostname={}, request={}",
-          request.getClusterName(), request.getServiceGroupName(), request.getServiceName(), request.getComponentName(), request.getHostname(), request);
+        LOG.debug("Received a createHostComponent request, clusterName={}, serviceGroupName={}, serviceName={}, " +
+                  "componentName={}, componentType={}, hostname={}, request={}", request.getClusterName(),
+                  request.getServiceGroupName(), request.getServiceName(), request.getComponentName(),
+                  request.getComponentType(), request.getHostname(), request);
       }
 
       if (!hostComponentNames.containsKey(request.getClusterName())) {
@@ -1254,7 +1263,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       }
     }
 
-    if (request.getComponentName() != null) {
+    if (request.getComponentName() != null ) {
       if (StringUtils.isBlank(request.getServiceName())) {
 
         // !!! FIXME the assumption that a component is unique across all stacks is a ticking
@@ -1267,7 +1276,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         }
 
         if (StringUtils.isBlank(serviceName)) {
-          LOG.error("Unable to find service for component {}", request.getComponentName());
+          LOG.error("Unable to find service for component Name : {}", request.getComponentName());
           throw new ServiceComponentHostNotFoundException(
               cluster.getClusterName(), null, request.getComponentName(), request.getHostname());
         }
@@ -1323,11 +1332,15 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       Set<ServiceComponent> components = new HashSet<>();
       if (request.getComponentName() != null) {
         components.add(s.getServiceComponent(request.getComponentName()));
-      } else {
+      }else {
         components.addAll(s.getServiceComponents().values());
       }
       for (ServiceComponent sc : components) {
-        if (request.getComponentName() != null) {
+        if (request.getComponentId() != null && sc.getId() != null) {
+          if (sc.getId() != request.getComponentId()) {
+            continue;
+          }
+        } else if (request.getComponentName() != null && sc.getName() != null) {
           if (!sc.getName().equals(request.getComponentName())) {
             continue;
           }
@@ -1388,7 +1401,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
             response.add(r);
           } catch (ServiceComponentHostNotFoundException e) {
-            if (request.getServiceName() == null || request.getComponentName() == null) {
+            if (request.getServiceName() == null || request.getComponentId() == null) {
               // Ignore the exception if either the service name or component name are not specified.
               // This is an artifact of how we get host_components and can happen in the case where
               // we get all host_components for a host, for example.
@@ -1400,7 +1413,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
               // condition.
               LOG.debug("ServiceComponentHost not found ", e);
               throw new ServiceComponentHostNotFoundException(cluster.getClusterName(),
-                  request.getServiceName(), request.getComponentName(), request.getHostname());
+                  request.getServiceName(), request.getComponentId(), request.getHostname());
             }
           }
         } else {
@@ -3562,10 +3575,14 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         || request.getClusterName().isEmpty()
         || request.getComponentName() == null
         || request.getComponentName().isEmpty()
+        || request.getServiceName() == null
+        || request.getServiceName().isEmpty()
+        || request.getServiceGroupName() == null
+        || request.getServiceGroupName().isEmpty()
         || request.getHostname() == null
         || request.getHostname().isEmpty()) {
       throw new IllegalArgumentException("Invalid arguments"
-          + ", cluster name, component name and host name should be"
+          + ", cluster name, component name, service name, service group name and host name should be"
           + " provided");
     }
 
@@ -3593,6 +3610,11 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   @Override
   public String findService(Cluster cluster, String componentName) throws AmbariException {
     return cluster.getServiceByComponentName(componentName).getName();
+  }
+
+  @Override
+  public String findService(Cluster cluster, Long componentId) throws AmbariException {
+    return cluster.getServiceByComponentId(componentId).getName();
   }
 
   @Override
@@ -3635,8 +3657,8 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
         for (ServiceComponentHost sch : cluster.getServiceComponentHosts(request.getHostname())) {
           ServiceComponentHostRequest schr = new ServiceComponentHostRequest(request.getClusterName(),
-                  request.getServiceGroupName(), sch.getServiceName(), sch.getServiceComponentName(),
-                  sch.getHostName(), null);
+                  request.getServiceGroupName(), sch.getServiceName(), sch.getServiceComponentId(), sch.getServiceComponentName(),
+                  sch.getServiceComponentType(), sch.getHostName(), null);
           expanded.add(schr);
         }
       }
@@ -3662,6 +3684,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         + ", clusterName=" + request.getClusterName()
         + ", serviceName=" + request.getServiceName()
         + ", componentName=" + request.getComponentName()
+        + ", componentType=" + request.getComponentType()
         + ", hostname=" + request.getHostname()
         + ", request=" + request);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
@@ -26,7 +26,9 @@ public class ServiceComponentHostRequest {
   private String clusterName; // REF
   private String serviceGroupName;
   private String serviceName;
+  private Long componentId;
   private String componentName;
+  private String componentType;
   private String hostname;
   private String publicHostname;
   private String state;
@@ -39,15 +41,29 @@ public class ServiceComponentHostRequest {
   public ServiceComponentHostRequest(String clusterName,
                                      String serviceGroupName,
                                      String serviceName,
+                                     Long componentId,
                                      String componentName,
+                                     String componentType,
                                      String hostname,
                                      String desiredState) {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
     this.serviceName = serviceName;
+    this.componentId = componentId;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.hostname = hostname;
     this.desiredState = desiredState;
+  }
+
+  public ServiceComponentHostRequest(String clusterName,
+                                     String serviceGroupName,
+                                     String serviceName,
+                                     String componentName,
+                                     String componentType,
+                                     String hostname,
+                                     String desiredState) {
+    this(clusterName, serviceGroupName, serviceName, null, componentName, componentType, hostname, desiredState);
   }
 
   /**
@@ -75,6 +91,13 @@ public class ServiceComponentHostRequest {
   }
 
   /**
+   * @return the componentd
+   */
+  public Long getComponentId() {
+    return componentId;
+  }
+
+  /**
    * @return the componentName
    */
   public String getComponentName() {
@@ -88,6 +111,22 @@ public class ServiceComponentHostRequest {
     this.componentName = componentName;
   }
 
+  /**
+   * @param componentId the componentId to set
+   */
+  public void setComponentId(Long componentId) {
+    this.componentId = componentId;
+  }
+
+  /**
+   * @return the componentType
+   */
+  public String getComponentType() { return componentType; }
+
+  /**
+   * @param componentType the componenType to set
+   */
+  public void setComponentType(String componentType) { this.componentType = componentType; }
   /**
    * @return the hostname
    */
@@ -162,7 +201,9 @@ public class ServiceComponentHostRequest {
     sb.append("{" + " clusterName=").append(clusterName)
       .append(", serviceGroupName=").append(serviceGroupName)
       .append(", serviceName=").append(serviceName)
+      .append(", componentId=").append(componentId)
       .append(", componentName=").append(componentName)
+      .append(", componentType=").append(componentType)
       .append(", hostname=").append(hostname)
       .append(", publicHostname=").append(publicHostname)
       .append(", desiredState=").append(desiredState)
@@ -203,7 +244,9 @@ public class ServiceComponentHostRequest {
     return Objects.equals(clusterName, other.clusterName) &&
       Objects.equals(serviceGroupName, other.serviceGroupName) &&
       Objects.equals(serviceName, other.serviceName) &&
+      Objects.equals(componentId, other.componentId) &&
       Objects.equals(componentName, other.componentName) &&
+      Objects.equals(componentType, other.componentType) &&
       Objects.equals(hostname, other.hostname) &&
       Objects.equals(publicHostname, other.publicHostname) &&
       Objects.equals(desiredState, other.desiredState) &&
@@ -216,7 +259,7 @@ public class ServiceComponentHostRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(clusterName, serviceGroupName, serviceName, componentName, hostname, publicHostname,
-      desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
+    return Objects.hash(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType, hostname,
+      publicHostname, desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
@@ -35,6 +35,7 @@ public class ServiceComponentHostResponse {
   private String serviceType;
   private Long hostComponentId;
   private String componentName;
+  private String componentType;
   private String displayName;
   private String publicHostname;
   private String hostname;
@@ -53,9 +54,10 @@ public class ServiceComponentHostResponse {
 
   public ServiceComponentHostResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName,
                                       Long serviceId, String serviceName, String serviceType, Long hostComponentId,
-                                      String componentName, String displayName, String hostname, String publicHostname,
-                                      String liveState, String version, String desiredState, String desiredStackVersion,
-                                      String desiredRepositoryVersion, HostComponentAdminState adminState) {
+                                      String componentName, String componentType, String displayName, String hostname,
+                                      String publicHostname, String liveState, String version, String desiredState,
+                                      String desiredStackVersion, String desiredRepositoryVersion,
+                                      HostComponentAdminState adminState) {
     this.clusterId = clusterId;
     this.serviceGroupId = serviceGroupId;
     this.serviceGroupName = serviceGroupName;
@@ -65,6 +67,7 @@ public class ServiceComponentHostResponse {
     this.serviceType = serviceType;
     this.hostComponentId = hostComponentId;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.displayName = displayName;
     this.hostname = hostname;
     this.publicHostname = publicHostname;
@@ -150,10 +153,24 @@ public class ServiceComponentHostResponse {
   }
 
   /**
+   * @return the componentType
+   */
+  public String getComponentType() {
+    return componentType;
+  }
+
+  /**
    * @param componentName the componentName to set
    */
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  /**
+   * @param componentType the componentType to set
+   */
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   /**
@@ -339,6 +356,11 @@ public class ServiceComponentHostResponse {
       return false;
     }
 
+    if (componentType != null ?
+            !componentType.equals(that.componentType) : that.componentType != null) {
+      return false;
+    }
+
     if (displayName != null ?
             !displayName.equals(that.displayName) : that.displayName != null) {
       return false;
@@ -362,6 +384,7 @@ public class ServiceComponentHostResponse {
     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
     result = 71 * result + (serviceType != null ? serviceType.hashCode() : 0);
     result = 71 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 71 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 71 * result + (displayName != null ? displayName.hashCode() : 0);
     result = 71 * result + (hostname != null ? hostname.hashCode() : 0);
     return result;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
@@ -25,28 +25,30 @@ public class ServiceComponentRequest {
   private String serviceGroupName;
   private String serviceName; // GET/CREATE/UPDATE/DELETE
   private String componentName; // GET/CREATE/UPDATE/DELETE
+  private String componentType;
   private String desiredState; // CREATE/UPDATE
   private String componentCategory;
   private String recoveryEnabled; // CREATE/UPDATE
 
   public ServiceComponentRequest(String clusterName, String serviceGroupName, String serviceName,
-                                 String componentName, String desiredState) {
-    this(clusterName, serviceGroupName, serviceName, componentName, desiredState, null, null);
+                                 String componentName, String componentType, String desiredState) {
+    this(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState, null, null);
   }
 
   public ServiceComponentRequest(String clusterName, String serviceGroupName, String serviceName, String componentName,
-                                 String desiredState, String recoveryEnabled) {
-    this(clusterName, serviceGroupName, serviceName, componentName, desiredState, recoveryEnabled, null);
+                                 String componentType, String desiredState, String recoveryEnabled) {
+    this(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState, recoveryEnabled, null);
   }
 
   public ServiceComponentRequest(String clusterName, String serviceGroupName,
-                                 String serviceName, String componentName,
+                                 String serviceName, String componentName, String componentType,
                                  String desiredState, String recoveryEnabled,
                                  String componentCategory) {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
     this.serviceName = serviceName;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.desiredState = desiredState;
     this.recoveryEnabled = recoveryEnabled;
     this.componentCategory = componentCategory;
@@ -87,6 +89,18 @@ public class ServiceComponentRequest {
    */
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  /**
+   * @return the componentType
+   */
+  public String getComponentType() { return componentType; }
+
+  /**
+   * @param componentType the componentType to set
+   */
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   /**
@@ -141,8 +155,8 @@ public class ServiceComponentRequest {
 
   @Override
   public String toString() {
-    return String.format("[clusterName=%s, serviceGroupName=%s, serviceName=%s, componentName=%s, " +
+    return String.format("[clusterName=%s, serviceGroupName=%s, serviceName=%s, componentName=%s, componentType=%s, " +
       "desiredState=%s, recoveryEnabled=%s, componentCategory=%s]", clusterName, serviceGroupName,
-      serviceName, clusterName, desiredState, recoveryEnabled, componentCategory);
+      serviceName, componentName, componentType, desiredState, recoveryEnabled, componentCategory);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
@@ -33,7 +33,9 @@ public class ServiceComponentResponse {
   private Long serviceId; // REF
   private String serviceName;
   private String serviceType;
+  private Long componentId;
   private String componentName;
+  private String componentType;
   private String displayName;
   private String desiredStackId;
   private String desiredState;
@@ -44,10 +46,10 @@ public class ServiceComponentResponse {
   private RepositoryVersionState repoState;
 
   public ServiceComponentResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName,
-                                  Long serviceId, String serviceName, String serviceType, String componentName,
-                                  StackId desiredStackId, String desiredState, Map<String, Integer> serviceComponentStateCount,
-                                  boolean recoveryEnabled, String displayName, String desiredVersion,
-                                  RepositoryVersionState repoState) {
+                                  Long serviceId, String serviceName, String serviceType, Long componentId, String componentName,
+                                  String componentType, StackId desiredStackId, String desiredState,
+                                  Map<String, Integer> serviceComponentStateCount, boolean recoveryEnabled,
+                                  String displayName, String desiredVersion, RepositoryVersionState repoState) {
     this.clusterId = clusterId;
     this.clusterName = clusterName;
     this.serviceGroupId = serviceGroupId;
@@ -55,7 +57,9 @@ public class ServiceComponentResponse {
     this.serviceId = serviceId;
     this.serviceName = serviceName;
     this.serviceType = serviceType;
+    this.componentId = componentId;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.displayName = displayName;
     this.desiredStackId = desiredStackId.getStackId();
     this.desiredState = desiredState;
@@ -131,6 +135,34 @@ public class ServiceComponentResponse {
    */
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  /**
+   * @param componentId the componentId to set
+   */
+  public void setComponentName(Long componentId) {
+    this.componentId = componentId;
+  }
+
+  /**
+   * @return the componentType
+   */
+  public String getComponentType() {
+    return componentType;
+  }
+
+  /**
+   * @param componentType the componentType to set
+   */
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
+  }
+
+  /**
+   * @return the componentId
+   */
+  public Long getComponentId() {
+    return componentId;
   }
 
   /**
@@ -293,8 +325,18 @@ public class ServiceComponentResponse {
       return false;
     }
 
+    if (componentId != null ?
+            !componentId.equals(that.componentId) : that.componentId != null) {
+      return false;
+    }
+
     if (componentName != null ?
         !componentName.equals(that.componentName) : that.componentName != null){
+      return false;
+    }
+
+    if (componentType != null ?
+            !componentType.equals(that.componentType) : that.componentType != null){
       return false;
     }
 
@@ -315,7 +357,9 @@ public class ServiceComponentResponse {
     result = 71 * result + (serviceId != null ? serviceId.hashCode() : 0);
     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
     result = 71 * result + (serviceType != null ? serviceType.hashCode() : 0);
+    result = 71 * result + (componentId != null ? componentId.hashCode() : 0);
     result = 71 * result + (componentName != null ? componentName.hashCode():0);
+    result = 71 * result + (componentType != null ? componentType.hashCode():0);
     result = 71 * result + (displayName != null ? displayName.hashCode():0);
     return result;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractPropertyProvider.java
@@ -97,7 +97,6 @@ public abstract class AbstractPropertyProvider extends BaseProvider implements P
     this.componentMetrics = componentMetrics;
   }
 
-
   // ----- accessors ---------------------------------------------------------
 
   /**
@@ -477,7 +476,7 @@ public abstract class AbstractPropertyProvider extends BaseProvider implements P
 
   /**
    * Verify that the component metrics contains the property id.
-   * @param componentName Name of the component
+   * @param componentName  Name of the component
    * @param propertyId Property Id
    * @return true/false
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
@@ -505,10 +505,17 @@ public abstract class AbstractProviderModule implements ProviderModule,
   public boolean isCollectorComponentLive(String clusterName, MetricsService service) throws SystemException {
 
     final String collectorHostName = getCollectorHostName(clusterName, service);
+    Long componentId = null;
+    AmbariManagementController managementController = AmbariServer.getController();
+    try {
+      componentId = managementController.getClusters().getCluster(clusterName).getComponentId(Role.METRICS_COLLECTOR.name());
+    } catch (AmbariException e) {
+      e.printStackTrace();
+    }
 
     if (service.equals(GANGLIA)) {
       return HostStatusHelper.isHostComponentLive(managementController, clusterName, collectorHostName, "GANGLIA",
-        Role.GANGLIA_SERVER.name());
+        componentId, Role.GANGLIA_SERVER.name(), Role.GANGLIA_SERVER.name());
     } else if (service.equals(TIMELINE_METRICS)) {
       return metricsCollectorHAManager.isCollectorComponentLive(clusterName);
     }
@@ -1112,7 +1119,6 @@ public abstract class AbstractProviderModule implements ProviderModule,
                                                                       String clusterNamePropertyId,
                                                                       String hostNamePropertyId,
                                                                       String componentNamePropertyId) {
-
     return MetricsPropertyProvider.createInstance(type,
       PropertyHelper.getMetricPropertyIds(type), streamProvider, configuration,
       metricCacheProvider, hostProvider, serviceProvider, clusterNamePropertyId,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
@@ -119,7 +119,9 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
   protected static final String COMPONENT_CLUSTER_NAME_PROPERTY_ID = "ServiceComponentInfo/cluster_name";
   protected static final String COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID = "ServiceComponentInfo/service_group_name";
   protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID = "ServiceComponentInfo/service_name";
+  protected static final String COMPONENT_COMPONENT_ID_PROPERTY_ID = "ServiceComponentInfo/id";
   protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID = "ServiceComponentInfo/component_name";
+  protected static final String COMPONENT_COMPONENT_TYPE_PROPERTY_ID = "ServiceComponentInfo/component_type";
   protected static final String HOST_COMPONENT_HOST_NAME_PROPERTY_ID =
           PropertyHelper.getPropertyId("HostRoles", "host_name");
 
@@ -141,6 +143,7 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
   private static Set<String> propertyIds = Sets.newHashSet(
       COMPONENT_CLUSTER_NAME_PROPERTY_ID,
       COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
+      COMPONENT_COMPONENT_ID_PROPERTY_ID,
       COMPONENT_SERVICE_NAME_PROPERTY_ID,
       COMPONENT_COMPONENT_NAME_PROPERTY_ID,
       HOST_COMPONENT_HOST_NAME_PROPERTY_ID);
@@ -914,7 +917,9 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
             (String) properties.get(COMPONENT_CLUSTER_NAME_PROPERTY_ID),
             (String) properties.get(COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
             (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
+            (Long) properties.get(COMPONENT_COMPONENT_ID_PROPERTY_ID),
             (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+            (String) properties.get(COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
             (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
             null);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -94,7 +94,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
   protected static final String COMPONENT_SERVICE_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_id";
   protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_name";
   protected static final String COMPONENT_SERVICE_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_type";
+  protected static final String COMPONENT_COMPONENT_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "id";
   protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_name";
+  protected static final String COMPONENT_COMPONENT_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_type";
   protected static final String COMPONENT_DISPLAY_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "display_name";
   protected static final String COMPONENT_STATE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "state";
   protected static final String COMPONENT_CATEGORY_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "category";
@@ -120,7 +122,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
           COMPONENT_CLUSTER_NAME_PROPERTY_ID,
           COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
           COMPONENT_SERVICE_NAME_PROPERTY_ID,
-          COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+          COMPONENT_COMPONENT_ID_PROPERTY_ID,
+          COMPONENT_COMPONENT_NAME_PROPERTY_ID,
+          COMPONENT_COMPONENT_TYPE_PROPERTY_ID);
 
   /**
    * The property ids for an servce resource.
@@ -141,7 +145,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     PROPERTY_IDS.add(COMPONENT_SERVICE_ID_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_SERVICE_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_SERVICE_TYPE_PROPERTY_ID);
+    PROPERTY_IDS.add(COMPONENT_COMPONENT_ID_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+    PROPERTY_IDS.add(COMPONENT_COMPONENT_TYPE_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_DISPLAY_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_STATE_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_CATEGORY_PROPERTY_ID);
@@ -223,7 +229,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
         resource.setProperty(COMPONENT_SERVICE_ID_PROPERTY_ID, response.getServiceId());
         resource.setProperty(COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName());
         resource.setProperty(COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType());
+        resource.setProperty(COMPONENT_COMPONENT_ID_PROPERTY_ID, response.getComponentId());
         resource.setProperty(COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName());
+        resource.setProperty(COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType());
         resource.setProperty(COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName());
         resource.setProperty(COMPONENT_STATE_PROPERTY_ID, response.getDesiredState());
         resource.setProperty(COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory());
@@ -270,7 +278,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       setResourceProperty(resource, COMPONENT_SERVICE_ID_PROPERTY_ID, response.getServiceId(), requestedIds);
       setResourceProperty(resource, COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName(), requestedIds);
       setResourceProperty(resource, COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType(), requestedIds);
+      setResourceProperty(resource, COMPONENT_COMPONENT_ID_PROPERTY_ID, response.getComponentId(), requestedIds);
       setResourceProperty(resource, COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName(), requestedIds);
+      setResourceProperty(resource, COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType(), requestedIds);
       setResourceProperty(resource, COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName(), requestedIds);
       setResourceProperty(resource, COMPONENT_STATE_PROPERTY_ID, response.getDesiredState(), requestedIds);
       setResourceProperty(resource, COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory(), requestedIds);
@@ -363,6 +373,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
         (String) properties.get(COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
         (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
         (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+        (String) properties.get(COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
         (String) properties.get(COMPONENT_STATE_PROPERTY_ID),
         (String) properties.get(COMPONENT_RECOVERY_ENABLED_ID),
         (String) properties.get(COMPONENT_CATEGORY_PROPERTY_ID));
@@ -391,6 +402,13 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       Validate.notEmpty(request.getServiceGroupName(), "service group name should be non-empty");
       Validate.notEmpty(request.getServiceName(), "service name should be non-empty");
       Cluster cluster = getClusterForRequest(request, clusters);
+
+      // TODO: Multi_Component_Instance. When we go into multiple component instance mode, we will need make
+      // component_type as manadatory field. As of now, we are just copying component_name into component_type,
+      // if not provided. Further, need to add validation check too.
+      if(StringUtils.isBlank(request.getComponentType())) {
+        request.setComponentType(request.getComponentName());
+      }
 
       isAuthorized(cluster, getRequiredCreateAuthorizations());
 
@@ -454,7 +472,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     for (ServiceComponentRequest request : requests) {
       Cluster cluster = clusters.getCluster(request.getClusterName());
       Service s = cluster.getService(request.getServiceName());
-      ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName());
+      ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName(), request.getComponentType());
       sc.setDesiredRepositoryVersion(s.getDesiredRepositoryVersion());
 
       if (StringUtils.isNotEmpty(request.getDesiredState())) {
@@ -475,10 +493,10 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       } else {
         StackId stackId = s.getDesiredStackId();
         ComponentInfo componentInfo = ambariMetaInfo.getComponent(stackId.getStackName(),
-                stackId.getStackVersion(), s.getServiceType(), request.getComponentName());
+                stackId.getStackVersion(), s.getServiceType(), request.getComponentType());
         if (componentInfo == null) {
             throw new AmbariException("Could not get component information from stack definition: Stack=" +
-              stackId + ", Service=" + s.getServiceType() + ", Component=" + request.getComponentName());
+              stackId + ", Service=" + s.getServiceType() + ", Component type =" + request.getComponentType());
         }
         sc.setRecoveryEnabled(componentInfo.isRecoveryEnabled());
         LOG.info("Component: {}, recovery_enabled from stack definition:{}", componentInfo.getName(),
@@ -631,6 +649,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       final String serviceGroupName = request.getServiceGroupName();
       final String serviceName = request.getServiceName();
       final String componentName = request.getComponentName();
+      final String componentType = request.getComponentType();
 
       LOG.info("Received a updateComponent request: {}", request);
 
@@ -659,7 +678,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       State newState = getValidDesiredState(request);
 
       if (! maintenanceStateHelper.isOperationAllowed(reqOpLvl, s)) {
-        LOG.info("Operations cannot be applied to component " + componentName
+        LOG.info("Operations cannot be applied to component name : " + componentName + " with type : " + componentType
                 + " because service " + serviceName +
                 " is in the maintenance state of " + s.getMaintenanceState());
         continue;
@@ -674,8 +693,8 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
         boolean newRecoveryEnabled = Boolean.parseBoolean(request.getRecoveryEnabled());
         boolean oldRecoveryEnabled = sc.isRecoveryEnabled();
-        LOG.info("Component: {}, oldRecoveryEnabled: {}, newRecoveryEnabled {}",
-                componentName, oldRecoveryEnabled, newRecoveryEnabled);
+        LOG.info("ComponentName: {}, componentType: {}, oldRecoveryEnabled: {}, newRecoveryEnabled {}",
+                componentName, componentType, oldRecoveryEnabled, newRecoveryEnabled);
         if (newRecoveryEnabled != oldRecoveryEnabled) {
           if (newRecoveryEnabled) {
             recoveryEnabledComponents.add(sc);
@@ -712,6 +731,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + sc.getServiceName()
               + ", componentName=" + sc.getName()
+              + ", componentType=" + sc.getType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", currentDesiredState=" + oldScState
               + ", newDesiredState=" + newState);
@@ -725,6 +745,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + serviceName
               + ", componentName=" + sc.getName()
+              + ", componentType=" + sc.getType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", currentDesiredState=" + oldScState
               + ", newDesiredState=" + newState);
@@ -740,6 +761,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
                 + ", serviceGroupName=" + serviceGroupName
                 + ", serviceName=" + serviceName
                 + ", componentName=" + sc.getName()
+                + ", componentType=" + sc.getType()
                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
                 + ", hostname=" + sch.getHostName()
                 + ", currentState=" + oldSchState
@@ -754,6 +776,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
                 + ", serviceGroupName=" + serviceGroupName
                 + ", serviceName=" + serviceName
                 + ", componentName=" + sc.getName()
+                + ", componentType=" + sc.getType()
                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
                 + ", hostname=" + sch.getHostName()
                 + ", currentState=" + oldSchState
@@ -769,6 +792,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
                 + ", serviceGroupName=" + serviceGroupName
                 + ", serviceName=" + serviceName
                 + ", componentName=" + sc.getName()
+                + ", componentType=" + sc.getType()
                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
                 + ", hostname=" + sch.getHostName());
 
@@ -784,6 +808,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + sch.getServiceName()
               + ", componentName=" + sch.getServiceComponentName()
+              + ", componentType=" + sch.getServiceComponentType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", hostname=" + sch.getHostName()
               + ", currentState=" + oldSchState
@@ -801,6 +826,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + serviceName
               + ", componentName=" + sc.getName()
+              + ", componentType=" + sc.getType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", hostname=" + sch.getHostName()
               + ", currentState=" + oldSchState
@@ -914,14 +940,15 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     if (StringUtils.isEmpty(request.getServiceName())) {
 
       String componentName = request.getComponentName();
+      String componentType = request.getComponentType();
 
-      String serviceName = getManagementController().findService(cluster, componentName);
+      String serviceName = getManagementController().findService(cluster, componentType);
 
-      debug("Looking up service name for component, componentName={}, serviceName={}", componentName, serviceName);
+      debug("Looking up service name for component, componentType={}, serviceName={}", componentType, serviceName);
 
       if (StringUtils.isEmpty(serviceName)) {
         throw new AmbariException("Could not find service for component"
-                + ", componentName=" + request.getComponentName()
+                + ", componentType=" + request.getComponentType()
                 + ", clusterName=" + cluster.getClusterName());
       }
       request.setServiceName(serviceName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -97,6 +97,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
   public static final String HOST_COMPONENT_SERVICE_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_type";
   public static final String HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "id";
   public static final String HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_name";
+  public static final String HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_type";
   public static final String HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "display_name";
   public static final String HOST_COMPONENT_HOST_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "host_name";
   public static final String HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "public_host_name";
@@ -123,8 +124,10 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
   public static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
       .put(Resource.Type.Cluster, HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID)
       .put(Resource.Type.Host, HOST_COMPONENT_HOST_NAME_PROPERTY_ID)
-      .put(Resource.Type.HostComponent, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)
+      .put(Resource.Type.HostComponent, HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID)
       .put(Resource.Type.Component, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)
+      .put(Resource.Type.Service, HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID)
+      .put(Resource.Type.ServiceGroup, HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID)
       .build();
 
   /**
@@ -135,7 +138,9 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID,
       HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
       HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID,
+      HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID,
       HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID,
+      HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID,
       HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID,
       HOST_COMPONENT_HOST_NAME_PROPERTY_ID,
       HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID,
@@ -215,6 +220,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
         resource.setProperty(HOST_COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType());
         resource.setProperty(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID, response.getHostComponentId());
         resource.setProperty(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName());
+        resource.setProperty(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType());
         resource.setProperty(HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName());
         resource.setProperty(HOST_COMPONENT_HOST_NAME_PROPERTY_ID, response.getHostname());
         resource.setProperty(HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID, response.getPublicHostname());
@@ -287,6 +293,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       setResourceProperty(resource, HOST_COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType(), requestedIds);
       setResourceProperty(resource, HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID, response.getHostComponentId(), requestedIds);
       setResourceProperty(resource, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName(), requestedIds);
+      setResourceProperty(resource, HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType(), requestedIds);
       setResourceProperty(resource, HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName(), requestedIds);
       setResourceProperty(resource, HOST_COMPONENT_HOST_NAME_PROPERTY_ID, response.getHostname(), requestedIds);
       setResourceProperty(resource, HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID, response.getPublicHostname(), requestedIds);
@@ -677,6 +684,8 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
             + ", clusterId=" + cluster.getClusterId()
             + ", serviceName=" + sch.getServiceName()
             + ", componentName=" + sch.getServiceComponentName()
+            + ", componentType=" + sch.getServiceComponentType()
+            + ", componentType=" + sch.getServiceComponentType()
             + ", hostname=" + sch.getHostName()
             + ", currentState=" + oldSchState
             + ", newDesiredState=" + newState);
@@ -722,13 +731,33 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
    * @return the component request object
    */
   private ServiceComponentHostRequest getRequest(Map<String, Object> properties) {
-    ServiceComponentHostRequest serviceComponentHostRequest = new ServiceComponentHostRequest(
-        (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
+    ServiceComponentHostRequest serviceComponentHostRequest = null;
+    if (properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID) != null) {
+      Long hostComponentId = properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID) instanceof String ?
+              Long.parseLong((String) properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID)) :
+              (Long) properties.get(HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID);
+
+      serviceComponentHostRequest = new ServiceComponentHostRequest(
+              (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
+              hostComponentId,
+              (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
+    } else {
+      serviceComponentHostRequest = new ServiceComponentHostRequest(
+              (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
+              (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
+
+    }
+
     serviceComponentHostRequest.setState((String) properties.get(HOST_COMPONENT_STATE_PROPERTY_ID));
     if (properties.get(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID) != null) {
       serviceComponentHostRequest.setStaleConfig(
@@ -765,6 +794,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
             (String) properties.get(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
             (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
             (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+            (String) properties.get(HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
             (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
             (String) properties.get(HOST_COMPONENT_STATE_PROPERTY_ID));
     if (properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID) != null) {
@@ -967,12 +997,13 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
    * @param request  the request to log
    */
   private void logRequestInfo(String msg, ServiceComponentHostRequest request) {
-    LOG.info("{}, clusterName={}, serviceGroupName={}, serviceName={}, componentName={}, hostname={}, request={}",
+    LOG.info("{}, clusterName={}, serviceGroupName={}, serviceName={}, componentName={}, componentType={}, hostname={}, request={}",
         msg,
         request.getClusterName(),
         request.getServiceGroupName(),
         request.getServiceName(),
         request.getComponentName(),
+        request.getComponentType(),
         request.getHostname(),
         request);
   }
@@ -992,6 +1023,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       .append(", serviceGroupName=").append(request.getServiceGroupName())
       .append(", serviceName=").append(request.getServiceName())
       .append(", componentName=").append(request.getComponentName())
+      .append(", componentType=").append(request.getComponentType())
       .append(", hostname=").append(request.getHostname())
       .append(", currentState=").append(oldState == null ? "null" : oldState)
       .append(", newDesiredState=").append(newDesiredState == null ? "null" : newDesiredState);
@@ -1031,10 +1063,14 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
         || request.getClusterName().isEmpty()
         || request.getComponentName() == null
         || request.getComponentName().isEmpty()
+        || request.getServiceName() == null
+        || request.getServiceName().isEmpty()
+        || request.getServiceGroupName() == null
+        || request.getServiceGroupName().isEmpty()
         || request.getHostname() == null
         || request.getHostname().isEmpty()) {
       throw new IllegalArgumentException("Invalid arguments"
-          + ", cluster name, component name and host name should be"
+          + ", cluster name, component name, service name, service group name and host name should be"
           + " provided");
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -958,7 +958,9 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
           ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster.getClusterName(),
                                                                              sch.getServiceGroupName(),
                                                                              sch.getServiceName(),
+                                                                             sch.getHostComponentId(),
                                                                              sch.getServiceComponentName(),
+                                                                             sch.getServiceComponentType(),
                                                                              sch.getHostName(),
                                                                              null);
           schrs.add(schr);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
@@ -38,11 +38,11 @@ import org.slf4j.LoggerFactory;
 public class HostStatusHelper {
 
   private static final Logger LOG =
-    LoggerFactory.getLogger(HostStatusHelper.class);
+          LoggerFactory.getLogger(HostStatusHelper.class);
 
   public static boolean isHostComponentLive(AmbariManagementController managementController,
-                                             String clusterName, String hostName,
-                                      String serviceName, String componentName) {
+                                            String clusterName, String hostName, String serviceName,
+                                            Long componentId, String componentName, String componentType) {
     if (clusterName == null) {
       return false;
     }
@@ -54,11 +54,11 @@ public class HostStatusHelper {
       Cluster cluster = clusters.getCluster(clusterName);
       Service s = cluster.getService(serviceName);
       ServiceComponentHostRequest componentRequest =
-        new ServiceComponentHostRequest(clusterName, s.getServiceGroupName(), serviceName, componentName, hostName,
-                null);
+              new ServiceComponentHostRequest(clusterName, s.getServiceGroupName(), serviceName, componentId, componentName, componentType,
+                      hostName, null);
 
       Set<ServiceComponentHostResponse> hostComponents =
-        managementController.getHostComponents(Collections.singleton(componentRequest));
+              managementController.getHostComponents(Collections.singleton(componentRequest));
 
       componentHostResponse = hostComponents.size() == 1 ? hostComponents.iterator().next() : null;
     } catch (AmbariException e) {
@@ -68,7 +68,7 @@ public class HostStatusHelper {
 
     //Cluster without SCH
     return componentHostResponse != null &&
-      componentHostResponse.getLiveState().equals(State.STARTED.name());
+            componentHostResponse.getLiveState().equals(State.STARTED.name());
   }
 
   public static boolean isHostLive(AmbariManagementController managementController, String clusterName, String hostName) {
@@ -88,6 +88,6 @@ public class HostStatusHelper {
     }
     //Cluster without host
     return hostResponse != null &&
-      !hostResponse.getHostState().equals(HostState.HEARTBEAT_LOST);
+            !hostResponse.getHostState().equals(HostState.HEARTBEAT_LOST);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProvider.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import org.apache.ambari.server.ServiceNotFoundException;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.jmx.JMXHostProvider;
 import org.apache.ambari.server.controller.jmx.JMXPropertyProvider;
 import org.apache.ambari.server.controller.metrics.MetricHostProvider;
@@ -162,21 +164,24 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
       for (Resource r : resources) {
         String clusterName = r.getPropertyValue(clusterNamePropertyId).toString();
         String componentName = r.getPropertyValue(componentNamePropertyId).toString();
-
         Cluster cluster = clusters.getCluster(clusterName);
         Service service = null;
 
+        Long componentId = null;
+        String componentType = null;
         try {
-          service = cluster.getServiceByComponentName(componentName);
+          componentId = cluster.getComponentId(componentName);
+          componentType = cluster.getComponentType(componentId);
+          service = cluster.getServiceByComponentId(componentId);
         } catch (ServiceNotFoundException e) {
-          LOG.debug("Could not load component {}", componentName);
+          LOG.debug("Could not load componentName {}", componentName);
           continue;
         }
 
         StackId stack = service.getDesiredStackId();
 
         List<MetricDefinition> defs = metaInfo.getMetrics(
-            stack.getStackName(), stack.getStackVersion(), service.getServiceType(), componentName, type.name());
+            stack.getStackName(), stack.getStackVersion(), service.getServiceType(), componentType, type.name());
 
         if (null == defs || 0 == defs.size()) {
           continue;
@@ -191,7 +196,7 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
           } else {
             PropertyProvider pp = getDelegate(m,
                 streamProvider, metricHostProvider,
-                clusterNamePropertyId, hostNamePropertyId,
+                clusterNamePropertyId, clusterName, hostNamePropertyId,
                 componentNamePropertyId, resourceStatePropertyId,
                 componentName);
             if (pp == null) {
@@ -221,10 +226,10 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
 
       if (jmxMap.size() > 0) {
         JMXPropertyProvider jpp = metricPropertyProviderFactory.createJMXPropertyProvider(jmxMap,
-            streamProvider,
-            jmxHostProvider, metricHostProvider,
-            clusterNamePropertyId, hostNamePropertyId,
-            componentNamePropertyId, resourceStatePropertyId);
+                streamProvider,
+                jmxHostProvider, metricHostProvider,
+                clusterNamePropertyId, hostNamePropertyId,
+                componentNamePropertyId, resourceStatePropertyId);
 
         jpp.populateResources(resources, request, predicate);
       } else {
@@ -320,7 +325,7 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
    * @param definition the metric definition for a component
    * @param streamProvider the stream provider
    * @param metricsHostProvider the metrics host provider
-   * @param clusterNamePropertyId the cluster name property id
+   * @param clusterNamePropertyId the cluster id property id
    * @param hostNamePropertyId the host name property id
    * @param componentNamePropertyId the component name property id
    * @param statePropertyId the state property id
@@ -331,24 +336,26 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
                                        StreamProvider streamProvider,
                                        MetricHostProvider metricsHostProvider,
                                        String clusterNamePropertyId,
+                                       String clusterName,
                                        String hostNamePropertyId,
                                        String componentNamePropertyId,
                                        String statePropertyId,
                                        String componentName) {
     Map<String, PropertyInfo> metrics = getPropertyInfo(definition);
-    HashMap<String, Map<String, PropertyInfo>> componentMetrics =
-      new HashMap<>();
+    HashMap<String, Map<String, PropertyInfo>> componentMetrics = new HashMap<>();
     componentMetrics.put(WRAPPED_METRICS_KEY, metrics);
 
     try {
       Class<?> clz = Class.forName(definition.getType());
 
       // use a Factory for the REST provider
+
       if (clz.equals(RestMetricsPropertyProvider.class)) {
+        // TODO : Multi_Metrics_Changes. We need to pass UniqueComponentName like :
+        // {SG_instance_name}_{service_instance_name}_component_name instead of just 'componentName'.
         return metricPropertyProviderFactory.createRESTMetricsPropertyProvider(
             definition.getProperties(), componentMetrics, streamProvider, metricsHostProvider,
-            clusterNamePropertyId, hostNamePropertyId, componentNamePropertyId, statePropertyId,
-            componentName);
+            clusterNamePropertyId, hostNamePropertyId, clusterNamePropertyId, statePropertyId, componentName);
       }
 
       try {
@@ -359,6 +366,8 @@ public class StackDefinedPropertyProvider implements PropertyProvider {
         Constructor<?> ct = clz.getConstructor(Map.class,
             Map.class, StreamProvider.class, MetricHostProvider.class,
             String.class, String.class, String.class, String.class, String.class);
+        // TODO : Multi_Metrics_Changes. Check if we need to pass UniqueComponentName like :
+        // {SG_instance_name}_{service_instance_name}_component_name instead of just 'componentId'.
         Object o = ct.newInstance(
             injector,
             definition.getProperties(), componentMetrics,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
@@ -151,7 +151,7 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
    * @param componentMetrics         the map of supported metrics
    * @param streamProvider           the stream provider
    * @param jmxHostProvider          the JMX host mapping
-   * @param metricHostProvider      the host mapping
+   * @param metricHostProvider       the host mapping
    * @param clusterNamePropertyId    the cluster name property id
    * @param hostNamePropertyId       the host name property id
    * @param componentNamePropertyId  the component name property id

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricPropertyProviderFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricPropertyProviderFactory.java
@@ -51,7 +51,7 @@ public interface MetricPropertyProviderFactory {
    * @param hostNamePropertyId
    *          the host name property id
    * @param componentNamePropertyId
-   *          the component name property id
+   *          the component Name property id
    * @param statePropertyId
    *          the state property id
    * @return the instantiated and injected {@link JMXPropertyProvider}.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProviderProxy.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPropertyProviderProxy.java
@@ -51,16 +51,16 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
   private String clusterNamePropertyId;
 
   public MetricsPropertyProviderProxy(
-    InternalType type,
-    Map<String, Map<String, PropertyInfo>> componentPropertyInfoMap,
-    URLStreamProvider streamProvider,
-    ComponentSSLConfiguration configuration,
-    TimelineMetricCacheProvider cacheProvider,
-    MetricHostProvider hostProvider,
-    MetricsServiceProvider serviceProvider,
-    String clusterNamePropertyId,
-    String hostNamePropertyId,
-    String componentNamePropertyId) {
+        InternalType type,
+        Map<String, Map<String, PropertyInfo>> componentPropertyInfoMap,
+        URLStreamProvider streamProvider,
+        ComponentSSLConfiguration configuration,
+        TimelineMetricCacheProvider cacheProvider,
+        MetricHostProvider hostProvider,
+        MetricsServiceProvider serviceProvider,
+        String clusterNamePropertyId,
+        String hostNamePropertyId,
+        String componentNamePropertyId) {
 
     super(componentPropertyInfoMap);
     this.metricsServiceProvider = serviceProvider;
@@ -133,7 +133,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
                                             MetricHostProvider hostProvider,
                                             String clusterNamePropertyId,
                                             String hostNamePropertyId,
-                                            String componentNamePropertyId) {
+                                            String componentIdPropertyId) {
 
     this.amsPropertyProvider = new AMSHostComponentPropertyProvider(
                                             componentPropertyInfoMap,
@@ -143,7 +143,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
                                             hostProvider,
                                             clusterNamePropertyId,
                                             hostNamePropertyId,
-                                            componentNamePropertyId);
+                                            componentIdPropertyId);
 
     this.gangliaPropertyProvider = new GangliaHostComponentPropertyProvider(
                                             componentPropertyInfoMap,
@@ -152,7 +152,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
                                             hostProvider,
                                             clusterNamePropertyId,
                                             hostNamePropertyId,
-                                            componentNamePropertyId);
+                                            componentIdPropertyId);
   }
 
   private void createComponentPropertyProviders(Map<String, Map<String, PropertyInfo>> componentPropertyInfoMap,
@@ -160,7 +160,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
                                                 ComponentSSLConfiguration configuration,
                                                 MetricHostProvider hostProvider,
                                                 String clusterNamePropertyId,
-                                                String componentNamePropertyId) {
+                                                String componentIdPropertyId) {
 
     this.amsPropertyProvider = new AMSComponentPropertyProvider(
                                             componentPropertyInfoMap,
@@ -169,7 +169,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
                                             cacheProvider,
                                             hostProvider,
                                             clusterNamePropertyId,
-                                            componentNamePropertyId);
+                                            componentIdPropertyId);
 
     this.gangliaPropertyProvider = new GangliaComponentPropertyProvider(
                                             componentPropertyInfoMap,
@@ -177,7 +177,7 @@ public class MetricsPropertyProviderProxy extends AbstractPropertyProvider {
                                             configuration,
                                             hostProvider,
                                             clusterNamePropertyId,
-                                            componentNamePropertyId);
+                                            componentIdPropertyId);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/RestMetricsPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/RestMetricsPropertyProvider.java
@@ -130,7 +130,7 @@ public class RestMetricsPropertyProvider extends ThreadPoolEnabledPropertyProvid
    * @param metricsProperties       the map of per-component metrics properties
    * @param componentMetrics        the map of supported metrics for component
    * @param streamProvider          the stream provider
-   * @param metricHostProvider     metricsHostProvider instance
+   * @param metricHostProvider      metricsHostProvider instance
    * @param clusterNamePropertyId   the cluster name property id
    * @param hostNamePropertyId      the host name property id
    * @param componentNamePropertyId the component name property id
@@ -215,7 +215,7 @@ public class RestMetricsPropertyProvider extends ThreadPoolEnabledPropertyProvid
     try {
       String clusterName = (String) resource.getPropertyValue(clusterNamePropertyId);
       Cluster cluster = clusters.getCluster(clusterName);
-      hostname = getHost(resource, clusterName, resourceComponentName);
+      hostname = getHost(resource, clusterName, componentName);
       if (hostname == null) {
         String msg = String.format("Unable to get component REST metrics. " +
             "No host name for %s.", resourceComponentName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaComponentPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaComponentPropertyProvider.java
@@ -14,6 +14,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *
+ *
  */
 
 package org.apache.ambari.server.controller.metrics.ganglia;
@@ -23,7 +26,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.internal.PropertyInfo;
 import org.apache.ambari.server.controller.internal.URLStreamProvider;
 import org.apache.ambari.server.controller.metrics.MetricHostProvider;
@@ -57,16 +63,11 @@ public class GangliaComponentPropertyProvider extends GangliaPropertyProvider {
   }
 
   @Override
-  protected String getComponentName(Resource resource) {
-    return (String) resource.getPropertyValue(getComponentNamePropertyId());
-  }
-
-  @Override
   protected Set<String> getGangliaClusterNames(Resource resource, String clusterName) {
-    String component = getComponentName(resource);
+    Long componentId = getComponentId(resource);
     
-    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(component) ?
-      GANGLIA_CLUSTER_NAME_MAP.get(component) :
+    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(componentId) ?
+      GANGLIA_CLUSTER_NAME_MAP.get(componentId) :
       Collections.emptyList());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostComponentPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostComponentPropertyProvider.java
@@ -23,7 +23,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.internal.PropertyInfo;
 import org.apache.ambari.server.controller.internal.URLStreamProvider;
 import org.apache.ambari.server.controller.metrics.MetricHostProvider;
@@ -41,10 +44,10 @@ public class GangliaHostComponentPropertyProvider extends GangliaPropertyProvide
                                               MetricHostProvider hostProvider,
                                               String clusterNamePropertyId,
                                               String hostNamePropertyId,
-                                              String componentNamePropertyId) {
+                                              String componentIdPropertyId) {
 
     super(componentPropertyInfoMap, streamProvider, configuration, hostProvider,
-        clusterNamePropertyId, hostNamePropertyId, componentNamePropertyId);
+        clusterNamePropertyId, hostNamePropertyId, componentIdPropertyId);
   }
 
 
@@ -56,16 +59,11 @@ public class GangliaHostComponentPropertyProvider extends GangliaPropertyProvide
   }
 
   @Override
-  protected String getComponentName(Resource resource) {
-    return (String) resource.getPropertyValue(getComponentNamePropertyId());
-  }
-
-  @Override
   protected Set<String> getGangliaClusterNames(Resource resource, String clusterName) {
-    String component = getComponentName(resource);
+    Long componentId = getComponentId(resource);
     
-    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(component) ?
-      GANGLIA_CLUSTER_NAME_MAP.get(component) :
+    return new HashSet<>(GANGLIA_CLUSTER_NAME_MAP.containsKey(componentId) ?
+      GANGLIA_CLUSTER_NAME_MAP.get(componentId) :
       Collections.emptyList());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaHostPropertyProvider.java
@@ -73,6 +73,17 @@ public class GangliaHostPropertyProvider extends GangliaPropertyProvider {
     return (String) resource.getPropertyValue(getHostNamePropertyId());
   }
 
+  // TODO : Multi_Metrics_Changes. Confirm that getComponentId is correct, as we are passing '*' in Name and Type below.
+  @Override
+  protected Long getComponentId(Resource resource) {
+    return getComponentId(resource);
+  }
+
+  @Override
+  protected String getComponentType(Resource resource) {
+    return "*";
+  }
+
   @Override
   protected String getComponentName(Resource resource) {
     return "*";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.controller.metrics.ganglia;
 
 import static org.apache.ambari.server.controller.metrics.MetricsServiceProvider.MetricsService.GANGLIA;
 
+import com.google.inject.Inject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -36,7 +37,10 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.internal.PropertyInfo;
 import org.apache.ambari.server.controller.internal.URLStreamProvider;
 import org.apache.ambari.server.controller.metrics.MetricHostProvider;
@@ -60,7 +64,6 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
    */
   static final Map<String, List<String>> GANGLIA_CLUSTER_NAME_MAP = new HashMap<>();
 
-  
   static {
     GANGLIA_CLUSTER_NAME_MAP.put("NAMENODE",           Collections.singletonList("HDPNameNode"));
     GANGLIA_CLUSTER_NAME_MAP.put("DATANODE",           Arrays.asList("HDPDataNode", "HDPSlaves"));
@@ -88,11 +91,12 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
                                  MetricHostProvider hostProvider,
                                  String clusterNamePropertyId,
                                  String hostNamePropertyId,
-                                 String componentNamePropertyId) {
+                                 String componentIdPropertyId) {
 
     super(componentPropertyInfoMap, streamProvider,configuration,
       hostProvider, clusterNamePropertyId, hostNamePropertyId,
-      componentNamePropertyId);
+            componentIdPropertyId);
+
   }
 
 
@@ -131,15 +135,6 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
 
 
   /**
-   * Get the component name property id.
-   *
-   * @return the component name property id
-   */
-  protected String getComponentNamePropertyId() {
-    return componentNamePropertyId;
-  }
-
-  /**
    * Get the host name property id.
    *
    * @return the host name property id
@@ -159,6 +154,7 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
 
 
   // ----- helper methods ----------------------------------------------------
+
 
   /**
    * Get the request objects containing all the information required to

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSComponentPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSComponentPropertyProvider.java
@@ -19,7 +19,10 @@ package org.apache.ambari.server.controller.metrics.timeline;
 
 import java.util.Map;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.internal.PropertyInfo;
 import org.apache.ambari.server.controller.internal.URLStreamProvider;
 import org.apache.ambari.server.controller.metrics.MetricHostProvider;
@@ -34,21 +37,16 @@ public class AMSComponentPropertyProvider extends AMSPropertyProvider {
                                           TimelineMetricCacheProvider cacheProvider,
                                           MetricHostProvider hostProvider,
                                           String clusterNamePropertyId,
-                                          String componentNamePropertyId) {
+                                          String componentIdPropertyId) {
 
     super(componentPropertyInfoMap, streamProvider, configuration,
-      cacheProvider, hostProvider, clusterNamePropertyId, null, componentNamePropertyId);
+      cacheProvider, hostProvider, clusterNamePropertyId, null, componentIdPropertyId);
   }
 
   @Override
   protected String getHostName(Resource resource) {
       return hostProvider
-        .getExternalHostName((String) resource.getPropertyValue(clusterNamePropertyId), (String) resource.getPropertyValue(componentNamePropertyId))
+        .getExternalHostName((String) resource.getPropertyValue(clusterNamePropertyId), (String) resource.getPropertyValue(componentIdPropertyId))
         .orElse(null);
-  }
-
-  @Override
-  protected String getComponentName(Resource resource) {
-    return (String) resource.getPropertyValue(componentNamePropertyId);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostComponentPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostComponentPropertyProvider.java
@@ -19,7 +19,10 @@ package org.apache.ambari.server.controller.metrics.timeline;
 
 import java.util.Map;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.internal.PropertyInfo;
 import org.apache.ambari.server.controller.internal.URLStreamProvider;
 import org.apache.ambari.server.controller.metrics.MetricHostProvider;
@@ -35,22 +38,15 @@ public class AMSHostComponentPropertyProvider extends AMSPropertyProvider {
                                  MetricHostProvider hostProvider,
                                  String clusterNamePropertyId,
                                  String hostNamePropertyId,
-                                 String componentNamePropertyId) {
+                                 String componentIdPropertyId) {
 
     super(componentPropertyInfoMap, streamProvider, configuration,
       cacheProvider, hostProvider, clusterNamePropertyId, hostNamePropertyId,
-      componentNamePropertyId);
+            componentIdPropertyId);
   }
 
   @Override
   protected String getHostName(Resource resource) {
     return (String) resource.getPropertyValue(hostNamePropertyId);
-  }
-
-  @Override
-  protected String getComponentName(Resource resource) {
-    String componentName = (String) resource.getPropertyValue(componentNamePropertyId);
-
-    return componentName;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSHostPropertyProvider.java
@@ -46,6 +46,17 @@ public class AMSHostPropertyProvider extends AMSPropertyProvider {
   }
 
   @Override
+  protected Long getComponentId(Resource resource) {
+    return (Long) resource.getPropertyValue(componentIdPropertyId);
+  }
+
+  @Override
+  protected String getComponentType(Resource resource) {
+    return "HOST";
+  }
+
+  // TODO : Multi_Metrics_Changes. Confirm if its always going to be HOST ?
+  @Override
   protected String getComponentName(Resource resource) {
     return "HOST";
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/AMSPropertyProvider.java
@@ -246,7 +246,7 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
               setQueryParams(hostComponentHostMetricParams, hostNamesBatch, true, componentName);
               TimelineMetrics metricsResponse = getTimelineMetricsFromCache(
                 getTimelineAppMetricCacheKey(hostComponentHostMetrics,
-                  componentName, hostNamesBatch, uriBuilder.toString()), componentName);
+                  hostNamesBatch, componentName, uriBuilder.toString()), componentName);
 
               if (metricsResponse != null) {
                 timelineMetrics.getMetrics().addAll(metricsResponse.getMetrics());
@@ -258,7 +258,7 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
               setQueryParams(nonHostComponentHostMetricParams, hostNamesBatch, false, componentName);
               TimelineMetrics metricsResponse = getTimelineMetricsFromCache(
                 getTimelineAppMetricCacheKey(nonHostComponentMetrics,
-                  componentName, hostNamesBatch, uriBuilder.toString()), componentName);
+                        hostNamesBatch, componentName, uriBuilder.toString()), componentName);
 
               if (metricsResponse != null) {
                 timelineMetrics.getMetrics().addAll(metricsResponse.getMetrics());
@@ -576,9 +576,6 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
     if (metricPropertyIds.containsKey(HBASE_REGIONSERVER.name())) {
       amsMetrics.putAll(metricPropertyIds.get(HBASE_REGIONSERVER.name()));
     }
-    if (!amsMetrics.isEmpty()) {
-      super.getComponentMetrics().putAll(Collections.singletonMap(METRICS_COLLECTOR.name(), amsMetrics));
-    }
 
     return super.getComponentMetrics();
   }
@@ -666,7 +663,7 @@ public abstract class AMSPropertyProvider extends MetricsPropertyProvider {
       for (String id : ids) {
         Map<String, PropertyInfo> propertyInfoMap = new HashMap<>();
 
-        String componentName = getOverridenComponentName(resource);
+        String componentName  = getOverridenComponentName(resource);
 
         Map<String, PropertyInfo> componentMetricMap = getComponentMetrics().get(componentName);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
@@ -89,7 +89,7 @@ public class DefaultServiceCalculatedState implements ServiceCalculatedState {
           StackId stackId = service.getDesiredStackId();
 
           ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-            serviceName, null, null, null);
+            serviceName, null, null, null, null, null);
 
           Set<ServiceComponentHostResponse> hostComponentResponses =
             managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
@@ -52,7 +52,7 @@ public final class FlumeServiceCalculatedState extends DefaultServiceCalculatedS
       if (cluster != null && managementControllerProvider != null) {
         Service service = cluster.getService(serviceName);
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
@@ -54,7 +54,7 @@ public final class HBaseServiceCalculatedState extends DefaultServiceCalculatedS
         StackId stackId = service.getDesiredStackId();
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
@@ -54,7 +54,7 @@ public final class HDFSServiceCalculatedState extends DefaultServiceCalculatedSt
         StackId stackId = service.getDesiredStackId();
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null,null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
@@ -55,7 +55,7 @@ public final class HiveServiceCalculatedState extends DefaultServiceCalculatedSt
 
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
@@ -54,7 +54,7 @@ public final class OozieServiceCalculatedState extends DefaultServiceCalculatedS
         StackId stackId = service.getDesiredStackId();
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
@@ -55,7 +55,7 @@ public final class YARNServiceCalculatedState extends DefaultServiceCalculatedSt
 
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
@@ -89,21 +89,17 @@ public class HostComponentDesiredStateDAO {
    * @param clusterId Cluster ID
    * @param serviceGroupId Service Group ID
    * @param serviceId Service ID
-   * @param componentName Component Name
+   * @param componentId Component Id
    * @param hostId Host ID
    * @return Return the Host Component Desired State entity that match the criteria.
    */
   @RequiresSession
   public HostComponentDesiredStateEntity findByIndex(Long clusterId, Long serviceGroupId, Long serviceId,
-                                                     String componentName, Long hostId) {
+                                                     Long componentId, Long hostId) {
     final TypedQuery<HostComponentDesiredStateEntity> query = entityManagerProvider.get()
       .createNamedQuery("HostComponentDesiredStateEntity.findByIndex", HostComponentDesiredStateEntity.class);
 
-    query.setParameter("clusterId", clusterId);
-    query.setParameter("serviceGroupId", serviceGroupId);
-    query.setParameter("serviceId", serviceId);
-    query.setParameter("componentName", componentName);
-    query.setParameter("hostId", hostId);
+    query.setParameter("id", componentId);
 
     return daoUtils.selectSingle(query);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
@@ -42,6 +42,9 @@ public class HostComponentStateDAO {
   @Inject
   HostDAO hostDAO;
 
+  @Inject
+  HostComponentDesiredStateDAO hostComponentDesiredStateDAO;
+
   @RequiresSession
   public HostComponentStateEntity findById(long id) {
     return entityManagerProvider.get().find(HostComponentStateEntity.class, id);
@@ -120,22 +123,18 @@ public class HostComponentStateDAO {
    *          Service Group ID
    * @param serviceId
    *          Service ID
-   * @param componentName
-   *          Component Name
+   * @param componentId
+   *          Component ID
    * @param hostId
    *          Host ID
    * @return Return all of the Host Component States that match the criteria.
    */
   @RequiresSession
   public HostComponentStateEntity findByIndex(Long clusterId, Long serviceGroupId, Long serviceId,
-                                              String componentName, Long hostId) {
+                                              Long componentId, Long hostId) {
     final TypedQuery<HostComponentStateEntity> query = entityManagerProvider.get().createNamedQuery(
         "HostComponentStateEntity.findByIndex", HostComponentStateEntity.class);
-    query.setParameter("clusterId", clusterId);
-    query.setParameter("serviceGroupId", serviceGroupId);
-    query.setParameter("serviceId", serviceId);
-    query.setParameter("componentName", componentName);
-    query.setParameter("hostId", hostId);
+    query.setParameter("id", componentId);
 
     return daoUtils.selectSingle(query);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
@@ -83,7 +83,7 @@ public class ServiceComponentDesiredStateDAO {
    */
   @RequiresSession
   public ServiceComponentDesiredStateEntity findByName(long clusterId, long serviceGroupId, long serviceId,
-       String componentName) {
+       String componentName, String componentType) {
     EntityManager entityManager = entityManagerProvider.get();
     TypedQuery<ServiceComponentDesiredStateEntity> query = entityManager.createNamedQuery(
         "ServiceComponentDesiredStateEntity.findByName", ServiceComponentDesiredStateEntity.class);
@@ -92,6 +92,41 @@ public class ServiceComponentDesiredStateDAO {
     query.setParameter("serviceGroupId", serviceGroupId);
     query.setParameter("serviceId", serviceId);
     query.setParameter("componentName", componentName);
+    query.setParameter("componentType", componentType);
+
+    ServiceComponentDesiredStateEntity entity = null;
+    List<ServiceComponentDesiredStateEntity> entities = daoUtils.selectList(query);
+    if (null != entities && !entities.isEmpty()) {
+      entity = entities.get(0);
+    }
+
+    return entity;
+  }
+
+  /**
+   * Finds a {@link ServiceComponentDesiredStateEntity} by a combination of
+   * cluster, service, and component.
+   *
+   * @param clusterId
+   *          the cluster ID
+   * @param serviceGroupId
+   *          the service group ID
+   * @param serviceId
+   *          the service ID
+   * @param componentId
+   *          the component id (not {@code null})
+   */
+  @RequiresSession
+  public ServiceComponentDesiredStateEntity findById(long clusterId, long serviceGroupId, long serviceId,
+                                                       Long componentId) {
+    EntityManager entityManager = entityManagerProvider.get();
+    TypedQuery<ServiceComponentDesiredStateEntity> query = entityManager.createNamedQuery(
+            "ServiceComponentDesiredStateEntity.findById", ServiceComponentDesiredStateEntity.class);
+
+    query.setParameter("clusterId", clusterId);
+    query.setParameter("serviceGroupId", serviceGroupId);
+    query.setParameter("serviceId", serviceId);
+    query.setParameter("id", componentId);
 
     ServiceComponentDesiredStateEntity entity = null;
     List<ServiceComponentDesiredStateEntity> entities = daoUtils.selectList(query);
@@ -123,8 +158,8 @@ public class ServiceComponentDesiredStateDAO {
   }
 
   @Transactional
-  public void removeByName(long clusterId, long serviceGroupId, long serviceId, String componentName) {
-    ServiceComponentDesiredStateEntity entity = findByName(clusterId, serviceGroupId, serviceId, componentName);
+  public void removeByName(long clusterId, long serviceGroupId, long serviceId, String componentName, String componentType) {
+    ServiceComponentDesiredStateEntity entity = findByName(clusterId, serviceGroupId, serviceId, componentName, componentType);
     if (null != entity) {
       entityManagerProvider.get().remove(entity);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
@@ -48,7 +48,7 @@ import com.google.common.base.Objects;
   name = "hostcomponentdesiredstate",
   uniqueConstraints = @UniqueConstraint(
     name = "UQ_hcdesiredstate_name",
-    columnNames = { "component_name", "service_id", "host_id", "service_group_id", "cluster_id" }) )
+    columnNames = { "component_name", "service_id", "service_group_id", "cluster_id" }) )
 @TableGenerator(
   name = "hostcomponentdesiredstate_id_generator",
   table = "ambari_sequences",
@@ -66,7 +66,7 @@ import com.google.common.base.Objects;
     "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.clusterId=:clusterId AND hcds.serviceGroupId=:serviceGroupId AND hcds.serviceId=:serviceId AND hcds.componentName=:componentName AND hcds.hostEntity.hostName=:hostName"),
 
   @NamedQuery(name = "HostComponentDesiredStateEntity.findByIndex", query =
-    "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.clusterId=:clusterId AND hcds.serviceGroupId=:serviceGroupId AND hcds.serviceId=:serviceId AND hcds.componentName=:componentName AND hcds.hostId=:hostId"),
+    "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.id=:id")
 })
 public class HostComponentDesiredStateEntity {
 
@@ -91,6 +91,9 @@ public class HostComponentDesiredStateEntity {
   @Column(name = "component_name", insertable = false, updatable = false)
   private String componentName = "";
 
+  @Column(name = "component_type", insertable = false, updatable = false)
+  private String componentType = "";
+
   @Basic
   @Column(name = "desired_state", nullable = false, insertable = true, updatable = true)
   @Enumerated(value = EnumType.STRING)
@@ -105,7 +108,8 @@ public class HostComponentDesiredStateEntity {
     @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false),
     @JoinColumn(name = "service_group_id", referencedColumnName = "service_group_id", nullable = false),
     @JoinColumn(name = "service_id", referencedColumnName = "service_id", nullable = false),
-    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false)})
+    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false),
+    @JoinColumn(name = "component_type", referencedColumnName = "component_type", nullable = false) })
   private ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity;
 
   @ManyToOne
@@ -152,6 +156,14 @@ public class HostComponentDesiredStateEntity {
 
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  public String getComponentType() {
+    return defaultString(componentType);
+  }
+
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   public State getDesiredState() {
@@ -209,6 +221,10 @@ public class HostComponentDesiredStateEntity {
       return false;
     }
 
+    if (!Objects.equal(componentType, that.componentType)) {
+      return false;
+    }
+
     if (!Objects.equal(desiredState, that.desiredState)) {
       return false;
     }
@@ -228,6 +244,7 @@ public class HostComponentDesiredStateEntity {
     result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 31 * result + (desiredState != null ? desiredState.hashCode() : 0);
     return result;
   }
@@ -264,6 +281,7 @@ public class HostComponentDesiredStateEntity {
   public String toString() {
     return Objects.toStringHelper(this).add("clusterId", clusterId).add(
       "serviceGroupId", serviceGroupId).add("serviceId", serviceId).add("componentName",
-      componentName).add("hostId", hostId).add("desiredState", desiredState).toString();
+      componentName).add("componentType", componentType).add("hostId", hostId).add("desiredState",
+      desiredState).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -30,16 +30,22 @@ import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 
+import javax.persistence.UniqueConstraint;
 import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.state.UpgradeState;
 
 import com.google.common.base.Objects;
 
 @Entity
-@Table(name = "hostcomponentstate")
+@Table(
+    name = "hostcomponentstate",
+    uniqueConstraints = @UniqueConstraint(
+                name = "unq_scdesiredstate_name",
+                columnNames = { "component_name", "service_id" , "service_group_id", "cluster_id" }) )
 @TableGenerator(
     name = "hostcomponentstate_id_generator",
     table = "ambari_sequences",
@@ -76,15 +82,16 @@ import com.google.common.base.Objects;
                 "AND hcs.version != :version"),
     @NamedQuery(
         name = "HostComponentStateEntity.findByIndex",
-        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.clusterId=:clusterId " +
-                "AND hcs.serviceGroupId=:serviceGroupId AND hcs.serviceId=:serviceId AND hcs.componentName=:componentName AND hcs.hostId=:hostId") })
-
+        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.id=:id") })
 public class HostComponentStateEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.TABLE, generator = "hostcomponentstate_id_generator")
   @Column(name = "id", nullable = false, insertable = true, updatable = false)
   private Long id;
+
+  @Column(name = "host_component_desired_state_id", nullable = false, insertable = false, updatable = false)
+  private Long hostComponentDesiredStateId;
 
   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
   private Long clusterId;
@@ -100,6 +107,9 @@ public class HostComponentStateEntity {
 
   @Column(name = "component_name", nullable = false, insertable = false, updatable = false)
   private String componentName;
+
+  @Column(name = "component_type", nullable = false, insertable = false, updatable = false)
+  private String componentType;
 
   /**
    * Version reported by host component during last status update.
@@ -117,15 +127,22 @@ public class HostComponentStateEntity {
 
   @ManyToOne
   @JoinColumns({
+    //@JoinColumn(name = "id", referencedColumnName = "id", nullable = false),
     @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false),
     @JoinColumn(name = "service_group_id", referencedColumnName = "service_group_id", nullable = false),
     @JoinColumn(name = "service_id", referencedColumnName = "service_id", nullable = false),
-    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false) })
+    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false),
+    @JoinColumn(name = "component_type", referencedColumnName = "component_type", nullable = false) })
   private ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity;
 
   @ManyToOne
   @JoinColumn(name = "host_id", referencedColumnName = "host_id", nullable = false)
   private HostEntity hostEntity;
+
+  @OneToOne
+  @JoinColumn(name = "host_component_desired_state_id", referencedColumnName = "id", nullable = false)
+  private HostComponentDesiredStateEntity hostComponentDesiredStateEntity;
+
 
   public Long getId() {
     return id;
@@ -169,6 +186,26 @@ public class HostComponentStateEntity {
 
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  public Long getHostComponentDesiredStateId() {
+    return hostComponentDesiredStateEntity != null ? hostComponentDesiredStateEntity.getId() : null;
+  }
+
+  public void setComponentId(Long componentId) {
+    this.id = componentId;
+  }
+
+  public Long getComponentId() {
+    return id;
+  }
+
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
+  }
+
+  public String getComponentType() {
+    return componentType;
   }
 
   public State getCurrentState() {
@@ -228,6 +265,11 @@ public class HostComponentStateEntity {
       return false;
     }
 
+    if (componentType != null ? !componentType.equals(that.componentType)
+            : that.componentType != null) {
+      return false;
+    }
+
     if (currentState != null ? !currentState.equals(that.currentState)
         : that.currentState != null) {
       return false;
@@ -239,6 +281,10 @@ public class HostComponentStateEntity {
     }
 
     if (hostEntity != null ? !hostEntity.equals(that.hostEntity) : that.hostEntity != null) {
+      return false;
+    }
+
+    if (hostComponentDesiredStateEntity != null ? !hostComponentDesiredStateEntity.equals(that.hostComponentDesiredStateEntity) : that.hostComponentDesiredStateEntity != null) {
       return false;
     }
 
@@ -256,7 +302,9 @@ public class HostComponentStateEntity {
     result = 31 * result + (serviceGroupId != null ? serviceGroupId.intValue() : 0);
     result = 31 * result + (serviceId != null ? serviceId.intValue() : 0);
     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
+    result = 31 * result + (hostComponentDesiredStateEntity != null ? hostComponentDesiredStateEntity.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 31 * result + (currentState != null ? currentState.hashCode() : 0);
     result = 31 * result + (upgradeState != null ? upgradeState.hashCode() : 0);
     result = 31 * result + (version != null ? version.hashCode() : 0);
@@ -267,8 +315,7 @@ public class HostComponentStateEntity {
     return serviceComponentDesiredStateEntity;
   }
 
-  public void setServiceComponentDesiredStateEntity(
-      ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity) {
+  public void setServiceComponentDesiredStateEntity(ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity) {
     this.serviceComponentDesiredStateEntity = serviceComponentDesiredStateEntity;
   }
 
@@ -280,14 +327,22 @@ public class HostComponentStateEntity {
     this.hostEntity = hostEntity;
   }
 
+  public HostComponentDesiredStateEntity getHostComponentDesiredStateEntity() {
+    return hostComponentDesiredStateEntity;
+  }
+
+  public void setHostComponentDesiredStateEntity(HostComponentDesiredStateEntity hostComponentDesiredStateEntity) {
+    this.hostComponentDesiredStateEntity = hostComponentDesiredStateEntity;
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public String toString() {
     return Objects.toStringHelper(this).add("clusterId", clusterId).add("serviceGroupId", serviceGroupId).add(
-      "serviceId", serviceId).add("componentName", componentName).add(
-      "hostId", hostId).add("state", currentState).toString();
+      "serviceId", serviceId).add("componentId", id).add("componentName", componentName).add
+            ("componentType", componentType).add("hostId", hostId).add("state", currentState).toString();
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
@@ -43,6 +43,7 @@ import javax.persistence.UniqueConstraint;
 import org.apache.ambari.server.state.RepositoryVersionState;
 import org.apache.ambari.server.state.State;
 
+
 @Entity
 @Table(
     name = "servicecomponentdesiredstate",
@@ -62,7 +63,15 @@ import org.apache.ambari.server.state.State;
     query = "SELECT scds FROM ServiceComponentDesiredStateEntity scds WHERE scds.clusterId = :clusterId " +
       "AND scds.serviceGroupId = :serviceGroupId " +
       "AND scds.serviceId = :serviceId " +
-      "AND scds.componentName = :componentName") })
+      "AND scds.componentName = :componentName " +
+      "AND scds.componentType = :componentType" ),
+  @NamedQuery(
+    name = "ServiceComponentDesiredStateEntity.findById",
+    query = "SELECT scds FROM ServiceComponentDesiredStateEntity scds WHERE scds.clusterId = :clusterId " +
+      "AND scds.serviceGroupId = :serviceGroupId " +
+      "AND scds.serviceId = :serviceId " +
+      "AND scds.id = :id" )})
+
 public class ServiceComponentDesiredStateEntity {
 
   @Id
@@ -74,6 +83,9 @@ public class ServiceComponentDesiredStateEntity {
 
   @Column(name = "component_name", nullable = false, insertable = true, updatable = true)
   private String componentName;
+
+  @Column(name = "component_type", nullable = false, insertable = true, updatable = true)
+  private String componentType;
 
   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
   private Long clusterId;
@@ -153,6 +165,22 @@ public class ServiceComponentDesiredStateEntity {
 
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  public void setComponentId(Long componentId) {
+    this.id = componentId;
+  }
+
+  public Long getComponentId() {
+    return id;
+  }
+
+  public String getComponentType() {
+    return componentType;
+  }
+
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   public State getDesiredState() {
@@ -237,6 +265,9 @@ public class ServiceComponentDesiredStateEntity {
     if (componentName != null ? !componentName.equals(that.componentName) : that.componentName != null) {
       return false;
     }
+    if (componentType != null ? !componentType.equals(that.componentType) : that.componentType != null) {
+      return false;
+    }
     if (desiredState != null ? !desiredState.equals(that.desiredState) : that.desiredState != null) {
       return false;
     }
@@ -254,6 +285,7 @@ public class ServiceComponentDesiredStateEntity {
     result = 31 * result + (serviceGroupId != null ? serviceGroupId.hashCode() : 0);
     result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 31 * result + (desiredState != null ? desiredState.hashCode() : 0);
     result = 31 * result + (desiredRepositoryVersion != null ? desiredRepositoryVersion.hashCode() : 0);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -162,6 +162,22 @@ public interface Cluster {
   Service getServiceByComponentName(String componentName) throws AmbariException;
 
   /**
+   * Gets a service from the given component Id.
+   *
+   * @param componentId
+   * @return
+   * @throws AmbariException
+   */
+
+  Service getServiceByComponentId(Long componentId) throws AmbariException;
+
+  Long getComponentId(String componentName) throws AmbariException;
+
+  String getComponentName(Long componentId) throws AmbariException;
+
+  String getComponentType(Long componentId) throws AmbariException;
+
+  /**
    * Get all services
    *
    * @return

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
@@ -54,6 +54,8 @@ public interface Service {
   ServiceComponent getServiceComponent(String componentName)
       throws AmbariException;
 
+  ServiceComponent getServiceComponent(Long componentId) throws AmbariException;
+
   Map<String, ServiceComponent> getServiceComponents();
 
   void addServiceComponents(Map<String, ServiceComponent> components)
@@ -72,7 +74,7 @@ public interface Service {
 
   void debugDump(StringBuilder sb);
 
-  ServiceComponent addServiceComponent(String serviceComponentName)
+  ServiceComponent addServiceComponent(String serviceComponentName, String serviceComponentType)
       throws AmbariException;
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
@@ -28,6 +28,10 @@ public interface ServiceComponent {
 
   String getName();
 
+  String getType();
+
+  Long getId();
+
   /**
    * Get a true or false value specifying
    * if auto start was enabled for this component.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
@@ -19,9 +19,12 @@ package org.apache.ambari.server.state;
 
 import org.apache.ambari.server.orm.entities.ServiceComponentDesiredStateEntity;
 
+import com.google.inject.assistedinject.Assisted;
+
 public interface ServiceComponentFactory {
 
-  ServiceComponent createNew(Service service, String componentName);
+  ServiceComponent createNew(Service service, @Assisted("componentName") String componentName,
+                             @Assisted("componentType") String componentType);
 
   ServiceComponent createExisting(Service service, ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity);
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
@@ -71,10 +71,22 @@ public interface ServiceComponentHost {
   String getServiceType();
 
   /**
-   * Get the ServiceComponent this object maps to
+   * Get the ServiceComponent's Id this object maps to
+   * @return Id of the ServiceComponent
+   */
+  public Long getServiceComponentId();
+
+  /**
+   * Get the ServiceComponent's Name this object maps to
    * @return Name of the ServiceComponent
    */
   String getServiceComponentName();
+
+  /**
+   * Get the ServiceComponent's Type this object maps to
+   * @return Type of the ServiceComponent
+   */
+  String getServiceComponentType();
 
   /**
    * Get the Host this object maps to

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
@@ -70,7 +70,9 @@ public class ServiceComponentImpl implements ServiceComponent {
       LoggerFactory.getLogger(ServiceComponentImpl.class);
   private final Service service;
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+  private Long componentId;
   private final String componentName;
+  private final String componentType;
   private String displayName;
   private boolean isClientComponent;
   private boolean isMasterComponent;
@@ -103,8 +105,8 @@ public class ServiceComponentImpl implements ServiceComponent {
   private MaintenanceStateHelper maintenanceStateHelper;
 
   @AssistedInject
-  public ServiceComponentImpl(@Assisted Service service, @Assisted String componentName,
-      AmbariMetaInfo ambariMetaInfo,
+  public ServiceComponentImpl(@Assisted Service service, @Assisted("componentName") String componentName,
+      @Assisted("componentType") String componentType, AmbariMetaInfo ambariMetaInfo,
       ServiceComponentDesiredStateDAO serviceComponentDesiredStateDAO,
       ClusterServiceDAO clusterServiceDAO, ServiceComponentHostFactory serviceComponentHostFactory,
       AmbariEventPublisher eventPublisher)
@@ -113,6 +115,7 @@ public class ServiceComponentImpl implements ServiceComponent {
     this.ambariMetaInfo = ambariMetaInfo;
     this.service = service;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.serviceComponentDesiredStateDAO = serviceComponentDesiredStateDAO;
     this.clusterServiceDAO = clusterServiceDAO;
     this.serviceComponentHostFactory = serviceComponentHostFactory;
@@ -120,6 +123,7 @@ public class ServiceComponentImpl implements ServiceComponent {
 
     ServiceComponentDesiredStateEntity desiredStateEntity = new ServiceComponentDesiredStateEntity();
     desiredStateEntity.setComponentName(componentName);
+    desiredStateEntity.setComponentType(componentType);
     desiredStateEntity.setDesiredState(State.INIT);
     desiredStateEntity.setServiceGroupId(service.getServiceGroupId());
     desiredStateEntity.setServiceId(service.getServiceId());
@@ -138,7 +142,7 @@ public class ServiceComponentImpl implements ServiceComponent {
     StackId stackId = service.getDesiredStackId();
     try {
       ComponentInfo compInfo = ambariMetaInfo.getComponent(stackId.getStackName(),
-          stackId.getStackVersion(), service.getServiceType(), componentName);
+          stackId.getStackVersion(), service.getServiceType(), componentType);
       isClientComponent = compInfo.isClient();
       isMasterComponent = compInfo.isMaster();
       isVersionAdvertised = compInfo.isVersionAdvertised();
@@ -149,6 +153,7 @@ public class ServiceComponentImpl implements ServiceComponent {
           + ", clusterName=" + service.getCluster().getClusterName()
           + ", serviceName=" + service.getServiceType()
           + ", componentName=" + componentName
+          + ", componentType=" + componentType
           + ", stackInfo=" + stackId.getStackId());
     }
   }
@@ -172,6 +177,7 @@ public class ServiceComponentImpl implements ServiceComponent {
 
     desiredStateEntityId = serviceComponentDesiredStateEntity.getId();
     componentName = serviceComponentDesiredStateEntity.getComponentName();
+    componentType = serviceComponentDesiredStateEntity.getComponentType();
 
     updateComponentInfo();
 
@@ -181,7 +187,7 @@ public class ServiceComponentImpl implements ServiceComponent {
         hostComponentStateEntity.getClusterId(),
         hostComponentStateEntity.getServiceGroupId(),
         hostComponentStateEntity.getServiceId(),
-        hostComponentStateEntity.getComponentName(),
+        hostComponentStateEntity.getHostComponentDesiredStateId(),
         hostComponentStateEntity.getHostId()
       );
 
@@ -191,9 +197,11 @@ public class ServiceComponentImpl implements ServiceComponent {
             hostComponentStateEntity, hostComponentDesiredStateEntity));
       } catch(ProvisionException ex) {
         StackId currentStackId = getDesiredStackId();
-        LOG.error(String.format("Can not get host component info: stackName=%s, stackVersion=%s, serviceName=%s, componentName=%s, hostname=%s",
-          currentStackId.getStackName(), currentStackId.getStackVersion(),
-          service.getName(),serviceComponentDesiredStateEntity.getComponentName(), hostComponentStateEntity.getHostName()));
+        LOG.error(String.format("Cannot get host component info: stackName=%s, stackVersion=%s, serviceName=%s, componentName=%s, " +
+                        "componentType=%s, hostname=%s",
+          currentStackId.getStackName(), currentStackId.getStackVersion(), service.getName(),
+          serviceComponentDesiredStateEntity.getComponentName(), serviceComponentDesiredStateEntity.getComponentType(),
+          hostComponentStateEntity.getHostName()));
         ex.printStackTrace();
       }
     }
@@ -202,6 +210,16 @@ public class ServiceComponentImpl implements ServiceComponent {
   @Override
   public String getName() {
     return componentName;
+  }
+
+  @Override
+  public String getType() {
+    return componentType;
+  }
+
+  @Override
+  public Long getId() {
+    return desiredStateEntityId;
   }
 
   /**
@@ -219,7 +237,7 @@ public class ServiceComponentImpl implements ServiceComponent {
     } else {
       LOG.warn("Trying to fetch a member from an entity object that may " +
               "have been previously deleted, serviceName = " + service.getName() + ", " +
-              "componentName = " + componentName);
+              "componentName = " + componentName + ", componentType = " + componentType);
     }
     return false;
   }
@@ -232,8 +250,8 @@ public class ServiceComponentImpl implements ServiceComponent {
   @Override
   public void setRecoveryEnabled(boolean recoveryEnabled) {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Setting RecoveryEnabled of Component, clusterName={}, clusterId={}, serviceName={}, componentName={}, oldRecoveryEnabled={}, newRecoveryEnabled={}",
-        service.getCluster().getClusterName(), service.getCluster().getClusterId(), service.getName(), getName(), isRecoveryEnabled(), recoveryEnabled);
+      LOG.debug("Setting RecoveryEnabled of Component, clusterName={}, clusterId={}, serviceName={}, componentName={}, componentType={}, oldRecoveryEnabled={}, newRecoveryEnabled={}",
+        service.getCluster().getClusterName(), service.getCluster().getClusterId(), service.getName(), getName(), getType(), isRecoveryEnabled(), recoveryEnabled);
     }
 
     ServiceComponentDesiredStateEntity desiredStateEntity = serviceComponentDesiredStateDAO.findById(
@@ -346,7 +364,7 @@ public class ServiceComponentImpl implements ServiceComponent {
       } else {
         LOG.warn("Trying to fetch a member from an entity object that may " +
           "have been previously deleted, serviceName = " + getServiceName() + ", " +
-          "componentName = " + componentName);
+          "componentName = " + componentName + ", componentType = " + componentType);
       }
 
     return null;
@@ -439,7 +457,7 @@ public class ServiceComponentImpl implements ServiceComponent {
     }
     ServiceComponentResponse r = new ServiceComponentResponse(getClusterId(),
         cluster.getClusterName(), sg.getServiceGroupId(), sg.getServiceGroupName(), service.getServiceId(),
-        service.getName(), service.getServiceType(), getName(), desiredStackId, getDesiredState().toString(),
+        service.getName(), service.getServiceType(), getId(), getName(), getType(), desiredStackId, getDesiredState().toString(),
         getServiceComponentStateCount(), isRecoveryEnabled(), displayName, repositoryVersionEntity.getVersion(),
         getRepositoryState());
 
@@ -514,7 +532,7 @@ public class ServiceComponentImpl implements ServiceComponent {
       if (!sch.canBeRemoved()) {
         LOG.warn("Found non removable hostcomponent when trying to" + " delete service component"
             + ", clusterName=" + getClusterName() + ", serviceName=" + getServiceName()
-            + ", componentName=" + getName() + ", state=" + sch.getState() + ", hostname="
+            + ", componentName=" + getName() + ", componentType=" + getType() + ", state=" + sch.getState() + ", hostname="
             + sch.getHostName());
         return false;
       }
@@ -529,12 +547,12 @@ public class ServiceComponentImpl implements ServiceComponent {
     try {
       LOG.info("Deleting all servicecomponenthosts for component" + ", clusterName="
           + getClusterName() + ", serviceName=" + getServiceName() + ", componentName=" + getName()
-          + ", recoveryEnabled=" + isRecoveryEnabled());
+          + ", componentType=" + getType() + ", recoveryEnabled=" + isRecoveryEnabled());
       for (ServiceComponentHost sch : hostComponents.values()) {
         if (!sch.canBeRemoved()) {
           throw new AmbariException("Found non removable hostcomponent " + " when trying to delete"
               + " all hostcomponents from servicecomponent" + ", clusterName=" + getClusterName()
-              + ", serviceName=" + getServiceName() + ", componentName=" + getName()
+              + ", serviceName=" + getServiceName() + ", componentName=" + getName() + ", componentType=" + getType()
               + ", recoveryEnabled=" + isRecoveryEnabled() + ", hostname=" + sch.getHostName());
         }
       }
@@ -555,13 +573,14 @@ public class ServiceComponentImpl implements ServiceComponent {
     try {
       ServiceComponentHost sch = getServiceComponentHost(hostname);
       LOG.info("Deleting servicecomponenthost for cluster" + ", clusterName=" + getClusterName()
-          + ", serviceName=" + getServiceName() + ", componentName=" + getName()
+          + ", serviceName=" + getServiceName() + ", componentName=" + getName() + ", componentType=" + getType()
           + ", recoveryEnabled=" + isRecoveryEnabled() + ", hostname=" + sch.getHostName());
       if (!sch.canBeRemoved()) {
         throw new AmbariException("Could not delete hostcomponent from cluster"
             + ", clusterName=" + getClusterName()
             + ", serviceName=" + getServiceName()
             + ", componentName=" + getName()
+            + ", componentType=" + getType()
             + ", recoveryEnabled=" + isRecoveryEnabled()
             + ", hostname=" + sch.getHostName());
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1187,6 +1187,58 @@ public class ClusterImpl implements Cluster {
     throw new ServiceNotFoundException(getClusterName(), "component: " + componentName);
   }
 
+  @Override
+  public Service getServiceByComponentId(Long componentId) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getId().equals(componentId)) {
+          return service;
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
+  }
+
+  @Override
+  public String getComponentName(Long componentId) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getId() == componentId) {
+          return component.getName();
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
+  }
+
+
+  @Override
+  public String getComponentType(Long componentId) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getId() == componentId) {
+          return component.getType();
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
+  }
+
+  @Override
+  public Long getComponentId(String componentName) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getName().equals(componentName)) {
+          return component.getId();
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Name: " + componentName);
+  }
 
   @Override
   public ServiceGroup getServiceGroup(String serviceGroupName) throws ServiceGroupNotFoundException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -370,7 +370,7 @@ public class AmbariContext {
 
       for (String component : topology.getBlueprint().getComponentNames(service)) {
         String recoveryEnabled = topology.getBlueprint().getRecoveryEnabled(service, component);
-        componentRequests.add(new ServiceComponentRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, component, null, recoveryEnabled));
+        componentRequests.add(new ServiceComponentRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, component, component, recoveryEnabled));
       }
     }
 
@@ -446,7 +446,7 @@ public class AmbariContext {
         //todo: handle this in a generic manner.  These checks are all over the code
         try {
           if (cluster.getService(service) != null && !component.equals(RootComponent.AMBARI_SERVER.name())) {
-            requests.add(new ServiceComponentHostRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, component, hostName, null));
+            requests.add(new ServiceComponentHostRequest(clusterName, DEFAULT_SERVICE_GROUP_NAME, service, null, component, component, hostName, null));
           }
         } catch(AmbariException se) {
           LOG.warn("Service already deleted from cluster: {}", service);

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -270,6 +270,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -286,6 +287,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -294,15 +296,17 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR(32) NOT NULL,
   restart_required SMALLINT NOT NULL DEFAULT 0,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -310,7 +314,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -289,6 +289,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
+  component_type VARCHAR(100) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -305,6 +306,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
+  component_type VARCHAR(100) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -313,15 +315,17 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
   restart_required TINYINT(1) NOT NULL DEFAULT 0,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
+  component_type VARCHAR(100) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -329,7 +333,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -269,6 +269,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
+  component_type VARCHAR2(255) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   service_group_id NUMBER(19) NOT NULL,
   service_id NUMBER(19) NOT NULL,
@@ -285,6 +286,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id NUMBER(19) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
+  component_type VARCHAR2(255) NOT NULL,
   desired_state VARCHAR2(255) NOT NULL,
   host_id NUMBER(19) NOT NULL,
   service_group_id NUMBER(19) NOT NULL,
@@ -293,14 +295,16 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR2(32) NOT NULL,
   restart_required NUMBER(1) DEFAULT 0 NOT NULL,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, host_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, host_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE TABLE hostcomponentstate (
   id NUMBER(19) NOT NULL,
+  host_component_desired_state_id NUMBER(19) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
+  component_type VARCHAR2(255) NOT NULL,
   version VARCHAR2(32) DEFAULT 'UNKNOWN' NOT NULL,
   current_state VARCHAR2(255) NOT NULL,
   host_id NUMBER(19) NOT NULL,
@@ -308,7 +312,9 @@ CREATE TABLE hostcomponentstate (
   service_id NUMBER(19) NOT NULL,
   upgrade_state VARCHAR2(32) DEFAULT 'NONE' NOT NULL,
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -271,6 +271,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -287,6 +288,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -295,14 +297,16 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR(32) NOT NULL,
   restart_required SMALLINT NOT NULL DEFAULT 0,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -310,7 +314,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -268,6 +268,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   service_group_id NUMERIC(19) NOT NULL,
   service_id NUMERIC(19) NOT NULL,
@@ -284,6 +285,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id NUMERIC(19) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id NUMERIC(19) NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -292,14 +294,16 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
   restart_required BIT NOT NULL DEFAULT 0,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE TABLE hostcomponentstate (
   id NUMERIC(19) NOT NULL,
+  host_component_desired_state_id NUMERIC(19) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id NUMERIC(19) NOT NULL,
@@ -307,7 +311,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT PK_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -282,6 +282,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -298,6 +299,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -306,14 +308,16 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR(32) NOT NULL,
   restart_required BIT NOT NULL DEFAULT 0,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY CLUSTERED (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -321,7 +325,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT PK_hostcomponentstate PRIMARY KEY CLUSTERED (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_desired_state_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE NONCLUSTERED INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/key_properties.json
+++ b/ambari-server/src/main/resources/key_properties.json
@@ -11,7 +11,7 @@
     "ServiceGroup": "HostRoles/service_group_name",
     "Host": "HostRoles/host_name",
     "Service": "HostRoles/service_name",
-    "HostComponent": "HostRoles/component_name",
+    "HostComponent": "HostRoles/id",
     "Component": "HostRoles/component_name"
   },
   "Action": {

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
@@ -155,11 +155,11 @@ public class HeartbeatProcessorTest {
   public void testHeartbeatWithConfigs() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -223,7 +223,7 @@ public class HeartbeatProcessorTest {
   public void testRestartRequiredAfterInstallClient() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -287,11 +287,11 @@ public class HeartbeatProcessorTest {
   public void testHeartbeatCustomCommandWithConfigs() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -370,11 +370,11 @@ public class HeartbeatProcessorTest {
   public void testHeartbeatCustomStartStop() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -453,11 +453,11 @@ public class HeartbeatProcessorTest {
   public void testStatusHeartbeat() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -574,7 +574,7 @@ public class HeartbeatProcessorTest {
       throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -692,7 +692,7 @@ public class HeartbeatProcessorTest {
   public void testUpgradeSpecificHandling() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -785,7 +785,7 @@ public class HeartbeatProcessorTest {
   public void testCommandStatusProcesses() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
 
@@ -863,11 +863,11 @@ public class HeartbeatProcessorTest {
   public void testComponentUpgradeFailReport() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
@@ -974,11 +974,11 @@ public class HeartbeatProcessorTest {
   public void testComponentUpgradeInProgressReport() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
@@ -1230,10 +1230,10 @@ public class HeartbeatProcessorTest {
   public void testComponentInProgressStatusSafeAfterStatusReport() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).
         addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).
         addServiceComponentHost(DummyHostname1);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
@@ -186,9 +186,9 @@ public class TestHeartbeatHandler {
 
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
-    hdfs.addServiceComponent(NAMENODE);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     Collection<Host> hosts = cluster.getHosts();
     assertEquals(hosts.size(), 1);
 
@@ -237,9 +237,9 @@ public class TestHeartbeatHandler {
   public void testStatusHeartbeatWithAnnotation() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
-    hdfs.addServiceComponent(NAMENODE);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
 
     ActionQueue aq = new ActionQueue();
 
@@ -287,10 +287,10 @@ public class TestHeartbeatHandler {
   public void testLiveStatusUpdateAfterStopFailed() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).
         addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, DATANODE);
     hdfs.getServiceComponent(NAMENODE).
         addServiceComponentHost(DummyHostname1);
 
@@ -391,15 +391,15 @@ public class TestHeartbeatHandler {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     // Create helper after creating service to avoid race condition caused by asynchronous recovery configs
@@ -467,15 +467,15 @@ public class TestHeartbeatHandler {
     /*
      * Add three service components enabled for auto start.
      */
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(HDFS_CLIENT).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT).setRecoveryEnabled(true);
     hdfs.getServiceComponent(HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
@@ -796,11 +796,11 @@ public class TestHeartbeatHandler {
   public void testTaskInProgressHandling() throws Exception, InvalidStateTransitionException {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -852,11 +852,11 @@ public class TestHeartbeatHandler {
   public void testOPFailedEventForAbortedTask() throws Exception, InvalidStateTransitionException {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -922,11 +922,11 @@ public class TestHeartbeatHandler {
   public void testStatusHeartbeat() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
@@ -982,9 +982,9 @@ public class TestHeartbeatHandler {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Host hostObject = clusters.getHost(DummyHostname1);
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(NAMENODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
@@ -1062,9 +1062,9 @@ public class TestHeartbeatHandler {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Host hostObject = clusters.getHost(DummyHostname1);
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(NAMENODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
@@ -1388,7 +1388,7 @@ public class TestHeartbeatHandler {
   public void testCommandStatusProcesses_empty() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
@@ -176,11 +176,11 @@ public class TestHeartbeatMonitor {
     clusters.mapAndPublishHostsToCluster(hostNames, clusterName);
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
 
     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
@@ -279,16 +279,16 @@ public class TestHeartbeatMonitor {
     clusters.mapAndPublishHostsToCluster(hostNames, clusterName);
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost
     (hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost
     (hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).
         addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost
     (hostname1);
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost
@@ -387,11 +387,11 @@ public class TestHeartbeatMonitor {
 
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
 
     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
@@ -469,13 +469,13 @@ public class TestHeartbeatMonitor {
 
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(hostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -589,11 +589,11 @@ public class TestHeartbeatMonitor {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
 
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
 
     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
@@ -151,7 +151,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", "HDP-2.6.0.0");
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -159,7 +159,7 @@ public class RecoveryConfigHelperTest {
     assertEquals(recoveryConfig.getEnabledComponents(), "DATANODE");
 
     // Install HDFS::NAMENODE to trigger a component installed event
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
     // Verify that the config is stale now
@@ -186,10 +186,10 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", "HDP-2.6.0.0");
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -223,7 +223,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", "HDP-2.6.0.0");
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setDesiredState(State.INSTALLED);
 
@@ -264,10 +264,10 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", "HDP-2.6.0.0");
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -300,7 +300,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", "HDP-2.6.0.0");
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -344,7 +344,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", "HDP-2.6.0.0");
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
 
     // Add SCH to Host1 and Host2
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost("Host1");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -581,8 +581,8 @@ public class AmbariCustomCommandExecutionHelperTest {
     OrmTestHelper ormTestHelper = injector.getInstance(OrmTestHelper.class);
     RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.6"), "2.0.6-1234");
     createService("c1", "CORE", "HADOOP_CLIENTS", repositoryVersion);
-    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
-    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
+    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
+    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", 1L, "SOME_CLIENT_FOR_SERVICE_CHECK", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
 
     //make sure there are no HDFS_CLIENT components from HDFS service
     Cluster c1 = clusters.getCluster("c1");
@@ -745,7 +745,7 @@ public class AmbariCustomCommandExecutionHelperTest {
 
     // add a repo version associated with a component
     ServiceComponentDesiredStateEntity componentEntity = componentDAO.findByName(cluster.getClusterId(), serviceYARN.getServiceGroupId(),
-        serviceYARN.getServiceId(), componentRM.getName());
+        serviceYARN.getServiceId(), componentRM.getName(), componentRM.getType());
 
     ServiceComponentVersionEntity componentVersionEntity = new ServiceComponentVersionEntity();
     componentVersionEntity.setRepositoryVersion(repositoryVersion);
@@ -794,29 +794,30 @@ public class AmbariCustomCommandExecutionHelperTest {
     createService(clusterName, serviceGroupName, "ZOOKEEPER", repositoryVersion);
     createService(clusterName, serviceGroupName, "FLUME", repositoryVersion);
 
-    createServiceComponent(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "YARN", "NODEMANAGER", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", "GANGLIA_SERVER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", "GANGLIA_MONITOR", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", State.INIT);
 
     // this component should be not installed on any host
-    createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", "FLUME_HANDLER", State.INIT);
   }
 
 
   private void createServiceComponentHosts(String clusterName, String serviceGroupName, String hostPrefix) throws AmbariException, AuthorizationException {
     String hostC6401 = hostPrefix + "-c6401";
     String hostC6402 = hostPrefix + "-c6402";
-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", hostC6401, null);
-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6401, null);
-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", hostC6401, State.INIT);
-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", hostC6401, State.INIT);
-    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostC6401, State.INIT);
+    // TODO : Numbers for component Id may not be correct.
+    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 1L, "RESOURCEMANAGER", "RESOURCEMANAGER", hostC6401, null);
+    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 2L, "NODEMANAGER", "NODEMANAGER", hostC6401, null);
+    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 3L, "GANGLIA_SERVER", "GANGLIA_SERVER", hostC6401, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 4L, "GANGLIA_MONITOR", "GANGLIA_MONITOR", hostC6401, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", 5L, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", hostC6401, State.INIT);
 
-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6402, null);
-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", hostC6402, State.INIT);
-    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostC6402, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 6L,"NODEMANAGER", "NODEMANAGER", hostC6402, null);
+    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 7L,"GANGLIA_MONITOR", "GANGLIA_MONITOR", hostC6402, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", 8L, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", hostC6402, State.INIT);
   }
   private void addHost(String hostname, String clusterName) throws AmbariException {
     clusters.addHost(hostname);
@@ -849,16 +850,17 @@ public class AmbariCustomCommandExecutionHelperTest {
   }
 
   private void createServiceComponent(
-    String clusterName, String serviceGroupName, String serviceName, String componentName, State desiredState
+    String clusterName, String serviceGroupName, String serviceName, String componentName, String componentType, State desiredState
   ) throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(ambariManagementController, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(
-    String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState
+    String clusterName, String serviceGroupName, String serviceName, Long componentId, String componentName, String componentType, String hostname, State desiredState
   ) throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType,
+            hostname, desiredState != null ? desiredState.name() : null);
     ambariManagementController.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -846,7 +846,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
     setRequests.add(request1);
@@ -913,7 +913,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -978,7 +978,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
     request1.setState("INSTALLED");
 
 
@@ -1055,7 +1055,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
     request1.setMaintenanceState("ON");
 
 
@@ -1139,13 +1139,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host1", null);
+        "cluster1", "CORE", "service1", "component2", "component2","host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1238,13 +1238,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service2", "component2", "host1", null);
+        "cluster1", "CORE", "service2", "component2", "component2", "host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1344,13 +1344,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service2", "component2", "host1", null);
+        "cluster1", "CORE", "service2", "component2", "component2", "host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1452,13 +1452,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", null, null);
+        "cluster1", "CORE", "service1", "component1", "component1", null, null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host2", null);
+        "cluster1", "CORE", "service1", "component2", "component2", "host2", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", null, null);
+        "cluster1", "CORE", "service1", "component3", "component3", null, null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1537,13 +1537,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host1", null);
+        "cluster1", "CORE", "service1", "component2", "component2", "host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1592,13 +1592,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host2", null);
+        "cluster1", "CORE", "service1", "component2", "component2", "host2", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1657,7 +1657,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", null, null);
+        "cluster1", "CORE", "service1", "component1", "component1", null, null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1737,7 +1737,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", null, null, null, null);
+        "cluster1", "CORE", null, null, null, null, null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -410,7 +410,7 @@ public class AmbariManagementControllerTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
-        serviceName, componentName, dStateStr);
+        serviceName, componentName, componentName, dStateStr);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
@@ -423,7 +423,7 @@ public class AmbariManagementControllerTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
-        serviceName, componentName, hostname, dStateStr);
+        serviceName, componentName, componentName, hostname, dStateStr);
     controller.createHostComponents(Collections.singleton(r));
   }
 
@@ -436,7 +436,7 @@ public class AmbariManagementControllerTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
-        serviceName, componentName, hostname, dStateStr);
+        serviceName, componentName, componentName, hostname, dStateStr);
     controller.deleteHostComponents(Collections.singleton(r));
   }
 
@@ -506,7 +506,7 @@ public class AmbariManagementControllerTest {
     for (ServiceComponent sc : s.getServiceComponents().values()) {
       for (ServiceComponentHost sch : sc.getServiceComponentHosts().values()) {
         ServiceComponentHostRequest schr = new ServiceComponentHostRequest
-          (clusterName, serviceGroupName, serviceName, sc.getName(),
+          (clusterName, serviceGroupName, serviceName, sc.getName(), sc.getType(),
             sch.getHostName(), State.INSTALLED.name());
         requests.add(schr);
       }
@@ -952,7 +952,7 @@ public class AmbariManagementControllerTest {
         .getService(serviceName).getServiceComponent(componentName));
 
     ServiceComponentRequest r =
-        new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, null, null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, null, null, null);
     Set<ServiceComponentResponse> response = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(1, response.size());
 
@@ -991,7 +991,7 @@ public class AmbariManagementControllerTest {
     try {
       set1.clear();
       ServiceComponentRequest rInvalid =
-          new ServiceComponentRequest(cluster1, null, null, null, null);
+          new ServiceComponentRequest(cluster1, null, null, null, null, null);
       set1.add(rInvalid);
       ComponentResourceProviderTest.createComponents(controller, set1);
       fail("Expected failure for invalid requests");
@@ -1002,7 +1002,7 @@ public class AmbariManagementControllerTest {
     try {
       set1.clear();
       ServiceComponentRequest rInvalid =
-          new ServiceComponentRequest(cluster1, "s1", null, null, null);
+          new ServiceComponentRequest(cluster1, "s1", null, null, null, null);
       set1.add(rInvalid);
       ComponentResourceProviderTest.createComponents(controller, set1);
       fail("Expected failure for invalid requests");
@@ -1052,11 +1052,11 @@ public class AmbariManagementControllerTest {
 
     set1.clear();
     ServiceComponentRequest valid1 =
-        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null);
     ServiceComponentRequest valid2 =
-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", "JOBTRACKER", null);
     ServiceComponentRequest valid3 =
-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", "TASKTRACKER", null);
     set1.add(valid1);
     set1.add(valid2);
     set1.add(valid3);
@@ -1065,9 +1065,9 @@ public class AmbariManagementControllerTest {
     try {
       set1.clear();
       ServiceComponentRequest rInvalid1 =
-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
+          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
       ServiceComponentRequest rInvalid2 =
-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
+          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
       set1.add(rInvalid1);
       set1.add(rInvalid2);
       ComponentResourceProviderTest.createComponents(controller, set1);
@@ -1079,9 +1079,9 @@ public class AmbariManagementControllerTest {
     try {
       set1.clear();
       ServiceComponentRequest rInvalid1 =
-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
+          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
       ServiceComponentRequest rInvalid2 =
-          new ServiceComponentRequest(cluster2, serviceGroupName, "HDFS", "HDFS_CLIENT", null);
+          new ServiceComponentRequest(cluster2, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
       set1.add(rInvalid1);
       set1.add(rInvalid2);
       ComponentResourceProviderTest.createComponents(controller, set1);
@@ -1093,7 +1093,7 @@ public class AmbariManagementControllerTest {
     try {
       set1.clear();
       ServiceComponentRequest rInvalid =
-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", null);
+          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null);
       set1.add(rInvalid);
       ComponentResourceProviderTest.createComponents(controller, set1);
       fail("Expected failure for already existing component");
@@ -1164,7 +1164,7 @@ public class AmbariManagementControllerTest {
     // issue an install command, expect retry is enabled
     ServiceComponentHostRequest
         schr =
-        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "INSTALLED");
+        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "INSTALLED");
     Map<String, String> requestProps = new HashMap<>();
     requestProps.put("phase", "INITIAL_INSTALL");
     RequestStatusResponse rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
@@ -1190,7 +1190,7 @@ public class AmbariManagementControllerTest {
     }
 
     // issue an start command but no retry as phase is only INITIAL_INSTALL
-    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "STARTED");
+    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "STARTED");
     rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
     stages = actionDB.getAllStages(rsr.getRequestId());
     Assert.assertEquals(1, stages.size());
@@ -1220,7 +1220,7 @@ public class AmbariManagementControllerTest {
 
     // issue an start command and retry is expected
     requestProps.put("phase", "INITIAL_START");
-    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "STARTED");
+    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "STARTED");
     rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
     stages = actionDB.getAllStages(rsr.getRequestId());
     Assert.assertEquals(1, stages.size());
@@ -1250,7 +1250,7 @@ public class AmbariManagementControllerTest {
     controller.updateClusters(Collections.singleton(crReq), null);
 
     requestProps.put("phase", "INITIAL_START");
-    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "STARTED");
+    schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "STARTED");
     rsr = updateHostComponents(Collections.singleton(schr), requestProps, false);
     stages = actionDB.getAllStages(rsr.getRequestId());
     Assert.assertEquals(1, stages.size());
@@ -1373,11 +1373,11 @@ public class AmbariManagementControllerTest {
 
     Set<ServiceComponentRequest> set1 = new HashSet<>();
     ServiceComponentRequest valid1 =
-        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null);
     ServiceComponentRequest valid2 =
-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "JOBTRACKER", "JOBTRACKER", null);
     ServiceComponentRequest valid3 =
-        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", null);
+        new ServiceComponentRequest(cluster1, serviceGroupName, "MAPREDUCE", "TASKTRACKER", "TASKTRACKER", null);
     set1.add(valid1);
     set1.add(valid2);
     set1.add(valid3);
@@ -1481,7 +1481,7 @@ public class AmbariManagementControllerTest {
 
     ServiceComponentHostRequest r =
         new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName,
-            componentName2, null, null);
+            componentName2, componentName2, null, null);
 
     Set<ServiceComponentHostResponse> response =
         controller.getHostComponents(Collections.singleton(r));
@@ -1511,16 +1511,16 @@ public class AmbariManagementControllerTest {
       new HashSet<>();
     ServiceComponentHostRequest r1 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-            componentName1, host1, State.INIT.toString());
+            componentName1, componentName1, host1, State.INIT.toString());
     ServiceComponentHostRequest r2 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-            componentName2, host1, State.INIT.toString());
+            componentName2, componentName2, host1, State.INIT.toString());
     ServiceComponentHostRequest r3 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-            componentName1, host2, State.INIT.toString());
+            componentName1, componentName1, host2, State.INIT.toString());
     ServiceComponentHostRequest r4 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-            componentName2, host2, State.INIT.toString());
+            componentName2, componentName2, host2, State.INIT.toString());
 
     set1.add(r1);
     set1.add(r2);
@@ -1550,7 +1550,7 @@ public class AmbariManagementControllerTest {
   @Test(expected = IllegalArgumentException.class)
   public void createHostComponentsRequestRejectedWithoutClusterName() throws Exception {
     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-      new ServiceComponentHostRequest(null, "CORE", "HDFS", "NAMENODE", "host1", null)
+      new ServiceComponentHostRequest(null, "CORE", "HDFS", "NAMENODE", "NAMENODE", "host1", null)
     );
     controller.createHostComponents(requests);
   }
@@ -1558,7 +1558,7 @@ public class AmbariManagementControllerTest {
   @Test(expected = IllegalArgumentException.class)
   public void createHostComponentsRequestRejectedWithoutComponentName() throws Exception {
     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-      new ServiceComponentHostRequest("foo", "CORE", "HDFS", null, "host1", null)
+      new ServiceComponentHostRequest("foo", "CORE", "HDFS", null, null, "host1", null)
     );
     controller.createHostComponents(requests);
   }
@@ -1566,7 +1566,7 @@ public class AmbariManagementControllerTest {
   @Test(expected = IllegalArgumentException.class)
   public void createHostComponentsRequestRejectedWithoutHostname() throws Exception {
     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", null, null)
+      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", "NAMENODE",null, null)
     );
     controller.createHostComponents(requests);
   }
@@ -1574,7 +1574,7 @@ public class AmbariManagementControllerTest {
   @Test(expected = ParentObjectNotFoundException.class)
   public void createHostComponentsRequestRejectedForNonexistentCluster() throws Exception {
     Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", "host1", null)
+      new ServiceComponentHostRequest("foo", "CORE", "HDFS", "NAMENODE", "NAMENODE", "host1", null)
     );
     controller.createHostComponents(requests);
   }
@@ -1619,7 +1619,7 @@ public class AmbariManagementControllerTest {
 
     try {
       ServiceComponentHostRequest rInvalid =
-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
       controller.createHostComponents(Collections.singleton(rInvalid));
       fail("Expected failure for invalid service");
     } catch (IllegalArgumentException e) {
@@ -1636,24 +1636,24 @@ public class AmbariManagementControllerTest {
 
     try {
       ServiceComponentHostRequest rInvalid =
-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
       controller.createHostComponents(Collections.singleton(rInvalid));
       fail("Expected failure for invalid service");
     } catch (Exception e) {
       // Expected
     }
 
-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "NAMENODE");
+    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
     s1.addServiceComponent(sc1);
-    ServiceComponent sc2 = serviceComponentFactory.createNew(s2, "NAMENODE");
+    ServiceComponent sc2 = serviceComponentFactory.createNew(s2, "NAMENODE", "NAMENODE");
     s2.addServiceComponent(sc2);
-    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "NAMENODE");
+    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "NAMENODE", "NAMENODE");
     s3.addServiceComponent(sc3);
 
 
     try {
       ServiceComponentHostRequest rInvalid =
-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
       controller.createHostComponents(Collections.singleton(rInvalid));
       fail("Expected failure for invalid host");
     } catch (Exception e) {
@@ -1678,7 +1678,7 @@ public class AmbariManagementControllerTest {
 
     try {
       ServiceComponentHostRequest rInvalid =
-          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+          new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
       controller.createHostComponents(Collections.singleton(rInvalid));
       fail("Expected failure for invalid host cluster mapping");
     } catch (Exception e) {
@@ -1691,13 +1691,13 @@ public class AmbariManagementControllerTest {
     clusters.mapAndPublishHostsToCluster(hostnames, cluster2);
 
     ServiceComponentHostRequest valid =
-        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
     controller.createHostComponents(Collections.singleton(valid));
 
     try {
       Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-        new ServiceComponentHostRequest(clusterFoo, "SG1", "HDFS", "NAMENODE", host2, null),
-        new ServiceComponentHostRequest(clusterFoo, "SG2", "HDFS", "NAMENODE", host2, null)
+        new ServiceComponentHostRequest(clusterFoo, "SG1", "HDFS", "NAMENODE", "NAMENODE", host2, null),
+        new ServiceComponentHostRequest(clusterFoo, "SG2", "HDFS", "NAMENODE", "NAMENODE", host2, null)
       );
       controller.createHostComponents(requests);
       fail("Expected failure for wrong service requests as the SG1 service group doesn't exist on cluster");
@@ -1707,8 +1707,8 @@ public class AmbariManagementControllerTest {
 
     try {
       Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", host2, null),
-        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", host3, null)
+        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host2, null),
+        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host3, null)
       );
       controller.createHostComponents(requests);
       fail("Expected failure for multiple clusters");
@@ -1718,8 +1718,8 @@ public class AmbariManagementControllerTest {
 
     try {
       Set<ServiceComponentHostRequest> requests = ImmutableSet.of(
-        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host1, null),
-        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", host2, null)
+        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null),
+        new ServiceComponentHostRequest(clusterFoo, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host2, null)
       );
       controller.createHostComponents(requests);
       fail("Expected failure for already existing");
@@ -1732,11 +1732,11 @@ public class AmbariManagementControllerTest {
     Assert.assertEquals(0, foo.getServiceComponentHosts(host3).size());
 
     ServiceComponentHostRequest valid1 =
-        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+        new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
     controller.createHostComponents(Collections.singleton(valid1));
 
     ServiceComponentHostRequest valid2 =
-        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", host1, null);
+        new ServiceComponentHostRequest(cluster2, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null);
     controller.createHostComponents(Collections.singleton(valid2));
 
     Assert.assertEquals(1, foo.getServiceComponentHosts(host1).size());
@@ -2333,12 +2333,12 @@ public class AmbariManagementControllerTest {
     Service s1 = serviceFactory.createNew(c1, c1.addServiceGroup(serviceGroupName, "HDP-0.2"), new ArrayList<>(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s1);
     s1.setDesiredState(State.INSTALLED);
-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
+    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
     s1.addServiceComponent(sc1);
     sc1.setDesiredState(State.UNINSTALLED);
 
     ServiceComponentRequest r = new ServiceComponentRequest(cluster1, serviceGroupName,
-       s1.getName(), sc1.getName(), null);
+       s1.getName(), sc1.getName(), sc1.getType(), null);
 
     Set<ServiceComponentResponse> resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
@@ -2388,14 +2388,14 @@ public class AmbariManagementControllerTest {
     s2.setDesiredState(State.INSTALLED);
     s4.setDesiredState(State.INSTALLED);
 
-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
-    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE");
-    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER");
-    ServiceComponent sc4 = serviceComponentFactory.createNew(s4, "HIVE_SERVER");
-    ServiceComponent sc5 = serviceComponentFactory.createNew(s4, "HIVE_CLIENT");
-    ServiceComponent sc6 = serviceComponentFactory.createNew(s4, "MYSQL_SERVER");
-    ServiceComponent sc7 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_SERVER");
-    ServiceComponent sc8 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_CLIENT");
+    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
+    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
+    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
+    ServiceComponent sc4 = serviceComponentFactory.createNew(s4, "HIVE_SERVER", "HIVE_SERVER");
+    ServiceComponent sc5 = serviceComponentFactory.createNew(s4, "HIVE_CLIENT", "HIVE_CLIENT");
+    ServiceComponent sc6 = serviceComponentFactory.createNew(s4, "MYSQL_SERVER", "MYSQL_SERVER");
+    ServiceComponent sc7 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+    ServiceComponent sc8 = serviceComponentFactory.createNew(s5, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
 
     s1.addServiceComponent(sc1);
     s1.addServiceComponent(sc2);
@@ -2414,7 +2414,7 @@ public class AmbariManagementControllerTest {
     sc8.setDesiredState(State.UNINSTALLED);
 
     ServiceComponentRequest r = new ServiceComponentRequest(null, null, null,
-        null, null);
+        null, null, null);
 
     try {
       ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
@@ -2425,25 +2425,25 @@ public class AmbariManagementControllerTest {
 
     // all comps per cluster
     r = new ServiceComponentRequest(c1.getClusterName(), null,
-        null, null, null);
+        null, null, null, null);
     Set<ServiceComponentResponse> resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(3, resps.size());
 
     // all comps per cluster filter on state
     r = new ServiceComponentRequest(c2.getClusterName(), null,
-        null, null, State.UNINSTALLED.toString());
+        null, null, null, State.UNINSTALLED.toString());
     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(4, resps.size());
 
     // all comps for given service
     r = new ServiceComponentRequest(c2.getClusterName(), null,
-        s5.getName(), null, null);
+        s5.getName(), null, null, null);
     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     // all comps for given service filter by state
     r = new ServiceComponentRequest(c2.getClusterName(), null,
-        s4.getName(), null, State.INIT.toString());
+        s4.getName(), null, null, State.INIT.toString());
     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
     Assert.assertEquals(sc4.getName(),
@@ -2451,7 +2451,7 @@ public class AmbariManagementControllerTest {
 
     // get single given comp
     r = new ServiceComponentRequest(c2.getClusterName(), null,
-        null, sc5.getName(), State.INIT.toString());
+        null, sc5.getName(), sc5.getType(), State.INIT.toString());
     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
     Assert.assertEquals(sc5.getName(),
@@ -2459,7 +2459,7 @@ public class AmbariManagementControllerTest {
 
     // get single given comp and given svc
     r = new ServiceComponentRequest(c2.getClusterName(), null,
-        s4.getName(), sc5.getName(), State.INIT.toString());
+        s4.getName(), sc5.getName(), sc5.getType(), State.INIT.toString());
     resps = ComponentResourceProviderTest.getComponents(controller, Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
     Assert.assertEquals(sc5.getName(),
@@ -2469,11 +2469,11 @@ public class AmbariManagementControllerTest {
     ServiceComponentRequest r1, r2, r3;
     Set<ServiceComponentRequest> reqs = new HashSet<>();
     r1 = new ServiceComponentRequest(c2.getClusterName(), null,
-        null, null, State.UNINSTALLED.toString());
+        null, null, null, State.UNINSTALLED.toString());
     r2 = new ServiceComponentRequest(c1.getClusterName(), null,
-        null, null, null);
+        null, null, null, null);
     r3 = new ServiceComponentRequest(c1.getClusterName(), null,
-        null, null, State.INIT.toString());
+        null, null, null, State.INIT.toString());
     reqs.addAll(Arrays.asList(r1, r2, r3));
     resps = ComponentResourceProviderTest.getComponents(controller, reqs);
     Assert.assertEquals(7, resps.size());
@@ -2490,7 +2490,7 @@ public class AmbariManagementControllerTest {
     ServiceGroup serviceGroup = c1.addServiceGroup("CORE", HDP_0_1);
     Service s1 = serviceFactory.createNew(c1, serviceGroup, new ArrayList<>(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s1);
-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
+    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
     s1.addServiceComponent(sc1);
     sc1.setDesiredState(State.UNINSTALLED);
     ServiceComponentHost sch1 = serviceComponentHostFactory.createNew(sc1, host1);
@@ -2505,7 +2505,7 @@ public class AmbariManagementControllerTest {
 
     ServiceComponentHostRequest r =
         new ServiceComponentHostRequest(c1.getClusterName(), null,
-            null, null, null, null);
+            null, null, null, null, null);
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
@@ -2591,30 +2591,30 @@ public class AmbariManagementControllerTest {
     s1.getServiceComponent(componentName3).getServiceComponentHost(host2).updateActualConfigs(actualConfig);
 
     ServiceComponentHostRequest r =
-        new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+        new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(5, resps.size());
 
     //Get all host components with stale config = true
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setStaleConfig("true");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     //Get all host components with stale config = false
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setStaleConfig("false");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(3, resps.size());
 
     //Get all host components with stale config = false and hostname filter
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host1, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host1, null);
     r.setStaleConfig("false");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     //Get all host components with stale config = false and hostname filter
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host2, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host2, null);
     r.setStaleConfig("true");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
@@ -2659,30 +2659,30 @@ public class AmbariManagementControllerTest {
         setComponentAdminState(HostComponentAdminState.INSERVICE);
 
     ServiceComponentHostRequest r =
-        new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+        new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(5, resps.size());
 
     //Get all host components with decommissiond = true
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setAdminState("DECOMMISSIONED");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
     //Get all host components with decommissioned = false
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setAdminState("INSERVICE");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
     //Get all host components with decommissioned = some random string
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setAdminState("INSTALLED");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(0, resps.size());
 
     //Update adminState
-    r = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, null);
+    r = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, null);
     r.setAdminState("DECOMMISSIONED");
     try {
       updateHostComponents(Collections.singleton(r), new HashMap<>(), false);
@@ -2871,9 +2871,9 @@ public class AmbariManagementControllerTest {
     s1.setDesiredState(State.INSTALLED);
     s2.setDesiredState(State.INSTALLED);
 
-    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE");
-    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE");
-    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER");
+    ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
+    ServiceComponent sc2 = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
+    ServiceComponent sc3 = serviceComponentFactory.createNew(s3, "HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
 
     s1.addServiceComponent(sc1);
     s1.addServiceComponent(sc2);
@@ -2902,7 +2902,7 @@ public class AmbariManagementControllerTest {
     sch5.setDesiredState(State.UNINSTALLED);
 
     ServiceComponentHostRequest r =
-        new ServiceComponentHostRequest(null, null, null, null, null, null);
+        new ServiceComponentHostRequest(null, null, null, null, null, null, null);
 
     try {
       controller.getHostComponents(Collections.singleton(r));
@@ -2912,14 +2912,14 @@ public class AmbariManagementControllerTest {
     }
 
     // all across cluster
-    r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
+    r = new ServiceComponentHostRequest(c1.getClusterName(), null, null, null,
         null, null, null);
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(6, resps.size());
 
     // all for service
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s1.getName(),
-        null, null, null);
+        null, null, null, null);
     resps = controller.getHostComponents(Collections.singleton(r));
     Set<String> actual = resps.stream()
       .map(AmbariManagementControllerTest::serviceComponentHostToString)
@@ -2932,65 +2932,65 @@ public class AmbariManagementControllerTest {
 
     // all for component
     r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
-        sc3.getName(), null, null);
+        sc3.getName(), sc3.getType(), null, null);
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
     // all for host
     r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
-        null, host2, null);
+        null, null, host2, null);
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     // all across cluster with state filter
     r = new ServiceComponentHostRequest(c1.getClusterName(), null, null,
-        null, null, State.UNINSTALLED.toString());
+        null, null, null, State.UNINSTALLED.toString());
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
     // all for service with state filter
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s1.getName(),
-        null, null, State.INIT.toString());
+        null, null, null, State.INIT.toString());
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     // all for component with state filter
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
-        sc3.getName(), null, State.INSTALLED.toString());
+        sc3.getName(), sc3.getType(), null, State.INSTALLED.toString());
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(0, resps.size());
 
     // all for host with state filter
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
-        null, host2, State.INIT.toString());
+        null, null, host2, State.INIT.toString());
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
     // for service and host
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
-        null, host1, null);
+        null, null, host1, null);
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(0, resps.size());
 
     // single sch - given service and host and component
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
-        sc3.getName(), host3, State.INSTALLED.toString());
+        sc3.getName(), sc3.getType(), host3, State.INSTALLED.toString());
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(0, resps.size());
 
     // single sch - given service and host and component
     r = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
-        sc3.getName(), host3, null);
+        sc3.getName(), sc3.getType(), host3, null);
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
 
     ServiceComponentHostRequest r1, r2, r3;
     r1 = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
-        null, host3, null);
+        null, null, host3, null);
     r2 = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, s3.getName(),
-        sc3.getName(), host2, null);
+        sc3.getName(), sc3.getType(), host2, null);
     r3 = new ServiceComponentHostRequest(c1.getClusterName(), serviceGroupName, null,
-        null, host2, null);
+        null, null, host2, null);
     Set<ServiceComponentHostRequest> reqs =
       new HashSet<>();
     reqs.addAll(Arrays.asList(r1, r2, r3));
@@ -3237,22 +3237,22 @@ public class AmbariManagementControllerTest {
       new HashSet<>();
     ServiceComponentHostRequest r1 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName1, host1, State.INIT.toString());
+            componentName1, componentName1, host1, State.INIT.toString());
     ServiceComponentHostRequest r2 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName2, host1, State.INIT.toString());
+            componentName2, componentName2, host1, State.INIT.toString());
     ServiceComponentHostRequest r3 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName1, host2, State.INIT.toString());
+            componentName1, componentName1, host2, State.INIT.toString());
     ServiceComponentHostRequest r4 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName2, host2, State.INIT.toString());
+            componentName2, componentName2, host2, State.INIT.toString());
     ServiceComponentHostRequest r5 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName2,
-            componentName3, host1, State.INIT.toString());
+            componentName3, componentName3, host1, State.INIT.toString());
     ServiceComponentHostRequest r6 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName4, host2, State.INIT.toString());
+            componentName4, componentName4, host2, State.INIT.toString());
 
     set1.add(r1);
     set1.add(r2);
@@ -3480,19 +3480,19 @@ public class AmbariManagementControllerTest {
       new HashSet<>();
     ServiceComponentHostRequest r1 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName1, host1, State.INIT.toString());
+            componentName1, componentName1, host1, State.INIT.toString());
     ServiceComponentHostRequest r2 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName2, host1, State.INIT.toString());
+            componentName2, componentName2, host1, State.INIT.toString());
     ServiceComponentHostRequest r3 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName1, host2, State.INIT.toString());
+            componentName1, componentName1, host2, State.INIT.toString());
     ServiceComponentHostRequest r4 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName2, host2, State.INIT.toString());
+            componentName2, componentName2, host2, State.INIT.toString());
     ServiceComponentHostRequest r5 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName3, host1, State.INIT.toString());
+            componentName3, componentName3, host1, State.INIT.toString());
 
     set1.add(r1);
     set1.add(r2);
@@ -3533,13 +3533,13 @@ public class AmbariManagementControllerTest {
 
     // confirm an UNKOWN doesn't fail
     req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-        sc3.getName(), State.INSTALLED.toString());
+        sc3.getName(), sc3.getType(), State.INSTALLED.toString());
     reqs.add(req1);
     ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
     try {
       reqs.clear();
       req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-          sc1.getName(), State.INIT.toString());
+          sc1.getName(), sc1.getType(), State.INIT.toString());
       reqs.add(req1);
       ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
       fail("Expected failure for invalid state update");
@@ -3565,7 +3565,7 @@ public class AmbariManagementControllerTest {
     try {
       reqs.clear();
       req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-          sc1.getName(), State.STARTED.toString());
+          sc1.getName(), sc1.getType(), State.STARTED.toString());
       reqs.add(req1);
       ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
       fail("Expected failure for invalid state update");
@@ -3590,11 +3590,11 @@ public class AmbariManagementControllerTest {
 
     reqs.clear();
     req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-        sc1.getName(), State.INSTALLED.toString());
+        sc1.getName(), sc1.getType(), State.INSTALLED.toString());
     req2 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-        sc2.getName(), State.INSTALLED.toString());
+        sc2.getName(), sc2.getType(), State.INSTALLED.toString());
     req3 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-        sc3.getName(), State.INSTALLED.toString());
+        sc3.getName(), sc3.getType(), State.INSTALLED.toString());
     reqs.add(req1);
     reqs.add(req2);
     reqs.add(req3);
@@ -3637,9 +3637,9 @@ public class AmbariManagementControllerTest {
     // test no-op
     reqs.clear();
     req1 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-        sc1.getName(), State.INSTALLED.toString());
+        sc1.getName(), sc1.getType(), State.INSTALLED.toString());
     req2 = new ServiceComponentRequest(cluster1, serviceGroupName, serviceName1,
-        sc2.getName(), State.INSTALLED.toString());
+        sc2.getName(), sc2.getType(), State.INSTALLED.toString());
     reqs.add(req1);
     reqs.add(req2);
     trackAction = ComponentResourceProviderTest.updateComponents(controller, reqs, Collections.emptyMap(), true);
@@ -3670,19 +3670,19 @@ public class AmbariManagementControllerTest {
       new HashSet<>();
     ServiceComponentHostRequest r1 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName1, host1, State.INIT.toString());
+            componentName1, componentName1, host1, State.INIT.toString());
     ServiceComponentHostRequest r2 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName2, host1, State.INIT.toString());
+            componentName2, componentName2, host1, State.INIT.toString());
     ServiceComponentHostRequest r3 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName1, host2, State.INIT.toString());
+            componentName1, componentName1, host2, State.INIT.toString());
     ServiceComponentHostRequest r4 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName2, host2, State.INIT.toString());
+            componentName2, componentName2, host2, State.INIT.toString());
     ServiceComponentHostRequest r5 =
         new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-            componentName3, host1, State.INIT.toString());
+            componentName3, componentName3, host1, State.INIT.toString());
 
     set1.add(r1);
     set1.add(r2);
@@ -3739,19 +3739,19 @@ public class AmbariManagementControllerTest {
     try {
       reqs.clear();
       req1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-          componentName1, host1,
+          componentName1, componentName1, host1,
           State.INSTALLED.toString());
       req2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-          componentName1, host2,
+          componentName1, componentName2, host2,
           State.INSTALLED.toString());
       req3 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-          componentName2, host1,
+          componentName2, componentName2, host1,
           State.INSTALLED.toString());
       req4 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-          componentName2, host2,
+          componentName2, componentName2, host2,
           State.INSTALLED.toString());
       req5 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-          componentName3, host1,
+          componentName3, componentName3, host1,
           State.STARTED.toString());
       reqs.add(req1);
       reqs.add(req2);
@@ -3766,15 +3766,15 @@ public class AmbariManagementControllerTest {
 
     reqs.clear();
     req1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, null,
-        componentName1, host1, State.INSTALLED.toString());
+        componentName1, componentName1, host1, State.INSTALLED.toString());
     req2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName1, host2, State.INSTALLED.toString());
+        componentName1, componentName1, host2, State.INSTALLED.toString());
     req3 = new ServiceComponentHostRequest(cluster1, serviceGroupName, null,
-        componentName2, host1, State.INSTALLED.toString());
+        componentName2, componentName2, host1, State.INSTALLED.toString());
     req4 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName2, host2, State.INSTALLED.toString());
+        componentName2, componentName2, host2, State.INSTALLED.toString());
     req5 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName3, host1, State.INSTALLED.toString());
+        componentName3, componentName3, host1, State.INSTALLED.toString());
     reqs.add(req1);
     reqs.add(req2);
     reqs.add(req3);
@@ -3806,10 +3806,10 @@ public class AmbariManagementControllerTest {
     // test no-op
     reqs.clear();
     req1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName1, host1,
+        componentName1, componentName1, host1,
         State.INSTALLED.toString());
     req2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName1, host2,
+        componentName1, componentName1, host2,
         State.INSTALLED.toString());
     reqs.add(req1);
     reqs.add(req2);
@@ -3854,11 +3854,11 @@ public class AmbariManagementControllerTest {
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
     Service mapred = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
 
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
-    hdfs.addServiceComponent(Role.NAMENODE.name());
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
 
-    mapred.addServiceComponent(Role.RESOURCEMANAGER.name());
+    mapred.addServiceComponent(Role.RESOURCEMANAGER.name(), Role.RESOURCEMANAGER.name());
 
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
@@ -4011,9 +4011,9 @@ public class AmbariManagementControllerTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup(serviceGroupName, "HDP-2.0.7");
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
 
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
-    hdfs.addServiceComponent(Role.NAMENODE.name());
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
 
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
@@ -4118,11 +4118,11 @@ public class AmbariManagementControllerTest {
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
     Service hive = cluster.addService(serviceGroup, "HIVE", "HIVE", repositoryVersion);
 
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
-    hdfs.addServiceComponent(Role.NAMENODE.name());
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
 
-    hive.addServiceComponent(Role.HIVE_SERVER.name());
+    hive.addServiceComponent(Role.HIVE_SERVER.name(), Role.HIVE_SERVER.name());
 
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
@@ -4386,8 +4386,8 @@ public class AmbariManagementControllerTest {
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
     Service mapReduce = cluster.addService(serviceGroup, "MAPREDUCE", "MAPREDUCE", repositoryVersion);
 
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
-    mapReduce.addServiceComponent(Role.MAPREDUCE_CLIENT.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+    mapReduce.addServiceComponent(Role.MAPREDUCE_CLIENT.name(), Role.MAPREDUCE_CLIENT.name());
 
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
     mapReduce.getServiceComponent(Role.MAPREDUCE_CLIENT.name()).addServiceComponentHost(host2);
@@ -4620,14 +4620,14 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeC", "v1");
     schReqs.clear();
     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-            componentName1, host1, null));
+            componentName1, componentName1, host1, null));
     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
 
     configVersions.clear();
     configVersions.put("typeC", "v1");
     configVersions.put("typeD", "v1");
     scReqs.clear();
-    scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, componentName2, null));
+    scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, componentName2, componentName2, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
     // update configs at service level
@@ -4647,7 +4647,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeC", "v1");
     schReqs.clear();
     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-            componentName1, host1, null));
+            componentName1, componentName1, host1, null));
     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
 
     // update configs at SC level
@@ -4656,7 +4656,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeD", "v1");
     scReqs.clear();
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-            componentName1, null));
+            componentName1, componentName1, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
   }
@@ -4762,7 +4762,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeC", "v1");
     schReqs.clear();
     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-        componentName1, host1, null));
+        componentName1, componentName1, host1, null));
     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
 
     configVersions.clear();
@@ -4770,7 +4770,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeD", "v1");
     scReqs.clear();
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-        componentName2, null));
+        componentName2, componentName2, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
     // update configs at service level
@@ -4789,7 +4789,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeC", "v1");
     schReqs.clear();
     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-        componentName1, host1, null));
+        componentName1, componentName1, host1, null));
     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
 
     // update configs at SC level
@@ -4798,7 +4798,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("typeD", "v1");
     scReqs.clear();
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-        componentName1, null));
+        componentName1, componentName1, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
   }
@@ -4892,7 +4892,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("hdfs-site", "version1");
     schReqs.clear();
     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-      componentName1, host1, null));
+      componentName1, componentName1, host1, null));
     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
 
     // Reconfigure SCH level
@@ -4900,7 +4900,7 @@ public class AmbariManagementControllerTest {
     configVersions.put("core-site", "version122");
     schReqs.clear();
     schReqs.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-      componentName1, host1, null));
+      componentName1, componentName1, host1, null));
     assertNull(updateHostComponents(schReqs, Collections.emptyMap(), true));
 
     // Clear Entity Manager
@@ -4911,11 +4911,11 @@ public class AmbariManagementControllerTest {
     configVersions.put("core-site", "version1");
     configVersions.put("hdfs-site", "version1");
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-      componentName2, null));
+      componentName2, componentName2, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-      componentName1, null));
+      componentName1, componentName1, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
     // Reconfigure SC level
@@ -4924,12 +4924,12 @@ public class AmbariManagementControllerTest {
 
     scReqs.clear();
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-      componentName2, null));
+      componentName2, componentName2, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
     scReqs.clear();
     scReqs.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName,
-      componentName1, null));
+      componentName1, componentName1, null));
     assertNull(ComponentResourceProviderTest.updateComponents(controller, scReqs, Collections.emptyMap(), true));
 
     entityManager.clear();
@@ -5638,7 +5638,7 @@ public class AmbariManagementControllerTest {
 
     // Reinstall SCH
     ServiceComponentHostRequest schr = new ServiceComponentHostRequest
-      (cluster1, serviceGroupName, serviceName, componentName3, host3, State.INSTALLED.name());
+      (cluster1, serviceGroupName, serviceName, componentName3, componentName3, host3, State.INSTALLED.name());
     Set<ServiceComponentHostRequest> setReqs = new
       HashSet<>();
     setReqs.add(schr);
@@ -5836,13 +5836,13 @@ public class AmbariManagementControllerTest {
     createServiceComponentHost(cluster1, serviceGroupName, serviceName, componentName1,
         host2, null);
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-        componentName1, host2, State.INSTALLED.toString());
+        componentName1, componentName1, host2, State.INSTALLED.toString());
     Set<ServiceComponentHostRequest> requests = new HashSet<>();
     requests.add(r);
     updateHostComponents(requests, Collections.emptyMap(), true);
     s.getServiceComponent(componentName1).getServiceComponentHost(host2).setState(State.INSTALLED);
     r = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-        componentName1, host2, State.STARTED.toString());
+        componentName1, componentName1, host2, State.STARTED.toString());
     requests.clear();
     requests.add(r);
     updateHostComponents(requests, Collections.emptyMap(), true);
@@ -5921,11 +5921,11 @@ public class AmbariManagementControllerTest {
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
     Service mapred = cluster.addService(serviceGroup, "YARN", "YARN",  repositoryVersion);
 
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
-    hdfs.addServiceComponent(Role.NAMENODE.name());
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
 
-    mapred.addServiceComponent(Role.RESOURCEMANAGER.name());
+    mapred.addServiceComponent(Role.RESOURCEMANAGER.name(), Role.RESOURCEMANAGER.name());
 
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
@@ -6019,11 +6019,11 @@ public class AmbariManagementControllerTest {
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
     Service mapred = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
 
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
-    hdfs.addServiceComponent(Role.NAMENODE.name());
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
 
-    mapred.addServiceComponent(Role.RESOURCEMANAGER.name());
+    mapred.addServiceComponent(Role.RESOURCEMANAGER.name(), Role.RESOURCEMANAGER.name());
 
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(host1);
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(host1);
@@ -7291,7 +7291,7 @@ public class AmbariManagementControllerTest {
           sch.setState(State.STOPPING);
         } else if (sch.getServiceComponentName().equals("DATANODE")) {
           ServiceComponentHostRequest r1 = new ServiceComponentHostRequest
-            (cluster1, serviceGroupName, serviceName, sch.getServiceComponentName(),
+            (cluster1, serviceGroupName, serviceName, sch.getServiceComponentName(), sch.getServiceComponentType(),
               sch.getHostName(), State.INSTALLED.name());
           Set<ServiceComponentHostRequest> reqs1 = new
             HashSet<>();
@@ -7522,7 +7522,7 @@ public class AmbariManagementControllerTest {
     }
 
     // issue an installed state request without failure
-    ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", host2, "INSTALLED");
+    ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster1, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host2, "INSTALLED");
     Map<String, String> requestProps = new HashMap<>();
     requestProps.put("datanode", "dn_value");
     requestProps.put("namenode", "nn_value");
@@ -7569,11 +7569,11 @@ public class AmbariManagementControllerTest {
 
     Set<ServiceComponentHostRequest> set1 = new HashSet<>();
     ServiceComponentHostRequest r1 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName1, host1, State.INIT.toString());
+        componentName1, componentName1, host1, State.INIT.toString());
     ServiceComponentHostRequest r2 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName2, host1, State.INIT.toString());
+        componentName2, componentName2, host1, State.INIT.toString());
     ServiceComponentHostRequest r3 = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName1,
-        componentName3, host1, State.INIT.toString());
+        componentName3, componentName3, host1, State.INIT.toString());
 
     set1.add(r1);
     set1.add(r2);
@@ -7678,7 +7678,7 @@ public class AmbariManagementControllerTest {
     Set<ServiceComponentHostRequest> schRequests = new HashSet<>();
     // delete HC
     schRequests.clear();
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, componentName1, host1, null));
     try {
       controller.deleteHostComponents(schRequests);
       Assert.fail("Expect failure while deleting.");
@@ -7702,12 +7702,12 @@ public class AmbariManagementControllerTest {
     sc6.getServiceComponentHosts().values().iterator().next().setState(State.INIT);
 
     schRequests.clear();
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName2, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName3, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName4, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName5, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName6, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName1, componentName1, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName2, componentName2, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, hdfs, componentName3, componentName3, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName4, componentName4, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName5, componentName5, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, mapred, componentName6, componentName6, host1, null));
     DeleteStatusMetaData deleteStatusMetaData = controller.deleteHostComponents(schRequests);
     Assert.assertEquals(0, deleteStatusMetaData.getExceptionForKeys().size());
   }
@@ -7865,15 +7865,15 @@ public class AmbariManagementControllerTest {
     // Case 1: Delete host that is still part of cluster, but do not specify the cluster_name in the request
     Set<ServiceComponentHostRequest> schRequests = new HashSet<>();
     // Disable HC for non-clients
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, host1, "DISABLED"));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, host1, "DISABLED"));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, componentName1, host1, "DISABLED"));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, componentName2, host1, "DISABLED"));
     updateHostComponents(schRequests, new HashMap<>(), false);
 
     // Delete HC
     schRequests.clear();
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, host1, null));
-    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName3, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName1, componentName1, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName2, componentName2, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName, componentName3, componentName3, host1, null));
     controller.deleteHostComponents(schRequests);
 
     Assert.assertEquals(0, cluster.getServiceComponentHosts(host1).size());
@@ -8042,7 +8042,7 @@ public class AmbariManagementControllerTest {
     sch.handleEvent(new ServiceComponentHostStartedEvent (sch.getServiceComponentName(), sch.getHostName(), System.currentTimeMillis()));
 
     Set<ServiceComponentHostRequest> schRequests = new HashSet<>();
-    schRequests.add(new ServiceComponentHostRequest(cluster1, null, null, null, host1, null));
+    schRequests.add(new ServiceComponentHostRequest(cluster1, null, null, null, null, host1, null));
 
     DeleteStatusMetaData deleteStatusMetaData = controller.deleteHostComponents(schRequests);
     Assert.assertEquals(1, deleteStatusMetaData.getExceptionForKeys().size());
@@ -8194,24 +8194,24 @@ public class AmbariManagementControllerTest {
     ServiceResourceProviderTest.createServices(amc, repositoryVersionDAO, serviceRequests);
 
     Set<ServiceComponentRequest> serviceComponentRequests = new HashSet<>();
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", "DATANODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", "HISTORYSERVER", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null));
 
     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
 
     Set<ServiceComponentHostRequest> componentHostRequests = new HashSet<>();
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "DATANODE", "DATANODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", "HISTORYSERVER", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(clusterName, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", host1, null));
 
     amc.createHostComponents(componentHostRequests);
 
@@ -8295,10 +8295,10 @@ public class AmbariManagementControllerTest {
     ServiceResourceProviderTest.updateServices(amc, serviceRequests, mapRequestProps, true, false);
 
     Set<ServiceComponentRequest> serviceComponentRequests = new HashSet<>();
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", "NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", "DATANODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", "HDFS_CLIENT", null));
 
     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
 
@@ -8310,11 +8310,11 @@ public class AmbariManagementControllerTest {
     HostResourceProviderTest.createHosts(amc, hostRequests);
 
     Set<ServiceComponentHostRequest> componentHostRequests = new HashSet<>();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host2, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host3, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host2, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host3, null));
 
 
     amc.createHostComponents(componentHostRequests);
@@ -8349,33 +8349,33 @@ public class AmbariManagementControllerTest {
     }
 
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "DISABLED"));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "DISABLED"));
 
     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
 
     Assert.assertEquals(State.DISABLED, componentHost.getState());
 
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "INSTALLED"));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "INSTALLED"));
 
     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
 
     Assert.assertEquals(State.INSTALLED, componentHost.getState());
 
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "DISABLED"));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "DISABLED"));
 
     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
 
     Assert.assertEquals(State.DISABLED, componentHost.getState());
 
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host2, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host2, null));
 
     amc.createHostComponents(componentHostRequests);
 
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host2, "INSTALLED"));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host2, "INSTALLED"));
 
     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
 
@@ -8396,7 +8396,7 @@ public class AmbariManagementControllerTest {
     }
 
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, null));
 
     amc.deleteHostComponents(componentHostRequests);
 
@@ -8409,7 +8409,7 @@ public class AmbariManagementControllerTest {
 
     // should be able to add the host component back
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, null));
     amc.createHostComponents(componentHostRequests);
     namenodes = cluster.getService(serviceName).getServiceComponent("NAMENODE").getServiceComponentHosts();
     assertEquals(2, namenodes.size());
@@ -8419,7 +8419,7 @@ public class AmbariManagementControllerTest {
     componentHost.handleEvent(new ServiceComponentHostInstallEvent(componentHost.getServiceComponentName(), componentHost.getHostName(), System.currentTimeMillis(), version));
     componentHost.handleEvent(new ServiceComponentHostOpSucceededEvent(componentHost.getServiceComponentName(), componentHost.getHostName(), System.currentTimeMillis()));
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", host1, "INSTALLED"));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", host1, "INSTALLED"));
     updateHostComponents(amc, componentHostRequests, mapRequestProps, true);
     assertEquals(State.INSTALLED, namenodes.get(host1).getState());
 
@@ -8435,7 +8435,7 @@ public class AmbariManagementControllerTest {
 
     // make disabled
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host2, "DISABLED"));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host2, "DISABLED"));
     updateHostComponents(amc, componentHostRequests, mapRequestProps, false);
     org.junit.Assert.assertEquals(State.DISABLED, sch.getState());
 
@@ -8463,7 +8463,7 @@ public class AmbariManagementControllerTest {
 
     // confirm delete
     componentHostRequests.clear();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", host2, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", host2, null));
     amc.deleteHostComponents(componentHostRequests);
 
     sch = null;
@@ -8516,19 +8516,19 @@ public class AmbariManagementControllerTest {
     ServiceResourceProviderTest.updateServices(amc, serviceRequests, mapRequestProps, true, false);
     //Crate service components
     serviceComponentRequests = new HashSet<>();
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "NAMENODE", "NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "DATANODE", "DATANODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(cluster1, serviceGroupName, serviceName, "HDFS_CLIENT", "HDFS_CLIENT", null));
     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
 
     //Create ServiceComponentHosts
     componentHostRequests = new HashSet<>();
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "host1", null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "host1", null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", host1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "host2", null));
-    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "host3", null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", "host1", null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "NAMENODE", "NAMENODE", "host1", null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", host1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", "host2", null));
+    componentHostRequests.add(new ServiceComponentHostRequest(cluster1, serviceGroupName, null, "DATANODE", "DATANODE", "host3", null));
     amc.createHostComponents(componentHostRequests);
 
 
@@ -8577,12 +8577,12 @@ public class AmbariManagementControllerTest {
     ServiceResourceProviderTest.createServices(amc, repositoryVersionDAO, serviceRequests);
 
     Set<ServiceComponentRequest> serviceComponentRequests = new HashSet<>();
-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "DATANODE", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "RESOURCEMANAGER", null));
-    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "NODEMANAGER", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "NAMENODE", "NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "HDFS", "DATANODE", "DATANODE", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "MAPREDUCE2", "HISTORYSERVER", "HISTORYSERVER", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", null));
+    serviceComponentRequests.add(new ServiceComponentRequest(CLUSTER_NAME, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", null));
 
     ComponentResourceProviderTest.createComponents(amc, serviceComponentRequests);
 
@@ -8592,12 +8592,12 @@ public class AmbariManagementControllerTest {
     HostResourceProviderTest.createHosts(amc, hostRequests);
 
     Set<ServiceComponentHostRequest> componentHostRequests = new HashSet<>();
-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "DATANODE", HOST1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NAMENODE", HOST1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "SECONDARY_NAMENODE", HOST1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "HISTORYSERVER", HOST1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "RESOURCEMANAGER", HOST1, null));
-    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NODEMANAGER", HOST1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "DATANODE", "DATANODE", HOST1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NAMENODE", "NAMENODE", HOST1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "SECONDARY_NAMENODE", "SECONDARY_NAMENODE", HOST1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "HISTORYSERVER", "HISTORYSERVER", HOST1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "RESOURCEMANAGER", "RESOURCEMANAGER", HOST1, null));
+    componentHostRequests.add(new ServiceComponentHostRequest(CLUSTER_NAME, serviceGroupName, null, "NODEMANAGER", "NODEMANAGER", HOST1, null));
 
     amc.createHostComponents(componentHostRequests);
 
@@ -9792,30 +9792,30 @@ public class AmbariManagementControllerTest {
     s1.getServiceComponent(componentName2).getServiceComponentHost(host2).updateActualConfigs(actualConfigOld);
     s1.getServiceComponent(componentName3).getServiceComponentHost(host2).updateActualConfigs(actualConfig);
 
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(5, resps.size());
 
     // Get all host components with stale config = true
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setStaleConfig("true");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     // Get all host components with stale config = false
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, null, null);
     r.setStaleConfig("false");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(3, resps.size());
 
     // Get all host components with stale config = false and hostname filter
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host1, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host1, null);
     r.setStaleConfig("false");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(2, resps.size());
 
     // Get all host components with stale config = false and hostname filter
-    r = new ServiceComponentHostRequest(cluster1, null, null, null, host2, null);
+    r = new ServiceComponentHostRequest(cluster1, null, null, null, null, host2, null);
     r.setStaleConfig("true");
     resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
@@ -10010,7 +10010,7 @@ public class AmbariManagementControllerTest {
     startService(cluster1, serviceGroupName, serviceName, false, false);
 
     ServiceComponentHostRequest req = new ServiceComponentHostRequest(cluster1, serviceGroupName, serviceName,
-        componentName1, host1, "INSTALLED");
+        componentName1, componentName1, host1, "INSTALLED");
 
     Map<String, String> requestProperties = new HashMap<>();
     requestProperties.put("namenode", "p1");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
@@ -224,13 +224,13 @@ public class BackgroundCustomCommandExecutionTest {
   private void createServiceComponent(String clusterName, String serviceGroupName,
       String serviceName, String componentName, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
@@ -106,7 +106,7 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
     controller.updateClusters(Collections.singleton(cr) , null);
 
 
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null, null);
     r.setStaleConfig("true");
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
@@ -127,7 +127,7 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
     controller.updateClusters(Collections.singleton(cr) , null);
 
 
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null, null);
     r.setStaleConfig("true");
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(4, resps.size());
@@ -215,13 +215,13 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
   private void createServiceComponent(String clusterName, String serviceGroupName,
       String serviceName, String componentName, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
     controller.createHostComponents(Collections.singleton(r));
 
     //set actual config

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
@@ -245,7 +245,7 @@ public class ClientConfigResourceProviderTest {
     serviceOsSpecificHashMap.put("key", osSpecific);
 
     ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, clusterName, 1L, "CORE", 1L, serviceName, serviceName, 1L,
-        componentName, displayName, hostName, publicHostname, desiredState, "", null, null, null,
+        componentName, componentName, displayName, hostName, publicHostname, desiredState, "", null, null, null,
         null);
 
     Set<ServiceComponentHostResponse> responses = new LinkedHashSet<>();
@@ -502,7 +502,7 @@ public class ClientConfigResourceProviderTest {
     serviceOsSpecificHashMap.put("key", osSpecific);
 
     ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, clusterName, 1L, "CORE", 1L, serviceName, serviceName, 1L,
-        componentName, displayName, hostName, publicHostName, desiredState, "", null, null, null,
+        componentName, componentName, displayName, hostName, publicHostName, desiredState, "", null, null, null,
         null);
 
     Set<ServiceComponentHostResponse> responses = new LinkedHashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -152,7 +152,7 @@ public class ComponentResourceProviderTest {
     expect(componentInfo.isRecoveryEnabled()).andReturn(true).anyTimes();
     expect(ambariMetaInfo.getComponent("HDP", "99", "Service100", "Component100")).andReturn(componentInfo).anyTimes();
 
-    expect(serviceComponentFactory.createNew(service, "Component100")).andReturn(serviceComponent);
+    expect(serviceComponentFactory.createNew(service, "Component100", "Component100")).andReturn(serviceComponent);
 
     ServiceComponentResponse componentResponse = createNiceMock(ServiceComponentResponse.class);
     expect(serviceComponent.convertToResponse()).andReturn(componentResponse);
@@ -251,13 +251,13 @@ public class ComponentResourceProviderTest {
     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
 
     expect(serviceComponent1.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component100", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 1L, "Component100", "Component100", stackId, "", serviceComponentStateCountMap,
               true /* recovery enabled */, "Component100 Client", null, null));
     expect(serviceComponent2.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component101", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 2L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component101 Client", null, null));
     expect(serviceComponent3.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component102", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 3L, "Component102", "Component102", stackId, "", serviceComponentStateCountMap,
               true /* recovery enabled */, "Component102 Client", "1.1", RepositoryVersionState.CURRENT));
 
     expect(ambariMetaInfo.getComponent("FOO", "1.0", null, "Component100")).andReturn(
@@ -431,13 +431,13 @@ public class ComponentResourceProviderTest {
     expect(component3Info.getCategory()).andReturn(null);
 
     expect(serviceComponent1.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component101", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component101 Client", null, null));
     expect(serviceComponent2.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component102", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 2L, "Component102", "Component102",stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component102 Client", null, null));
     expect(serviceComponent3.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component103", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 3L, "Component103", "Component103", stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component103 Client", null, null));
     expect(serviceComponent1.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
     expect(serviceComponent2.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
@@ -740,7 +740,7 @@ public class ComponentResourceProviderTest {
     expect(component1Info.getCategory()).andReturn(null);
 
     expect(serviceComponent1.convertToResponse()).andReturn(
-        new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component101", stackId, "", serviceComponentStateCountMap,
+        new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
             false /* recovery not enabled */, "Component101 Client", null, null));
     expect(serviceComponent1.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
@@ -112,7 +112,7 @@ public class HostComponentResourceProviderTest {
 
     AbstractControllerResourceProvider.init(resourceProviderFactory);
 
-    ServiceComponentHostRequest request = new ServiceComponentHostRequest("Cluster100", SERVICE_GROUP_NAME, "Service100", "Component100", "Host100", null);
+    ServiceComponentHostRequest request = new ServiceComponentHostRequest("Cluster100", SERVICE_GROUP_NAME, "Service100", "Component100", "Component100", "Host100", null);
     Set<ServiceComponentHostRequest> expectedRequests = Collections.singleton(request);
     expect(managementController.createHostComponents(eq(expectedRequests))).andReturn(null).once();
 
@@ -183,17 +183,17 @@ public class HostComponentResourceProviderTest {
     String repositoryVersion2 = "0.2-1234";
 
     allResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
+        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100", "Host100", "Host100",
         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
         stackId2.getStackId(), repositoryVersion2, null));
 
     allResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component 101", "Host100", "Host100",
+        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", "Component 101", "Host100", "Host100",
         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
         stackId2.getStackId(), repositoryVersion2, null));
 
     allResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102", "Host100", "Host100",
+        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102", "Host100", "Host100",
         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
         stackId2.getStackId(), repositoryVersion2, null));
 
@@ -350,7 +350,7 @@ public class HostComponentResourceProviderTest {
 
     Set<ServiceComponentHostResponse> nameResponse = new HashSet<>();
     nameResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
+        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100","Component 100", "Host100", "Host100",
         "INSTALLED", "", "", "", "", null));
 
     // set expectations
@@ -450,7 +450,7 @@ public class HostComponentResourceProviderTest {
         new HostComponentResourceProvider(managementController, injector);
 
     // set expectations
-    ServiceComponentHostRequest request = new ServiceComponentHostRequest(null, null, null, "Component100", "Host100", null);
+    ServiceComponentHostRequest request = new ServiceComponentHostRequest(null, null, null, "Component100", "Component100", "Host100", null);
     expect(managementController.deleteHostComponents(Collections.singleton(request))).andReturn(deleteStatusMetaData);
 
     // replay
@@ -535,7 +535,7 @@ public class HostComponentResourceProviderTest {
 
     Set<ServiceComponentHostResponse> nameResponse = new HashSet<>();
     nameResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
+        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100", "Host100", "Host100",
         "INSTALLED", "", "", "", "", null));
 
     // set expectations

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
@@ -314,11 +314,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100","Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -409,11 +409,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -501,11 +501,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100",  "Component100","Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "INSTALLED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103",  "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -688,7 +688,7 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -772,11 +772,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "INSTALLED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
@@ -123,14 +123,14 @@ public class JMXHostProviderTest {
   private void createServiceComponent(String clusterName, String serviceGroupName,
                                       String serviceName, String componentName, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(String clusterName, String serviceGroupName,
                                           String serviceName, String componentName, String hostname,
                                           State desiredState) throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
@@ -256,7 +256,7 @@ public class ServiceDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
-            serviceName, componentName, dStateStr);
+            serviceName, componentName, componentName, dStateStr);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
@@ -269,7 +269,7 @@ public class ServiceDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
-            serviceName, componentName, hostname, dStateStr);
+            serviceName, componentName, componentName, hostname, dStateStr);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
@@ -251,7 +251,7 @@ public class ServiceGroupDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
-            serviceName, componentName, dStateStr);
+            serviceName, componentName, componentName, dStateStr);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
@@ -264,7 +264,7 @@ public class ServiceGroupDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
-            serviceName, componentName, hostname, dStateStr);
+            serviceName, componentName, componentName, hostname, dStateStr);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
@@ -142,22 +142,22 @@ public class StackDefinedPropertyProviderTest {
     RepositoryVersionEntity repositoryVersion = helper.getOrCreateRepositoryVersion(stackId, stackId.getStackVersion());
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service service = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
-    service.addServiceComponent("NAMENODE");
-    service.addServiceComponent("DATANODE");
-    service.addServiceComponent("JOURNALNODE");
+    service.addServiceComponent("NAMENODE", "NAMENODE");
+    service.addServiceComponent("DATANODE", "DATANODE");
+    service.addServiceComponent("JOURNALNODE", "JOURNALNODE");
 
     service = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
-    service.addServiceComponent("RESOURCEMANAGER");
+    service.addServiceComponent("RESOURCEMANAGER", "RESOURCEMANAGER");
 
     service = cluster.addService(serviceGroup, "HBASE", "HBASE", repositoryVersion);
-    service.addServiceComponent("HBASE_MASTER");
-    service.addServiceComponent("HBASE_REGIONSERVER");
+    service.addServiceComponent("HBASE_MASTER", "HBASE_MASTER");
+    service.addServiceComponent("HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
 
     stackId = new StackId("HDP-2.1.1");
     repositoryVersion = helper.getOrCreateRepositoryVersion(stackId, stackId.getStackVersion());
 
     service = cluster.addService(serviceGroup, "STORM", "STORM", repositoryVersion);
-    service.addServiceComponent("STORM_REST_API");
+    service.addServiceComponent("STORM_REST_API", "STORM_REST_API");
 
     clusters.addHost("h1");
     Host host = clusters.getHost("h1");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
@@ -177,11 +177,11 @@ public class UpgradeSummaryResourceProviderTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service service = cluster.addService(serviceGroup, "ZOOKEEPER", "ZOOKEEPER", repoVersionEntity);
 
-    ServiceComponent component = service.addServiceComponent("ZOOKEEPER_SERVER");
+    ServiceComponent component = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
     ServiceComponentHost sch = component.addServiceComponentHost("h1");
     sch.setVersion("2.2.0.0");
 
-    component = service.addServiceComponent("ZOOKEEPER_CLIENT");
+    component = service.addServiceComponent("ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
     sch = component.addServiceComponentHost("h1");
     sch.setVersion("2.2.0.0");
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
@@ -43,8 +43,8 @@ public final class DefaultServiceCalculatedStateTest extends GeneralServiceCalcu
 
   @Override
   protected void createComponentsAndHosts() throws Exception{
-    ServiceComponent masterComponent = service.addServiceComponent("ZOOKEEPER_SERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("ZOOKEEPER_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
@@ -41,7 +41,7 @@ public class FlumeServiceCalculatedStateTest extends GeneralServiceCalculatedSta
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("FLUME_HANDLER");
+    ServiceComponent masterComponent = service.addServiceComponent("FLUME_HANDLER", "FLUME_HANDLER");
 
 
     for (String hostName: hosts){

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
@@ -41,9 +41,9 @@ public class HBaseServiceCalculatedStateTest extends GeneralServiceCalculatedSta
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("HBASE_MASTER");
-    ServiceComponent secondMasterComponent = service.addServiceComponent("HBASE_REGIONSERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("HBASE_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("HBASE_MASTER", "HBASE_MASTER");
+    ServiceComponent secondMasterComponent = service.addServiceComponent("HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("HBASE_CLIENT", "HBASE_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
@@ -42,9 +42,9 @@ public class HDFSServiceCalculatedStateTest extends GeneralServiceCalculatedStat
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("NAMENODE");
-    ServiceComponent masterComponent1 = service.addServiceComponent("SECONDARY_NAMENODE");
-    ServiceComponent clientComponent = service.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("NAMENODE", "NAMENODE");
+    ServiceComponent masterComponent1 = service.addServiceComponent("SECONDARY_NAMENODE", "SECONDARY_NAMENODE");
+    ServiceComponent clientComponent = service.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
@@ -42,11 +42,11 @@ public class HiveServiceCalculatedStateTest extends GeneralServiceCalculatedStat
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("HIVE_METASTORE");
-    ServiceComponent secondMasterComponent = service.addServiceComponent("HIVE_SERVER");
-    ServiceComponent thirdMasterComponent = service.addServiceComponent("WEBHCAT_SERVER");
-    ServiceComponent fourMasterComponent = service.addServiceComponent("MYSQL_SERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("HIVE_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("HIVE_METASTORE", "HIVE_METASTORE");
+    ServiceComponent secondMasterComponent = service.addServiceComponent("HIVE_SERVER", "HIVE_SERVER");
+    ServiceComponent thirdMasterComponent = service.addServiceComponent("WEBHCAT_SERVER", "WEBHCAT_SERVER");
+    ServiceComponent fourMasterComponent = service.addServiceComponent("MYSQL_SERVER", "MYSQL_SERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("HIVE_CLIENT", "HIVE_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
@@ -41,8 +41,8 @@ public class OozieServiceCalculatedStateTest extends GeneralServiceCalculatedSta
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("OOZIE_SERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("OOZIE_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("OOZIE_SERVER", "OOZIE_SERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("OOZIE_CLIENT", "OOZIE_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
@@ -42,9 +42,9 @@ public class YarnServiceCalculatedStateTest extends GeneralServiceCalculatedStat
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("RESOURCEMANAGER");
-    ServiceComponent secondMasterComponent = service.addServiceComponent("NODEMANAGER");
-    ServiceComponent clientComponent = service.addServiceComponent("YARN_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("RESOURCEMANAGER", "RESOURCEMANAGER");
+    ServiceComponent secondMasterComponent = service.addServiceComponent("NODEMANAGER", "NODEMANAGER");
+    ServiceComponent clientComponent = service.addServiceComponent("YARN_CLIENT", "YARN_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
@@ -366,7 +366,7 @@ public class EventsTest {
     Service service = m_cluster.getService(serviceName);
     Assert.assertNotNull(service);
 
-    ServiceComponent component = m_componentFactory.createNew(service, "DATANODE");
+    ServiceComponent component = m_componentFactory.createNew(service, "DATANODE", "DATANODE");
     service.addServiceComponent(component);
     component.setDesiredState(State.INSTALLED);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
@@ -558,7 +558,7 @@ public class HostVersionOutOfSyncListenerTest {
     for (Map.Entry<String, List<Integer>> component : topology.entrySet()) {
 
       String componentName = component.getKey();
-      cl.getService(serviceName).addServiceComponent(componentName);
+      cl.getService(serviceName).addServiceComponent(componentName, componentName);
 
       for (Integer hostIndex : component.getValue()) {
         cl.getService(serviceName)
@@ -580,7 +580,7 @@ public class HostVersionOutOfSyncListenerTest {
     Service service = cl.getService(serviceName);
 
     if (!service.getServiceComponents().containsKey(componentName)) {
-      service.addServiceComponent(componentName);
+      service.addServiceComponent(componentName, componentName);
     }
 
     ServiceComponent component = service.getServiceComponent(componentName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
@@ -469,7 +469,7 @@ public class OrmTestHelper {
     Service service = cluster.getService(serviceName);
     assertNotNull(service);
 
-    ServiceComponent datanode = componentFactory.createNew(service, "DATANODE");
+    ServiceComponent datanode = componentFactory.createNew(service, "DATANODE", "DATANODE");
 
     service.addServiceComponent(datanode);
     datanode.setDesiredState(State.INSTALLED);
@@ -480,7 +480,7 @@ public class OrmTestHelper {
     sch.setDesiredState(State.INSTALLED);
     sch.setState(State.INSTALLED);
 
-    ServiceComponent namenode = componentFactory.createNew(service, "NAMENODE");
+    ServiceComponent namenode = componentFactory.createNew(service, "NAMENODE", "NAMENODE");
 
     service.addServiceComponent(namenode);
     namenode.setDesiredState(State.INSTALLED);
@@ -504,7 +504,7 @@ public class OrmTestHelper {
     assertNotNull(service);
 
     ServiceComponent resourceManager = componentFactory.createNew(service,
-        "RESOURCEMANAGER");
+        "RESOURCEMANAGER", "RESOURCEMANAGER");
 
     service.addServiceComponent(resourceManager);
     resourceManager.setDesiredState(State.INSTALLED);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
@@ -511,7 +511,7 @@ public class ComponentVersionCheckActionTest {
     try {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
-      serviceComponent = serviceComponentFactory.createNew(service, componentName);
+      serviceComponent = serviceComponentFactory.createNew(service, componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
@@ -269,7 +269,7 @@ public class CreateAndConfigureActionTest {
     try {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
-      serviceComponent = serviceComponentFactory.createNew(service, componentName);
+      serviceComponent = serviceComponentFactory.createNew(service, componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
@@ -116,7 +116,7 @@ public class ServiceComponentTest {
   public void testCreateServiceComponent() throws AmbariException {
     String componentName = "DATANODE2";
     ServiceComponent component = serviceComponentFactory.createNew(service,
-        componentName);
+        componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -138,7 +138,7 @@ public class ServiceComponentTest {
   public void testGetAndSetServiceComponentInfo() throws AmbariException {
     String componentName = "NAMENODE";
     ServiceComponent component = serviceComponentFactory.createNew(service,
-        componentName);
+        componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -162,7 +162,7 @@ public class ServiceComponentTest {
     long serviceId = 1;
 
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     ServiceComponent sc1 = serviceComponentFactory.createExisting(service,
         serviceComponentDesiredStateEntity);
@@ -200,7 +200,7 @@ public class ServiceComponentTest {
   @Test
   public void testAddAndGetServiceComponentHosts() throws AmbariException {
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -253,18 +253,19 @@ public class ServiceComponentTest {
 
     long serviceGroupId = 1;
     long serviceId = 1;
+    long componentId = 1;
 
     HostComponentDesiredStateEntity desiredStateEntity =
         desiredStateDAO.findByIndex(
           cluster.getClusterId(),
           serviceGroupId,
-                serviceId,
-          componentName,
+          serviceId,
+          componentId,
           hostEntity1.getHostId()
         );
 
     HostComponentStateEntity stateEntity = liveStateDAO.findByIndex(cluster.getClusterId(),
-            serviceGroupId, serviceId, componentName, hostEntity1.getHostId());
+            serviceGroupId, serviceId, componentId, hostEntity1.getHostId());
 
     ServiceComponentHost sch = serviceComponentHostFactory.createExisting(sc,
         stateEntity, desiredStateEntity);
@@ -278,7 +279,7 @@ public class ServiceComponentTest {
   @Test
   public void testConvertToResponse() throws AmbariException {
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     addHostToCluster("h1", service.getCluster().getClusterName());
@@ -339,7 +340,7 @@ public class ServiceComponentTest {
   public void testCanBeRemoved() throws Exception {
     String componentName = "NAMENODE";
     ServiceComponent component = serviceComponentFactory.createNew(service,
-                                                                   componentName);
+                                                                   componentName, componentName);
     addHostToCluster("h1", service.getCluster().getClusterName());
     ServiceComponentHost sch = serviceComponentHostFactory.createNew(component, "h1");
     component.addServiceComponentHost(sch);
@@ -367,7 +368,7 @@ public class ServiceComponentTest {
         ServiceComponentDesiredStateDAO.class);
 
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -380,7 +381,7 @@ public class ServiceComponentTest {
     long serviceId = 1;
 
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     Assert.assertNotNull(serviceComponentDesiredStateEntity);
 
@@ -420,7 +421,7 @@ public class ServiceComponentTest {
 
     // verify history is gone, too
     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     Assert.assertNull(serviceComponentDesiredStateEntity);
  }
@@ -431,7 +432,7 @@ public class ServiceComponentTest {
         ServiceComponentDesiredStateDAO.class);
 
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -444,7 +445,7 @@ public class ServiceComponentTest {
     long serviceId = 1;
 
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     StackDAO stackDAO = injector.getInstance(StackDAO.class);
     StackEntity stackEntity = stackDAO.find("HDP", "2.2.0");
@@ -475,7 +476,7 @@ public class ServiceComponentTest {
         serviceComponentDesiredStateEntity);
 
     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     assertEquals(1, serviceComponentDesiredStateEntity.getVersions().size());
     ServiceComponentVersionEntity persistedVersion = serviceComponentDesiredStateEntity.getVersions().iterator().next();
@@ -489,7 +490,7 @@ public class ServiceComponentTest {
         ServiceComponentDesiredStateDAO.class);
 
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -502,7 +503,7 @@ public class ServiceComponentTest {
     long serviceId = 1;
 
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     StackDAO stackDAO = injector.getInstance(StackDAO.class);
     StackEntity stackEntity = stackDAO.find("HDP", "2.2.0");
@@ -532,7 +533,7 @@ public class ServiceComponentTest {
         serviceComponentDesiredStateEntity);
 
     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     assertEquals(1, serviceComponentDesiredStateEntity.getVersions().size());
     ServiceComponentVersionEntity persistedVersion = serviceComponentDesiredStateEntity.getVersions().iterator().next();
@@ -542,7 +543,7 @@ public class ServiceComponentTest {
     sc.delete();
 
     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
     Assert.assertNull(serviceComponentDesiredStateEntity);
 
 
@@ -559,7 +560,7 @@ public class ServiceComponentTest {
 
     String componentName = "NAMENODE";
 
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
 
     StackId newStackId = new StackId("HDP-2.2.0");
     RepositoryVersionEntity repositoryVersion = helper.getOrCreateRepositoryVersion(newStackId,
@@ -575,7 +576,8 @@ public class ServiceComponentTest {
     long serviceGroupId = 1;
     long serviceId = 1;
 
-    ServiceComponentDesiredStateEntity entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+    ServiceComponentDesiredStateEntity entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(),
+            serviceGroupId, serviceId, componentName, componentName);
 
     RepositoryVersionEntity repoVersion2201 = helper.getOrCreateRepositoryVersion(
         component.getDesiredStackId(), "2.2.0.1");
@@ -597,7 +599,7 @@ public class ServiceComponentTest {
     sch1.setVersion("2.2.0.1");
     sch2.setVersion("2.2.0.2");
     sc.updateRepositoryState("2.2.0.2");
-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
 
     // !!! case 2: component desired is UNKNOWN, all h-c same version
@@ -605,7 +607,7 @@ public class ServiceComponentTest {
     sch1.setVersion("2.2.0.1");
     sch2.setVersion("2.2.0.1");
     sc.updateRepositoryState("2.2.0.1");
-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
 
     // !!! case 3: component desired is known, any component reports different version
@@ -613,7 +615,7 @@ public class ServiceComponentTest {
     sch1.setVersion("2.2.0.1");
     sch2.setVersion("2.2.0.2");
     sc.updateRepositoryState("2.2.0.2");
-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
 
     // !!! case 4: component desired is known, component reports same as desired, mix of h-c versions
@@ -621,7 +623,7 @@ public class ServiceComponentTest {
     sch1.setVersion("2.2.0.1");
     sch2.setVersion("2.2.0.2");
     sc.updateRepositoryState("2.2.0.1");
-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
     assertEquals(RepositoryVersionState.OUT_OF_SYNC, entity.getRepositoryState());
 
     // !!! case 5: component desired is known, component reports same as desired, all h-c the same
@@ -629,7 +631,7 @@ public class ServiceComponentTest {
     sch1.setVersion("2.2.0.1");
     sch2.setVersion("2.2.0.1");
     sc.updateRepositoryState("2.2.0.1");
-    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+    entity = serviceComponentDesiredStateDAO.findByName(cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
     assertEquals(RepositoryVersionState.CURRENT, entity.getRepositoryState());
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
@@ -100,7 +100,7 @@ public class ServiceTest {
       org.junit.Assert.assertTrue(service.canBeRemoved());
     }
 
-    ServiceComponent component = service.addServiceComponent("NAMENODE");
+    ServiceComponent component = service.addServiceComponent("NAMENODE", "NAMENODE");
 
     // component can be removed
     component.setDesiredState(State.INSTALLED);
@@ -179,11 +179,11 @@ public class ServiceTest {
     Assert.assertTrue(s.getServiceComponents().isEmpty());
 
     ServiceComponent sc1 =
-        serviceComponentFactory.createNew(s, "NAMENODE");
+        serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     ServiceComponent sc2 =
-        serviceComponentFactory.createNew(s, "DATANODE1");
+        serviceComponentFactory.createNew(s, "DATANODE1", "DATANODE1");
     ServiceComponent sc3 =
-        serviceComponentFactory.createNew(s, "DATANODE2");
+        serviceComponentFactory.createNew(s, "DATANODE2", "DATANODE2");
 
     Map<String, ServiceComponent> comps = new
       HashMap<>();
@@ -205,7 +205,7 @@ public class ServiceTest {
 
     s.addServiceComponent(sc3);
 
-    ServiceComponent sc4 = s.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent sc4 = s.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
     Assert.assertNotNull(s.getServiceComponent(sc4.getName()));
     Assert.assertEquals(State.INIT,
         s.getServiceComponent("HDFS_CLIENT").getDesiredState());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
@@ -595,7 +595,7 @@ public class ClusterDeadlockTest {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
@@ -237,20 +237,20 @@ public class ClusterImplTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
 
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
+    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
     nameNode.addServiceComponentHost(hostName1);
 
-    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE");
+    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE", "DATANODE");
     dataNode.addServiceComponentHost(hostName1);
     dataNode.addServiceComponentHost(hostName2);
 
-    ServiceComponent hdfsClient = hdfs.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent hdfsClient = hdfs.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
     hdfsClient.addServiceComponentHost(hostName1);
     hdfsClient.addServiceComponentHost(hostName2);
 
     Service tez = cluster.addService(serviceGroup, serviceToDelete, serviceToDelete, repositoryVersion);
 
-    ServiceComponent tezClient = tez.addServiceComponent("TEZ_CLIENT");
+    ServiceComponent tezClient = tez.addServiceComponent("TEZ_CLIENT", "TEZ_CLIENT");
     ServiceComponentHost tezClientHost1 =  tezClient.addServiceComponentHost(hostName1);
     ServiceComponentHost tezClientHost2 = tezClient.addServiceComponentHost(hostName2);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
@@ -343,22 +343,22 @@ public class ClusterTest {
     cluster.addService(s3);
 
     // Add HDFS components
-    ServiceComponent sc1CompA = serviceComponentFactory.createNew(s1, "NAMENODE");
-    ServiceComponent sc1CompB = serviceComponentFactory.createNew(s1, "DATANODE");
-    ServiceComponent sc1CompC = serviceComponentFactory.createNew(s1, "HDFS_CLIENT");
+    ServiceComponent sc1CompA = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
+    ServiceComponent sc1CompB = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
+    ServiceComponent sc1CompC = serviceComponentFactory.createNew(s1, "HDFS_CLIENT", "HDFS_CLIENT");
     s1.addServiceComponent(sc1CompA);
     s1.addServiceComponent(sc1CompB);
     s1.addServiceComponent(sc1CompC);
 
     // Add ZK
-    ServiceComponent sc2CompA = serviceComponentFactory.createNew(s2, "ZOOKEEPER_SERVER");
-    ServiceComponent sc2CompB = serviceComponentFactory.createNew(s2, "ZOOKEEPER_CLIENT");
+    ServiceComponent sc2CompA = serviceComponentFactory.createNew(s2, "ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+    ServiceComponent sc2CompB = serviceComponentFactory.createNew(s2, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
     s2.addServiceComponent(sc2CompA);
     s2.addServiceComponent(sc2CompB);
 
     // Add Ganglia
-    ServiceComponent sc3CompA = serviceComponentFactory.createNew(s3, "GANGLIA_SERVER");
-    ServiceComponent sc3CompB = serviceComponentFactory.createNew(s3, "GANGLIA_MONITOR");
+    ServiceComponent sc3CompA = serviceComponentFactory.createNew(s3, "GANGLIA_SERVER", "GANGLIA_SERVER");
+    ServiceComponent sc3CompB = serviceComponentFactory.createNew(s3, "GANGLIA_MONITOR", "GANGLIA_MONITOR");
     s3.addServiceComponent(sc3CompA);
     s3.addServiceComponent(sc3CompB);
 
@@ -633,7 +633,7 @@ public class ClusterTest {
 
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s);
-    ServiceComponent sc = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent sc = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(sc);
 
     ServiceComponentHost sch =
@@ -651,7 +651,7 @@ public class ClusterTest {
         iterator.next();
         Service s1 = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "PIG", "PIG", repositoryVersion);
         c1.addService(s1);
-        ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "PIG");
+        ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "PIG", "PIG");
         s1.addServiceComponent(sc1);
         ServiceComponentHost sch1 = serviceComponentHostFactory.createNew(sc1, "h1");
         sc1.addServiceComponentHost(sch1);
@@ -673,12 +673,12 @@ public class ClusterTest {
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
     s.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
@@ -703,12 +703,12 @@ public class ClusterTest {
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
     s.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
@@ -739,12 +739,12 @@ public class ClusterTest {
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(),  "HDFS",  "HDFS", repositoryVersion);
     c1.addService(s);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
     s.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
@@ -776,19 +776,19 @@ public class ClusterTest {
     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
     c1.addService(sfMR);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
     sfHDFS.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
     sfHDFS.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
     scDN.addServiceComponentHost(scDNH2);
 
-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
+    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
     sfMR.addServiceComponent(scJT);
     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
     scJT.addServiceComponentHost(schJTH1);
@@ -834,19 +834,19 @@ public class ClusterTest {
     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
     c1.addService(sfMR);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
     sfHDFS.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
     sfHDFS.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
     scDN.addServiceComponentHost(scDNH2);
 
-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
+    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
     sfMR.addServiceComponent(scJT);
     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
     scJT.addServiceComponentHost(schJTH1);
@@ -893,19 +893,19 @@ public class ClusterTest {
     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
     c1.addService(sfMR);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
     sfHDFS.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
     sfHDFS.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
     scDN.addServiceComponentHost(scDNH2);
 
-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
+    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
     sfMR.addServiceComponent(scJT);
     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
     scJT.addServiceComponentHost(schJTH1);
@@ -1076,7 +1076,7 @@ public class ClusterTest {
     c1.addService(serviceGroup, "MAPREDUCE", "MAPREDUCE", repositoryVersion);
 
     Service hdfs = c1.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
+    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
 
     assertEquals(2, c1.getServices().size());
     assertEquals(2, injector.getProvider(EntityManager.class).get().
@@ -1541,8 +1541,8 @@ public class ClusterTest {
     c1.addService(hdfs);
 
     // Add HDFS components
-    ServiceComponent datanode = serviceComponentFactory.createNew(hdfs, "NAMENODE");
-    ServiceComponent namenode = serviceComponentFactory.createNew(hdfs, "DATANODE");
+    ServiceComponent datanode = serviceComponentFactory.createNew(hdfs, "NAMENODE", "NAMENODE");
+    ServiceComponent namenode = serviceComponentFactory.createNew(hdfs, "DATANODE", "DATANODE");
     hdfs.addServiceComponent(datanode);
     hdfs.addServiceComponent(namenode);
 
@@ -1874,12 +1874,12 @@ public class ClusterTest {
 
     ServiceGroup serviceGroup = c1.addServiceGroup("CORE", stackId.getStackId());
     Service service = c1.addService(serviceGroup, "ZOOKEEPER", "ZOOKEEPER", repositoryVersion);
-    ServiceComponent sc = service.addServiceComponent("ZOOKEEPER_SERVER");
+    ServiceComponent sc = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
     sc.addServiceComponentHost("h-1");
     sc.addServiceComponentHost("h-2");
 
     service = c1.addService(serviceGroup, "SQOOP", "SQOOP", repositoryVersion);
-    sc = service.addServiceComponent("SQOOP");
+    sc = service.addServiceComponent("SQOOP", "SQOOP");
     sc.addServiceComponentHost("h-3");
 
     HostEntity hostEntity = hostDAO.findByName("h-3");

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
@@ -374,7 +374,7 @@ public class ClustersDeadlockTest {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
@@ -432,10 +432,10 @@ public class ClustersTest {
 
     //Assert.assertNotNull(injector.getInstance(ClusterServiceDAO.class).findByClusterAndServiceNames(c1, "HDFS"));
 
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
-    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE");
+    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
+    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE", "DATANODE");
 
-    ServiceComponent serviceCheckNode = hdfs.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent serviceCheckNode = hdfs.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
 
     ServiceComponentHost nameNodeHost = nameNode.addServiceComponentHost(h1);
     HostEntity nameNodeHostEntity = hostDAO.findByName(nameNodeHost.getHostName());
@@ -448,13 +448,13 @@ public class ClustersTest {
 
     Assert.assertNotNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
       nameNodeHost.getClusterId(), 1L, 1L,
-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()));
+      nameNodeHost.getServiceComponentId(),  nameNodeHostEntity.getHostId()));
 
     Assert.assertNotNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(
       nameNodeHost.getClusterId(),
       1L,
       1L,
-      nameNodeHost.getServiceComponentName(),
+      nameNodeHost.getServiceComponentId(),
       nameNodeHostEntity.getHostId()
     ));
     Assert.assertEquals(2, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config").getResultList().size());
@@ -492,11 +492,11 @@ public class ClustersTest {
     Assert.assertEquals(2, hostDAO.findAll().size());
     Assert.assertNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
       nameNodeHost.getClusterId(), 1L, 1L,
-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()));
+      nameNodeHost.getServiceComponentId(), nameNodeHostEntity.getHostId()));
 
     Assert.assertNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(
       nameNodeHost.getClusterId(), 1L, 1L,
-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()
+      nameNodeHost.getServiceComponentId(), nameNodeHostEntity.getHostId()
     ));
     Assert.assertEquals(0, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config").getResultList().size());
     Assert.assertEquals(0, injector.getProvider(EntityManager.class).get().createQuery("SELECT state FROM ClusterStateEntity state").getResultList().size());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
@@ -243,7 +243,7 @@ public class ConcurrentServiceConfigVersionTest {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
@@ -139,7 +139,7 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
     clusters.mapHostToCluster(hostName, "c1");
 
     Service service = installService("HDFS");
-    addServiceComponent(service, "NAMENODE");
+    addServiceComponent(service, "NAMENODE", "NAMENODE");
   }
 
   @After
@@ -151,8 +151,8 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
    */
   @Test()
   public void testConcurrentWriteDeadlock() throws Exception {
-    ServiceComponentHost nameNodeSCH = createNewServiceComponentHost("HDFS", "NAMENODE", "c6401");
-    ServiceComponentHost dataNodeSCH = createNewServiceComponentHost("HDFS", "DATANODE", "c6401");
+    ServiceComponentHost nameNodeSCH = createNewServiceComponentHost("HDFS", "NAMENODE", "NAMENODE", "c6401");
+    ServiceComponentHost dataNodeSCH = createNewServiceComponentHost("HDFS", "DATANODE", "DATANODE", "c6401");
 
     List<ServiceComponentHost> serviceComponentHosts = new ArrayList<>();
     serviceComponentHosts.add(nameNodeSCH);
@@ -229,10 +229,10 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
   }
 
   private ServiceComponentHost createNewServiceComponentHost(String svc,
-      String svcComponent, String hostName) throws AmbariException {
+      String svcComponentName, String svcComponentType, String hostName) throws AmbariException {
     Assert.assertNotNull(cluster.getConfigGroups());
     Service s = installService(svc);
-    ServiceComponent sc = addServiceComponent(s, svcComponent);
+    ServiceComponent sc = addServiceComponent(s, svcComponentName, svcComponentType);
 
     ServiceComponentHost sch = serviceComponentHostFactory.createNew(sc, hostName);
 
@@ -258,13 +258,13 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
   }
 
   private ServiceComponent addServiceComponent(Service service,
-      String componentName) throws AmbariException {
+      String componentName, String svcComponentType) throws AmbariException {
     ServiceComponent serviceComponent = null;
     try {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, svcComponentType);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
@@ -202,7 +202,7 @@ public class ServiceComponentHostTest {
     try {
       sc = s.getServiceComponent(svcComponent);
     } catch (ServiceComponentNotFoundException e) {
-      sc = serviceComponentFactory.createNew(s, svcComponent);
+      sc = serviceComponentFactory.createNew(s, svcComponent, svcComponent);
       s.addServiceComponent(sc);
     }
 
@@ -1057,7 +1057,7 @@ public class ServiceComponentHostTest {
       cluster.getClusterId(),
       customServiceGroup.getServiceGroupId(),
       sch1.getServiceId(),
-      sch1.getServiceComponentName(),
+      sch1.getServiceComponentId(),
       hostEntity.getHostId()
     );
     Assert.assertEquals(MaintenanceState.OFF, entity.getMaintenanceState());
@@ -1070,7 +1070,7 @@ public class ServiceComponentHostTest {
       cluster.getClusterId(),
       customServiceGroup.getServiceGroupId(),
       sch1.getServiceId(),
-      sch1.getServiceComponentName(),
+      sch1.getServiceComponentId(),
       hostEntity.getHostId()
     );
     Assert.assertEquals(MaintenanceState.ON, entity.getMaintenanceState());

--- a/ambari-web/app/controllers/wizard/step8_controller.js
+++ b/ambari-web/app/controllers/wizard/step8_controller.js
@@ -1051,7 +1051,7 @@ App.WizardStep8Controller = Em.Controller.extend(App.AddSecurityConfigs, App.wiz
     this.get('selectedServices').forEach(function (_service) {
       var serviceName = _service.get('serviceName');
       var componentsData = serviceComponents.filterProperty('serviceName', serviceName).map(function (_component) {
-        return { "ServiceComponentInfo": { "component_name": _component.get('componentName') } };
+        return { "ServiceComponentInfo": { "component_name": _component.get('componentName'), "component_type": _component.get('componentName') } };
       });
 
       // Service must be specified in terms of a query for creating multiple components at the same time.
@@ -1459,7 +1459,8 @@ App.WizardStep8Controller = Em.Controller.extend(App.AddSecurityConfigs, App.wiz
         "host_components": [
           {
             "HostRoles": {
-              "component_name": componentName
+              "component_name": componentName,
+              "component_type": componentName
             }
           }
         ]

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -1432,7 +1432,8 @@ var urls = {
           "components": [
             {
               "ServiceComponentInfo": {
-                "component_name": data.componentName
+                "component_name": data.componentName,
+                "component_type": data.componentName
               }
             }
           ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

**BACKGROUND:**

Given that in Ambari, we refer components of a services in 2 ways: 

  - **1.** One from the Service component APIs : 
    **http://<AmbariServerHost>:8080/api/v1/clusters/<clusterName>/services/<ServiceName>/components/<componentName>**

  - **2.** From the host component APIs (which tell us the host on which the current component is resides)
    **http://<AmbariServerHost>:8080/api/v1/clusters/<clusterName>/hosts/<hostName>/host_components/<hostComponentName>**

_Note that, we of now, we are referring both 1and 2 using the component names_

But in the multi-component world for Ambari, we will come up with a situation like this, as shown below:

 - **A.** If **core** _Service Group_ has its **HDFS_CLIENT** type component named as **HDFS_CLIENT** 
    **Core -> HDFS -> HDFS_CLIENT**
 - **B.** And at the same time, we have **edw** _Service Group_ having its **HDFS_CLIENT** type component named as **HDFS_CLIENT** : 
    **edw -> HDFS -> HDFS_CLIENT**

There is  no good way to distinguish a given host component in **A** and **B**, if we continue to refer them with the component name end point (No. **2** API call). 
However, No. **1** call is still fine as we will not allow 2 names for the same component within a given service, thus making it unique and allowing us to continue using the component names endpoint.   




****WORK DONE****


In order to support multi-instance for components of a given service, we need to enhance the **Host Components API** so that they can distinguish **one component instance of a service** from **another component instance of a service** with the same Name.

The way to achieve this is to move Host Components API to be **ID** (number) based end point, compared to earlier being a name based endpoint. This will allow us to distinguish  **Core -> HDFS -> HDFS_CLIENT** from **edw -> HDFS -> HDFS_CLIENT**, as an example.

Thus, following changes are required:

  - New field : **component_type** (eg: HDFS_CLIENT, HIVE_SERVER, ZOOKEEPER_SERVER etc)
  - Existing field : **component_name** will now hold the actual name given for the component at the time of install. For example: 
     - **HDFS_CLIENT_EDW** for component_type **HDFS_CLIENT**
     - **HIVE_SERVER** FOR component_type **HIVE_SERVER**  _(name can be same as type also)_
     - **HIVE_SERVER1** for component_type **HIVE_SERVER**
     - **ZOOKEEPER_SERVER_FOR_KAFKA** for component_type **ZOOKEEPER_SERVER**, and so forth.
     
  - A way to identify the HOST component uniquely via API calls, by way of referring them by **ID** instead of name.


**MODIFIED API CALLs:**

1. POST SERVICE COMPONENT API call 
 
- CHANGE : New field **component_type**
- POST http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components

  Body :

 ```
  [{"ServiceComponentInfo":{"component_name":"HDFS_CLIENT2","component_type":"HDFS_CLIENT"}}]
```

  Response:
  

```
{
  "resources" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2",
      "ServiceComponentInfo" : {
        "category" : null,
        "cluster_id" : 2,
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "component_type" : "HDFS_CLIENT",
        "desired_stack" : "HDP-2.6",
        "desired_version" : "NOT_REQUIRED",
        "display_name" : "HDFS Client",
        "id" : 51,
        "recovery_enabled" : false,
        "service_group_id" : 2,
        "service_group_name" : "core",
        "service_id" : 3,
        "service_name" : "HDFS",
        "service_type" : "HDFS",
        "state" : "STARTED",
        "total_count" : {
          "installFailedCount" : 0,
          "unknownCount" : 0,
          "installedCount" : 0,
          "initCount" : 0,
          "installedAndMaintenanceOffCount" : 0,
          "startedCount" : 0,
          "totalCount" : 0
        }
      }
    }
  ]
}
```

  

2. POST HOST COMPONENT API call 

- CHANGE : New field **component_type**
- POST http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components
  Body
  
`   {"HostRoles":{"cluster_name": "c1","component_name":"HDFS_CLIENT2","component_type":"HDFS_CLIENT"}}
  `
- Response:
  
```
   {
  "resources" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51",
      "HostRoles" : {
        "actual_configs" : { },
        "cluster_id" : 2,
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "component_type" : "HDFS_CLIENT",
        "desired_admin_state" : null,
        "desired_repository_version" : "2.6.4.0-91",
        "desired_stack_id" : "HDP-2.6",
        "display_name" : "HDFS_CLIENT2",
        "host_name" : "<host1>",
        "id" : 51,
        "maintenance_state" : null,
        "public_host_name" : "<host1>",
        "service_group_id" : 2,
        "service_group_name" : "core",
        "service_id" : 3,
        "service_name" : "HDFS",
        "service_type" : "HDFS",
        "stale_configs" : false,
        "state" : "INIT",
        "upgrade_state" : "NONE",
        "version" : "UNKNOWN"
      },
      "host" : {
        "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>"
      }
    }
  ]
}
```



3. GET SERVICE COMPONENT:

   - CHANGE: **host_components** sub-resource will be referenced with end point as ID one.

   - GET http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2

   - Response: 
     
 
```
   {
  "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2",
  "ServiceComponentInfo" : {
    "category" : null,
    "cluster_id" : 2,
    "cluster_name" : "c1",
    "component_name" : "HDFS_CLIENT2",
    "component_type" : "HDFS_CLIENT",
    "desired_stack" : "HDP-2.6",
    "desired_version" : "2.6.4.0-91",
    "display_name" : "HDFS Client",
    "id" : 51,
    "init_count" : 1,
    "install_failed_count" : 0,
    "installed_and_maintenance_off_count" : 0,
    "installed_count" : 0,
    "recovery_enabled" : "false",
    "repository_state" : "NOT_REQUIRED",
    "service_group_id" : 2,
    "service_group_name" : "core",
    "service_id" : 3,
    "service_name" : "HDFS",
    "service_type" : "HDFS",
    "started_count" : 0,
    "state" : "STARTED",
    "total_count" : 1,
    "unknown_count" : 0
  },
  "host_components" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51",
      "HostRoles" : {
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "host_name" : "<host1>",
        "id" : 51,
        "service_group_name" : "core",
        "service_name" : "HDFS"
      }
    }
  ]
}
```

   


4. GET HOST COMPONENT:

   - CHANGE: Called with ID based end point

   - GET http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51

   - Response:

    
 
```
   {
  "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51",
  "HostRoles" : {
    "cluster_name" : "c1",
    "component_name" : "HDFS_CLIENT2",
    "component_type" : "HDFS_CLIENT",
    "desired_repository_version" : "2.6.4.0-91",
    "desired_stack_id" : "HDP-2.6",
    "desired_state" : "INIT",
    "display_name" : "HDFS_CLIENT2",
    "host_name" : "<host1>",
    "id" : 51,
    "maintenance_state" : "OFF",
    "public_host_name" : "<host1>",
    "reload_configs" : false,
    "service_group_name" : "core",
    "service_name" : "HDFS",
    "stale_configs" : false,
    "state" : "INIT",
    "upgrade_state" : "NONE",
    "version" : "UNKNOWN",
    "actual_configs" : { }
  },
  "host" : {
    "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>"
  },
  "processes" : [ ],
  "component" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2",
      "ServiceComponentInfo" : {
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "service_group_name" : "core",
        "service_name" : "HDFS"
      }
    }
  ]
}
```

  
5. UPDATE SERVICE COMPONENTS
    - NO CHANGE

6. UPDATE HOST COMPONENTS 
   - CHANGE: API end point is ID based now.

 7. DELETE SERVICE COMPONENT:
     - No CHANGE

8. DELETE HOST COMPONENT: 
    - CHANGE: API end point is ID based now.

## How was this patch tested?

Tested on live cluster, Details given above.