### PR TITLE
[AMBARI-23156] Remove Required Group Name and Expose Lifecycle to API

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeGroupResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeGroupResourceProvider.java
@@ -57,6 +57,7 @@ public class UpgradeGroupResourceProvider extends AbstractControllerResourceProv
   protected static final String UPGRADE_CLUSTER_NAME = "UpgradeGroup/cluster_name";
   protected static final String UPGRADE_GROUP_NAME = "UpgradeGroup/name";
   protected static final String UPGRADE_GROUP_TITLE = "UpgradeGroup/title";
+  protected static final String UPGRADE_GROUP_LIFECYCLE = "UpgradeGroup/lifecycle";
   protected static final String UPGRADE_GROUP_PROGRESS_PERCENT = "UpgradeGroup/progress_percent";
   protected static final String UPGRADE_GROUP_STATUS = "UpgradeGroup/status";
   protected static final String UPGRADE_GROUP_DISPLAY_STATUS = "UpgradeGroup/display_status";
@@ -68,6 +69,7 @@ public class UpgradeGroupResourceProvider extends AbstractControllerResourceProv
 
   private static final Set<String> PK_PROPERTY_IDS = new HashSet<>(
     Arrays.asList(UPGRADE_REQUEST_ID, UPGRADE_GROUP_ID));
+
   private static final Set<String> PROPERTY_IDS = new HashSet<>();
 
   private static final Map<Resource.Type, String> KEY_PROPERTY_IDS = new HashMap<>();
@@ -90,6 +92,7 @@ public class UpgradeGroupResourceProvider extends AbstractControllerResourceProv
     PROPERTY_IDS.add(UPGRADE_GROUP_TOTAL_TASKS);
     PROPERTY_IDS.add(UPGRADE_GROUP_IN_PROGRESS_TASKS);
     PROPERTY_IDS.add(UPGRADE_GROUP_COMPLETED_TASKS);
+    PROPERTY_IDS.add(UPGRADE_GROUP_LIFECYCLE);
 
     // keys
     KEY_PROPERTY_IDS.put(Resource.Type.UpgradeGroup, UPGRADE_GROUP_ID);
@@ -183,6 +186,7 @@ public class UpgradeGroupResourceProvider extends AbstractControllerResourceProv
     setResourceProperty(resource, UPGRADE_GROUP_ID, group.getId(), requestedIds);
     setResourceProperty(resource, UPGRADE_GROUP_NAME, group.getName(), requestedIds);
     setResourceProperty(resource, UPGRADE_GROUP_TITLE, group.getTitle(), requestedIds);
+    setResourceProperty(resource, UPGRADE_GROUP_LIFECYCLE, group.getLifecycle(), requestedIds);
 
     return resource;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -822,6 +822,7 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
 
       if(!itemEntities.isEmpty()) {
         UpgradeGroupEntity groupEntity = new UpgradeGroupEntity();
+        groupEntity.setLifecycle(group.lifecycle);
         groupEntity.setName(group.name);
         groupEntity.setTitle(group.title);
         groupEntity.setItems(itemEntities);

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeGroupEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeGroupEntity.java
@@ -23,6 +23,8 @@ import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -31,6 +33,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
+
+import org.apache.ambari.server.state.stack.upgrade.LifecycleType;
 
 /**
  * Models a single upgrade group as part of an entire {@link UpgradeEntity}.
@@ -57,8 +61,12 @@ public class UpgradeGroupEntity {
   @Column(name = "upgrade_id", nullable = false, insertable = false, updatable = false)
   private Long upgradeId;
 
+  @Column(name = "lifecycle", length=255, nullable = false)
+  @Enumerated(value = EnumType.STRING)
+  private LifecycleType lifecycle;
+
   @Basic
-  @Column(name = "group_name", length=255, nullable = false)
+  @Column(name = "group_name", length=255, nullable = true)
   private String groupName;
 
   @Basic
@@ -134,6 +142,20 @@ public class UpgradeGroupEntity {
       item.setGroupEntity(this);
     }
     upgradeItems = items;
+  }
+
+  /**
+   * @return the lifecycle for the group
+   */
+  public LifecycleType getLifecycle() {
+    return lifecycle;
+  }
+
+  /**
+   * @param type the lifecycle for the group
+   */
+  public void setLifecycle(LifecycleType type) {
+    lifecycle = type;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -74,7 +74,7 @@ import org.apache.ambari.server.state.stack.upgrade.Grouping;
 import org.apache.ambari.server.state.stack.upgrade.HostOrderGrouping;
 import org.apache.ambari.server.state.stack.upgrade.HostOrderItem;
 import org.apache.ambari.server.state.stack.upgrade.HostOrderItem.HostOrderActionType;
-import org.apache.ambari.server.state.stack.upgrade.Lifecycle;
+import org.apache.ambari.server.state.stack.upgrade.LifecycleType;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeScope;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.apache.commons.collections.CollectionUtils;
@@ -1297,7 +1297,7 @@ public class UpgradeContext {
       // verify that the upgradepack has the required grouping and set the
       // action items on it
       HostOrderGrouping hostOrderGrouping = null;
-      List<Grouping> groupings = upgradePack.getGroups(Lifecycle.LifecycleType.UPGRADE, direction);
+      List<Grouping> groupings = upgradePack.getGroups(LifecycleType.UPGRADE, direction);
       for (Grouping grouping : groupings) {
         if (grouping instanceof HostOrderGrouping) {
           hostOrderGrouping = (HostOrderGrouping) grouping;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -61,7 +61,7 @@ import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.UpgradePack.ProcessingComponent;
 import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.Grouping;
-import org.apache.ambari.server.state.stack.upgrade.Lifecycle;
+import org.apache.ambari.server.state.stack.upgrade.LifecycleType;
 import org.apache.ambari.server.state.stack.upgrade.ManualTask;
 import org.apache.ambari.server.state.stack.upgrade.RestartTask;
 import org.apache.ambari.server.state.stack.upgrade.ServiceCheckGrouping;
@@ -302,7 +302,7 @@ public class UpgradeHelper {
     List<UpgradeGroupHolder> groups = new ArrayList<>();
 
     UpgradeGroupHolder previousGroupHolder = null;
-    for (Grouping group : upgradePack.getGroups(Lifecycle.LifecycleType.UPGRADE, context.getDirection())) {
+    for (Grouping group : upgradePack.getGroups(LifecycleType.UPGRADE, context.getDirection())) {
 
       // !!! grouping is not scoped to context
       if (!context.isScoped(group.scope)) {
@@ -318,6 +318,7 @@ public class UpgradeHelper {
 
       UpgradeGroupHolder groupHolder = new UpgradeGroupHolder();
       groupHolder.name = group.name;
+      groupHolder.lifecycle = group.lifecycle;
       groupHolder.title = group.title;
       groupHolder.groupClass = group.getClass();
       groupHolder.skippable = group.skippable;
@@ -700,15 +701,22 @@ public class UpgradeHelper {
    * Short-lived objects that hold information about upgrade groups
    */
   public static class UpgradeGroupHolder {
+
+    /**
+     * The lifecycle
+     */
+    public LifecycleType lifecycle;
+
     /**
      *
      */
     private boolean processingGroup;
 
     /**
-     * The name
+     * The title
      */
     public String name;
+
     /**
      * The title
      */

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
@@ -45,6 +45,7 @@ import org.apache.ambari.server.state.stack.upgrade.CreateAndConfigureTask;
 import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.Grouping;
 import org.apache.ambari.server.state.stack.upgrade.Lifecycle;
+import org.apache.ambari.server.state.stack.upgrade.LifecycleType;
 import org.apache.ambari.server.state.stack.upgrade.ServiceCheckGrouping;
 import org.apache.ambari.server.state.stack.upgrade.Task;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
@@ -225,7 +226,7 @@ public class UpgradePack {
    *          the direction to return the ordered groups
    * @return the list of groups
    */
-  public List<Grouping> getGroups(Lifecycle.LifecycleType type, Direction direction) {
+  public List<Grouping> getGroups(LifecycleType type, Direction direction) {
 
     // !!! lifecycles are bound to be only one per-type per-Upgrade Pack, so findFirst() is ok here
     Optional<Lifecycle> optional = lifecycles.stream().filter(l -> l.type == type).findFirst();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlTransient;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.stack.HostsType;
@@ -84,6 +85,9 @@ public class Grouping {
 
   @XmlElement(name="scope")
   public UpgradeScope scope = UpgradeScope.ANY;
+
+  @XmlTransient
+  public LifecycleType lifecycle;
 
   /**
    * A condition element with can prevent this entire group from being scheduled
@@ -411,6 +415,10 @@ public class Grouping {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("name", name).toString();
+    return Objects.toStringHelper(this)
+        .add("name", name)
+        .add("title", title)
+        .toString();
+
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Lifecycle.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Lifecycle.java
@@ -17,18 +17,14 @@
  */
 package org.apache.ambari.server.state.stack.upgrade;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -37,14 +33,14 @@ import javax.xml.bind.annotation.XmlRootElement;
  * namely:
  *
  * <ol>
- *   <li>INSTALL</li>
- *   <li>QUIET</li>
- *   <li>SNAPSHOT</li>
- *   <li>PREPARE</li>
- *   <li>STOP</li>
- *   <li>UPGRADE</li>
- *   <li>START</li>
- *   <li>FINALIZE</li>
+ *   <li>{@link LifecycleType#INSTALL}</li>
+ *   <li>{@link LifecycleType#QUIET}</li>
+ *   <li>{@link LifecycleType#SNAPSHOT}</li>
+ *   <li>{@link LifecycleType#PREPARE}</li>
+ *   <li>{@link LifecycleType#STOP}</li>
+ *   <li>{@link LifecycleType#UPGRADE}</li>
+ *   <li>{@link LifecycleType#START}</li>
+ *   <li>{@link LifecycleType#FINALIZE}</li>
  * </ol>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -58,76 +54,16 @@ public class Lifecycle {
   @XmlElement(name="group")
   public List<Grouping> groups;
 
+
   /**
-   * Identifies the lifecycle types
+   * Post-processes the groups for their enclosing lifecycle type
    */
-  @XmlEnum
-  public enum LifecycleType {
-
-    /**
-     * Work required that can be classified as installation.  Normally installation of
-     * bits occurs outside the scope of upgrade orchestration.
-     */
-    @XmlEnumValue("install")
-    INSTALL(1.0f),
-
-    /**
-     * Work to stop and wait on, for example, queues or topologies.
-     */
-    @XmlEnumValue("quiet")
-    QUIET(2.0f),
-
-    /**
-     * Work required to snapshot or other backup.
-     */
-    @XmlEnumValue("snapshot")
-    SNAPSHOT(3.0f),
-
-    /**
-     * Work required to prepare to upgrade.
-     */
-    @XmlEnumValue("prepare")
-    PREPARE(4.0f),
-
-    /**
-     * Work required to stop a service.
-     */
-    @XmlEnumValue("stop")
-    STOP(5.0f),
-
-    /**
-     * For a Rolling upgrade, work required to restart and upgrade the service.
-     */
-    @XmlEnumValue("upgrade")
-    UPGRADE(6.0f),
-
-    /**
-     * Work required to start a service.
-     */
-    @XmlEnumValue("start")
-    START(7.0f),
-
-    /**
-     * Work required to finalize.  Will not happen until the end of the upgrade.
-     */
-    @XmlEnumValue("finalize")
-    FINALIZE(8.0f);
-
-    private float m_order;
-
-    private LifecycleType(float order) {
-      m_order = order;
+  protected void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+    if (null == groups) {
+      return;
     }
 
-
-    /**
-     * Returns the ordered collection of lifecycle types.  This is prefered over {@link #values()}
-     * to preserve ordering when adding new values.
-     */
-    public static Collection<LifecycleType> ordered() {
-      return Stream.of(LifecycleType.values()).sorted((l1, l2) ->
-        Float.compare(l1.m_order, l2.m_order)).collect(Collectors.toList());
-    }
+    groups.stream().forEach(group -> group.lifecycle = type);
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/LifecycleType.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/LifecycleType.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.state.stack.upgrade;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+
+/**
+ * Identifies the lifecycle types
+ */
+@XmlEnum
+public enum LifecycleType {
+
+  /**
+   * Work required that can be classified as installation.  Normally installation of
+   * bits occurs outside the scope of upgrade orchestration.
+   */
+  @XmlEnumValue("install")
+  INSTALL(1.0f),
+
+  /**
+   * Work to stop and wait on, for example, queues or topologies.
+   */
+  @XmlEnumValue("quiet")
+  QUIET(2.0f),
+
+  /**
+   * Work required to snapshot or other backup.
+   */
+  @XmlEnumValue("snapshot")
+  SNAPSHOT(3.0f),
+
+  /**
+   * Work required to prepare to upgrade.
+   */
+  @XmlEnumValue("prepare")
+  PREPARE(4.0f),
+
+  /**
+   * Work required to stop a service.
+   */
+  @XmlEnumValue("stop")
+  STOP(5.0f),
+
+  /**
+   * For a Rolling upgrade, work required to restart and upgrade the service.
+   */
+  @XmlEnumValue("upgrade")
+  UPGRADE(6.0f),
+
+  /**
+   * Work required to start a service.
+   */
+  @XmlEnumValue("start")
+  START(7.0f),
+
+  /**
+   * Work required to finalize.  Will not happen until the end of the upgrade.
+   */
+  @XmlEnumValue("finalize")
+  FINALIZE(8.0f);
+
+  private float m_order;
+
+  private LifecycleType(float order) {
+    m_order = order;
+  }
+
+
+  /**
+   * Returns the ordered collection of lifecycle types.  This is prefered over {@link #values()}
+   * to preserve ordering when adding new values.
+   */
+  public static Collection<LifecycleType> ordered() {
+    return Stream.of(LifecycleType.values()).sorted((l1, l2) ->
+      Float.compare(l1.m_order, l2.m_order)).collect(Collectors.toList());
+  }
+}

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -1011,6 +1011,7 @@ CREATE TABLE upgrade (
 CREATE TABLE upgrade_group (
   upgrade_group_id BIGINT NOT NULL,
   upgrade_id BIGINT NOT NULL,
+  lifecycle VARCHAR(64) DEFAULT 'UPGRADE' NOT NULL,
   group_name VARCHAR(255) DEFAULT '' NOT NULL,
   group_title VARCHAR(1024) DEFAULT '' NOT NULL,
   CONSTRAINT PK_upgrade_group PRIMARY KEY (upgrade_group_id),

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -1028,6 +1028,7 @@ CREATE TABLE upgrade (
 CREATE TABLE upgrade_group (
   upgrade_group_id BIGINT NOT NULL,
   upgrade_id BIGINT NOT NULL,
+  lifecycle VARCHAR(64) DEFAULT 'UPGRADE' NOT NULL,
   group_name VARCHAR(255) DEFAULT '' NOT NULL,
   group_title VARCHAR(1024) DEFAULT '' NOT NULL,
   CONSTRAINT PK_upgrade_group PRIMARY KEY (upgrade_group_id),

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -1006,6 +1006,7 @@ CREATE TABLE upgrade (
 CREATE TABLE upgrade_group (
   upgrade_group_id NUMBER(19) NOT NULL,
   upgrade_id NUMBER(19) NOT NULL,
+  lifecycle VARCHAR(64) DEFAULT 'UPGRADE' NOT NULL,
   group_name VARCHAR2(255) DEFAULT '' NOT NULL,
   group_title VARCHAR2(1024) DEFAULT '' NOT NULL,
   CONSTRAINT PK_upgrade_group PRIMARY KEY (upgrade_group_id),

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -1011,6 +1011,7 @@ CREATE TABLE upgrade (
 CREATE TABLE upgrade_group (
   upgrade_group_id BIGINT NOT NULL,
   upgrade_id BIGINT NOT NULL,
+  lifecycle VARCHAR(64) DEFAULT 'UPGRADE' NOT NULL,
   group_name VARCHAR(255) DEFAULT '' NOT NULL,
   group_title VARCHAR(1024) DEFAULT '' NOT NULL,
   CONSTRAINT PK_upgrade_group PRIMARY KEY (upgrade_group_id),

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -1006,6 +1006,7 @@ CREATE TABLE upgrade (
 CREATE TABLE upgrade_group (
   upgrade_group_id NUMERIC(19) NOT NULL,
   upgrade_id NUMERIC(19) NOT NULL,
+  lifecycle VARCHAR(64) DEFAULT 'UPGRADE' NOT NULL,
   group_name VARCHAR(255) DEFAULT '' NOT NULL,
   group_title VARCHAR(1024) DEFAULT '' NOT NULL,
   CONSTRAINT PK_upgrade_group PRIMARY KEY (upgrade_group_id),

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -1029,6 +1029,7 @@ CREATE TABLE upgrade (
 CREATE TABLE upgrade_group (
   upgrade_group_id BIGINT NOT NULL,
   upgrade_id BIGINT NOT NULL,
+  lifecycle VARCHAR(64) DEFAULT 'UPGRADE' NOT NULL,
   group_name VARCHAR(255) DEFAULT '' NOT NULL,
   group_title VARCHAR(1024) DEFAULT '' NOT NULL,
   CONSTRAINT PK_upgrade_group PRIMARY KEY CLUSTERED (upgrade_group_id),

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -159,10 +159,10 @@
         </xs:complexType>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="name" type="xs:string" use="required" />
+    <xs:attribute name="name" type="xs:string" use="optional" />
     <xs:attribute name="title" type="xs:string" use="required" />
   </xs:complexType>
-  
+
   <xs:complexType name="cluster">
     <xs:complexContent>
       <xs:extension base="abstract-group-type">
@@ -425,15 +425,7 @@
         <xs:element name="lifecycle" minOccurs="1" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="order" type="order-type">
-                <xs:unique name="unique-by-group">
-                  <xs:annotation>
-                    <xs:documentation>Ensures that the element "processing" does not have duplicate services</xs:documentation>
-                  </xs:annotation>
-                  <xs:selector xpath="lifecycle/group" />
-                  <xs:field xpath="@name" />
-                </xs:unique>
-              </xs:element>
+              <xs:element name="order" type="order-type" />
             </xs:sequence>
             <xs:attribute name="type" type="lifecycle-type" use="required" />
           </xs:complexType>
@@ -463,7 +455,4 @@
     </xs:unique>
 
   </xs:element>
-  
-
-
 </xs:schema>

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/dao/UpgradeDAOTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/dao/UpgradeDAOTest.java
@@ -43,6 +43,7 @@ import org.apache.ambari.server.state.RepositoryType;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.UpgradeState;
 import org.apache.ambari.server.state.stack.upgrade.Direction;
+import org.apache.ambari.server.state.stack.upgrade.LifecycleType;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.junit.After;
 import org.junit.Assert;
@@ -105,8 +106,8 @@ public class UpgradeDAOTest {
     entity.setDowngradeAllowed(true);
 
     UpgradeGroupEntity group = new UpgradeGroupEntity();
-    group.setName("group_name");
     group.setTitle("group title");
+    group.setLifecycle(LifecycleType.UPGRADE);
 
     // create 2 items
     List<UpgradeItemEntity> items = new ArrayList<>();
@@ -152,7 +153,7 @@ public class UpgradeDAOTest {
 
     assertNotNull(group);
     Assert.assertNotSame(entity.getUpgradeGroups().get(0), group);
-    assertEquals("group_name", group.getName());
+    Assert.assertNull(group.getName());
     assertEquals("group title", group.getTitle());
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/stack/UpgradePackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/stack/UpgradePackTest.java
@@ -31,8 +31,9 @@ import org.apache.ambari.server.stack.ModuleFileUnmarshaller;
 import org.apache.ambari.server.state.stack.UpgradePack.PrerequisiteCheckConfig;
 import org.apache.ambari.server.state.stack.upgrade.Grouping;
 import org.apache.ambari.server.state.stack.upgrade.Lifecycle;
-import org.apache.ambari.server.state.stack.upgrade.Lifecycle.LifecycleType;
+import org.apache.ambari.server.state.stack.upgrade.LifecycleType;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.util.CollectionUtils;
 
@@ -72,8 +73,13 @@ public class UpgradePackTest {
     assertFalse(startLifecycle.isPresent());
 
     List<Grouping> groups = upgradeLifecycle.get().groups;
-
     assertEquals(29, groups.size());
+    assertEquals(LifecycleType.UPGRADE, groups.get(0).lifecycle);
+
+    Optional<Grouping> optional = groups.stream().filter(g -> "Kafka".equals(g.title)).findFirst();
+    assertTrue(optional.isPresent());
+    Assert.assertNull(optional.get().name);
+
     assertEquals(12, upgradepack.getPrerequisiteChecks().size());
 
     PrerequisiteCheckConfig checkConfig = upgradepack.getPrerequisiteCheckConfig();

--- a/ambari-server/src/test/resources/mpacks-v2/upgrade-packs/upgrade-basic.xml
+++ b/ambari-server/src/test/resources/mpacks-v2/upgrade-packs/upgrade-basic.xml
@@ -150,8 +150,7 @@
         </service>
       </group>
   
-  
-      <group name="KAFKA" title="Kafka">
+      <group title="Kafka">
         <skippable>true</skippable>
         <service name="KAFKA">
           <component>KAFKA_BROKER</component>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The upgrade group name is no longer required, and add lifecycle to the database + endpoint

## How was this patch tested?

Unit tests, no more tests are broken then before this patch:

```
[ERROR] Tests run: 4959, Failures: 109, Errors: 128, Skipped: 43
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 30:04 min
[INFO] Finished at: 2018-03-06T10:26:07-05:00
[INFO] Final Memory: 87M/1941M
[INFO] ------------------------------------------------------------------------
```