### PR TITLE
[AMBARI-23195] Missing LdapFacade in ambari-server check-database

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyChecker.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyChecker.java
@@ -22,6 +22,7 @@ import java.util.Enumeration;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.audit.AuditLoggerModule;
 import org.apache.ambari.server.controller.ControllerModule;
+import org.apache.ambari.server.ldap.LdapModule;
 import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.utils.EventBusSynchronizer;
 import org.apache.log4j.FileAppender;
@@ -98,7 +99,7 @@ public class DatabaseConsistencyChecker {
     DatabaseConsistencyChecker databaseConsistencyChecker = null;
     try {
 
-      Injector injector = Guice.createInjector(new CheckHelperControllerModule(), new CheckHelperAuditModule());
+      Injector injector = Guice.createInjector(new CheckHelperControllerModule(), new CheckHelperAuditModule(), new LdapModule());
       databaseConsistencyChecker = injector.getInstance(DatabaseConsistencyChecker.class);
 
       databaseConsistencyChecker.startPersistenceService();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ambari-server check-database`
```
Using python  /usr/bin/python
Checking database
ERROR: Exiting with exit code 1.
REASON: Database check failed to complete: No errors and warnings were found.
...
Caused by: com.google.inject.CreationException: Unable to create injector, see the following errors:

1) No implementation for org.apache.ambari.server.ldap.service.LdapFacade was bound.
  while locating org.apache.ambari.server.ldap.service.LdapFacade
    for field at org.apache.ambari.server.controller.internal.AmbariServerLDAPConfigurationHandler.ldapFacade(AmbariServerLDAPConfigurationHandler.java:43)
  at org.apache.ambari.server.controller.ControllerModule.bindByAnnotation(ControllerModule.java:568)

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at org.apache.ambari.server.checks.DatabaseConsistencyChecker.main(DatabaseConsistencyChecker.java:101)
```

This was caused by a missing LDAP module in the Guice Injector

## How was this patch tested?

Manually tested:

```
[root@c7401 ~]# ambari-server check-database
Using python  /usr/bin/python
Checking database
No errors and warnings were found.
Ambari Server 'check-database' completed successfully.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.