### PR TITLE
AMBARI-23092. Deleting a Group from the Group detail page navigates t…

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/userManagement/GroupEditCtrl.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/userManagement/GroupEditCtrl.js
@@ -104,7 +104,7 @@ function($scope, $rootScope, Group, $routeParams, Cluster, View, Alert, Confirma
           });
         }
         group.destroy().then(function() {
-          $location.path('/userManagement?tab=groups');
+          $location.url('/userManagement?tab=groups');
           if (clusterPrivilegesIds.length) {
             Cluster.deleteMultiplePrivileges($rootScope.cluster.Clusters.cluster_name, clusterPrivilegesIds);
           }


### PR DESCRIPTION
…o the Cluster Information page

## What changes were proposed in this pull request?
Deleting a Group from the Group detail page navigates to the Cluster Information page	


## How was this patch tested?
manually


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.