### PR TITLE
[AMBARI-22937] Deactivate unsupported stack definitions in Ambari

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.4/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/metainfo.xml
@@ -17,7 +17,7 @@
 -->
 <metainfo>
     <versions>
-	  <active>true</active>
+	  <active>false</active>
     </versions>
     <extends>2.3</extends>
     <minJdk>1.7</minJdk>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/metainfo.xml
@@ -17,7 +17,7 @@
 -->
 <metainfo>
   <versions>
-    <active>true</active>
+    <active>false</active>
   </versions>
   <extends>2.4</extends>
   <minJdk>1.7</minJdk>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/metainfo.xml
@@ -17,7 +17,7 @@
 -->
 <metainfo>
   <versions>
-    <active>true</active>
+    <active>false</active>
   </versions>
   <extends>2.5</extends>
 </metainfo>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Deactivate unsupported stack definitions in Ambari. This includes HDP versions before 2.6.

Active Stacks
```
./3.0/metainfo.xml:    <active>true</active>
./2.6/metainfo.xml:    <active>true</active>
./2.5/metainfo.xml:    <active>true</active>
./2.4/metainfo.xml:    <active>true</active>
./2.3/metainfo.xml:    <active>true</active>
```

There is no enforcement of minimum stack level during the upgrade process. The user is expected to have performed the necessary actions to meet the documented minimum stack level.

**NOTE**: .../ambari-server/src/main/resources/stacks/HDP/2.3/metainfo.xml was already disabled.

## How was this patch tested?

Manually viewed unsupported stacks were not presented in the UI.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.