### PR TITLE
[AMBARI-23053] Fix unexpected indent error

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka_broker.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka_broker.py
@@ -1,4 +1,4 @@
-  """
+"""
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information


### PR DESCRIPTION
## What changes were proposed in this pull request?

Trivial fix for Python indentation error, which causes RPM build failure:

```
[INFO] Compiling ambari-server/target/rpm/ambari-server/buildroot/var/lib/ambari-server/resources/common-services/KAFKA/0.8.1/package/scripts/kafka_broker.py ...
[INFO] Sorry: IndentationError: unexpected indent (kafka_broker.py, line 1)
[INFO] error: Bad exit status from /var/tmp/rpm-tmp.JbA4Ib (%install)
```

## How was this patch tested?

Before the fix, Kafka-related Python unit tests failed with:

```
ERROR: test_configure_sasl_ssl_kerberos (test_kafka_broker_other_sasl.TestKafkaBroker)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ambari-server/src/test/python/stacks/2.6/KAFKA/test_kafka_broker_other_sasl.py", line 84, in test_configure_sasl_ssl_kerberos
    target = RMFTestCase.TARGET_COMMON_SERVICES
  File "ambari-server/src/test/python/stacks/utils/RMFTestCase.py", line 126, in executeScript
    script_module = imp.load_source(classname, script_path)
  File "ambari-server/src/test/python/stacks/utils/../../../../main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka_broker.py", line 1
    """
    ^
IndentationError: unexpected indent
```

With the fix, `kafka_broker.py` is loaded successfully and the test proceeds, though it still fails eventually:

```
ERROR: test_configure_sasl_ssl_kerberos (test_kafka_broker_other_sasl.TestKafkaBroker)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ambari-server/src/test/python/stacks/2.6/KAFKA/test_kafka_broker_other_sasl.py", line 84, in test_configure_sasl_ssl_kerberos
    target = RMFTestCase.TARGET_COMMON_SERVICES
  File "ambari-server/src/test/python/stacks/utils/RMFTestCase.py", line 131, in executeScript
    Script.repository_util = RepositoryUtil(self.config_dict, set())
  File "ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py", line 40, in __init__
    repo_rhel_suse =  get_cluster_setting_value('repo_suse_rhel_template')
  File "ambari-common/src/main/python/resource_management/libraries/functions/cluster_settings.py", line 52, in get_cluster_setting_value
    return settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, setting_name)
  File "ambari-common/src/main/python/resource_management/libraries/functions/settings.py", line 88, in get_setting_value
    Logger.info("In get_setting_value(). Passed-in settings type : {0}, setting(s) : {1}".format(setting_type, setting_name))
  File "ambari-common/src/main/python/resource_management/core/logger.py", line 75, in info
    Logger.logger.info(Logger.filter_text(text))
AttributeError: 'NoneType' object has no attribute 'info'
```
