### PR TITLE
AMBARI-23196. Add reverted changes back (reverted in : AMBARI-23183) after merging branch 'branch-feature-AMBARI-14714-ui' into 'branch-feature-AMBARI-14714' (AMBARI-23193).

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
@@ -25,7 +25,7 @@ import json
 from resource_management.libraries.script import Script
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.default import default
-from resource_management.libraries.functions.cluster_settings import get_cluster_setting_value, get_cluster_setting
+from resource_management.libraries.functions.cluster_settings import get_cluster_setting_value
 
 def get_not_managed_resources():
   """
@@ -35,7 +35,7 @@ def get_not_managed_resources():
   """
   config = Script.get_config()
   not_managed_hdfs_path_list = json.loads(config['hostLevelParams']['not_managed_hdfs_path_list'])[:]
-  if get_cluster_setting('managed_hdfs_resource_property_names') is not None:
+  if get_cluster_setting_value('managed_hdfs_resource_property_names') is not None:
     managed_hdfs_resource_property_names = get_cluster_setting_value('managed_hdfs_resource_property_names')
     managed_hdfs_resource_property_list = filter(None, [property.strip() for property in managed_hdfs_resource_property_names.split(',')])
 

--- a/ambari-web/app/controllers/wizard/step8_controller.js
+++ b/ambari-web/app/controllers/wizard/step8_controller.js
@@ -1198,6 +1198,7 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
     }, this);
     selectedMasterComponents.mapProperty('component').uniq().forEach(function (component) {
       var hostNames = [];
+      let serviceName = App.StackServiceComponent.find().findProperty('componentName', component).get('serviceName');
       if (masterOnAllHosts.length > 0) {
         var compOnAllHosts = false;
         for (var i=0; i < masterOnAllHosts.length; i++) {
@@ -1208,11 +1209,11 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
         }
         if (!compOnAllHosts) {
           hostNames = selectedMasterComponents.filterProperty('component', component).filterProperty('isInstalled', false).mapProperty('hostName');
-          this.registerHostsToComponent(hostNames, component);
+          this.registerHostsToComponent(hostNames, component, serviceName);
         }
       } else {
         hostNames = selectedMasterComponents.filterProperty('component', component).filterProperty('isInstalled', false).mapProperty('hostName');
-        this.registerHostsToComponent(hostNames, component);
+        this.registerHostsToComponent(hostNames, component, serviceName);
       }
     }, this);
   },
@@ -1274,6 +1275,7 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
       var hostNames = [];
       var compOnAllHosts;
       if (_slave.componentName !== 'CLIENT') {
+        let serviceName = App.StackServiceComponent.find().findProperty('componentName', _slave.componentName).get('serviceName');
         if (slaveOnAllHosts.length > 0) {
           compOnAllHosts = false;
           for (var i=0; i < slaveOnAllHosts.length; i++) {
@@ -1286,16 +1288,18 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
           }
           if (!compOnAllHosts) {
             hostNames = _slave.hosts.filterProperty('isInstalled', false).mapProperty('hostName');
-            this.registerHostsToComponent(hostNames, _slave.componentName);
+            this.registerHostsToComponent(hostNames, _slave.componentName, serviceName);
           }
         } else {
           hostNames = _slave.hosts.filterProperty('isInstalled', false).mapProperty('hostName');
-          this.registerHostsToComponent(hostNames, _slave.componentName);
+          this.registerHostsToComponent(hostNames, _slave.componentName, serviceName);
         }
       }
       else {
         clients.forEach(function (_client) {
           hostNames = _slave.hosts.mapProperty('hostName');
+          let compName = _client.component_name
+          let serviceName = App.StackServiceComponent.find().findProperty('componentName', compName).get('serviceName')
           // The below logic to install clients to existing/New master hosts should not be applied to Add Host wizard.
           // This is with the presumption that Add Host controller does not add any new Master component to the cluster
           if (!this.get('isAddHost')) {
@@ -1326,11 +1330,11 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
             }
             if (!compOnAllHosts) {
               hostNames = hostNames.uniq();
-              this.registerHostsToComponent(hostNames, _client.component_name);
+              this.registerHostsToComponent(hostNames, _client.component_name, serviceName);
             }
           } else {
             hostNames = hostNames.uniq();
-            this.registerHostsToComponent(hostNames, _client.component_name);
+            this.registerHostsToComponent(hostNames, _client.component_name, serviceName);
           }
         }, this);
       }
@@ -1387,7 +1391,8 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
           // If a dependency for being co-hosted is derived between existing client and selected new master but that
           // dependency is already satisfied in the cluster then disregard the derived dependency
           this.removeClientsFromList(_clientName, hostNames);
-          this.registerHostsToComponent(hostNames, _clientName);
+          let serviceName = App.StackServiceComponent.find().findProperty('componentName', _clientName).get('serviceName')
+          this.registerHostsToComponent(hostNames, _clientName, serviceName);
           if(hostNames.length > 0) {
             this.get('content.additionalClients').pushObject({hostNames: hostNames, componentName: _clientName});
           }
@@ -1436,9 +1441,9 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
     this.get('content.services').filterProperty('isSelected').forEach(function (service) {
       service.get('serviceComponents').filterProperty('isRequiredOnAllHosts').forEach(function (component) {
         if (service.get('isInstalled') && notInstalledHosts.length) {
-          this.registerHostsToComponent(notInstalledHosts.mapProperty('hostName'), component.get('componentName'));
+          this.registerHostsToComponent(notInstalledHosts.mapProperty('hostName'), component.get('componentName'), component.get('serviceName'));
         } else if (!service.get('isInstalled') && registeredHosts.length) {
-          this.registerHostsToComponent(registeredHosts.mapProperty('hostName'), component.get('componentName'));
+          this.registerHostsToComponent(registeredHosts.mapProperty('hostName'), component.get('componentName'), component.get('serviceName'));
         }
       }, this);
     }, this);
@@ -1448,9 +1453,9 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
     if (hiveService) {
       var hiveDb = this.get('content.serviceConfigProperties').findProperty('name', 'hive_database');
       if (hiveDb.value === "New MySQL Database") {
-        this.registerHostsToComponent(masterHosts.filterProperty('component', 'HIVE_SERVER').mapProperty('hostName'), 'MYSQL_SERVER');
+        this.registerHostsToComponent(masterHosts.filterProperty('component', 'HIVE_SERVER').mapProperty('hostName'), 'MYSQL_SERVER', 'HIVE');
       } else if (hiveDb.value === "New PostgreSQL Database") {
-        this.registerHostsToComponent(masterHosts.filterProperty('component', 'HIVE_SERVER').mapProperty('hostName'), 'POSTGRESQL_SERVER');
+        this.registerHostsToComponent(masterHosts.filterProperty('component', 'HIVE_SERVER').mapProperty('hostName'), 'POSTGRESQL_SERVER', 'HIVE');
       }
     }
   },
@@ -1462,7 +1467,7 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
    * @param {String} componentName
    * @method registerHostsToComponent
    */
-  registerHostsToComponent: function (hostNames, componentName) {
+  registerHostsToComponent: function (hostNames, componentName, serviceName) {
     if (!hostNames.length) return;
 
     var queryStr = '';
@@ -1480,7 +1485,9 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
         "host_components": [
           {
             "HostRoles": {
-              "component_name": componentName
+              "component_name": componentName,
+              "service_group_name": this.content.selectedMpacks[0].id,
+              "service_name": serviceName
             }
           }
         ]

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -206,7 +206,8 @@ App.StackService = DS.Model.extend({
   }.property('coSelectedServices', 'serviceName'),
 
   isHiddenOnSelectServicePage: function () {
-    var hiddenServices = ['MAPREDUCE2'];
+    //var hiddenServices = ['MAPREDUCE2'];
+    var hiddenServices = [];
     return hiddenServices.contains(this.get('serviceName')) || !this.get('isInstallable') || this.get('doNotShowAndInstall');
   }.property('serviceName', 'isInstallable'),
 
@@ -340,7 +341,7 @@ App.StackService.componentsOrderForService = {
 
 //@TODO: Write unit test for no two keys in the object should have any intersecting elements in their values
 App.StackService.coSelected = {
-  'YARN': ['MAPREDUCE2']
+  //'YARN': ['MAPREDUCE2']
 };
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- AMBARI-22945 added code for passing servoce_name and service_group-name while creating Host Components. But, in AMBARI-23183, we reverted the UI related changes to have a smooth merge from Ui branch.
  -- We are bringing that change in with a slight tweak of reading *mpackname* to be passed as Service_group-name directly, instead of earlier where we were passing the default '*core*' SG read from *App.get('defaultServiceGroupName')*.


- AMBARI-23177 :  Yarn-MR separation and minor deployment fixes


## How was this patch tested?

Tested on cluster.