### PR TITLE
[AMBARI-22981] Updating Hadoop RPC Encryption Properties During Upgrade

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
@@ -53,18 +53,14 @@
       </component>
       <component name="DATANODE">
         <changes>
-          <definition xsi:type="configure" id="hdfs_set_data_transfer_protection"
-                      summary="Enables SASL for authentication of data transfer protocol">
+          <definition xsi:type="configure" id="hdfs_set_data_transfer_protection" summary="Enables SASL for authentication of data transfer protocol">
             <type>hdfs-site</type>
-            <set key="dfs.data.transfer.protection" value="authentication,privacy" if-type="hdfs-site"
-                 if-key="dfs.http.policy" if-value="HTTPS_ONLY"/>
+            <set key="dfs.data.transfer.protection" value="authentication,privacy" if-type="cluster-env" if-key="security_enabled" if-value="true" />
           </definition>
 
-          <definition xsi:type="configure" id="hdfs_set_hadoop_rpc_protection_on_kerberized_cluster"
-                      summary="Encrypting the data transfered between hadoop services and clients">
+          <definition xsi:type="configure" id="hdfs_set_hadoop_rpc_protection_on_kerberized_cluster" summary="Encrypting the data transfered between hadoop services and clients">
             <type>core-site</type>
-            <set key="hadoop.rpc.protection" value="authentication,privacy" if-type="cluster-env"
-                 if-key="security_enabled" if-value="true"/>
+            <set key="hadoop.rpc.protection" value="authentication,privacy" if-type="cluster-env" if-key="security_enabled" if-value="true" />
           </definition>
         </changes>
       </component>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
@@ -55,12 +55,12 @@
         <changes>
           <definition xsi:type="configure" id="hdfs_set_data_transfer_protection" summary="Enables SASL for authentication of data transfer protocol">
             <type>hdfs-site</type>
-            <set key="dfs.data.transfer.protection" value="authentication,privacy" if-type="cluster-env" if-key="security_enabled" if-value="true" />
+            <set key="dfs.data.transfer.protection" value="authentication,privacy" />
           </definition>
 
           <definition xsi:type="configure" id="hdfs_set_hadoop_rpc_protection_on_kerberized_cluster" summary="Encrypting the data transfered between hadoop services and clients">
             <type>core-site</type>
-            <set key="hadoop.rpc.protection" value="authentication,privacy" if-type="cluster-env" if-key="security_enabled" if-value="true" />
+            <set key="hadoop.rpc.protection" value="authentication,privacy" />
           </definition>
         </changes>
       </component>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-3.0.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-3.0.xml
@@ -295,14 +295,13 @@
             <!--HDFS-->
             <execute-stage service="HDFS" component="DATANODE"
                            title="Enables SASL for authentication of data transfer protocol">
-                <condition xsi:type="config" type="hdfs-site" property="dfs.http.policy" value="HTTPS_ONLY"
-                           comparison="equals"/>
+                <condition xsi:type="security" type="kerberos" />
                 <task xsi:type="configure" id="hdfs_set_data_transfer_protection"/>
             </execute-stage>
 
             <execute-stage service="HDFS" component="DATANODE"
                            title="Encrypting the data transfered between hadoop services and clients">
-                <condition xsi:type="security" type="kerberos"/>
+                <condition xsi:type="security" type="kerberos" />
                 <task xsi:type="configure" id="hdfs_set_hadoop_rpc_protection_on_kerberized_cluster"/>
             </execute-stage>
 

--- a/ambari-web/app/data/configs/wizards/secure_mapping.js
+++ b/ambari-web/app/data/configs/wizards/secure_mapping.js
@@ -39,6 +39,14 @@ var props = [
     "serviceName": "HDFS"
   },
   {
+    "name": "hadoop.rpc.protection",
+    "templateName": [],
+    "foreignKey": null,
+    "value": "authentication,privacy",
+    "filename": "core-site.xml",
+    "serviceName": "HDFS"
+  },
+  {
     "name": "hadoop.security.auth_to_local",
     "templateName": ["resourcemanager_primary_name", "kerberos_domain", "yarn_user", "nodemanager_primary_name", "namenode_primary_name", "hdfs_user", "datanode_primary_name", "hbase_master_primary_name", "hbase_user","hbase_regionserver_primary_name","oozie_primary_name","oozie_user","jobhistory_primary_name","mapred_user","journalnode_principal_name","falcon_primary_name","falcon_user"],
     "foreignKey": null,
@@ -166,6 +174,14 @@ var props = [
     "foreignKey": null,
     "value": "0.0.0.0:<templateName[0]>",
     "nonSecureValue": "0.0.0.0:50075",
+    "filename": "hdfs-site.xml",
+    "serviceName": "HDFS"
+  },
+  {
+    "name": "dfs.data.transfer.protection",
+    "templateName": [],
+    "foreignKey": null,
+    "value": "authentication,privacy",
     "filename": "hdfs-site.xml",
     "serviceName": "HDFS"
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

During a stack upgrade to any version of HDP 3.0.0, the following properties should be added in a secure cluster:
- in core-site.xml: `hadoop.rpc.protection=authentication,privacy`
- in hdfs-site.xml: `dfs.data.transfer.protection=authentication,privacy`

## How was this patch tested?

Manually executed integration tests:

1. had an Ambari 2.7 with an installed secured cluster (HDFS + ZK + Kerberos)
2. registered and installed version HDP-3.0.0.2 (build 132; already contains fix for [HDFS-13081](https://issues.apache.org/jira/browse/HDFS-13081))
3. edited the required file resources (XML and JS files on the host where `ambari-server` is running)
4. restarted the server
5. disabled 'Service Auto Start'
6. performed the upgrade (on Stack and Versions / Versions I clicked the Upgrade button and selected the 'Express' option)
7. checked the outcome of the upgrade process
  7.1 `core-site.xml` was updated as expected
  7.2 `hdfs-site.xml` was updated as expected
  7.3 all services started successfully

See screenshots as proofs.