### PR TITLE
[AMBARI-16302] "Hadoop Root Logger" does not take effect when changing the value

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-env.xml
@@ -46,6 +46,13 @@
       # Path to jsvc required by secure HDP 2.0 datanode
       export JSVC_HOME={{jsvc_path}}
 
+      # HADOOP_ROOT_LOGGER is shared by the hadoop client and the
+      # daemons. This is restrict to daemons only.
+      INVOKER="${0##*/}"
+      if [ "$INVOKER" == "hadoop-daemon.sh" ]; then
+        export HADOOP_ROOT_LOGGER=${HADOOP_ROOT_LOGGER:-{{hadoop_root_logger}}}
+      fi
+
 
       # The maximum amount of heap to use, in MB. Default is 1000.
       export HADOOP_HEAPSIZE="{{hadoop_heapsize}}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The option "Hadoop Root Logger" doesn't take effect even if you change the value. This PR make it possible to change the option.

## How was this patch tested?

manual test
(Built branch-2.6 w/ this patch, checked java option had been changed when changing "Hadoop Root Logger" option in Ambari Web)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.