### PR TITLE
[AMBARI-23194] Values instance has no attribute 'master_key' during ambari-server reset

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -500,6 +500,15 @@ def init_setup_parser_options(parser):
   parser.add_option_group(other_group)
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
+def init_reset_parser_options(parser):
+  other_group = optparse.OptionGroup(parser, 'Other options')
+
+  # the --master-key option is needed in the event passwords in the ambari.properties file are encrypted
+  other_group.add_option('--master-key', default=None, help="Master key for encrypting passwords", dest="master_key")
+
+  parser.add_option_group(other_group)
+
+@OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_start_parser_options(parser):
   parser.add_option('-g', '--debug', action="store_true", dest='debug', default=False,
                     help="Start ambari-server in debug mode")
@@ -823,7 +832,7 @@ def init_action_parser(action, parser):
     START_ACTION: init_start_parser_options,
     STOP_ACTION: init_empty_parser_options,
     RESTART_ACTION: init_start_parser_options,
-    RESET_ACTION: init_empty_parser_options,
+    RESET_ACTION: init_reset_parser_options,
     STATUS_ACTION: init_empty_parser_options,
     UPGRADE_ACTION: init_empty_parser_options,
     LDAP_SETUP_ACTION: init_ldap_setup_parser_options,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ambari-server reset -s`
```
Using python  /usr/bin/python
Resetting ambari-server
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
**** WARNING **** You are about to reset and clear the Ambari Server database. This will remove all cluster host and configuration information from the database. You will be required to re-configure the Ambari server and re-run the cluster wizard.
Are you SURE you want to perform the reset [yes/no] (yes)?
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
Traceback (most recent call last):
  File "/usr/sbin/ambari-server.py", line 1033, in <module>
    mainBody()
  File "/usr/sbin/ambari-server.py", line 1003, in mainBody
    main(options, args, parser)
  File "/usr/sbin/ambari-server.py", line 953, in main
    action_obj.execute()
  File "/usr/sbin/ambari-server.py", line 79, in execute
    self.fn(*self.args, **self.kwargs)
  File "/usr/lib/ambari-server/lib/ambari_server/serverSetup.py", line 1326, in reset
    _reset_database(options)
  File "/usr/lib/ambari-server/lib/ambari_server/serverSetup.py", line 1052, in _reset_database
    dbmsAmbari = factory.create(options, properties)
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration.py", line 501, in create
    dbmsConfig = desc.create_config(options, properties, dbId)
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration.py", line 81, in create_config
    return self.fn_create_config(options, properties, self.storage_key, dbId)
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration_linux.py", line 881, in createPGConfig
    return PGConfig(options, properties, storage_type)
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration_linux.py", line 391, in __init__
    super(PGConfig, self).__init__(options, properties, storage_type)
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration_linux.py", line 94, in __init__
    self.database_password = DBMSConfig._read_password_from_properties(properties, options)
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration.py", line 222, in _read_password_from_properties
    database_password = decrypt_password_for_alias(properties, JDBC_RCA_PASSWORD_ALIAS, options)
  File "/usr/lib/ambari-server/lib/ambari_server/serverConfiguration.py", line 940, in decrypt_password_for_alias
    return read_passwd_for_alias(alias, masterKey, options)
  File "/usr/lib/ambari-server/lib/ambari_server/serverConfiguration.py", line 911, in read_passwd_for_alias
    if options is not None and options.master_key is not None and options.master_key:
AttributeError: Values instance has no attribute 'master_key'
```

`grep passwd /etc/ambari-server/conf/ambari.properties`
```
server.jdbc.user.passwd=${alias=ambari.db.password}
```

To solve this, the --master-key command line option was added. 

## How was this patch tested?

Manually tested.

```
[root@c7401 ~]# ambari-server reset --help
Using python  /usr/bin/python
Resetting ambari-server
Usage: ambari-server.py action [options]

Options:
  -h, --help            show this help message and exit
  -v, --verbose         Print verbose status messages
  -s, --silent          Silently accepts default prompt values. For db-cleanup
                        command, silent mode will stop ambari server.

  Other options:
    --master-key=MASTER_KEY
                        Master key for encrypting passwords
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.