### PR TITLE
[AMBARI-22875] Checkstyle fix

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -515,7 +515,10 @@
             <encoding>UTF-8</encoding>
             <consoleOutput>true</consoleOutput>
             <failsOnError>true</failsOnError>
-            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            <sourceDirectories>
+              <sourceDirectory>src/main/java</sourceDirectory>
+              <sourceDirectory>src/test/java</sourceDirectory>
+            </sourceDirectories>
             <linkXRef>false</linkXRef>
           </configuration>
           <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Checkstyle processes the generated sources directory, too, and gives errors due to different import ordering:

```
$ mvn -am -pl ambari-server -DskipTests -Drat.skip test
...
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
[ERROR] ambari-server/target/generated-sources/annotations/org/apache/ambari/server/topology/ResolvedComponent_Builder.java:7: Wrong order for 'java.util.EnumSet' import. [ImportOrder]
[ERROR] ambari-server/target/generated-sources/annotations/org/apache/ambari/server/topology/ResolvedComponent_Builder.java:11: 'javax.annotation.Generated' should be separated from previous imports. [ImportOrder]
[ERROR] ambari-server/target/generated-sources/annotations/org/apache/ambari/server/topology/ResolvedComponent_Builder.java:13: 'org.apache.ambari.server.state.StackId' should be separated from previous imports. [ImportOrder]
Audit done.
```

## How was this patch tested?

No checkstyle errors with the fix:

```
$ mvn -am -pl ambari-server -DskipTests -Drat.skip test
...
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
```

Temporarily introduced violations to verify that checkstyle does process regular `src` directories:

```
$ mvn -am -pl ambari-server -DskipTests -Drat.skip test
...
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
[ERROR] ambari-server/src/main/java/org/apache/ambari/server/api/services/ServiceService.java:26:8: Unused import - javax.ws.rs.HEAD. [UnusedImports]
[ERROR] ambari-server/src/test/java/org/apache/ambari/server/RandomPortJerseyTest.java:23: Wrong order for 'java.io.IOException' import. [ImportOrder]
Audit done.
`