### PR TITLE
[AMBARI-22649] Avoid using uninitialized logger, reduce verbosity

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/logger.py
+++ b/ambari-common/src/main/python/resource_management/core/logger.py
@@ -76,7 +76,8 @@ class Logger:
 
   @staticmethod
   def debug(text):
-    Logger.logger.debug(Logger.filter_text(text))
+    if Logger.logger:
+      Logger.logger.debug(Logger.filter_text(text))
 
   @staticmethod
   def error_resource(resource):

--- a/ambari-common/src/main/python/resource_management/libraries/functions/settings.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/settings.py
@@ -42,7 +42,7 @@ def get_setting_type_entries(setting_type, setting_names=None):
     """
     from resource_management.libraries.functions.default import default
 
-    Logger.info("In get_setting_type_entries(). Passed-in settings type : {0}, setting(s) : {1}".format(setting_type, setting_names))
+    Logger.debug("In get_setting_type_entries(). Passed-in settings type : {0}, setting(s) : {1}".format(setting_type, setting_names))
 
     if not is_setting_type_supported(setting_type):
         Logger.error("Does not support retrieving settings for settings_type : {0}".format(setting_type))
@@ -51,7 +51,7 @@ def get_setting_type_entries(setting_type, setting_names=None):
     settings = default(setting_type, None)
 
     if settings is None:
-        Logger.info("Couldn't retrieve '"+setting_type+"'.")
+        Logger.debug("Couldn't retrieve '"+setting_type+"'.")
         return None
 
     if setting_names is None: # Return all settings
@@ -85,7 +85,7 @@ def get_setting_value(setting_type, setting_name):
     """
     from resource_management.libraries.functions.default import default
 
-    Logger.info("In get_setting_value(). Passed-in settings type : {0}, setting(s) : {1}".format(setting_type, setting_name))
+    Logger.debug("In get_setting_value(). Passed-in settings type : {0}, setting(s) : {1}".format(setting_type, setting_name))
 
     if not is_setting_type_supported(setting_type):
         Logger.error("Does not support retrieving settings for settings_type : {0}".format(setting_type))
@@ -97,7 +97,7 @@ def get_setting_value(setting_type, setting_name):
     settings = default(setting_type, None)
 
     if settings is None:
-        Logger.info("Couldn't retrieve '"+setting_type+"'.")
+        Logger.debug("Couldn't retrieve '"+setting_type+"'.")
         return None
 
     return convert_value(settings.get(setting_name))

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
@@ -54,7 +54,7 @@ def check_stack_feature(stack_feature, stack_version):
   # TODO : Removed the below if of reading from cluster_env, once we have removed stack_features from there
   # and have started using /stackSettings as source of truth.
   if stack_features_setting is None:
-    Logger.info("Couldn't retrieve 'stack_features' from /stackSettings. Retrieving from cluster_env now.")
+    Logger.debug("Couldn't retrieve 'stack_features' from /stackSettings. Retrieving from cluster_env now.")
     stack_features_setting = default("/configurations/cluster-env/"+stack_settings.STACK_FEATURES_SETTING, None)
 
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_select.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_select.py
@@ -192,7 +192,7 @@ def get_packages(scope, service_name = None, component_name = None):
   # TODO : Removed the below if of reading from cluster_env, once we have removed stack_packages from there
   # and have started using /stackSettings as source of truth.
   if stack_packages_setting is None:
-    Logger.info("Couldn't retrieve 'stack_packages' from /stackSettings. Retrieving from cluster_env now.")
+    Logger.debug("Couldn't retrieve 'stack_packages' from /stackSettings. Retrieving from cluster_env now.")
     stack_packages_setting = default("/configurations/cluster-env/"+stack_settings.STACK_PACKAGES_SETTING, None)
 
   if stack_packages_setting is None:

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_tools.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_tools.py
@@ -50,7 +50,7 @@ def get_stack_tool(name):
   # TODO : Removed the below if of reading from cluster_env, once we have removed stack_tools from there
   # and have started using /stackSettings as source of truth.
   if stack_tools_setting is None:
-    Logger.info("Couldn't retrieve 'stack_tools' from /stackSettings. Retrieving from cluster_env now.")
+    Logger.debug("Couldn't retrieve 'stack_tools' from /stackSettings. Retrieving from cluster_env now.")
     stack_tools_setting = default("/configurations/cluster-env/"+stack_settings.STACK_TOOLS_SETTING, None)
 
   if stack_tools_setting:


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Use of uninitialized `logger` from the `settings` library (which replaced `config['cluster-env']`) caused 472 test errors.
2. Logging all "normal" settings lookup operations at `info` level causes output of Python test run to triple (3MB instead of 1MB).

This change lowers log level to debug for "normal" settings lookup, and silently ignores debug messages if logger is not yet initialized.

Example of the error:

```
ERROR: test_start_default_distributed (test_metrics_collector.TestMetricsCollector)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ambari-common/src/test/python/mock/mock.py", line 1199, in patched
    return func(*args, **keywargs)
  File "ambari-server/src/test/python/stacks/2.0.6/AMBARI_METRICS/test_metrics_collector.py", line 38, in test_start_default_distributed
    target = RMFTestCase.TARGET_COMMON_SERVICES
  File "ambari-server/src/test/python/stacks/utils/RMFTestCase.py", line 131, in executeScript
    Script.repository_util = RepositoryUtil(self.config_dict, set())
  File "ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py", line 40, in __init__
    repo_rhel_suse =  get_cluster_setting_value('repo_suse_rhel_template')
  File "ambari-common/src/main/python/resource_management/libraries/functions/cluster_settings.py", line 52, in get_cluster_setting_value
    return settings.get_setting_value(settings.CLUSTER_SETTINGS_TYPE, setting_name)
  File "ambari-common/src/main/python/resource_management/libraries/functions/settings.py", line 88, in get_setting_value
    Logger.info("In get_setting_value(). Passed-in settings type : {0}, setting(s) : {1}".format(setting_type, setting_name))
  File "ambari-common/src/main/python/resource_management/core/logger.py", line 75, in info
    Logger.logger.info(Logger.filter_text(text))
AttributeError: 'NoneType' object has no attribute 'info'
```

Python test results before the change:

```
Total run:1134
Total errors:502
Total failures:14
```

## How was this patch tested?

Python unit test failures decreased to:

```
Total run:1134
Total errors:30
Total failures:14
```

[skip ci]