### PR TITLE
AMBARI-23183. Revert UI changes made to branch : branch-feature-AMBARI-14714

### DIFF
--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -206,8 +206,7 @@ App.StackService = DS.Model.extend({
   }.property('coSelectedServices', 'serviceName'),
 
   isHiddenOnSelectServicePage: function () {
-    //var hiddenServices = ['MAPREDUCE2'];
-      var hiddenServices = [];
+    var hiddenServices = ['MAPREDUCE2'];
     return hiddenServices.contains(this.get('serviceName')) || !this.get('isInstallable') || this.get('doNotShowAndInstall');
   }.property('serviceName', 'isInstallable'),
 
@@ -341,7 +340,7 @@ App.StackService.componentsOrderForService = {
 
 //@TODO: Write unit test for no two keys in the object should have any intersecting elements in their values
 App.StackService.coSelected = {
-//    'YARN': ['MAPREDUCE2']
+  'YARN': ['MAPREDUCE2']
 };
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- As we are going for a merge of "branch-feature-AMBARI-14714" (Backend changes) and "branch-feature-AMBARI-14714-ui" (UI changes) branch to and fro, removing the bare minimum changes made in "branch-feature-AMBARI-14714" ambari-web code base, to make the merge smooth.

- UI code changes undone:
   

   1. AMBARI-22945 : Added UI code in *step8_controller.js* to pass the *default* service_group_name (=core) and service_name for Host component creation, as the "branch-feature-AMBARI-14714" branch assumes that service_group created would be names *"core"*. But, "branch-feature-AMBARI-14714-ui" branch has moved forward using *stack_name* and *version* as the name for the service_group (eg: HDPCore-version). Thus, this UI related changes anyways needs to be revisited.
    2. AMBARI-23177 : YARN and MR separation changes made in *ambari-web/app/models/stack_service.js*. We will bring it back after the merge.

## How was this patch tested?

