### PR TITLE
[AMBARI-23145]. Stack Advisor Should not Use 'accessible-node-labels' as a Queue Name (amagyar)

### DIFF
--- a/ambari-server/src/test/python/stacks/2.5/common/test_stack_advisor.py
+++ b/ambari-server/src/test/python/stacks/2.5/common/test_stack_advisor.py
@@ -1677,7 +1677,7 @@ class TestHDP25StackAdvisor(TestCase):
                                   'yarn.scheduler.capacity.root.default.state=RUNNING\n'
                                   'yarn.scheduler.capacity.maximum-am-resource-percent=1\n'
                                   'yarn.scheduler.capacity.root.default.acl_submit_applications=*\n'
-                                  'yarn.scheduler.capacity.root.default.capacity=100\n'
+                                  'yarn.scheduler.capacity.root.accessible-node-labels.default.capacity=100\n'
                                   'yarn.scheduler.capacity.root.acl_administer_queue=*\n'
                                   'yarn.scheduler.capacity.node-locality-delay=40\n'
                                   'yarn.scheduler.capacity.queue-mappings-override.enable=false\n'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari UI can not save changes due to Ambari StackAdvisor failing if accessible-node-labels is used as a queue name:

_Error details: float() argument must be a string or a number_ 

Names like accessible-node-labels is filtered out.

## How was this patch tested?

Followed the steps in the EAR. Reproduced it with unittest.