### PR TITLE
[AMBARI-22875] Dependency check should ignore unknown services

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -44,6 +44,8 @@ import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.topology.Cardinality;
 import org.apache.ambari.server.topology.Configuration;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -54,6 +56,8 @@ import com.google.common.collect.ImmutableSet;
  */
 // TODO move to topology package
 public class Stack implements StackDefinition {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Stack.class);
 
   /**
    * Stack info
@@ -143,6 +147,11 @@ public class Stack implements StackDefinition {
     if (!stackInfo.getServices().isEmpty()) {
       registerConditionalDependencies();
     }
+
+    String stackId = new StackId(stackInfo.getName(), stackInfo.getVersion()).getStackId();
+    LOG.info("Loaded stack {}", stackId);
+    LOG.debug("Services in stack {}: {}", stackId, serviceComponents);
+    LOG.debug("Components in stack {}: {}", stackId, componentService);
   }
 
   /**
@@ -216,6 +225,8 @@ public class Stack implements StackDefinition {
       if (serviceInfo != null) {
         return serviceInfo.getComponentByName(component);
       }
+    } else {
+      LOG.warn("No service found for component {}.  Known components: {}", component, componentService.keySet());
     }
     return null;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix NPE thrown by `DependencyAndCardinalityValidator` if it encountered an unknown component as a dependency target.
2. Client component dependencies were previously only added to the topology if their parent service was present via other components.  With client components extracted to their own services this check no longer seems to make sense.

## How was this patch tested?

Tested deployment of HDFS with various scenarios.

1. If `HADOOP_CLIENT` is missing, it is added:
    ```
     INFO [ambari-client-thread-37] DependencyAndCardinalityValidator:159 - Added component HADOOP_CLIENT in host group node to satisfy host-level dependency for component Component{name=NFS_GATEWAY, mpackInstance=null, serviceInstance=null, provisionAction=null}
    ```
2. If `HADOOP_CLIENT` is already present:
    ```
    DEBUG [ambari-client-thread-39] DependencyAndCardinalityValidator:120 - Processing dependency [HADOOP_CLIENTS/HADOOP_CLIENT] for component [Component{name=NFS_GATEWAY, mpackInstance=null, serviceInstance=null, provisionAction=null}]
    DEBUG [ambari-client-thread-39] DependencyAndCardinalityValidator:155 - Host group node contains component HADOOP_CLIENT and satisfies host-level dependency for component Component{name=NFS_GATEWAY, mpackInstance=null, serviceInstance=null, provisionAction=null}
    ```
3. `HADOOP_CLIENT` missed for first component that depends on it, but found for subsequent component:
    ```
    DEBUG [ambari-client-thread-41] DependencyAndCardinalityValidator:120 - Processing dependency [HADOOP_CLIENTS/HADOOP_CLIENT] for component [Component{name=NFS_GATEWAY, mpackInstance=null, serviceInstance=null, provisionAction=null}]
     INFO [ambari-client-thread-41] DependencyAndCardinalityValidator:159 - Added component HADOOP_CLIENT in host group node to satisfy host-level dependency for component Component{name=NFS_GATEWAY, mpackInstance=null, serviceInstance=null, provisionAction=null}
    DEBUG [ambari-client-thread-41] DependencyAndCardinalityValidator:120 - Processing dependency [HADOOP_CLIENTS/HADOOP_CLIENT] for component [Component{name=HISTORYSERVER, mpackInstance=null, serviceInstance=null, provisionAction=null}]
    DEBUG [ambari-client-thread-41] DependencyAndCardinalityValidator:155 - Host group node contains component HADOOP_CLIENT and satisfies host-level dependency for component Component{name=HISTORYSERVER, mpackInstance=null, serviceInstance=null, provisionAction=null}
    ```
4. Reference to unknown components ignored:
    ```
    DEBUG [ambari-client-thread-39] DependencyAndCardinalityValidator:120 - Processing dependency [TEZ/TEZ_CLIENT] for component [Component{name=HISTORYSERVER, mpackInstance=null, serviceInstance=null, provisionAction=null}]
    DEBUG [ambari-client-thread-39] DependencyAndCardinalityValidator:125 - The component [TEZ_CLIENT] is not associated with any known services, skipping dependency
    DEBUG [ambari-client-thread-39] DependencyAndCardinalityValidator:120 - Processing dependency [SLIDER/SLIDER] for component [Component{name=HISTORYSERVER, mpackInstance=null, serviceInstance=null, provisionAction=null}]
    DEBUG [ambari-client-thread-39] DependencyAndCardinalityValidator:125 - The component [SLIDER] is not associated with any known services, skipping dependency
    ```