### PR TITLE
AMBARI-21008 Integrate AlertTargetService and subresources with swagger

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
@@ -54,7 +54,7 @@ import io.swagger.annotations.ApiResponses;
  * targets.
  */
 @Path("/alert_targets/")
-@Api(value = "/Alerts", description = "Endpoint for alert specific operations")
+@Api(value = "Alerts", description = "Endpoint for alert specific operations")
 public class AlertTargetService extends BaseService {
 
   public static final String ALERT_TARGET_REQUEST_TYPE = "org.apache.ambari.server.controller.AlertTargetSwagger";

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
@@ -54,7 +54,7 @@ import io.swagger.annotations.ApiResponses;
  * targets.
  */
 @Path("/alert_targets/")
-@Api(value = "/alerts", description = "Endpoint for alert specific operations")
+@Api(value = "/Alerts", description = "Endpoint for alert specific operations")
 public class AlertTargetService extends BaseService {
 
   public static final String ALERT_TARGET_REQUEST_TYPE = "org.apache.ambari.server.controller.AlertTargetSwagger";

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.ambari.annotations.ApiIgnore;
 import org.apache.ambari.server.api.resources.AlertTargetResourceDefinition;
 import org.apache.ambari.server.api.resources.ResourceInstance;
 import org.apache.ambari.server.controller.AlertTargetSwagger;
@@ -68,8 +67,24 @@ public class AlertTargetService extends BaseService {
    * @param ui      uri info
    * @return alert target resource representation
    */
-  @GET @ApiIgnore // documented below
+  @GET
   @Produces("text/plain")
+  @ApiOperation(value = "Returns all alert targets", response = AlertTargetSwagger.class, responseContainer = "List")
+  @ApiImplicitParams({
+          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, defaultValue = "AlertTarget/*", dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_SORT, value = QUERY_SORT_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_PAGE_SIZE, value = QUERY_PAGE_SIZE_DESCRIPTION, defaultValue = DEFAULT_PAGE_SIZE, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_FROM, value = QUERY_FROM_DESCRIPTION, allowableValues = QUERY_FROM_VALUES, defaultValue = DEFAULT_FROM, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_TO, value = QUERY_TO_DESCRIPTION, allowableValues = QUERY_TO_VALUES, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getTargets(@Context HttpHeaders headers,
       @Context UriInfo ui) {
     return handleRequest(headers, null, ui, Request.Type.GET,
@@ -88,7 +103,7 @@ public class AlertTargetService extends BaseService {
   @GET
   @Path("{targetId}")
   @Produces("text/plain")
-  @ApiOperation(value = "Returns a single alert target", response = AlertTargetSwagger.class, responseContainer = "List")
+  @ApiOperation(value = "Returns a single alert target", response = AlertTargetSwagger.class, nickname = "getTarget")
   @ApiImplicitParams({
           @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, defaultValue = "AlertTarget/*", dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
           @ApiImplicitParam(name = QUERY_SORT, value = QUERY_SORT_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AlertTargetService.java
@@ -33,18 +33,42 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.ambari.annotations.ApiIgnore;
+import org.apache.ambari.server.api.resources.AlertTargetResourceDefinition;
 import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.controller.AlertTargetSwagger;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.state.alert.AlertTarget;
+import org.apache.http.HttpStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+
 
 /**
  * The {@link AlertTargetService} handles CRUD operation requests for alert
  * targets.
  */
 @Path("/alert_targets/")
+@Api(value = "/alerts", description = "Endpoint for alert specific operations")
 public class AlertTargetService extends BaseService {
 
-  @GET @ApiIgnore // until documented
+  public static final String ALERT_TARGET_REQUEST_TYPE = "org.apache.ambari.server.controller.AlertTargetSwagger";
+
+  /**
+   * Handles GET /alert_targets
+   * Get all alert targets.
+   *
+   * @param headers http headers
+   * @param ui      uri info
+   * @return alert target resource representation
+   */
+  @GET @ApiIgnore // documented below
   @Produces("text/plain")
   public Response getTargets(@Context HttpHeaders headers,
       @Context UriInfo ui) {
@@ -52,35 +76,122 @@ public class AlertTargetService extends BaseService {
         createAlertTargetResource(null));
   }
 
-  @GET @ApiIgnore // until documented
-  @Produces("text/plain")
+  /**
+   * Handles GET /alert_targets/{targetId}
+   * Get a specific alert target.
+   *
+   * @param headers   http headers
+   * @param ui        uri info
+   * @param targetId  alert target id
+   * @return alert target resource representation
+   */
+  @GET
   @Path("{targetId}")
+  @Produces("text/plain")
+  @ApiOperation(value = "Returns a single alert target", response = AlertTargetSwagger.class, responseContainer = "List")
+  @ApiImplicitParams({
+          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, defaultValue = "AlertTarget/*", dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_SORT, value = QUERY_SORT_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_PAGE_SIZE, value = QUERY_PAGE_SIZE_DESCRIPTION, defaultValue = DEFAULT_PAGE_SIZE, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_FROM, value = QUERY_FROM_DESCRIPTION, allowableValues = QUERY_FROM_VALUES, defaultValue = DEFAULT_FROM, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = QUERY_TO, value = QUERY_TO_DESCRIPTION, allowableValues = QUERY_TO_VALUES, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getTargets(@Context HttpHeaders headers,
-      @Context UriInfo ui, @PathParam("targetId") Long targetId) {
+      @Context UriInfo ui, @ApiParam(value = "alert target id") @PathParam("targetId") Long targetId) {
     return handleRequest(headers, null, ui, Request.Type.GET,
         createAlertTargetResource(targetId));
   }
 
-  @POST @ApiIgnore // until documented
+  /**
+   * Handles POST /alert_targets
+   * Create a specific alert target.
+   *
+   * @param body     http body
+   * @param headers  http headers
+   * @param ui       uri info
+   *
+   * @return alert target resource representation
+   */
+  @POST
   @Produces("text/plain")
+  @ApiOperation(value = "Creates an alert target")
+  @ApiImplicitParams({
+          @ApiImplicitParam(dataType = ALERT_TARGET_REQUEST_TYPE, paramType = PARAM_TYPE_BODY),
+          @ApiImplicitParam(name = AlertTargetResourceDefinition.VALIDATE_CONFIG_DIRECTIVE, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+          @ApiImplicitParam(name = AlertTargetResourceDefinition.OVERWRITE_DIRECTIVE, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY)
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response createTarget(String body, @Context HttpHeaders headers,
       @Context UriInfo ui) {
     return handleRequest(headers, body, ui, Request.Type.POST,
         createAlertTargetResource(null));
   }
 
-  @PUT @ApiIgnore // until documented
-  @Produces("text/plain")
+  /**
+   * Handles PUT /alert_targets/{targetId}
+   * Updates a specific alert target.
+   *
+   * @param body     http body
+   * @param headers  http headers
+   * @param ui       uri info
+   * @param targetId alert target id
+   *
+   * @return information regarding updated alert target
+   */
+  @PUT
   @Path("{targetId}")
-  public Response updateGroup(String body, @Context HttpHeaders headers,
+  @Produces("text/plain")
+  @ApiOperation(value = "Updates an alert target")
+  @ApiImplicitParams({
+          @ApiImplicitParam(dataType = ALERT_TARGET_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
+  public Response updateTarget(String body, @Context HttpHeaders headers,
       @Context UriInfo ui, @PathParam("targetId") Long targetId) {
     return handleRequest(headers, body, ui, Request.Type.PUT,
         createAlertTargetResource(targetId));
   }
 
-  @DELETE @ApiIgnore // until documented
-  @Produces("text/plain")
+  /**
+   * Handles DELETE /alert_target/{targetId}
+   * Deletes a specific alert target.
+   *
+   * @param headers  http headers
+   * @param ui       uri info
+   * @param targetId alert target id
+   *
+   * @return alert target resource representation
+   */
+  @DELETE
   @Path("{targetId}")
+  @Produces("text/plain")
+  @ApiOperation(value = "Deletes an alert target")
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response deleteTarget(String body, @Context HttpHeaders headers,
       @Context UriInfo ui, @PathParam("targetId") Long targetId) {
     return handleRequest(headers, body, ui, Request.Type.DELETE,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AlertTargetSwagger.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AlertTargetSwagger.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ambari.server.controller.internal.AlertGroupResourceProvider;
+import org.apache.ambari.server.controller.internal.AlertTargetResourceProvider;
+
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * Request / response schema for AlertTarget API Swagger documentation generation. The interface only serves documentation
+ * generation purposes, it is not meant to be implemented.
+ */
+public interface AlertTargetSwagger extends ApiModel {
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.ID_PROPERTY_ID)
+    Long getId();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.NAME_PROPERTY_ID)
+    String getName();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.DESCRIPTION_PROPERTY_ID)
+    String getDescription();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.NOTIFICATION_TYPE_PROPERTY_ID)
+    String getNotificationType();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.ENABLED_PROPERTY_ID)
+    Boolean isEnabled();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.PROPERTIES_PROPERTY_ID)
+    Map<String, String> getProperties();
+
+    // it should be Set<AlertState> but Swagger doesn't support list of enums
+    @ApiModelProperty(name = AlertTargetResourceProvider.STATES_PROPERTY_ID)
+    List<String> getAlertStates();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.GLOBAL_PROPERTY_ID)
+    Boolean isGlobal();
+
+    @ApiModelProperty(name = AlertTargetResourceProvider.GROUPS_PROPERTY_ID)
+    List<AlertGroup> getAlertGroups();
+
+    interface AlertGroup {
+        @ApiModelProperty(name = AlertGroupResourceProvider.ID_PROPERTY_ID)
+        Long getId();
+
+        @ApiModelProperty(name = "cluster_id")
+        Long getClusterId();
+
+        @ApiModelProperty(name = AlertGroupResourceProvider.NAME_PROPERTY_ID)
+        String getGroupName();
+
+        @ApiModelProperty(name = AlertGroupResourceProvider.DEFAULT_PROPERTY_ID)
+        Boolean isDefault();
+    }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AlertTargetSwagger.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AlertTargetSwagger.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.ambari.server.controller.internal.AlertGroupResourceProvider;
 import org.apache.ambari.server.controller.internal.AlertTargetResourceProvider;
+import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 
 import io.swagger.annotations.ApiModelProperty;
 
@@ -32,45 +33,52 @@ import io.swagger.annotations.ApiModelProperty;
  */
 public interface AlertTargetSwagger extends ApiModel {
 
-    @ApiModelProperty(name = AlertTargetResourceProvider.ID_PROPERTY_ID)
-    Long getId();
+    @ApiModelProperty(name = AlertTargetResourceProvider.ALERT_TARGET)
+    AlertTargetInfo getAlertTargetInfo();
 
-    @ApiModelProperty(name = AlertTargetResourceProvider.NAME_PROPERTY_ID)
-    String getName();
+    interface AlertTargetInfo {
 
-    @ApiModelProperty(name = AlertTargetResourceProvider.DESCRIPTION_PROPERTY_ID)
-    String getDescription();
-
-    @ApiModelProperty(name = AlertTargetResourceProvider.NOTIFICATION_TYPE_PROPERTY_ID)
-    String getNotificationType();
-
-    @ApiModelProperty(name = AlertTargetResourceProvider.ENABLED_PROPERTY_ID)
-    Boolean isEnabled();
-
-    @ApiModelProperty(name = AlertTargetResourceProvider.PROPERTIES_PROPERTY_ID)
-    Map<String, String> getProperties();
-
-    // it should be Set<AlertState> but Swagger doesn't support list of enums
-    @ApiModelProperty(name = AlertTargetResourceProvider.STATES_PROPERTY_ID)
-    List<String> getAlertStates();
-
-    @ApiModelProperty(name = AlertTargetResourceProvider.GLOBAL_PROPERTY_ID)
-    Boolean isGlobal();
-
-    @ApiModelProperty(name = AlertTargetResourceProvider.GROUPS_PROPERTY_ID)
-    List<AlertGroup> getAlertGroups();
-
-    interface AlertGroup {
-        @ApiModelProperty(name = AlertGroupResourceProvider.ID_PROPERTY_ID)
+        @ApiModelProperty(name = AlertTargetResourceProvider.ID_PROPERTY_ID)
         Long getId();
 
-        @ApiModelProperty(name = "cluster_id")
-        Long getClusterId();
+        @ApiModelProperty(name = AlertTargetResourceProvider.NAME_PROPERTY_ID)
+        String getName();
 
-        @ApiModelProperty(name = AlertGroupResourceProvider.NAME_PROPERTY_ID)
-        String getGroupName();
+        @ApiModelProperty(name = AlertTargetResourceProvider.DESCRIPTION_PROPERTY_ID)
+        String getDescription();
 
-        @ApiModelProperty(name = AlertGroupResourceProvider.DEFAULT_PROPERTY_ID)
-        Boolean isDefault();
+        @ApiModelProperty(name = AlertTargetResourceProvider.NOTIFICATION_TYPE_PROPERTY_ID)
+        String getNotificationType();
+
+        @ApiModelProperty(name = AlertTargetResourceProvider.ENABLED_PROPERTY_ID)
+        Boolean isEnabled();
+
+        @ApiModelProperty(name = AlertTargetResourceProvider.PROPERTIES_PROPERTY_ID)
+        Map<String, String> getProperties();
+
+        // it should be Set<AlertState> but Swagger doesn't support list of enums
+        @ApiModelProperty(name = AlertTargetResourceProvider.STATES_PROPERTY_ID)
+        List<String> getAlertStates();
+
+        @ApiModelProperty(name = AlertTargetResourceProvider.GLOBAL_PROPERTY_ID)
+        Boolean isGlobal();
+
+        @ApiModelProperty(name = AlertTargetResourceProvider.GROUPS_PROPERTY_ID)
+        List<AlertGroup> getAlertGroups();
+
+        interface AlertGroup {
+
+            @ApiModelProperty(name = AlertGroupResourceProvider.ID_PROPERTY_ID)
+            Long getId();
+
+            @ApiModelProperty(name = ClusterResourceProvider.CLUSTER_ID)
+            Long getClusterId();
+
+            @ApiModelProperty(name = AlertGroupResourceProvider.NAME_PROPERTY_ID)
+            String getGroupName();
+
+            @ApiModelProperty(name = AlertGroupResourceProvider.DEFAULT_PROPERTY_ID)
+            Boolean isDefault();
+        }
     }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertGroupResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertGroupResourceProvider.java
@@ -42,6 +42,7 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.events.AlertGroupsUpdateEvent;
 import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.events.publishers.StateUpdateEventPublisher;
@@ -71,12 +72,20 @@ public class AlertGroupResourceProvider extends
   private static final Logger LOG = LoggerFactory.getLogger(AlertGroupResourceProvider.class);
 
   public static final String ALERT_GROUP = "AlertGroup";
-  public static final String ALERT_GROUP_ID = "AlertGroup/id";
-  public static final String ALERT_GROUP_CLUSTER_NAME = "AlertGroup/cluster_name";
-  public static final String ALERT_GROUP_NAME = "AlertGroup/name";
-  public static final String ALERT_GROUP_DEFAULT = "AlertGroup/default";
-  public static final String ALERT_GROUP_DEFINITIONS = "AlertGroup/definitions";
-  public static final String ALERT_GROUP_TARGETS = "AlertGroup/targets";
+
+  public static final String ID_PROPERTY_ID = "id";
+  public static final String CLUSTER_NAME_PROPERTY_ID = "cluster_name";
+  public static final String NAME_PROPERTY_ID = "name";
+  public static final String DEFAULT_PROPERTY_ID = "default";
+  public static final String DEFINITIONS_PROPERTY_ID = "definitions";
+  public static final String TARGETS_PROPERTY_ID = "targets";
+
+  public static final String ALERT_GROUP_ID = ALERT_GROUP + PropertyHelper.EXTERNAL_PATH_SEP + ID_PROPERTY_ID;
+  public static final String ALERT_GROUP_CLUSTER_NAME = ALERT_GROUP + PropertyHelper.EXTERNAL_PATH_SEP + CLUSTER_NAME_PROPERTY_ID;
+  public static final String ALERT_GROUP_NAME = ALERT_GROUP + PropertyHelper.EXTERNAL_PATH_SEP + NAME_PROPERTY_ID;
+  public static final String ALERT_GROUP_DEFAULT = ALERT_GROUP + PropertyHelper.EXTERNAL_PATH_SEP + DEFAULT_PROPERTY_ID;
+  public static final String ALERT_GROUP_DEFINITIONS = ALERT_GROUP + PropertyHelper.EXTERNAL_PATH_SEP + DEFINITIONS_PROPERTY_ID;
+  public static final String ALERT_GROUP_TARGETS = ALERT_GROUP + PropertyHelper.EXTERNAL_PATH_SEP + TARGETS_PROPERTY_ID;
 
   private static final Set<String> PK_PROPERTY_IDS = new HashSet<>(
     Arrays.asList(ALERT_GROUP_ID, ALERT_GROUP_CLUSTER_NAME));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProvider.java
@@ -70,17 +70,28 @@ public class AlertTargetResourceProvider extends
  AbstractAuthorizedResourceProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(AlertTargetResourceProvider.class);
-
+    
   public static final String ALERT_TARGET = "AlertTarget";
-  public static final String ALERT_TARGET_ID = "AlertTarget/id";
-  public static final String ALERT_TARGET_NAME = "AlertTarget/name";
-  public static final String ALERT_TARGET_DESCRIPTION = "AlertTarget/description";
-  public static final String ALERT_TARGET_NOTIFICATION_TYPE = "AlertTarget/notification_type";
-  public static final String ALERT_TARGET_PROPERTIES = "AlertTarget/properties";
-  public static final String ALERT_TARGET_GROUPS = "AlertTarget/groups";
-  public static final String ALERT_TARGET_STATES = "AlertTarget/alert_states";
-  public static final String ALERT_TARGET_GLOBAL = "AlertTarget/global";
-  public static final String ALERT_TARGET_ENABLED = "AlertTarget/enabled";
+
+  public static final String ID_PROPERTY_ID = "id";
+  public static final String NAME_PROPERTY_ID = "name";
+  public static final String DESCRIPTION_PROPERTY_ID = "description";
+  public static final String NOTIFICATION_TYPE_PROPERTY_ID = "notification_type";
+  public static final String PROPERTIES_PROPERTY_ID = "properties";
+  public static final String GROUPS_PROPERTY_ID = "groups";
+  public static final String STATES_PROPERTY_ID = "alert_states";
+  public static final String GLOBAL_PROPERTY_ID = "global";
+  public static final String ENABLED_PROPERTY_ID = "enabled";
+
+  public static final String ALERT_TARGET_ID = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + ID_PROPERTY_ID;
+  public static final String ALERT_TARGET_NAME = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + NAME_PROPERTY_ID;
+  public static final String ALERT_TARGET_DESCRIPTION = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + DESCRIPTION_PROPERTY_ID;
+  public static final String ALERT_TARGET_NOTIFICATION_TYPE = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + NOTIFICATION_TYPE_PROPERTY_ID;
+  public static final String ALERT_TARGET_PROPERTIES = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + PROPERTIES_PROPERTY_ID;
+  public static final String ALERT_TARGET_GROUPS = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + GROUPS_PROPERTY_ID;
+  public static final String ALERT_TARGET_STATES = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + STATES_PROPERTY_ID;
+  public static final String ALERT_TARGET_GLOBAL = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + GLOBAL_PROPERTY_ID;
+  public static final String ALERT_TARGET_ENABLED = ALERT_TARGET + PropertyHelper.EXTERNAL_PATH_SEP + ENABLED_PROPERTY_ID;
 
   private static final Set<String> PK_PROPERTY_IDS = new HashSet<>(
       Arrays.asList(ALERT_TARGET_ID, ALERT_TARGET_NAME));

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertTarget.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertTarget.java
@@ -25,7 +25,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * The {@link AlertTarget} class represents a dispatch mechanism and audience
- * that will receive information about alerts int he system.
+ * that will receive information about alerts in the system.
  */
 public class AlertTarget {
 


### PR DESCRIPTION
Change-Id: Icdbc0221f7d66fc27c051b0cacf04534f3875ae4

## What changes were proposed in this pull request?

Add swagger documentation to AlertTarget API endpoints

## How was this patch tested?

Generate swagger docs by 

```
test -Drat.skip -Dcheckstyle.skip -DskipTests -Dgenerate.swagger.resources
```

then manually checking Swagger output at `ambari-server/docs/api/generated/index.html`

checkstyle using:

```
clean checkstyle:checkstyle -pl ambari-server
```

API endpoint calls at `api/v1/alert_targets` have also been tested manually

please review @Jetly-Jaimin @adoroszlai @benyoka 