### PR TITLE
AMBARI-23218. Remove delete custom command from Ambari Infra Solr stack.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
@@ -68,14 +68,6 @@
                 <background>true</background>
               </commandScript>
             </customCommand>
-            <customCommand>
-              <name>DELETE</name>
-              <commandScript>
-                <script>scripts/infra_solr.py</script>
-                <scriptType>PYTHON</scriptType>
-                <timeout>600</timeout>
-              </commandScript>
-            </customCommand>
           </customCommands>
           <dependencies>
             <dependency>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/collection.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/collection.py
@@ -88,17 +88,3 @@ def restore_collection(env):
       status_check_cmd = command_commons.create_solr_api_request_command(solr_status_request_path, status_check_json_output)
       command_commons.snapshot_status_check(status_check_cmd, status_check_json_output, command_commons.backup_name, False,
         log_output=command_commons.log_output, tries=command_commons.request_tries, time_interval=command_commons.request_time_interval)
-
-def delete_collection(env):
-    """
-    Delete specific Solr collection - used on ranger_audits by default
-    """
-    import params, command_commons
-    env.set_params(command_commons)
-
-    Logger.info(format("Delete Solr Collection: {collection}"))
-
-    solr_request_path = format("admin/collections?action=DELETE&name={collection}&wt=json")
-    delete_api_cmd = command_commons.create_solr_api_request_command(solr_request_path)
-
-    Execute(delete_api_cmd, user=params.infra_solr_user, logoutput=True)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove delete collection custom command, as it can be dangerous if someone click on that -> all audits will disappear from ranger audits (anyway it can be done by one curl command, so lets just use that one)

## How was this patch tested?

unrelated test failures

please review @kasakrisz @zeroflag @g-boros