### PR TITLE
[AMBARI-23137] Allow users to skip backup steps on Express Upgrades to save time. (swagle)

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -158,8 +158,10 @@ class NameNodeDefault(NameNode):
     hdfs_binary = self.get_hdfs_binary()
     namenode_upgrade.prepare_upgrade_check_for_previous_dir()
     namenode_upgrade.prepare_upgrade_enter_safe_mode(hdfs_binary)
-    namenode_upgrade.prepare_upgrade_save_namespace(hdfs_binary)
-    namenode_upgrade.prepare_upgrade_backup_namenode_dir()
+    if not params.skip_namenode_save_namespace_express:
+      namenode_upgrade.prepare_upgrade_save_namespace(hdfs_binary)
+    if not params.skip_namenode_namedir_backup_express:
+      namenode_upgrade.prepare_upgrade_backup_namenode_dir()
     namenode_upgrade.prepare_upgrade_finalize_previous_upgrades(hdfs_binary)
 
     # Call -rollingUpgrade prepare

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/params_linux.py
@@ -131,6 +131,10 @@ if stack_version_formatted and check_stack_feature(StackFeature.ROLLING_UPGRADE,
     else:
       hadoop_secure_dn_user = '""'
 
+# Parameters for upgrade packs
+skip_namenode_save_namespace_express = default("/configurations/cluster-env/stack_upgrade_express_skip_namenode_save_namespace", False)
+skip_namenode_namedir_backup_express = default("/configurations/cluster-env/stack_upgrade_express_skip_backup_namenode_dir", False)
+
 ambari_libs_dir = "/var/lib/ambari-agent/lib"
 limits_conf_dir = "/etc/security/limits.d"
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-2.6.xml
@@ -176,7 +176,7 @@
       </execute-stage>
 
       <execute-stage service="HBASE" component="HBASE_MASTER" title="Snapshot HBASE">
-        <condition xsi:type="config" type="cluster-env" property="stack.upgrade.express.skip.hbase.snapshot" comparison="not-equals" value="true"/>
+        <condition xsi:type="config" type="cluster-env" property="stack_upgrade_express_skip_hbase_snapshot" comparison="not-equals" value="true"/>
         <task xsi:type="execute" hosts="master">
           <script>scripts/hbase_upgrade.py</script>
           <function>take_snapshot</function>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-2.6.xml
@@ -176,6 +176,7 @@
       </execute-stage>
 
       <execute-stage service="HBASE" component="HBASE_MASTER" title="Snapshot HBASE">
+        <condition xsi:type="config" type="cluster-env" property="stack.upgrade.express.skip.hbase.snapshot" comparison="not-equals" value="true"/>
         <task xsi:type="execute" hosts="master">
           <script>scripts/hbase_upgrade.py</script>
           <function>take_snapshot</function>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/upgrade-2.6.xml
@@ -69,7 +69,7 @@
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
 
       <execute-stage service="HBASE" component="HBASE_MASTER" title="Pre Upgrade HBase Backup">
-        <condition xsi:type="config" type="cluster-env" property="stack.upgrade.rolling.skip.hbase.snapshot" comparison="not-equals" value="true"/>
+        <condition xsi:type="config" type="cluster-env" property="stack_upgrade_rolling_skip_hbase_snapshot" comparison="not-equals" value="true"/>
         <task xsi:type="execute" hosts="master">
           <script>scripts/hbase_upgrade.py</script>
           <function>take_snapshot</function>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/upgrade-2.6.xml
@@ -69,6 +69,7 @@
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
 
       <execute-stage service="HBASE" component="HBASE_MASTER" title="Pre Upgrade HBase Backup">
+        <condition xsi:type="config" type="cluster-env" property="stack.upgrade.rolling.skip.hbase.snapshot" comparison="not-equals" value="true"/>
         <task xsi:type="execute" hosts="master">
           <script>scripts/hbase_upgrade.py</script>
           <function>take_snapshot</function>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow cluster-env parameters to enable skip time-consuming backups during EU on large clusters.

## How was this patch tested?

Ran python unit tests.