### PR TITLE
AMBARI-23116 added emty kafka broker handling to stackadvisor

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/stack_advisor.py
@@ -349,7 +349,7 @@ class HDP23StackAdvisor(HDP22StackAdvisor):
     putKafkaBrokerAttributes = self.putPropertyAttribute(configurations, "kafka-broker")
 
     if security_enabled:
-      kafka_user = kafka_env.get('kafka_user') if kafka_env is not None else None
+      kafka_user = kafka_env.get('kafka_user')
 
       if kafka_user is not None:
         kafka_super_users = kafka_broker.get('super.users') if kafka_broker is not None else None

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/stack_advisor.py
@@ -337,6 +337,10 @@ class HDP23StackAdvisor(HDP22StackAdvisor):
 
     servicesList = [service["StackServices"]["service_name"] for service in services["services"]]
     kafka_broker = getServicesSiteProperties(services, "kafka-broker")
+    kafka_env = getServicesSiteProperties(services, "kafka-env")
+
+    if not kafka_env: #Kafka check not required
+      return
 
     security_enabled = self.isSecurityEnabled(services)
 
@@ -345,7 +349,6 @@ class HDP23StackAdvisor(HDP22StackAdvisor):
     putKafkaBrokerAttributes = self.putPropertyAttribute(configurations, "kafka-broker")
 
     if security_enabled:
-      kafka_env = getServicesSiteProperties(services, "kafka-env")
       kafka_user = kafka_env.get('kafka_user') if kafka_env is not None else None
 
       if kafka_user is not None:

--- a/ambari-server/src/test/python/stacks/2.3/common/test_stack_advisor.py
+++ b/ambari-server/src/test/python/stacks/2.3/common/test_stack_advisor.py
@@ -324,6 +324,11 @@ class TestHDP23StackAdvisor(TestCase):
           },
           "property_attributes": {}
         },
+        "kafka-env": {
+          "properties": {
+            "kafka_user" : "custom_kafka"
+          }
+        },
         "kafka-broker": {
           "properties": {
             "authorizer.class.name" : "kafka.security.auth.SimpleAclAuthorizer"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle missing kafka config in stack advisor

## How was this patch tested?

Unit tests passed.
Tested on a live cluster.

@swagle Please review 
