### PR TITLE
AMBARI-23192. NoClassDefFoundError on Files View on S3 (amagyar)

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -516,6 +516,11 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${fasterxml.jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${fasterxml.jackson.version}</version>
       </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

NoClassDefFoundError was caused by an incorrect version from jackson-core.

In /var/lib/ambari-server/resources/views/work/FILES{1.0.0}/WEB-INF/lib/ there was jackson-core-2.2.3.jar (instead of 2.9.4).

jackson-core, jackson-databind and jackson-annotations should all have the same version (2.9.4).

## How was this patch tested?

by checking https://AMBARI_SERVER/#/main/views/FILES/1.0.0/HDFS_FILE_VIEW
