### PR TITLE
[AMBARI-22883] Let HostSummaryRenderer add Hosts/os_type property to the query

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/HostSummaryRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/HostSummaryRenderer.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.ambari.server.api.query.QueryInfo;
 import org.apache.ambari.server.api.services.Result;
 import org.apache.ambari.server.api.services.ResultImpl;
 import org.apache.ambari.server.api.util.TreeNode;
@@ -63,6 +65,13 @@ public class HostSummaryRenderer extends DefaultRenderer {
   }
 
   @Override
+  public TreeNode<Set<String>> finalizeProperties(TreeNode<QueryInfo> queryTree, boolean isCollection) {
+    TreeNode<Set<String>> propertiesNode = super.finalizeProperties(queryTree, isCollection);
+    propertiesNode.getObject().add(HostResourceProvider.HOST_OS_TYPE_PROPERTY_ID);
+    return propertiesNode;
+  }
+
+  @Override
   public Result finalizeResult(Result queryResult) {
     TreeNode<Resource> queryResultTree = queryResult.getResultTree();
     // Iterate over all returned flattened hosts and build the summary info
@@ -96,4 +105,5 @@ public class HostSummaryRenderer extends DefaultRenderer {
     resource.setProperty(HostResourceProvider.SUMMARY_PROPERTY_ID, summary);
     return result;
   }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -155,7 +155,6 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
   public static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
       .put(Resource.Type.Host, HOST_HOST_NAME_PROPERTY_ID)
       .put(Resource.Type.Cluster, HOST_CLUSTER_NAME_PROPERTY_ID)
-      .put(Resource.Type.HostComponent, HOST_OS_TYPE_PROPERTY_ID)
       .build();
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

`HostSummaryRenderer` needs `os_type` to be present in the query.  Currently this is achieved by treating it as a "key" for the `Host` resource in `HostResourceProvider`.

1. This does not reflect the reality of the model: cluster name and host name are the keys.  If we want to summarize by eg. status or amount of memory, do they suddenly become keys?
2. It breaks a bunch of unit tests.

This change removes the "fake" key, and adds the required property in the renderer's hook method `finalizeProperties`.

## How was this patch tested?

Tested on local cluster.

```
$ curl http://$AMBARI_SERVER:8080/api/v1/clusters/TEST/hosts?format=summary
HTTP/1.1 200 OK
...
{
  "summary" : [
    {
      "operating_systems" : {
        "centos7" : 2
      }
    }
  ]
}
```