### PR TITLE
[AMBARI-23235] SQL errors in schema create script for Oracle

### DIFF
--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -233,7 +233,7 @@ CREATE TABLE hostcomponentstate (
   component_name VARCHAR2(255) NOT NULL,
   version VARCHAR2(32) DEFAULT 'UNKNOWN' NOT NULL,
   current_state VARCHAR2(255) NOT NULL,
-  last_live_state VARCHAR2(255) NOT NULL DEFAULT 'UNKNOWN',
+  last_live_state VARCHAR2(255) DEFAULT 'UNKNOWN' NOT NULL,
   host_id NUMBER(19) NOT NULL,
   service_name VARCHAR2(255) NOT NULL,
   upgrade_state VARCHAR2(32) DEFAULT 'NONE' NOT NULL,
@@ -960,11 +960,11 @@ CREATE TABLE kerberos_keytab (
 );
 
 CREATE TABLE kerberos_keytab_principal (
-  kkp_id BIGINT NOT NULL DEFAULT 0,
+  kkp_id NUMBER(19) DEFAULT 0 NOT NULL,
   keytab_path VARCHAR2(255) NOT NULL,
   principal_name VARCHAR2(255) NOT NULL,
   host_id NUMBER(19),
-  is_distributed NUMBER(1) NOT NULL DEFAULT 0,
+  is_distributed NUMBER(1) DEFAULT 0 NOT NULL,
   CONSTRAINT PK_kkp PRIMARY KEY (kkp_id),
   CONSTRAINT FK_kkp_keytab_path FOREIGN KEY (keytab_path) REFERENCES kerberos_keytab (keytab_path),
   CONSTRAINT FK_kkp_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
@@ -973,7 +973,7 @@ CREATE TABLE kerberos_keytab_principal (
 );
 
 CREATE TABLE kkp_mapping_service (
-  kkp_id BIGINT NOT NULL DEFAULT 0,
+  kkp_id NUMBER(19) DEFAULT 0 NOT NULL,
   service_name VARCHAR(255) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
   CONSTRAINT PK_kkp_mapping_service PRIMARY KEY (kkp_id, service_name, component_name),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix errors due to invalid constructs used in schema create script for Oracle.

1. `DEFAULT` should precede `NOT NULL`
2. `BIGINT` is invalid, should be `NUMBER(19)`

```
  last_live_state VARCHAR2(255) NOT NULL DEFAULT 'UNKNOWN',
                                         *
ERROR at line 7:
ORA-00907: missing right parenthesis

  kkp_id BIGINT NOT NULL DEFAULT 0,
                         *
ERROR at line 2:
ORA-00907: missing right parenthesis

  kkp_id BIGINT DEFAULT 0 NOT NULL,
         *
ERROR at line 2:
ORA-00902: invalid datatype
```

## How was this patch tested?

Ran `Ambari-DDL-Oracle-CREATE.sql`, verified that no errors were thrown, tables were created.

```
SQL> desc hostcomponentstate
 Name                                      Null?    Type
 ----------------------------------------- -------- ----------------------------
 ID                                        NOT NULL NUMBER(19)
 CLUSTER_ID                                NOT NULL NUMBER(19)
 COMPONENT_NAME                            NOT NULL VARCHAR2(255)
 VERSION                                   NOT NULL VARCHAR2(32)
 CURRENT_STATE                             NOT NULL VARCHAR2(255)
 LAST_LIVE_STATE                           NOT NULL VARCHAR2(255)
 HOST_ID                                   NOT NULL NUMBER(19)
 SERVICE_NAME                              NOT NULL VARCHAR2(255)
 UPGRADE_STATE                             NOT NULL VARCHAR2(32)

SQL> desc kerberos_keytab_principal
 Name                                      Null?    Type
 ----------------------------------------- -------- ----------------------------
 KKP_ID                                    NOT NULL NUMBER(19)
 KEYTAB_PATH                               NOT NULL VARCHAR2(255)
 PRINCIPAL_NAME                            NOT NULL VARCHAR2(255)
 HOST_ID                                            NUMBER(19)
 IS_DISTRIBUTED                            NOT NULL NUMBER(1)

SQL> desc kkp_mapping_service
 Name                                      Null?    Type
 ----------------------------------------- -------- ----------------------------
 KKP_ID                                    NOT NULL NUMBER(19)
 SERVICE_NAME                              NOT NULL VARCHAR2(255)
 COMPONENT_NAME                            NOT NULL VARCHAR2(255)
```