### PR TITLE
AMBARI-23167 - StackOverflowError thrown during cluster creation

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/MpackEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/MpackEntity.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -73,7 +74,11 @@ public class MpackEntity {
    * organized by operating system. A single operating system can have multiple
    * repo URLs defined for it for a given management pack.
    */
-  @OneToMany(orphanRemoval = true, cascade = CascadeType.ALL, mappedBy = "mpackEntity")
+  @OneToMany(
+      orphanRemoval = true,
+      fetch = FetchType.EAGER,
+      cascade = { CascadeType.MERGE, CascadeType.REFRESH, CascadeType.REMOVE },
+      mappedBy = "mpackEntity")
   private List<RepoOsEntity> repositoryOperatingSystems = new ArrayList<>();
 
   public Long getId() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
@@ -217,10 +217,10 @@ public class RepoDefinitionEntity {
    */
   @Override
   public String toString() {
-    return new ToStringBuilder(null)
-      .append("id", repoID)
-      .append("name", repoName)
-      .append("tags", repoTags)
+    return Objects.toStringHelper(this)
+      .add("id", repoID)
+      .add("name", repoName)
+      .add("tags", repoTags)
       .toString();
   }  
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
@@ -35,7 +35,6 @@ import javax.persistence.TableGenerator;
 
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
-import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.google.common.base.Objects;
 
@@ -139,16 +138,6 @@ public class RepoOsEntity {
     return mpackId;
   }
 
-  /**
-   * Sets the management pack ID.
-   *
-   * @param mpackId
-   *          the ID of the management pack which owns this repository.
-   */
-  public void setMpackId(long mpackId) {
-    this.mpackId = mpackId;
-  }
-
   public String getFamily() {
     return family;
   }
@@ -182,7 +171,6 @@ public class RepoOsEntity {
    */
   public void setMpackEntity(MpackEntity mpackEntity) {
     this.mpackEntity = mpackEntity;
-    mpackId = mpackEntity.getId();
   }
 
   /**
@@ -190,7 +178,8 @@ public class RepoOsEntity {
    */
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(mpackId, family, ambariManaged, repoDefinitionEntities);
+    return java.util.Objects.hash(mpackId, mpackEntity, family, ambariManaged,
+        repoDefinitionEntities);
   }
 
   /**
@@ -212,6 +201,7 @@ public class RepoOsEntity {
 
     RepoOsEntity that = (RepoOsEntity) object;
     return Objects.equal(mpackId, that.mpackId)
+        && Objects.equal(mpackEntity, that.mpackEntity)
         && Objects.equal(ambariManaged, that.ambariManaged)
         && Objects.equal(family, that.family)
         && Objects.equal(repoDefinitionEntities, that.repoDefinitionEntities);
@@ -222,10 +212,10 @@ public class RepoOsEntity {
    */
   @Override
   public String toString() {
-    return new ToStringBuilder(null)
-        .append("mpackId", mpackId)
-        .append("family", family)
-        .append("isManagedByAmbari", ambariManaged)
+    return Objects.toStringHelper(this)
+        .add("mpackId", mpackId)
+        .add("family", family)
+        .add("isManagedByAmbari", ambariManaged)
         .toString();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There was a weird compiler-based issue causing all sorts of trouble with JPA and the way in which it clones IndirectList for this MpackEntity->RepoOsEntity relationship. It kept trying to clone the ManyToOne relationship as well, causing a StackOverflowError. Eclipse IDE built classes didn't see this problem. 

Tried several approaches, none of which worked, so we decided to make the relationship EAGER anyway since we typically need these entities.

## How was this patch tested?

Manually.