### PR TITLE
[AMBARI-23067] Upgrading commons-collections to 3.2.2 due to security concerns

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -78,9 +78,20 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+      <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>1.9.3</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1034,6 +1034,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.4</version>
@@ -1109,6 +1113,10 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
         </exclusion>
@@ -1119,6 +1127,10 @@
       <artifactId>apacheds-core-integ</artifactId>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
@@ -1140,6 +1152,10 @@
       <artifactId>apacheds-kerberos-codec</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
         </exclusion>
@@ -1150,6 +1166,10 @@
       <artifactId>apacheds-core</artifactId>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
@@ -1169,6 +1189,12 @@
       <groupId>org.apache.directory.shared</groupId>
       <artifactId>shared-ldap</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -1422,6 +1448,12 @@
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity</artifactId>
       <version>1.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>
@@ -1483,6 +1515,10 @@
           <artifactId>commons-beanutils-core</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
@@ -1520,6 +1556,12 @@
       <artifactId>utility</artifactId>
       <version>1.0.0.0-SNAPSHOT</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>commons-beanutils</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>    <!-- has to be compile-time dependency on junit -->
@@ -53,6 +57,10 @@
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -65,6 +73,10 @@
         <exclusion>
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per [CVE-2015-6420](https://nvd.nist.gov/vuln/detail/CVE-2015-6420)
>Serialized-object interfaces in certain Cisco Collaboration and Social Media; Endpoint Clients and Client Software; Network Application, Service, and Acceleration; Network and Content Security Devices; Network Management and Provisioning; Routing and Switching - Enterprise and Service Provider; Unified Computing; Voice and Unified Communications Devices; Video, Streaming, TelePresence, and Transcoding Devices; Wireless; and Cisco Hosted Services products allow remote attackers to execute arbitrary commands via a crafted serialized Java object, related to the Apache Commons Collections (ACC) library.

>'Vulnerable software and versions' contains `cpe:2.3:a:apache:commons_collections:*:*:*:*:*:*:*:*    versions up to (including) 3.2.1`

Per [CVE-2017-15708](https://nvd.nist.gov/vuln/detail/CVE-2017-15708)
>In Apache Synapse, by default no authentication is required for Java Remote Method Invocation (RMI). So Apache Synapse 3.0.1 or all previous releases (3.0.0, 2.1.0, 2.0.0, 1.2, 1.1.2, 1.1.1) allows remote code execution attacks that can be performed by injecting specially crafted serialized objects. And the presence of Apache Commons Collections 3.2.1 (commons-collections-3.2.1.jar) or previous versions in Synapse distribution makes this exploitable. To mitigate the issue, we need to limit RMI access to trusted users only. Further upgrading to 3.0.1 version will eliminate the risk of having said Commons Collection version. In Synapse 3.0.1, Commons Collection has been updated to 3.2.2 version.

So that we need to upgrade commons-collections to at least 3.2.2; at the time of this issue being fixed there is more recent versions in `org.apache.commons:commons-collection4` (v4.1) but it would require code modification due to package name changes

## How was this patch tested?
After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
ambari-server smolnar$ mvn dependency:tree -Dverbose=true -Dincludes=commons-collections

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building Ambari Server 2.6.1.0.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.6.1.0.0
[INFO] \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 17.905 s
[INFO] Finished at: 2018-02-26T11:28:59+01:00
[INFO] Final Memory: 30M/397M
[INFO] ------------------------------------------------------------------------
```

2.) I executed `mvn clean test` in `ambari-project`, `utility` and in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 35:27 min
[INFO] Finished at: 2018-02-26T11:48:38+01:00
[INFO] Final Memory: 74M/1590M
[INFO] ------------------------------------------------------------------------
```

3.) In addition to this; I replaced the content of `usr/lib/ambari-server` in my vagrant host with the content from `ambari-server/target/ambari-server-2.6.0.0.0-dist/usr/lib/ambari-server` (where commons-collections appeared with version 3.2.2) and restarted the server; logged in and did some actions (in this case I added HBase in my cluster); there were no any issues.
