### PR TITLE
[AMBARI-23021] ServiceInfo: credential_store_supported attempts to overwrite maintenance_state

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -413,7 +413,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
 
     o = properties.get(SERVICE_CREDENTIAL_STORE_SUPPORTED_PROPERTY_ID);
     if (null != o) {
-      svcRequest.setMaintenanceState(o.toString());
+      svcRequest.setCredentialStoreSupported(o.toString());
     }
 
     return svcRequest;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide the correct error message in response for trying to update the `credential_store_supported` property.

## How was this patch tested?

Tested on local cluster:

```
$ curl -X PUT -d '{ "ServiceInfo": { "credential_store_supported": "true" } }' "http://$AMBARI_SERVER:8080/api/v1/clusters/TEST/services/ZOOKEEPER"
HTTP/1.1 400 Bad Request
...
{
  "status" : 400,
  "message" : "java.lang.IllegalArgumentException: Invalid arguments, cannot update credential_store_supported as it is set only via service definition. Service=ZOOKEEPER"
}
```

Related unit test:

```
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.88 s - in org.apache.ambari.server.controller.internal.ServiceResourceProviderTest
```