### PR TITLE
[AMBARI-23140] Fixed typo in unit test

### DIFF
--- a/ambari-client/groovy-client/src/test/groovy/org/apache/ambari/groovy/client/AmbariHostsTest.groovy
+++ b/ambari-client/groovy-client/src/test/groovy/org/apache/ambari/groovy/client/AmbariHostsTest.groovy
@@ -28,7 +28,7 @@ class AmbariHostsTest extends AbstractAmbariClientTest {
 
   def "test get host components as map when there is no cluster yet"() {
     given:
-    ambari.metaClass.getHostComponenets = { return null }
+    ambari.metaClass.getHostComponents = { return null }
 
     when:
     def result = ambari.getHostComponentsMap("host")


### PR DESCRIPTION
## What changes were proposed in this pull request?

There was a unit test failure due to a typo; fixed that issue

## How was this patch tested?

Running the uni tests in ambari-client/groovy-client:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.groovy.client.AmbariHostsTest
[INFO] Running org.apache.ambari.groovy.client.AmbariClustersTest
[INFO] Running org.apache.ambari.groovy.client.AmbariBlueprintsTest
[INFO] Running org.apache.ambari.groovy.client.AmbariRecommendTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.256 s - in org.apache.ambari.groovy.client.AmbariClustersTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.282 s - in org.apache.ambari.groovy.client.AmbariHostsTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.334 s - in org.apache.ambari.groovy.client.AmbariRecommendTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.547 s - in org.apache.ambari.groovy.client.AmbariBlueprintsTest
[INFO] Running org.apache.ambari.groovy.client.AmbariServiceConfigurationTest
[INFO] Running org.apache.ambari.groovy.client.AmbariServicesTest
[INFO] Running org.apache.ambari.groovy.client.AmbariTasksTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.043 s - in org.apache.ambari.groovy.client.AmbariServicesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.093 s - in org.apache.ambari.groovy.client.AmbariServiceConfigurationTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.068 s - in org.apache.ambari.groovy.client.AmbariTasksTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- apache-rat-plugin:0.12:check (default) @ groovy-client ---
[INFO] Enabled default license matchers.
[INFO] Will parse SCM ignores for exclusions...
[INFO] Finished adding exclusions from SCM ignore files.
[INFO] 61 implicit excludes (use -debug for more details).
[INFO] Exclude: **/*.iml
[INFO] Exclude: src/main/resources/blueprints/**
[INFO] Exclude: src/test/resources/**
[INFO] 16 resources included (use -debug for more details)
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 16 licenses.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.621 s
[INFO] Finished at: 2018-03-05T08:36:20+01:00
[INFO] Final Memory: 18M/321M
[INFO] ------------------------------------------------------------------------
```