### PR TITLE
AMBARI-23099. Let custom service users to access Log Search collections.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -156,9 +156,9 @@ if security_enabled:
   default_ranger_audit_users = ','.join(ranger_audit_names_from_principals)
 
   infra_solr_logsearch_service_users = []
-  logsearch_kerberos_service_user = get_name_from_principal(default('configurations/logsearch-env/logsearch_kerberos_principal', 'logsearch'))
+  logsearch_kerberos_service_user = get_name_from_principal(default('/configurations/logsearch-env/logsearch_kerberos_principal', 'logsearch'))
   infra_solr_logsearch_service_users.append(logsearch_kerberos_service_user)
-  logsearch_kerberos_service_users_str = str(default('configurations/logsearch-env/logsearch_kerberos_service_users', ''))
+  logsearch_kerberos_service_users_str = str(default('/configurations/logsearch-env/logsearch_kerberos_service_users', ''))
   if logsearch_kerberos_service_users_str and logsearch_kerberos_service_users_str.strip():
     logsearch_kerberos_service_users = logsearch_kerberos_service_users_str.split(',')
     infra_solr_logsearch_service_users.extend(logsearch_kerberos_service_users)

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -155,6 +155,14 @@ if security_enabled:
   ranger_audit_names_from_principals = [ get_name_from_principal(x) for x in ranger_audit_principals ]
   default_ranger_audit_users = ','.join(ranger_audit_names_from_principals)
 
+  infra_solr_logsearch_service_users = []
+  logsearch_kerberos_service_user = get_name_from_principal(default('configurations/logsearch-env/logsearch_kerberos_principal', 'logsearch'))
+  infra_solr_logsearch_service_users.append(logsearch_kerberos_service_user)
+  logsearch_kerberos_service_users_str = default('configurations/logsearch-env/logsearch_kerberos_service_users', '')
+  if not logsearch_kerberos_service_users_str:
+    logsearch_kerberos_service_users = logsearch_kerberos_service_users_str.split(',')
+    infra_solr_logsearch_service_users.extend(logsearch_kerberos_service_users)
+
 infra_solr_ranger_audit_service_users = format(config['configurations']['infra-solr-security-json']['infra_solr_ranger_audit_service_users']).split(',')
 infra_solr_security_json_content = config['configurations']['infra-solr-security-json']['content']
 
@@ -177,7 +185,6 @@ logsearch_audit_logs_collection = default('configurations/logsearch-properties/l
 
 ranger_admin_kerberos_service_user = get_name_from_principal(default('configurations/ranger-admin-site/ranger.admin.kerberos.principal', 'rangeradmin'))
 atlas_kerberos_service_user = get_name_from_principal(default('configurations/application-properties/atlas.authentication.principal', 'atlas'))
-logsearch_kerberos_service_user = get_name_from_principal(default('configurations/logsearch-env/logsearch_kerberos_principal', 'logsearch'))
 logfeeder_kerberos_service_user = get_name_from_principal(default('configurations/logfeeder-env/logfeeder_kerberos_principal', 'logfeeder'))
 infra_solr_kerberos_service_user = get_name_from_principal(default('configurations/infra-solr-env/infra_solr_kerberos_principal', 'infra-solr'))
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -158,8 +158,8 @@ if security_enabled:
   infra_solr_logsearch_service_users = []
   logsearch_kerberos_service_user = get_name_from_principal(default('configurations/logsearch-env/logsearch_kerberos_principal', 'logsearch'))
   infra_solr_logsearch_service_users.append(logsearch_kerberos_service_user)
-  logsearch_kerberos_service_users_str = default('configurations/logsearch-env/logsearch_kerberos_service_users', '')
-  if not logsearch_kerberos_service_users_str:
+  logsearch_kerberos_service_users_str = str(default('configurations/logsearch-env/logsearch_kerberos_service_users', ''))
+  if logsearch_kerberos_service_users_str and logsearch_kerberos_service_users_str.strip():
     logsearch_kerberos_service_users = logsearch_kerberos_service_users_str.split(',')
     infra_solr_logsearch_service_users.extend(logsearch_kerberos_service_users)
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/templates/infra-solr-security.json.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/templates/infra-solr-security.json.j2
@@ -23,7 +23,11 @@
     "class": "org.apache.solr.security.InfraRuleBasedAuthorizationPlugin",
     "user-role": {
       "{{infra_solr_kerberos_service_user}}@{{kerberos_realm}}": "admin",
+{% if infra_solr_logsearch_service_users %}
+{%   for logsearch_kerberos_service_user in infra_solr_logsearch_service_users %}
       "{{logsearch_kerberos_service_user}}@{{kerberos_realm}}": ["{{infra_solr_role_logsearch}}", "{{infra_solr_role_ranger_admin}}", "{{infra_solr_role_dev}}"],
+{%   endfor %}
+{% endif %}
       "{{logfeeder_kerberos_service_user}}@{{kerberos_realm}}": ["{{infra_solr_role_logfeeder}}", "{{infra_solr_role_dev}}"],
       "{{atlas_kerberos_service_user}}@{{kerberos_realm}}": ["{{infra_solr_role_atlas}}", "{{infra_solr_role_ranger_audit}}", "{{infra_solr_role_dev}}"],
 {% if infra_solr_ranger_audit_service_users %}

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logsearch-env.xml
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logsearch-env.xml
@@ -106,6 +106,19 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>logsearch_kerberos_service_users</name>
+    <display-name>Log Search service users</display-name>
+    <value/>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
+    <description>
+      List of comma separated kerberos service users who can read from logsearch collections if the cluster is
+      secure. (logsearch user supported by default)
+    </description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>logsearch_truststore_location</name>
     <value>/usr/lib/ambari-logsearch-portal/conf/keys/logsearch.jks</value>
     <display-name>Log Search trust store location</display-name>

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
@@ -141,7 +141,7 @@ if security_enabled:
   logsearch_solr_service_users = []
   logsearch_kerberos_service_user = get_name_from_principal(logsearch_kerberos_principal)
   logsearch_solr_service_users.append(logsearch_kerberos_service_user)
-  logsearch_kerberos_service_users_str = str(default('configurations/logsearch-env/logsearch_kerberos_service_users', ''))
+  logsearch_kerberos_service_users_str = str(default('/configurations/logsearch-env/logsearch_kerberos_service_users', ''))
   if logsearch_kerberos_service_users_str and logsearch_kerberos_service_users_str.strip():
     logsearch_kerberos_service_users = logsearch_kerberos_service_users_str.split(',')
     logsearch_solr_service_users.extend(logsearch_kerberos_service_users)

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
@@ -138,6 +138,14 @@ if security_enabled:
   zk_principal_user = zk_principal_name.split('/')[0]
   zk_security_opts = format('-Dzookeeper.sasl.client=true -Dzookeeper.sasl.client.username={zk_principal_user} -Dzookeeper.sasl.clientconfig=Client')
 
+  logsearch_solr_service_users = []
+  logsearch_kerberos_service_user = get_name_from_principal(logsearch_kerberos_principal)
+  logsearch_solr_service_users.append(logsearch_kerberos_service_user)
+  logsearch_kerberos_service_users_str = default('configurations/logsearch-env/logsearch_kerberos_service_users', '')
+  if not logsearch_kerberos_service_users_str:
+    logsearch_kerberos_service_users = logsearch_kerberos_service_users_str.split(',')
+    logsearch_solr_service_users.extend(logsearch_kerberos_service_users)
+
 logsearch_spnego_host = config['configurations']['logsearch-properties']['logsearch.spnego.kerberos.host'].replace('_HOST', _hostname_lowercase)
 
 #####################################

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
@@ -141,8 +141,8 @@ if security_enabled:
   logsearch_solr_service_users = []
   logsearch_kerberos_service_user = get_name_from_principal(logsearch_kerberos_principal)
   logsearch_solr_service_users.append(logsearch_kerberos_service_user)
-  logsearch_kerberos_service_users_str = default('configurations/logsearch-env/logsearch_kerberos_service_users', '')
-  if not logsearch_kerberos_service_users_str:
+  logsearch_kerberos_service_users_str = str(default('configurations/logsearch-env/logsearch_kerberos_service_users', ''))
+  if logsearch_kerberos_service_users_str and logsearch_kerberos_service_users_str.strip():
     logsearch_kerberos_service_users = logsearch_kerberos_service_users_str.split(',')
     logsearch_solr_service_users.extend(logsearch_kerberos_service_users)
 

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/setup_logsearch.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/setup_logsearch.py
@@ -142,7 +142,7 @@ def setup_logsearch():
   if params.security_enabled and not params.logsearch_use_external_solr:
     solr_cloud_util.add_solr_roles(params.config,
                                    roles = [params.infra_solr_role_logsearch, params.infra_solr_role_ranger_admin, params.infra_solr_role_dev],
-                                   new_service_principals = [params.logsearch_kerberos_principal])
+                                   new_service_principals = params.logsearch_solr_service_users)
     solr_cloud_util.add_solr_roles(params.config,
                                    roles = [params.infra_solr_role_logfeeder, params.infra_solr_role_dev],
                                    new_service_principals = [params.logfeeder_kerberos_principal])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add additional configuration property to logsearch ambari stack code-> extra logsearch service users. These users will be able to read/write logsearch collection data in Solr.

There are 2 use cases:
- during Solr start, create new roles (based on the logsearch property)
- during Log Search start create new roles (based on the logsearch property)

Second option is needed because it's possible to add Log Search after cluster install (+ using custom usernames can be problematic in that case)

## How was this patch tested?
UT: unrelated python test failures only (with mysql_service)
FT: in progress

please review @kasakrisz @swagle 