### PR TITLE
[AMBARI-23177] Yarn-MR separation and minor deployment fixes

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
@@ -35,7 +35,7 @@ def get_not_managed_resources():
   """
   config = Script.get_config()
   not_managed_hdfs_path_list = json.loads(config['hostLevelParams']['not_managed_hdfs_path_list'])[:]
-  if get_cluster_setting('managed_hdfs_resource_property_names') not None:
+  if get_cluster_setting('managed_hdfs_resource_property_names') is not None:
     managed_hdfs_resource_property_names = get_cluster_setting_value('managed_hdfs_resource_property_names')
     managed_hdfs_resource_property_list = filter(None, [property.strip() for property in managed_hdfs_resource_property_names.split(',')])
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
@@ -25,6 +25,7 @@ import json
 from resource_management.libraries.script import Script
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.default import default
+from resource_management.libraries.functions.cluster_settings import *
 
 def get_not_managed_resources():
   """
@@ -34,8 +35,8 @@ def get_not_managed_resources():
   """
   config = Script.get_config()
   not_managed_hdfs_path_list = json.loads(config['hostLevelParams']['not_managed_hdfs_path_list'])[:]
-  if 'managed_hdfs_resource_property_names' in config['configurations']['cluster-env']:
-    managed_hdfs_resource_property_names = config['configurations']['cluster-env']['managed_hdfs_resource_property_names']
+  if get_cluster_setting('managed_hdfs_resource_property_names') not None:
+    managed_hdfs_resource_property_names = get_cluster_setting_value('managed_hdfs_resource_property_names')
     managed_hdfs_resource_property_list = filter(None, [property.strip() for property in managed_hdfs_resource_property_names.split(',')])
 
     for property_name in managed_hdfs_resource_property_list:

--- a/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
@@ -25,7 +25,7 @@ import json
 from resource_management.libraries.script import Script
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.default import default
-from resource_management.libraries.functions.cluster_settings import *
+from resource_management.libraries.functions.cluster_settings import get_cluster_setting_value, get_cluster_setting
 
 def get_not_managed_resources():
   """

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
@@ -37,7 +37,7 @@ import javax.persistence.TableGenerator;
 
 import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.stack.RepoTag;
-import org.apache.commons.lang.builder.ToStringBuilder;
+
 
 import com.google.common.base.Objects;
 

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -206,7 +206,7 @@ App.StackService = DS.Model.extend({
   }.property('coSelectedServices', 'serviceName'),
 
   isHiddenOnSelectServicePage: function () {
-    var hiddenServices = ['MAPREDUCE2'];
+    var hiddenServices = [];
     return hiddenServices.contains(this.get('serviceName')) || !this.get('isInstallable') || this.get('doNotShowAndInstall');
   }.property('serviceName', 'isInstallable'),
 

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -206,7 +206,8 @@ App.StackService = DS.Model.extend({
   }.property('coSelectedServices', 'serviceName'),
 
   isHiddenOnSelectServicePage: function () {
-    var hiddenServices = [];
+    //var hiddenServices = ['MAPREDUCE2'];
+      var hiddenServices = [];
     return hiddenServices.contains(this.get('serviceName')) || !this.get('isInstallable') || this.get('doNotShowAndInstall');
   }.property('serviceName', 'isInstallable'),
 
@@ -340,7 +341,7 @@ App.StackService.componentsOrderForService = {
 
 //@TODO: Write unit test for no two keys in the object should have any intersecting elements in their values
 App.StackService.coSelected = {
-
+//    'YARN': ['MAPREDUCE2']
 };
 
 


### PR DESCRIPTION
1. Checkstyle failure for RepoDefinitionEntity.java
2. MR is set as hidden services
3. py script uses cluster env instead of cluster settings

(Please fill in changes proposed in this fix)

Deploy zookeeper using new mpacks

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.