### PR TITLE
[AMBARI-22875] Adopt changes in Host Component API for Blueprint cluster creation

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -70,6 +70,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -840,7 +841,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     final boolean runSmokeTest = "true".equals(getQueryParameterValue(
         QUERY_PARAMETERS_RUN_SMOKE_TEST_ID, predicate));
 
-    Set<String> queryIds = Collections.singleton(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+    Set<String> queryIds = ImmutableSet.copyOf(keyPropertyIds.values());
 
     Request queryRequest = PropertyHelper.getReadRequest(queryIds);
     // will take care of 404 exception

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -255,19 +255,6 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     return findResources(request, predicate, requests);
   }
 
-  private Set<Resource> getResourcesForUpdate(Request request, Predicate predicate)
-    throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
-
-    final Set<ServiceComponentHostRequest> requests = new HashSet<>();
-
-    for (Map<String, Object> propertyMap : getPropertyMaps(predicate)) {
-      requests.add(getRequest(propertyMap));
-    }
-
-    return findResources(request, predicate, requests);
-  }
-
-
   private Set<Resource> findResources(Request request, final Predicate predicate,
                                       final Set<ServiceComponentHostRequest> requests)
           throws SystemException, NoSuchResourceException, NoSuchParentResourceException {
@@ -846,7 +833,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Request queryRequest = PropertyHelper.getReadRequest(queryIds);
     // will take care of 404 exception
 
-    Set<Resource> matchingResources = getResourcesForUpdate(queryRequest, predicate);
+    Set<Resource> matchingResources = getResources(queryRequest, predicate);
 
     for (Resource queryResource : matchingResources) {
       //todo: predicate evaluation was removed for BUG-28737 and the removal of this breaks


### PR DESCRIPTION
## What changes were proposed in this pull request?

Host Component API now requires service group name and service name for update requests.

This change ensures that all required properties are passed in the read request that retrieves the host component resources for update, to be able to include the same required properties in the update request itself.

In addition, the method `getResourcesForUpdate` is being removed, since it is a duplicate of `getResources`.  They had been different before 8c92ed631f1.

## How was this patch tested?

Successfully installed cluster using blueprint.

Verified that GET/PUT API requests for the multiple `host_components` endpoint work:

```
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components"
{
  "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components",
  "items" : [
    {
      "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components/1",
      "HostRoles" : {
        "cluster_name" : "TEST",
        "component_name" : "ZOOKEEPER_CLIENT",
        "host_name" : "c7401.ambari.apache.org",
        "id" : 1,
        "service_group_name" : "HDPCORE",
        "service_name" : "ZOOKEEPER_CLIENTS"
      },
      "host" : {
        "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org"
      }
    },
    {
      "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components/2",
      "HostRoles" : {
        "cluster_name" : "TEST",
        "component_name" : "ZOOKEEPER_SERVER",
        "host_name" : "c7401.ambari.apache.org",
        "id" : 2,
        "service_group_name" : "HDPCORE",
        "service_name" : "ZOOKEEPER"
      },
      "host" : {
        "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org"
      }
    }
  ]
}

$ curl -X PUT -d '{ "HostRoles": { "desired_state": "INSTALLED" } }' \
  "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components"
{
  "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/requests/6",
  "Requests" : {
    "id" : 6,
    "status" : "Accepted"
  }
}

$ curl -X PUT -d '{ "HostRoles": { "desired_state": "STARTED" } }' \
  "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components?HostRoles/component_name=ZOOKEEPER_SERVER"
{
  "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/requests/7",
  "Requests" : {
    "id" : 7,
    "status" : "Accepted"
  }
}
```

Related unit test:

```
[INFO] Running org.apache.ambari.server.controller.internal.HostComponentResourceProviderTest
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.991 s - in org.apache.ambari.server.controller.internal.HostComponentResourceProviderTest
```