### PR TITLE
AMBARI-23101. Rhel6: Deploy with NewMySQL for Hive fails

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
@@ -46,18 +46,18 @@ class MysqlServer(Script):
   def start(self, env, rolling_restart=False):
     import params
     env.set_params(params)
-    mysql_service(daemon_name=params.daemon_name, action='start')
+    mysql_service(action='start')
 
   def stop(self, env, rolling_restart=False):
     import params
     env.set_params(params)
-    mysql_service(daemon_name=params.daemon_name, action='stop')
+    mysql_service(action='stop')
 
   def status(self, env):
     import status_params
     env.set_params(status_params)
 
-    mysql_service(daemon_name=status_params.daemon_name, action='status')
+    mysql_service(action='status')
 
 
 if __name__ == "__main__":

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_service.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_service.py
@@ -18,10 +18,25 @@ limitations under the License.
 
 """
 
+import os
 from resource_management import *
 
+SERVICES_DIR = '/etc/init.d'
+POSSIBLE_DAEMON_NAMES = ['mysql', 'mysqld', 'mariadb']
 
-def mysql_service(daemon_name=None, action='start'): 
+def get_daemon_name():
+  import status_params
+  
+  for possible_daemon_name in status_params.POSSIBLE_DAEMON_NAMES:
+    daemon_path = os.path.join(status_params.SERVICES_DIR, possible_daemon_name)
+    if os.path.exists(daemon_path):
+      return possible_daemon_name
+
+  raise Fail("Could not find service daemon for mysql")
+
+def mysql_service(action='start'): 
+  daemon_name = get_daemon_name()
+  
   status_cmd = format("pgrep -l '^{process_name}$'")
   cmd = ('service', daemon_name, action)
 

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_users.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_users.py
@@ -19,6 +19,7 @@ limitations under the License.
 """
 
 from resource_management import *
+from mysql_service import get_daemon_name
 
 # Used to add hive access to the needed components
 def mysql_adduser():
@@ -30,6 +31,8 @@ def mysql_adduser():
   )
   hive_server_host = format("{hive_server_host}")
   hive_metastore_host = format("{hive_metastore_host}")
+  
+  daemon_name = get_daemon_name()
 
   add_metastore_cmd = "bash -x {mysql_adduser_path} {daemon_name} {hive_metastore_user_name} {hive_metastore_user_passwd!p} {hive_metastore_host}"
   add_hiveserver_cmd = "bash -x {mysql_adduser_path} {daemon_name} {hive_metastore_user_name} {hive_metastore_user_passwd!p} {hive_server_host}"
@@ -54,6 +57,8 @@ def mysql_deluser():
   )
   hive_server_host = format("{hive_server_host}")
   hive_metastore_host = format("{hive_metastore_host}")
+  
+  daemon_name = get_daemon_name()
 
   del_hiveserver_cmd = "bash -x {mysql_deluser_path} {daemon_name} {hive_metastore_user_name} {hive_server_host}"
   del_metastore_cmd = "bash -x {mysql_deluser_path} {daemon_name} {hive_metastore_user_name} {hive_metastore_host}"

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
@@ -505,7 +505,6 @@ parquet_logging_properties = None
 if 'parquet-logging' in config['configurations']:
   parquet_logging_properties = config['configurations']['parquet-logging']['content']
 
-daemon_name = status_params.daemon_name
 process_name = status_params.process_name
 hive_env_sh_template = config['configurations']['hive-env']['content']
 

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/status_params.py
@@ -73,12 +73,9 @@ else:
   mariadb_redhat_support = str(mariadb_redhat_support)
   Logger.info('MariaDB RedHat Support: %s' % mariadb_redhat_support)
   process_name = 'mysqld'
-  if OSCheck.is_suse_family() or OSCheck.is_ubuntu_family():
-    daemon_name = 'mysql'
-  elif OSCheck.is_redhat_family() and int(OSCheck.get_os_major_version()) >= 7 and mariadb_redhat_support.lower() == "true":
-    daemon_name = 'mariadb'
-  else:
-    daemon_name = 'mysqld'
+
+  SERVICES_DIR = '/etc/init.d'
+  POSSIBLE_DAEMON_NAMES = ['mysql', 'mysqld', 'mariadb']
 
   # Security related/required params
   hostname = config['hostname']

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
@@ -17,11 +17,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+import os
 from mock.mock import MagicMock, call, patch
 from stacks.utils.RMFTestCase import *
 
 from only_for_platform import not_for_platform, PLATFORM_WINDOWS
 
+@patch("os.path.exists", MagicMock(return_value=True))
 @not_for_platform(PLATFORM_WINDOWS)
 class TestMySqlServer(RMFTestCase):
   COMMON_SERVICES_PACKAGE_DIR = "HIVE/0.12.0.2.0/package"


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py", line 64, in <module>
    MysqlServer().execute()
  File "/usr/lib/python2.6/site-packages/resource_management/libraries/script/script.py", line 375, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py", line 34, in install
    self.configure(env)
  File "/usr/lib/python2.6/site-packages/resource_management/libraries/script/script.py", line 120, in locking_configure
    original_configure(obj, *args, **kw)
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py", line 44, in configure
    mysql_configure()
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_utils.py", line 34, in mysql_configure
    mysql_users.mysql_adduser()
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_users.py", line 44, in mysql_adduser
    path='/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'
  File "/usr/lib/python2.6/site-packages/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/python2.6/site-packages/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/python2.6/site-packages/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/python2.6/site-packages/resource_management/core/providers/system.py", line 262, in action_run
    tries=self.resource.tries, try_sleep=self.resource.try_sleep)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 72, in inner
    result = function(command, **kwargs)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 102, in checked_call
    tries=tries, try_sleep=try_sleep, timeout_kill_strategy=timeout_kill_strategy)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 150, in _call_wrapper
    result = _call(command, **kwargs_copy)
  File "/usr/lib/python2.6/site-packages/resource_management/core/shell.py", line 303, in _call
    raise ExecutionFailed(err_msg, code, out, err)
resource_management.core.exceptions.ExecutionFailed: Execution of 'bash -x /var/lib/ambari-agent/tmp/addMysqlUser.sh mysqld hive [PROTECTED] ctr-e138-1518143905142-49064-01-000005.hwx.site' returned 1. + mysqldservice=mysqld
+ mysqldbuser=hive
+ mysqldbpasswd=password
+ userhost=ctr-e138-1518143905142-49064-01-000005.hwx.site
+ /var/lib/ambari-agent/ambari-sudo.sh service mysqld restart
mysqld: unrecognized service
+ echo 'Adding user hive@% and removing users with empty name'
Adding user hive@% and removing users with empty name
+ /var/lib/ambari-agent/ambari-sudo.sh mysql -u root -e 'CREATE USER '\''hive'\''@'\''%'\'' IDENTIFIED BY '\''password'\'';'
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (111)
+ /var/lib/ambari-agent/ambari-sudo.sh mysql -u root -e 'GRANT ALL PRIVILEGES ON *.* TO '\''hive'\''@'\''%'\'';'
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (111)
+ /var/lib/ambari-agent/ambari-sudo.sh mysql -u root -e 'DELETE FROM mysql.user WHERE user='\'''\'';'
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (111)
+ /var/lib/ambari-agent/ambari-sudo.sh mysql -u root -e 'flush privileges;'
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (111)
+ /var/lib/ambari-agent/ambari-sudo.sh service mysqld stop
mysqld: unrecognized service