### PR TITLE
[AMBARI-23108] Upgrading commons-collections dependency to 3.2.2 due to security concerns

### DIFF
--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -205,6 +205,10 @@
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -215,6 +219,10 @@
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -233,6 +241,10 @@
       <artifactId>apacheds-kerberos-codec</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
         </exclusion>
@@ -243,6 +255,10 @@
       <artifactId>apacheds-core</artifactId>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
           <artifactId>ehcache-core</artifactId>
@@ -262,6 +278,12 @@
       <groupId>org.apache.directory.shared</groupId>
       <artifactId>shared-ldap</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -507,6 +529,12 @@
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity</artifactId>
       <version>1.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per [CVE-2015-6420](https://nvd.nist.gov/vuln/detail/CVE-2015-6420)
>Serialized-object interfaces in certain Cisco Collaboration and Social Media; Endpoint Clients and Client Software; Network Application, Service, and Acceleration; Network and Content Security Devices; Network Management and Provisioning; Routing and Switching - Enterprise and Service Provider; Unified Computing; Voice and Unified Communications Devices; Video, Streaming, TelePresence, and Transcoding Devices; Wireless; and Cisco Hosted Services products allow remote attackers to execute arbitrary commands via a crafted serialized Java object, related to the Apache Commons Collections (ACC) library.

>'Vulnerable software and versions' contains `cpe:2.3:a:apache:commons_collections:*:*:*:*:*:*:*:*    versions up to (including) 3.2.1`

Per [CVE-2017-15708](https://nvd.nist.gov/vuln/detail/CVE-2017-15708)
>In Apache Synapse, by default no authentication is required for Java Remote Method Invocation (RMI). So Apache Synapse 3.0.1 or all previous releases (3.0.0, 2.1.0, 2.0.0, 1.2, 1.1.2, 1.1.1) allows remote code execution attacks that can be performed by injecting specially crafted serialized objects. And the presence of Apache Commons Collections 3.2.1 (commons-collections-3.2.1.jar) or previous versions in Synapse distribution makes this exploitable. To mitigate the issue, we need to limit RMI access to trusted users only. Further upgrading to 3.0.1 version will eliminate the risk of having said Commons Collection version. In Synapse 3.0.1, Commons Collection has been updated to 3.2.2 version.

So that we need to upgrade commons-collections to at least 3.2.2; at the time of this issue is being fixed there are more recent versions in `org.apache.commons:commons-collection4` (v4.1) but it would require code modification due to package name changes

## How was this patch tested?
After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
ambari-funtest smolnar$ mvn dependency:tree -Dverbose=true -Dincludes=commons-collections

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building Ambari Functional Tests 2.6.1.0.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-funtest ---
[INFO] org.apache.ambari:ambari-funtest:jar:2.6.1.0.0
[INFO] \- org.apache.ambari:ambari-server:jar:2.6.1.0.0:compile
[INFO]    \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.090 s
[INFO] Finished at: 2018-02-28T16:28:41+01:00
[INFO] Final Memory: 41M/1007M
[INFO] ------------------------------------------------------------------------
```

2.) I executed `mvn clean install` `ambari-funtest`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.832 s
[INFO] Finished at: 2018-02-28T16:29:51+01:00
[INFO] Final Memory: 46M/511M
[INFO] ------------------------------------------------------------------------
```

As far as I know this project is out of use currently.