### PR TITLE
[AMBARI-22883] Count of each OS type is always 1

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/HostSummaryRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/HostSummaryRenderer.java
@@ -83,7 +83,7 @@ public class HostSummaryRenderer extends DefaultRenderer {
       Resource resource = node.getObject();
       String osType = (String) resource.getPropertyValue(HostResourceProvider.HOST_OS_TYPE_PROPERTY_ID);
       if (StringUtils.isNotBlank(osType)) {
-        osTypeCount.put(osType, osTypeCount.getOrDefault(osTypeCount, 0) + 1);
+        osTypeCount.merge(osType, 1, Integer::sum);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The hosts summary request returns at most a count of 1 per OS due to a typo in the key passed to `getOrDefault`.

```
$ curl "http://$AMBARI_SERVER:8080/api/v1/clusters/TEST/hosts"
HTTP/1.1 200 OK
{
  "href" : "http://192.168.73.101:8080/api/v1/clusters/TEST/hosts",
  "items" : [
    {
      "href" : "http://192.168.73.101:8080/api/v1/clusters/TEST/hosts/c7301.ambari.apache.org",
      "Hosts" : {
        "cluster_name" : "TEST",
        "host_name" : "c7301.ambari.apache.org",
        "os_type" : "centos7"
      }
    },
    {
      "href" : "http://192.168.73.101:8080/api/v1/clusters/TEST/hosts/c7302.ambari.apache.org",
      "Hosts" : {
        "cluster_name" : "TEST",
        "host_name" : "c7302.ambari.apache.org",
        "os_type" : "centos7"
      }
    }
  ]
}

$ curl "http://$AMBARI_SERVER:8080/api/v1/clusters/TEST/hosts?format=summary"
HTTP/1.1 200 OK
{
  "href" : "http://192.168.73.101:8080/api/v1/clusters/TEST/hosts?format=summary",
  "summary" : [
    {
      "operating_systems" : {
        "centos7" : 1
      }
    }
  ]
}
```

## How was this patch tested?

```
$ curl "http://$AMBARI_SERVER:8080/api/v1/clusters/TEST/hosts?format=summary"
HTTP/1.1 200 OK
{
  "href" : "http://192.168.73.101:8080/api/v1/clusters/TEST/hosts?format=summary",
  "summary" : [
    {
      "operating_systems" : {
        "centos7" : 2
      }
    }
  ]
}
```