### PR TITLE
AMBARI-23222. Ambari-agent fails to connect to server with two_way_auth = true

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
+++ b/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
@@ -213,7 +213,8 @@ class HeartbeatThread(threading.Thread):
     Create a stomp connection
     """
     connection_url = 'wss://{0}:{1}/agent/stomp/v1'.format(self.config.server_hostname, self.config.secured_url_port)
-    self.connection = security.establish_connection(connection_url)
+    connection_helper = security.VerifiedHTTPSConnection(self.config.server_hostname, connection_url, self.config)
+    self.connection = connection_helper.connect()
 
   def add_listeners(self):
     """

--- a/ambari-agent/src/main/python/ambari_agent/security.py
+++ b/ambari-agent/src/main/python/ambari_agent/security.py
@@ -42,12 +42,12 @@ GEN_AGENT_KEY = 'openssl req -new -newkey rsa:1024 -nodes -keyout "%(keysdir)s' 
 KEY_FILENAME = '%(hostname)s.key'
 
 
-class VerifiedHTTPSConnection(httplib.HTTPSConnection):
+class VerifiedHTTPSConnection:
   """ Connecting using ssl wrapped sockets """
-  def __init__(self, host, port=None, config=None):
-    httplib.HTTPSConnection.__init__(self, host, port=port)
+  def __init__(self, host, connection_url, config):
     self.two_way_ssl_required = False
     self.host = host
+    self.connection_url = connection_url
     self.config = config
 
   def connect(self):
@@ -57,11 +57,11 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
       logger.info(
         'Server require two-way SSL authentication. Use it instead of one-way...')
 
+    logging.info("Connecting to {0}".format(self.connection_url))
+
+
     if not self.two_way_ssl_required:
-      sock = self.create_connection()
-      self.sock = ssl.wrap_socket(sock, cert_reqs=ssl.CERT_NONE)
-      logger.info('SSL connection established. Two-way SSL authentication is '
-                  'turned off on the server.')
+      conn = AmbariStompConnection(self.connection_url)
     else:
       self.certMan = CertificateManager(self.config, self.host)
       self.certMan.initSecurity()
@@ -69,67 +69,41 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
       agent_crt = self.certMan.getAgentCrtName()
       server_crt = self.certMan.getSrvrCrtName()
 
-      sock = self.create_connection()
+      ssl_options = {
+        'keyfile': agent_key,
+        'certfile': agent_crt,
+        'cert_reqs': ssl.CERT_REQUIRED,
+        'ca_certs': server_crt
+      }
 
-      try:
-        self.sock = ssl.wrap_socket(sock,
-                                    keyfile=agent_key,
-                                    certfile=agent_crt,
-                                    cert_reqs=ssl.CERT_REQUIRED,
-                                    ca_certs=server_crt)
-        logger.info('SSL connection established. Two-way SSL authentication '
-                    'completed successfully.')
-      except ssl.SSLError as err:
-        logger.error('Two-way SSL authentication failed. Ensure that '
-                     'server and agent certificates were signed by the same CA '
-                     'and restart the agent. '
-                     '\nIn order to receive a new agent certificate, remove '
-                     'existing certificate file from keys directory. As a '
-                     'workaround you can turn off two-way SSL authentication in '
-                     'server configuration(ambari.properties) '
-                     '\nExiting..')
-        raise err
+      conn = AmbariStompConnection(self.connection_url, ssl_options=ssl_options)
 
-  def create_connection(self):
-    if self.sock:
-      self.sock.close()
-    logger.info("SSL Connect being called.. connecting to the server")
-    sock = socket.create_connection((self.host, self.port), 60)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-    if self._tunnel_host:
-      self.sock = sock
-      self._tunnel()
+    self.establish_connection(conn)
+    return conn
 
-    return sock
-
-def establish_connection(connection_url):
-  """
-  Create a stomp connection
-  """
-  logging.info("Connecting to {0}".format(connection_url))
-
-  conn = AmbariStompConnection(connection_url)
-  try:
-    conn.start()
-    conn.connect(wait=True)
-  except Exception as ex:
+  def establish_connection(self, conn):
+    """
+    Create a stomp connection
+    """
     try:
-      conn.disconnect()
-    except:
-      logger.exception("Exception during conn.disconnect()")
+      conn.start()
+      conn.connect(wait=True)
+    except Exception as ex:
+      try:
+        conn.disconnect()
+      except:
+        logger.exception("Exception during conn.disconnect()")
 
-    if isinstance(ex, socket_error):
-      logger.warn("Could not connect to {0}".format(connection_url))
+      if isinstance(ex, socket_error):
+        logger.warn("Could not connect to {0}. {1}".format(self.connection_url, str(ex)))
 
-    raise
-
-  return conn
+      raise
 
 class AmbariStompConnection(WsConnection):
-  def __init__(self, url):
+  def __init__(self, *args, **kwargs):
     self.lock = threading.RLock()
     self.correlation_id = -1
-    WsConnection.__init__(self, url)
+    WsConnection.__init__(self, *args, **kwargs)
 
   def send(self, destination, message, content_type=None, headers=None, **keyword_headers):
     with self.lock:

--- a/ambari-agent/src/test/python/ambari_agent/TestSecurity.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestSecurity.py
@@ -59,59 +59,6 @@ class TestSecurity(unittest.TestCase):
   def tearDown(self):
     # enable stdout
     sys.stdout = sys.__stdout__
-
-
-  ### VerifiedHTTPSConnection ###
-
-  @patch.object(security.CertificateManager, "initSecurity")
-  @patch("socket.create_connection")
-  @patch("ssl.wrap_socket")
-  def test_VerifiedHTTPSConnection_connect(self, wrap_socket_mock,
-                                           create_connection_mock,
-                                            init_security_mock):
-    init_security_mock.return_value = None
-    self.config.set('security', 'keysdir', '/dummy-keysdir')
-    connection = security.VerifiedHTTPSConnection("example.com",
-      self.config.get('server', 'secured_url_port'), self.config)
-    connection._tunnel_host = False
-    connection.sock = None
-    connection.connect()
-    self.assertTrue(wrap_socket_mock.called)
-
-  ### VerifiedHTTPSConnection with no certificates creation
-  @patch.object(security.CertificateManager, "initSecurity")
-  @patch("socket.create_connection")
-  @patch("ssl.wrap_socket")
-  def test_Verified_HTTPSConnection_non_secure_connect(self, wrap_socket_mock,
-                                                    create_connection_mock,
-                                                    init_security_mock):
-    connection = security.VerifiedHTTPSConnection("example.com",
-      self.config.get('server', 'secured_url_port'), self.config)
-    connection._tunnel_host = False
-    connection.sock = None
-    connection.connect()
-    self.assertFalse(init_security_mock.called)
-
-  ### VerifiedHTTPSConnection with two-way SSL authentication enabled
-  @patch.object(security.CertificateManager, "initSecurity")
-  @patch("socket.create_connection")
-  @patch("ssl.wrap_socket")
-  def test_Verified_HTTPSConnection_two_way_ssl_connect(self, wrap_socket_mock,
-                                                    create_connection_mock,
-                                                    init_security_mock):
-    wrap_socket_mock.side_effect=ssl.SSLError()
-    connection = security.VerifiedHTTPSConnection("example.com",
-      self.config.get('server', 'secured_url_port'), self.config)
-    self.config.isTwoWaySSLConnection = MagicMock(return_value=True)
-
-    connection._tunnel_host = False
-    connection.sock = None
-    try:
-      connection.connect()
-    except ssl.SSLError:
-      pass
-    self.assertTrue(init_security_mock.called)
-
   ### CachedHTTPSConnection ###
 
   @patch.object(security.VerifiedHTTPSConnection, "connect")

--- a/ambari-common/src/main/python/ambari_stomp/adapter/websocket.py
+++ b/ambari-common/src/main/python/ambari_stomp/adapter/websocket.py
@@ -64,11 +64,11 @@ class QueuedWebSocketClient(WebSocketClient):
     self.messages.put(StopIteration)
 
 class WsTransport(Transport):
-  def __init__(self, url):
+  def __init__(self, url, ssl_options=None):
     Transport.__init__(self, (0, 0), False, False, 0.0, 0.0, 0.0, 0.0, 0, False, None, None, None, None, False,
     DEFAULT_SSL_VERSION, None, None, None)
     self.current_host_and_port = (0, 0) # mocking
-    self.ws = QueuedWebSocketClient(url, protocols=['http-only', 'chat'])
+    self.ws = QueuedWebSocketClient(url, protocols=['http-only', 'chat'], ssl_options=ssl_options)
     self.ws.daemon = False
 
   def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
@@ -124,8 +124,8 @@ class WsTransport(Transport):
       logger.exception("Exception during Transport.stop(self)")
 
 class WsConnection(BaseConnection, Protocol12):
-  def __init__(self, url):
-    self.transport = WsTransport(url)
+  def __init__(self, url, ssl_options=None):
+    self.transport = WsTransport(url, ssl_options=ssl_options)
     self.transport.set_listener('ws-listener', self)
     self.transactions = {}
     Protocol12.__init__(self, self.transport, (0, 0))


### PR DESCRIPTION
ERROR 2018-03-13 17:15:04,264 security.py:122 - Could not connect to wss://ctr-e138-1518143905142-94896-01-000002.hwx.site:8441/agent/stomp/v1
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/ambari_agent/security.py", line 113, in establish_connection
    conn.start()
  File "/usr/lib/ambari-agent/lib/ambari_stomp/connect.py", line 46, in start
    self.transport.start()
  File "/usr/lib/ambari-agent/lib/ambari_stomp/transport.py", line 109, in start
    self.attempt_connection()
  File "/usr/lib/ambari-agent/lib/ambari_stomp/adapter/websocket.py", line 89, in attempt_connection
    self.ws.connect()
  File "/usr/lib/ambari-agent/lib/ambari_ws4py/client/__init__.py", line 216, in connect
    self.sock.connect(self.bind_addr)
  File "/usr/lib64/python2.7/ssl.py", line 869, in connect
    self._real_connect(addr, False)
  File "/usr/lib64/python2.7/ssl.py", line 860, in _real_connect
    self.do_handshake()
  File "/usr/lib64/python2.7/ssl.py", line 833, in do_handshake
    self._sslobj.do_handshake()
SSLError: [SSL: SSLV3_ALERT_BAD_CERTIFICATE] sslv3 alert bad certificate (_ssl.c:579)