### PR TITLE
AMBARI-23184. Metrics Collector Install failed

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/FileCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/FileCache.py
@@ -26,6 +26,8 @@ import zipfile
 import urllib2
 import urllib
 
+from ambari_agent.Utils import execute_with_retries
+
 logger = logging.getLogger()
 
 class CachingException(Exception):
@@ -257,13 +259,21 @@ class FileCache():
     directory and any parent directories if needed. May throw exceptions
     on permission problems
     """
+    CLEAN_DIRECTORY_TRIES = 5
+    CLEAN_DIRECTORY_TRY_SLEEP = 0.25
+
     logger.debug("Invalidating directory {0}".format(directory))
     try:
       if os.path.exists(directory):
         if os.path.isfile(directory): # It would be a strange situation
           os.unlink(directory)
         elif os.path.isdir(directory):
-          shutil.rmtree(directory)
+          """
+          Execute shutil.rmtree(directory) multiple times.
+          Reason: race condition, where a file (e.g. *.pyc) in deleted directory
+          is created during function is running, causing it to fail.
+          """
+          execute_with_retries(CLEAN_DIRECTORY_TRIES, CLEAN_DIRECTORY_TRY_SLEEP, OSError, shutil.rmtree, directory)
         # create directory itself and any parent directories
       os.makedirs(directory)
     except Exception, err:

--- a/ambari-agent/src/main/python/ambari_agent/Utils.py
+++ b/ambari-agent/src/main/python/ambari_agent/Utils.py
@@ -18,6 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
+import time
 import threading
 import collections
 from functools import wraps
@@ -215,3 +216,12 @@ def lazy_property(undecorated):
       return v
 
   return decorated
+
+def execute_with_retries(tries, try_sleep, rety_exception_class, func, *args, **kwargs):
+  for i in range(tries):
+    try:
+      func(*args, **kwargs)
+    except rety_exception_class:
+      if i==tries-1:
+        raise
+      time.sleep(try_sleep)

--- a/ambari-agent/src/main/python/ambari_agent/Utils.py
+++ b/ambari-agent/src/main/python/ambari_agent/Utils.py
@@ -217,11 +217,11 @@ def lazy_property(undecorated):
 
   return decorated
 
-def execute_with_retries(tries, try_sleep, rety_exception_class, func, *args, **kwargs):
+def execute_with_retries(tries, try_sleep, retry_exception_class, func, *args, **kwargs):
   for i in range(tries):
     try:
       func(*args, **kwargs)
-    except rety_exception_class:
+    except retry_exception_class:
       if i==tries-1:
         raise
       time.sleep(try_sleep)


### PR DESCRIPTION
Caught an exception while executing custom service command: <class 'ambari_agent.AgentException.AgentException'>: 'Script /var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_collector.py does not exist'; 'Script /var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_collector.py does not exist'

WARNING 2018-03-02 12:21:35,414 FileCache.py:183 - Error occurred during cache update. Error tolerate setting is set to true, so ignoring this error and continuing with current cache. Error details: ('Can not invalidate cache directory {0}: {1}', u'/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package', "[Errno 39] Directory not empty: '/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package'")


shutil.rmtree fails with the following: "Directory not empty", however it should empty all the dirs.

After some research I found out this can be the reason:

1. shutil.rmtree found A is a non-empty directory
2. shutil.rmtree try to remove all contents recursively
3. shutil.rmtree has finished remote all contents recursively
4. another process produces some file / directory in A
5. shutil try to remove A itself and failed
Another process can be possibly a status_commands executor which created *.pyc file and caused this.

