### PR TITLE
AMBARI-23147 - Expose Repository CRUD via the Mpack Endpoint

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackResourceDefinition.java
@@ -28,16 +28,11 @@ import org.apache.ambari.server.api.util.TreeNode;
 import org.apache.ambari.server.controller.internal.ResourceImpl;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.Resource.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Resource Definition for Mpack Resource types.
  */
 public class MpackResourceDefinition extends BaseResourceDefinition {
-
-  private final static Logger LOG =
-          LoggerFactory.getLogger(MpackResourceDefinition.class);
 
   public MpackResourceDefinition(Type resourceType) {
     super(Resource.Type.Mpack);
@@ -61,6 +56,7 @@ public class MpackResourceDefinition extends BaseResourceDefinition {
   public Set<SubResourceDefinition> getSubResourceDefinitions() {
     Set<SubResourceDefinition> setChildren = new HashSet<>();
     setChildren.add(new SubResourceDefinition(Resource.Type.StackVersion, null, false));
+    setChildren.add(new SubResourceDefinition(Resource.Type.OperatingSystem, null, true));
     return setChildren;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/OperatingSystemReadOnlyResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/OperatingSystemReadOnlyResourceDefinition.java
@@ -18,17 +18,24 @@
 
 package org.apache.ambari.server.api.resources;
 
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.ambari.annotations.Experimental;
+import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.Resource.Type;
 
-public class OperatingSystemResourceDefinition extends BaseResourceDefinition {
+@Deprecated
+@Experimental(feature = ExperimentalFeature.REPO_VERSION_REMOVAL)
+public class OperatingSystemReadOnlyResourceDefinition extends BaseResourceDefinition {
 
-  public OperatingSystemResourceDefinition(Type resourceType) {
+  public OperatingSystemReadOnlyResourceDefinition(Type resourceType) {
     super(resourceType);
   }
 
-  public OperatingSystemResourceDefinition() {
-    super(Resource.Type.OperatingSystem);
+  public OperatingSystemReadOnlyResourceDefinition() {
+    super(Resource.Type.OperatingSystemReadOnly);
   }
 
   @Override
@@ -40,4 +47,10 @@ public class OperatingSystemResourceDefinition extends BaseResourceDefinition {
   public String getSingularName() {
     return "operating_system";
   }
+
+  @Override
+  public Set<SubResourceDefinition> getSubResourceDefinitions() {
+    return Collections.singleton(new SubResourceDefinition(Resource.Type.Repository));
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/RepositoryVersionResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/RepositoryVersionResourceDefinition.java
@@ -40,7 +40,7 @@ public class RepositoryVersionResourceDefinition extends BaseResourceDefinition 
 
   @Override
   public Set<SubResourceDefinition> getSubResourceDefinitions() {
-    return Collections.singleton(new SubResourceDefinition(Resource.Type.OperatingSystem));
+    return Collections.singleton(new SubResourceDefinition(Resource.Type.OperatingSystemReadOnly));
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ResourceInstanceFactoryImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ResourceInstanceFactoryImpl.java
@@ -258,6 +258,10 @@ public class ResourceInstanceFactoryImpl implements ResourceInstanceFactory {
         resourceDefinition = new OperatingSystemResourceDefinition();
         break;
 
+      case OperatingSystemReadOnly:
+        resourceDefinition = new OperatingSystemReadOnlyResourceDefinition();
+        break;
+
       case Repository:
         resourceDefinition = new RepositoryResourceDefinition();
         break;
@@ -418,7 +422,7 @@ public class ResourceInstanceFactoryImpl implements ResourceInstanceFactory {
       case CompatibleRepositoryVersion:
         resourceDefinition = new SimpleResourceDefinition(Resource.Type.CompatibleRepositoryVersion,
             "compatible_repository_version", "compatible_repository_versions",
-            Resource.Type.OperatingSystem);
+            Resource.Type.OperatingSystemReadOnly);
         break;
 
       case HostStackVersion:

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/StackVersionResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/StackVersionResourceDefinition.java
@@ -50,7 +50,7 @@ public class StackVersionResourceDefinition extends BaseResourceDefinition {
 
     Set<SubResourceDefinition> children = new HashSet<>();
 
-    children.add(new SubResourceDefinition(Resource.Type.OperatingSystem));
+    children.add(new SubResourceDefinition(Resource.Type.OperatingSystemReadOnly));
     children.add(new SubResourceDefinition(Resource.Type.StackService));
     children.add(new SubResourceDefinition(Resource.Type.StackLevelConfiguration));
     children.add(new SubResourceDefinition(Resource.Type.RepositoryVersion));

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/VersionDefinitionResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/VersionDefinitionResourceDefinition.java
@@ -49,7 +49,7 @@ public class VersionDefinitionResourceDefinition extends BaseResourceDefinition 
 
   @Override
   public Set<SubResourceDefinition> getSubResourceDefinitions() {
-    return Collections.singleton(new SubResourceDefinition(Type.OperatingSystem));
+    return Collections.singleton(new SubResourceDefinition(Type.OperatingSystemReadOnly));
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/CompatibleRepositoryVersionService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/CompatibleRepositoryVersionService.java
@@ -90,12 +90,12 @@ public class CompatibleRepositoryVersionService extends BaseService {
    * @return operating systems service
    */
   @Path("{repositoryVersionId}/operating_systems")
-  public OperatingSystemService getOperatingSystemsHandler(@PathParam("repositoryVersionId") String repositoryVersionId) {
+  public OperatingSystemReadOnlyService getOperatingSystemsHandler(@PathParam("repositoryVersionId") String repositoryVersionId) {
     Map<Resource.Type, String> mapIds = new HashMap<>();
     mapIds.putAll(parentKeyProperties);
     mapIds.put(Resource.Type.CompatibleRepositoryVersion, repositoryVersionId);
 
-    return new OperatingSystemService(mapIds);
+    return new OperatingSystemReadOnlyService(mapIds);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/MpacksService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/MpacksService.java
@@ -41,6 +41,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
@@ -150,6 +151,19 @@ public class MpacksService extends BaseService {
     return handleRequest(headers, body, ui, Request.Type.GET,
             createMpackResource(id));
   }
+
+  /**
+   * Handles ANY {id}/operating_systems request
+   *
+   * @return operating system service
+   */
+  // TODO: find a way to handle this with Swagger (refactor or custom annotation?)
+  @Path("{id}/operating_systems")
+  public OperatingSystemService getOperatingSystemsHandler(
+      @ApiParam @PathParam("id") String mpackId) {
+    return new OperatingSystemService(mpackId);
+  }
+
 
   @DELETE
   @Path("{id}")

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/OperatingSystemReadOnlyService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/OperatingSystemReadOnlyService.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.api.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.ambari.annotations.ApiIgnore;
+import org.apache.ambari.annotations.Experimental;
+import org.apache.ambari.annotations.ExperimentalFeature;
+import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.controller.spi.Resource;
+
+/**
+ * Service responsible for operating systems requests.
+ */
+@Deprecated
+@Experimental(feature = ExperimentalFeature.REPO_VERSION_REMOVAL)
+public class OperatingSystemReadOnlyService extends BaseService {
+
+  /**
+   * Extra properties to be inserted into created resource.
+   */
+  private Map<Resource.Type, String> parentKeyProperties;
+
+  /**
+   * Constructor.
+   *
+   * @param parentKeyProperties extra properties to be inserted into created resource
+   */
+  public OperatingSystemReadOnlyService(Map<Resource.Type, String> parentKeyProperties) {
+    this.parentKeyProperties = parentKeyProperties;
+  }
+
+  /**
+   * Gets all operating systems.
+   * Handles: GET /operating_systems requests.
+   *
+   * @param headers http headers
+   * @param ui      uri info
+   */
+  @GET @ApiIgnore // until documented
+  @Produces("text/plain")
+  public Response getOperatingSystems(@Context HttpHeaders headers, @Context UriInfo ui) {
+    return handleRequest(headers, null, ui, Request.Type.GET, createResource(null));
+  }
+
+  /**
+   * Gets a single operating system.
+   * Handles: GET /operating_systems/{osType} requests.
+   *
+   * @param headers http headers
+   * @param ui      uri info
+   * @param osType  os type
+   * @return information regarding the specified operating system
+   */
+  @GET @ApiIgnore // until documented
+  @Path("{osType}")
+  @Produces("text/plain")
+  public Response getOperatingSystem(@Context HttpHeaders headers, @Context UriInfo ui, @PathParam("osType") String osType) {
+    return handleRequest(headers, null, ui, Request.Type.GET, createResource(osType));
+  }
+
+  /**
+   * Handles ANY /{osType}/repositories requests.
+   *
+   * @param osType the os type
+   * @return repositories service
+   */
+  @Path("{osType}/repositories")
+  public RepositoryService getOperatingSystemsHandler(@PathParam("osType") String osType) {
+    final Map<Resource.Type, String> mapIds = new HashMap<>();
+    mapIds.putAll(parentKeyProperties);
+    mapIds.put(Resource.Type.OperatingSystemReadOnly, osType);
+    return new RepositoryService(mapIds);
+  }
+
+  /**
+   * Create an operating system resource instance.
+   *
+   * @param osType os type
+   *
+   * @return an operating system instance
+   */
+  private ResourceInstance createResource(String osType) {
+    final Map<Resource.Type, String> mapIds = new HashMap<>();
+    mapIds.putAll(parentKeyProperties);
+    mapIds.put(Resource.Type.OperatingSystemReadOnly, osType);
+    return createResource(Resource.Type.OperatingSystemReadOnly, mapIds);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/OperatingSystemService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/OperatingSystemService.java
@@ -20,7 +20,10 @@ package org.apache.ambari.server.api.services;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -34,77 +37,135 @@ import org.apache.ambari.server.api.resources.ResourceInstance;
 import org.apache.ambari.server.controller.spi.Resource;
 
 /**
- * Service responsible for operating systems requests.
+ * The {@link OperatingSystemService} is a sub resource off of
+ * {@link MpacksService} which provides the ability to expose and update
+ * repositories which ship with management packs.
  */
 public class OperatingSystemService extends BaseService {
 
   /**
-   * Extra properties to be inserted into created resource.
+   * The parent of each OS resource.
    */
-  private Map<Resource.Type, String> parentKeyProperties;
+  private final String m_mpackId;
 
   /**
    * Constructor.
    *
-   * @param parentKeyProperties extra properties to be inserted into created resource
+   * @param parentKeyProperties
+   *          extra properties to be inserted into created resource
    */
-  public OperatingSystemService(Map<Resource.Type, String> parentKeyProperties) {
-    this.parentKeyProperties = parentKeyProperties;
+  public OperatingSystemService(String mpackId) {
+    m_mpackId = mpackId;
   }
 
   /**
-   * Gets all operating systems.
-   * Handles: GET /operating_systems requests.
+   * Gets all operating systems. Handles: GET /operating_systems requests.
    *
-   * @param headers http headers
-   * @param ui      uri info
+   * @param headers
+   *          http headers
+   * @param ui
+   *          uri info
    */
-  @GET @ApiIgnore // until documented
+  @GET
+  @ApiIgnore
   @Produces("text/plain")
   public Response getOperatingSystems(@Context HttpHeaders headers, @Context UriInfo ui) {
     return handleRequest(headers, null, ui, Request.Type.GET, createResource(null));
   }
 
   /**
-   * Gets a single operating system.
-   * Handles: GET /operating_systems/{osType} requests.
+   * Gets a single operating system. Handles: GET /operating_systems/{osType}
+   * requests.
    *
-   * @param headers http headers
-   * @param ui      uri info
-   * @param osType  os type
+   * @param headers
+   *          http headers
+   * @param ui
+   *          uri info
+   * @param osType
+   *          os type
    * @return information regarding the specified operating system
    */
-  @GET @ApiIgnore // until documented
+  @GET
+  @ApiIgnore
   @Path("{osType}")
   @Produces("text/plain")
-  public Response getOperatingSystem(@Context HttpHeaders headers, @Context UriInfo ui, @PathParam("osType") String osType) {
+  public Response getOperatingSystem(@Context HttpHeaders headers, @Context UriInfo ui,
+      @PathParam("osType") String osType) {
     return handleRequest(headers, null, ui, Request.Type.GET, createResource(osType));
   }
 
   /**
-   * Handles ANY /{osType}/repositories requests.
+   * Creates the repositories and properties of a specified operating system.
    *
-   * @param osType the os type
-   * @return repositories service
+   * @param headers
+   *          http headers
+   * @param ui
+   *          uri info
+   * @param osType
+   *          os type
+   * @return information regarding the specified operating system
    */
-  @Path("{osType}/repositories")
-  public RepositoryService getOperatingSystemsHandler(@PathParam("osType") String osType) {
-    final Map<Resource.Type, String> mapIds = new HashMap<>();
-    mapIds.putAll(parentKeyProperties);
-    mapIds.put(Resource.Type.OperatingSystem, osType);
-    return new RepositoryService(mapIds);
+  @POST
+  @ApiIgnore
+  @Path("{osType}")
+  @Produces("text/plain")
+  public Response createOperatingSystem(String body, @Context HttpHeaders headers,
+      @Context UriInfo ui, @PathParam("osType") String osType) {
+    return handleRequest(headers, body, ui, Request.Type.POST, createResource(osType));
+  }
+
+  /**
+   * Updates the repositories and properties of a specified operating system.
+   *
+   * @param headers
+   *          http headers
+   * @param ui
+   *          uri info
+   * @param osType
+   *          os type
+   * @return information regarding the specified operating system
+   */
+  @PUT
+  @ApiIgnore
+  @Path("{osType}")
+  @Produces("text/plain")
+  public Response updateOperatingSystem(String body, @Context HttpHeaders headers,
+      @Context UriInfo ui,
+      @PathParam("osType") String osType) {
+    return handleRequest(headers, body, ui, Request.Type.PUT, createResource(osType));
+  }
+
+  /**
+   * Removes the specified operating system.
+   *
+   * @param headers
+   *          http headers
+   * @param ui
+   *          uri info
+   * @param osType
+   *          os type
+   * @return the delete request status
+   */
+  @DELETE
+  @ApiIgnore
+  @Path("{osType}")
+  @Produces("text/plain")
+  public Response deleteOperatingSystem(@Context HttpHeaders headers, @Context UriInfo ui,
+      @PathParam("osType") String osType) {
+    return handleRequest(headers, null, ui, Request.Type.DELETE, createResource(osType));
   }
 
   /**
    * Create an operating system resource instance.
    *
-   * @param osType os type
+   * @param osType
+   *          os type
    *
    * @return an operating system instance
    */
   private ResourceInstance createResource(String osType) {
     final Map<Resource.Type, String> mapIds = new HashMap<>();
-    mapIds.putAll(parentKeyProperties);
+    mapIds.put(Resource.Type.Mpack, m_mpackId);
     mapIds.put(Resource.Type.OperatingSystem, osType);
     return createResource(Resource.Type.OperatingSystem, mapIds);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/RepositoryVersionService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/RepositoryVersionService.java
@@ -138,11 +138,11 @@ public class RepositoryVersionService extends BaseService {
    * @return operating systems service
    */
   @Path("{repositoryVersionId}/operating_systems")
-  public OperatingSystemService getOperatingSystemsHandler(@PathParam("repositoryVersionId") String repositoryVersionId) {
+  public OperatingSystemReadOnlyService getOperatingSystemsHandler(@PathParam("repositoryVersionId") String repositoryVersionId) {
     final Map<Resource.Type, String> mapIds = new HashMap<>();
     mapIds.putAll(parentKeyProperties);
     mapIds.put(Resource.Type.RepositoryVersion, repositoryVersionId);
-    return new OperatingSystemService(mapIds);
+    return new OperatingSystemReadOnlyService(mapIds);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/StacksService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/StacksService.java
@@ -869,12 +869,12 @@ public class StacksService extends BaseService {
    */
   // TODO: find a way to handle this with Swagger (refactor or custom annotation?)
   @Path("{stackName}/versions/{stackVersion}/operating_systems")
-  public OperatingSystemService getOperatingSystemsHandler(@ApiParam @PathParam("stackName") String stackName,
+  public OperatingSystemReadOnlyService getOperatingSystemsHandler(@ApiParam @PathParam("stackName") String stackName,
                                                            @ApiParam @PathParam("stackVersion") String stackVersion) {
     final Map<Resource.Type, String> stackProperties = new HashMap<>();
     stackProperties.put(Resource.Type.Stack, stackName);
     stackProperties.put(Resource.Type.StackVersion, stackVersion);
-    return new OperatingSystemService(stackProperties);
+    return new OperatingSystemReadOnlyService(stackProperties);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/VersionDefinitionService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/VersionDefinitionService.java
@@ -70,10 +70,10 @@ public class VersionDefinitionService extends BaseService {
    * @return operating systems service
    */
   @Path("{versionNumber}/operating_systems")
-  public OperatingSystemService getOperatingSystemsHandler(@PathParam("versionNumber") String versionNumber) {
+  public OperatingSystemReadOnlyService getOperatingSystemsHandler(@PathParam("versionNumber") String versionNumber) {
     final Map<Resource.Type, String> mapIds = new HashMap<>();
     mapIds.put(Resource.Type.VersionDefinition, versionNumber);
-    return new OperatingSystemService(mapIds);
+    return new OperatingSystemReadOnlyService(mapIds);
   }
 
   @POST @ApiIgnore // until documented

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/request/eventcreator/RepositoryVersionEventCreator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/request/eventcreator/RepositoryVersionEventCreator.java
@@ -33,7 +33,7 @@ import org.apache.ambari.server.audit.event.AuditEvent;
 import org.apache.ambari.server.audit.event.request.AddRepositoryVersionRequestAuditEvent;
 import org.apache.ambari.server.audit.event.request.ChangeRepositoryVersionRequestAuditEvent;
 import org.apache.ambari.server.audit.event.request.DeleteRepositoryVersionRequestAuditEvent;
-import org.apache.ambari.server.controller.internal.OperatingSystemResourceProvider;
+import org.apache.ambari.server.controller.internal.OperatingSystemReadOnlyResourceProvider;
 import org.apache.ambari.server.controller.internal.RepositoryResourceProvider;
 import org.apache.ambari.server.controller.internal.RepositoryVersionResourceProvider;
 import org.apache.ambari.server.controller.spi.Resource;
@@ -160,7 +160,7 @@ public class RepositoryVersionEventCreator implements RequestAuditEventCreator {
     for (Object entry : set) {
       if (entry instanceof Map) {
         Map<?, ?> map = (Map<?, ?>) entry;
-        String osType = (String) map.get(OperatingSystemResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
+        String osType = (String) map.get(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
         if (!result.containsKey(osType)) {
           result.put(osType, new LinkedList<>());
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompatibleRepositoryVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompatibleRepositoryVersionResourceProvider.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.StaticallyInject;
-import org.apache.ambari.server.api.resources.OperatingSystemResourceDefinition;
+import org.apache.ambari.server.api.resources.OperatingSystemReadOnlyResourceDefinition;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.predicate.AndPredicate;
@@ -78,7 +78,7 @@ public class CompatibleRepositoryVersionResourceProvider extends ReadOnlyResourc
   public static final String REPOSITORY_UPGRADES_SUPPORTED_TYPES_ID            = "CompatibleRepositoryVersions/upgrade_types";
   public static final String REPOSITORY_VERSION_SERVICES                       = "CompatibleRepositoryVersions/services";
   public static final String REPOSITORY_VERSION_STACK_SERVICES                 = "CompatibleRepositoryVersions/stack_services";
-  public static final String SUBRESOURCE_OPERATING_SYSTEMS_PROPERTY_ID         = new OperatingSystemResourceDefinition().getPluralName();
+  public static final String SUBRESOURCE_OPERATING_SYSTEMS_PROPERTY_ID         = new OperatingSystemReadOnlyResourceDefinition().getPluralName();
   private static final String REPOSITORY_STACK_VALUE                           = "stack_value";
 
   private static Set<String> pkPropertyIds = Collections.singleton(REPOSITORY_VERSION_ID_PROPERTY_ID);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/DefaultProviderModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/DefaultProviderModule.java
@@ -124,6 +124,8 @@ public class DefaultProviderModule extends AbstractProviderModule {
         return new StageResourceProvider(managementController);
       case OperatingSystem:
         return new OperatingSystemResourceProvider(managementController);
+      case OperatingSystemReadOnly:
+        return new OperatingSystemReadOnlyResourceProvider(managementController);
       case Repository:
         return new RepositoryResourceProvider(managementController);
       case Setting:

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -55,7 +54,6 @@ import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.registry.Registry;
 import org.apache.ambari.server.registry.RegistryMpack;
 import org.apache.ambari.server.registry.RegistryMpackVersion;
-import org.apache.ambari.server.state.Module;
 import org.apache.ambari.server.state.StackId;
 import org.apache.commons.lang.Validate;
 
@@ -78,8 +76,8 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
   public static final String MPACK_URI = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_uri";
   public static final String MODULES = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "modules";
   public static final String STACK_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "stack_name";
-  public static final String STACK_VERSION_PROPERTY_ID =
-    RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "stack_version";
+  public static final String STACK_VERSION_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "stack_version";
+  public static final String OS_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "operating_systems";
 
   private static Set<String> pkPropertyIds = new HashSet<>(
     Arrays.asList(MPACK_RESOURCE_ID, STACK_NAME_PROPERTY_ID, STACK_VERSION_PROPERTY_ID));
@@ -115,6 +113,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
     PROPERTY_IDS.add(MODULES);
     PROPERTY_IDS.add(STACK_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(STACK_VERSION_PROPERTY_ID);
+    PROPERTY_IDS.add(OS_PROPERTY_ID);
 
     // keys
     KEY_PROPERTY_IDS.put(Resource.Type.Mpack, MPACK_RESOURCE_ID);
@@ -249,11 +248,12 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
     Long mpackId = null;
     if (predicate == null) {
       // Fetch all mpacks
-      Set<MpackResponse> responses = (HashSet)getManagementController().getMpacks();
+      Set<MpackResponse> responses = getManagementController().getMpacks();
       if (null == responses) {
         responses = Collections.emptySet();
       }
-      for (MpackResponse response : responses){
+
+      for (MpackResponse response : responses) {
         Resource resource = new ResourceImpl(Resource.Type.Mpack);
         resource.setProperty(MPACK_RESOURCE_ID, response.getId());
         resource.setProperty(MPACK_ID, response.getMpackId());
@@ -262,60 +262,52 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
         resource.setProperty(MPACK_URI, response.getMpackUri());
         resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
         resource.setProperty(REGISTRY_ID, response.getRegistryId());
+
         results.add(resource);
       }
     } else {
       // Fetch a particular mpack based on id
       Map<String, Object> propertyMap = new HashMap<>(PredicateHelper.getProperties(predicate));
-      if (propertyMap.containsKey(STACK_NAME_PROPERTY_ID) && propertyMap.containsKey(STACK_VERSION_PROPERTY_ID)) {
+      if (propertyMap.containsKey(STACK_NAME_PROPERTY_ID)
+          && propertyMap.containsKey(STACK_VERSION_PROPERTY_ID)) {
         String stackName = (String) propertyMap.get(STACK_NAME_PROPERTY_ID);
         String stackVersion = (String) propertyMap.get(STACK_VERSION_PROPERTY_ID);
         StackEntity stackEntity = stackDAO.find(stackName, stackVersion);
         mpackId = stackEntity.getMpackId();
-        if (mpackId != null) {
-          MpackResponse response = getManagementController().getMpack(mpackId);
-          Resource resource = new ResourceImpl(Resource.Type.Mpack);
-          if (null != response) {
-            resource.setProperty(MPACK_RESOURCE_ID, response.getId());
-            resource.setProperty(MPACK_ID, response.getMpackId());
-            resource.setProperty(MPACK_NAME, response.getMpackName());
-            resource.setProperty(MPACK_VERSION, response.getMpackVersion());
-            resource.setProperty(MPACK_URI, response.getMpackUri());
-            resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
-            resource.setProperty(REGISTRY_ID, response.getRegistryId());
-            resource.setProperty(STACK_NAME_PROPERTY_ID, stackName);
-            resource.setProperty(STACK_VERSION_PROPERTY_ID, stackVersion);
-            results.add(resource);
-          }
-        }
-        return results;
-      }
-
-      if (propertyMap.containsKey(MPACK_RESOURCE_ID)) {
+      } else if (propertyMap.containsKey(MPACK_RESOURCE_ID)) {
         Object objMpackId = propertyMap.get(MPACK_RESOURCE_ID);
-        if (objMpackId != null)
+        if (objMpackId != null) {
           mpackId = Long.valueOf((String) objMpackId);
-
-          MpackResponse response = getManagementController().getMpack(mpackId);
-          Resource resource = new ResourceImpl(Resource.Type.Mpack);
-          if (null != response) {
-            resource.setProperty(MPACK_RESOURCE_ID, response.getId());
-            resource.setProperty(MPACK_ID, response.getMpackId());
-            resource.setProperty(MPACK_NAME, response.getMpackName());
-            resource.setProperty(MPACK_VERSION, response.getMpackVersion());
-            resource.setProperty(MPACK_URI, response.getMpackUri());
-            resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
-            resource.setProperty(REGISTRY_ID, response.getRegistryId());
-            List<Module> modules = getManagementController().getModules(response.getId());
-            resource.setProperty(MODULES, modules);
-            results.add(resource);
-          }
+        }
       }
+
+      if (null == mpackId) {
+        throw new IllegalArgumentException(
+            "Either the management pack ID or the stack name and version are required when searching");
+      }
+
+      MpackResponse response = getManagementController().getMpack(mpackId);
+      Resource resource = new ResourceImpl(Resource.Type.Mpack);
+      if (null != response) {
+        resource.setProperty(MPACK_RESOURCE_ID, response.getId());
+        resource.setProperty(MPACK_ID, response.getMpackId());
+        resource.setProperty(MPACK_NAME, response.getMpackName());
+        resource.setProperty(MPACK_VERSION, response.getMpackVersion());
+        resource.setProperty(MPACK_URI, response.getMpackUri());
+        resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
+        resource.setProperty(REGISTRY_ID, response.getRegistryId());
+
+        StackId stackId = new StackId(response.getStackId());
+        resource.setProperty(STACK_NAME_PROPERTY_ID, stackId.getStackName());
+        resource.setProperty(STACK_VERSION_PROPERTY_ID, stackId.getStackVersion());
+        results.add(resource);
+      }
+
       if (results.isEmpty()) {
-        throw new NoSuchResourceException(
-          "The requested resource doesn't exist: " + predicate);
+        throw new NoSuchResourceException("The requested resource doesn't exist: " + predicate);
       }
     }
+
     return results;
   }
 
@@ -350,8 +342,8 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
                 @Override
                 public DeleteStatusMetaData invoke() throws AmbariException {
                   if (stackEntity != null) {
-                    repositoryVersionDAO
-                      .removeByStack(new StackId(stackEntity.getStackName() + "-" + stackEntity.getStackVersion()));
+                    repositoryVersionDAO.removeByStack(new StackId(
+                        stackEntity.getStackName() + "-" + stackEntity.getStackVersion()));
                     stackDAO.removeByMpack(mpackId);
                     notifyDelete(Resource.Type.Stack, predicate);
                   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/OperatingSystemReadOnlyResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/OperatingSystemReadOnlyResourceProvider.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.annotations.Experimental;
+import org.apache.ambari.annotations.ExperimentalFeature;
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.OperatingSystemRequest;
+import org.apache.ambari.server.controller.OperatingSystemResponse;
+import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
+import org.apache.ambari.server.controller.spi.NoSuchResourceException;
+import org.apache.ambari.server.controller.spi.Predicate;
+import org.apache.ambari.server.controller.spi.Request;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.controller.spi.Resource.Type;
+import org.apache.ambari.server.controller.spi.SystemException;
+import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
+
+import com.google.common.collect.Sets;
+
+@Deprecated
+@Experimental(feature = ExperimentalFeature.REPO_VERSION_REMOVAL)
+public class OperatingSystemReadOnlyResourceProvider extends ReadOnlyResourceProvider {
+
+  public static final String OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID            = PropertyHelper.getPropertyId("OperatingSystems", "stack_name");
+  public static final String OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID         = PropertyHelper.getPropertyId("OperatingSystems", "stack_version");
+  public static final String OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID               = PropertyHelper.getPropertyId("OperatingSystems", "os_type");
+  public static final String OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID = PropertyHelper.getPropertyId("OperatingSystems", "repository_version_id");
+  public static final String OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID = PropertyHelper.getPropertyId("OperatingSystems", "version_definition_id");
+  public static final String OPERATING_SYSTEM_AMBARI_MANAGED_REPOS              = "OperatingSystems/ambari_managed_repositories";
+
+  private static Set<String> pkPropertyIds = Sets.newHashSet(
+      OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID,
+      OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID,
+      OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID);
+
+  public static Set<String> propertyIds = Sets.newHashSet(
+      OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID,
+      OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID,
+      OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID,
+      OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID,
+      OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID,
+      OPERATING_SYSTEM_AMBARI_MANAGED_REPOS);
+
+  public static Map<Type, String> keyPropertyIds = new HashMap<Type, String>() {
+    {
+      put(Resource.Type.OperatingSystemReadOnly, OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
+      put(Resource.Type.Stack, OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID);
+      put(Resource.Type.StackVersion, OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID);
+      put(Resource.Type.RepositoryVersion, OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID);
+      put(Resource.Type.CompatibleRepositoryVersion, OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID);
+      put(Resource.Type.VersionDefinition, OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID);
+    }
+  };
+
+  protected OperatingSystemReadOnlyResourceProvider(AmbariManagementController managementController) {
+    super(Resource.Type.OperatingSystemReadOnly, propertyIds, keyPropertyIds, managementController);
+  }
+
+  @Override
+  public Set<Resource> getResources(Request request, Predicate predicate)
+      throws SystemException, UnsupportedPropertyException,
+      NoSuchResourceException, NoSuchParentResourceException {
+
+    final Set<OperatingSystemRequest> requests = new HashSet<>();
+
+    if (predicate == null) {
+      requests.add(getRequest(Collections.emptyMap()));
+    } else {
+      for (Map<String, Object> propertyMap : getPropertyMaps(predicate)) {
+        requests.add(getRequest(propertyMap));
+      }
+    }
+
+    Set<String> requestedIds = getRequestPropertyIds(request, predicate);
+
+    Set<OperatingSystemResponse> responses = getResources(new Command<Set<OperatingSystemResponse>>() {
+      @Override
+      public Set<OperatingSystemResponse> invoke() throws AmbariException {
+        return getManagementController().getOperatingSystems(requests);
+      }
+    });
+
+    Set<Resource> resources = new HashSet<>();
+
+    for (OperatingSystemResponse response : responses) {
+      Resource resource = new ResourceImpl(Resource.Type.OperatingSystemReadOnly);
+
+      setResourceProperty(resource, OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID,
+          response.getStackName(), requestedIds);
+
+      setResourceProperty(resource, OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID,
+          response.getStackVersion(), requestedIds);
+
+      setResourceProperty(resource, OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID,
+          response.getOsType(), requestedIds);
+
+      setResourceProperty(resource, OPERATING_SYSTEM_AMBARI_MANAGED_REPOS, response.isAmbariManagedRepos(),
+          requestedIds);
+
+      if (response.getRepositoryVersionId() != null) {
+        setResourceProperty(resource, OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID,
+            response.getRepositoryVersionId(), requestedIds);
+      }
+
+      if (response.getVersionDefinitionId() != null) {
+        setResourceProperty(resource, OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID,
+            response.getVersionDefinitionId(), requestedIds);
+      }
+
+      resources.add(resource);
+    }
+
+    return resources;
+  }
+
+  private OperatingSystemRequest getRequest(Map<String, Object> properties) {
+    final OperatingSystemRequest request = new OperatingSystemRequest(
+        (String) properties.get(OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID),
+        (String) properties.get(OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID),
+        (String) properties.get(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID));
+
+    if (properties.containsKey(OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID)) {
+      request.setRepositoryVersionId(Long.parseLong(properties.get(OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID).toString()));
+    }
+
+    if (properties.containsKey(OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID)) {
+      request.setVersionDefinitionId(properties.get(OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID).toString());
+    }
+
+    return request;
+  }
+
+  @Override
+  protected Set<String> getPKPropertyIds() {
+    return pkPropertyIds;
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/OperatingSystemResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/OperatingSystemResourceProvider.java
@@ -1,5 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
@@ -18,142 +17,335 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.StaticallyInject;
 import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.OperatingSystemRequest;
-import org.apache.ambari.server.controller.OperatingSystemResponse;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.NoSuchResourceException;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Request;
+import org.apache.ambari.server.controller.spi.RequestStatus;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.Resource.Type;
+import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.ambari.server.orm.dao.MpackDAO;
+import org.apache.ambari.server.orm.entities.MpackEntity;
+import org.apache.ambari.server.orm.entities.RepoDefinitionEntity;
+import org.apache.ambari.server.orm.entities.RepoOsEntity;
+import org.apache.ambari.server.security.authorization.AuthorizationException;
+import org.apache.ambari.server.state.RepositoryInfo;
+import org.apache.commons.lang.StringUtils;
 
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
 
-public class OperatingSystemResourceProvider extends ReadOnlyResourceProvider {
+/**
+ * The {@link OperatingSystemResourceProvider} is used to provide CRUD
+ * capabilities for repositories based on an operating system.
+ */
+@StaticallyInject
+public class OperatingSystemResourceProvider extends AbstractControllerResourceProvider {
 
-  public static final String OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID            = PropertyHelper.getPropertyId("OperatingSystems", "stack_name");
-  public static final String OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID         = PropertyHelper.getPropertyId("OperatingSystems", "stack_version");
-  public static final String OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID               = PropertyHelper.getPropertyId("OperatingSystems", "os_type");
-  public static final String OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID = PropertyHelper.getPropertyId("OperatingSystems", "repository_version_id");
-  public static final String OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID = PropertyHelper.getPropertyId("OperatingSystems", "version_definition_id");
-  public static final String OPERATING_SYSTEM_AMBARI_MANAGED_REPOS              = "OperatingSystems/ambari_managed_repositories";
+  public static final String OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID = PropertyHelper.getPropertyId("OperatingSystems", "os_type");
+  public static final String OPERATING_SYSTEM_IS_AMBARI_MANAGED = PropertyHelper.getPropertyId("OperatingSystems","is_ambari_managed");
 
-  private static Set<String> pkPropertyIds = Sets.newHashSet(
-      OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID,
-      OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID,
-      OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID);
+  public static final String OPERATING_SYSTEM_REPOS = PropertyHelper.getPropertyId("OperatingSystems","repositories");
+  public static final String OPERATING_SYSTEM_MPACK_ID = PropertyHelper.getPropertyId("OperatingSystems", "mpack_id");
+
+  private static Set<String> pkPropertyIds = Sets.newHashSet(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
 
   public static Set<String> propertyIds = Sets.newHashSet(
+      OPERATING_SYSTEM_MPACK_ID,
       OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID,
-      OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID,
-      OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID,
-      OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID,
-      OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID,
-      OPERATING_SYSTEM_AMBARI_MANAGED_REPOS);
+      OPERATING_SYSTEM_IS_AMBARI_MANAGED, OPERATING_SYSTEM_REPOS);
 
   public static Map<Type, String> keyPropertyIds = new HashMap<Type, String>() {
     {
+      put(Resource.Type.Mpack, OPERATING_SYSTEM_MPACK_ID);
       put(Resource.Type.OperatingSystem, OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
-      put(Resource.Type.Stack, OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID);
-      put(Resource.Type.StackVersion, OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID);
-      put(Resource.Type.RepositoryVersion, OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID);
-      put(Resource.Type.CompatibleRepositoryVersion, OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID);
-      put(Resource.Type.VersionDefinition, OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID);
     }
   };
+
+  /**
+   * Used to update
+   */
+  @Inject
+  private static MpackDAO s_mpackDAO;
+
+  /**
+   * Used to deserialize the repository JSON into an object.
+   */
+  @Inject
+  private static Gson s_gson;
 
   protected OperatingSystemResourceProvider(AmbariManagementController managementController) {
     super(Resource.Type.OperatingSystem, propertyIds, keyPropertyIds, managementController);
   }
 
-  @Override
-  public Set<Resource> getResources(Request request, Predicate predicate)
-      throws SystemException, UnsupportedPropertyException,
-      NoSuchResourceException, NoSuchParentResourceException {
-
-    final Set<OperatingSystemRequest> requests = new HashSet<>();
-
-    if (predicate == null) {
-      requests.add(getRequest(Collections.emptyMap()));
-    } else {
-      for (Map<String, Object> propertyMap : getPropertyMaps(predicate)) {
-        requests.add(getRequest(propertyMap));
-      }
-    }
-
-    Set<String> requestedIds = getRequestPropertyIds(request, predicate);
-
-    Set<OperatingSystemResponse> responses = getResources(new Command<Set<OperatingSystemResponse>>() {
-      @Override
-      public Set<OperatingSystemResponse> invoke() throws AmbariException {
-        return getManagementController().getOperatingSystems(requests);
-      }
-    });
-
-    Set<Resource> resources = new HashSet<>();
-
-    for (OperatingSystemResponse response : responses) {
-      Resource resource = new ResourceImpl(Resource.Type.OperatingSystem);
-
-      setResourceProperty(resource, OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID,
-          response.getStackName(), requestedIds);
-
-      setResourceProperty(resource, OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID,
-          response.getStackVersion(), requestedIds);
-
-      setResourceProperty(resource, OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID,
-          response.getOsType(), requestedIds);
-
-      setResourceProperty(resource, OPERATING_SYSTEM_AMBARI_MANAGED_REPOS, response.isAmbariManagedRepos(),
-          requestedIds);
-
-      if (response.getRepositoryVersionId() != null) {
-        setResourceProperty(resource, OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID,
-            response.getRepositoryVersionId(), requestedIds);
-      }
-
-      if (response.getVersionDefinitionId() != null) {
-        setResourceProperty(resource, OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID,
-            response.getVersionDefinitionId(), requestedIds);
-      }
-
-      resources.add(resource);
-    }
-
-    return resources;
-  }
-
-  private OperatingSystemRequest getRequest(Map<String, Object> properties) {
-    final OperatingSystemRequest request = new OperatingSystemRequest(
-        (String) properties.get(OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID),
-        (String) properties.get(OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID),
-        (String) properties.get(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID));
-
-    if (properties.containsKey(OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID)) {
-      request.setRepositoryVersionId(Long.parseLong(properties.get(OPERATING_SYSTEM_REPOSITORY_VERSION_ID_PROPERTY_ID).toString()));
-    }
-
-    if (properties.containsKey(OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID)) {
-      request.setVersionDefinitionId(properties.get(OPERATING_SYSTEM_VERSION_DEFINITION_ID_PROPERTY_ID).toString());
-    }
-
-    return request;
-  }
-
+  /**
+   * {@inheritDoc}
+   */
   @Override
   protected Set<String> getPKPropertyIds() {
     return pkPropertyIds;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Set<Resource> getResources(Request request, Predicate predicate)
+      throws SystemException, UnsupportedPropertyException,
+      NoSuchResourceException, NoSuchParentResourceException {
+
+    Set<String> requestPropertyIds = getRequestPropertyIds(request, predicate);
+
+    // use a collection which preserves order since JPA sorts the results
+    Set<Resource> results = new LinkedHashSet<>();
+
+    for (Map<String, Object> propertyMap : getPropertyMaps(predicate)) {
+      String mpackIdString = (String) propertyMap.get(OPERATING_SYSTEM_MPACK_ID);
+      Long mpackId = Long.valueOf(mpackIdString);
+      MpackEntity mpackEntity = s_mpackDAO.findById(mpackId);
+      List<RepoOsEntity> repositoryOperatingSystems = mpackEntity.getRepositoryOperatingSystems();
+      for (RepoOsEntity repoOsEntity : repositoryOperatingSystems) {
+        Resource resource = toResource(repoOsEntity, requestPropertyIds);
+        results.add(resource);
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public RequestStatus deleteResources(Request request, Predicate predicate) throws SystemException,
+      UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
+
+    for (Map<String, Object> propertyMap : getPropertyMaps(predicate)) {
+      String mpackIdString = (String) propertyMap.get(OPERATING_SYSTEM_MPACK_ID);
+      Long mpackId = Long.valueOf(mpackIdString);
+
+      if (StringUtils.isBlank(mpackIdString)) {
+        throw new IllegalArgumentException(
+            String.format("The property %s is required", OPERATING_SYSTEM_MPACK_ID));
+      }
+
+      String operatingSystem = (String)propertyMap.get(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
+      if (StringUtils.isBlank(operatingSystem)) {
+        throw new IllegalArgumentException(
+            String.format("The property %s is required", OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID));
+      }
+
+      MpackEntity mpackEntity = s_mpackDAO.findById(mpackId);
+      List<RepoOsEntity> repositoryOperatingSystems = mpackEntity.getRepositoryOperatingSystems();
+      Iterator<RepoOsEntity> iterator = repositoryOperatingSystems.iterator();
+      while (iterator.hasNext()) {
+        RepoOsEntity repoOsEntity = iterator.next();
+        if (StringUtils.equals(operatingSystem, repoOsEntity.getFamily())) {
+          iterator.remove();
+        }
+      }
+
+      mpackEntity = s_mpackDAO.merge(mpackEntity);
+    }
+
+    notifyDelete(Resource.Type.OperatingSystem, predicate);
+    return getRequestStatus(null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public RequestStatus createResources(final Request request) throws SystemException,
+      UnsupportedPropertyException, ResourceAlreadyExistsException, NoSuchParentResourceException {
+
+    createResources(new Command<Void>() {
+      @Override
+      public Void invoke() throws AmbariException, AuthorizationException {
+        createOperatingSystem(request.getProperties());
+        return null;
+      }
+    });
+    notifyCreate(Resource.Type.OperatingSystem, request);
+
+    return getRequestStatus(null);
+  }
+
+  private void createOperatingSystem(Set<Map<String, Object>> requestMaps)
+      throws AmbariException, AuthorizationException {
+    for (Map<String, Object> requestMap : requestMaps) {
+      String mpackIdString = (String) requestMap.get(OPERATING_SYSTEM_MPACK_ID);
+      Long mpackId = Long.valueOf(mpackIdString);
+
+      if (StringUtils.isBlank(mpackIdString)) {
+        throw new IllegalArgumentException(
+            String.format("The property %s is required", OPERATING_SYSTEM_MPACK_ID));
+      }
+
+      String operatingSystem = (String) requestMap.get(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
+      if (StringUtils.isBlank(operatingSystem)) {
+        throw new IllegalArgumentException(
+            String.format("The property %s is required", OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID));
+      }
+
+      MpackEntity mpackEntity = s_mpackDAO.findById(mpackId);
+      if (null == mpackEntity) {
+        throw new IllegalArgumentException(
+            String.format("The mpack with ID %s was not found", mpackId));
+      }
+
+      RepoOsEntity repositoryOsEntity = new RepoOsEntity();
+      repositoryOsEntity.setFamily(operatingSystem);
+      repositoryOsEntity.setMpackEntity(mpackEntity);
+      populateEntity(repositoryOsEntity, requestMap);
+
+      mpackEntity.getRepositoryOperatingSystems().add(repositoryOsEntity);
+      mpackEntity = s_mpackDAO.merge(mpackEntity);
+
+      s_mpackDAO.refresh(mpackEntity);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public RequestStatus updateResources(Request request, Predicate predicate) throws SystemException,
+      UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
+
+    for (Map<String, Object> requestPropMap : request.getProperties()) {
+      for (Map<String, Object> propertyMap : getPropertyMaps(requestPropMap, predicate)) {
+        String mpackIdString = (String) propertyMap.get(OPERATING_SYSTEM_MPACK_ID);
+        Long mpackId = Long.valueOf(mpackIdString);
+
+        if (StringUtils.isBlank(mpackIdString)) {
+          throw new IllegalArgumentException(
+              String.format("The property %s is required", OPERATING_SYSTEM_MPACK_ID));
+        }
+
+        String operatingSystem = (String) propertyMap.get(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID);
+        if (StringUtils.isBlank(operatingSystem)) {
+          throw new IllegalArgumentException(
+              String.format("The property %s is required", OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID));
+        }
+
+        MpackEntity mpackEntity = s_mpackDAO.findById(mpackId);
+        if (null == mpackEntity) {
+          throw new IllegalArgumentException(
+              String.format("The mpack with ID %s was not found", mpackId));
+        }
+
+        List<RepoOsEntity> repositoryOperatingSystems = mpackEntity.getRepositoryOperatingSystems();
+        for (RepoOsEntity repoOsEntity : repositoryOperatingSystems) {
+          if (StringUtils.equals(operatingSystem, repoOsEntity.getFamily())) {
+            try {
+              populateEntity(repoOsEntity, propertyMap);
+            } catch( AmbariException ambariException ) {
+              throw new SystemException(ambariException.getMessage(), ambariException);
+            }
+          }
+        }
+
+        mpackEntity = s_mpackDAO.merge(mpackEntity);
+      }
+    }
+
+    notifyUpdate(Resource.Type.OperatingSystem, request, predicate);
+    return getRequestStatus(null);
+  }
+
+  /**
+   * Convert the repository entity to a response resource for serialization.
+   *
+   * @param repositoryOsEntity
+   *          the operating system result to seralize.
+   * @param requestedIds
+   *          the list of requested IDs to use when setting optional properties.
+   * @return the resource to be serialized in the response.
+   */
+  private Resource toResource(RepoOsEntity repositoryOsEntity, Set<String> requestedIds) {
+    Resource resource = new ResourceImpl(Resource.Type.OperatingSystem);
+
+    resource.setProperty(OPERATING_SYSTEM_MPACK_ID, repositoryOsEntity.getMpackId());
+    resource.setProperty(OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID, repositoryOsEntity.getFamily());
+    resource.setProperty(OPERATING_SYSTEM_IS_AMBARI_MANAGED, repositoryOsEntity.isAmbariManaged());
+
+    Set<RepositoryInfo> repositories = new LinkedHashSet<>();
+    for (RepoDefinitionEntity repoDefinitionEntity : repositoryOsEntity.getRepoDefinitionEntities()) {
+      RepositoryInfo repositoryInfo = new RepositoryInfo();
+      repositoryInfo.setAmbariManagedRepositories(repositoryOsEntity.isAmbariManaged());
+      repositoryInfo.setBaseUrl(repoDefinitionEntity.getBaseUrl());
+      repositoryInfo.setComponents(repoDefinitionEntity.getComponents());
+      repositoryInfo.setDistribution(repoDefinitionEntity.getDistribution());
+      repositoryInfo.setMirrorsList(repoDefinitionEntity.getMirrors());
+      repositoryInfo.setOsType(repositoryOsEntity.getFamily());
+      repositoryInfo.setTags(repoDefinitionEntity.getTags());
+      repositoryInfo.setUnique(repoDefinitionEntity.isUnique());
+      repositoryInfo.setRepoId(repoDefinitionEntity.getRepoID());
+      repositoryInfo.setRepoName(repoDefinitionEntity.getRepoName());
+
+      repositories.add(repositoryInfo);
+    }
+
+    resource.setProperty(OPERATING_SYSTEM_REPOS, repositories);
+
+    return resource;
+  }
+
+  /**
+   * Merges the map of properties into the specified entity. If the entity is
+   * being created, an {@link IllegalArgumentException} is thrown when a
+   * required property is absent. When updating, missing properties are assume
+   * to not have changed.
+   *
+   * @param entity
+   *          the entity to merge the properties into (not {@code null}).
+   * @param requestMap
+   *          the map of properties (not {@code null}).
+   * @throws AmbariException
+   */
+  private void populateEntity(RepoOsEntity entity, Map<String, Object> requestMap)
+      throws AmbariException, AuthorizationException {
+
+    if (requestMap.containsKey(OPERATING_SYSTEM_IS_AMBARI_MANAGED)) {
+      String isAmbariManagedString = (String) requestMap.get(OPERATING_SYSTEM_IS_AMBARI_MANAGED);
+      entity.setAmbariManaged(Boolean.valueOf(isAmbariManagedString));
+    }
+
+    if (requestMap.containsKey(OPERATING_SYSTEM_REPOS)) {
+      java.lang.reflect.Type listType = new TypeToken<ArrayList<RepositoryInfo>>(){}.getType();
+
+      @SuppressWarnings("unchecked")
+      Set<Map<String, Object>> repoMaps = (Set<Map<String, Object>>) requestMap.get(
+          OPERATING_SYSTEM_REPOS);
+
+      String json = s_gson.toJson(repoMaps);
+      List<RepositoryInfo> repositories = s_gson.fromJson(json, listType);
+      List<RepoDefinitionEntity> repoDefinitionEntities = entity.getRepoDefinitionEntities();
+      repoDefinitionEntities.clear();
+
+      for (RepositoryInfo repositoryInfo : repositories) {
+        RepoDefinitionEntity repoDefinitionEntity = RepoDefinitionEntity.from(repositoryInfo);
+        repoDefinitionEntity.setRepoOs(entity);
+        repoDefinitionEntities.add(repoDefinitionEntity);
+      }
+    }
+  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryResourceProvider.java
@@ -101,7 +101,7 @@ public class RepositoryResourceProvider extends AbstractControllerResourceProvid
       put(Resource.Type.Stack, REPOSITORY_STACK_NAME_PROPERTY_ID);
       put(Resource.Type.StackVersion, REPOSITORY_STACK_VERSION_PROPERTY_ID);
       put(Resource.Type.ClusterStackVersion, REPOSITORY_CLUSTER_STACK_VERSION_PROPERTY_ID);
-      put(Resource.Type.OperatingSystem, REPOSITORY_OS_TYPE_PROPERTY_ID);
+      put(Resource.Type.OperatingSystemReadOnly, REPOSITORY_OS_TYPE_PROPERTY_ID);
       put(Resource.Type.Repository, REPOSITORY_REPO_ID_PROPERTY_ID);
       put(Resource.Type.RepositoryVersion, REPOSITORY_REPOSITORY_VERSION_ID_PROPERTY_ID);
       put(Resource.Type.VersionDefinition, REPOSITORY_VERSION_DEFINITION_ID_PROPERTY_ID);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProvider.java
@@ -30,7 +30,7 @@ import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.ObjectNotFoundException;
-import org.apache.ambari.server.api.resources.OperatingSystemResourceDefinition;
+import org.apache.ambari.server.api.resources.OperatingSystemReadOnlyResourceDefinition;
 import org.apache.ambari.server.api.resources.RepositoryResourceDefinition;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
@@ -88,7 +88,7 @@ public class RepositoryVersionResourceProvider extends AbstractAuthorizedResourc
   public static final String REPOSITORY_VERSION_DISPLAY_NAME_PROPERTY_ID       = PropertyHelper.getPropertyId("RepositoryVersions", "display_name");
   public static final String REPOSITORY_VERSION_HIDDEN_PROPERTY_ID             = PropertyHelper.getPropertyId("RepositoryVersions", "hidden");
   public static final String REPOSITORY_VERSION_RESOLVED_PROPERTY_ID           = PropertyHelper.getPropertyId("RepositoryVersions", "resolved");
-  public static final String SUBRESOURCE_OPERATING_SYSTEMS_PROPERTY_ID         = new OperatingSystemResourceDefinition().getPluralName();
+  public static final String SUBRESOURCE_OPERATING_SYSTEMS_PROPERTY_ID         = new OperatingSystemReadOnlyResourceDefinition().getPluralName();
   public static final String SUBRESOURCE_REPOSITORIES_PROPERTY_ID              = new RepositoryResourceDefinition().getPluralName();
 
   public static final String REPOSITORY_VERSION_TYPE_PROPERTY_ID               = "RepositoryVersions/type";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
@@ -59,8 +59,6 @@ import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
 import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.security.authorization.ResourceType;
 import org.apache.ambari.server.security.authorization.RoleAuthorization;
-import org.apache.ambari.server.stack.RepoUtil;
-import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.RepositoryType;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
@@ -81,7 +79,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -617,15 +614,8 @@ public class VersionDefinitionResourceProvider extends AbstractAuthorizedResourc
 
     entity.setStack(stackEntity);
 
-    List<RepositoryInfo> repos = holder.xml.repositoryInfo.getRepositories();
-
-    // Add service repositories (these are not contained by the VDF but are there in the stack model)
-    ListMultimap<String, RepositoryInfo> stackReposByOs =
-        s_metaInfo.get().getStack(stackId.getStackName(), stackId.getStackVersion()).getRepositoriesByOs();
-    repos.addAll(RepoUtil.getServiceRepos(repos, stackReposByOs));
-
-
-    entity.addRepoOsEntities(mpackEntity.getRepositoryOperatingSystems());
+    List<RepoOsEntity> repositoryOperatingSystems = mpackEntity.getRepositoryOperatingSystems();
+    entity.addRepoOsEntities(repositoryOperatingSystems);
 
     entity.setVersion(holder.xml.release.getFullVersion());
     entity.setDisplayName(stackId, holder.xml.release);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
@@ -34,7 +34,7 @@ import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.StaticallyInject;
-import org.apache.ambari.server.api.resources.OperatingSystemResourceDefinition;
+import org.apache.ambari.server.api.resources.OperatingSystemReadOnlyResourceDefinition;
 import org.apache.ambari.server.api.resources.RepositoryResourceDefinition;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
@@ -127,7 +127,7 @@ public class VersionDefinitionResourceProvider extends AbstractAuthorizedResourc
 
   public static final String DIRECTIVE_SKIP_URL_CHECK = "skip_url_check";
 
-  public static final String SUBRESOURCE_OPERATING_SYSTEMS_PROPERTY_ID  = new OperatingSystemResourceDefinition().getPluralName();
+  public static final String SUBRESOURCE_OPERATING_SYSTEMS_PROPERTY_ID  = new OperatingSystemReadOnlyResourceDefinition().getPluralName();
 
   @Inject
   private static RepositoryVersionDAO s_repoVersionDAO;
@@ -759,17 +759,17 @@ public class VersionDefinitionResourceProvider extends AbstractAuthorizedResourc
       ObjectNode osBase = factory.objectNode();
 
       ObjectNode osElement = factory.objectNode();
-      osElement.put(PropertyHelper.getPropertyName(OperatingSystemResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS),
+      osElement.put(PropertyHelper.getPropertyName(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS),
           os.isAmbariManaged());
-      osElement.put(PropertyHelper.getPropertyName(OperatingSystemResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID),
+      osElement.put(PropertyHelper.getPropertyName(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID),
           os.getFamily());
 
-      osElement.put(PropertyHelper.getPropertyName(OperatingSystemResourceProvider.OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID),
+      osElement.put(PropertyHelper.getPropertyName(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_STACK_NAME_PROPERTY_ID),
           entity.getStackName());
-      osElement.put(PropertyHelper.getPropertyName(OperatingSystemResourceProvider.OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID),
+      osElement.put(PropertyHelper.getPropertyName(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_STACK_VERSION_PROPERTY_ID),
           entity.getStackVersion());
 
-      osBase.put(PropertyHelper.getPropertyCategory(OperatingSystemResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS),
+      osBase.put(PropertyHelper.getPropertyCategory(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS),
           osElement);
 
       ArrayNode reposArray = factory.arrayNode();
@@ -813,7 +813,7 @@ public class VersionDefinitionResourceProvider extends AbstractAuthorizedResourc
       subs.add(osBase);
     }
 
-    res.setProperty(new OperatingSystemResourceDefinition().getPluralName(), subs);
+    res.setProperty(new OperatingSystemReadOnlyResourceDefinition().getPluralName(), subs);
   }
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/spi/Resource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/spi/Resource.java
@@ -109,6 +109,7 @@ public interface Resource {
     Extension,
     ExtensionVersion,
     OperatingSystem,
+    OperatingSystemReadOnly,
     Repository,
     StackService,
     StackConfiguration,
@@ -245,6 +246,7 @@ public interface Resource {
     public static final Type Extension = InternalType.Extension.getType();
     public static final Type ExtensionVersion = InternalType.ExtensionVersion.getType();
     public static final Type OperatingSystem = InternalType.OperatingSystem.getType();
+    public static final Type OperatingSystemReadOnly = InternalType.OperatingSystemReadOnly.getType();
     public static final Type Repository = InternalType.Repository.getType();
     public static final Type StackService = InternalType.StackService.getType();
     public static final Type StackConfiguration = InternalType.StackConfiguration.getType();

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -522,11 +522,12 @@ public class MpackManager {
     if (resultSet.size() == 0 && stackEntity == null) {
       LOG.info("Adding mpack {}-{} to the database", mpackName, mpackVersion);
 
-      MpackEntity mpackEntity = new MpackEntity();
+      final MpackEntity mpackEntity = new MpackEntity();
       mpackEntity.setMpackName(mpackName);
       mpackEntity.setMpackVersion(mpackVersion);
       mpackEntity.setMpackUri(mpack.getMpackUri());
       mpackEntity.setRegistryId(mpack.getRegistryId());
+      mpackDAO.create(mpackEntity);
 
       List<RepoOsEntity> repositoryOperatingSystems = repoVersionHelper.createRepoOsEntities(
           mpack.getRepositoryXml().getRepositories());
@@ -535,10 +536,9 @@ public class MpackManager {
           operatingSystem -> operatingSystem.setMpackEntity(mpackEntity));
 
       mpackEntity.setRepositoryOperatingSystems(repositoryOperatingSystems);
-
-      mpackDAO.create(mpackEntity);
-      return mpackEntity.getId();
+      return mpackDAO.merge(mpackEntity).getId();
     }
+
     //mpack already exists
     return null;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -536,8 +536,8 @@ public class MpackManager {
 
       mpackEntity.setRepositoryOperatingSystems(repositoryOperatingSystems);
 
-      Long mpackId = mpackDAO.create(mpackEntity);
-      return mpackId;
+      mpackDAO.create(mpackEntity);
+      return mpackEntity.getId();
     }
     //mpack already exists
     return null;

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/CrudDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/CrudDAO.java
@@ -95,7 +95,7 @@ public class CrudDAO<E, K> {
    * @param entity entity to create
    */
   @Transactional
-  protected void create(E entity) {
+  public void create(E entity) {
     entityManagerProvider.get().persist(entity);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/MpackDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/MpackDAO.java
@@ -24,7 +24,6 @@ import javax.persistence.TypedQuery;
 
 import org.apache.ambari.server.orm.RequiresSession;
 import org.apache.ambari.server.orm.entities.MpackEntity;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +34,15 @@ import com.google.inject.persist.Transactional;
 
 
 @Singleton
-public class MpackDAO {
+public class MpackDAO extends CrudDAO<MpackEntity, Long> {
+
+  /**
+   * Constructor.
+   */
+  public MpackDAO() {
+    super(MpackEntity.class);
+  }
+
   protected final static Logger LOG = LoggerFactory.getLogger(MpackDAO.class);
 
   /**
@@ -49,15 +56,6 @@ public class MpackDAO {
    */
   @Inject
   private DaoUtils m_daoUtils;
-
-  /**
-   * Persists a new mpack
-   */
-  @Transactional
-  public Long create(MpackEntity mpackEntity) {
-    m_entityManagerProvider.get().persist(mpackEntity);
-    return mpackEntity.getId();
-  }
 
   /**
    * Gets an mpack with the specified ID.
@@ -83,18 +81,6 @@ public class MpackDAO {
     TypedQuery<MpackEntity> query = m_entityManagerProvider.get().createNamedQuery("MpackEntity.findByNameVersion", MpackEntity.class);
     query.setParameter("mpackName", mpackName);
     query.setParameter("mpackVersion", mpackVersion);
-    return m_daoUtils.selectList(query);
-  }
-
-  /**
-   * Gets all mpacks stored in the database across all clusters.
-   *
-   * @return all mpacks or an empty list if none exist (never {@code null}).
-   */
-  @RequiresSession
-  public List<MpackEntity> findAll() {
-    TypedQuery<MpackEntity> query = m_entityManagerProvider.get().createNamedQuery(
-            "MpackEntity.findAll", MpackEntity.class);
     return m_daoUtils.selectList(query);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
@@ -37,6 +37,7 @@ import javax.persistence.TableGenerator;
 
 import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.stack.RepoTag;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.google.common.base.Objects;
 
@@ -210,6 +211,18 @@ public class RepoDefinitionEntity {
         && Objects.equal(distribution, that.distribution)
         && Objects.equal(components, that.components);
   }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    return new ToStringBuilder(null)
+      .append("id", repoID)
+      .append("name", repoName)
+      .append("tags", repoTags)
+      .toString();
+  }  
 
   /**
    * Builds a {@link RepoDefinitionEntity} from a {@link RepositoryInfo} instance.

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
@@ -35,6 +35,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 
+import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.stack.RepoTag;
 
 import com.google.common.base.Objects;
@@ -209,4 +210,23 @@ public class RepoDefinitionEntity {
         && Objects.equal(distribution, that.distribution)
         && Objects.equal(components, that.components);
   }
-}
+
+  /**
+   * Builds a {@link RepoDefinitionEntity} from a {@link RepositoryInfo} instance.
+   *
+   * @param repositoryInfo  the repository to build from.
+   * @return  a newly created {@link RepoDefinitionEntity} which is not yet persisted.
+   */
+  public static RepoDefinitionEntity from(RepositoryInfo repositoryInfo) {
+      RepoDefinitionEntity repositoryDefinition = new RepoDefinitionEntity();
+      repositoryDefinition.setBaseUrl(repositoryInfo.getBaseUrl());
+      repositoryDefinition.setRepoName(repositoryInfo.getRepoName());
+      repositoryDefinition.setRepoID(repositoryInfo.getRepoId());
+      repositoryDefinition.setDistribution(repositoryInfo.getDistribution());
+      repositoryDefinition.setComponents(repositoryInfo.getComponents());
+      repositoryDefinition.setMirrors(repositoryInfo.getMirrorsList());
+      repositoryDefinition.setUnique(repositoryInfo.isUnique());
+      repositoryDefinition.setTags(repositoryInfo.getTags());
+      return repositoryDefinition;
+    }
+  }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
@@ -35,6 +35,7 @@ import javax.persistence.TableGenerator;
 
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.google.common.base.Objects;
 
@@ -214,5 +215,17 @@ public class RepoOsEntity {
         && Objects.equal(ambariManaged, that.ambariManaged)
         && Objects.equal(family, that.family)
         && Objects.equal(repoDefinitionEntities, that.repoDefinitionEntities);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    return new ToStringBuilder(null)
+        .append("mpackId", mpackId)
+        .append("family", family)
+        .append("isManagedByAmbari", ambariManaged)
+        .toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.orm.entities;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -59,7 +58,6 @@ public class RepoOsEntity {
   /**
    * The ID of the mpack that this repository entry belongs to.
    */
-  @Basic
   @Column(name = "mpack_id", updatable = false, insertable = false)
   private long mpackId;
 
@@ -183,6 +181,7 @@ public class RepoOsEntity {
    */
   public void setMpackEntity(MpackEntity mpackEntity) {
     this.mpackEntity = mpackEntity;
+    mpackId = mpackEntity.getId();
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryVersionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryVersionEntity.java
@@ -363,7 +363,7 @@ public class RepositoryVersionEntity {
    */
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(stack, version, displayName, repoOsEntities);
+    return java.util.Objects.hash(stack, version, displayName);
   }
 
   /**
@@ -385,8 +385,7 @@ public class RepositoryVersionEntity {
 
     RepositoryVersionEntity that = (RepositoryVersionEntity) object;
     return Objects.equal(stack, that.stack) && Objects.equal(version, that.version)
-        && Objects.equal(displayName, that.displayName)
-        && Objects.equal(repoOsEntities, that.repoOsEntities);
+        && Objects.equal(displayName, that.displayName);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryVersionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryVersionEntity.java
@@ -119,7 +119,7 @@ public class RepositoryVersionEntity {
   /**
    * one-to-many association to {@link RepoOsEntity}
    */
-  @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "repositoryVersionEntity", orphanRemoval = true)
+  @OneToMany(fetch = FetchType.EAGER, mappedBy = "repositoryVersionEntity", orphanRemoval = true)
   private List<RepoOsEntity> repoOsEntities = new ArrayList<>();
 
   @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "repositoryVersion")

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/RepositoryInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/RepositoryInfo.java
@@ -23,23 +23,60 @@ import java.util.Set;
 
 import org.apache.ambari.server.controller.RepositoryResponse;
 import org.apache.ambari.server.state.stack.RepoTag;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
 
 public class RepositoryInfo {
+  @JsonProperty("base_url")
+  @SerializedName("base_url")
   private String baseUrl;
+
+  @JsonProperty("os_type")
+  @SerializedName("os_type")
   private String osType;
+
+  @JsonProperty("repo_id")
+  @SerializedName("repo_id")
   private String repoId;
+
+  @JsonProperty("repo_name")
+  @SerializedName("repo_name")
   private String repoName;
+
+  @JsonProperty("distribution")
+  @SerializedName("distribution")
   private String distribution;
+
+  @JsonProperty("components")
+  @SerializedName("components")
   private String components;
+
+  @JsonProperty("mirrors_list")
+  @SerializedName("mirrors_list")
   private String mirrorsList;
+
+  @JsonProperty("default_base_url")
+  @SerializedName("default_base_url")
   private String defaultBaseUrl;
+
+  @JsonIgnore
   private boolean repoSaved = false;
+
+  @JsonProperty("unique")
+  @SerializedName("unique")
   private boolean unique = false;
+
+  @JsonProperty("ambari_managed")
+  @SerializedName("ambari_managed")
   private boolean ambariManagedRepositories = true;
+
+  @JsonProperty("tags")
+  @SerializedName("tags")
   private Set<RepoTag> tags = new HashSet<>();
 
   /**
@@ -187,8 +224,12 @@ public class RepositoryInfo {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     RepositoryInfo that = (RepositoryInfo) o;
     return repoSaved == that.repoSaved &&
         unique == that.unique &&

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/RepositoryXml.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/RepositoryXml.java
@@ -33,6 +33,7 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.apache.ambari.server.stack.Validable;
 import org.apache.ambari.server.state.RepositoryInfo;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * Represents the repository file <code>$STACK_VERSION/repos/repoinfo.xml</code>.
@@ -43,6 +44,7 @@ public class RepositoryXml implements Validable{
 
   @XmlElement(name="latest")
   private String latestUri;
+
   @XmlElement(name="os")
   private List<Os> oses = new ArrayList<>();
 
@@ -82,7 +84,7 @@ public class RepositoryXml implements Validable{
 
   @Override
   public void addErrors(Collection<String> errors) {
-    this.errorSet.addAll(errors);
+    errorSet.addAll(errors);
   }
 
   /**
@@ -105,6 +107,7 @@ public class RepositoryXml implements Validable{
   @XmlAccessorType(XmlAccessType.FIELD)
   public static class Os {
     @XmlAttribute(name="family")
+    @JsonProperty("os_type")
     private String family;
 
     @XmlElement(name="package-version")
@@ -143,16 +146,30 @@ public class RepositoryXml implements Validable{
    */
   @XmlAccessorType(XmlAccessType.FIELD)
   public static class Repo {
+    @JsonProperty("base_url")
     private String baseurl = null;
+
+    @JsonProperty("mirrors_list")
     private String mirrorslist = null;
+
+    @JsonProperty("repo_id")
     private String repoid = null;
+
+    @JsonProperty("repo_name")
     private String reponame = null;
+
+    @JsonProperty("distribution")
     private String distribution = null;
+
+    @JsonProperty("components")
     private String components = null;
+
+    @JsonProperty("unique")
     private boolean unique = false;
 
     @XmlElementWrapper(name="tags")
     @XmlElement(name="tag")
+    @JsonProperty("tags")
     private Set<RepoTag> tags = new HashSet<>();
 
     private Repo() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -35,7 +35,7 @@ import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.ActionExecutionContext;
 import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.internal.OperatingSystemResourceProvider;
+import org.apache.ambari.server.controller.internal.OperatingSystemReadOnlyResourceProvider;
 import org.apache.ambari.server.controller.internal.RepositoryResourceProvider;
 import org.apache.ambari.server.controller.internal.RepositoryVersionResourceProvider;
 import org.apache.ambari.server.controller.spi.SystemException;
@@ -141,11 +141,11 @@ public class RepositoryVersionHelper {
 
       final RepoOsEntity operatingSystemEntity = new RepoOsEntity();
 
-      operatingSystemEntity.setFamily(osObj.get(OperatingSystemResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID).getAsString());
+      operatingSystemEntity.setFamily(osObj.get(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID).getAsString());
 
-      if (osObj.has(OperatingSystemResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS)) {
+      if (osObj.has(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS)) {
         operatingSystemEntity.setAmbariManaged(osObj.get(
-            OperatingSystemResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS).getAsBoolean());
+            OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_AMBARI_MANAGED_REPOS).getAsBoolean());
       }
 
       for (JsonElement repositoryElement: osObj.get(RepositoryVersionResourceProvider.SUBRESOURCE_REPOSITORIES_PROPERTY_ID).getAsJsonArray()) {
@@ -195,17 +195,7 @@ public class RepositoryVersionHelper {
       RepoOsEntity operatingSystemEntity = new RepoOsEntity();
       List<RepoDefinitionEntity> repositoriesList = new ArrayList<>();
       for (RepositoryInfo repository : operatingSystem.getValue()) {
-        RepoDefinitionEntity repositoryDefinition = new RepoDefinitionEntity();
-        repositoryDefinition.setBaseUrl(repository.getBaseUrl());
-        repositoryDefinition.setRepoName(repository.getRepoName());
-        repositoryDefinition.setRepoID(repository.getRepoId());
-        repositoryDefinition.setDistribution(repository.getDistribution());
-        repositoryDefinition.setComponents(repository.getComponents());
-        repositoryDefinition.setMirrors(repository.getMirrorsList());
-        repositoryDefinition.setUnique(repository.isUnique());
-
-        repositoryDefinition.setTags(repository.getTags());
-
+        RepoDefinitionEntity repositoryDefinition = RepoDefinitionEntity.from(repository);
         repositoriesList.add(repositoryDefinition);
         operatingSystemEntity.setAmbariManaged(repository.isAmbariManagedRepositories());
       }

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/query/QueryImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/query/QueryImplTest.java
@@ -263,7 +263,7 @@ public class QueryImplTest {
     TreeNode<Resource> opSystemNode = opSystemsNode.getChild("OperatingSystem:1");
     Assert.assertEquals("OperatingSystem:1", opSystemNode.getName());
     Resource osResource = opSystemNode.getObject();
-    Assert.assertEquals(Resource.Type.OperatingSystem, opSystemNode.getObject().getType());
+    Assert.assertEquals(Resource.Type.OperatingSystemReadOnly, opSystemNode.getObject().getType());
 
     Assert.assertEquals("centos5", osResource.getPropertyValue("OperatingSystems/os_type"));
   }
@@ -470,7 +470,7 @@ public class QueryImplTest {
 
     TreeNode<Resource> opSystemNode = opSystemsNode.getChild("OperatingSystem:1");
     Assert.assertEquals("OperatingSystem:1", opSystemNode.getName());
-    Assert.assertEquals(Resource.Type.OperatingSystem, opSystemNode.getObject().getType());
+    Assert.assertEquals(Resource.Type.OperatingSystemReadOnly, opSystemNode.getObject().getType());
 
     Assert.assertEquals(1, opSystemNode.getChildren().size());
     TreeNode<Resource> repositoriesNode = opSystemNode.getChild("repositories");

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/RepositoryVersionResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/RepositoryVersionResourceDefinitionTest.java
@@ -46,7 +46,7 @@ public class RepositoryVersionResourceDefinitionTest {
     final RepositoryVersionResourceDefinition resourceDefinition = new RepositoryVersionResourceDefinition();
     final Set<SubResourceDefinition> subResourceDefinitions = resourceDefinition.getSubResourceDefinitions ();
     final Iterator<SubResourceDefinition> iterator = subResourceDefinitions.iterator();
-    Assert.assertEquals(Resource.Type.OperatingSystem, iterator.next().getType());
+    Assert.assertEquals(Resource.Type.OperatingSystemReadOnly, iterator.next().getType());
     Assert.assertEquals(1, subResourceDefinitions.size());
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/StackVersionResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/StackVersionResourceDefinitionTest.java
@@ -54,7 +54,7 @@ public class StackVersionResourceDefinitionTest {
 
     for (SubResourceDefinition subResource : subResources) {
       Resource.Type type = subResource.getType();
-      if (type.equals(Resource.Type.OperatingSystem)) {
+      if (type.equals(Resource.Type.OperatingSystemReadOnly)) {
         operatingSystemFound = true;
       } else if (type.equals(Resource.Type.StackService)) {
         serviceFound = true;

--- a/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/RepositoryVersionEventCreatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/RepositoryVersionEventCreatorTest.java
@@ -31,7 +31,7 @@ import org.apache.ambari.server.audit.event.request.AddRepositoryVersionRequestA
 import org.apache.ambari.server.audit.event.request.ChangeRepositoryVersionRequestAuditEvent;
 import org.apache.ambari.server.audit.event.request.DeleteRepositoryVersionRequestAuditEvent;
 import org.apache.ambari.server.audit.request.eventcreator.RepositoryVersionEventCreator;
-import org.apache.ambari.server.controller.internal.OperatingSystemResourceProvider;
+import org.apache.ambari.server.controller.internal.OperatingSystemReadOnlyResourceProvider;
 import org.apache.ambari.server.controller.internal.RepositoryResourceProvider;
 import org.apache.ambari.server.controller.internal.RepositoryVersionResourceProvider;
 import org.apache.ambari.server.controller.spi.Resource;
@@ -128,7 +128,7 @@ public class RepositoryVersionEventCreatorTest extends AuditEventCreatorTestBase
 
     // ***
     Map<String, Object> operatingSystem = new HashMap<>();
-    operatingSystem.put(OperatingSystemResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID, "redhat7");
+    operatingSystem.put(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID, "redhat7");
 
     Set<Map<String,String>> repositories = new HashSet<>();
 
@@ -143,7 +143,7 @@ public class RepositoryVersionEventCreatorTest extends AuditEventCreatorTestBase
     operatingSystem.put("repositories", repositories);
     // ***
     Map<String, Object> operatingSystem2 = new HashMap<>();
-    operatingSystem2.put(OperatingSystemResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID, "redhat6");
+    operatingSystem2.put(OperatingSystemReadOnlyResourceProvider.OPERATING_SYSTEM_OS_TYPE_PROPERTY_ID, "redhat6");
 
     Set<Map<String,String>> repositories2 = new HashSet<>();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -1925,10 +1925,9 @@ public class AmbariManagementControllerImplTest {
 
     replay(manager, clusters, cluster, injector, stackId, configuration, repositoryVersionEntity, configHelper);
 
-    AmbariManagementControllerImpl ambariManagementControllerImpl =
-        createMockBuilder(AmbariManagementControllerImpl.class)
-            .addMockedMethod("getRcaParameters")
-            .withConstructor(manager, clusters, injector).createNiceMock();
+    AmbariManagementControllerImpl ambariManagementControllerImpl = createMockBuilder(
+        AmbariManagementControllerImpl.class).withConstructor(manager, clusters,
+            injector).createNiceMock();
 
     replay(ambariManagementControllerImpl);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClusterControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClusterControllerImplTest.java
@@ -941,7 +941,7 @@ public class ClusterControllerImplTest {
       providers.put(Resource.Type.Host, new TestHostResourceProvider());
       providers.put(Resource.Type.Stack, new TestStackResourceProvider());
       providers.put(Resource.Type.StackVersion, new TestStackVersionResourceProvider());
-      providers.put(Resource.Type.OperatingSystem, new TestOperatingSystemResourceProvider());
+      providers.put(Resource.Type.OperatingSystemReadOnly, new TestOperatingSystemResourceProvider());
       providers.put(Resource.Type.Repository, new TestRepositoryResourceProvider());
       providers.put(Resource.Type.RepositoryVersion, new TestRepositoryVersionResourceProvider());
       providers.put(Resource.Type.CompatibleRepositoryVersion, new TestCompatibleRepositoryVersionResourceProvider());
@@ -1174,7 +1174,7 @@ public class ClusterControllerImplTest {
 
   private static class TestOperatingSystemResourceProvider extends TestResourceProvider {
     private TestOperatingSystemResourceProvider() {
-      super(OperatingSystemResourceProvider.propertyIds, OperatingSystemResourceProvider.keyPropertyIds);
+      super(OperatingSystemReadOnlyResourceProvider.propertyIds, OperatingSystemReadOnlyResourceProvider.keyPropertyIds);
     }
 
     @Override
@@ -1186,7 +1186,7 @@ public class ClusterControllerImplTest {
       keyPropertyValues.add("centos6");
       keyPropertyValues.add("oraclelinux5");
 
-      return getResources(Resource.Type.OperatingSystem, predicate, "OperatingSystems/os_type", keyPropertyValues);
+      return getResources(Resource.Type.OperatingSystemReadOnly, predicate, "OperatingSystems/os_type", keyPropertyValues);
     }
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RequestImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RequestImplTest.java
@@ -214,7 +214,7 @@ public class RequestImplTest {
     Assert.assertTrue(validPropertyIds.contains("Versions/stack_version"));
     Assert.assertTrue(validPropertyIds.contains("Versions/min_upgrade_version"));
 
-    request = PropertyHelper.getReadRequest(OperatingSystemResourceProvider.propertyIds);
+    request = PropertyHelper.getReadRequest(OperatingSystemReadOnlyResourceProvider.propertyIds);
     validPropertyIds = request.getPropertyIds();
 
     //OperatingSystem resource properties


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the removal of version definitions and repository versions, we need a new way of exposing and managing repositories. Since repositories are now associated with management packs, it makes sense to expose these off of the mpack endpoint.

Overview of changes:
- Renamed and deprecated existing OS and Repository resource provider frameworks. This was done to preserve existing functionality of the web client until they implement the new APIs.

- Creation of a new sub resource provider for Operating Systems. We don't need management of individual repositories as that is overkill and causes a lot of extra code.

## How was this patch tested?
Deployment of a simple mpack, HDPCore. Manual verification of GET/PUT/POST/DELETE verbs for now (will create Jira for tests separately).