### PR TITLE
[AMBARI-23152] Clean up dup vars in params in Slider (dili)

### DIFF
--- a/ambari-server/src/main/resources/common-services/SLIDER/0.60.0.2.2/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/SLIDER/0.60.0.2.2/package/scripts/params_linux.py
@@ -50,10 +50,8 @@ slider_tar_gz = format('{slider_lib_dir}/slider.tar.gz')
 user_group = config['configurations']['cluster-env']['user_group']
 hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
 
-
 kinit_path_local = get_kinit_path(default('/configurations/kerberos-env/executable_search_paths', None))
 security_enabled = config['configurations']['cluster-env']['security_enabled']
-hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
 hdfs_principal_name = config['configurations']['hadoop-env']['hdfs_principal_name']
 hdfs_user_keytab = config['configurations']['hadoop-env']['hdfs_user_keytab']
 


### PR DESCRIPTION
Remove dup hdfs_user var

## What changes were proposed in this pull request?
Remove dup hdfs_user var

## How was this patch tested?
Patch a trunk cluster with the change and run cluster install

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.