### PR TITLE
[Ambari 23133] Hooks scripts has hadoop specific code

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -63,7 +63,8 @@ sudo = AMBARI_SUDO_BINARY
 ambari_server_hostname = config['clusterHostInfo']['ambari_server_host'][0]
 
 stack_version_unformatted = config['hostLevelParams']['stack_version']
-stack_version_formatted = format_stack_version(stack_version_unformatted)
+stack_version_formatted = config['hostLevelParams']['stack_version']
+#stack_version_formatted = format_stack_version(stack_version_unformatted)
 
 upgrade_type = Script.get_upgrade_type(default("/commandParams/upgrade_type", ""))
 version = default("/commandParams/version", None)
@@ -109,7 +110,10 @@ def is_secure_port(port):
 # force the use of "current" in the hook
 hdfs_user_nofile_limit = default("/configurations/hadoop-env/hdfs_user_nofile_limit", "128000")
 hadoop_home = stack_select.get_hadoop_dir("home")
-hadoop_libexec_dir = stack_select.get_hadoop_dir("libexec")
+stack_name = default("/hostLevelParams/stack_name", None)
+stack_name = stack_name.lower()
+component_directory = "namenode"
+hadoop_libexec_dir = format("/usr/hwx/mpacks/{stack_name}/{stack_version_formatted}/{component_directory}/libexec")
 hadoop_lib_home = stack_select.get_hadoop_dir("lib")
 
 hadoop_dir = "/etc/hadoop"

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/shared_initialization.py
@@ -189,6 +189,9 @@ def setup_hadoop_env():
     # create /etc/hadoop
     Directory(params.hadoop_dir, mode=0755)
 
+    #Write out the conf directory
+    #TODO: Change with instance manager
+    Directory(params.hadoop_conf_dir, mode=0755)
     # write out hadoop-env.sh, but only if the directory exists
     if os.path.exists(params.hadoop_conf_dir):
       File(os.path.join(params.hadoop_conf_dir, 'hadoop-env.sh'), owner=tc_owner,

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -340,7 +340,7 @@ App.StackService.componentsOrderForService = {
 
 //@TODO: Write unit test for no two keys in the object should have any intersecting elements in their values
 App.StackService.coSelected = {
-  'YARN': ['MAPREDUCE2']
+
 };
 
 


### PR DESCRIPTION
Stack hooks have hadoop paths. Need to refactor it. A stop gap fix is made in this request.
hadoop_conf_dir is not getting created.
YARN & MAPREDUCE should not be coselected services

(Please fill in changes proposed in this fix)

## How was this patch tested?

Install HDFS & HADOOP_CLIENTS

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.