### PR TITLE
[AMBARI-23185] Added a new CLI option in the setup-ldap tool to indicate whether to force LDAP auth method even if another one - or none at all - is already configured

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -558,7 +558,7 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-sync-username-collisions-behavior', default=None, help="Handling behavior for username collisions [convert/skip] for LDAP sync", dest="ldap_sync_username_collisions_behavior")
   parser.add_option('--ldap-force-lowercase-usernames', default=None, help="Declares whether to force the ldap user name to be lowercase or leave as-is", dest="ldap_force_lowercase_usernames")
   parser.add_option('--ldap-pagination-enabled', default=None, help="Determines whether results from LDAP are paginated when requested", dest="ldap_pagination_enabled")
-  parser.add_option('--ldap-enforcement', default=None, help="Forces the use of LDAP even if other (i.e. PAM) authentication method is configured already or if there is no authentication method configured at all", dest="ldap_enforcement")
+  parser.add_option('--ldap-force-setup', action="store_true", default=False, help="Forces the use of LDAP even if other (i.e. PAM) authentication method is configured already or if there is no authentication method configured at all", dest="ldap_force_setup")
   parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
   parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -558,6 +558,7 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-sync-username-collisions-behavior', default=None, help="Handling behavior for username collisions [convert/skip] for LDAP sync", dest="ldap_sync_username_collisions_behavior")
   parser.add_option('--ldap-force-lowercase-usernames', default=None, help="Declares whether to force the ldap user name to be lowercase or leave as-is", dest="ldap_force_lowercase_usernames")
   parser.add_option('--ldap-pagination-enabled', default=None, help="Determines whether results from LDAP are paginated when requested", dest="ldap_pagination_enabled")
+  parser.add_option('--ldap-enforcement', default=None, help="Forces the use of LDAP even if other (i.e. PAM) authentication method is configured already or if there is no authentication method configured at all", dest="ldap_enforcement")
   parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
   parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -84,6 +84,7 @@ LDAP_MGR_USERNAME_PROPERTY = "ambari.ldap.connectivity.bind_dn"
 LDAP_MGR_PASSWORD_FILENAME = "ldap-password.dat"
 LDAP_ANONYMOUS_BIND="ambari.ldap.connectivity.anonymous_bind"
 LDAP_USE_SSL="ambari.ldap.connectivity.use_ssl"
+NO_AUTH_METHOD_CONFIGURED = "no auth method"
 
 def read_master_key(isReset=False, options = None):
   passwordPattern = ".*"
@@ -718,11 +719,11 @@ def setup_ldap(options):
 
   enforce_ldap = options.ldap_force_setup if options.ldap_force_setup is not None else False
   if not enforce_ldap:
-    current_client_security = get_value_from_properties(properties,CLIENT_SECURITY,"no auth method")
+    current_client_security = get_value_from_properties(properties, CLIENT_SECURITY, NO_AUTH_METHOD_CONFIGURED)
     if current_client_security != 'ldap':
-      query = "Currently '" + current_client_security + "' is configured, do you wish to use LDAP instead [y/n] ({0})? "
-      ldap_setup_default = 'y' if current_client_security == "no auth method" else 'n'
-      if get_YN_input(query.format(ldap_setup_default), True if ldap_setup_default == 'y' else False):
+      query = "Currently '{0}' is configured, do you wish to use LDAP instead [y/n] ({1})? "
+      ldap_setup_default = 'y' if current_client_security == NO_AUTH_METHOD_CONFIGURED else 'n'
+      if get_YN_input(query.format(current_client_security, ldap_setup_default), ldap_setup_default == 'y'):
         pass
       else:
         err = "Currently '" + current_client_security + "' configured. Can not setup LDAP."

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -716,7 +716,7 @@ def setup_ldap(options):
     err = 'Ambari Server is not running.'
     raise FatalException(1, err)
 
-  enforce_ldap = True if options.ldap_enforcement is not None and options.ldap_enforcement == 'true' else False
+  enforce_ldap = options.ldap_force_setup if options.ldap_force_setup is not None else False
   if not enforce_ldap:
     current_client_security = get_value_from_properties(properties,CLIENT_SECURITY,"no auth method")
     if current_client_security != 'ldap':

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -720,8 +720,9 @@ def setup_ldap(options):
   if not enforce_ldap:
     current_client_security = get_value_from_properties(properties,CLIENT_SECURITY,"no auth method")
     if current_client_security != 'ldap':
-      query = "Currently '" + current_client_security + "' is configured, do you wish to use LDAP instead [y/n] (n)? "
-      if get_YN_input(query, False):
+      query = "Currently '" + current_client_security + "' is configured, do you wish to use LDAP instead [y/n] ({0})? "
+      ldap_setup_default = 'y' if current_client_security == "no auth method" else 'n'
+      if get_YN_input(query.format(ldap_setup_default), True if ldap_setup_default == 'y' else False):
         pass
       else:
         err = "Currently '" + current_client_security + "' configured. Can not setup LDAP."

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -716,14 +716,16 @@ def setup_ldap(options):
     err = 'Ambari Server is not running.'
     raise FatalException(1, err)
 
-  current_client_security = get_value_from_properties(properties,CLIENT_SECURITY,"no auth method")
-  if current_client_security != 'ldap':
-    query = "Currently '" + current_client_security + "' is configured, do you wish to use LDAP instead [y/n] (n)? "
-    if get_YN_input(query, False):
-      pass
-    else:
-      err = "Currently '" + current_client_security + "' configured. Can not setup LDAP."
-      raise FatalException(1, err)
+  enforce_ldap = True if options.ldap_enforcement is not None and options.ldap_enforcement == 'true' else False
+  if not enforce_ldap:
+    current_client_security = get_value_from_properties(properties,CLIENT_SECURITY,"no auth method")
+    if current_client_security != 'ldap':
+      query = "Currently '" + current_client_security + "' is configured, do you wish to use LDAP instead [y/n] (n)? "
+      if get_YN_input(query, False):
+        pass
+      else:
+        err = "Currently '" + current_client_security + "' configured. Can not setup LDAP."
+        raise FatalException(1, err)
 
   isSecure = get_is_secure(properties)
 

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7590,6 +7590,62 @@ class TestAmbariServer(TestCase):
     sys.stdout = sys.__stdout__
     pass
 
+  @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSecurity.get_YN_input")
+  @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
+  @patch("ambari_server.setupSecurity.is_server_runing")
+  def test_setup_ldap_enforcement_cli_option(self, is_server_runing_method, get_ambari_properties_method,
+                                            get_validated_string_input_method, get_YN_input_method, urlopen_method):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_server_runing_method.return_value = (True, 0)
+
+    def yn_input_side_effect(*args, **kwargs):
+      if 'do you wish to use LDAP instead' in args[0]:
+        raise Exception("ShouldNotBeInvoked") # should not be asked
+      else:
+        return False if 'TrustStore' in args[0] else True
+
+    get_YN_input_method.side_effect = yn_input_side_effect
+    get_ambari_properties_method.return_value = Properties()
+
+    def valid_input_side_effect(*args, **kwargs):
+      if 'lower-case' in args[0] or 'paginated' in args[0]:
+        return 'false'
+      if 'Bind anonymously' in args[0]:
+        return 'true'
+      if 'username collisions' in args[0]:
+        return 'skip'
+      if 'URL Port' in args[0]:
+        return '1'
+      if 'Ambari Admin' in args[0]:
+        return 'admin'
+      if 'Primary URL' in args[0]:
+        return kwargs['answer']
+      if args[1] == "true" or args[1] == "false":
+        return args[1]
+      else:
+        return "test"
+
+    get_validated_string_input_method.side_effect = valid_input_side_effect
+
+    response = MagicMock()
+    response.getcode.return_value = 200
+    urlopen_method.return_value = response
+
+    options = self._create_empty_options_mock()
+    options.ldap_enforcement = 'true'
+
+    setup_ldap(options)
+
+    self.assertTrue(urlopen_method.called)
+
+    sys.stdout = sys.__stdout__
+    pass
+
   @patch("urllib2.urlopen")
   @patch("ambari_server.setupSecurity.get_validated_string_input")
   @patch("ambari_server.setupSecurity.get_ambari_properties")
@@ -8674,6 +8730,7 @@ class TestAmbariServer(TestCase):
     options.ldap_save_settings = None
     options.ldap_referral = None
     options.ldap_bind_anonym = None
+    options.ldap_enforcement = None
     options.ambari_admin_username = None
     options.ambari_admin_password = None
     options.ldap_sync_admin_name = None

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -136,7 +136,7 @@ CURR_AMBARI_VERSION = "2.0.0"
 @patch.object(platform, "linux_distribution", new = MagicMock(return_value=('Redhat', '6.4', 'Final')))
 @patch("ambari_server.dbConfiguration_linux.get_postgre_hba_dir", new = MagicMock(return_value = "/var/lib/pgsql/data"))
 @patch("ambari_server.dbConfiguration_linux.get_postgre_running_status", new = MagicMock(return_value = "running"))
-class TestAmbariServer:#(TestCase):
+class TestAmbariServer(TestCase):
   def setUp(self):
     out = StringIO.StringIO()
     sys.stdout = out
@@ -3171,7 +3171,7 @@ class TestAmbariServer:#(TestCase):
     pass
 
   @not_for_platform(PLATFORM_WINDOWS)
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   def test_check_ambari_java_version_is_valid(self, popenMock):
     # case 1:  jdk7 is picked for stacks
     properties = Properties()

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -1,7 +1,7 @@
 '''
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
+distributed with this work for additional informationldap_force_setup
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
@@ -7637,7 +7637,7 @@ class TestAmbariServer(TestCase):
     urlopen_method.return_value = response
 
     options = self._create_empty_options_mock()
-    options.ldap_enforcement = 'true'
+    options.ldap_force_setup = True
 
     setup_ldap(options)
 
@@ -8730,7 +8730,7 @@ class TestAmbariServer(TestCase):
     options.ldap_save_settings = None
     options.ldap_referral = None
     options.ldap_bind_anonym = None
-    options.ldap_enforcement = None
+    options.ldap_force_setup = None
     options.ambari_admin_username = None
     options.ambari_admin_password = None
     options.ldap_sync_admin_name = None

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -1,7 +1,7 @@
 '''
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional informationldap_force_setup
+distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of the job in [AMBARI-22905](https://issues.apache.org/jira/browse/AMBARI-23185) a change has been made to ask a question in case there is no configured authentication method or the one is different than LDAP (previously that question has been asked only if `PAM` auth method was configured).

To allow any automated test to bypass that question we introduced a new CLI option calledc`ldap-enforcement'. Whenever this option is used and set to `true` the setup-ldap tool will not even consider the current authentication method check.

In addition to this I enabled `TestAmbariServer` Python test class and fix and error in it (so that I was able to write my own unit test case).

## How was this patch tested?

A new Python unit test case has been added to cover this use case; latest test results in `ambari-server`:

```
----------------------------------------------------------------------
Total run:125
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
Downloading from maven2-repository.atlassian: https://maven.atlassian.com/repository/public/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from maven2-repository.dev.java.net: http://download.java.net/maven/2/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading from maven2-glassfish-repository.dev.java.net: http://download.java.net/maven/glassfish/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:17 min
[INFO] Finished at: 2018-03-10T00:01:21+01:00
[INFO] Final Memory: 114M/1683M
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing I also executed integration tests like this:

1. copied to modified Python files on the host where my `ambari-server` is running
2. checked and found that there is no `client.security` was set in `ambari.properties`
3. executed `ambari-server setup-ldap`: the question was shown as expected
4. executed `ambari-server setup-ldap --ldap-enforcement=false`: the question was shown as expected
5. executed `ambari-server setup-ldap --ldap-enforcement=true`: the question was **not** shown as expected

```
[root@c7401 ~]# ambari-server setup-ldap
Using python  /usr/bin/python
Currently 'no auth method' is configured, do you wish to use LDAP instead [y/n] (n)? ^C
Aborting ... Keyboard Interrupt.

[root@c7401 ~]# ambari-server setup-ldap --ldap-enforcement=false
Using python  /usr/bin/python
Currently 'no auth method' is configured, do you wish to use LDAP instead [y/n] (n)? ^C
Aborting ... Keyboard Interrupt.

[root@c7401 ~]# ambari-server setup-ldap --ldap-enforcement=true
Using python  /usr/bin/python
Primary URL Host* : ^C
Aborting ... Keyboard Interrupt.
```
