### PR TITLE
[AMBARI-23129] Multiple issues while executing Ambari server upgrade to Ambari 2.7.0

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -1077,7 +1077,9 @@ public class AmbariServer {
 
       setupProxyAuth();
 
-      injector.getInstance(GuiceJpaInitializer.class);
+      // Start and Initialize JPA
+      GuiceJpaInitializer jpaInitializer = injector.getInstance(GuiceJpaInitializer.class);
+      jpaInitializer.setInitialized(); // This must be called to alert Ambari that JPA is initialized.
 
       DatabaseConsistencyCheckHelper.checkDBVersionCompatible();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/DBAccessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/DBAccessor.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ambari.server.configuration.Configuration.DatabaseType;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -372,16 +373,33 @@ public interface DBAccessor {
    * Execute select {@code columnName} from {@code tableName}
    * where {@code columnNames} values = {@code values}
    *
-   * @param tableName
-   * @param columnName
-   * @param columnNames
-   * @param values
-   * @param ignoreFailure
-   * @return
+   * @param tableName            the table name
+   * @param columnName           the name of the column with the data to select
+   * @param conditionColumnNames an array of column names to use in the where clause
+   * @param conditionValues      an array of value to pair with the column names in conditionColumnNames
+   * @param ignoreFailure        true to ignore failures executing the query; false otherwise (errors building the query will be thrown, however)
+   * @return a list of integers
    * @throws SQLException
    */
-  List<Integer> getIntColumnValues(String tableName, String columnName, String[] columnNames,
-                                   String[] values, boolean ignoreFailure) throws SQLException;
+  List<Integer> getIntColumnValues(String tableName, String columnName, String[] conditionColumnNames,
+                                   String[] conditionValues, boolean ignoreFailure) throws SQLException;
+
+  /**
+   * Execute select {@code keyColumnName}, {@code valueColumnName} from {@code tableName}
+   * where {@code columnNames} values = {@code values}
+   *
+   * @param tableName            the table name
+   * @param keyColumnName        the name of the column with the key data to select
+   * @param valueColumnName      the name of the column with the value data to select
+   * @param conditionColumnNames an array of column names to use in the where clause
+   * @param conditionValues      an array of value to pair with the column names in conditionColumnNames
+   * @param ignoreFailure        true to ignore failures executing the query; false otherwise (errors building the query will be thrown, however)
+   * @return a map of key to values
+   * @throws SQLException
+   */
+  Map<Long, String> getKeyToStringColumnMap(String tableName, String keyColumnName, String valueColumnName,
+                                            String[] conditionColumnNames, String[] conditionValues,
+                                            boolean ignoreFailure) throws SQLException;
 
   /**
    * Drop table from schema

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/GuiceJpaInitializer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/GuiceJpaInitializer.java
@@ -22,16 +22,41 @@ import org.apache.ambari.server.events.JpaInitializedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.persist.PersistService;
 
 /**
- * This class needs to be instantiated with guice to initialize Guice-persist
+ * This class needs to be instantiated with Guice to initialize Guice-persist
  */
+@Singleton
 public class GuiceJpaInitializer {
-  
+
+  private final AmbariEventPublisher publisher;
+
+  /**
+   * GuiceJpaInitializer constructor.
+   * <p>
+   * Starts the JPA service and holds on to an {@link AmbariEventPublisher} for future use.
+   *
+   * @param service   the persist service
+   * @param publisher the Ambari event publisher
+   */
   @Inject
   public GuiceJpaInitializer(PersistService service, AmbariEventPublisher publisher) {
+    this.publisher = publisher;
     service.start();
+  }
+
+  /**
+   * Called to indicate that the JPA service is initialized and ready for use.
+   * <p>
+   * This means that the schema for the underlying database matches the JPA entity objects expectations
+   * and the PersistService has been started.
+   * <p>
+   * A {@link JpaInitializedEvent} is published so that subscribers can perform database-related tasks
+   * when the infrastructure is ready.
+   */
+  public void setInitialized() {
     publisher.publish(new JpaInitializedEvent());
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -99,12 +99,12 @@ public class ClustersImpl implements Clusters {
 
   private static final Logger LOG = LoggerFactory.getLogger(ClustersImpl.class);
 
-  private final ConcurrentHashMap<String, Cluster> clusters = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Long, Cluster> clustersById = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Host> hosts = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Long, Host> hostsById = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Set<Cluster>> hostClusterMap = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Set<Host>> clusterHostMap = new ConcurrentHashMap<>();
+  private ConcurrentHashMap<String, Cluster> clustersByName = null;
+  private ConcurrentHashMap<Long, Cluster> clustersById = null;
+  private ConcurrentHashMap<String, Host> hostsByName = null;
+  private ConcurrentHashMap<Long, Host> hostsById = null;
+  private ConcurrentHashMap<String, Set<Cluster>> hostClustersMap = null;
+  private ConcurrentHashMap<String, Set<Host>> clusterHostsMap1 = null;
 
   @Inject
   private ClusterDAO clusterDAO;
@@ -169,41 +169,143 @@ public class ClustersImpl implements Clusters {
   }
 
   /**
-   * Inititalizes all of the in-memory state collections that this class
-   * unfortunately uses. It's annotated with {@link Inject} as a way to define a
-   * very simple lifecycle with Guice where the constructor is instantiated
-   * (allowing injected members) followed by this method which initiailizes the
-   * state of the instance.
+   * Gets the internal clusters-by-name map, ensuring that the relevant data has been previously initialized.
+   *
+   * @return a map of the requested data
+   */
+  private ConcurrentHashMap<String, Cluster> getClustersByName() {
+    if (clustersByName == null) {
+      safelyLoadClustersAndHosts();
+    }
+    return clustersByName;
+  }
+
+  /**
+   * Gets the internal clusters-by-id map, ensuring that the relevant data has been previously initialized.
+   *
+   * @return a map of the requested data
+   */
+  private ConcurrentHashMap<Long, Cluster> getClustersById() {
+    if (clustersById == null) {
+      safelyLoadClustersAndHosts();
+    }
+    return clustersById;
+  }
+
+  /**
+   * Gets the internal hosts-by-name map, ensuring that the relevant data has been previously initialized.
+   *
+   * @return a map of the requested data
+   */
+  private ConcurrentHashMap<String, Host> getHostsByName() {
+    if (hostsByName == null) {
+      safelyLoadClustersAndHosts();
+    }
+    return hostsByName;
+  }
+
+  /**
+   * Gets the internal hosts-by-id map, ensuring that the relevant data has been previously initialized.
+   *
+   * @return a map of the requested data
+   */
+  private ConcurrentHashMap<Long, Host> getHostsById() {
+    if (hostsById == null) {
+      safelyLoadClustersAndHosts();
+    }
+    return hostsById;
+  }
+
+  /**
+   * Gets the internal host/clusters map, ensuring that the relevant data has been previously initialized.
+   *
+   * @return a map of the requested data
+   */
+  private ConcurrentHashMap<String, Set<Cluster>> getHostClustersMap() {
+    if (hostClustersMap == null) {
+      safelyLoadClustersAndHosts();
+    }
+    return hostClustersMap;
+  }
+
+  /**
+   * Gets the internal cluster/hosts map, ensuring that the relevant data has been previously initialized.
+   *
+   * @return a map of the requested data
+   */
+  private ConcurrentHashMap<String, Set<Host>> getClusterHostsMap() {
+    if (clusterHostsMap1 == null) {
+      safelyLoadClustersAndHosts();
+    }
+    return clusterHostsMap1;
+  }
+
+  /**
+   * Safely initializes all of the in-memory state collections that this class.
+   * <p>
+   * This method is synchronized so that the data can be loaded only if needed.  If most than one of
+   * the relevant get methods are concurrently invoked, this method should ensure that {@link #loadClustersAndHosts()}
+   * will be entered once.  Subsequent calls will bypass {@link #loadClustersAndHosts()} since the
+   * relevant variables will no longer be null.
+   *
+   * @see #getClustersByName()
+   * @see #getClustersById()
+   * @see #getHostsByName()
+   * @see #getHostsById()
+   * @see #getClusterHostsMap()
+   * @see #getHostClustersMap()
+   */
+  synchronized private void safelyLoadClustersAndHosts() {
+    if (clustersByName == null || clustersById == null ||
+        hostsByName == null || hostsById == null ||
+        hostClustersMap == null || clusterHostsMap1 == null) {
+      loadClustersAndHosts();
+    }
+  }
+
+  /**
+   * Initializes all of the in-memory state collections that this class
+   * unfortunately uses.
+   * <p>
+   * This method should be called only once, when the data is first needed.
    * <p/>
    * Because some of these stateful initializations may actually reference this
    * {@link Clusters} instance, we must do this after the object has been
    * instantiated and injected.
    */
-  @Inject
   @Transactional
-  void loadClustersAndHosts() {
+  private void loadClustersAndHosts() {
+    LOG.info("Initializing cluster and host data.");
+
+    clustersByName = new ConcurrentHashMap<>();
+    clustersById = new ConcurrentHashMap<>();
+    hostsByName = new ConcurrentHashMap<>();
+    hostsById = new ConcurrentHashMap<>();
+    hostClustersMap = new ConcurrentHashMap<>();
+    clusterHostsMap1 = new ConcurrentHashMap<>();
+
     List<HostEntity> hostEntities = hostDAO.findAll();
     for (HostEntity hostEntity : hostEntities) {
       Host host = hostFactory.create(hostEntity);
-      hosts.put(hostEntity.getHostName(), host);
+      hostsByName.put(hostEntity.getHostName(), host);
       hostsById.put(hostEntity.getHostId(), host);
     }
 
     for (ClusterEntity clusterEntity : clusterDAO.findAll()) {
       Cluster currentCluster = clusterFactory.create(clusterEntity);
-      clusters.put(clusterEntity.getClusterName(), currentCluster);
+      clustersByName.put(clusterEntity.getClusterName(), currentCluster);
       clustersById.put(currentCluster.getClusterId(), currentCluster);
-      clusterHostMap.put(currentCluster.getClusterName(), Collections.newSetFromMap(new ConcurrentHashMap<>()));
+      clusterHostsMap1.put(currentCluster.getClusterName(), Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }
 
     for (HostEntity hostEntity : hostEntities) {
       Set<Cluster> cSet = Collections.newSetFromMap(new ConcurrentHashMap<Cluster, Boolean>());
-      hostClusterMap.put(hostEntity.getHostName(), cSet);
+      hostClustersMap.put(hostEntity.getHostName(), cSet);
 
-      Host host = hosts.get(hostEntity.getHostName());
+      Host host = getHostsByName().get(hostEntity.getHostName());
       for (ClusterEntity clusterEntity : hostEntity.getClusterEntities()) {
-        clusterHostMap.get(clusterEntity.getClusterName()).add(host);
-        cSet.add(clusters.get(clusterEntity.getClusterName()));
+        clusterHostsMap1.get(clusterEntity.getClusterName()).add(host);
+        cSet.add(clustersByName.get(clusterEntity.getClusterName()));
       }
     }
   }
@@ -219,7 +321,7 @@ public class ClustersImpl implements Clusters {
       throws AmbariException {
     Cluster cluster = null;
 
-    if (clusters.containsKey(clusterName)) {
+    if (getClustersByName().containsKey(clusterName)) {
       throw new DuplicateResourceException(
           "Attempted to create a Cluster which already exists" + ", clusterName=" + clusterName);
     }
@@ -256,9 +358,9 @@ public class ClustersImpl implements Clusters {
     }
 
     cluster = clusterFactory.create(clusterEntity);
-    clusters.put(clusterName, cluster);
-    clustersById.put(cluster.getClusterId(), cluster);
-    clusterHostMap.put(clusterName,
+    getClustersByName().put(clusterName, cluster);
+    getClustersById().put(cluster.getClusterId(), cluster);
+    getClusterHostsMap().put(clusterName,
         Collections.newSetFromMap(new ConcurrentHashMap<>()));
 
     cluster.setCurrentStackVersion(stackId);
@@ -277,7 +379,7 @@ public class ClustersImpl implements Clusters {
       throws AmbariException {
     Cluster cluster = null;
     if (clusterName != null) {
-      cluster = clusters.get(clusterName);
+      cluster = getClustersByName().get(clusterName);
     }
     if (null == cluster) {
       throw new ClusterNotFoundException(clusterName);
@@ -291,7 +393,7 @@ public class ClustersImpl implements Clusters {
     throws AmbariException {
     Cluster cluster = null;
     if (clusterId != null) {
-      cluster = clustersById.get(clusterId);
+      cluster = getClustersById().get(clusterId);
     }
     if (null == cluster) {
       throw new ClusterNotFoundException(clusterId);
@@ -302,6 +404,7 @@ public class ClustersImpl implements Clusters {
 
   @Override
   public Cluster getClusterById(long id) throws AmbariException {
+    ConcurrentHashMap<Long, Cluster> clustersById = getClustersById();
     Cluster cluster = clustersById.get(id);
     if (null == cluster) {
       throw new ClusterNotFoundException("clusterID=" + id);
@@ -312,13 +415,13 @@ public class ClustersImpl implements Clusters {
 
   @Override
   public List<Host> getHosts() {
-    return new ArrayList<>(hosts.values());
+    return new ArrayList<>(getHostsByName().values());
   }
 
   @Override
   public Set<Cluster> getClustersForHost(String hostname)
       throws AmbariException {
-    Set<Cluster> clusters = hostClusterMap.get(hostname);
+    Set<Cluster> clusters = getHostClustersMap().get(hostname);
     if(clusters == null){
       throw new HostNotFoundException(hostname);
     }
@@ -331,7 +434,7 @@ public class ClustersImpl implements Clusters {
 
   @Override
   public Host getHost(String hostname) throws AmbariException {
-    Host host = hosts.get(hostname);
+    Host host = getHostsByName().get(hostname);
     if (null == host) {
       throw new HostNotFoundException(hostname);
     }
@@ -341,7 +444,7 @@ public class ClustersImpl implements Clusters {
 
   @Override
   public boolean hostExists(String hostname){
-    return hosts.containsKey(hostname);
+    return getHostsByName().containsKey(hostname);
   }
 
   /**
@@ -349,7 +452,7 @@ public class ClustersImpl implements Clusters {
    */
   @Override
   public boolean isHostMappedToCluster(long clusterId, String hostName) {
-    Set<Cluster> clusters = hostClusterMap.get(hostName);
+    Set<Cluster> clusters = getHostClustersMap().get(hostName);
     for (Cluster cluster : clusters) {
       if (clusterId == cluster.getClusterId()) {
         return true;
@@ -361,11 +464,11 @@ public class ClustersImpl implements Clusters {
 
   @Override
   public Host getHostById(Long hostId) throws AmbariException {
-    if (!hostsById.containsKey(hostId)) {
+    if (!getHostsById().containsKey(hostId)) {
       throw new HostNotFoundException("Host Id = " + hostId);
     }
 
-    return hostsById.get(hostId);
+    return getHostsById().get(hostId);
   }
 
   /**
@@ -376,7 +479,7 @@ public class ClustersImpl implements Clusters {
     Long hostId = host.getHostId();
 
     if (null != hostId) {
-      hostsById.put(hostId, host);
+      getHostsById().put(hostId, host);
     }
   }
 
@@ -388,7 +491,7 @@ public class ClustersImpl implements Clusters {
    */
   @Override
   public void addHost(String hostname) throws AmbariException {
-    if (hosts.containsKey(hostname)) {
+    if (getHostsByName().containsKey(hostname)) {
       throw new AmbariException(MessageFormat.format("Duplicate entry for Host {0}", hostname));
     }
 
@@ -407,9 +510,9 @@ public class ClustersImpl implements Clusters {
 
     // the hosts by ID map is updated separately since the host has not yet
     // been persisted yet - the below event is what causes the persist
-    hosts.put(hostname, host);
+    getHostsByName().put(hostname, host);
 
-    hostClusterMap.put(hostname,
+    getHostClustersMap().put(hostname,
         Collections.newSetFromMap(new ConcurrentHashMap<>()));
 
     if (LOG.isDebugEnabled()) {
@@ -469,7 +572,7 @@ public class ClustersImpl implements Clusters {
     Host host = null;
     for (String hostName : hostSet) {
       if (null != hostName) {
-          host= hosts.get(hostName);
+          host= getHostsByName().get(hostName);
         if (host == null) {
           throw new HostNotFoundException(hostName);
         }
@@ -516,9 +619,10 @@ public class ClustersImpl implements Clusters {
 
     Host host = getHost(hostname);
     Cluster cluster = getCluster(clusterName);
+    ConcurrentHashMap<String, Set<Cluster>> hostClustersMap = getHostClustersMap();
 
     // check to ensure there are no duplicates
-    for (Cluster c : hostClusterMap.get(hostname)) {
+    for (Cluster c : hostClustersMap.get(hostname)) {
       if (c.getClusterName().equals(clusterName)) {
         throw new DuplicateResourceException("Attempted to create a host which already exists: clusterName=" +
           clusterName + ", hostName=" + hostname);
@@ -532,8 +636,8 @@ public class ClustersImpl implements Clusters {
     }
 
     mapHostClusterEntities(hostname, clusterId);
-    hostClusterMap.get(hostname).add(cluster);
-    clusterHostMap.get(clusterName).add(host);
+    hostClustersMap.get(hostname).add(cluster);
+    getClusterHostsMap().get(clusterName).add(host);
   }
 
   @Transactional
@@ -550,13 +654,16 @@ public class ClustersImpl implements Clusters {
 
   @Override
   public Map<String, Cluster> getClusters() {
-    return Collections.unmodifiableMap(clusters);
+    return Collections.unmodifiableMap(getClustersByName());
   }
 
   @Override
   public void updateClusterName(String oldName, String newName) {
+    ConcurrentHashMap<String, Cluster> clusters = getClustersByName();
     clusters.put(newName, clusters.remove(oldName));
-    clusterHostMap.put(newName, clusterHostMap.remove(oldName));
+
+    ConcurrentHashMap<String, Set<Host>> clusterHostsMap = getClusterHostsMap();
+    clusterHostsMap.put(newName, clusterHostsMap.remove(oldName));
 
     //TODO metadata update
   }
@@ -566,7 +673,7 @@ public class ClustersImpl implements Clusters {
   public void debugDump(StringBuilder sb) {
     sb.append("Clusters=[ ");
     boolean first = true;
-    for (Cluster c : clusters.values()) {
+    for (Cluster c : getClustersByName().values()) {
       if (!first) {
         sb.append(" , ");
       }
@@ -583,7 +690,7 @@ public class ClustersImpl implements Clusters {
       throws AmbariException {
 
     Map<String, Host> hosts = new HashMap<>();
-    for (Host h : clusterHostMap.get(clusterName)) {
+    for (Host h : getClusterHostsMap().get(clusterName)) {
       hosts.put(h.getHostName(), h);
     }
 
@@ -595,7 +702,7 @@ public class ClustersImpl implements Clusters {
       throws AmbariException {
     Map<Long, Host> hosts = new HashMap<>();
 
-    for (Host h : clusterHostMap.get(clusterName)) {
+    for (Host h : getClusterHostsMap().get(clusterName)) {
       HostEntity hostEntity = hostDAO.findByName(h.getHostName());
       hosts.put(hostEntity.getHostId(), h);
     }
@@ -615,11 +722,11 @@ public class ClustersImpl implements Clusters {
     cluster.delete();
 
     // clear maps
-    for (Set<Cluster> clusterSet : hostClusterMap.values()) {
+    for (Set<Cluster> clusterSet : getHostClustersMap().values()) {
       clusterSet.remove(cluster);
     }
-    clusterHostMap.remove(cluster.getClusterName());
-    clusters.remove(clusterName);
+    getClusterHostsMap().remove(cluster.getClusterName());
+    getClustersByName().remove(clusterName);
   }
 
   @Override
@@ -652,8 +759,8 @@ public class ClustersImpl implements Clusters {
 
       unmapHostClusterEntities(hostname, cluster.getClusterId());
 
-      hostClusterMap.get(hostname).remove(cluster);
-      clusterHostMap.get(cluster.getClusterName()).remove(host);
+      getHostClustersMap().get(hostname).remove(cluster);
+      getClusterHostsMap().get(cluster.getClusterName()).remove(host);
     }
 
     deleteConfigGroupHostMapping(hostEntity.getHostId());
@@ -677,7 +784,7 @@ public class ClustersImpl implements Clusters {
   @Transactional
   void deleteConfigGroupHostMapping(Long hostId) throws AmbariException {
     // Remove Config group mapping
-    for (Cluster cluster : clusters.values()) {
+    for (Cluster cluster : getClustersByName().values()) {
       for (ConfigGroup configGroup : cluster.getConfigGroups().values()) {
         configGroup.removeHost(hostId);
       }
@@ -697,7 +804,7 @@ public class ClustersImpl implements Clusters {
     // unmapping hosts from a cluster modifies the collections directly; keep
     // a copy of this to ensure that we can pass in the original set of
     // clusters that the host belonged to to the host removal event
-    Set<Cluster> clusters = hostClusterMap.get(hostname);
+    Set<Cluster> clusters = getHostClustersMap().get(hostname);
     if (clusters == null) {
       throw new HostNotFoundException(hostname);
     }
@@ -724,7 +831,7 @@ public class ClustersImpl implements Clusters {
    */
   @Transactional
   void deleteHostEntityRelationships(String hostname) throws AmbariException {
-    if (!hosts.containsKey(hostname)) {
+    if (!getHostsByName().containsKey(hostname)) {
       throw new HostNotFoundException("Could not find host " + hostname);
     }
 
@@ -737,13 +844,13 @@ public class ClustersImpl implements Clusters {
     // Remove from all clusters in the cluster_host_mapping table.
     // This will also remove from kerberos_principal_hosts, hostconfigmapping,
     // and configgrouphostmapping
-    Set<Cluster> clusters = hostClusterMap.get(hostname);
+    Set<Cluster> clusters = getHostClustersMap().get(hostname);
     Set<Long> clusterIds = Sets.newHashSet();
     for (Cluster cluster : clusters) {
       clusterIds.add(cluster.getClusterId());
     }
 
-    Host host = hosts.get(hostname);
+    Host host = getHostsByName().get(hostname);
     unmapHostFromClusters(host, clusters);
     hostDAO.refresh(entity);
 
@@ -772,8 +879,8 @@ public class ClustersImpl implements Clusters {
     topologyHostInfoDAO.removeByHost(entity);
 
     // Remove from dictionaries
-    hosts.remove(hostname);
-    hostsById.remove(entity.getHostId());
+    getHostsByName().remove(hostname);
+    getHostsById().remove(entity.getHostId());
 
     hostDAO.remove(entity);
 
@@ -812,10 +919,10 @@ public class ClustersImpl implements Clusters {
   @Override
   public int getClusterSize(String clusterName) {
     int hostCount = 0;
-
-    Set<Host> hosts = clusterHostMap.get(clusterName);
+    ConcurrentHashMap<String, Set<Host>> clusterHostsMap = getClusterHostsMap();
+    Set<Host> hosts = clusterHostsMap.get(clusterName);
     if (null != hosts) {
-      hostCount = clusterHostMap.get(clusterName).size();
+      hostCount = clusterHostsMap.get(clusterName).size();
     }
 
     return hostCount;
@@ -879,7 +986,7 @@ public class ClustersImpl implements Clusters {
   public void invalidate(Cluster cluster) {
     ClusterEntity clusterEntity = clusterDAO.findById(cluster.getClusterId());
     Cluster currentCluster = clusterFactory.create(clusterEntity);
-    clusters.put(clusterEntity.getClusterName(), currentCluster);
-    clustersById.put(currentCluster.getClusterId(), currentCluster);
+    getClustersByName().put(clusterEntity.getClusterName(), currentCluster);
+    getClustersById().put(currentCluster.getClusterId(), currentCluster);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -273,7 +273,6 @@ public class ClustersImpl implements Clusters {
    * {@link Clusters} instance, we must do this after the object has been
    * instantiated and injected.
    */
-  @Transactional
   private void loadClustersAndHosts() {
     LOG.info("Initializing cluster and host data.");
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
@@ -236,7 +236,6 @@ public class AmbariLdapDataPopulatorTest {
     LdapServerProperties ldapServerProperties = createNiceMock(LdapServerProperties.class);
     expect(configurationProvider.get()).andReturn(configuration).anyTimes();
     expect(configuration.ldapEnabled()).andReturn(false);
-    expect(configuration.getLdapServerProperties()).andReturn(ldapServerProperties);
     replay(ldapTemplate, ldapServerProperties, configurationProvider, configuration);
 
     final AmbariLdapDataPopulatorTestInstance populator = new AmbariLdapDataPopulatorTestInstance(configurationProvider, users);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeTest.java
@@ -217,8 +217,6 @@ public class UpgradeTest {
       }
      }
 
-    schemaUpgradeHelper.startPersistenceService();
-
     schemaUpgradeHelper.executePreDMLUpdates(upgradeCatalogs);
 
     schemaUpgradeHelper.executeDMLUpdates(upgradeCatalogs, "test");
@@ -226,8 +224,6 @@ public class UpgradeTest {
     schemaUpgradeHelper.executeOnPostUpgrade(upgradeCatalogs);
 
     LOG.info("Upgrade successful.");
-
-    schemaUpgradeHelper.stopPersistenceService();
   }
 
   private String getLastVersion() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

*1. An NPE is thrown will initializing the Ambari server upgrade catalog*

`com.google.inject.persist.jpa.JpaPersistService#begin`
```
    public void begin() {
        Preconditions.checkState(null == this.entityManager.get(), "Work already begun on this thread. Looks like you have called UnitOfWork.begin() twice without a balancing call to end() in between.");
        this.entityManager.set(this.emFactory.createEntityManager());
    }
```

`this.emFactory` is `null`.

*Cause*
`com.google.inject.persist.jpa.JpaPersistService#start()` was not called before `com.google.inject.persist.jpa.JpaPersistService#begin` to do order of operations in `org.apache.ambari.server.upgrade.SchemaUpgradeHelper#main`.  

*Solution*
Ensure `com.google.inject.persist.jpa.JpaPersistService#start()` is being called before `com.google.inject.persist.jpa.JpaPersistService#begin` in `org.apache.ambari.server.upgrade.SchemaUpgradeHelper#main`.  

-----

*2. Missing repo_os, repo_definition, and repo_tags tables*

The `repo_os`, `repo_definition`, and `repo_tags` tables were  never added to the UpgradeCatalog implementation.  The migration logic is also needed.

*Solution*
Add the missing tables and logic while executing `org.apache.ambari.server.upgrade.UpgradeCatalog270#executeDDLUpdates`. 

-----

*3. Entity classes are initialized before the schema of the underlying database is updated*

*Solution*
Notify relevant classes that the persistence infrastructure is ready after DDL updates have been applied. 

The `org.apache.ambari.server.events.publishers.AmbariEventPublisher` is to be used for issuing  a `org.apache.ambari.server.events.JpaInitializedEvent`.

-----

*4. JVM does not exit after performing upgrade*

After executing `ambari-server upgrade`, the JVM process hangs and does not exit.  According to the logs, no errors have occurred.

*Cause*
The cause of this is several non-daemon threads not being shutdown by Ambari code. 

*Solution*
Change relevant non-daemon threads to daemon threads and ensure any thread polls are not forcing one thread to be alive at all times. 

## How was this patch tested?

Ran unit tests.
Executed Ambari upgrade
Executed Ambari, started and stop services

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.