### PR TITLE
AMBARI-22781. Fix OneFS blueprint installation (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -1542,6 +1542,10 @@ public class BlueprintConfigurationProcessor {
                 return origValue;
             }
 
+            if (topology.hasHadoopCompatibleFileSystem()) {
+              return origValue;
+            }
+
             throw new IllegalArgumentException(
                 String.format("Unable to update configuration property '%s' with topology information. " +
                     "Component '%s' is mapped to an invalid number of hosts '%s'.", propertyName, component, matchingGroupCount));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -1435,18 +1435,17 @@ public class BlueprintConfigurationProcessor {
     /**
      * Update the property with the new host name which runs the associated component.
      *
-     * @param propertyName  name of property
-     * @param origValue     original value of property
-     * @param properties    all properties
-     * @param topology      cluster topology
-     *
+     * @param propertyName name of property
+     * @param origValue    original value of property
+     * @param properties   all properties
+     * @param topology     cluster topology
      * @return updated property value with old host name replaced by new host name
      */
     @Override
     public String updateForClusterCreate(String propertyName,
                                          String origValue,
                                          Map<String, Map<String, String>> properties,
-                                         ClusterTopology topology)  {
+                                         ClusterTopology topology) {
 
       String replacedValue = super.updateForClusterCreate(propertyName, origValue, properties, topology);
       if (!Objects.equals(origValue, replacedValue)) {
@@ -1456,7 +1455,7 @@ public class BlueprintConfigurationProcessor {
         if (matchingGroupCount == 1) {
           //todo: warn if > 1 hosts
           return replacePropertyValue(origValue,
-              topology.getHostAssignmentsForComponent(component).iterator().next(), properties);
+            topology.getHostAssignmentsForComponent(component).iterator().next(), properties);
         } else {
           //todo: extract all hard coded HA logic
           Cardinality cardinality = topology.getBlueprint().getStack().getCardinality(component);
@@ -1507,7 +1506,7 @@ public class BlueprintConfigurationProcessor {
               }
             }
 
-            if ((isOozieServerHAEnabled(properties)) && isComponentOozieServer() && (matchingGroupCount > 1))     {
+            if ((isOozieServerHAEnabled(properties)) && isComponentOozieServer() && (matchingGroupCount > 1)) {
               if (!origValue.contains("localhost")) {
                 // if this Oozie property is a FQDN, then simply return it
                 return origValue;
@@ -1537,18 +1536,18 @@ public class BlueprintConfigurationProcessor {
 
             if ((isComponentAppTimelineServer() || isComponentHistoryServer()) &&
               (matchingGroupCount > 1 && origValue != null && !origValue.contains("localhost"))) {
-                // in case of multiple component instances of AppTimelineServer or History Server leave custom value
-                // if set
-                return origValue;
+              // in case of multiple component instances of AppTimelineServer or History Server leave custom value
+              // if set
+              return origValue;
             }
 
-            if (topology.hasHadoopCompatibleFileSystem()) {
+            if (topology.isComponentHadoopCompatible(component)) {
               return origValue;
             }
 
             throw new IllegalArgumentException(
-                String.format("Unable to update configuration property '%s' with topology information. " +
-                    "Component '%s' is mapped to an invalid number of hosts '%s'.", propertyName, component, matchingGroupCount));
+              String.format("Unable to update configuration property '%s' with topology information. " +
+                "Component '%s' is mapped to an invalid number of hosts '%s'.", propertyName, component, matchingGroupCount));
           }
         }
       }
@@ -1696,6 +1695,7 @@ public class BlueprintConfigurationProcessor {
     public String getComponentName() {
       return component;
     }
+
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -261,6 +261,9 @@ public class Stack {
     return componentInfo;
   }
 
+  /**
+   * @return an optional ServiceInfo of the given serviceName or Optional.empty() if the service doesn't exist in the stack
+   */
   public Optional<ServiceInfo> getServiceInfo(String serviceName) {
     try {
       return Optional.of(controller.getAmbariMetaInfo().getService(getName(), getVersion(), serviceName));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
@@ -42,6 +43,7 @@ import org.apache.ambari.server.state.ComponentInfo;
 import org.apache.ambari.server.state.DependencyInfo;
 import org.apache.ambari.server.state.PropertyDependencyInfo;
 import org.apache.ambari.server.state.PropertyInfo;
+import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
@@ -257,6 +259,14 @@ public class Stack {
       }
     }
     return componentInfo;
+  }
+
+  public Optional<ServiceInfo> getServiceInfo(String serviceName) {
+    try {
+      return Optional.of(controller.getAmbariMetaInfo().getService(getName(), getVersion(), serviceName));
+    } catch (AmbariException e) {
+      return Optional.empty();
+    }
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -62,6 +62,7 @@ public class ServiceInfo implements Validable{
   public static final AbstractMap.SimpleEntry<String, String> DEFAULT_SERVICE_INSTALLABLE_PROPERTY = new AbstractMap.SimpleEntry<>("installable", "true");
   public static final AbstractMap.SimpleEntry<String, String> DEFAULT_SERVICE_MANAGED_PROPERTY = new AbstractMap.SimpleEntry<>("managed", "true");
   public static final AbstractMap.SimpleEntry<String, String> DEFAULT_SERVICE_MONITORED_PROPERTY = new AbstractMap.SimpleEntry<>("monitored", "true");
+  public static final String HADOOP_COMPATIBLE_FS = "HCFS";
   /**
    * Format version. Added at schema ver 2
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Blueprint.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
+import org.apache.ambari.server.state.ServiceInfo;
 
 /**
  * Blueprint representation.
@@ -77,6 +78,11 @@ public interface Blueprint {
    * @return collection of all represented service names
    */
   Collection<String> getServices();
+
+  /**
+  * @return collection of all service infos
+   */
+  Collection<ServiceInfo> getServiceInfos();
 
   /**
    * Get the components that are included in the blueprint for the specified service.

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
@@ -181,7 +181,7 @@ public interface ClusterTopology {
   String getDefaultPassword();
 
   /**
-   * @return true if a service with serviceType=HCFS exists
+   * @return true if the given component belongs to a service that has serviceType=HCFS
    */
-  boolean hasHadoopCompatibleFileSystem();
+  boolean isComponentHadoopCompatible(String component);
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
@@ -180,4 +180,8 @@ public interface ClusterTopology {
 
   String getDefaultPassword();
 
+  /**
+   * @return true if a service with serviceType=HCFS exists
+   */
+  boolean hasHadoopCompatibleFileSystem();
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
@@ -33,6 +33,7 @@ import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.RequestStatusResponse;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
+import org.apache.ambari.server.state.ServiceInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -311,6 +312,11 @@ public class ClusterTopologyImpl implements ClusterTopology {
   @Override
   public String getDefaultPassword() {
     return defaultPassword;
+  }
+
+  @Override
+  public boolean hasHadoopCompatibleFileSystem() {
+    return blueprint.getServiceInfos().stream().anyMatch(each -> ServiceInfo.HADOOP_COMPATIBLE_FS.equals(each.getServiceType()));
   }
 
   private void registerHostGroupInfo(Map<String, HostGroupInfo> requestedHostGroupInfoMap) throws InvalidTopologyException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.topology;
 
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_AND_START;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_ONLY;
+import static org.apache.ambari.server.state.ServiceInfo.HADOOP_COMPATIBLE_FS;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +34,6 @@ import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.RequestStatusResponse;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
-import org.apache.ambari.server.state.ServiceInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -315,8 +315,12 @@ public class ClusterTopologyImpl implements ClusterTopology {
   }
 
   @Override
-  public boolean hasHadoopCompatibleFileSystem() {
-    return blueprint.getServiceInfos().stream().anyMatch(each -> ServiceInfo.HADOOP_COMPATIBLE_FS.equals(each.getServiceType()));
+  public boolean isComponentHadoopCompatible(String component) {
+    return blueprint.getServiceInfos().stream()
+      .filter(service -> service.getComponentByName(component) != null)
+      .findFirst()
+      .map(service -> HADOOP_COMPATIBLE_FS.equals(service.getServiceType()))
+      .orElse(false);
   }
 
   private void registerHostGroupInfo(Map<String, HostGroupInfo> requestedHostGroupInfoMap) throws InvalidTopologyException {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -145,6 +145,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
   public void init() throws Exception {
     expect(bp.getStack()).andReturn(stack).anyTimes();
     expect(bp.getName()).andReturn("test-bp").anyTimes();
+    expect(bp.getServiceInfos()).andReturn(Collections.emptyList()).anyTimes();
 
     expect(stack.getName()).andReturn(STACK_NAME).atLeastOnce();
     expect(stack.getVersion()).andReturn(STACK_VERSION).atLeastOnce();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterTopologyImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterTopologyImplTest.java
@@ -19,11 +19,14 @@
 package org.apache.ambari.server.topology;
 
 import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.createNiceMock;
 import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.reset;
 import static org.powermock.api.easymock.PowerMock.verify;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +34,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.state.ServiceInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -217,6 +221,24 @@ public class ClusterTopologyImplTest {
     TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
     replayAll();
     new ClusterTopologyImpl(null, request);
+  }
+
+  @Test
+  public void testHasHadoopCompatibleFsWhenThereIsHCFS() throws Exception {
+    ServiceInfo hcfs = new ServiceInfo();
+    hcfs.setServiceType(ServiceInfo.HADOOP_COMPATIBLE_FS);
+    expect(blueprint.getServiceInfos()).andReturn(Arrays.asList(hcfs)).anyTimes();
+    replayAll();
+    TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
+    assertTrue(new ClusterTopologyImpl(null, request).hasHadoopCompatibleFileSystem());
+  }
+
+  @Test
+  public void testHasHadoopCompatibleFsWhenThereIsNoHCFS() throws Exception {
+    expect(blueprint.getServiceInfos()).andReturn(Arrays.asList(new ServiceInfo())).anyTimes();
+    replayAll();
+    TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
+    assertFalse(new ClusterTopologyImpl(null, request).hasHadoopCompatibleFileSystem());
   }
 
   private class TestTopologyRequest implements TopologyRequest {


### PR DESCRIPTION
## What changes were proposed in this pull request?

OneFS blueprint installation failed because SingleHostTopologyUpdater tried to determine the namenode host which doesn't exist in a onefs setup. 

## How was this patch tested?

I used the following minimal blueprint to create a cluster with OneFS.

```json
{
  "configurations": [
      {
          "onefs": {
              "properties": {
                  "onefs_host": "scisilon.fqdn"
              }
          }
      }
  ],
  "host_groups": [{
      "name": "host_group_1",
      "components": [
          { "name": "ZOOKEEPER_SERVER" },
          { "name": "ZOOKEEPER_CLIENT" },
          { "name": "ONEFS_CLIENT" }
      ],
      "cardinality": "1"
  }],
  "Blueprints": {
      "stack_name": "HDP",
      "stack_version": "2.6"
  }
 }
```