### PR TITLE
[AMBARI-23203] Add mpack-instance-manager package dependency for ambari-agent (dsen)

### DIFF
--- a/ambari-agent/src/main/package/dependencies.properties
+++ b/ambari-agent/src/main/package/dependencies.properties
@@ -28,5 +28,5 @@
 # Such a format is respected by install_ambari_tarball.py by default, 
 # however should be encouraged manually in pom.xml.
 
-rpm.dependency.list=openssl,\nRequires: rpm-python,\nRequires: zlib,\nRequires: python >= 2.6
-deb.dependency.list=openssl, zlibc, python (>= 2.6)
+rpm.dependency.list=mpack-instance-manager,openssl,\nRequires: rpm-python,\nRequires: zlib,\nRequires: python >= 2.6
+deb.dependency.list=mpack-instance-manager, openssl, zlibc, python (>= 2.6)


### PR DESCRIPTION


## What changes were proposed in this pull request?
mpack-instance-manager package should be installed with ambari-agent package