### PR TITLE
AMBARI-23106: Generate localjceks://file/{path} urls 

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
@@ -57,7 +57,7 @@ def update_credential_provider_path(config, config_type, dest_provider_path, fil
     # make a copy of the config dictionary since it is read-only
     config_copy = config.copy()
     # overwrite the provider path with the path specified
-    config_copy[HADOOP_CREDENTIAL_PROVIDER_PROPERTY_NAME] = 'jceks://file{0}'.format(dest_provider_path)
+    config_copy[HADOOP_CREDENTIAL_PROVIDER_PROPERTY_NAME] = 'localjceks://file{0}'.format(dest_provider_path)
     return config_copy
   return config
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/security_commons.py
@@ -32,7 +32,7 @@ FILE_TYPE_JAAS_CONF = 'JAAS_CONF'
 HADOOP_CREDENTIAL_PROVIDER_PROPERTY_NAME = 'hadoop.security.credential.provider.path'
 
 # Copy JCEKS provider to service specific location and update the ACL
-def update_credential_provider_path(config, config_type, dest_provider_path, file_owner, file_group):
+def update_credential_provider_path(config, config_type, dest_provider_path, file_owner, file_group, use_local_jceks=False):
   """
   Copies the JCEKS file for the specified config from the default location to the given location,
   and sets the ACLs for the specified owner and group. Also updates the config type's configuration
@@ -57,7 +57,10 @@ def update_credential_provider_path(config, config_type, dest_provider_path, fil
     # make a copy of the config dictionary since it is read-only
     config_copy = config.copy()
     # overwrite the provider path with the path specified
-    config_copy[HADOOP_CREDENTIAL_PROVIDER_PROPERTY_NAME] = 'localjceks://file{0}'.format(dest_provider_path)
+    if use_local_jceks:
+      config_copy[HADOOP_CREDENTIAL_PROVIDER_PROPERTY_NAME] = 'localjceks://file{0}'.format(dest_provider_path)
+    else:
+      config_copy[HADOOP_CREDENTIAL_PROVIDER_PROPERTY_NAME] = 'jceks://file{0}'.format(dest_provider_path)
     return config_copy
   return config
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie.py
@@ -121,7 +121,8 @@ def oozie(is_server=False, upgrade_type=None):
                                                       'oozie-site',
                                                       os.path.join(params.conf_dir, 'oozie-site.jceks'),
                                                       params.oozie_user,
-                                                      params.user_group
+                                                      params.user_group,
+                                                      use_local_jceks=True
                                                       )
 
   XmlConfig("oozie-site.xml",


### PR DESCRIPTION
Generate localjceks://file/{path} urls for local certificate providers


## What changes were proposed in this pull request?



Ambari generates 'jceks://file/{filepath}' as a credential provider URL, which force using the JavaKeyStoreProvider - which uses the hdfs API to access the local file system.

This cause problems, when the local file system access from that API is disabled - for security reasons, for example in Oozie. Fortunately, there is a LocalJavaKeyStoreProvider which can be used in this case, which can be accessed with  a 'localjceks://file/{filepath}' URL

## How was this patch tested?

Manually tested with Oozie. Before the patch, the generated oozie-site.xml contained jceks://file/usr/hdp/current/oozie-server/conf/oozie-site.jceks, after the patch, it became localjceks://file/usr/hdp/current/oozie-server/conf/oozie-site.jceks
 