### PR TITLE
AMBARI-23122 Yarn Queue Manager is not case sensitive

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/adapters.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/adapters.js
@@ -186,7 +186,6 @@ App.QueueAdapter = DS.Adapter.extend({
    *
    */
   find: function(store, type, id) {
-    id = id.toLowerCase();
     var record = store.getById(type,id);
     var key = type.typeKey;
     var json = {};

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/components/pathInput.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/components/pathInput.js
@@ -67,7 +67,7 @@ App.PathInputComponent = Em.Component.extend({
       this.$().typeahead({
           source: this.get('pathSource'),
           matcher: function (item) {
-            return ~item.toLowerCase().indexOf(this.query.toLowerCase());
+            return ~item.indexOf(this.query);
           },
           minLength:2,
           items:100,

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/components/totalCapacity.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/components/totalCapacity.js
@@ -72,7 +72,7 @@ App.TotalCapacityComponent = Ember.Component.extend({
     },
     toggleLabel:function (labelName, queue) {
       var q = queue || this.get('currentQueue'),
-          labelRecord = q.store.getById('label',[q.get('path'),labelName].join('.').toLowerCase());
+          labelRecord = q.store.getById('label',[q.get('path'),labelName].join('.'));
 
       if (q.get('labels').contains(labelRecord)) {
         q.recurseRemoveLabel(labelRecord);

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/capsched.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/capsched.js
@@ -61,7 +61,7 @@ App.CapschedController = Ember.Controller.extend({
     var effectCapRatio = 1;
     while (queue !== null) {
       effectCapRatio *= queue.get('capacity') / 100;
-      queue = allQueues.findBy('id', queue.get('parentPath').toLowerCase()) || null;
+      queue = allQueues.findBy('id', queue.get('parentPath')) || null;
     }
     var effectCapPercent = effectCapRatio * 100,
     absoluteCap = parseFloat(effectCapPercent).toFixed(this.get('precision'));
@@ -90,7 +90,7 @@ App.CapschedController = Ember.Controller.extend({
       if (queue.get('labels').findBy('name', labelName)) {
         var qlabel = queue.get('labels').findBy('id', [queue.get('id'), labelName].join('.'));
         effectCapRatio *= qlabel.get('capacity') / 100;
-        queue = allQueues.findBy('id', queue.get('parentPath').toLowerCase()) || null;
+        queue = allQueues.findBy('id', queue.get('parentPath')) || null;
       } else {
         return 0;
       }

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/editqueue.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/editqueue.js
@@ -234,12 +234,12 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
     * Returns inherited maximum applications for a queue
     */
    getInheritedMaximumApplications: function() {
-     var parentQ = this.store.getById('queue', this.get('content.parentPath').toLowerCase());
+     var parentQ = this.store.getById('queue', this.get('content.parentPath'));
      while (parentQ !== null) {
        if (parentQ.get('maximum_applications')) {
          return parentQ.get('maximum_applications');
        }
-       parentQ = this.store.getById('queue', parentQ.get('parentPath').toLowerCase());
+       parentQ = this.store.getById('queue', parentQ.get('parentPath'));
      }
      return this.get('scheduler.maximum_applications');
    },
@@ -272,12 +272,12 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
     * Returns inherited maximum am resource percent for a queue
     */
    getInheritedMaxAmResourcePercent: function() {
-     var parentQ = this.store.getById('queue', this.get('content.parentPath').toLowerCase());
+     var parentQ = this.store.getById('queue', this.get('content.parentPath'));
      while (parentQ !== null) {
        if (parentQ.get('maximum_am_resource_percent')) {
          return parentQ.get('maximum_am_resource_percent');
        }
-       parentQ = this.store.getById('queue', parentQ.get('parentPath').toLowerCase());
+       parentQ = this.store.getById('queue', parentQ.get('parentPath'));
      }
      return this.get('scheduler.maximum_am_resource_percent');
    },
@@ -409,7 +409,7 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
         } else {
           permissions.push('*');
         }
-        currentQ = this.store.getById('queue', currentQ.get('parentPath').toLowerCase());
+        currentQ = this.store.getById('queue', currentQ.get('parentPath'));
       }
       permissions.reverse();//root permission at the 0th position.
       return permissions;
@@ -435,7 +435,7 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
      * @return {App.Queue}
      */
     parentQueue: function () {
-      return this.store.getById('queue', this.get('content.parentPath').toLowerCase());
+      return this.store.getById('queue', this.get('content.parentPath'));
     }.property('content.parentPath'),
 
     /*
@@ -538,7 +538,7 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
        };
        childrenQs.forEach(function(queue) {
          var qLabel = ctrl.store.getById('label', [queue.get('path'), labelName].join('.')),
-         parentQ = ctrl.store.getById('queue', queue.get('parentPath').toLowerCase());
+         parentQ = ctrl.store.getById('queue', queue.get('parentPath'));
          var cql = {
            label: qLabel,
            queue: queue,
@@ -597,13 +597,13 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
    getDefaultNodeLabelExpressionInherited: function() {
      var store = this.get('store'),
      currentQ = this.get('content'),
-     parentQ = store.getById('queue', currentQ.get('parentPath').toLowerCase()),
+     parentQ = store.getById('queue', currentQ.get('parentPath')),
      dnlexpr = null;
      while (parentQ !== null) {
        if (parentQ.get('default_node_label_expression') !== null) {
          return parentQ.get('default_node_label_expression');
        }
-       parentQ = store.getById('queue', parentQ.get('parentPath').toLowerCase());
+       parentQ = store.getById('queue', parentQ.get('parentPath'));
      }
      return dnlexpr;
    },
@@ -669,14 +669,14 @@ App.CapschedQueuesconfEditqueueController = Ember.Controller.extend({
    getInheritedQueuePreemption: function() {
      var store = this.get('store'),
      currentQ = this.get('content'),
-     parentQ = store.getById('queue', currentQ.get('parentPath').toLowerCase()),
+     parentQ = store.getById('queue', currentQ.get('parentPath')),
      preemption = '';
      while (parentQ !== null) {
        if (!parentQ.get('isPreemptionInherited')) {
          preemption = parentQ.get('disable_preemption');
          return (preemption==='true')?true:false;
        }
-       parentQ = store.getById('queue', parentQ.get('parentPath').toLowerCase());
+       parentQ = store.getById('queue', parentQ.get('parentPath'));
      }
      return preemption;
    },

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queue.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queue.js
@@ -125,7 +125,7 @@ App.QueueController = Ember.ObjectController.extend({
     var childrenNames = queue.get('queuesArray');
 
     childrenNames.forEach(function (childName) {
-      var queueRecord = queue.store.getById('queue',[queue.get('id'),childName.toLowerCase()].join('.'));
+      var queueRecord = queue.store.getById('queue',[queue.get('id'),childName].join('.'));
 
       skeletonArray.push(queue.store.buildDeletedQueue(queueRecord));
 
@@ -203,7 +203,7 @@ App.QueueController = Ember.ObjectController.extend({
    * @return {App.Queue}
    */
   parentQueue: function () {
-    return this.store.getById('queue',this.get('content.parentPath').toLowerCase());
+    return this.store.getById('queue',this.get('content.parentPath'));
   }.property('content.parentPath'),
 
   /**
@@ -326,7 +326,7 @@ App.QueueController = Ember.ObjectController.extend({
       } else {
         permissions.push('*');
       }
-      currentQ = this.store.getById('queue', currentQ.get('parentPath').toLowerCase());
+      currentQ = this.store.getById('queue', currentQ.get('parentPath'));
     }
     permissions.reverse();//root permission at the 0th position.
     return permissions;

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queues.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queues.js
@@ -33,14 +33,14 @@ App.QueuesController = Ember.ArrayController.extend({
       this.set('isWaitingPath',true);
     },
     addQ:function (parentPath,name) {
-      if (!parentPath || this.get('hasNewQueue') || !this.store.hasRecordForId('queue',parentPath.toLowerCase())) {
+      if (!parentPath || this.get('hasNewQueue') || !this.store.hasRecordForId('queue',parentPath)) {
         return;
       }
       name = name || '';
       var newQueue,
           store = this.get('store'),
           existed = store.get('deletedQueues').findBy('path',[parentPath,name].join('.')),
-          leafQueueNames = store.getById('queue',parentPath.toLowerCase()).get('queuesArray'),
+          leafQueueNames = store.getById('queue',parentPath).get('queuesArray'),
           newInLeaf = Em.isEmpty(leafQueueNames),
           totalLeafCapacity,
           freeLeafCapacity;
@@ -51,7 +51,7 @@ App.QueuesController = Ember.ArrayController.extend({
 
         if (!newInLeaf) {
           totalLeafCapacity = leafQueueNames.reduce(function (capacity,queueName) {
-            return store.getById('queue', [parentPath,queueName].join('.').toLowerCase()).get('capacity') + capacity;
+            return store.getById('queue', [parentPath,queueName].join('.')).get('capacity') + capacity;
           },0);
 
           freeLeafCapacity = (totalLeafCapacity < 100) ? 100 - totalLeafCapacity : 0;
@@ -88,7 +88,7 @@ App.QueuesController = Ember.ArrayController.extend({
         this.set('newQueue',null);
       }
       if (record.isCurrent) {
-        this.transitionToRoute('queue',record.get('parentPath').toLowerCase())
+        this.transitionToRoute('queue',record.get('parentPath'))
           .then(Em.run.schedule('afterRender', function () {
             record.get('store').recurceRemoveQueue(record);
           }));
@@ -230,7 +230,7 @@ App.QueuesController = Ember.ArrayController.extend({
     newQueue.setProperties({
       name: props.name.replace(/\s/g, ''),
       path: props.parentPath+'.'+props.name,
-      id: (props.parentPath+'.'+props.name).toLowerCase()
+      id: (props.parentPath+'.'+props.name)
     });
 
   }.observes('newQueue.name'),

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queuesconf.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queuesconf.js
@@ -50,7 +50,7 @@ App.CapschedQueuesconfController = Ember.Controller.extend({
       parentPath = this.get('selectedQueue.path'),
       queuePath = [parentPath, queueName].join('.'),
       depth = parentPath.split('.').length,
-      leafQueueNames = store.getById('queue', parentPath.toLowerCase()).get('queuesArray'),
+      leafQueueNames = store.getById('queue', parentPath).get('queuesArray'),
       newInLeaf = Ember.isEmpty(leafQueueNames),
       totalLeafCapacity,
       freeLeafCapacity,
@@ -59,14 +59,14 @@ App.CapschedQueuesconfController = Ember.Controller.extend({
       this.send('clearCreateQueue');
       if (!newInLeaf) {
         totalLeafCapacity = leafQueueNames.reduce(function (capacity, qName) {
-          return store.getById('queue', [parentPath, qName].join('.').toLowerCase()).get('capacity') + capacity;
+          return store.getById('queue', [parentPath, qName].join('.')).get('capacity') + capacity;
         }, 0);
         freeLeafCapacity = (totalLeafCapacity < 100) ? 100 - totalLeafCapacity : 0;
       }
       var qCapacity = (newInLeaf) ? 100 : freeLeafCapacity;
       var requireRestart = (this.get('selectedQueue.isLeafQ') && !this.get('selectedQueue.isNewQueue'))? true : false;
       newQueue = store.createRecord('queue', {
-        id: queuePath.toLowerCase(),
+        id: queuePath,
         name: queueName,
         path: queuePath,
         parentPath: parentPath,
@@ -133,7 +133,7 @@ App.CapschedQueuesconfController = Ember.Controller.extend({
       if (delQ.get('isNew')) {
         this.set('newQueue', null);
       }
-      this.transitionToRoute('capsched.queuesconf.editqueue', delQ.get('parentPath').toLowerCase())
+      this.transitionToRoute('capsched.queuesconf.editqueue', delQ.get('parentPath'))
       .then(Em.run.schedule('afterRender', function () {
         that.get('store').recurceRemoveQueue(delQ);
       }));
@@ -302,8 +302,8 @@ App.CapschedQueuesconfController = Ember.Controller.extend({
     var allLabels = this.get('allNodeLabels'),
     store = this.get('store'),
     ctrl = this,
-    queue = store.getById('queue', queuePath.toLowerCase()),
-    parentQ = store.getById('queue', queue.get('parentPath').toLowerCase()),
+    queue = store.getById('queue', queuePath),
+    parentQ = store.getById('queue', queue.get('parentPath')),
     children = store.all('queue').filterBy('depth', queue.get('depth') + 1).filterBy('parentPath', queue.get('path'));
 
     if (Ember.isEmpty(queue.get('labels'))) {
@@ -337,7 +337,7 @@ App.CapschedQueuesconfController = Ember.Controller.extend({
     var allLabels = this.get('allNodeLabels'),
     store = this.get('store'),
     ctrl = this,
-    queue = store.getById('queue', queuePath.toLowerCase()),
+    queue = store.getById('queue', queuePath),
     children = store.all('queue').filterBy('depth', queue.get('depth') + 1).filterBy('parentPath', queue.get('path'));
 
     allLabels.forEach(function(lab) {
@@ -592,7 +592,7 @@ App.CapschedQueuesconfController = Ember.Controller.extend({
 
    saveAndUpdateQueueSuccess: function(newQ) {
      var parentPath = newQ.get('parentPath'),
-     parentQ = this.store.getById('queue', parentPath.toLowerCase()),
+     parentQ = this.store.getById('queue', parentPath),
      pQueues = parentQ.get('queues') ? parentQ.get('queues').split(",") : [];
      pQueues.addObject(newQ.get('name'));
      pQueues.sort();

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/models/queue.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/models/queue.js
@@ -99,7 +99,7 @@ App.Queue = DS.Model.extend({
 
       if (this.get('_accessAllLabels')) {
           labels.forEach(function (lb) {
-            var containsByParent = (Em.isEmpty(this.get('parentPath')))?true:this.store.getById('queue',this.get('parentPath').toLowerCase()).get('labels').findBy('name',lb.get('name'));
+            var containsByParent = (Em.isEmpty(this.get('parentPath')))?true:this.store.getById('queue',this.get('parentPath')).get('labels').findBy('name',lb.get('name'));
             if (!this.get('labels').contains(lb) && !!containsByParent) {
               this.get('labels').pushObject(lb);
             }

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/serializers.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/serializers.js
@@ -86,7 +86,7 @@ App.SerializerMixin = Em.Mixin.create({
         base_path = this.PREFIX + "." + path,
         labelsPath = base_path + ".accessible-node-labels",
         q = {
-          id: path.toLowerCase(),
+          id: path,
           name: data.name,
           path: path,
           parentPath: data.parentPath,

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/store.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/store.js
@@ -131,7 +131,7 @@ function _fillRmQueueStateIntoQueues(data, store) {
 function _getRmQueueStates(queueInfo, qPath, qStates) {
   var qObj = {
     name: queueInfo.queueName,
-    path: qPath.toLowerCase(),
+    path: qPath,
     state: queueInfo.state || 'RUNNING'
   };
   qStates.addObject(qObj);
@@ -222,7 +222,7 @@ App.ApplicationStore = DS.Store.extend({
       return;
     } else {
       queue.get('queuesArray').forEach(function (queueName) {
-        this.recurceRemoveQueue(this.getById('queue',[queue.get('path'),queueName].join('.').toLowerCase()));
+        this.recurceRemoveQueue(this.getById('queue',[queue.get('path'),queueName].join('.')));
       }.bind(this));
 
       if (!queue.get('isNewQueue')){
@@ -283,7 +283,7 @@ App.ApplicationStore = DS.Store.extend({
 
   createFromDeleted: function (deletedQueue) {
     var newQueue = this.createRecord('queue', {
-      id: [deletedQueue.parentPath,deletedQueue.name].join('.').toLowerCase(),
+      id: [deletedQueue.parentPath,deletedQueue.name].join('.'),
       name: deletedQueue.name,
       parentPath: deletedQueue.parentPath,
       depth: deletedQueue.parentPath.split('.').length
@@ -318,7 +318,7 @@ App.ApplicationStore = DS.Store.extend({
 
   copyFromDeleted: function (deletedQueue, parent, name) {
     var newQueue = this.createRecord('queue', {
-      id: [parent,name].join('.').toLowerCase(),
+      id: [parent,name].join('.'),
       name: name,
       path: [parent,name].join('.'),
       parentPath: parent,


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-23122 Yarn Queue Manager is not case sensitive

When Queue is loaded to ambari-view we were differenciating each queue with unique id which is pathname.toLowerCase() due to which if two queues has same name it was only displaying once. This is not required.

also while adding new Queue in view no need to search case insensitive, the search should be case Sensitive.

## How was this patch tested?
**1) Created case sensitive queue names in scheduler in advanced configs of YARN in ambari -- > the Case senstive queue's are displayed correctly in Capacity scheduler**
**2) Created Case sensitive queue's using capacity scheduler and saved the configs , the changes are reflecting in RM UI and also in scheduler configs of YARN**
**3) changed some configs of one of case sensitive Queue in capacity scheduler, the changes are reflecting correctly in RM UI and also in scheduler configs of YARN.**

[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.34 s - in org.apache.ambari.view.capacityscheduler.ConfigurationServiceTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 58.489 s
[INFO] Finished at: 2018-03-05T14:51:31+05:30
[INFO] Final Memory: 41M/340M
[INFO] ------------------------------------------------------------------------