### PR TITLE
[AMBARI-22194] Remove accidental jline.internal.Log import

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/VersionDefinitionXml.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/VersionDefinitionXml.java
@@ -65,13 +65,13 @@ import org.apache.ambari.server.state.stack.RepositoryXml.Os;
 import org.apache.ambari.server.utils.VersionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-import jline.internal.Log;
 
 /**
  * Class that wraps a repository definition file.
@@ -79,6 +79,8 @@ import jline.internal.Log;
 @XmlRootElement(name="repository-version")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class VersionDefinitionXml {
+
+  private static final Logger LOG = LoggerFactory.getLogger(VersionDefinitionXml.class);
 
   public static String SCHEMA_LOCATION = "version_definition.xsd";
 
@@ -369,7 +371,7 @@ public class VersionDefinitionXml {
     try {
       stackPackages = gson.fromJson(stackPackagesJson, type);
     } catch( Exception exception ) {
-      Log.warn("Unable to deserialize the stack packages JSON, assuming no service dependencies",
+      LOG.warn("Unable to deserialize the stack packages JSON, assuming no service dependencies",
           exception);
 
       return missingDependencies;


### PR DESCRIPTION
## What changes were proposed in this pull request?

While reviewing #493, I was looking for how Ambari Server uses the `jline:jline` dependency, and found that it only appears once.  This single usage was added in c19f363c877776623fd42d285717e6e95b9036ad, I believe accidentally, probably as a last minute change, since it is not part of the [reviewed patch](https://reviews.apache.org/r/62871/diff/2/).

I'd like to replace it with the regular slf4j logger, since the jline one is not properly initialized and simply logs to `System.err`.

(Note that `jline:jline` is a transitive dependency, so it is not being removed here.  However, if this change is accepted, then #493 won't need to add it as explicit dependency.)

CC @smolnar82 

## How was this patch tested?

Artificially triggered the exception, compared outputs without and with the change.

Before, `ambari-server.out`:

```
[WARN] Unable to deserialize the stack packages JSON, assuming no service dependencies
```

After, `ambari-server.log`:

```
28 Feb 2018 15:25:31,509  WARN [ambari-client-thread-40] VersionDefinitionXml:375 - Unable to deserialize the stack packages JSON, assuming no service dependencies
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 5
...
```