### PR TITLE
[AMBARI-23117] Missing 'hash' in alert update message.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
@@ -26,6 +26,7 @@ import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +91,11 @@ public class AgentConfigsHolder extends AgentHostDataHolder<AgentConfigsUpdateEv
     data.setTimestamp(null);
     data.setHash(getHash(data));
     data.setTimestamp(System.currentTimeMillis());
+  }
+
+  @Override
+  protected boolean isIdentifierValid(AgentConfigsUpdateEvent data) {
+    return StringUtils.isNotEmpty(data.getHash()) && data.getTimestamp() != null;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentDataHolder.java
@@ -23,6 +23,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import org.apache.ambari.server.agent.stomp.dto.Hashable;
+import org.apache.commons.lang.StringUtils;
 
 import com.google.gson.Gson;
 
@@ -38,6 +39,10 @@ public abstract class AgentDataHolder<T extends Hashable> {
   protected void regenerateDataIdentifiers(T data) {
     data.setHash(null);
     data.setHash(getHash(data));
+  }
+
+  protected boolean isIdentifierValid(T data) {
+    return StringUtils.isNotEmpty(data.getHash());
   }
 
   protected String getHash(T data) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
@@ -71,6 +71,12 @@ public abstract class AgentHostDataHolder<T extends AmbariHostUpdateEvent & Hash
       regenerateDataIdentifiers(hostData);
       setIdentifiersToEventUpdate(update, hostData);
       stateUpdateEventPublisher.publish(update);
+    } else {
+      // in case update does not have changes empty identifiers should be populated anyway
+      T hostData = getData(update.getHostId());
+      if (!isIdentifierValid(hostData)) {
+        regenerateDataIdentifiers(hostData);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid sending data with empty identifier to agent

## How was this patch tested?
unit tests
simple deploy