### PR TITLE
[AMBARI-23221] Before-start hook is failed when hdfs is not available

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
@@ -325,7 +325,7 @@ else:
   namenode_rpc = default('/configurations/hdfs-site/dfs.namenode.rpc-address', default_fs)
 
 # if HDFS is not installed in the cluster, then don't try to access namenode_rpc
-if "core-site" in config['configurations'] and namenode_rpc:
+if has_namenode and namenode_rpc and "core-site" in config['configurations']:
   port_str = namenode_rpc.split(':')[-1].strip()
   try:
     nn_rpc_client_port = int(port_str)


### PR DESCRIPTION
On custom stacks where no hdfs or some replacement is presented before-start hooks does not work properly because of missing keys in config.