### PR TITLE
[AMBARI-23172] Build fails for Debian (jdeb plugin not found). (swagle)

### DIFF
--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -136,6 +136,23 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.vafer</groupId>
+        <artifactId>jdeb</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <goals>
+              <goal>jdeb</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+          <submodules>false</submodules>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <version>0.12</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Build failure on ambari-serviceadvisor, added the jdeb plugin to pom.xml

## How was this patch tested?

Waiting on the build to confirm.