### PR TITLE
Few more unit test fixes

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/HostServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/HostServiceTest.java
@@ -48,8 +48,8 @@ public class HostServiceTest extends BaseServiceTest {
 
     //getHosts
     service = new TestHostService("clusterName", null);
-    m = service.getClass().getMethod("getHosts", String.class, HttpHeaders.class, UriInfo.class);
-    args = new Object[] {null, getHttpHeaders(), getUriInfo()};
+    m = service.getClass().getMethod("getHosts", String.class, HttpHeaders.class, UriInfo.class, String.class);
+    args = new Object[] {null, getHttpHeaders(), getUriInfo(), null};
     listInvocations.add(new ServiceTestInvocation(Request.Type.GET, service, m, args, null));
 
     //createHost

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -6738,7 +6738,7 @@ public class AmbariManagementControllerTest {
   public void testGetStackServices() throws Exception {
     StackServiceRequest request = new StackServiceRequest(STACK_NAME, NEW_STACK_VERSION, null);
     Set<StackServiceResponse> responses = controller.getStackServices(Collections.singleton(request));
-    Assert.assertEquals(12, responses.size());
+    Assert.assertEquals(13, responses.size());
 
 
     StackServiceRequest requestWithParams = new StackServiceRequest(STACK_NAME, NEW_STACK_VERSION, SERVICE_NAME);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/MpackResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/MpackResourceProviderTest.java
@@ -111,9 +111,7 @@ public class MpackResourceProviderTest {
     // replay
     replay(m_dao);
 
-    ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
-            type
-    );
+    ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(type, m_amc);
 
     // create the request
     Request request = PropertyHelper.getReadRequest();
@@ -182,8 +180,7 @@ public class MpackResourceProviderTest {
     // replay
     replay(m_dao,m_amc);
 
-    ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
-            type);
+    ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(type, m_amc);
 
     // create the request
     Request request = PropertyHelper.getReadRequest();
@@ -222,8 +219,7 @@ public class MpackResourceProviderTest {
     replay(m_amc,request);
     // end expectations
 
-    MpackResourceProvider provider = (MpackResourceProvider) AbstractControllerResourceProvider.getResourceProvider(
-            Resource.Type.Mpack);
+    MpackResourceProvider provider = (MpackResourceProvider) AbstractControllerResourceProvider.getResourceProvider(Resource.Type.Mpack, m_amc);
 
     AbstractResourceProviderTest.TestObserver observer = new AbstractResourceProviderTest.TestObserver();
     ((ObservableResourceProvider)provider).addObserver(observer);

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.stack;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -39,6 +40,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.Role;
@@ -301,10 +304,11 @@ public class StackManagerTest {
     assertNotNull(si);
 
     //should include all stacks in hierarchy
-    assertEquals(18, services.size());
+    assertEquals(19, services.size());
 
-    HashSet<String> expectedServices = new HashSet<>();
+    Set<String> expectedServices = new TreeSet<>();
     expectedServices.add("GANGLIA");
+    expectedServices.add("HADOOP_CLIENTS");
     expectedServices.add("HBASE");
     expectedServices.add("HCATALOG");
     expectedServices.add("HDFS");
@@ -323,12 +327,13 @@ public class StackManagerTest {
     expectedServices.add("SPARK3");
     expectedServices.add("SYSTEMML");
 
+    assertEquals(expectedServices, services.stream().map(ServiceInfo::getName).collect(toCollection(TreeSet::new)));
     ServiceInfo pigService = null;
     for (ServiceInfo service : services) {
       if (service.getName().equals("PIG")) {
         pigService = service;
       }
-      assertTrue(expectedServices.remove(service.getName()));
+      assertTrue(service.getName(), expectedServices.remove(service.getName()));
     }
     assertTrue(expectedServices.isEmpty());
 
@@ -524,7 +529,7 @@ public class StackManagerTest {
   public void testMonitoringServicePropertyInheritance() throws Exception{
     StackInfo stack = stackManager.getStack("HDP", "2.0.8");
     Collection<ServiceInfo> allServices = stack.getServices();
-    assertEquals(15, allServices.size());
+    assertEquals(16, allServices.size());
 
     boolean monitoringServiceFound = false;
 
@@ -545,9 +550,10 @@ public class StackManagerTest {
     StackInfo stack = stackManager.getStack("HDP", "2.0.6");
     Collection<ServiceInfo> allServices = stack.getServices();
 
-    assertEquals(12, allServices.size());
+    assertEquals(13, allServices.size());
     HashSet<String> expectedServices = new HashSet<>();
     expectedServices.add("GANGLIA");
+    expectedServices.add("HADOOP_CLIENTS");
     expectedServices.add("HBASE");
     expectedServices.add("HCATALOG");
     expectedServices.add("HDFS");

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertDefinitionHashTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertDefinitionHashTest.java
@@ -103,6 +103,7 @@ public class AlertDefinitionHashTest extends TestCase {
     List<ServiceComponentHost> serviceComponentHosts = new ArrayList<>();
     ServiceComponentHost sch = EasyMock.createNiceMock(ServiceComponentHost.class);
     expect(sch.getServiceName()).andReturn("HDFS").anyTimes();
+    expect(sch.getServiceType()).andReturn("HDFS").anyTimes();
     expect(sch.getServiceComponentName()).andReturn("NAMENODE").anyTimes();
     expect(sch.getHostName()).andReturn(HOSTNAME).anyTimes();
     EasyMock.replay(sch);
@@ -111,6 +112,7 @@ public class AlertDefinitionHashTest extends TestCase {
     // add HDFS/DN
     sch = EasyMock.createNiceMock(ServiceComponentHost.class);
     expect(sch.getServiceName()).andReturn("HDFS").anyTimes();
+    expect(sch.getServiceType()).andReturn("HDFS").anyTimes();
     expect(sch.getServiceComponentName()).andReturn("DATANODE").anyTimes();
     expect(sch.getHostName()).andReturn(HOSTNAME).anyTimes();
     EasyMock.replay(sch);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix few more unit test failures/errors on branch-feature-AMBARI-14714 caused by #204, #252, 17e4330db3, #285.  The remaining failures need more domain knowledge, will file separate issues.

## How was this patch tested?

```
mvn -DskipPythonTests -Dcheckstyle.skip -Drat.skip clean test \
  -Dtest=AlertDefinitionHashTest,AmbariManagementControllerTest,HostServiceTest,MpackResourceProviderTest,StackManagerTest
```

Before:

```
Tests run: 157, Failures: 9, Errors: 7, Skipped: 5
```

After:

```
Tests run: 157, Failures: 6, Errors: 2, Skipped: 5
```