### PR TITLE
AMBARI-23219 - Set mariadb the default database for Hive on Amazon Linux 2 distribution

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/resources/os_family.json
+++ b/ambari-common/src/main/python/ambari_commons/resources/os_family.json
@@ -79,7 +79,7 @@
     "aliases": {
       "amazon2015": "amazon6",
       "amazon2016": "amazon6",
-      "amazon2017": "amazon6",
+      "amazon2017": "redhat7",
       "suse11sp3": "suse11"
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mysql is not available in the amzn2-core.repo used by Amazon Linux 2 2017.12. However it is the default database dependency for Hive. Amazon Linux 2 alias set to redhat7 because in this case mariadb will be installed instead of Mysql. 

## How was this patch tested?

Manual testing using Virtual Box image: https://cdn.amazonlinux.com/os-images/2017.12.0.20171212.2/virtualbox/
1. Install ambari server and agent via yum.
2. Replace the value 'amazon6' to 'redhat7' in the os_family.json files for key 'amazon2017'
3. Run ambari server setup -s
4. Reset ambari agent
5. Run ambari server and deploy a cluster containing Hive.
6. Run Hive service check.

Please review:
@aonishuk @swagle 