### PR TITLE
[AMBARI-23232] Set full name (cn) when creating user accounts in FreeIPA server

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandler.java
@@ -171,7 +171,7 @@ public class IPAKerberosOperationHandler extends KDCKerberosOperationHandler {
     } else {
       String principalName = deconstructedPrincipal.getPrincipalName();
 
-      if (!principalName.equals(principal.toLowerCase())) {
+      if (!principalName.equals(principalName.toLowerCase())) {
         LOG.warn("{} is not in lowercase. FreeIPA does not recognize user " +
             "principals that are not entirely in lowercase. This can lead to issues with kinit and keytabs. Make " +
             "sure users are in lowercase.", principalName);
@@ -185,6 +185,8 @@ public class IPAKerberosOperationHandler extends KDCKerberosOperationHandler {
           "--first",
           deconstructedPrincipal.getPrimary(),
           "--last",
+          deconstructedPrincipal.getPrimary(),
+          "--cn",
           deconstructedPrincipal.getPrimary()
       };
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set full name (cn) when creating user accounts in FreeIPA server.

{code:title=Example IPA CLI}
ipa user-add user1 --principal user1@AMBARI.APACHE.ORG --first user1 --last user1 --cn "user1"
{code}

The new argument is "{{--cn "user1"}}.

This may allow for compatibility with IPA server version 3.x 

Also fixed cause for warning log message to be created due to incorrect conditional.

## How was this patch tested?

Manually tested against FreeIPA version 4.5.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.