### PR TITLE
AMBARI-23101. Rhel6: Deploy with NewMySQL for Hive fails (aonishuk)

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/dummy_files/alert_definitions.json
+++ b/ambari-agent/src/test/python/ambari_agent/dummy_files/alert_definitions.json
@@ -7,9 +7,9 @@
       {
         "name": "namenode_process", 
         "service": "HDFS", 
-        "component": "NAMENODE", 
-        "interval": 6, 
         "enabled": true, 
+        "interval": 6, 
+        "component": "NAMENODE", 
         "label": "NameNode process", 
         "source": {
           "reporting": {

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
@@ -45,18 +45,18 @@ class MysqlServer(Script):
   def start(self, env, rolling_restart=False):
     import params
     env.set_params(params)
-    mysql_service(daemon_name=params.daemon_name, action='start')
+    mysql_service(action='start')
 
   def stop(self, env, rolling_restart=False):
     import params
     env.set_params(params)
-    mysql_service(daemon_name=params.daemon_name, action='stop')
+    mysql_service(action='stop')
 
   def status(self, env):
     import status_params
     env.set_params(status_params)
 
-    mysql_service(daemon_name=status_params.daemon_name, action='status')
+    mysql_service(action='status')
 
 
 if __name__ == "__main__":

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_service.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_service.py
@@ -18,12 +18,25 @@ limitations under the License.
 
 """
 
+import os
 from resource_management.core.resources.system import Execute
 from resource_management.core.exceptions import ComponentIsNotRunning, Fail
 from resource_management.libraries.functions.format import format
 
 
-def mysql_service(daemon_name=None, action='start'): 
+def get_daemon_name():
+  import status_params
+
+  for possible_daemon_name in status_params.POSSIBLE_DAEMON_NAMES:
+    daemon_path = os.path.join(status_params.SERVICES_DIR, possible_daemon_name)
+    if os.path.exists(daemon_path):
+      return possible_daemon_name
+
+  raise Fail("Could not find service daemon for mysql")
+
+def mysql_service(action='start'): 
+  daemon_name = get_daemon_name()
+  
   status_cmd = format("pgrep -l '^{process_name}$'")
   cmd = ('service', daemon_name, action)
 

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_users.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_users.py
@@ -21,6 +21,7 @@ limitations under the License.
 from resource_management.core.resources.system import Execute, File
 from resource_management.core.source import StaticFile
 from resource_management.libraries.functions.format import format
+from mysql_service import get_daemon_name
 
 # Used to add hive access to the needed components
 def mysql_adduser():
@@ -32,6 +33,8 @@ def mysql_adduser():
   )
   hive_server_host = format("{hive_server_host}")
   hive_metastore_host = format("{hive_metastore_host}")
+  
+  daemon_name = get_daemon_name()
 
   add_metastore_cmd = "bash -x {mysql_adduser_path} {daemon_name} {hive_metastore_user_name} {hive_metastore_user_passwd!p} {hive_metastore_host}"
   add_hiveserver_cmd = "bash -x {mysql_adduser_path} {daemon_name} {hive_metastore_user_name} {hive_metastore_user_passwd!p} {hive_server_host}"
@@ -56,6 +59,8 @@ def mysql_deluser():
   )
   hive_server_host = format("{hive_server_host}")
   hive_metastore_host = format("{hive_metastore_host}")
+  
+  daemon_name = get_daemon_name()
 
   del_hiveserver_cmd = "bash -x {mysql_deluser_path} {daemon_name} {hive_metastore_user_name} {hive_server_host}"
   del_metastore_cmd = "bash -x {mysql_deluser_path} {daemon_name} {hive_metastore_user_name} {hive_metastore_host}"

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
@@ -504,7 +504,6 @@ parquet_logging_properties = None
 if 'parquet-logging' in config['configurations']:
   parquet_logging_properties = config['configurations']['parquet-logging']['content']
 
-daemon_name = status_params.daemon_name
 process_name = status_params.process_name
 hive_env_sh_template = config['configurations']['hive-env']['content']
 

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/status_params.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/status_params.py
@@ -69,10 +69,9 @@ else:
   webhcat_pid_file = format('{hcat_pid_dir}/webhcat.pid')
 
   process_name = 'mysqld'
-  if OSCheck.is_suse_family() or OSCheck.is_ubuntu_family():
-    daemon_name = 'mysql'
-  else:
-    daemon_name = 'mysqld'
+  SERVICES_DIR = '/etc/init.d'
+  POSSIBLE_DAEMON_NAMES = ['mysql', 'mysqld', 'mariadb']
+
 
   # Security related/required params
   hostname = config['agentLevelParams']['hostname']

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
@@ -17,11 +17,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+import os
 from mock.mock import MagicMock, call, patch
 from stacks.utils.RMFTestCase import *
 
 from only_for_platform import not_for_platform, PLATFORM_WINDOWS
 
+@patch("os.path.exists", MagicMock(return_value=True))
 @not_for_platform(PLATFORM_WINDOWS)
 class TestMySqlServer(RMFTestCase):
   COMMON_SERVICES_PACKAGE_DIR = "HIVE/0.12.0.2.0/package"


### PR DESCRIPTION
Here is the reason for this issue:
Looks like QE installed mysql-community instead of mysql on centos6. Which is something centos6 does not really use/need usually.
Later when Ambari tries to install mysql it gets this:

Package mysql-server-5.1.73-8.el6_8.x86_64 is obsoleted by mysql-community-server-5.7.21-1.el6.x86_64 which is already installed