### PR TITLE
[AMBARI-23093] Eliminated the org.apache.zookeeper:zookeeper dependency due to security concerns

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1474,6 +1474,12 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-common</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -1504,12 +1510,22 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-auth</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+         <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <exclusions>
+        <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils-core</artifactId>
@@ -1594,6 +1610,10 @@
             <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per [CVE-2016-5017](https://nvd.nist.gov/vuln/detail/CVE-2016-5017)
>Buffer overflow in the C cli shell in Apache Zookeeper before 3.4.9 and 3.5.x before 3.5.3, when using the "cmd:" batch mode syntax, allows attackers to have unspecified impact via a long command string.

Per [CVE-2017-5637](https://nvd.nist.gov/vuln/detail/CVE-2017-5637)
>Two four letter word commands "wchp/wchc" are CPU intensive and could cause spike of CPU utilization on Apache ZooKeeper server if abused, which leads to the server unable to serve legitimate client requests. Apache ZooKeeper thru version 3.4.9 and 3.5.2 suffer from this issue, fixed in 3.4.10, 3.5.3, and later.

So that I eliminated `org.apache.zookeper:zookeeper` from `ambari-server`'s build (it was never directly referenced; it's been a transitive dependency). However I needed to add a direct dependency of `jline:jline` (we already have a managed version of this library in `ambari-project`).

## How was this patch tested?
After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
ambari-server smolnar$ mvn dependency:tree -Dverbose=true -Dincludes=*zookeeper*

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building Ambari Server 2.6.1.0.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.828 s
[INFO] Finished at: 2018-02-27T14:52:46+01:00
[INFO] Final Memory: 46M/1213M
[INFO] ------------------------------------------------------------------------
```

2.) I executed `mvn clean test` in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 37:34 min
[INFO] Finished at: 2018-02-27T15:31:13+01:00
[INFO] Final Memory: 189M/1723M
[INFO] ------------------------------------------------------------------------
```

3.) In addition to this; I replaced the content of `usr/lib/ambari-server` in my vagrant host with the content from `ambari-server/target/ambari-server-2.6.0.0.0-dist/usr/lib/ambari-server` (where there was no zookeeper.jar) and restarted the server; logged in and did some actions (in this case I added created a cluster (HDFS only) via blueprints and then added Zookeeper); there were no any issues.