### PR TITLE
[AMBARI-23109] Upgrading org.apache.httpcomponents:httpclient dependency to v4.5.5 due to security concerns

### DIFF
--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -486,7 +486,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -527,16 +526,27 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-common</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-server</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.1.4</version>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
@@ -554,12 +564,6 @@
           <artifactId>bcprov-jdk15on</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per [CVE-2014-3577](https://nvd.nist.gov/vuln/detail/CVE-2014-3577)
>org.apache.http.conn.ssl.AbstractVerifier in Apache HttpComponents HttpClient before 4.3.5 and HttpAsyncClient before 4.0.2 does not properly verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a "CN=" string in a field in the distinguished name (DN) of a certificate, as demonstrated by the "foo,CN=www.apache.org" string in the O field.

Per [CVE-2015-5262](https://nvd.nist.gov/vuln/detail/CVE-2015-5262)
>http/conn/ssl/SSLConnectionSocketFactory.java in Apache HttpComponents HttpClient before 4.3.6 ignores the http.socket.timeout configuration setting during an SSL handshake, which allows remote attackers to cause a denial of service (HTTPS call hang) via unspecified vectors.

So that we need to upgrade to a more recent version (>4.3.6); at the time of this issue is being fixed the latest one is 4.5.5

## How was this patch tested?
After updating the affected pom.xml files I've done the following:

1.) Checking Maven's dependency resolution:
```
ambari-funtest smolnar$ mvn dependency:tree -Dincludes=*:*httpclient*

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building Ambari Functional Tests 2.6.1.0.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-funtest ---
[INFO] org.apache.ambari:ambari-funtest:jar:2.6.1.0.0
[INFO] \- org.apache.httpcomponents:httpclient:jar:4.5.5:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.428 s
[INFO] Finished at: 2018-02-28T20:24:57+01:00
[INFO] Final Memory: 45M/1212M
[INFO] ------------------------------------------------------------------------

```

2.) I executed `mvn clean install` for `ambari-funtest` (using -am to build its local dependencies):
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Main ........................................ SUCCESS [  4.250 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.014 s]
[INFO] Ambari Views ....................................... SUCCESS [  1.229 s]
[INFO] utility ............................................ SUCCESS [  0.316 s]
[INFO] ambari-metrics ..................................... SUCCESS [  0.466 s]
[INFO] Ambari Metrics Common .............................. SUCCESS [  4.689 s]
[INFO] Ambari Server ...................................... SUCCESS [01:43 min]
[INFO] Ambari Functional Tests ............................ SUCCESS [  1.024 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:56 min
[INFO] Finished at: 2018-02-28T20:29:58+01:00
[INFO] Final Memory: 105M/1743M
[INFO] ------------------------------------------------------------------------
```

As far as I know this project (ambari-funtest) is out of use currently.
