### PR TITLE
[AMBARI-23231] Server service_check does not get executed for new mpacks (dsen)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2256,9 +2256,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
           continue;
         }
         for (Service s : entry.getValue()) {
-          // Ignoring the "*_CLIENTS" services, as there won't be an separate
-          // Service Check defined for them.
-          if (!s.isClientOnlyService() && runSmokeTest && (State.INSTALLED == s.getDesiredState() &&
+          if (runSmokeTest && (State.INSTALLED == s.getDesiredState() &&
                   maintenanceStateHelper.isOperationAllowed(opLvl, s))) {
             smokeTestServices.add(s);
           }
@@ -3207,7 +3205,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
           customCommandExecutionHelper.addServiceCheckAction(stage, componentForServiceCheck.getHostName(), smokeTestRole,
               nowTimestamp, componentForServiceCheck.getServiceGroupName(), componentForServiceCheck.getServiceName(),
-              componentForServiceCheck.getServiceComponentName(), null, false, false, service.getName());
+              componentForServiceCheck.getServiceComponentName(), null, false, false, service);
 
         } catch (AmbariException e) {
             LOG.warn("Nothing to do for service check as could not find role or"


### PR DESCRIPTION
## What changes were proposed in this pull request?
When running service check on client component that is not part of the service, the script name should be passed from the service metainfo that initiated the service check.
Also reverted client service checks skipping condition, this should be handled by metainfo changes

## How was this patch tested?
Manually