### PR TITLE
AMBARI-23105. Exception caught while installing Timeline Service V2.0

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
+++ b/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
@@ -30,7 +30,7 @@ class ConfigurationBuilder:
 
   def get_configuration(self, cluster_id, service_name, component_name, configurations_timestamp=None):
     if cluster_id:
-      if configurations_timestamp and configurations_timestamp != self.configurations_cache.timestamp:
+      if configurations_timestamp and self.configurations_cache.timestamp < configurations_timestamp:
         raise Exception("Command requires configs with timestamp={0} but configs on agent have timestamp={1}".format(configurations_timestamp, self.configurations_cache.timestamp))
 
       metadata_cache = self.metadata_cache[cluster_id]

--- a/ambari-common/src/main/python/resource_management/libraries/functions/namenode_ha_utils.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/namenode_ha_utils.py
@@ -175,7 +175,7 @@ def get_property_for_active_namenode(hdfs_site, property_name, security_enabled,
     name_services = get_nameservices(hdfs_site)
     if len(name_services) > 1:
       raise Fail('Multiple name services not supported by this function')
-    name_service = name_services(hdfs_site)[0]
+    name_service = name_services[0]
     active_namenodes = get_namenode_states(hdfs_site, security_enabled, run_user)[0]
 
     if not len(active_namenodes):


### PR DESCRIPTION
Workaround solution for below issue. The jira to solve this properly will be created. Since this blocks us badly. For now the workaround gonna be committed
> Caught an exception while executing custom service command: <type 'exceptions.Exception'>: Command requires configs with timestamp=1519782088331 but configs on agent have timestamp=1519783511993; Command requires configs with timestamp=1519782088331 but configs on agent have timestamp=1519783511993


Second issue:

> File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/namenode_ha_utils.py", line 178, in get_property_for_active_namenode
    name_service = name_services(hdfs_site)[0]
TypeError: 'list' object is not callable 