### PR TITLE
FIX AMBARI-23095 knoxsso.redirect.whitelist.regex port not required

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/KNOX/configuration/knoxsso-topology.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/KNOX/configuration/knoxsso-topology.xml
@@ -107,7 +107,7 @@
               &lt;/param&gt;
               &lt;param&gt;
                  &lt;name&gt;knoxsso.redirect.whitelist.regex&lt;/name&gt;
-                 &lt;value&gt;^https?:\/\/(localhost|127\.0\.0\.1|0:0:0:0:0:0:0:1|::1)(:[0-9]+)?(\/|\/.*)$&lt;/value&gt;
+                 &lt;value&gt;^https?:\/\/(localhost|127\.0\.0\.1|0:0:0:0:0:0:0:1|::1)(:[0-9]+)?(\/|\/.*)?$&lt;/value&gt;
               &lt;/param&gt;
           &lt;/service&gt;
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/KNOX/configuration/knoxsso-topology.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/KNOX/configuration/knoxsso-topology.xml
@@ -107,7 +107,7 @@
               &lt;/param&gt;
               &lt;param&gt;
                  &lt;name&gt;knoxsso.redirect.whitelist.regex&lt;/name&gt;
-                 &lt;value&gt;^https?:\/\/(localhost|127\.0\.0\.1|0:0:0:0:0:0:0:1|::1):[0-9].*$&lt;/value&gt;
+                 &lt;value&gt;^https?:\/\/(localhost|127\.0\.0\.1|0:0:0:0:0:0:0:1|::1)(:[0-9]+)?(\/|\/.*)$&lt;/value&gt;
               &lt;/param&gt;
           &lt;/service&gt;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- make port number optional
- if there are any characters after the hostname or port, make sure it starts with /

## How was this patch tested?

Used on several clusters