### PR TITLE
[AMBARI-23091] Zeppelin Notebook SSL credentials in Ambari UI are in …

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/configuration/zeppelin-config.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/configuration/zeppelin-config.xml
@@ -139,14 +139,22 @@
   <property>
     <name>zeppelin.ssl.keystore.password</name>
     <value>change me</value>
+    <property-type>PASSWORD</property-type>
     <description>Keystore password. Can be obfuscated by the Jetty Password tool</description>
+    <value-attributes>
+      <type>password</type>
+    </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
     <name>zeppelin.ssl.key.manager.password</name>
     <value>change me</value>
+    <property-type>PASSWORD</property-type>
     <description>Key Manager password. Defaults to keystore password. Can be obfuscated.
         </description>
+    <value-attributes>
+      <type>password</type>
+    </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
@@ -167,9 +175,13 @@
   <property>
     <name>zeppelin.ssl.truststore.password</name>
     <value>change me</value>
+    <property-type>PASSWORD</property-type>
     <description>Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to
             the keystore password
         </description>
+    <value-attributes>
+      <type>password</type>
+    </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
   <property>

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/configuration/zeppelin-config.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/configuration/zeppelin-config.xml
@@ -145,14 +145,22 @@
   <property>
     <name>zeppelin.ssl.keystore.password</name>
     <value>change me</value>
+    <property-type>PASSWORD</property-type>
     <description>Keystore password. Can be obfuscated by the Jetty Password tool</description>
+    <value-attributes>
+      <type>password</type>
+    </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>
   <property>
     <name>zeppelin.ssl.key.manager.password</name>
     <value>change me</value>
+    <property-type>PASSWORD</property-type>
     <description>Key Manager password. Defaults to keystore password. Can be obfuscated.
         </description>
+    <value-attributes>
+      <type>password</type>
+    </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>
   <property>
@@ -173,9 +181,13 @@
   <property>
     <name>zeppelin.ssl.truststore.password</name>
     <value>change me</value>
+    <property-type>PASSWORD</property-type>
     <description>Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to
             the keystore password
         </description>
+    <value-attributes>
+      <type>password</type>
+    </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>
   <property>


### PR DESCRIPTION
…plain text rather than being hidden

## What changes were proposed in this pull request?

Added code to stack advisor which will update storage property in zeppelin to FileSystemNotebookRepo if user deploying cluster with HDP 2.6.3 and higher.

## How was this patch tested?

Deployed new cluster with different HDP stack versions.
Also tried to change value fro storage property after deploy.
Validated data which UI sent to BE and response afrom BE.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.