### PR TITLE
AMBARI-22945. Enhance host components API to support multiple host component instances.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ServiceComponentHostNotFoundException.java
@@ -31,4 +31,13 @@ public class ServiceComponentHostNotFoundException
         + ", hostName=" + hostName);
   }
 
+  public ServiceComponentHostNotFoundException(String clusterName,
+      String serviceName, Long serviceComponentId, String hostName) {
+    super("ServiceComponentHost not found"
+            + ", clusterName=" + clusterName
+            + ", serviceName=" + serviceName
+            + ", serviceComponentId=" + serviceComponentId
+            + ", hostName=" + hostName);
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/RootClusterSettingService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/RootClusterSettingService.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.ambari.server.api.resources.ResourceInstance;
 import org.apache.ambari.server.controller.ReadOnlyConfigurationResponse;
-import org.apache.ambari.server.controller.internal.MpackResourceProvider;
 import org.apache.ambari.server.controller.internal.RootClusterSettingsResourceProvider;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.http.HttpStatus;
@@ -69,8 +68,6 @@ public class RootClusterSettingService extends BaseService {
   @ApiOperation(value = "Returns information for all the read only 'cluster settings'",
           response = ReadOnlyConfigurationResponse.ReadOnlyConfigurationResponseSwagger.class, responseContainer = RESPONSE_CONTAINER_LIST)
   @ApiImplicitParams({
-          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING,
-                  paramType = PARAM_TYPE_QUERY, defaultValue = MpackResourceProvider.MPACK_RESOURCE_ID),
           @ApiImplicitParam(name = QUERY_SORT, value = QUERY_SORT_DESCRIPTION, dataType = DATA_TYPE_STRING,
                   paramType = PARAM_TYPE_QUERY),
           @ApiImplicitParam(name = QUERY_PAGE_SIZE, value = QUERY_PAGE_SIZE_DESCRIPTION, defaultValue = DEFAULT_PAGE_SIZE,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
@@ -510,6 +510,19 @@ public interface AmbariManagementController {
   String findService(Cluster cluster, String componentName) throws AmbariException;
 
   /**
+   * Get service name by cluster instance and component id
+   *
+   * @param cluster the cluster instance
+   * @param componentId the component id in Long type
+   *
+   * @return a service name
+   *
+   * @throws  AmbariException if service name is null or empty
+   */
+
+  String findService(Cluster cluster, Long componentId) throws AmbariException;
+
+  /**
    * Get the clusters for this management controller.
    *
    * @return the clusters

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
@@ -26,7 +26,9 @@ public class ServiceComponentHostRequest {
   private String clusterName; // REF
   private String serviceGroupName;
   private String serviceName;
+  private Long componentId;
   private String componentName;
+  private String componentType;
   private String hostname;
   private String publicHostname;
   private String state;
@@ -39,15 +41,29 @@ public class ServiceComponentHostRequest {
   public ServiceComponentHostRequest(String clusterName,
                                      String serviceGroupName,
                                      String serviceName,
+                                     Long componentId,
                                      String componentName,
+                                     String componentType,
                                      String hostname,
                                      String desiredState) {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
     this.serviceName = serviceName;
+    this.componentId = componentId;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.hostname = hostname;
     this.desiredState = desiredState;
+  }
+
+  public ServiceComponentHostRequest(String clusterName,
+                                     String serviceGroupName,
+                                     String serviceName,
+                                     String componentName,
+                                     String componentType,
+                                     String hostname,
+                                     String desiredState) {
+    this(clusterName, serviceGroupName, serviceName, null, componentName, componentType, hostname, desiredState);
   }
 
   /**
@@ -75,6 +91,13 @@ public class ServiceComponentHostRequest {
   }
 
   /**
+   * @return the componentd
+   */
+  public Long getComponentId() {
+    return componentId;
+  }
+
+  /**
    * @return the componentName
    */
   public String getComponentName() {
@@ -88,6 +111,22 @@ public class ServiceComponentHostRequest {
     this.componentName = componentName;
   }
 
+  /**
+   * @param componentId the componentId to set
+   */
+  public void setComponentId(Long componentId) {
+    this.componentId = componentId;
+  }
+
+  /**
+   * @return the componentType
+   */
+  public String getComponentType() { return componentType; }
+
+  /**
+   * @param componentType the componenType to set
+   */
+  public void setComponentType(String componentType) { this.componentType = componentType; }
   /**
    * @return the hostname
    */
@@ -162,7 +201,9 @@ public class ServiceComponentHostRequest {
     sb.append("{" + " clusterName=").append(clusterName)
       .append(", serviceGroupName=").append(serviceGroupName)
       .append(", serviceName=").append(serviceName)
+      .append(", componentId=").append(componentId)
       .append(", componentName=").append(componentName)
+      .append(", componentType=").append(componentType)
       .append(", hostname=").append(hostname)
       .append(", publicHostname=").append(publicHostname)
       .append(", desiredState=").append(desiredState)
@@ -203,7 +244,9 @@ public class ServiceComponentHostRequest {
     return Objects.equals(clusterName, other.clusterName) &&
       Objects.equals(serviceGroupName, other.serviceGroupName) &&
       Objects.equals(serviceName, other.serviceName) &&
+      Objects.equals(componentId, other.componentId) &&
       Objects.equals(componentName, other.componentName) &&
+      Objects.equals(componentType, other.componentType) &&
       Objects.equals(hostname, other.hostname) &&
       Objects.equals(publicHostname, other.publicHostname) &&
       Objects.equals(desiredState, other.desiredState) &&
@@ -216,7 +259,7 @@ public class ServiceComponentHostRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(clusterName, serviceGroupName, serviceName, componentName, hostname, publicHostname,
-      desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
+    return Objects.hash(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType, hostname,
+      publicHostname, desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
@@ -24,6 +24,8 @@ import org.apache.ambari.server.state.HostComponentAdminState;
 import org.apache.ambari.server.state.HostConfig;
 import org.apache.ambari.server.state.UpgradeState;
 
+import io.swagger.annotations.ApiModelProperty;
+
 public class ServiceComponentHostResponse {
 
   private Long clusterId; // REF
@@ -35,6 +37,7 @@ public class ServiceComponentHostResponse {
   private String serviceType;
   private Long hostComponentId;
   private String componentName;
+  private String componentType;
   private String displayName;
   private String publicHostname;
   private String hostname;
@@ -53,9 +56,10 @@ public class ServiceComponentHostResponse {
 
   public ServiceComponentHostResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName,
                                       Long serviceId, String serviceName, String serviceType, Long hostComponentId,
-                                      String componentName, String displayName, String hostname, String publicHostname,
-                                      String liveState, String version, String desiredState, String desiredStackVersion,
-                                      String desiredRepositoryVersion, HostComponentAdminState adminState) {
+                                      String componentName, String componentType, String displayName, String hostname,
+                                      String publicHostname, String liveState, String version, String desiredState,
+                                      String desiredStackVersion, String desiredRepositoryVersion,
+                                      HostComponentAdminState adminState) {
     this.clusterId = clusterId;
     this.serviceGroupId = serviceGroupId;
     this.serviceGroupName = serviceGroupName;
@@ -65,6 +69,7 @@ public class ServiceComponentHostResponse {
     this.serviceType = serviceType;
     this.hostComponentId = hostComponentId;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.displayName = displayName;
     this.hostname = hostname;
     this.publicHostname = publicHostname;
@@ -150,10 +155,24 @@ public class ServiceComponentHostResponse {
   }
 
   /**
+   * @return the componentType
+   */
+  public String getComponentType() {
+    return componentType;
+  }
+
+  /**
    * @param componentName the componentName to set
    */
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  /**
+   * @param componentType the componentType to set
+   */
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   /**
@@ -339,6 +358,11 @@ public class ServiceComponentHostResponse {
       return false;
     }
 
+    if (componentType != null ?
+            !componentType.equals(that.componentType) : that.componentType != null) {
+      return false;
+    }
+
     if (displayName != null ?
             !displayName.equals(that.displayName) : that.displayName != null) {
       return false;
@@ -362,6 +386,7 @@ public class ServiceComponentHostResponse {
     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
     result = 71 * result + (serviceType != null ? serviceType.hashCode() : 0);
     result = 71 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 71 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 71 * result + (displayName != null ? displayName.hashCode() : 0);
     result = 71 * result + (hostname != null ? hostname.hashCode() : 0);
     return result;
@@ -436,5 +461,14 @@ public class ServiceComponentHostResponse {
   public UpgradeState getUpgradeState() {
     return upgradeState;
   }
+
+  /**
+   * Interface to help correct Swagger documentation generation
+   */
+  public interface ServiceComponentHostResponseSwagger extends ApiModel {
+    @ApiModelProperty(name = "HostRoles")
+    ServiceComponentHostResponse getServiceComponentHostResponse();
+  }
+
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentRequest.java
@@ -27,28 +27,30 @@ public class ServiceComponentRequest {
   private String serviceGroupName;
   private String serviceName; // GET/CREATE/UPDATE/DELETE
   private String componentName; // GET/CREATE/UPDATE/DELETE
+  private String componentType;
   private String desiredState; // CREATE/UPDATE
   private String componentCategory;
   private String recoveryEnabled; // CREATE/UPDATE
 
   public ServiceComponentRequest(String clusterName, String serviceGroupName, String serviceName,
-                                 String componentName, String desiredState) {
-    this(clusterName, serviceGroupName, serviceName, componentName, desiredState, null, null);
+                                 String componentName, String componentType, String desiredState) {
+    this(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState, null, null);
   }
 
   public ServiceComponentRequest(String clusterName, String serviceGroupName, String serviceName, String componentName,
-                                 String desiredState, String recoveryEnabled) {
-    this(clusterName, serviceGroupName, serviceName, componentName, desiredState, recoveryEnabled, null);
+                                 String componentType, String desiredState, String recoveryEnabled) {
+    this(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState, recoveryEnabled, null);
   }
 
   public ServiceComponentRequest(String clusterName, String serviceGroupName,
-                                 String serviceName, String componentName,
+                                 String serviceName, String componentName, String componentType,
                                  String desiredState, String recoveryEnabled,
                                  String componentCategory) {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
     this.serviceName = serviceName;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.desiredState = desiredState;
     this.recoveryEnabled = recoveryEnabled;
     this.componentCategory = componentCategory;
@@ -89,6 +91,18 @@ public class ServiceComponentRequest {
    */
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  /**
+   * @return the componentType
+   */
+  public String getComponentType() { return componentType; }
+
+  /**
+   * @param componentType the componentType to set
+   */
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   /**
@@ -143,9 +157,9 @@ public class ServiceComponentRequest {
 
   @Override
   public String toString() {
-    return String.format("[clusterName=%s, serviceGroupName=%s, serviceName=%s, componentName=%s, " +
+    return String.format("[clusterName=%s, serviceGroupName=%s, serviceName=%s, componentName=%s, componentType=%s, " +
       "desiredState=%s, recoveryEnabled=%s, componentCategory=%s]", clusterName, serviceGroupName,
-      serviceName, clusterName, desiredState, recoveryEnabled, componentCategory);
+      serviceName, componentName, componentType, desiredState, recoveryEnabled, componentCategory);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentResponse.java
@@ -33,7 +33,9 @@ public class ServiceComponentResponse {
   private Long serviceId; // REF
   private String serviceName;
   private String serviceType;
+  private Long componentId;
   private String componentName;
+  private String componentType;
   private String displayName;
   private String desiredStackId;
   private String desiredState;
@@ -44,10 +46,10 @@ public class ServiceComponentResponse {
   private RepositoryVersionState repoState;
 
   public ServiceComponentResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName,
-                                  Long serviceId, String serviceName, String serviceType, String componentName,
-                                  StackId desiredStackId, String desiredState, Map<String, Integer> serviceComponentStateCount,
-                                  boolean recoveryEnabled, String displayName, String desiredVersion,
-                                  RepositoryVersionState repoState) {
+                                  Long serviceId, String serviceName, String serviceType, Long componentId, String componentName,
+                                  String componentType, StackId desiredStackId, String desiredState,
+                                  Map<String, Integer> serviceComponentStateCount, boolean recoveryEnabled,
+                                  String displayName, String desiredVersion, RepositoryVersionState repoState) {
     this.clusterId = clusterId;
     this.clusterName = clusterName;
     this.serviceGroupId = serviceGroupId;
@@ -55,7 +57,9 @@ public class ServiceComponentResponse {
     this.serviceId = serviceId;
     this.serviceName = serviceName;
     this.serviceType = serviceType;
+    this.componentId = componentId;
     this.componentName = componentName;
+    this.componentType = componentType;
     this.displayName = displayName;
     this.desiredStackId = desiredStackId.getStackId();
     this.desiredState = desiredState;
@@ -131,6 +135,34 @@ public class ServiceComponentResponse {
    */
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  /**
+   * @param componentId the componentId to set
+   */
+  public void setComponentName(Long componentId) {
+    this.componentId = componentId;
+  }
+
+  /**
+   * @return the componentType
+   */
+  public String getComponentType() {
+    return componentType;
+  }
+
+  /**
+   * @param componentType the componentType to set
+   */
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
+  }
+
+  /**
+   * @return the componentId
+   */
+  public Long getComponentId() {
+    return componentId;
   }
 
   /**
@@ -293,8 +325,18 @@ public class ServiceComponentResponse {
       return false;
     }
 
+    if (componentId != null ?
+            !componentId.equals(that.componentId) : that.componentId != null) {
+      return false;
+    }
+
     if (componentName != null ?
         !componentName.equals(that.componentName) : that.componentName != null){
+      return false;
+    }
+
+    if (componentType != null ?
+            !componentType.equals(that.componentType) : that.componentType != null){
       return false;
     }
 
@@ -315,7 +357,9 @@ public class ServiceComponentResponse {
     result = 71 * result + (serviceId != null ? serviceId.hashCode() : 0);
     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
     result = 71 * result + (serviceType != null ? serviceType.hashCode() : 0);
+    result = 71 * result + (componentId != null ? componentId.hashCode() : 0);
     result = 71 * result + (componentName != null ? componentName.hashCode():0);
+    result = 71 * result + (componentType != null ? componentType.hashCode():0);
     result = 71 * result + (displayName != null ? displayName.hashCode():0);
     return result;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
@@ -505,10 +505,17 @@ public abstract class AbstractProviderModule implements ProviderModule,
   public boolean isCollectorComponentLive(String clusterName, MetricsService service) throws SystemException {
 
     final String collectorHostName = getCollectorHostName(clusterName, service);
+    Long componentId = null;
+    try {
+      componentId = managementController.getClusters().getCluster(clusterName).getComponentId(Role.METRICS_COLLECTOR.name());
+    } catch (AmbariException e) {
+      e.printStackTrace();
+    }
 
     if (service.equals(GANGLIA)) {
+      // TODO : Multi_Metrics_Changes. Is there is more than one instance of GANGLIA_SERVER, type and name would be different.
       return HostStatusHelper.isHostComponentLive(managementController, clusterName, collectorHostName, "GANGLIA",
-        Role.GANGLIA_SERVER.name());
+        componentId, Role.GANGLIA_SERVER.name(), Role.GANGLIA_SERVER.name());
     } else if (service.equals(TIMELINE_METRICS)) {
       return metricsCollectorHAManager.isCollectorComponentLive(clusterName);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
@@ -119,7 +119,9 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
   protected static final String COMPONENT_CLUSTER_NAME_PROPERTY_ID = "ServiceComponentInfo/cluster_name";
   protected static final String COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID = "ServiceComponentInfo/service_group_name";
   protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID = "ServiceComponentInfo/service_name";
+  protected static final String COMPONENT_COMPONENT_ID_PROPERTY_ID = "ServiceComponentInfo/id";
   protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID = "ServiceComponentInfo/component_name";
+  protected static final String COMPONENT_COMPONENT_TYPE_PROPERTY_ID = "ServiceComponentInfo/component_type";
   protected static final String HOST_COMPONENT_HOST_NAME_PROPERTY_ID =
           PropertyHelper.getPropertyId("HostRoles", "host_name");
 
@@ -141,6 +143,7 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
   private static Set<String> propertyIds = Sets.newHashSet(
       COMPONENT_CLUSTER_NAME_PROPERTY_ID,
       COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
+      COMPONENT_COMPONENT_ID_PROPERTY_ID,
       COMPONENT_SERVICE_NAME_PROPERTY_ID,
       COMPONENT_COMPONENT_NAME_PROPERTY_ID,
       HOST_COMPONENT_HOST_NAME_PROPERTY_ID);
@@ -913,7 +916,9 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
             (String) properties.get(COMPONENT_CLUSTER_NAME_PROPERTY_ID),
             (String) properties.get(COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
             (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
+            (Long) properties.get(COMPONENT_COMPONENT_ID_PROPERTY_ID),
             (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+            (String) properties.get(COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
             (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
             null);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -94,7 +94,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
   protected static final String COMPONENT_SERVICE_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_id";
   protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_name";
   protected static final String COMPONENT_SERVICE_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_type";
+  protected static final String COMPONENT_COMPONENT_ID_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "id";
   protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_name";
+  protected static final String COMPONENT_COMPONENT_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "component_type";
   protected static final String COMPONENT_DISPLAY_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "display_name";
   protected static final String COMPONENT_STATE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "state";
   protected static final String COMPONENT_CATEGORY_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "category";
@@ -120,7 +122,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
           COMPONENT_CLUSTER_NAME_PROPERTY_ID,
           COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID,
           COMPONENT_SERVICE_NAME_PROPERTY_ID,
-          COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+          COMPONENT_COMPONENT_ID_PROPERTY_ID,
+          COMPONENT_COMPONENT_NAME_PROPERTY_ID,
+          COMPONENT_COMPONENT_TYPE_PROPERTY_ID);
 
   /**
    * The property ids for an servce resource.
@@ -141,7 +145,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     PROPERTY_IDS.add(COMPONENT_SERVICE_ID_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_SERVICE_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_SERVICE_TYPE_PROPERTY_ID);
+    PROPERTY_IDS.add(COMPONENT_COMPONENT_ID_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+    PROPERTY_IDS.add(COMPONENT_COMPONENT_TYPE_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_DISPLAY_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_STATE_PROPERTY_ID);
     PROPERTY_IDS.add(COMPONENT_CATEGORY_PROPERTY_ID);
@@ -223,7 +229,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
         resource.setProperty(COMPONENT_SERVICE_ID_PROPERTY_ID, response.getServiceId());
         resource.setProperty(COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName());
         resource.setProperty(COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType());
+        resource.setProperty(COMPONENT_COMPONENT_ID_PROPERTY_ID, response.getComponentId());
         resource.setProperty(COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName());
+        resource.setProperty(COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType());
         resource.setProperty(COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName());
         resource.setProperty(COMPONENT_STATE_PROPERTY_ID, response.getDesiredState());
         resource.setProperty(COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory());
@@ -270,7 +278,9 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       setResourceProperty(resource, COMPONENT_SERVICE_ID_PROPERTY_ID, response.getServiceId(), requestedIds);
       setResourceProperty(resource, COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName(), requestedIds);
       setResourceProperty(resource, COMPONENT_SERVICE_TYPE_PROPERTY_ID, response.getServiceType(), requestedIds);
+      setResourceProperty(resource, COMPONENT_COMPONENT_ID_PROPERTY_ID, response.getComponentId(), requestedIds);
       setResourceProperty(resource, COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName(), requestedIds);
+      setResourceProperty(resource, COMPONENT_COMPONENT_TYPE_PROPERTY_ID, response.getComponentType(), requestedIds);
       setResourceProperty(resource, COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName(), requestedIds);
       setResourceProperty(resource, COMPONENT_STATE_PROPERTY_ID, response.getDesiredState(), requestedIds);
       setResourceProperty(resource, COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory(), requestedIds);
@@ -363,6 +373,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
         (String) properties.get(COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID),
         (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
         (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
+        (String) properties.get(COMPONENT_COMPONENT_TYPE_PROPERTY_ID),
         (String) properties.get(COMPONENT_STATE_PROPERTY_ID),
         (String) properties.get(COMPONENT_RECOVERY_ENABLED_ID),
         (String) properties.get(COMPONENT_CATEGORY_PROPERTY_ID));
@@ -391,6 +402,13 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       Validate.notEmpty(request.getServiceGroupName(), "service group name should be non-empty");
       Validate.notEmpty(request.getServiceName(), "service name should be non-empty");
       Cluster cluster = getClusterForRequest(request, clusters);
+
+      // TODO: Multi_Component_Instance. When we go into multiple component instance mode, we will need make
+      // component_type as manadatory field. As of now, we are just copying component_name into component_type,
+      // if not provided. Further, need to add validation check too.
+      if(StringUtils.isBlank(request.getComponentType())) {
+        request.setComponentType(request.getComponentName());
+      }
 
       isAuthorized(cluster, getRequiredCreateAuthorizations());
 
@@ -454,7 +472,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     for (ServiceComponentRequest request : requests) {
       Cluster cluster = clusters.getCluster(request.getClusterName());
       Service s = cluster.getService(request.getServiceName());
-      ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName());
+      ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName(), request.getComponentType());
       sc.setDesiredRepositoryVersion(s.getDesiredRepositoryVersion());
 
       if (StringUtils.isNotEmpty(request.getDesiredState())) {
@@ -475,10 +493,10 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       } else {
         StackId stackId = s.getDesiredStackId();
         ComponentInfo componentInfo = ambariMetaInfo.getComponent(stackId.getStackName(),
-                stackId.getStackVersion(), s.getServiceType(), request.getComponentName());
+                stackId.getStackVersion(), s.getServiceType(), request.getComponentType());
         if (componentInfo == null) {
             throw new AmbariException("Could not get component information from stack definition: Stack=" +
-              stackId + ", Service=" + s.getServiceType() + ", Component=" + request.getComponentName());
+              stackId + ", Service=" + s.getServiceType() + ", Component type =" + request.getComponentType());
         }
         sc.setRecoveryEnabled(componentInfo.isRecoveryEnabled());
         LOG.info("Component: {}, recovery_enabled from stack definition:{}", componentInfo.getName(),
@@ -631,6 +649,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       final String serviceGroupName = request.getServiceGroupName();
       final String serviceName = request.getServiceName();
       final String componentName = request.getComponentName();
+      final String componentType = request.getComponentType();
 
       LOG.info("Received a updateComponent request: {}", request);
 
@@ -659,7 +678,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       State newState = getValidDesiredState(request);
 
       if (! maintenanceStateHelper.isOperationAllowed(reqOpLvl, s)) {
-        LOG.info("Operations cannot be applied to component " + componentName
+        LOG.info("Operations cannot be applied to component name : " + componentName + " with type : " + componentType
                 + " because service " + serviceName +
                 " is in the maintenance state of " + s.getMaintenanceState());
         continue;
@@ -674,8 +693,8 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
         boolean newRecoveryEnabled = Boolean.parseBoolean(request.getRecoveryEnabled());
         boolean oldRecoveryEnabled = sc.isRecoveryEnabled();
-        LOG.info("Component: {}, oldRecoveryEnabled: {}, newRecoveryEnabled {}",
-                componentName, oldRecoveryEnabled, newRecoveryEnabled);
+        LOG.info("ComponentName: {}, componentType: {}, oldRecoveryEnabled: {}, newRecoveryEnabled {}",
+                componentName, componentType, oldRecoveryEnabled, newRecoveryEnabled);
         if (newRecoveryEnabled != oldRecoveryEnabled) {
           if (newRecoveryEnabled) {
             recoveryEnabledComponents.add(sc);
@@ -712,6 +731,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + sc.getServiceName()
               + ", componentName=" + sc.getName()
+              + ", componentType=" + sc.getType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", currentDesiredState=" + oldScState
               + ", newDesiredState=" + newState);
@@ -725,6 +745,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + serviceName
               + ", componentName=" + sc.getName()
+              + ", componentType=" + sc.getType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", currentDesiredState=" + oldScState
               + ", newDesiredState=" + newState);
@@ -740,6 +761,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
                 + ", serviceGroupName=" + serviceGroupName
                 + ", serviceName=" + serviceName
                 + ", componentName=" + sc.getName()
+                + ", componentType=" + sc.getType()
                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
                 + ", hostname=" + sch.getHostName()
                 + ", currentState=" + oldSchState
@@ -754,6 +776,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
                 + ", serviceGroupName=" + serviceGroupName
                 + ", serviceName=" + serviceName
                 + ", componentName=" + sc.getName()
+                + ", componentType=" + sc.getType()
                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
                 + ", hostname=" + sch.getHostName()
                 + ", currentState=" + oldSchState
@@ -769,6 +792,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
                 + ", serviceGroupName=" + serviceGroupName
                 + ", serviceName=" + serviceName
                 + ", componentName=" + sc.getName()
+                + ", componentType=" + sc.getType()
                 + ", recoveryEnabled=" + sc.isRecoveryEnabled()
                 + ", hostname=" + sch.getHostName());
 
@@ -784,6 +808,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + sch.getServiceName()
               + ", componentName=" + sch.getServiceComponentName()
+              + ", componentType=" + sch.getServiceComponentType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", hostname=" + sch.getHostName()
               + ", currentState=" + oldSchState
@@ -801,6 +826,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
               + ", serviceGroupName=" + serviceGroupName
               + ", serviceName=" + serviceName
               + ", componentName=" + sc.getName()
+              + ", componentType=" + sc.getType()
               + ", recoveryEnabled=" + sc.isRecoveryEnabled()
               + ", hostname=" + sch.getHostName()
               + ", currentState=" + oldSchState
@@ -914,14 +940,16 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     if (StringUtils.isEmpty(request.getServiceName())) {
 
       String componentName = request.getComponentName();
+      String componentType = request.getComponentType();
 
-      String serviceName = getManagementController().findService(cluster, componentName);
+      String serviceName = getManagementController().findService(cluster, componentType);
 
-      debug("Looking up service name for component, componentName={}, serviceName={}", componentName, serviceName);
+      debug("Looking up service name for component, componentType={}, serviceName={}", componentType, serviceName);
 
       if (StringUtils.isEmpty(serviceName)) {
-        throw new AmbariException("Could not find service for component"
-                + ", componentName=" + request.getComponentName()
+        throw new AmbariException("Could not find service for component."
+                + " componentName=" + request.getComponentName()
+                + " componentType=" + request.getComponentType()
                 + ", clusterName=" + cluster.getClusterName());
       }
       request.setServiceName(serviceName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -957,7 +957,9 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
           ServiceComponentHostRequest schr = new ServiceComponentHostRequest(cluster.getClusterName(),
                                                                              sch.getServiceGroupName(),
                                                                              sch.getServiceName(),
+                                                                             sch.getHostComponentId(),
                                                                              sch.getServiceComponentName(),
+                                                                             sch.getServiceComponentType(),
                                                                              sch.getHostName(),
                                                                              null);
           schrs.add(schr);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStatusHelper.java
@@ -41,8 +41,8 @@ public class HostStatusHelper {
     LoggerFactory.getLogger(HostStatusHelper.class);
 
   public static boolean isHostComponentLive(AmbariManagementController managementController,
-                                             String clusterName, String hostName,
-                                      String serviceName, String componentName) {
+                                            String clusterName, String hostName, String serviceName,
+                                            Long componentId, String componentName, String componentType) {
     if (clusterName == null) {
       return false;
     }
@@ -54,8 +54,8 @@ public class HostStatusHelper {
       Cluster cluster = clusters.getCluster(clusterName);
       Service s = cluster.getService(serviceName);
       ServiceComponentHostRequest componentRequest =
-        new ServiceComponentHostRequest(clusterName, s.getServiceGroupName(), serviceName, componentName, hostName,
-                null);
+        new ServiceComponentHostRequest(clusterName, s.getServiceGroupName(), serviceName, componentId, componentName, componentType,
+              hostName, null);
 
       Set<ServiceComponentHostResponse> hostComponents =
         managementController.getHostComponents(Collections.singleton(componentRequest));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -668,6 +668,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
 
       LOG.info("Received a updateService request"
           + ", clusterName=" + request.getClusterName()
+          + ", serviceGroupName=" + request.getServiceGroupName()
           + ", serviceName=" + request.getServiceName()
           + ", request=" + request);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaPropertyProvider.java
@@ -60,7 +60,6 @@ public abstract class GangliaPropertyProvider extends MetricsPropertyProvider {
    */
   static final Map<String, List<String>> GANGLIA_CLUSTER_NAME_MAP = new HashMap<>();
 
-  
   static {
     GANGLIA_CLUSTER_NAME_MAP.put("NAMENODE",           Collections.singletonList("HDPNameNode"));
     GANGLIA_CLUSTER_NAME_MAP.put("DATANODE",           Arrays.asList("HDPDataNode", "HDPSlaves"));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedState.java
@@ -89,7 +89,7 @@ public class DefaultServiceCalculatedState implements ServiceCalculatedState {
           StackId stackId = service.getDesiredStackId();
 
           ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-            serviceName, null, null, null);
+            serviceName, null, null, null, null, null);
 
           Set<ServiceComponentHostResponse> hostComponentResponses =
             managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedState.java
@@ -52,7 +52,7 @@ public final class FlumeServiceCalculatedState extends DefaultServiceCalculatedS
       if (cluster != null && managementControllerProvider != null) {
         Service service = cluster.getService(serviceName);
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedState.java
@@ -54,7 +54,7 @@ public final class HBaseServiceCalculatedState extends DefaultServiceCalculatedS
         StackId stackId = service.getDesiredStackId();
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedState.java
@@ -54,7 +54,7 @@ public final class HDFSServiceCalculatedState extends DefaultServiceCalculatedSt
         StackId stackId = service.getDesiredStackId();
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null,null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedState.java
@@ -55,7 +55,7 @@ public final class HiveServiceCalculatedState extends DefaultServiceCalculatedSt
 
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedState.java
@@ -54,7 +54,7 @@ public final class OozieServiceCalculatedState extends DefaultServiceCalculatedS
         StackId stackId = service.getDesiredStackId();
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/state/YARNServiceCalculatedState.java
@@ -55,7 +55,7 @@ public final class YARNServiceCalculatedState extends DefaultServiceCalculatedSt
 
 
         ServiceComponentHostRequest request = new ServiceComponentHostRequest(clusterName, service.getServiceGroupName(),
-          serviceName, null, null, null);
+          serviceName, null, null, null, null, null);
 
         Set<ServiceComponentHostResponse> hostComponentResponses =
           managementControllerProvider.get().getHostComponents(Collections.singleton(request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
@@ -86,24 +86,15 @@ public class HostComponentDesiredStateDAO {
   /**
    * Retrieve the single Host Component Desired State for the given unique cluster, service, component, and host.
    *
-   * @param clusterId Cluster ID
-   * @param serviceGroupId Service Group ID
-   * @param serviceId Service ID
-   * @param componentName Component Name
-   * @param hostId Host ID
+   * @param componentId Component Id
    * @return Return the Host Component Desired State entity that match the criteria.
    */
   @RequiresSession
-  public HostComponentDesiredStateEntity findByIndex(Long clusterId, Long serviceGroupId, Long serviceId,
-                                                     String componentName, Long hostId) {
+  public HostComponentDesiredStateEntity findByIndex(Long componentId) {
     final TypedQuery<HostComponentDesiredStateEntity> query = entityManagerProvider.get()
       .createNamedQuery("HostComponentDesiredStateEntity.findByIndex", HostComponentDesiredStateEntity.class);
 
-    query.setParameter("clusterId", clusterId);
-    query.setParameter("serviceGroupId", serviceGroupId);
-    query.setParameter("serviceId", serviceId);
-    query.setParameter("componentName", componentName);
-    query.setParameter("hostId", hostId);
+    query.setParameter("id", componentId);
 
     return daoUtils.selectSingle(query);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
@@ -42,6 +42,9 @@ public class HostComponentStateDAO {
   @Inject
   HostDAO hostDAO;
 
+  @Inject
+  HostComponentDesiredStateDAO hostComponentDesiredStateDAO;
+
   @RequiresSession
   public HostComponentStateEntity findById(long id) {
     return entityManagerProvider.get().find(HostComponentStateEntity.class, id);
@@ -120,22 +123,18 @@ public class HostComponentStateDAO {
    *          Service Group ID
    * @param serviceId
    *          Service ID
-   * @param componentName
-   *          Component Name
+   * @param componentId
+   *          Component ID
    * @param hostId
    *          Host ID
    * @return Return all of the Host Component States that match the criteria.
    */
   @RequiresSession
   public HostComponentStateEntity findByIndex(Long clusterId, Long serviceGroupId, Long serviceId,
-                                              String componentName, Long hostId) {
+                                              Long componentId, Long hostId) {
     final TypedQuery<HostComponentStateEntity> query = entityManagerProvider.get().createNamedQuery(
         "HostComponentStateEntity.findByIndex", HostComponentStateEntity.class);
-    query.setParameter("clusterId", clusterId);
-    query.setParameter("serviceGroupId", serviceGroupId);
-    query.setParameter("serviceId", serviceId);
-    query.setParameter("componentName", componentName);
-    query.setParameter("hostId", hostId);
+    query.setParameter("id", componentId);
 
     return daoUtils.selectSingle(query);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ServiceComponentDesiredStateDAO.java
@@ -82,7 +82,7 @@ public class ServiceComponentDesiredStateDAO {
    */
   @RequiresSession
   public ServiceComponentDesiredStateEntity findByName(long clusterId, long serviceGroupId, long serviceId,
-       String componentName) {
+       String componentName, String componentType) {
     EntityManager entityManager = entityManagerProvider.get();
     TypedQuery<ServiceComponentDesiredStateEntity> query = entityManager.createNamedQuery(
         "ServiceComponentDesiredStateEntity.findByName", ServiceComponentDesiredStateEntity.class);
@@ -91,6 +91,38 @@ public class ServiceComponentDesiredStateDAO {
     query.setParameter("serviceGroupId", serviceGroupId);
     query.setParameter("serviceId", serviceId);
     query.setParameter("componentName", componentName);
+    query.setParameter("componentType", componentType);
+
+    ServiceComponentDesiredStateEntity entity = null;
+    List<ServiceComponentDesiredStateEntity> entities = daoUtils.selectList(query);
+    if (null != entities && !entities.isEmpty()) {
+      entity = entities.get(0);
+    }
+
+    return entity;
+  }
+
+  /**
+   * Finds a {@link ServiceComponentDesiredStateEntity} by a combination of
+   * cluster, service, and component.
+   *
+   * @param clusterId
+   *          the cluster ID
+   * @param serviceGroupId
+   *          the service group ID
+   * @param serviceId
+   *          the service ID
+   * @param componentId
+   *          the component id (not {@code null})
+   */
+  @RequiresSession
+  public ServiceComponentDesiredStateEntity findById(long clusterId, long serviceGroupId, long serviceId,
+                                                       Long componentId) {
+    EntityManager entityManager = entityManagerProvider.get();
+    TypedQuery<ServiceComponentDesiredStateEntity> query = entityManager.createNamedQuery(
+            "ServiceComponentDesiredStateEntity.findById", ServiceComponentDesiredStateEntity.class);
+
+    query.setParameter("id", componentId);
 
     ServiceComponentDesiredStateEntity entity = null;
     List<ServiceComponentDesiredStateEntity> entities = daoUtils.selectList(query);
@@ -122,8 +154,8 @@ public class ServiceComponentDesiredStateDAO {
   }
 
   @Transactional
-  public void removeByName(long clusterId, long serviceGroupId, long serviceId, String componentName) {
-    ServiceComponentDesiredStateEntity entity = findByName(clusterId, serviceGroupId, serviceId, componentName);
+  public void removeByName(long clusterId, long serviceGroupId, long serviceId, String componentName, String componentType) {
+    ServiceComponentDesiredStateEntity entity = findByName(clusterId, serviceGroupId, serviceId, componentName, componentType);
     if (null != entity) {
       entityManagerProvider.get().remove(entity);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
@@ -66,7 +66,7 @@ import com.google.common.base.Objects;
     "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.clusterId=:clusterId AND hcds.serviceGroupId=:serviceGroupId AND hcds.serviceId=:serviceId AND hcds.componentName=:componentName AND hcds.hostEntity.hostName=:hostName"),
 
   @NamedQuery(name = "HostComponentDesiredStateEntity.findByIndex", query =
-    "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.clusterId=:clusterId AND hcds.serviceGroupId=:serviceGroupId AND hcds.serviceId=:serviceId AND hcds.componentName=:componentName AND hcds.hostId=:hostId"),
+    "SELECT hcds from HostComponentDesiredStateEntity hcds WHERE hcds.id=:id")
 })
 public class HostComponentDesiredStateEntity {
 
@@ -91,6 +91,9 @@ public class HostComponentDesiredStateEntity {
   @Column(name = "component_name", insertable = false, updatable = false)
   private String componentName = "";
 
+  @Column(name = "component_type", insertable = false, updatable = false)
+  private String componentType = "";
+
   @Basic
   @Column(name = "desired_state", nullable = false, insertable = true, updatable = true)
   @Enumerated(value = EnumType.STRING)
@@ -105,7 +108,8 @@ public class HostComponentDesiredStateEntity {
     @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false),
     @JoinColumn(name = "service_group_id", referencedColumnName = "service_group_id", nullable = false),
     @JoinColumn(name = "service_id", referencedColumnName = "service_id", nullable = false),
-    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false)})
+    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false),
+    @JoinColumn(name = "component_type", referencedColumnName = "component_type", nullable = false) })
   private ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity;
 
   @ManyToOne
@@ -152,6 +156,14 @@ public class HostComponentDesiredStateEntity {
 
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  public String getComponentType() {
+    return defaultString(componentType);
+  }
+
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
   }
 
   public State getDesiredState() {
@@ -209,6 +221,10 @@ public class HostComponentDesiredStateEntity {
       return false;
     }
 
+    if (!Objects.equal(componentType, that.componentType)) {
+      return false;
+    }
+
     if (!Objects.equal(desiredState, that.desiredState)) {
       return false;
     }
@@ -228,6 +244,7 @@ public class HostComponentDesiredStateEntity {
     result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 31 * result + (desiredState != null ? desiredState.hashCode() : 0);
     return result;
   }
@@ -264,6 +281,7 @@ public class HostComponentDesiredStateEntity {
   public String toString() {
     return Objects.toStringHelper(this).add("clusterId", clusterId).add(
       "serviceGroupId", serviceGroupId).add("serviceId", serviceId).add("componentName",
-      componentName).add("hostId", hostId).add("desiredState", desiredState).toString();
+      componentName).add("componentType", componentType).add("hostId", hostId).add("desiredState",
+      desiredState).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -30,8 +30,11 @@ import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
+
+import javax.persistence.UniqueConstraint;
 
 import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.state.UpgradeState;
@@ -39,7 +42,11 @@ import org.apache.ambari.server.state.UpgradeState;
 import com.google.common.base.Objects;
 
 @Entity
-@Table(name = "hostcomponentstate")
+@Table(
+    name = "hostcomponentstate",
+    uniqueConstraints = @UniqueConstraint(
+                name = "UQ_hostcomponentstate_name",
+                columnNames = { "component_name", "service_id" , "host_id", "service_group_id", "cluster_id" }) )
 @TableGenerator(
     name = "hostcomponentstate_id_generator",
     table = "ambari_sequences",
@@ -76,15 +83,16 @@ import com.google.common.base.Objects;
                 "AND hcs.version != :version"),
     @NamedQuery(
         name = "HostComponentStateEntity.findByIndex",
-        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.clusterId=:clusterId " +
-                "AND hcs.serviceGroupId=:serviceGroupId AND hcs.serviceId=:serviceId AND hcs.componentName=:componentName AND hcs.hostId=:hostId") })
-
+        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.id=:id") })
 public class HostComponentStateEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.TABLE, generator = "hostcomponentstate_id_generator")
   @Column(name = "id", nullable = false, insertable = true, updatable = false)
   private Long id;
+
+  @Column(name = "host_component_desired_state_id", nullable = false, insertable = false, updatable = false)
+  private Long hostComponentDesiredStateId;
 
   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
   private Long clusterId;
@@ -100,6 +108,9 @@ public class HostComponentStateEntity {
 
   @Column(name = "component_name", nullable = false, insertable = false, updatable = false)
   private String componentName;
+
+  @Column(name = "component_type", nullable = false, insertable = false, updatable = false)
+  private String componentType;
 
   /**
    * Version reported by host component during last status update.
@@ -120,12 +131,17 @@ public class HostComponentStateEntity {
     @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false),
     @JoinColumn(name = "service_group_id", referencedColumnName = "service_group_id", nullable = false),
     @JoinColumn(name = "service_id", referencedColumnName = "service_id", nullable = false),
-    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false) })
+    @JoinColumn(name = "component_name", referencedColumnName = "component_name", nullable = false),
+    @JoinColumn(name = "component_type", referencedColumnName = "component_type", nullable = false) })
   private ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity;
 
   @ManyToOne
   @JoinColumn(name = "host_id", referencedColumnName = "host_id", nullable = false)
   private HostEntity hostEntity;
+
+  @OneToOne
+  @JoinColumn(name = "host_component_desired_state_id", referencedColumnName = "id", nullable = false)
+  private HostComponentDesiredStateEntity hostComponentDesiredStateEntity;
 
   public Long getId() {
     return id;
@@ -169,6 +185,26 @@ public class HostComponentStateEntity {
 
   public void setComponentName(String componentName) {
     this.componentName = componentName;
+  }
+
+  public Long getHostComponentDesiredStateId() {
+    return hostComponentDesiredStateEntity != null ? hostComponentDesiredStateEntity.getId() : null;
+  }
+
+  public void setComponentId(Long componentId) {
+    this.id = componentId;
+  }
+
+  public Long getComponentId() {
+    return id;
+  }
+
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
+  }
+
+  public String getComponentType() {
+    return componentType;
   }
 
   public State getCurrentState() {
@@ -228,6 +264,11 @@ public class HostComponentStateEntity {
       return false;
     }
 
+    if (componentType != null ? !componentType.equals(that.componentType)
+            : that.componentType != null) {
+      return false;
+    }
+
     if (currentState != null ? !currentState.equals(that.currentState)
         : that.currentState != null) {
       return false;
@@ -239,6 +280,10 @@ public class HostComponentStateEntity {
     }
 
     if (hostEntity != null ? !hostEntity.equals(that.hostEntity) : that.hostEntity != null) {
+      return false;
+    }
+
+    if (hostComponentDesiredStateEntity != null ? !hostComponentDesiredStateEntity.equals(that.hostComponentDesiredStateEntity) : that.hostComponentDesiredStateEntity != null) {
       return false;
     }
 
@@ -256,7 +301,9 @@ public class HostComponentStateEntity {
     result = 31 * result + (serviceGroupId != null ? serviceGroupId.intValue() : 0);
     result = 31 * result + (serviceId != null ? serviceId.intValue() : 0);
     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
+    result = 31 * result + (hostComponentDesiredStateEntity != null ? hostComponentDesiredStateEntity.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 31 * result + (currentState != null ? currentState.hashCode() : 0);
     result = 31 * result + (upgradeState != null ? upgradeState.hashCode() : 0);
     result = 31 * result + (version != null ? version.hashCode() : 0);
@@ -267,8 +314,7 @@ public class HostComponentStateEntity {
     return serviceComponentDesiredStateEntity;
   }
 
-  public void setServiceComponentDesiredStateEntity(
-      ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity) {
+  public void setServiceComponentDesiredStateEntity(ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity) {
     this.serviceComponentDesiredStateEntity = serviceComponentDesiredStateEntity;
   }
 
@@ -280,14 +326,22 @@ public class HostComponentStateEntity {
     this.hostEntity = hostEntity;
   }
 
+  public HostComponentDesiredStateEntity getHostComponentDesiredStateEntity() {
+    return hostComponentDesiredStateEntity;
+  }
+
+  public void setHostComponentDesiredStateEntity(HostComponentDesiredStateEntity hostComponentDesiredStateEntity) {
+    this.hostComponentDesiredStateEntity = hostComponentDesiredStateEntity;
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public String toString() {
     return Objects.toStringHelper(this).add("clusterId", clusterId).add("serviceGroupId", serviceGroupId).add(
-      "serviceId", serviceId).add("componentName", componentName).add(
-      "hostId", hostId).add("state", currentState).toString();
+      "serviceId", serviceId).add("componentId", id).add("componentName", componentName).add
+            ("componentType", componentType).add("hostId", hostId).add("state", currentState).toString();
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceComponentDesiredStateEntity.java
@@ -62,7 +62,13 @@ import org.apache.ambari.server.state.State;
     query = "SELECT scds FROM ServiceComponentDesiredStateEntity scds WHERE scds.clusterId = :clusterId " +
       "AND scds.serviceGroupId = :serviceGroupId " +
       "AND scds.serviceId = :serviceId " +
-      "AND scds.componentName = :componentName") })
+      "AND scds.componentName = :componentName " +
+      "AND scds.componentType = :componentType" ),
+  @NamedQuery(
+    name = "ServiceComponentDesiredStateEntity.findById",
+    query = "SELECT scds FROM ServiceComponentDesiredStateEntity scds WHERE scds.id = :id" )
+})
+
 public class ServiceComponentDesiredStateEntity {
 
   @Id
@@ -74,6 +80,9 @@ public class ServiceComponentDesiredStateEntity {
 
   @Column(name = "component_name", nullable = false, insertable = true, updatable = true)
   private String componentName;
+
+  @Column(name = "component_type", nullable = false, insertable = true, updatable = true)
+  private String componentType;
 
   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
   private Long clusterId;
@@ -154,6 +163,14 @@ public class ServiceComponentDesiredStateEntity {
     this.componentName = componentName;
   }
 
+  public String getComponentType() {
+    return componentType;
+  }
+
+  public void setComponentType(String componentType) {
+    this.componentType = componentType;
+  }
+
   public State getDesiredState() {
     return desiredState;
   }
@@ -224,6 +241,9 @@ public class ServiceComponentDesiredStateEntity {
     if (componentName != null ? !componentName.equals(that.componentName) : that.componentName != null) {
       return false;
     }
+    if (componentType != null ? !componentType.equals(that.componentType) : that.componentType != null) {
+      return false;
+    }
     if (desiredState != null ? !desiredState.equals(that.desiredState) : that.desiredState != null) {
       return false;
     }
@@ -241,6 +261,7 @@ public class ServiceComponentDesiredStateEntity {
     result = 31 * result + (serviceGroupId != null ? serviceGroupId.hashCode() : 0);
     result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (componentType != null ? componentType.hashCode() : 0);
     result = 31 * result + (desiredState != null ? desiredState.hashCode() : 0);
     result = 31 * result + (desiredRepositoryVersion != null ? desiredRepositoryVersion.hashCode() : 0);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -162,6 +162,22 @@ public interface Cluster {
   Service getServiceByComponentName(String componentName) throws AmbariException;
 
   /**
+   * Gets a service from the given component Id.
+   *
+   * @param componentId
+   * @return
+   * @throws AmbariException
+   */
+
+  Service getServiceByComponentId(Long componentId) throws AmbariException;
+
+  Long getComponentId(String componentName) throws AmbariException;
+
+  String getComponentName(Long componentId) throws AmbariException;
+
+  String getComponentType(Long componentId) throws AmbariException;
+
+  /**
    * Get all services
    *
    * @return

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Service.java
@@ -74,7 +74,7 @@ public interface Service {
 
   void debugDump(StringBuilder sb);
 
-  ServiceComponent addServiceComponent(String serviceComponentName)
+  ServiceComponent addServiceComponent(String serviceComponentName, String serviceComponentType)
       throws AmbariException;
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
@@ -30,6 +30,10 @@ public interface ServiceComponent {
 
   String getName();
 
+  String getType();
+
+  Long getId();
+
   /**
    * Get a true or false value specifying
    * if auto start was enabled for this component.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentFactory.java
@@ -19,9 +19,12 @@ package org.apache.ambari.server.state;
 
 import org.apache.ambari.server.orm.entities.ServiceComponentDesiredStateEntity;
 
+import com.google.inject.assistedinject.Assisted;
+
 public interface ServiceComponentFactory {
 
-  ServiceComponent createNew(Service service, String componentName);
+  ServiceComponent createNew(Service service, @Assisted("componentName") String componentName,
+                             @Assisted("componentType") String componentType);
 
   ServiceComponent createExisting(Service service, ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity);
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
@@ -71,10 +71,22 @@ public interface ServiceComponentHost {
   String getServiceType();
 
   /**
-   * Get the ServiceComponent this object maps to
+   * Get the ServiceComponent's Id this object maps to
+   * @return Id of the ServiceComponent
+   */
+  public Long getServiceComponentId();
+
+  /**
+   * Get the ServiceComponent's Name this object maps to
    * @return Name of the ServiceComponent
    */
   String getServiceComponentName();
+
+  /**
+   * Get the ServiceComponent's Type this object maps to
+   * @return Type of the ServiceComponent
+   */
+  String getServiceComponentType();
 
   /**
    * Get the Host this object maps to

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
@@ -80,7 +80,8 @@ public class ServiceImpl implements Service {
 
   private final Cluster cluster;
   private final ServiceGroup serviceGroup;
-  private final ConcurrentMap<String, ServiceComponent> components = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, ServiceComponent> componentsByName = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Long, ServiceComponent> componentsById = new ConcurrentHashMap<>();
   private List<ServiceKey> serviceDependencies = new ArrayList<>();
   private boolean isClientOnlyService;
   private boolean isCredentialStoreSupported;
@@ -226,10 +227,12 @@ public class ServiceImpl implements Service {
       for (ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity
           : serviceEntity.getServiceComponentDesiredStateEntities()) {
         try {
-            components.put(serviceComponentDesiredStateEntity.getComponentName(),
-                serviceComponentFactory.createExisting(this,
-                    serviceComponentDesiredStateEntity));
-          } catch(ProvisionException ex) {
+            ServiceComponent svcComponent = serviceComponentFactory.createExisting(this,
+                    serviceComponentDesiredStateEntity);
+            componentsByName.put(serviceComponentDesiredStateEntity.getComponentName(), svcComponent);
+            componentsById.put(serviceComponentDesiredStateEntity.getId(), svcComponent);
+
+        } catch(ProvisionException ex) {
             StackId stackId = new StackId(serviceComponentDesiredStateEntity.getDesiredStack());
             LOG.error(String.format("Can not get component info: stackName=%s, stackVersion=%s, serviceName=%s, componentName=%s",
               stackId.getStackName(), stackId.getStackVersion(),
@@ -304,13 +307,13 @@ public class ServiceImpl implements Service {
 
   @Override
   public Map<String, ServiceComponent> getServiceComponents() {
-    return new HashMap<>(components);
+    return new HashMap<>(componentsByName);
   }
 
   @Override
   public void addServiceComponents(
-      Map<String, ServiceComponent> components) throws AmbariException {
-    for (ServiceComponent sc : components.values()) {
+      Map<String, ServiceComponent> componentsByName) throws AmbariException {
+    for (ServiceComponent sc : componentsByName.values()) {
       addServiceComponent(sc);
     }
   }
@@ -326,7 +329,7 @@ public class ServiceImpl implements Service {
 
   @Override
   public void addServiceComponent(ServiceComponent component) throws AmbariException {
-    if (components.containsKey(component.getName())) {
+    if (componentsByName.containsKey(component.getName())) {
       throw new AmbariException("Cannot add duplicate ServiceComponent"
           + ", clusterName=" + cluster.getClusterName()
           + ", clusterId=" + cluster.getClusterId()
@@ -335,13 +338,13 @@ public class ServiceImpl implements Service {
           + ", serviceComponentName=" + component.getName());
     }
 
-    components.put(component.getName(), component);
+    componentsByName.put(component.getName(), component);
   }
 
   @Override
-  public ServiceComponent addServiceComponent(String serviceComponentName)
+  public ServiceComponent addServiceComponent(String serviceComponentName, String serviceComponentType)
       throws AmbariException {
-    ServiceComponent component = serviceComponentFactory.createNew(this, serviceComponentName);
+    ServiceComponent component = serviceComponentFactory.createNew(this, serviceComponentName, serviceComponentType);
     addServiceComponent(component);
     return component;
   }
@@ -349,7 +352,7 @@ public class ServiceImpl implements Service {
   @Override
   public ServiceComponent getServiceComponent(String componentName)
       throws AmbariException {
-    ServiceComponent serviceComponent = components.get(componentName);
+    ServiceComponent serviceComponent = componentsByName.get(componentName);
     if (null == serviceComponent) {
       throw new ServiceComponentNotFoundException(cluster.getClusterName(),
           getName(), getServiceType(), serviceGroup.getServiceGroupName(), componentName);
@@ -468,8 +471,8 @@ public class ServiceImpl implements Service {
     serviceDesiredStateEntity.setDesiredRepositoryVersion(repositoryVersionEntity);
     serviceDesiredStateDAO.merge(serviceDesiredStateEntity);
 
-    Collection<ServiceComponent> components = getServiceComponents().values();
-    for (ServiceComponent component : components) {
+    Collection<ServiceComponent> componentsByName = getServiceComponents().values();
+    for (ServiceComponent component : componentsByName) {
       component.setDesiredRepositoryVersion(repositoryVersionEntity);
     }
   }
@@ -481,12 +484,12 @@ public class ServiceImpl implements Service {
   @Deprecated
   @Experimental(feature = ExperimentalFeature.REPO_VERSION_REMOVAL)
   public RepositoryVersionState getRepositoryState() {
-    if (components.isEmpty()) {
+    if (componentsByName.isEmpty()) {
       return RepositoryVersionState.NOT_REQUIRED;
     }
 
     List<RepositoryVersionState> states = new ArrayList<>();
-    for( ServiceComponent component : components.values() ){
+    for( ServiceComponent component : componentsByName.values() ){
       states.add(component.getRepositoryState());
     }
 
@@ -658,9 +661,9 @@ public class ServiceImpl implements Service {
       .append(", clusterId=").append(cluster.getClusterId())
       .append(", desiredStackVersion=").append(getDesiredStackId())
       .append(", desiredState=").append(getDesiredState())
-      .append(", components=[ ");
+      .append(", componentsByName=[ ");
     boolean first = true;
-    for (ServiceComponent sc : components.values()) {
+    for (ServiceComponent sc : componentsByName.values()) {
       if (!first) {
         sb.append(" , ");
       }
@@ -711,11 +714,11 @@ public class ServiceImpl implements Service {
   @Override
   public boolean canBeRemoved() {
     //
-    // A service can be deleted if all it's components
+    // A service can be deleted if all it's componentsByName
     // can be removed, irrespective of the state of
     // the service itself.
     //
-    for (ServiceComponent sc : components.values()) {
+    for (ServiceComponent sc : componentsByName.values()) {
       if (!sc.canBeRemoved()) {
         LOG.warn("Found non-removable component when trying to delete service" + ", clusterName="
             + cluster.getClusterName() + ", serviceName=" + getName() + ", serviceType="
@@ -757,22 +760,22 @@ public class ServiceImpl implements Service {
   public void deleteAllComponents() throws AmbariException {
     lock.lock();
     try {
-      LOG.info("Deleting all components for service" + ", clusterName=" + cluster.getClusterName()
+      LOG.info("Deleting all componentsByName for service" + ", clusterName=" + cluster.getClusterName()
           + ", serviceName=" + getName());
       // FIXME check dependencies from meta layer
-      for (ServiceComponent component : components.values()) {
+      for (ServiceComponent component : componentsByName.values()) {
         if (!component.canBeRemoved()) {
           throw new AmbariException("Found non removable component when trying to"
-              + " delete all components from service" + ", clusterName=" + cluster.getClusterName()
+              + " delete all componentsByName from service" + ", clusterName=" + cluster.getClusterName()
               + ", serviceName=" + getName() + ", componentName=" + component.getName());
         }
       }
 
-      for (ServiceComponent serviceComponent : components.values()) {
+      for (ServiceComponent serviceComponent : componentsByName.values()) {
         serviceComponent.delete();
       }
 
-      components.clear();
+      componentsByName.clear();
     } finally {
       lock.unlock();
     }
@@ -795,7 +798,7 @@ public class ServiceImpl implements Service {
       }
 
       component.delete();
-      components.remove(componentName);
+      componentsByName.remove(componentName);
     } finally {
       lock.unlock();
     }
@@ -809,7 +812,7 @@ public class ServiceImpl implements Service {
   @Override
   @Transactional
   public void delete() throws AmbariException {
-    List<Component> components = getComponents(); // XXX temporal coupling, need to call this BEFORE deletingAllComponents
+    List<Component> componentsByName = getComponents(); // XXX temporal coupling, need to call this BEFORE deletingAllComponents
     deleteAllComponents();
     deleteAllServiceConfigs();
 
@@ -824,7 +827,7 @@ public class ServiceImpl implements Service {
 
     ServiceRemovedEvent event = new ServiceRemovedEvent(getClusterId(), stackId.getStackName(), stackId.getStackVersion(),
                                                         getName(), getServiceType(),
-                                                        serviceGroup.getServiceGroupName(), components);
+                                                        serviceGroup.getServiceGroupName(), componentsByName);
 
     eventPublisher.publish(event);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1187,6 +1187,58 @@ public class ClusterImpl implements Cluster {
     throw new ServiceNotFoundException(getClusterName(), "component: " + componentName);
   }
 
+  @Override
+  public Service getServiceByComponentId(Long componentId) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getId().equals(componentId)) {
+          return service;
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
+  }
+
+  @Override
+  public String getComponentName(Long componentId) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getId().equals(componentId)) {
+          return component.getName();
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
+  }
+
+
+  @Override
+  public String getComponentType(Long componentId) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getId().equals(componentId)) {
+          return component.getType();
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Id: " + componentId);
+  }
+
+  @Override
+  public Long getComponentId(String componentName) throws AmbariException {
+    for (Service service : services.values()) {
+      for (ServiceComponent component : service.getServiceComponents().values()) {
+        if (component.getName().equals(componentName)) {
+          return component.getId();
+        }
+      }
+    }
+
+    throw new ServiceNotFoundException(getClusterName(), "component Name: " + componentName);
+  }
 
   @Override
   public ServiceGroup getServiceGroup(String serviceGroupName) throws ServiceGroupNotFoundException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -372,7 +372,7 @@ public class AmbariContext {
       .collect(toSet());
 
     Set<ServiceComponentRequest> componentRequests = topology.getComponents()
-      .map(c -> new ServiceComponentRequest(clusterName, c.effectiveServiceGroupName(), c.effectiveServiceName(), c.componentName(), null,
+      .map(c -> new ServiceComponentRequest(clusterName, c.effectiveServiceGroupName(), c.effectiveServiceName(), c.componentName(), c.componentName(),
         topology.getSetting().getRecoveryEnabled(c.effectiveServiceName(), c.componentName()))) // FIXME settings by service type or name?
       .collect(toSet());
 
@@ -442,7 +442,7 @@ public class AmbariContext {
 
     final Set<ServiceComponentHostRequest> requests = components
       .filter(component -> !component.componentName().equals(RootComponent.AMBARI_SERVER.name()))
-      .map(component -> new ServiceComponentHostRequest(clusterName, component.effectiveServiceGroupName(), component.effectiveServiceName(), component.componentName(), hostName, null))
+      .map(component -> new ServiceComponentHostRequest(clusterName, component.effectiveServiceGroupName(), component.effectiveServiceName(), component.componentName(), component.componentName(),hostName, null))
       .collect(toSet());
 
     try {

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -283,6 +283,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -299,6 +300,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -314,8 +316,10 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -323,7 +327,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -302,6 +302,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
+  component_type VARCHAR(100) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -318,6 +319,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
+  component_type VARCHAR(100) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -333,8 +335,10 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
+  component_type VARCHAR(100) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -342,7 +346,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -282,6 +282,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
+  component_type VARCHAR2(255) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   service_group_id NUMBER(19) NOT NULL,
   service_id NUMBER(19) NOT NULL,
@@ -298,6 +299,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id NUMBER(19) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
+  component_type VARCHAR2(255) NOT NULL,
   desired_state VARCHAR2(255) NOT NULL,
   host_id NUMBER(19) NOT NULL,
   service_group_id NUMBER(19) NOT NULL,
@@ -306,14 +308,16 @@ CREATE TABLE hostcomponentdesiredstate (
   maintenance_state VARCHAR2(32) NOT NULL,
   restart_required NUMBER(1) DEFAULT 0 NOT NULL,
   CONSTRAINT PK_hostcomponentdesiredstate PRIMARY KEY (id),
-  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, host_id, cluster_id),
+  CONSTRAINT UQ_hcdesiredstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hcdesiredstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
   CONSTRAINT hstcmpnntdesiredstatecmpnntnme FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE TABLE hostcomponentstate (
   id NUMBER(19) NOT NULL,
+  host_component_desired_state_id NUMBER(19) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
+  component_type VARCHAR2(255) NOT NULL,
   version VARCHAR2(32) DEFAULT 'UNKNOWN' NOT NULL,
   current_state VARCHAR2(255) NOT NULL,
   host_id NUMBER(19) NOT NULL,
@@ -321,7 +325,9 @@ CREATE TABLE hostcomponentstate (
   service_id NUMBER(19) NOT NULL,
   upgrade_state VARCHAR2(32) DEFAULT 'NONE' NOT NULL,
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -284,6 +284,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -300,6 +301,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -314,8 +316,10 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -323,7 +327,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -281,6 +281,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   service_group_id NUMERIC(19) NOT NULL,
   service_id NUMERIC(19) NOT NULL,
@@ -297,6 +298,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id NUMERIC(19) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id NUMERIC(19) NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -311,8 +313,10 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id NUMERIC(19) NOT NULL,
+  host_component_desired_state_id NUMERIC(19) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id NUMERIC(19) NOT NULL,
@@ -320,7 +324,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT PK_hostcomponentstate PRIMARY KEY (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -147,6 +147,7 @@ CREATE TABLE servicegroups (
   id BIGINT NOT NULL,
   service_group_name VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
+  stack_id BIGINT NOT NULL,
   CONSTRAINT PK_servicegroups PRIMARY KEY (id, cluster_id),
   CONSTRAINT FK_servicegroups_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters (cluster_id),
   CONSTRAINT FK_servicegroups_stack_id FOREIGN KEY (stack_id) REFERENCES stack (stack_id),
@@ -295,6 +296,7 @@ CREATE TABLE repo_tags (
 CREATE TABLE servicecomponentdesiredstate (
   id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   cluster_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
   service_id BIGINT NOT NULL,
@@ -311,6 +313,7 @@ CREATE TABLE hostcomponentdesiredstate (
   id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   desired_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
@@ -325,8 +328,10 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
+  host_component_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
+  component_type VARCHAR(255) NOT NULL,
   version VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN',
   current_state VARCHAR(255) NOT NULL,
   host_id BIGINT NOT NULL,
@@ -334,7 +339,9 @@ CREATE TABLE hostcomponentstate (
   service_id BIGINT NOT NULL,
   upgrade_state VARCHAR(32) NOT NULL DEFAULT 'NONE',
   CONSTRAINT PK_hostcomponentstate PRIMARY KEY CLUSTERED (id),
+  CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE NONCLUSTERED INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/key_properties.json
+++ b/ambari-server/src/main/resources/key_properties.json
@@ -11,7 +11,7 @@
     "ServiceGroup": "HostRoles/service_group_name",
     "Host": "HostRoles/host_name",
     "Service": "HostRoles/service_name",
-    "HostComponent": "HostRoles/component_name",
+    "HostComponent": "HostRoles/id",
     "Component": "HostRoles/component_name"
   },
   "Action": {

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatProcessorTest.java
@@ -155,11 +155,11 @@ public class HeartbeatProcessorTest {
   public void testHeartbeatWithConfigs() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -223,7 +223,7 @@ public class HeartbeatProcessorTest {
   public void testRestartRequiredAfterInstallClient() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -287,11 +287,11 @@ public class HeartbeatProcessorTest {
   public void testHeartbeatCustomCommandWithConfigs() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -370,11 +370,11 @@ public class HeartbeatProcessorTest {
   public void testHeartbeatCustomStartStop() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -453,11 +453,11 @@ public class HeartbeatProcessorTest {
   public void testStatusHeartbeat() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -574,7 +574,7 @@ public class HeartbeatProcessorTest {
       throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -692,7 +692,7 @@ public class HeartbeatProcessorTest {
   public void testUpgradeSpecificHandling() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -785,7 +785,7 @@ public class HeartbeatProcessorTest {
   public void testCommandStatusProcesses() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
 
@@ -863,11 +863,11 @@ public class HeartbeatProcessorTest {
   public void testComponentUpgradeFailReport() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
@@ -974,11 +974,11 @@ public class HeartbeatProcessorTest {
   public void testComponentUpgradeInProgressReport() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
@@ -1230,10 +1230,10 @@ public class HeartbeatProcessorTest {
   public void testComponentInProgressStatusSafeAfterStatusReport() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).
         addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).
         addServiceComponentHost(DummyHostname1);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
@@ -186,9 +186,9 @@ public class TestHeartbeatHandler {
 
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
-    hdfs.addServiceComponent(NAMENODE);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     Collection<Host> hosts = cluster.getHosts();
     assertEquals(hosts.size(), 1);
 
@@ -237,9 +237,9 @@ public class TestHeartbeatHandler {
   public void testStatusHeartbeatWithAnnotation() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
-    hdfs.addServiceComponent(NAMENODE);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
 
     ActionQueue aq = new ActionQueue();
 
@@ -287,10 +287,10 @@ public class TestHeartbeatHandler {
   public void testLiveStatusUpdateAfterStopFailed() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).
         addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, DATANODE);
     hdfs.getServiceComponent(NAMENODE).
         addServiceComponentHost(DummyHostname1);
 
@@ -391,15 +391,15 @@ public class TestHeartbeatHandler {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     // Create helper after creating service to avoid race condition caused by asynchronous recovery configs
@@ -467,15 +467,15 @@ public class TestHeartbeatHandler {
     /*
      * Add three service components enabled for auto start.
      */
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(HDFS_CLIENT).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT).setRecoveryEnabled(true);
     hdfs.getServiceComponent(HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
@@ -796,11 +796,11 @@ public class TestHeartbeatHandler {
   public void testTaskInProgressHandling() throws Exception, InvalidStateTransitionException {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -852,11 +852,11 @@ public class TestHeartbeatHandler {
   public void testOPFailedEventForAbortedTask() throws Exception, InvalidStateTransitionException {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE, SECONDARY_NAMENODE);
     hdfs.getServiceComponent(SECONDARY_NAMENODE).addServiceComponentHost(DummyHostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -922,11 +922,11 @@ public class TestHeartbeatHandler {
   public void testStatusHeartbeat() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(HDFS_CLIENT);
+    hdfs.addServiceComponent(HDFS_CLIENT, HDFS_CLIENT);
     hdfs.getServiceComponent(HDFS_CLIENT).addServiceComponentHost(DummyHostname1);
 
     ServiceComponentHost serviceComponentHost1 = clusters.getCluster(DummyCluster).getService(HDFS).
@@ -982,9 +982,9 @@ public class TestHeartbeatHandler {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Host hostObject = clusters.getHost(DummyHostname1);
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(NAMENODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
@@ -1062,9 +1062,9 @@ public class TestHeartbeatHandler {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Host hostObject = clusters.getHost(DummyHostname1);
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
-    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(NAMENODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
@@ -1388,7 +1388,7 @@ public class TestHeartbeatHandler {
   public void testCommandStatusProcesses_empty() throws Exception {
     Cluster cluster = heartbeatTestHelper.getDummyCluster();
     Service hdfs = addService(cluster, HDFS);
-    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(DATANODE, DATANODE);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setState(State.STARTED);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatMonitor.java
@@ -176,11 +176,11 @@ public class TestHeartbeatMonitor {
     clusters.mapAndPublishHostsToCluster(hostNames, clusterName);
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
 
     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
@@ -279,16 +279,16 @@ public class TestHeartbeatMonitor {
     clusters.mapAndPublishHostsToCluster(hostNames, clusterName);
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost
     (hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost
     (hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).
         addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost
     (hostname1);
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost
@@ -387,11 +387,11 @@ public class TestHeartbeatMonitor {
 
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
 
     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);
@@ -469,13 +469,13 @@ public class TestHeartbeatMonitor {
 
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.HDFS_CLIENT.name());
+    hdfs.addServiceComponent(Role.HDFS_CLIENT.name(), Role.HDFS_CLIENT.name());
     hdfs.getServiceComponent(Role.HDFS_CLIENT.name()).addServiceComponentHost(hostname1);
 
     ActionQueue aq = new ActionQueue();
@@ -589,11 +589,11 @@ public class TestHeartbeatMonitor {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, serviceName, serviceName, repositoryVersion);
 
-    hdfs.addServiceComponent(Role.DATANODE.name());
+    hdfs.addServiceComponent(Role.DATANODE.name(), Role.DATANODE.name());
     hdfs.getServiceComponent(Role.DATANODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.NAMENODE.name());
+    hdfs.addServiceComponent(Role.NAMENODE.name(), Role.NAMENODE.name());
     hdfs.getServiceComponent(Role.NAMENODE.name()).addServiceComponentHost(hostname1);
-    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name());
+    hdfs.addServiceComponent(Role.SECONDARY_NAMENODE.name(), Role.SECONDARY_NAMENODE.name());
     hdfs.getServiceComponent(Role.SECONDARY_NAMENODE.name()).addServiceComponentHost(hostname1);
 
     hdfs.getServiceComponent(Role.DATANODE.name()).getServiceComponentHost(hostname1).setState(State.INSTALLED);

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/query/render/MinimalRendererTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/query/render/MinimalRendererTest.java
@@ -382,7 +382,7 @@ public class MinimalRendererTest {
         Map<String, Map<String, Object>> componentProperties = componentResource.getPropertiesMap();
         assertEquals(1, componentProperties.size());
         assertEquals(1, componentProperties.get("HostRoles").size());
-        assertTrue(componentProperties.get("HostRoles").containsKey("component_name"));
+        assertTrue(componentProperties.get("HostRoles").containsKey("id"));
       }
     }
   }
@@ -450,7 +450,7 @@ public class MinimalRendererTest {
         Map<String, Map<String, Object>> componentProperties = componentResource.getPropertiesMap();
         assertEquals(1, componentProperties.size());
         assertEquals(1, componentProperties.get("HostRoles").size());
-        assertTrue(componentProperties.get("HostRoles").containsKey("component_name"));
+        assertTrue(componentProperties.get("HostRoles").containsKey("id"));
       }
     }
   }
@@ -514,21 +514,25 @@ public class MinimalRendererTest {
 
     // host 1 components
     Resource nnComponentResource = new ResourceImpl(Resource.Type.HostComponent);
+    nnComponentResource.setProperty("HostRoles/id", 1L);
     nnComponentResource.setProperty("HostRoles/component_name", "NAMENODE");
     nnComponentResource.setProperty("HostRoles/host_name", "testHost");
     nnComponentResource.setProperty("HostRoles/cluster_name", "testCluster");
 
     Resource dnComponentResource = new ResourceImpl(Resource.Type.HostComponent);
+    dnComponentResource.setProperty("HostRoles/id", 2L);
     dnComponentResource.setProperty("HostRoles/component_name", "DATANODE");
     dnComponentResource.setProperty("HostRoles/host_name", "testHost");
     dnComponentResource.setProperty("HostRoles/cluster_name", "testCluster");
 
     Resource jtComponentResource = new ResourceImpl(Resource.Type.HostComponent);
+    jtComponentResource.setProperty("HostRoles/id", 3L);
     jtComponentResource.setProperty("HostRoles/component_name", "JOBTRACKER");
     jtComponentResource.setProperty("HostRoles/host_name", "testHost");
     jtComponentResource.setProperty("HostRoles/cluster_name", "testCluster");
 
     Resource ttComponentResource = new ResourceImpl(Resource.Type.HostComponent);
+    ttComponentResource.setProperty("HostRoles/id", 4L);
     ttComponentResource.setProperty("HostRoles/component_name", "TASKTRACKER");
     jtComponentResource.setProperty("HostRoles/host_name", "testHost");
     jtComponentResource.setProperty("HostRoles/cluster_name", "testCluster");

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/RecoveryConfigHelperTest.java
@@ -151,7 +151,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion());
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -159,7 +159,7 @@ public class RecoveryConfigHelperTest {
     assertEquals(recoveryConfig.getEnabledComponents(), "DATANODE");
 
     // Install HDFS::NAMENODE to trigger a component installed event
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
     // Verify that the config is stale now
@@ -186,10 +186,10 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -223,7 +223,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
     hdfs.getServiceComponent(DATANODE).getServiceComponentHost(DummyHostname1).setDesiredState(State.INSTALLED);
 
@@ -264,10 +264,10 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
-    hdfs.addServiceComponent(NAMENODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(NAMENODE, NAMENODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(NAMENODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -300,7 +300,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost(DummyHostname1);
 
     // Get the recovery configuration
@@ -344,7 +344,7 @@ public class RecoveryConfigHelperTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", cluster.getDesiredStackVersion().getStackId());
     Service hdfs = cluster.addService(serviceGroup, HDFS, HDFS, repositoryVersion);
 
-    hdfs.addServiceComponent(DATANODE).setRecoveryEnabled(true);
+    hdfs.addServiceComponent(DATANODE, DATANODE).setRecoveryEnabled(true);
 
     // Add SCH to Host1 and Host2
     hdfs.getServiceComponent(DATANODE).addServiceComponentHost("Host1");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -580,8 +580,8 @@ public class AmbariCustomCommandExecutionHelperTest {
     OrmTestHelper ormTestHelper = injector.getInstance(OrmTestHelper.class);
     RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.6"), "2.0.6-1234");
     createService("c1", "CORE", "HADOOP_CLIENTS", repositoryVersion);
-    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
-    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
+    createServiceComponent("c1", "CORE", "HADOOP_CLIENTS", "SOME_CLIENT_FOR_SERVICE_CHECK", "SOME_CLIENT_FOR_SERVICE_CHECK", State.INIT);
+    createServiceComponentHost("c1", "CORE", "HADOOP_CLIENTS", 1L, "SOME_CLIENT_FOR_SERVICE_CHECK", "SOME_CLIENT_FOR_SERVICE_CHECK", "c1-c6403", State.INIT);
 
     //make sure there are no HDFS_CLIENT components from HDFS service
     Cluster c1 = clusters.getCluster("c1");
@@ -744,7 +744,7 @@ public class AmbariCustomCommandExecutionHelperTest {
 
     // add a repo version associated with a component
     ServiceComponentDesiredStateEntity componentEntity = componentDAO.findByName(cluster.getClusterId(), serviceYARN.getServiceGroupId(),
-        serviceYARN.getServiceId(), componentRM.getName());
+        serviceYARN.getServiceId(), componentRM.getName(), componentRM.getType());
 
     componentEntity.setDesiredRepositoryVersion(repositoryVersion);
     componentDAO.merge(componentEntity);
@@ -788,29 +788,30 @@ public class AmbariCustomCommandExecutionHelperTest {
     createService(clusterName, serviceGroupName, "ZOOKEEPER", repositoryVersion);
     createService(clusterName, serviceGroupName, "FLUME", repositoryVersion);
 
-    createServiceComponent(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "YARN", "NODEMANAGER", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", State.INIT);
-    createServiceComponent(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", "RESOURCEMANAGER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "YARN", "NODEMANAGER", "NODEMANAGER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", "GANGLIA_SERVER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", "GANGLIA_MONITOR", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", State.INIT);
 
     // this component should be not installed on any host
-    createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", State.INIT);
+    createServiceComponent(clusterName, serviceGroupName, "FLUME", "FLUME_HANDLER", "FLUME_HANDLER", State.INIT);
   }
 
 
   private void createServiceComponentHosts(String clusterName, String serviceGroupName, String hostPrefix) throws AmbariException, AuthorizationException {
     String hostC6401 = hostPrefix + "-c6401";
     String hostC6402 = hostPrefix + "-c6402";
-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "RESOURCEMANAGER", hostC6401, null);
-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6401, null);
-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_SERVER", hostC6401, State.INIT);
-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", hostC6401, State.INIT);
-    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostC6401, State.INIT);
+    // TODO : Numbers for component Id may not be correct.
+    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 1L, "RESOURCEMANAGER", "RESOURCEMANAGER", hostC6401, null);
+    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 2L, "NODEMANAGER", "NODEMANAGER", hostC6401, null);
+    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 3L, "GANGLIA_SERVER", "GANGLIA_SERVER", hostC6401, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 4L, "GANGLIA_MONITOR", "GANGLIA_MONITOR", hostC6401, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", 5L, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", hostC6401, State.INIT);
 
-    createServiceComponentHost(clusterName, serviceGroupName, "YARN", "NODEMANAGER", hostC6402, null);
-    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", "GANGLIA_MONITOR", hostC6402, State.INIT);
-    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostC6402, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "YARN", 6L,"NODEMANAGER", "NODEMANAGER", hostC6402, null);
+    createServiceComponentHost(clusterName, serviceGroupName, "GANGLIA", 7L,"GANGLIA_MONITOR", "GANGLIA_MONITOR", hostC6402, State.INIT);
+    createServiceComponentHost(clusterName, serviceGroupName, "ZOOKEEPER", 8L, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT", hostC6402, State.INIT);
   }
   private void addHost(String hostname, String clusterName) throws AmbariException {
     clusters.addHost(hostname);
@@ -843,16 +844,17 @@ public class AmbariCustomCommandExecutionHelperTest {
   }
 
   private void createServiceComponent(
-    String clusterName, String serviceGroupName, String serviceName, String componentName, State desiredState
+    String clusterName, String serviceGroupName, String serviceName, String componentName, String componentType, State desiredState
   ) throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentType, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(ambariManagementController, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(
-    String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState
+    String clusterName, String serviceGroupName, String serviceName, Long componentId, String componentName, String componentType, String hostname, State desiredState
   ) throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType,
+            hostname, desiredState != null ? desiredState.name() : null);
     ambariManagementController.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -73,9 +73,13 @@ import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.internal.RequestStageContainer;
 import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
+import org.apache.ambari.server.orm.dao.HostComponentStateDAO;
 import org.apache.ambari.server.orm.dao.RepositoryVersionDAO;
+import org.apache.ambari.server.orm.dao.ServiceComponentDesiredStateDAO;
+import org.apache.ambari.server.orm.entities.HostComponentStateEntity;
 import org.apache.ambari.server.orm.entities.LdapSyncSpecEntity;
 import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
+import org.apache.ambari.server.orm.entities.ServiceComponentDesiredStateEntity;
 import org.apache.ambari.server.registry.RegistryManager;
 import org.apache.ambari.server.security.authorization.Users;
 import org.apache.ambari.server.security.authorization.internal.InternalAuthenticationToken;
@@ -136,6 +140,10 @@ public class AmbariManagementControllerImplTest {
   private static final Users users = createMock(Users.class);
   private static final AmbariSessionManager sessionManager = createNiceMock(AmbariSessionManager.class);
   private static final RegistryManager registryManager = createNiceMock(RegistryManager.class);
+  private static final HostComponentStateEntity hostComponentStateEntity = createMock(HostComponentStateEntity.class);
+  private static final HostComponentStateDAO hostComponentStateDAO = createMock(HostComponentStateDAO.class);
+  private static final ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = createMock(ServiceComponentDesiredStateEntity.class);
+  private static final ServiceComponentDesiredStateDAO serviceComponentDesiredStateDAO = createMock(ServiceComponentDesiredStateDAO.class);
 
   @BeforeClass
   public static void setupAuthentication() {
@@ -147,7 +155,8 @@ public class AmbariManagementControllerImplTest {
 
   @Before
   public void before() throws Exception {
-    reset(ldapDataPopulator, clusters, actionDBAccessor, ambariMetaInfo, users, sessionManager);
+    reset(ldapDataPopulator, clusters, actionDBAccessor, ambariMetaInfo, users, sessionManager,
+            hostComponentStateEntity, hostComponentStateDAO, serviceComponentDesiredStateEntity, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -161,6 +170,9 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(null);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
 
     //replay
     replay(injector);
@@ -247,8 +259,11 @@ public class AmbariManagementControllerImplTest {
     CredentialStoreService credentialStoreService = createNiceMock(CredentialStoreService.class);
     expect(credentialStoreService.isInitialized(anyObject(CredentialStoreType.class))).andReturn(true).anyTimes();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
-    replay(injector, clusters, cluster, response, credentialStoreService);
+    replay(injector, clusters, cluster, response, credentialStoreService, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -263,7 +278,7 @@ public class AmbariManagementControllerImplTest {
     assertEquals(1, setResponses.size());
     assertTrue(setResponses.contains(response));
 
-    verify(injector, clusters, cluster, response, credentialStoreService);
+    verify(injector, clusters, cluster, response, credentialStoreService, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -291,8 +306,11 @@ public class AmbariManagementControllerImplTest {
     // getCluster
     expect(clusters.getCluster("cluster1")).andThrow(new ClusterNotFoundException("cluster1"));
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
-    replay(injector, clusters);
+    replay(injector, clusters, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -305,7 +323,7 @@ public class AmbariManagementControllerImplTest {
       // expected
     }
 
-    verify(injector, clusters);
+    verify(injector, clusters, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -354,8 +372,12 @@ public class AmbariManagementControllerImplTest {
     CredentialStoreService credentialStoreService = createNiceMock(CredentialStoreService.class);
     expect(credentialStoreService.isInitialized(anyObject(CredentialStoreType.class))).andReturn(true).anyTimes();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
-    replay(injector, clusters, cluster, cluster2, response, response2, credentialStoreService);
+    replay(injector, clusters, cluster, cluster2, response, response2, credentialStoreService,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -372,7 +394,8 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response));
     assertTrue(setResponses.contains(response2));
 
-    verify(injector, clusters, cluster, cluster2, response, response2, credentialStoreService);
+    verify(injector, clusters, cluster, cluster2, response, response2, credentialStoreService,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -409,6 +432,9 @@ public class AmbariManagementControllerImplTest {
     expect(clusters.getClusterById(1L)).andReturn(cluster).times(1);
     expect(cluster.getClusterName()).andReturn("clusterOld").times(1);
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     cluster.setClusterName("clusterNew");
     expectLastCall();
 
@@ -416,7 +442,8 @@ public class AmbariManagementControllerImplTest {
     expectLastCall();
 
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, configurationRequest);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, configurationRequest,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -424,7 +451,8 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, configurationRequest);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, configurationRequest,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -457,6 +485,9 @@ public class AmbariManagementControllerImplTest {
     expect(clusterRequest.getClusterName()).andReturn("clusterNew").anyTimes();
     expect(clusterRequest.getClusterId()).andReturn(1L).anyTimes();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     ConfigurationRequest configReq = new ConfigurationRequest();
     final Map<String, String> configReqProps = Maps.newHashMap();
     configReqProps.put("p1", null);
@@ -479,7 +510,8 @@ public class AmbariManagementControllerImplTest {
     expectLastCall();
 
     // replay mocks
-    replay(actionManager, cluster, clusters, config, injector, clusterRequest, sessionManager);
+    replay(actionManager, cluster, clusters, config, injector, clusterRequest, sessionManager,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -487,7 +519,8 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, config, injector, clusterRequest, sessionManager);
+    verify(actionManager, cluster, clusters, config, injector, clusterRequest, sessionManager,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -516,8 +549,12 @@ public class AmbariManagementControllerImplTest {
     expect(clusters.getClusterById(1L)).andReturn(cluster).times(1);
     expect(cluster.getClusterName()).andReturn("cluster").times(1);
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -525,7 +562,8 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -557,6 +595,9 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getClusterName()).andReturn("cluster").times(1);
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     expect(kerberosHelper.shouldExecuteCustomOperations(SecurityType.KERBEROS, null))
         .andReturn(false)
         .once();
@@ -566,7 +607,8 @@ public class AmbariManagementControllerImplTest {
     // Note: kerberosHelper.toggleKerberos is not called
 
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -574,7 +616,8 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
   /**
    * Ensure that when the cluster security type updated from NONE to KERBEROS, KerberosHandler.toggleKerberos
@@ -604,6 +647,9 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getClusterName()).andReturn("cluster").times(1);
     expect(cluster.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     expect(kerberosHelper.shouldExecuteCustomOperations(SecurityType.KERBEROS, null))
         .andReturn(false)
         .once();
@@ -617,8 +663,12 @@ public class AmbariManagementControllerImplTest {
         .andReturn(null)
         .once();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -626,7 +676,8 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -684,6 +735,9 @@ public class AmbariManagementControllerImplTest {
     expect(clusters.getClusterById(1L)).andReturn(cluster).times(1);
     expect(cluster.getClusterName()).andReturn("cluster").times(1);
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
 
     expect(kerberosHelper.shouldExecuteCustomOperations(SecurityType.NONE, null))
         .andReturn(false)
@@ -761,8 +815,12 @@ public class AmbariManagementControllerImplTest {
         .andThrow(new IllegalArgumentException("bad args!"))
         .once();
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -776,7 +834,8 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -804,11 +863,15 @@ public class AmbariManagementControllerImplTest {
     expect(clusterRequest.getClusterId()).andReturn(1L).times(4);
     expect(clusters.getClusterById(1L)).andReturn(cluster).times(1);
     expect(cluster.getClusterName()).andReturn("clusterOld").times(1);
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     cluster.setClusterName("clusterNew");
     expectLastCall().andThrow(new RollbackException());
 
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, injector);
@@ -820,7 +883,8 @@ public class AmbariManagementControllerImplTest {
     }
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -842,7 +906,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", 1L, "component1", "component1", "host1", null);
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
     setRequests.add(request1);
@@ -854,6 +918,19 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(maintHelper).anyTimes();
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
+    expect(hostComponentStateEntity.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getComponentName()).andReturn("component1").anyTimes();
+    expect(hostComponentStateEntity.getComponentType()).andReturn("component1").anyTimes();
+
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component1", "component1")).andReturn(serviceComponentDesiredStateEntity).anyTimes();
+    expect(serviceComponentDesiredStateEntity.getId()).andReturn(1L).times(2);
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
@@ -867,7 +944,7 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getName()).andReturn("service1").anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
-    expect(component.getName()).andReturn("component1");
+    expect(component.getId()).andReturn(1L).times(2);
     expect(component.getServiceComponentHosts()).andReturn(
         new HashMap<String, ServiceComponentHost>() {{
           put("host1", componentHost);
@@ -878,7 +955,8 @@ public class AmbariManagementControllerImplTest {
 
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, response, stack,
-        ambariMetaInfo, service, component, componentHost);
+        ambariMetaInfo, service, component, componentHost, hostComponentStateDAO, hostComponentStateEntity,
+        serviceComponentDesiredStateDAO, serviceComponentDesiredStateEntity);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -891,7 +969,9 @@ public class AmbariManagementControllerImplTest {
     assertEquals(1, setResponses.size());
     assertTrue(setResponses.contains(response));
 
-    verify(injector, clusters, cluster, host, response, stack, ambariMetaInfo, service, component, componentHost);
+    verify(injector, clusters, cluster, host, response, stack, ambariMetaInfo, service, component, componentHost,
+            hostComponentStateDAO, hostComponentStateEntity, serviceComponentDesiredStateDAO,
+            serviceComponentDesiredStateEntity);
   }
 
   @Test
@@ -909,7 +989,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", 1L, "component1", "component1", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -934,12 +1014,26 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getService("service1")).andReturn(service);
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
-    expect(component.getName()).andReturn("component1").anyTimes();
+    expect(component.getId()).andReturn(1L).anyTimes();
     expect(component.getServiceComponentHosts()).andReturn(null);
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
+    expect(hostComponentStateEntity.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getComponentName()).andReturn("component1").anyTimes();
+    expect(hostComponentStateEntity.getComponentType()).andReturn("component1").anyTimes();
+
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component1", "component1")).andReturn(serviceComponentDesiredStateEntity).anyTimes();
+    expect(serviceComponentDesiredStateEntity.getId()).andReturn(1L).anyTimes();
 
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, stack, ambariMetaInfo,
-        service, component);
+        service, component, hostComponentStateDAO, hostComponentStateEntity, serviceComponentDesiredStateDAO,
+            serviceComponentDesiredStateEntity);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -954,7 +1048,9 @@ public class AmbariManagementControllerImplTest {
 
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
-    verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component);
+    verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component,
+            hostComponentStateDAO, hostComponentStateEntity, serviceComponentDesiredStateDAO,
+            serviceComponentDesiredStateEntity);
   }
 
   @Test
@@ -974,7 +1070,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
     request1.setState("INSTALLED");
 
 
@@ -1018,9 +1114,12 @@ public class AmbariManagementControllerImplTest {
     expect(componentHost1.convertToResponse(null)).andReturn(response1);
     expect(componentHost1.getHostName()).andReturn("host1");
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, stack, ambariMetaInfo,
-        service, component, componentHost1, response1);
+        service, component, componentHost1, response1, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1031,7 +1130,8 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
     assertTrue(responses.size() == 1);
-    verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component, componentHost1, response1);
+    verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component, componentHost1, response1,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -1051,7 +1151,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
     request1.setMaintenanceState("ON");
 
 
@@ -1089,9 +1189,12 @@ public class AmbariManagementControllerImplTest {
     expect(componentHost1.convertToResponse(null)).andReturn(response1);
     expect(componentHost1.getHostName()).andReturn("host1");
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, stack, ambariMetaInfo,
-        service, component, componentHost1, response1);
+        service, component, componentHost1, response1, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1102,7 +1205,8 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
     assertTrue(responses.size() == 1);
-    verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component, componentHost1, response1);
+    verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component, componentHost1, response1,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -1135,13 +1239,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", 1L, "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host1", null);
+        "cluster1", "CORE", "service1", 2L, "component2", "component2","host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", 3L, "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1165,7 +1269,6 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component1);
     expect(service.getName()).andReturn("service1").anyTimes();
-    expect(component1.getName()).andReturn("component1");
     expect(component1.getServiceComponentHosts()).andReturn(
         new HashMap<String, ServiceComponentHost>() {{
           put("host1", componentHost1);
@@ -1175,23 +1278,60 @@ public class AmbariManagementControllerImplTest {
 
     expect(cluster.getServiceByComponentName("component2")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component2")).andReturn(component2);
-    expect(component2.getName()).andReturn("component2");
     expect(component2.getServiceComponentHosts()).andReturn(null);
     expect(componentHost2.getHostName()).andReturn("host1");
 
     expect(cluster.getServiceByComponentName("component3")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component3")).andReturn(component3);
-    expect(component3.getName()).andReturn("component3");
     expect(component3.getServiceComponentHosts()).andReturn(
         new HashMap<String, ServiceComponentHost>() {{
           put("host1", componentHost2);
         }});
     expect(componentHost2.convertToResponse(null)).andReturn(response2);
 
+    HostComponentStateEntity hostComponentStateEntity2 = createNiceMock(HostComponentStateEntity.class);
+    HostComponentStateEntity hostComponentStateEntity3 = createNiceMock(HostComponentStateEntity.class);
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
+    expect(hostComponentStateDAO.findById(2L)).andReturn(hostComponentStateEntity2).anyTimes();
+    expect(hostComponentStateDAO.findById(3L)).andReturn(hostComponentStateEntity3).anyTimes();
+
+    expect(hostComponentStateEntity.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getComponentName()).andReturn("component1").anyTimes();
+    expect(hostComponentStateEntity.getComponentType()).andReturn("component1").anyTimes();
+
+    expect(hostComponentStateEntity2.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getComponentName()).andReturn("component2").anyTimes();
+    expect(hostComponentStateEntity2.getComponentType()).andReturn("component2").anyTimes();
+
+    expect(hostComponentStateEntity3.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getComponentName()).andReturn("component3").anyTimes();
+    expect(hostComponentStateEntity3.getComponentType()).andReturn("component3").anyTimes();
+
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component1", "component1")).andReturn(serviceComponentDesiredStateEntity).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity2 = createMock(ServiceComponentDesiredStateEntity.class);
+
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component2", "component2")).andReturn(serviceComponentDesiredStateEntity2).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity3 = createMock(ServiceComponentDesiredStateEntity.class);
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component3", "component3")).andReturn(serviceComponentDesiredStateEntity3).anyTimes();
+    expect(serviceComponentDesiredStateEntity.getId()).andReturn(1L).times(2);
+
     // replay mocks
     replay(stateHelper, injector, clusters, cluster, host, stack,
         ambariMetaInfo, service, component1, component2, component3, componentHost1,
-        componentHost2, response1, response2);
+        componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1206,7 +1346,8 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response2));
 
     verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component1, component2, component3,
-        componentHost1, componentHost2, response1, response2);
+        componentHost1, componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
   }
 
   @Test
@@ -1234,13 +1375,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", 1L, "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service2", "component2", "host1", null);
+        "cluster1", "CORE", "service2", 2L, "component2", "component2", "host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", 3L, "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1270,7 +1411,6 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getService("service1")).andReturn(service);
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component1);
-    expect(component1.getName()).andReturn("component1");
     expect(component1.getServiceComponentHosts()).andReturn(new
                                                                HashMap<String, ServiceComponentHost>() {{
                                                                  put("host1", componentHost1);
@@ -1284,7 +1424,6 @@ public class AmbariManagementControllerImplTest {
     expect(service.getName()).andReturn("service1").anyTimes();
     expect(cluster.getServiceByComponentName("component3")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component3")).andReturn(component3);
-    expect(component3.getName()).andReturn("component3");
     expect(component3.getServiceComponentHosts()).andReturn(new
                                                                 HashMap<String, ServiceComponentHost>() {{
                                                                   put("host1", componentHost2);
@@ -1292,10 +1431,49 @@ public class AmbariManagementControllerImplTest {
     expect(componentHost2.convertToResponse(null)).andReturn(response2);
     expect(componentHost2.getHostName()).andReturn("host1");
 
+    HostComponentStateEntity hostComponentStateEntity2 = createNiceMock(HostComponentStateEntity.class);
+    HostComponentStateEntity hostComponentStateEntity3 = createNiceMock(HostComponentStateEntity.class);
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
+    expect(hostComponentStateDAO.findById(2L)).andReturn(hostComponentStateEntity2).anyTimes();
+    expect(hostComponentStateDAO.findById(3L)).andReturn(hostComponentStateEntity3).anyTimes();
+
+    expect(hostComponentStateEntity.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getComponentName()).andReturn("component1").anyTimes();
+    expect(hostComponentStateEntity.getComponentType()).andReturn("component1").anyTimes();
+
+    expect(hostComponentStateEntity2.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getComponentName()).andReturn("component2").anyTimes();
+    expect(hostComponentStateEntity2.getComponentType()).andReturn("component2").anyTimes();
+
+    expect(hostComponentStateEntity3.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getComponentName()).andReturn("component3").anyTimes();
+    expect(hostComponentStateEntity3.getComponentType()).andReturn("component3").anyTimes();
+
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component1", "component1")).andReturn(serviceComponentDesiredStateEntity).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity2 = createMock(ServiceComponentDesiredStateEntity.class);
+
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component2", "component2")).andReturn(serviceComponentDesiredStateEntity2).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity3 = createMock(ServiceComponentDesiredStateEntity.class);
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component3", "component3")).andReturn(serviceComponentDesiredStateEntity3).anyTimes();
+    expect(serviceComponentDesiredStateEntity.getId()).andReturn(1L).times(2);
+
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, stack, ambariMetaInfo,
         service, component1, component2, component3, componentHost1,
-        componentHost2, response1, response2);
+        componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1310,7 +1488,8 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response2));
 
     verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, component1, component2, component3,
-        componentHost1, componentHost2, response1, response2);
+        componentHost1, componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
   }
 
   @Test
@@ -1340,13 +1519,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", 1L, "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service2", "component2", "host1", null);
+        "cluster1", "CORE", "service2", 2L, "component2", "component2", "host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", 3L, "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1376,7 +1555,6 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getService("service1")).andReturn(service);
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
-    expect(component.getName()).andReturn("component1");
     expect(component.getServiceComponentHosts()).andReturn(ImmutableMap.<String, ServiceComponentHost>builder()
         .put("host1", componentHost1)
         .build());
@@ -1394,17 +1572,55 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getServiceByComponentName("component3")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component3")).andReturn(component3);
 
-    expect(component3.getName()).andReturn("component3");
     expect(component3.getServiceComponentHosts()).andReturn(ImmutableMap.<String, ServiceComponentHost>builder()
         .put("host1", componentHost2)
         .build());
     expect(componentHost2.convertToResponse(null)).andReturn(response2);
     expect(componentHost2.getHostName()).andReturn("host1");
 
+    HostComponentStateEntity hostComponentStateEntity2 = createNiceMock(HostComponentStateEntity.class);
+    HostComponentStateEntity hostComponentStateEntity3 = createNiceMock(HostComponentStateEntity.class);
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
+    expect(hostComponentStateDAO.findById(2L)).andReturn(hostComponentStateEntity2).anyTimes();
+    expect(hostComponentStateDAO.findById(3L)).andReturn(hostComponentStateEntity3).anyTimes();
+
+    expect(hostComponentStateEntity.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getComponentName()).andReturn("component1").anyTimes();
+    expect(hostComponentStateEntity.getComponentType()).andReturn("component1").anyTimes();
+
+    expect(hostComponentStateEntity2.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getComponentName()).andReturn("component2").anyTimes();
+    expect(hostComponentStateEntity2.getComponentType()).andReturn("component2").anyTimes();
+
+    expect(hostComponentStateEntity3.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getComponentName()).andReturn("component3").anyTimes();
+    expect(hostComponentStateEntity3.getComponentType()).andReturn("component3").anyTimes();
+
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component1", "component1")).andReturn(serviceComponentDesiredStateEntity).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity2 = createMock(ServiceComponentDesiredStateEntity.class);
+
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component2", "component2")).andReturn(serviceComponentDesiredStateEntity2).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity3 = createMock(ServiceComponentDesiredStateEntity.class);
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component3", "component3")).andReturn(serviceComponentDesiredStateEntity3).anyTimes();
+    expect(serviceComponentDesiredStateEntity.getId()).andReturn(1L).times(2);
+
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, stack, ambariMetaInfo,
         service, service2, component, component2, component3, componentHost1,
-        componentHost2, response1, response2);
+        componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1419,7 +1635,8 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response2));
 
     verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, service2, component, component2, component3,
-        componentHost1, componentHost2, response1, response2);
+        componentHost1, componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
   }
 
   @Test
@@ -1448,13 +1665,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", null, null);
+        "cluster1", "CORE", "service1", 1L, "component1", "component1", null, null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host2", null);
+        "cluster1", "CORE", "service1", 2L, "component2", "component2", "host2", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", null, null);
+        "cluster1", "CORE", "service1", 3L, "component3", "component3", null, null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1484,7 +1701,6 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
     expect(service.getName()).andReturn("service1").anyTimes();
-    expect(component.getName()).andReturn("component1");
     expect(component.getServiceComponentHosts()).andReturn(Collections.singletonMap("foo", componentHost1));
     expect(componentHost1.convertToResponse(null)).andReturn(response1);
     expect(componentHost1.getHostName()).andReturn("host1");
@@ -1494,15 +1710,53 @@ public class AmbariManagementControllerImplTest {
     expect(cluster.getService("service1")).andReturn(service);
     expect(cluster.getServiceByComponentName("component3")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component3")).andReturn(component3);
-    expect(component3.getName()).andReturn("component3");
     expect(component3.getServiceComponentHosts()).andReturn(Collections.singletonMap("foo", componentHost2));
     expect(componentHost2.convertToResponse(null)).andReturn(response2);
     expect(componentHost2.getHostName()).andReturn("host1");
 
+    HostComponentStateEntity hostComponentStateEntity2 = createNiceMock(HostComponentStateEntity.class);
+    HostComponentStateEntity hostComponentStateEntity3 = createNiceMock(HostComponentStateEntity.class);
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
+    expect(hostComponentStateDAO.findById(2L)).andReturn(hostComponentStateEntity2).anyTimes();
+    expect(hostComponentStateDAO.findById(3L)).andReturn(hostComponentStateEntity3).anyTimes();
+
+    expect(hostComponentStateEntity.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity.getComponentName()).andReturn("component1").anyTimes();
+    expect(hostComponentStateEntity.getComponentType()).andReturn("component1").anyTimes();
+
+    expect(hostComponentStateEntity2.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity2.getComponentName()).andReturn("component2").anyTimes();
+    expect(hostComponentStateEntity2.getComponentType()).andReturn("component2").anyTimes();
+
+    expect(hostComponentStateEntity3.getClusterId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceGroupId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getServiceId()).andReturn(1L).anyTimes();
+    expect(hostComponentStateEntity3.getComponentName()).andReturn("component3").anyTimes();
+    expect(hostComponentStateEntity3.getComponentType()).andReturn("component3").anyTimes();
+
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component1", "component1")).andReturn(serviceComponentDesiredStateEntity).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity2 = createMock(ServiceComponentDesiredStateEntity.class);
+
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component2", "component2")).andReturn(serviceComponentDesiredStateEntity2).anyTimes();
+    ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity3 = createMock(ServiceComponentDesiredStateEntity.class);
+    expect(serviceComponentDesiredStateDAO.findByName(1L, 1L, 1L,
+            "component3", "component3")).andReturn(serviceComponentDesiredStateEntity3).anyTimes();
+    expect(serviceComponentDesiredStateEntity.getId()).andReturn(1L).times(2);
+
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, host, stack, ambariMetaInfo,
         service, service2, component, component2, component3, componentHost1,
-        componentHost2, response1, response2);
+        componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1518,7 +1772,8 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response2));
 
     verify(injector, clusters, cluster, host, stack, ambariMetaInfo, service, service2, component, component2, component3,
-        componentHost1, componentHost2, response1, response2);
+        componentHost1, componentHost2, response1, response2, hostComponentStateDAO, serviceComponentDesiredStateDAO,
+            hostComponentStateEntity, hostComponentStateEntity2, hostComponentStateEntity3);
   }
 
   @Test
@@ -1533,13 +1788,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host1", null);
+        "cluster1", "CORE", "service1", "component2", "component2", "host1", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1554,12 +1809,15 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(maintHelper);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
     expect(clusters.getClustersForHost("host1")).andThrow(new HostNotFoundException("host1"));
 
     // replay mocks
-    replay(maintHelper, injector, clusters, cluster, stack, ambariMetaInfo);
+    replay(maintHelper, injector, clusters, cluster, stack, ambariMetaInfo, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1575,7 +1833,7 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
 
-    verify(injector, clusters, cluster, stack, ambariMetaInfo);
+    verify(injector, clusters, cluster, stack, ambariMetaInfo, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -1588,13 +1846,13 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", "host1", null);
+        "cluster1", "CORE", "service1", "component1", "component1", "host1", null);
 
     ServiceComponentHostRequest request2 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component2", "host2", null);
+        "cluster1", "CORE", "service1", "component2", "component2", "host2", null);
 
     ServiceComponentHostRequest request3 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component3", "host1", null);
+        "cluster1", "CORE", "service1", "component3", "component3", "host1", null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1611,6 +1869,9 @@ public class AmbariManagementControllerImplTest {
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andThrow(new ClusterNotFoundException("cluster1"));
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
 
     // replay mocks
     replay(maintHelper, injector, clusters, stack, ambariMetaInfo);
@@ -1653,7 +1914,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", "service1", "component1", null, null);
+        "cluster1", "CORE", "service1", "component1", "component1", null, null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1689,9 +1950,13 @@ public class AmbariManagementControllerImplTest {
     expect(componentHost1.getHostName()).andReturn("host1");
     expect(componentHost2.getHostName()).andReturn("host1");
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, response1, response2,
-        stack, ambariMetaInfo, service, component, componentHost1, componentHost2);
+        stack, ambariMetaInfo, service, component, componentHost1, componentHost2,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1705,7 +1970,8 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response1));
     assertTrue(setResponses.contains(response2));
 
-    verify(injector, clusters, cluster, response1, response2, stack, ambariMetaInfo, service, component, componentHost1, componentHost2);
+    verify(injector, clusters, cluster, response1, response2, stack, ambariMetaInfo, service, component, componentHost1,
+            componentHost2, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -1733,7 +1999,7 @@ public class AmbariManagementControllerImplTest {
 
     // requests
     ServiceComponentHostRequest request1 = new ServiceComponentHostRequest(
-        "cluster1", "CORE", null, null, null, null);
+        "cluster1", "CORE", null, null, null, null, null);
 
 
     Set<ServiceComponentHostRequest> setRequests = new HashSet<>();
@@ -1776,13 +2042,16 @@ public class AmbariManagementControllerImplTest {
     expect(componentHost2.getHostName()).andReturn("host1");
     expect(componentHost3.getHostName()).andReturn("host1");
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     expect(component2.getServiceComponentHosts()).andReturn(Collections.singletonMap("foobar", componentHost3));
     expect(componentHost3.convertToResponse(null)).andReturn(response3);
 
     // replay mocks
     replay(maintHelper, injector, clusters, cluster, response1, response2,
         response3, stack, ambariMetaInfo, service1, service2, component1, component2,
-        componentHost1, componentHost2, componentHost3);
+        componentHost1, componentHost2, componentHost3, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     //test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -1798,7 +2067,7 @@ public class AmbariManagementControllerImplTest {
     assertTrue(setResponses.contains(response3));
 
     verify(injector, clusters, cluster, response1, response2, response3, stack, ambariMetaInfo, service1, service2,
-        component1, component2, componentHost1, componentHost2, componentHost3);
+        component1, component2, componentHost1, componentHost2, componentHost3, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -1845,15 +2114,19 @@ public class AmbariManagementControllerImplTest {
 
     expect(serviceInfo.getOsSpecifics()).andReturn(osSpecificsService);
     expect(stackInfo.getOsSpecifics()).andReturn(osSpecificsStack);
+
     injector.injectMembers(capture(controllerCapture));
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(maintHelper).anyTimes();
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     OsFamily osFamilyMock = createNiceMock(OsFamily.class);
 
     EasyMock.expect(osFamilyMock.isVersionedOsFamilyExtendedByVersionedFamily("testOSFamily", "testOSFamily")).andReturn(true).times(3);
-    replay(maintHelper, injector, clusters, stackInfo, serviceInfo, osFamilyMock);
+    replay(maintHelper, injector, clusters, stackInfo, serviceInfo, osFamilyMock, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     AmbariManagementControllerImplTest.NestedTestClass nestedTestClass = this.new NestedTestClass(null, clusters,
         injector, osFamilyMock);
@@ -2000,7 +2273,8 @@ public class AmbariManagementControllerImplTest {
     expectLastCall().anyTimes();
 
     //replay
-    replay(ldapDataPopulator, clusters, actionDBAccessor, ambariMetaInfo, users, ldapBatchDto);
+    replay(ldapDataPopulator, clusters, actionDBAccessor, ambariMetaInfo, users, ldapBatchDto,
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     AmbariManagementControllerImpl controller = injector.getInstance(AmbariManagementControllerImpl.class);
 
@@ -2019,7 +2293,7 @@ public class AmbariManagementControllerImplTest {
 
     controller.synchronizeLdapUsersAndGroups(userRequest, groupRequest);
 
-    verify(ldapDataPopulator, clusters, users, ldapBatchDto);
+    verify(ldapDataPopulator, clusters, users, ldapBatchDto, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   private void setAmbariMetaInfo(AmbariMetaInfo metaInfo, AmbariManagementController controller) throws NoSuchFieldException, IllegalAccessException {
@@ -2041,6 +2315,10 @@ public class AmbariManagementControllerImplTest {
       binder.bind(Users.class).toInstance(users);
       binder.bind(AmbariSessionManager.class).toInstance(sessionManager);
       binder.bind(RegistryManager.class).toInstance(registryManager);
+      binder.bind(HostComponentStateEntity.class).toInstance(hostComponentStateEntity);
+      binder.bind(HostComponentStateDAO.class).toInstance(hostComponentStateDAO);
+      binder.bind(ServiceComponentDesiredStateEntity.class).toInstance(serviceComponentDesiredStateEntity);
+      binder.bind(ServiceComponentDesiredStateDAO.class).toInstance(serviceComponentDesiredStateDAO);
     }
   }
 
@@ -2071,12 +2349,15 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(null);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
 
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
+
     Configuration configuration = createNiceMock(Configuration.class);
     String[] suffices = {"/repodata/repomd.xml"};
     expect(configuration.getRepoValidationSuffixes("redhat6")).andReturn(suffices);
 
     // replay mocks
-    replay(injector, clusters, ambariMetaInfo, configuration);
+    replay(injector, clusters, ambariMetaInfo, configuration, hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);
@@ -2101,7 +2382,7 @@ public class AmbariManagementControllerImplTest {
       Assert.assertEquals("Could not access base url . file:///some/repo/repodata/repomd.xml . ", e.getMessage());
     }
 
-    verify(injector, clusters, ambariMetaInfo, configuration);
+    verify(injector, clusters, ambariMetaInfo, configuration, hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   @Test
@@ -2121,6 +2402,9 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(null);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
 
     RepositoryInfo dummyRepoInfo = new RepositoryInfo();
     dummyRepoInfo.setRepoName("repo_name");
@@ -2253,6 +2537,8 @@ public class AmbariManagementControllerImplTest {
     samplePacklet.setDefinition("nifi.tar.gz");
     packletArrayList.add(samplePacklet);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(null).atLeastOnce();
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
     expect(ambariMetaInfo.getModules(mpackId)).andReturn(packletArrayList).atLeastOnce();
     replay(ambariMetaInfo,injector);
     AmbariManagementController controller = new AmbariManagementControllerImpl(null, clusters, injector);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/BackgroundCustomCommandExecutionTest.java
@@ -224,13 +224,13 @@ public class BackgroundCustomCommandExecutionTest {
   private void createServiceComponent(String clusterName, String serviceGroupName,
       String serviceName, String componentName, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/RefreshYarnCapacitySchedulerReleaseConfigTest.java
@@ -106,7 +106,7 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
     controller.updateClusters(Collections.singleton(cr) , null);
 
 
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null, null);
     r.setStaleConfig("true");
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(1, resps.size());
@@ -127,7 +127,7 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
     controller.updateClusters(Collections.singleton(cr) , null);
 
 
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest("c1", null, null, null, null, null, null);
     r.setStaleConfig("true");
     Set<ServiceComponentHostResponse> resps = controller.getHostComponents(Collections.singleton(r));
     Assert.assertEquals(4, resps.size());
@@ -215,13 +215,13 @@ public class RefreshYarnCapacitySchedulerReleaseConfigTest {
   private void createServiceComponent(String clusterName, String serviceGroupName,
       String serviceName, String componentName, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(String clusterName, String serviceGroupName, String serviceName, String componentName, String hostname, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
     controller.createHostComponents(Collections.singleton(r));
 
     //set actual config

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
@@ -245,7 +245,7 @@ public class ClientConfigResourceProviderTest {
     serviceOsSpecificHashMap.put("key", osSpecific);
 
     ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, clusterName, 1L, "CORE", 1L, serviceName, serviceName, 1L,
-        componentName, displayName, hostName, publicHostname, desiredState, "", null, null, null,
+        componentName, componentName, displayName, hostName, publicHostname, desiredState, "", null, null, null,
         null);
 
     Set<ServiceComponentHostResponse> responses = new LinkedHashSet<>();
@@ -499,7 +499,7 @@ public class ClientConfigResourceProviderTest {
     serviceOsSpecificHashMap.put("key", osSpecific);
 
     ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, clusterName, 1L, "CORE", 1L, serviceName, serviceName, 1L,
-        componentName, displayName, hostName, publicHostName, desiredState, "", null, null, null,
+        componentName, componentName, displayName, hostName, publicHostName, desiredState, "", null, null, null,
         null);
 
     Set<ServiceComponentHostResponse> responses = new LinkedHashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -61,6 +61,8 @@ import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.utilities.PredicateBuilder;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.ambari.server.orm.dao.HostComponentStateDAO;
+import org.apache.ambari.server.orm.dao.ServiceComponentDesiredStateDAO;
 import org.apache.ambari.server.security.TestAuthenticationFactory;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.security.authorization.AuthorizationHelperInitializer;
@@ -152,7 +154,7 @@ public class ComponentResourceProviderTest {
     expect(componentInfo.isRecoveryEnabled()).andReturn(true).anyTimes();
     expect(ambariMetaInfo.getComponent("HDP", "99", "Service100", "Component100")).andReturn(componentInfo).anyTimes();
 
-    expect(serviceComponentFactory.createNew(service, "Component100")).andReturn(serviceComponent);
+    expect(serviceComponentFactory.createNew(service, "Component100", "Component100")).andReturn(serviceComponent);
 
     ServiceComponentResponse componentResponse = createNiceMock(ServiceComponentResponse.class);
     expect(serviceComponent.convertToResponse()).andReturn(componentResponse);
@@ -251,13 +253,13 @@ public class ComponentResourceProviderTest {
     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
 
     expect(serviceComponent1.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component100", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 1L, "Component100", "Component100", stackId, "", serviceComponentStateCountMap,
               true /* recovery enabled */, "Component100 Client", null, null));
     expect(serviceComponent2.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component101", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 2L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component101 Client", null, null));
     expect(serviceComponent3.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", "Component102", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "CORE", 1L, "Service100", "Service100", 3L, "Component102", "Component102", stackId, "", serviceComponentStateCountMap,
               true /* recovery enabled */, "Component102 Client", "1.1", RepositoryVersionState.CURRENT));
 
     expect(ambariMetaInfo.getComponent("FOO", "1.0", null, "Component100")).andReturn(
@@ -431,13 +433,13 @@ public class ComponentResourceProviderTest {
     expect(component3Info.getCategory()).andReturn(null);
 
     expect(serviceComponent1.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component101", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component101 Client", null, null));
     expect(serviceComponent2.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component102", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 2L, "Component102", "Component102",stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component102 Client", null, null));
     expect(serviceComponent3.convertToResponse()).andReturn(
-      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component103", stackId, "", serviceComponentStateCountMap,
+      new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 3L, "Component103", "Component103", stackId, "", serviceComponentStateCountMap,
               false /* recovery not enabled */, "Component103 Client", null, null));
     expect(serviceComponent1.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
     expect(serviceComponent2.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
@@ -740,7 +742,7 @@ public class ComponentResourceProviderTest {
     expect(component1Info.getCategory()).andReturn(null);
 
     expect(serviceComponent1.convertToResponse()).andReturn(
-        new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", "Component101", stackId, "", serviceComponentStateCountMap,
+        new ServiceComponentResponse(100L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", stackId, "", serviceComponentStateCountMap,
             false /* recovery not enabled */, "Component101 Client", null, null));
     expect(serviceComponent1.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
 
@@ -948,6 +950,8 @@ public class ComponentResourceProviderTest {
     MaintenanceStateHelper maintHelper = createNiceMock(MaintenanceStateHelper.class);
     Cluster cluster = createNiceMock(Cluster.class);
     Service service = createNiceMock(Service.class);
+    HostComponentStateDAO hostComponentStateDAO = createMock(HostComponentStateDAO.class);
+    ServiceComponentDesiredStateDAO serviceComponentDesiredStateDAO = createMock(ServiceComponentDesiredStateDAO.class);
 
     // requests
     ServiceComponentRequest request1 = new ServiceComponentRequest("cluster1", "CORE", "service1", "component1",
@@ -962,6 +966,9 @@ public class ComponentResourceProviderTest {
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(maintHelper);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(createNiceMock(KerberosHelper.class));
+
+    expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
+    expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
 
     // getComponents
     expect(clusters.getCluster("cluster1")).andReturn(cluster);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
@@ -112,7 +112,7 @@ public class HostComponentResourceProviderTest {
 
     AbstractControllerResourceProvider.init(resourceProviderFactory);
 
-    ServiceComponentHostRequest request = new ServiceComponentHostRequest("Cluster100", SERVICE_GROUP_NAME, "Service100", "Component100", "Host100", null);
+    ServiceComponentHostRequest request = new ServiceComponentHostRequest("Cluster100", SERVICE_GROUP_NAME, "Service100", "Component100", "Component100", "Host100", null);
     Set<ServiceComponentHostRequest> expectedRequests = Collections.singleton(request);
     expect(managementController.createHostComponents(eq(expectedRequests))).andReturn(null).once();
 
@@ -141,6 +141,7 @@ public class HostComponentResourceProviderTest {
     properties.put(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID, SERVICE_GROUP_NAME);
     properties.put(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID, "Service100");
     properties.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "Component100");
+    properties.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID, "Component100");
     properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "Host100");
 
     propertySet.add(properties);
@@ -183,17 +184,17 @@ public class HostComponentResourceProviderTest {
     String repositoryVersion2 = "0.2-1234";
 
     allResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
+        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100", "Host100", "Host100",
         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
         stackId2.getStackId(), repositoryVersion2, null));
 
     allResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component 101", "Host100", "Host100",
+        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component101", "Component101", "Component 101", "Host100", "Host100",
         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
         stackId2.getStackId(), repositoryVersion2, null));
 
     allResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102", "Host100", "Host100",
+        1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102", "Host100", "Host100",
         State.INSTALLED.toString(), stackId.getStackId(), State.STARTED.toString(),
         stackId2.getStackId(), repositoryVersion2, null));
 
@@ -350,7 +351,7 @@ public class HostComponentResourceProviderTest {
 
     Set<ServiceComponentHostResponse> nameResponse = new HashSet<>();
     nameResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
+        1L, "Cluster102", 1L, "ServiceGroup100", 1L, "Service100", "", 1L, "Component100", "Component100","Component 100", "Host100", "Host100",
         "INSTALLED", "", "", "", "", null));
 
     // set expectations
@@ -378,7 +379,7 @@ public class HostComponentResourceProviderTest {
     changedHosts.put("Component100", Collections.singletonMap(State.STARTED, changedComponentHosts));
 
     expect(managementController.addStages(null, cluster, mapRequestProps, null, null, null, changedHosts,
-        Collections.emptyList(), false, false)).andReturn(stageContainer).once();
+        Collections.emptyList(), false, false)).andReturn(stageContainer).anyTimes();
 
     stageContainer.persist();
     expect(stageContainer.getRequestStatusResponse()).andReturn(response).once();
@@ -411,7 +412,9 @@ public class HostComponentResourceProviderTest {
     Predicate predicate = new PredicateBuilder().property(
         HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID).equals("Cluster102").and().
         property(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID).equals("INSTALLED").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component100").toPredicate();
+            property(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID).equals("ServiceGroup100").and().
+            property(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID).equals("Service100").and().
+        property(HostComponentResourceProvider.HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID).equals(100L).toPredicate();
     RequestStatus requestStatus = provider.updateResources(request, predicate);
     Resource responseResource = requestStatus.getRequestResource();
     assertEquals("response msg", responseResource.getPropertyValue(PropertyHelper.getPropertyId("Requests", "message")));
@@ -450,7 +453,7 @@ public class HostComponentResourceProviderTest {
         new HostComponentResourceProvider(managementController, injector);
 
     // set expectations
-    ServiceComponentHostRequest request = new ServiceComponentHostRequest(null, null, null, "Component100", "Host100", null);
+    ServiceComponentHostRequest request = new ServiceComponentHostRequest(null, null, null, 1L, "Component100", "Component100", "Host100", null);
     expect(managementController.deleteHostComponents(Collections.singleton(request))).andReturn(deleteStatusMetaData);
 
     // replay
@@ -463,7 +466,9 @@ public class HostComponentResourceProviderTest {
     provider.addObserver(observer);
 
     Predicate predicate = new PredicateBuilder().
+        property(HostComponentResourceProvider.HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID).equals(1L).and().
         property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component100").and().
+        property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_TYPE_PROPERTY_ID).equals("Component100").and().
         property(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID).equals("Host100").toPredicate();
     provider.deleteResources(new RequestImpl(null, null, null, null), predicate);
 
@@ -535,7 +540,7 @@ public class HostComponentResourceProviderTest {
 
     Set<ServiceComponentHostResponse> nameResponse = new HashSet<>();
     nameResponse.add(new ServiceComponentHostResponse(
-        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100", "Host100", "Host100",
+        1L, "Cluster102", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100", "Host100", "Host100",
         "INSTALLED", "", "", "", "", null));
 
     // set expectations
@@ -588,7 +593,7 @@ public class HostComponentResourceProviderTest {
     Predicate predicate = new PredicateBuilder().property(
         HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID).equals("Cluster102").and().
         property(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID).equals("INSTALLED").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component100").toPredicate();
+        property(HostComponentResourceProvider.HOST_COMPONENT_HOST_COMPONENT_ID_PROPERTY_ID).equals(100L).toPredicate();
 
 
     try {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
@@ -314,11 +314,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100","Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L,"Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -409,11 +409,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -501,11 +501,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100",  "Component100","Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "INSTALLED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103",  "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -688,7 +688,7 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();
@@ -772,11 +772,11 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Set<Cluster> clusterSet = new HashSet<>();
     clusterSet.add(cluster);
 
-    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component 100",
+    ServiceComponentHostResponse shr1 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component100", "Component100", "Component 100",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
-    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component 102",
+    ServiceComponentHostResponse shr2 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component102", "Component102", "Component 102",
         "Host100", "Host100", "INSTALLED", "", null, null, null, null);
-    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component 103",
+    ServiceComponentHostResponse shr3 = new ServiceComponentHostResponse(1L, "Cluster100", 1L, "", 1L, "Service100", "", 1L, "Component103", "Component103", "Component 103",
         "Host100", "Host100", "STARTED", "", null, null, null, null);
 
     Set<ServiceComponentHostResponse> responses = new HashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
@@ -123,14 +123,14 @@ public class JMXHostProviderTest {
   private void createServiceComponent(String clusterName, String serviceGroupName,
                                       String serviceName, String componentName, State desiredState)
       throws AmbariException, AuthorizationException {
-    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, desiredState != null ? desiredState.name() : null);
+    ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, desiredState != null ? desiredState.name() : null);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
   private void createServiceComponentHost(String clusterName, String serviceGroupName,
                                           String serviceName, String componentName, String hostname,
                                           State desiredState) throws AmbariException, AuthorizationException {
-    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, hostname, desiredState != null ? desiredState.name() : null);
+    ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName, serviceName, componentName, componentName, hostname, desiredState != null ? desiredState.name() : null);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProviderTest.java
@@ -256,7 +256,7 @@ public class ServiceDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
-            serviceName, componentName, dStateStr);
+            serviceName, componentName, componentName, dStateStr);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
@@ -269,7 +269,7 @@ public class ServiceDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
-            serviceName, componentName, hostname, dStateStr);
+            serviceName, componentName, componentName, hostname, dStateStr);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupDependencyResourceProviderTest.java
@@ -251,7 +251,7 @@ public class ServiceGroupDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentRequest r = new ServiceComponentRequest(clusterName, serviceGroupName,
-            serviceName, componentName, dStateStr);
+            serviceName, componentName, componentName, dStateStr);
     ComponentResourceProviderTest.createComponents(controller, Collections.singleton(r));
   }
 
@@ -264,7 +264,7 @@ public class ServiceGroupDependencyResourceProviderTest {
       dStateStr = desiredState.toString();
     }
     ServiceComponentHostRequest r = new ServiceComponentHostRequest(clusterName, serviceGroupName,
-            serviceName, componentName, hostname, dStateStr);
+            serviceName, componentName, componentName, hostname, dStateStr);
     controller.createHostComponents(Collections.singleton(r));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackDefinedPropertyProviderTest.java
@@ -142,22 +142,22 @@ public class StackDefinedPropertyProviderTest {
     RepositoryVersionEntity repositoryVersion = helper.getOrCreateRepositoryVersion(stackId, stackId.getStackVersion());
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service service = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
-    service.addServiceComponent("NAMENODE");
-    service.addServiceComponent("DATANODE");
-    service.addServiceComponent("JOURNALNODE");
+    service.addServiceComponent("NAMENODE", "NAMENODE");
+    service.addServiceComponent("DATANODE", "DATANODE");
+    service.addServiceComponent("JOURNALNODE", "JOURNALNODE");
 
     service = cluster.addService(serviceGroup, "YARN", "YARN", repositoryVersion);
-    service.addServiceComponent("RESOURCEMANAGER");
+    service.addServiceComponent("RESOURCEMANAGER", "RESOURCEMANAGER");
 
     service = cluster.addService(serviceGroup, "HBASE", "HBASE", repositoryVersion);
-    service.addServiceComponent("HBASE_MASTER");
-    service.addServiceComponent("HBASE_REGIONSERVER");
+    service.addServiceComponent("HBASE_MASTER", "HBASE_MASTER");
+    service.addServiceComponent("HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
 
     stackId = new StackId("HDP-2.1.1");
     repositoryVersion = helper.getOrCreateRepositoryVersion(stackId, stackId.getStackVersion());
 
     service = cluster.addService(serviceGroup, "STORM", "STORM", repositoryVersion);
-    service.addServiceComponent("STORM_REST_API");
+    service.addServiceComponent("STORM_REST_API", "STORM_REST_API");
 
     clusters.addHost("h1");
     Host host = clusters.getHost("h1");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
@@ -177,11 +177,11 @@ public class UpgradeSummaryResourceProviderTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service service = cluster.addService(serviceGroup, "ZOOKEEPER", "ZOOKEEPER", repoVersionEntity);
 
-    ServiceComponent component = service.addServiceComponent("ZOOKEEPER_SERVER");
+    ServiceComponent component = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
     ServiceComponentHost sch = component.addServiceComponentHost("h1");
     sch.setVersion("2.2.0.0");
 
-    component = service.addServiceComponent("ZOOKEEPER_CLIENT");
+    component = service.addServiceComponent("ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
     sch = component.addServiceComponentHost("h1");
     sch.setVersion("2.2.0.0");
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/DefaultServiceCalculatedStateTest.java
@@ -43,8 +43,8 @@ public final class DefaultServiceCalculatedStateTest extends GeneralServiceCalcu
 
   @Override
   protected void createComponentsAndHosts() throws Exception{
-    ServiceComponent masterComponent = service.addServiceComponent("ZOOKEEPER_SERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("ZOOKEEPER_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/FlumeServiceCalculatedStateTest.java
@@ -41,7 +41,7 @@ public class FlumeServiceCalculatedStateTest extends GeneralServiceCalculatedSta
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("FLUME_HANDLER");
+    ServiceComponent masterComponent = service.addServiceComponent("FLUME_HANDLER", "FLUME_HANDLER");
 
 
     for (String hostName: hosts){

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HBaseServiceCalculatedStateTest.java
@@ -41,9 +41,9 @@ public class HBaseServiceCalculatedStateTest extends GeneralServiceCalculatedSta
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("HBASE_MASTER");
-    ServiceComponent secondMasterComponent = service.addServiceComponent("HBASE_REGIONSERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("HBASE_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("HBASE_MASTER", "HBASE_MASTER");
+    ServiceComponent secondMasterComponent = service.addServiceComponent("HBASE_REGIONSERVER", "HBASE_REGIONSERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("HBASE_CLIENT", "HBASE_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HDFSServiceCalculatedStateTest.java
@@ -42,9 +42,9 @@ public class HDFSServiceCalculatedStateTest extends GeneralServiceCalculatedStat
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("NAMENODE");
-    ServiceComponent masterComponent1 = service.addServiceComponent("SECONDARY_NAMENODE");
-    ServiceComponent clientComponent = service.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("NAMENODE", "NAMENODE");
+    ServiceComponent masterComponent1 = service.addServiceComponent("SECONDARY_NAMENODE", "SECONDARY_NAMENODE");
+    ServiceComponent clientComponent = service.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/HiveServiceCalculatedStateTest.java
@@ -42,11 +42,11 @@ public class HiveServiceCalculatedStateTest extends GeneralServiceCalculatedStat
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("HIVE_METASTORE");
-    ServiceComponent secondMasterComponent = service.addServiceComponent("HIVE_SERVER");
-    ServiceComponent thirdMasterComponent = service.addServiceComponent("WEBHCAT_SERVER");
-    ServiceComponent fourMasterComponent = service.addServiceComponent("MYSQL_SERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("HIVE_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("HIVE_METASTORE", "HIVE_METASTORE");
+    ServiceComponent secondMasterComponent = service.addServiceComponent("HIVE_SERVER", "HIVE_SERVER");
+    ServiceComponent thirdMasterComponent = service.addServiceComponent("WEBHCAT_SERVER", "WEBHCAT_SERVER");
+    ServiceComponent fourMasterComponent = service.addServiceComponent("MYSQL_SERVER", "MYSQL_SERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("HIVE_CLIENT", "HIVE_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/OozieServiceCalculatedStateTest.java
@@ -41,8 +41,8 @@ public class OozieServiceCalculatedStateTest extends GeneralServiceCalculatedSta
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("OOZIE_SERVER");
-    ServiceComponent clientComponent = service.addServiceComponent("OOZIE_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("OOZIE_SERVER", "OOZIE_SERVER");
+    ServiceComponent clientComponent = service.addServiceComponent("OOZIE_CLIENT", "OOZIE_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/state/YarnServiceCalculatedStateTest.java
@@ -42,9 +42,9 @@ public class YarnServiceCalculatedStateTest extends GeneralServiceCalculatedStat
 
   @Override
   protected void createComponentsAndHosts() throws Exception {
-    ServiceComponent masterComponent = service.addServiceComponent("RESOURCEMANAGER");
-    ServiceComponent secondMasterComponent = service.addServiceComponent("NODEMANAGER");
-    ServiceComponent clientComponent = service.addServiceComponent("YARN_CLIENT");
+    ServiceComponent masterComponent = service.addServiceComponent("RESOURCEMANAGER", "RESOURCEMANAGER");
+    ServiceComponent secondMasterComponent = service.addServiceComponent("NODEMANAGER", "NODEMANAGER");
+    ServiceComponent clientComponent = service.addServiceComponent("YARN_CLIENT", "YARN_CLIENT");
 
     for (String hostName: hosts){
       clusters.addHost(hostName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
@@ -366,7 +366,7 @@ public class EventsTest {
     Service service = m_cluster.getService(serviceName);
     Assert.assertNotNull(service);
 
-    ServiceComponent component = m_componentFactory.createNew(service, "DATANODE");
+    ServiceComponent component = m_componentFactory.createNew(service, "DATANODE", "DATANODE");
     service.addServiceComponent(component);
     component.setDesiredState(State.INSTALLED);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
@@ -558,7 +558,7 @@ public class HostVersionOutOfSyncListenerTest {
     for (Map.Entry<String, List<Integer>> component : topology.entrySet()) {
 
       String componentName = component.getKey();
-      cl.getService(serviceName).addServiceComponent(componentName);
+      cl.getService(serviceName).addServiceComponent(componentName, componentName);
 
       for (Integer hostIndex : component.getValue()) {
         cl.getService(serviceName)
@@ -580,7 +580,7 @@ public class HostVersionOutOfSyncListenerTest {
     Service service = cl.getService(serviceName);
 
     if (!service.getServiceComponents().containsKey(componentName)) {
-      service.addServiceComponent(componentName);
+      service.addServiceComponent(componentName, componentName);
     }
 
     ServiceComponent component = service.getServiceComponent(componentName);

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
@@ -468,7 +468,7 @@ public class OrmTestHelper {
     Service service = cluster.getService(serviceName);
     assertNotNull(service);
 
-    ServiceComponent datanode = componentFactory.createNew(service, "DATANODE");
+    ServiceComponent datanode = componentFactory.createNew(service, "DATANODE", "DATANODE");
 
     service.addServiceComponent(datanode);
     datanode.setDesiredState(State.INSTALLED);
@@ -479,7 +479,7 @@ public class OrmTestHelper {
     sch.setDesiredState(State.INSTALLED);
     sch.setState(State.INSTALLED);
 
-    ServiceComponent namenode = componentFactory.createNew(service, "NAMENODE");
+    ServiceComponent namenode = componentFactory.createNew(service, "NAMENODE", "NAMENODE");
 
     service.addServiceComponent(namenode);
     namenode.setDesiredState(State.INSTALLED);
@@ -503,7 +503,7 @@ public class OrmTestHelper {
     assertNotNull(service);
 
     ServiceComponent resourceManager = componentFactory.createNew(service,
-        "RESOURCEMANAGER");
+        "RESOURCEMANAGER", "RESOURCEMANAGER");
 
     service.addServiceComponent(resourceManager);
     resourceManager.setDesiredState(State.INSTALLED);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckActionTest.java
@@ -511,7 +511,7 @@ public class ComponentVersionCheckActionTest {
     try {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
-      serviceComponent = serviceComponentFactory.createNew(service, componentName);
+      serviceComponent = serviceComponentFactory.createNew(service, componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
@@ -269,7 +269,7 @@ public class CreateAndConfigureActionTest {
     try {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
-      serviceComponent = serviceComponentFactory.createNew(service, componentName);
+      serviceComponent = serviceComponentFactory.createNew(service, componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceComponentTest.java
@@ -109,7 +109,7 @@ public class ServiceComponentTest {
   public void testCreateServiceComponent() throws AmbariException {
     String componentName = "DATANODE2";
     ServiceComponent component = serviceComponentFactory.createNew(service,
-        componentName);
+        componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -131,7 +131,7 @@ public class ServiceComponentTest {
   public void testGetAndSetServiceComponentInfo() throws AmbariException {
     String componentName = "NAMENODE";
     ServiceComponent component = serviceComponentFactory.createNew(service,
-        componentName);
+        componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -155,7 +155,7 @@ public class ServiceComponentTest {
     long serviceId = 1;
 
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     ServiceComponent sc1 = serviceComponentFactory.createExisting(service,
         serviceComponentDesiredStateEntity);
@@ -193,7 +193,7 @@ public class ServiceComponentTest {
   @Test
   public void testAddAndGetServiceComponentHosts() throws AmbariException {
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -246,18 +246,13 @@ public class ServiceComponentTest {
 
     long serviceGroupId = 1;
     long serviceId = 1;
+    long componentId = 1;
 
     HostComponentDesiredStateEntity desiredStateEntity =
-        desiredStateDAO.findByIndex(
-          cluster.getClusterId(),
-          serviceGroupId,
-                serviceId,
-          componentName,
-          hostEntity1.getHostId()
-        );
+        desiredStateDAO.findByIndex(componentId);
 
     HostComponentStateEntity stateEntity = liveStateDAO.findByIndex(cluster.getClusterId(),
-            serviceGroupId, serviceId, componentName, hostEntity1.getHostId());
+            serviceGroupId, serviceId, componentId, hostEntity1.getHostId());
 
     ServiceComponentHost sch = serviceComponentHostFactory.createExisting(sc,
         stateEntity, desiredStateEntity);
@@ -271,7 +266,7 @@ public class ServiceComponentTest {
   @Test
   public void testConvertToResponse() throws AmbariException {
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     addHostToCluster("h1", service.getCluster().getClusterName());
@@ -332,7 +327,7 @@ public class ServiceComponentTest {
   public void testCanBeRemoved() throws Exception {
     String componentName = "NAMENODE";
     ServiceComponent component = serviceComponentFactory.createNew(service,
-                                                                   componentName);
+                                                                   componentName, componentName);
     addHostToCluster("h1", service.getCluster().getClusterName());
     ServiceComponentHost sch = serviceComponentHostFactory.createNew(component, "h1");
     component.addServiceComponentHost(sch);
@@ -360,7 +355,7 @@ public class ServiceComponentTest {
         ServiceComponentDesiredStateDAO.class);
 
     String componentName = "NAMENODE";
-    ServiceComponent component = serviceComponentFactory.createNew(service, componentName);
+    ServiceComponent component = serviceComponentFactory.createNew(service, componentName, componentName);
     service.addServiceComponent(component);
 
     ServiceComponent sc = service.getServiceComponent(componentName);
@@ -373,7 +368,7 @@ public class ServiceComponentTest {
     long serviceId = 1;
 
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     Assert.assertNotNull(serviceComponentDesiredStateEntity);
 
@@ -413,7 +408,7 @@ public class ServiceComponentTest {
 
     // verify history is gone, too
     serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(
-        cluster.getClusterId(), serviceGroupId, serviceId, componentName);
+        cluster.getClusterId(), serviceGroupId, serviceId, componentName, componentName);
 
     Assert.assertNull(serviceComponentDesiredStateEntity);
  }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
@@ -100,7 +100,7 @@ public class ServiceTest {
       org.junit.Assert.assertTrue(service.canBeRemoved());
     }
 
-    ServiceComponent component = service.addServiceComponent("NAMENODE");
+    ServiceComponent component = service.addServiceComponent("NAMENODE", "NAMENODE");
 
     // component can be removed
     component.setDesiredState(State.INSTALLED);
@@ -179,11 +179,11 @@ public class ServiceTest {
     Assert.assertTrue(s.getServiceComponents().isEmpty());
 
     ServiceComponent sc1 =
-        serviceComponentFactory.createNew(s, "NAMENODE");
+        serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     ServiceComponent sc2 =
-        serviceComponentFactory.createNew(s, "DATANODE1");
+        serviceComponentFactory.createNew(s, "DATANODE1", "DATANODE1");
     ServiceComponent sc3 =
-        serviceComponentFactory.createNew(s, "DATANODE2");
+        serviceComponentFactory.createNew(s, "DATANODE2", "DATANODE2");
 
     Map<String, ServiceComponent> comps = new
       HashMap<>();
@@ -205,7 +205,7 @@ public class ServiceTest {
 
     s.addServiceComponent(sc3);
 
-    ServiceComponent sc4 = s.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent sc4 = s.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
     Assert.assertNotNull(s.getServiceComponent(sc4.getName()));
     Assert.assertEquals(State.INIT,
         s.getServiceComponent("HDFS_CLIENT").getDesiredState());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterDeadlockTest.java
@@ -595,7 +595,7 @@ public class ClusterDeadlockTest {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
@@ -237,20 +237,20 @@ public class ClusterImplTest {
     ServiceGroup serviceGroup = cluster.addServiceGroup("CORE", stackId.getStackId());
     Service hdfs = cluster.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
 
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
+    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
     nameNode.addServiceComponentHost(hostName1);
 
-    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE");
+    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE", "DATANODE");
     dataNode.addServiceComponentHost(hostName1);
     dataNode.addServiceComponentHost(hostName2);
 
-    ServiceComponent hdfsClient = hdfs.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent hdfsClient = hdfs.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
     hdfsClient.addServiceComponentHost(hostName1);
     hdfsClient.addServiceComponentHost(hostName2);
 
     Service tez = cluster.addService(serviceGroup, serviceToDelete, serviceToDelete, repositoryVersion);
 
-    ServiceComponent tezClient = tez.addServiceComponent("TEZ_CLIENT");
+    ServiceComponent tezClient = tez.addServiceComponent("TEZ_CLIENT", "TEZ_CLIENT");
     ServiceComponentHost tezClientHost1 =  tezClient.addServiceComponentHost(hostName1);
     ServiceComponentHost tezClientHost2 = tezClient.addServiceComponentHost(hostName2);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
@@ -343,22 +343,22 @@ public class ClusterTest {
     cluster.addService(s3);
 
     // Add HDFS components
-    ServiceComponent sc1CompA = serviceComponentFactory.createNew(s1, "NAMENODE");
-    ServiceComponent sc1CompB = serviceComponentFactory.createNew(s1, "DATANODE");
-    ServiceComponent sc1CompC = serviceComponentFactory.createNew(s1, "HDFS_CLIENT");
+    ServiceComponent sc1CompA = serviceComponentFactory.createNew(s1, "NAMENODE", "NAMENODE");
+    ServiceComponent sc1CompB = serviceComponentFactory.createNew(s1, "DATANODE", "DATANODE");
+    ServiceComponent sc1CompC = serviceComponentFactory.createNew(s1, "HDFS_CLIENT", "HDFS_CLIENT");
     s1.addServiceComponent(sc1CompA);
     s1.addServiceComponent(sc1CompB);
     s1.addServiceComponent(sc1CompC);
 
     // Add ZK
-    ServiceComponent sc2CompA = serviceComponentFactory.createNew(s2, "ZOOKEEPER_SERVER");
-    ServiceComponent sc2CompB = serviceComponentFactory.createNew(s2, "ZOOKEEPER_CLIENT");
+    ServiceComponent sc2CompA = serviceComponentFactory.createNew(s2, "ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
+    ServiceComponent sc2CompB = serviceComponentFactory.createNew(s2, "ZOOKEEPER_CLIENT", "ZOOKEEPER_CLIENT");
     s2.addServiceComponent(sc2CompA);
     s2.addServiceComponent(sc2CompB);
 
     // Add Ganglia
-    ServiceComponent sc3CompA = serviceComponentFactory.createNew(s3, "GANGLIA_SERVER");
-    ServiceComponent sc3CompB = serviceComponentFactory.createNew(s3, "GANGLIA_MONITOR");
+    ServiceComponent sc3CompA = serviceComponentFactory.createNew(s3, "GANGLIA_SERVER", "GANGLIA_SERVER");
+    ServiceComponent sc3CompB = serviceComponentFactory.createNew(s3, "GANGLIA_MONITOR", "GANGLIA_MONITOR");
     s3.addServiceComponent(sc3CompA);
     s3.addServiceComponent(sc3CompB);
 
@@ -633,7 +633,7 @@ public class ClusterTest {
 
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s);
-    ServiceComponent sc = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent sc = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(sc);
 
     ServiceComponentHost sch =
@@ -651,7 +651,7 @@ public class ClusterTest {
         iterator.next();
         Service s1 = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "PIG", "PIG", repositoryVersion);
         c1.addService(s1);
-        ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "PIG");
+        ServiceComponent sc1 = serviceComponentFactory.createNew(s1, "PIG", "PIG");
         s1.addServiceComponent(sc1);
         ServiceComponentHost sch1 = serviceComponentHostFactory.createNew(sc1, "h1");
         sc1.addServiceComponentHost(sch1);
@@ -673,12 +673,12 @@ public class ClusterTest {
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
     s.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
@@ -703,12 +703,12 @@ public class ClusterTest {
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "HDFS", "HDFS", repositoryVersion);
     c1.addService(s);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
     s.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
@@ -739,12 +739,12 @@ public class ClusterTest {
     Service s = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(),  "HDFS",  "HDFS", repositoryVersion);
     c1.addService(s);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(s, "NAMENODE", "NAMENODE");
     s.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(s, "DATANODE", "DATANODE");
     s.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
@@ -776,19 +776,19 @@ public class ClusterTest {
     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
     c1.addService(sfMR);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
     sfHDFS.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
     sfHDFS.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
     scDN.addServiceComponentHost(scDNH2);
 
-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
+    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
     sfMR.addServiceComponent(scJT);
     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
     scJT.addServiceComponentHost(schJTH1);
@@ -834,19 +834,19 @@ public class ClusterTest {
     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
     c1.addService(sfMR);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
     sfHDFS.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
     sfHDFS.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
     scDN.addServiceComponentHost(scDNH2);
 
-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
+    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
     sfMR.addServiceComponent(scJT);
     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
     scJT.addServiceComponentHost(schJTH1);
@@ -893,19 +893,19 @@ public class ClusterTest {
     Service sfMR = serviceFactory.createNew(c1, serviceGroup, Collections.emptyList(), "MAPREDUCE", "MAPREDUCE", repositoryVersion);
     c1.addService(sfMR);
 
-    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE");
+    ServiceComponent scNN = serviceComponentFactory.createNew(sfHDFS, "NAMENODE", "NAMENODE");
     sfHDFS.addServiceComponent(scNN);
     ServiceComponentHost schNNH1 = serviceComponentHostFactory.createNew(scNN, "h1");
     scNN.addServiceComponentHost(schNNH1);
 
-    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE");
+    ServiceComponent scDN = serviceComponentFactory.createNew(sfHDFS, "DATANODE", "DATANODE");
     sfHDFS.addServiceComponent(scDN);
     ServiceComponentHost scDNH1 = serviceComponentHostFactory.createNew(scDN, "h1");
     scDN.addServiceComponentHost(scDNH1);
     ServiceComponentHost scDNH2 = serviceComponentHostFactory.createNew(scDN, "h2");
     scDN.addServiceComponentHost(scDNH2);
 
-    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER");
+    ServiceComponent scJT = serviceComponentFactory.createNew(sfMR, "JOBTRACKER", "JOBTRACKER");
     sfMR.addServiceComponent(scJT);
     ServiceComponentHost schJTH1 = serviceComponentHostFactory.createNew(scJT, "h1");
     scJT.addServiceComponentHost(schJTH1);
@@ -1076,7 +1076,7 @@ public class ClusterTest {
     c1.addService(serviceGroup, "MAPREDUCE", "MAPREDUCE", repositoryVersion);
 
     Service hdfs = c1.addService(serviceGroup, "HDFS", "HDFS", repositoryVersion);
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
+    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
 
     assertEquals(2, c1.getServices().size());
     assertEquals(2, injector.getProvider(EntityManager.class).get().
@@ -1541,8 +1541,8 @@ public class ClusterTest {
     c1.addService(hdfs);
 
     // Add HDFS components
-    ServiceComponent datanode = serviceComponentFactory.createNew(hdfs, "NAMENODE");
-    ServiceComponent namenode = serviceComponentFactory.createNew(hdfs, "DATANODE");
+    ServiceComponent datanode = serviceComponentFactory.createNew(hdfs, "NAMENODE", "NAMENODE");
+    ServiceComponent namenode = serviceComponentFactory.createNew(hdfs, "DATANODE", "DATANODE");
     hdfs.addServiceComponent(datanode);
     hdfs.addServiceComponent(namenode);
 
@@ -1874,12 +1874,12 @@ public class ClusterTest {
 
     ServiceGroup serviceGroup = c1.addServiceGroup("CORE", stackId.getStackId());
     Service service = c1.addService(serviceGroup, "ZOOKEEPER", "ZOOKEEPER", repositoryVersion);
-    ServiceComponent sc = service.addServiceComponent("ZOOKEEPER_SERVER");
+    ServiceComponent sc = service.addServiceComponent("ZOOKEEPER_SERVER", "ZOOKEEPER_SERVER");
     sc.addServiceComponentHost("h-1");
     sc.addServiceComponentHost("h-2");
 
     service = c1.addService(serviceGroup, "SQOOP", "SQOOP", repositoryVersion);
-    sc = service.addServiceComponent("SQOOP");
+    sc = service.addServiceComponent("SQOOP", "SQOOP");
     sc.addServiceComponentHost("h-3");
 
     HostEntity hostEntity = hostDAO.findByName("h-3");

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersDeadlockTest.java
@@ -374,7 +374,7 @@ public class ClustersDeadlockTest {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
@@ -432,10 +432,10 @@ public class ClustersTest {
 
     //Assert.assertNotNull(injector.getInstance(ClusterServiceDAO.class).findByClusterAndServiceNames(c1, "HDFS"));
 
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
-    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE");
+    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE", "NAMENODE");
+    ServiceComponent dataNode = hdfs.addServiceComponent("DATANODE", "DATANODE");
 
-    ServiceComponent serviceCheckNode = hdfs.addServiceComponent("HDFS_CLIENT");
+    ServiceComponent serviceCheckNode = hdfs.addServiceComponent("HDFS_CLIENT", "HDFS_CLIENT");
 
     ServiceComponentHost nameNodeHost = nameNode.addServiceComponentHost(h1);
     HostEntity nameNodeHostEntity = hostDAO.findByName(nameNodeHost.getHostName());
@@ -448,15 +448,9 @@ public class ClustersTest {
 
     Assert.assertNotNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
       nameNodeHost.getClusterId(), 1L, 1L,
-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()));
+      nameNodeHost.getServiceComponentId(),  nameNodeHostEntity.getHostId()));
 
-    Assert.assertNotNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(
-      nameNodeHost.getClusterId(),
-      1L,
-      1L,
-      nameNodeHost.getServiceComponentName(),
-      nameNodeHostEntity.getHostId()
-    ));
+    Assert.assertNotNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(nameNodeHost.getServiceComponentId()));
     Assert.assertEquals(2, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config").getResultList().size());
     Assert.assertEquals(1, injector.getProvider(EntityManager.class).get().createQuery("SELECT state FROM ClusterStateEntity state").getResultList().size());
     Assert.assertEquals(1, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config WHERE config.selected = 1").getResultList().size());
@@ -492,12 +486,9 @@ public class ClustersTest {
     Assert.assertEquals(2, hostDAO.findAll().size());
     Assert.assertNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
       nameNodeHost.getClusterId(), 1L, 1L,
-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()));
+      nameNodeHost.getServiceComponentId(), nameNodeHostEntity.getHostId()));
 
-    Assert.assertNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(
-      nameNodeHost.getClusterId(), 1L, 1L,
-      nameNodeHost.getServiceComponentName(), nameNodeHostEntity.getHostId()
-    ));
+    Assert.assertNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(nameNodeHost.getServiceComponentId()));
     Assert.assertEquals(0, injector.getProvider(EntityManager.class).get().createQuery("SELECT config FROM ClusterConfigEntity config").getResultList().size());
     Assert.assertEquals(0, injector.getProvider(EntityManager.class).get().createQuery("SELECT state FROM ClusterStateEntity state").getResultList().size());
     Assert.assertEquals(0, topologyRequestDAO.findByClusterId(cluster.getClusterId()).size());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ConcurrentServiceConfigVersionTest.java
@@ -243,7 +243,7 @@ public class ConcurrentServiceConfigVersionTest {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, componentName);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ServiceComponentHostConcurrentWriteDeadlockTest.java
@@ -139,7 +139,7 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
     clusters.mapHostToCluster(hostName, "c1");
 
     Service service = installService("HDFS");
-    addServiceComponent(service, "NAMENODE");
+    addServiceComponent(service, "NAMENODE", "NAMENODE");
   }
 
   @After
@@ -151,8 +151,8 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
    */
   @Test()
   public void testConcurrentWriteDeadlock() throws Exception {
-    ServiceComponentHost nameNodeSCH = createNewServiceComponentHost("HDFS", "NAMENODE", "c6401");
-    ServiceComponentHost dataNodeSCH = createNewServiceComponentHost("HDFS", "DATANODE", "c6401");
+    ServiceComponentHost nameNodeSCH = createNewServiceComponentHost("HDFS", "NAMENODE", "NAMENODE", "c6401");
+    ServiceComponentHost dataNodeSCH = createNewServiceComponentHost("HDFS", "DATANODE", "DATANODE", "c6401");
 
     List<ServiceComponentHost> serviceComponentHosts = new ArrayList<>();
     serviceComponentHosts.add(nameNodeSCH);
@@ -229,10 +229,10 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
   }
 
   private ServiceComponentHost createNewServiceComponentHost(String svc,
-      String svcComponent, String hostName) throws AmbariException {
+      String svcComponentName, String svcComponentType, String hostName) throws AmbariException {
     Assert.assertNotNull(cluster.getConfigGroups());
     Service s = installService(svc);
-    ServiceComponent sc = addServiceComponent(s, svcComponent);
+    ServiceComponent sc = addServiceComponent(s, svcComponentName, svcComponentType);
 
     ServiceComponentHost sch = serviceComponentHostFactory.createNew(sc, hostName);
 
@@ -258,13 +258,13 @@ public class ServiceComponentHostConcurrentWriteDeadlockTest {
   }
 
   private ServiceComponent addServiceComponent(Service service,
-      String componentName) throws AmbariException {
+      String componentName, String svcComponentType) throws AmbariException {
     ServiceComponent serviceComponent = null;
     try {
       serviceComponent = service.getServiceComponent(componentName);
     } catch (ServiceComponentNotFoundException e) {
       serviceComponent = serviceComponentFactory.createNew(service,
-          componentName);
+          componentName, svcComponentType);
       service.addServiceComponent(serviceComponent);
       serviceComponent.setDesiredState(State.INSTALLED);
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostTest.java
@@ -202,7 +202,7 @@ public class ServiceComponentHostTest {
     try {
       sc = s.getServiceComponent(svcComponent);
     } catch (ServiceComponentNotFoundException e) {
-      sc = serviceComponentFactory.createNew(s, svcComponent);
+      sc = serviceComponentFactory.createNew(s, svcComponent, svcComponent);
       s.addServiceComponent(sc);
     }
 
@@ -1053,26 +1053,14 @@ public class ServiceComponentHostTest {
     ServiceComponentHost sch2 = createNewServiceComponentHost(cluster, "HDFS", "DATANODE", hostName, customServiceGroup);
     ServiceComponentHost sch3 = createNewServiceComponentHost(cluster, "MAPREDUCE2", "HISTORYSERVER", hostName, customServiceGroup);
 
-    HostComponentDesiredStateEntity entity = hostComponentDesiredStateDAO.findByIndex(
-      cluster.getClusterId(),
-      customServiceGroup.getServiceGroupId(),
-      sch1.getServiceId(),
-      sch1.getServiceComponentName(),
-      hostEntity.getHostId()
-    );
+    HostComponentDesiredStateEntity entity = hostComponentDesiredStateDAO.findByIndex(sch1.getServiceComponentId());
     Assert.assertEquals(MaintenanceState.OFF, entity.getMaintenanceState());
     Assert.assertEquals(MaintenanceState.OFF, sch1.getMaintenanceState());
 
     sch1.setMaintenanceState(MaintenanceState.ON);
     Assert.assertEquals(MaintenanceState.ON, sch1.getMaintenanceState());
 
-    entity = hostComponentDesiredStateDAO.findByIndex(
-      cluster.getClusterId(),
-      customServiceGroup.getServiceGroupId(),
-      sch1.getServiceId(),
-      sch1.getServiceComponentName(),
-      hostEntity.getHostId()
-    );
+    entity = hostComponentDesiredStateDAO.findByIndex(sch1.getServiceComponentId());
     Assert.assertEquals(MaintenanceState.ON, entity.getMaintenanceState());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**BACKGROUND:**

Given that in Ambari, we refer components of a services in 2 ways: 

  - **1.** One from the Service component APIs : 
    **http://<AmbariServerHost>:8080/api/v1/clusters/<clusterName>/services/<ServiceName>/components/<componentName>**

  - **2.** From the host component APIs (which tell us the host on which the current component is resides)
    **http://<AmbariServerHost>:8080/api/v1/clusters/<clusterName>/hosts/<hostName>/host_components/<hostComponentName>**

_Note that, we are referring both 1and 2 using the component names_

But in the multi-component world for Ambari, we will come up with a situation like this, as shown below:

 - **A.** If **core** _Service Group_ has its **HDFS_CLIENT** type component named as **HDFS_CLIENT** 
    **Core -> HDFS -> HDFS_CLIENT**
 - **B.** And at the same time, we have **edw** _Service Group_ having its **HDFS_CLIENT** type component named as **HDFS_CLIENT** : 
    **edw -> HDFS -> HDFS_CLIENT**

There is  no good way to distinguish a given host component in **A** and **B**, if we continue to refer them with the component name end point (No. **2** API call). 
However, No. **1** call is still fine as we will not allow 2 names for the same component within a given service, thus making it unique and allowing us to continue using the component names endpoint.   




****WORK DONE****


In order to support multi-instance for components of a given service, we need to enhance the **Host Components API** so that they can distinguish **one component instance of a service** from **another component instance of a service** with the same Name.

The way to achieve this is to move Host Components API to be **ID** (number) based end point, compared to earlier being a name based endpoint. This will allow us to distinguish  **Core -> HDFS -> HDFS_CLIENT** from **edw -> HDFS -> HDFS_CLIENT**, as an example.

Thus, following changes are required:

  - New field : **component_type** (eg: HDFS_CLIENT, HIVE_SERVER, ZOOKEEPER_SERVER etc)
  - Existing field : **component_name** will now hold the actual name given for the component at the time of install. For example: 
     - **HDFS_CLIENT_EDW** for component_type **HDFS_CLIENT**
     - **HIVE_SERVER** FOR component_type **HIVE_SERVER**  _(name can be same as type also)_
     - **HIVE_SERVER1** for component_type **HIVE_SERVER**
     - **ZOOKEEPER_SERVER_FOR_KAFKA** for component_type **ZOOKEEPER_SERVER**, and so forth.
     
  - A way to identify the HOST component uniquely via API calls, by way of referring them by **ID** instead of name.


**MODIFIED API CALLs:**

1. POST SERVICE COMPONENT API call 
 
- CHANGE : New field **component_type**
- POST http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components

  Body :

 ```
  [{"ServiceComponentInfo":{"component_name":"HDFS_CLIENT2","component_type":"HDFS_CLIENT"}}]
```

  Response:
  

```
{
  "resources" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2",
      "ServiceComponentInfo" : {
        "category" : null,
        "cluster_id" : 2,
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "component_type" : "HDFS_CLIENT",
        "desired_stack" : "HDP-2.6",
        "desired_version" : "NOT_REQUIRED",
        "display_name" : "HDFS Client",
        "id" : 51,
        "recovery_enabled" : false,
        "service_group_id" : 2,
        "service_group_name" : "core",
        "service_id" : 3,
        "service_name" : "HDFS",
        "service_type" : "HDFS",
        "state" : "STARTED",
        "total_count" : {
          "installFailedCount" : 0,
          "unknownCount" : 0,
          "installedCount" : 0,
          "initCount" : 0,
          "installedAndMaintenanceOffCount" : 0,
          "startedCount" : 0,
          "totalCount" : 0
        }
      }
    }
  ]
}
```

  

2. POST HOST COMPONENT API call 

- CHANGE : New field **component_type**
- POST http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components
  Body
  
`   {"HostRoles":{
"component_name":"HDFS_CLIENT2",
"component_type":"HDFS_CLIENT",    
"service_group_name": "core", 
"service_name": "HDFS"}}
  `
- Response:
  
```
   {
  "resources" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51",
      "HostRoles" : {
        "actual_configs" : { },
        "cluster_id" : 2,
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "component_type" : "HDFS_CLIENT",
        "desired_admin_state" : null,
        "desired_repository_version" : "2.6.4.0-91",
        "desired_stack_id" : "HDP-2.6",
        "display_name" : "HDFS_CLIENT2",
        "host_name" : "<host1>",
        "id" : 51,
        "maintenance_state" : null,
        "public_host_name" : "<host1>",
        "service_group_id" : 2,
        "service_group_name" : "core",
        "service_id" : 3,
        "service_name" : "HDFS",
        "service_type" : "HDFS",
        "stale_configs" : false,
        "state" : "INIT",
        "upgrade_state" : "NONE",
        "version" : "UNKNOWN"
      },
      "host" : {
        "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>"
      }
    }
  ]
}
```



3. GET SERVICE COMPONENT:

   - CHANGE: **host_components** sub-resource will be referenced with end point as ID one.

   - GET http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2

   - Response: 
     
 
```
   {
  "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2",
  "ServiceComponentInfo" : {
    "category" : null,
    "cluster_id" : 2,
    "cluster_name" : "c1",
    "component_name" : "HDFS_CLIENT2",
    "component_type" : "HDFS_CLIENT",
    "desired_stack" : "HDP-2.6",
    "desired_version" : "2.6.4.0-91",
    "display_name" : "HDFS Client",
    "id" : 51,
    "init_count" : 1,
    "install_failed_count" : 0,
    "installed_and_maintenance_off_count" : 0,
    "installed_count" : 0,
    "recovery_enabled" : "false",
    "repository_state" : "NOT_REQUIRED",
    "service_group_id" : 2,
    "service_group_name" : "core",
    "service_id" : 3,
    "service_name" : "HDFS",
    "service_type" : "HDFS",
    "started_count" : 0,
    "state" : "STARTED",
    "total_count" : 1,
    "unknown_count" : 0
  },
  "host_components" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51",
      "HostRoles" : {
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "host_name" : "<host1>",
        "id" : 51,
        "service_group_name" : "core",
        "service_name" : "HDFS"
      }
    }
  ]
}
```

   


4. GET HOST COMPONENT:

   - CHANGE: Called with ID based end point

   - GET http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51

   - Response:

    
 
```
   {
  "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>/host_components/51",
  "HostRoles" : {
    "cluster_name" : "c1",
    "component_name" : "HDFS_CLIENT2",
    "component_type" : "HDFS_CLIENT",
    "desired_repository_version" : "2.6.4.0-91",
    "desired_stack_id" : "HDP-2.6",
    "desired_state" : "INIT",
    "display_name" : "HDFS_CLIENT2",
    "host_name" : "<host1>",
    "id" : 51,
    "maintenance_state" : "OFF",
    "public_host_name" : "<host1>",
    "reload_configs" : false,
    "service_group_name" : "core",
    "service_name" : "HDFS",
    "stale_configs" : false,
    "state" : "INIT",
    "upgrade_state" : "NONE",
    "version" : "UNKNOWN",
    "actual_configs" : { }
  },
  "host" : {
    "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/hosts/<host1>"
  },
  "processes" : [ ],
  "component" : [
    {
      "href" : "http://{{AmbariServer}}:8080/api/v1/clusters/<clusterName>/servicegroups/core/services/HDFS/components/HDFS_CLIENT2",
      "ServiceComponentInfo" : {
        "cluster_name" : "c1",
        "component_name" : "HDFS_CLIENT2",
        "service_group_name" : "core",
        "service_name" : "HDFS"
      }
    }
  ]
}
```

  
5. UPDATE SERVICE COMPONENTS
    - NO CHANGE

6. UPDATE HOST COMPONENTS 
   - CHANGE: API end point is ID based now.

 7. DELETE SERVICE COMPONENT:
     - No CHANGE

8. DELETE HOST COMPONENT: 
    - CHANGE: API end point is ID based now.

## How was this patch tested?

Tested on live cluster, Details given above.