### PR TITLE
AMBARI-23215. Update logic to skip *_CLIENT services Service Checks (SC), as there is no SC defined for them.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2256,7 +2256,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
           continue;
         }
         for (Service s : entry.getValue()) {
-          if (runSmokeTest && (State.INSTALLED == s.getDesiredState() &&
+          // Ignoring the "*_CLIENTS" services, as there won't be an separate
+          // Service Check defined for them.
+          if (!s.isClientOnlyService() && runSmokeTest && (State.INSTALLED == s.getDesiredState() &&
                   maintenanceStateHelper.isOperationAllowed(opLvl, s))) {
             smokeTestServices.add(s);
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- With advent of Mpacks, we have separated the *CLIENT* components from *SERVER* counterparts and will be separate services itself. 
 

- For example: *ZOOKEEPER_CLIENT* will be a separate service having category *CLIENT* and *ZOOKEEPER_SERVER* will be a separate service having category *MASTER*. (Similarly, for others like HDFS_CLEINT and so on.)

- As there are no Service Checks explicitly defined for the CLIENT Services, we need to update the code to skip running any SC calls for them.

## How was this patch tested?

Tested on cluster.