### PR TITLE
[AMBARI-23127] Allow default value of number of parallel tasks run during Upgrade to be customizable. (swagle)

### DIFF
--- a/ambari-server/docs/configuration/index.md
+++ b/ambari-server/docs/configuration/index.md
@@ -50,6 +50,10 @@ The following are the properties which can be used to configure Ambari.
 | agent.stack.retry.tries | The number of times an Ambari Agent should retry package installation when it fails due to a repository error. <br/><br/> This property is related to `agent.stack.retry.on_repo_unavailability`. |`5` | 
 | agent.task.timeout | The time, in seconds, before agent commands are killed. This does not include package installation commands. |`900` | 
 | agent.threadpool.size.max | The size of the Jetty connection pool used for handling incoming Ambari Agent requests. |`25` | 
+| agents.registration.queue.size | Queue size for agents in registration. |`200` | 
+| agents.reports.processing.period | Period in seconds with agents reports will be processed. |`1` | 
+| agents.reports.processing.start.timeout | Timeout in seconds before start processing of agents' reports. |`5` | 
+| agents.reports.thread.pool.size | Thread pool size for agents reports processing. |`10` | 
 | alerts.ambari.snmp.dispatcher.udp.port | The UDP port to use when binding the Ambari SNMP dispatcher on Ambari Server startup. If no port is specified, then a random port will be used. | | 
 | alerts.cache.enabled | Determines whether current alerts should be cached. Enabling this can increase performance on large cluster, but can also result in lost alert data if the cache is not flushed frequently. |`false` | 
 | alerts.cache.flush.interval | The time, in minutes, after which cached alert information is flushed to the database<br/><br/> This property is related to `alerts.cache.enabled`. |`10` | 
@@ -70,6 +74,7 @@ The following are the properties which can be used to configure Ambari.
 | api.csrfPrevention.enabled | Determines whether Cross-Site Request Forgery attacks are prevented by looking for the `X-Requested-By` header. |`true` | 
 | api.gzip.compression.enabled | Determines whether data sent to and from the Ambari service should be compressed. |`true` | 
 | api.gzip.compression.min.size | Used in conjunction with `api.gzip.compression.enabled`, determines the mininum size that an HTTP request must be before it should be compressed. This is measured in bytes. |`10240` | 
+| api.heartbeat.interval | Server to API STOMP endpoint heartbeat interval in milliseconds. |`10000` | 
 | api.ssl | Determines whether SSL is used in for secure connections to Ambari. When enabled, ambari-server setup-https must be run in order to properly configure keystores. |`false` | 
 | auditlog.enabled | Determines whether audit logging is enabled. |`true` | 
 | auditlog.logger.capacity | The size of the worker queue for audit logger events.<br/><br/> This property is related to `auditlog.enabled`. |`10000` | 
@@ -132,6 +137,7 @@ The following are the properties which can be used to configure Ambari.
 | logsearch.portal.connect.timeout | The time, in milliseconds, that the Ambari Server will wait while attempting to connect to the LogSearch Portal service. |`5000` | 
 | logsearch.portal.external.address | Address of an external LogSearch Portal service. (managed outside of Ambari) Using Ambari Credential store is required for this feature (credential: 'logsearch.admin.credential') | | 
 | logsearch.portal.read.timeout | The time, in milliseconds, that the Ambari Server will wait while attempting to read a response from the LogSearch Portal service. |`5000` | 
+| messaging.threadpool.size | Thread pool size for spring messaging |`1` | 
 | metadata.path | The location on the Ambari Server where the stack resources exist.<br/><br/>The following are examples of valid values:<ul><li>`/var/lib/ambari-server/resources/stacks`</ul> | | 
 | metrics.retrieval-service.cache.timeout | The amount of time, in minutes, that JMX and REST metrics retrieved directly can remain in the cache. |`30` | 
 | metrics.retrieval-service.request.ttl | The number of seconds to wait between issuing JMX or REST metric requests to the same endpoint. This property is used to throttle requests to the same URL being made too close together<br/><br/> This property is related to `metrics.retrieval-service.request.ttl.enabled`. |`5` | 
@@ -152,6 +158,7 @@ The following are the properties which can be used to configure Ambari.
 | recovery.retry_interval | The delay, in minutes, between automatic retry windows. | | 
 | recovery.type | The type of automatic recovery of failed services and components to use.<br/><br/>The following are examples of valid values:<ul><li>`DEFAULT`<li>`AUTO_START`<li>`FULL`</ul> | | 
 | recovery.window_in_minutes | The length of a recovery window, in minutes, in which recovery attempts can be retried.<br/><br/> This property is related to `recovery.max_count`. | | 
+| registration.threadpool.size | Thread pool size for agents registration |`10` | 
 | repo.validation.suffixes.default | The suffixes to use when validating most types of repositories. |`/repodata/repomd.xml` | 
 | repo.validation.suffixes.ubuntu | The suffixes to use when validating Ubuntu repositories. |`/dists/%s/Release` | 
 | repositories.legacy-override.enabled | This property is used in specific testing circumstances only. Its use otherwise will lead to very unpredictable results with repository management and package installation |`false` | 
@@ -270,7 +277,10 @@ The following are the properties which can be used to configure Ambari.
 | stack.upgrade.auto.retry.command.names.to.ignore | A comma-separate list of upgrade tasks names to skip when retrying failed commands automatically. |`"ComponentVersionCheckAction","FinalizeUpgradeAction"` | 
 | stack.upgrade.auto.retry.timeout.mins | The amount of time to wait in order to retry a command during a stack upgrade when an agent loses communication. This value must be greater than the `agent.task.timeout` value. |`0` | 
 | stack.upgrade.bypass.prechecks | Determines whether pre-upgrade checks will be skipped when performing a rolling or express stack upgrade. |`false` | 
+| stack.upgrade.default.parallelism | Default value of max number of tasks to schedule in parallel for upgrades. Upgrade packs can override this value. |`100` | 
 | stackadvisor.script | The location and name of the Python stack advisor script executed when configuring services. |`/var/lib/ambari-server/resources/scripts/stack_advisor.py` | 
+| stomp.max.message.size | The maximum size of a stomp text message. Default is 2 MB. |`2097152` | 
+| subscription.registry.cache.size | Maximal cache size for spring subscription registry. |`1500` | 
 | task.query.parameterlist.size | The maximum number of tasks which can be queried by ID from the database. |`999` | 
 | topology.task.creation.parallel | Indicates whether parallel topology task creation is enabled |`false` | 
 | topology.task.creation.parallel.threads | The number of threads to use for parallel topology task creation if enabled |`10` | 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -2595,6 +2595,12 @@ public class Configuration {
   public static final ConfigurationProperty<Integer> SERVER_SIDE_ALERTS_CORE_POOL_SIZE = new ConfigurationProperty<>(
           "alerts.server.side.scheduler.threadpool.size.core", 4);
 
+  /**
+   * Default value of Max number of tasks to schedule in parallel for upgrades.
+   */
+  @Markdown(description = "Default value of max number of tasks to schedule in parallel for upgrades. Upgrade packs can override this value.")
+  public static final ConfigurationProperty<Integer> DEFAULT_MAX_DEGREE_OF_PARALLELISM_FOR_UPGRADES = new ConfigurationProperty<>(
+    "stack.upgrade.default.parallelism", 100);
 
   private static final Logger LOG = LoggerFactory.getLogger(
     Configuration.class);
@@ -5498,6 +5504,13 @@ public class Configuration {
    */
   public boolean isSecurityPasswordEncryptionEnabled() {
     return Boolean.parseBoolean(getProperty(SECURITY_PASSWORD_ENCRYPTON_ENABLED));
+  }
+
+  /**
+   * @return default value of number of tasks to run in parallel during upgrades
+   */
+  public int getDefaultMaxParallelismForUpgrades() {
+    return Integer.parseInt(getProperty(DEFAULT_MAX_DEGREE_OF_PARALLELISM_FOR_UPGRADES));
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.ServiceNotFoundException;
 import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
 import org.apache.ambari.server.agent.ExecutionCommand.KeyNames;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.internal.AbstractControllerResourceProvider;
 import org.apache.ambari.server.controller.internal.PreUpgradeCheckResourceProvider;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
@@ -260,6 +261,12 @@ public class UpgradeContext {
    * Defines orchestration type.  This is not the repository type when reverting a patch.
    */
   private RepositoryType m_orchestration = RepositoryType.STANDARD;
+
+  /**
+   * Used to lookup overridable settings like default task parallelism
+   */
+  @Inject
+  private Configuration configuration;
 
   /**
    * Reading upgrade type from provided request  or if nothing were provided,
@@ -928,6 +935,13 @@ public class UpgradeContext {
 
   public long getPatchRevertUpgradeId() {
     return m_revertUpgradeId;
+  }
+
+  /**
+   * @return default value of number of tasks to run in parallel during upgrades
+   */
+  public int getDefaultMaxDegreeOfParallelism() {
+    return configuration.getDefaultMaxParallelismForUpgrades();
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -225,8 +225,13 @@ public class Grouping {
       // Expand some of the TaskWrappers into multiple based on the batch size.
       for (TaskWrapper tw : tasks) {
         List<Set<String>> hostSets = null;
-        if (m_grouping.parallelScheduler != null && m_grouping.parallelScheduler.maxDegreeOfParallelism > 0) {
-          hostSets = SetUtils.split(tw.getHosts(), m_grouping.parallelScheduler.maxDegreeOfParallelism);
+
+        if (m_grouping.parallelScheduler != null) {
+          int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
+          if (taskParallelism == Integer.MAX_VALUE) {
+            taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
+          }
+          hostSets = SetUtils.split(tw.getHosts(), taskParallelism);
         } else {
           hostSets = SetUtils.split(tw.getHosts(), 1);
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ParallelScheduler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ParallelScheduler.java
@@ -24,7 +24,8 @@ import javax.xml.bind.annotation.XmlElement;
  */
 public class ParallelScheduler {
 
-  public static int DEFAULT_MAX_DEGREE_OF_PARALLELISM = 100;
+  // This setting can be overriden using ambari.properties file
+  public static int DEFAULT_MAX_DEGREE_OF_PARALLELISM = Integer.MAX_VALUE;
 
   @XmlElement(name="max-degree-of-parallelism")
   public int maxDegreeOfParallelism = DEFAULT_MAX_DEGREE_OF_PARALLELISM;

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <url>http://ambari.apache.org/</url>
   <scm>
     <url>https://github.com/apache/ambari</url>
-    <connection>https://gitbox.apache.org/repos/asf/ambari.git</connection>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/ambari.git</connection>
   </scm>
   <licenses>
     <license>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new flag to server configuration in order to override default max parallelism.

## How was this patch tested?

Ran related unit tests.
Manual test pending.