### PR TITLE
[AMBARI-23236] Connection dropped during task execution caused stage abort.

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/Register.py
+++ b/ambari-agent/src/main/python/ambari_agent/Register.py
@@ -30,6 +30,7 @@ class Register:
   def __init__(self, config):
     self.config = config
     self.hardware = Hardware(self.config)
+    self.init_time_ms = int(1000*time.time())
 
   def build(self, response_id='-1'):
     timestamp = int(time.time()*1000)
@@ -48,6 +49,7 @@ class Register:
                  'hardwareProfile'   : self.hardware.get(),
                  'agentEnv'          : agentEnv,
                  'agentVersion'      : Utils.read_agent_version(self.config),
-                 'prefix'            : self.config.get('agent', 'prefix')
+                 'prefix'            : self.config.get('agent', 'prefix'),
+                 'agentStartTime'    : self.init_time_ms
                }
     return register

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ActionScheduler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ActionScheduler.java
@@ -1048,7 +1048,8 @@ class ActionScheduler implements Runnable {
   protected boolean wasAgentRestartedDuringOperation(Host host, Stage stage, String role) {
     String hostName = host.getHostName();
     long taskStartTime = stage.getHostRoleCommand(hostName, role).getStartTime();
-    return taskStartTime > 0 && taskStartTime <= host.getLastRegistrationTime();
+    long lastAgentStartTime = host.getLastAgentStartTime();
+    return taskStartTime > 0 && lastAgentStartTime > 0 && taskStartTime <= lastAgentStartTime;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
@@ -343,7 +343,7 @@ public class HeartBeatHandler {
     hostObject.handleEvent(new HostRegistrationRequestEvent(hostname,
         null != register.getPublicHostname() ? register.getPublicHostname() : hostname,
         new AgentVersion(register.getAgentVersion()), now, register.getHardwareProfile(),
-        register.getAgentEnv()));
+        register.getAgentEnv(), register.getAgentStartTime()));
 
     RegistrationResponse response = new RegistrationResponse();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/Register.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/Register.java
@@ -28,6 +28,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 public class Register {
   private int responseId = -1;
   private long timestamp;
+  private long agentStartTime;
   private String hostname;
   private int currentPingPort;
   private HostInfo hardwareProfile;
@@ -108,10 +109,19 @@ public class Register {
     this.currentPingPort = currentPingPort;
   }
 
+  public long getAgentStartTime() {
+    return agentStartTime;
+  }
+
+  public void setAgentStartTime(long agentStartTime) {
+    this.agentStartTime = agentStartTime;
+  }
+
   @Override
   public String toString() {
     String ret = "responseId=" + responseId + "\n" +
              "timestamp=" + timestamp + "\n" +
+             "startTime=" + agentStartTime + "\n" +
              "hostname="  + hostname + "\n" +
              "currentPingPort=" + currentPingPort + "\n" +
              "prefix=" + prefix + "\n";

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Host.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Host.java
@@ -250,6 +250,18 @@ public interface Host extends Comparable {
   void setLastRegistrationTime(long lastRegistrationTime);
 
   /**
+   * Time the Ambari Agent was started.
+   * ( Unix timestamp )
+   * @return the lastOnAgentStartRegistrationTime
+   */
+  long getLastAgentStartTime();
+
+  /**
+   * @param lastAgentStartTime the lastAgentStartTime to set
+   */
+  void setLastAgentStartTime(long lastAgentStartTime);
+
+  /**
    * Last time the Ambari Server received a heartbeat from the Host
    * ( Unix timestamp )
    * @return the lastHeartbeatTime

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostRegistrationRequestEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostRegistrationRequestEvent.java
@@ -31,20 +31,22 @@ public class HostRegistrationRequestEvent extends HostEvent {
   final AgentVersion agentVersion;
   final String publicHostName;
   final AgentEnv agentEnv;
+  final long agentStartTime;
 
   public HostRegistrationRequestEvent(String hostName,
-      AgentVersion agentVersion, long registrationTime, HostInfo hostInfo, AgentEnv env) {
-    this(hostName, hostName, agentVersion, registrationTime, hostInfo, env);
+      AgentVersion agentVersion, long registrationTime, HostInfo hostInfo, AgentEnv env, long agentStartTime) {
+    this(hostName, hostName, agentVersion, registrationTime, hostInfo, env, agentStartTime);
   }
   
   public HostRegistrationRequestEvent(String hostName, String publicName,
-      AgentVersion agentVersion, long registrationTime, HostInfo hostInfo, AgentEnv env) {
+      AgentVersion agentVersion, long registrationTime, HostInfo hostInfo, AgentEnv env, long agentStartTime) {
     super(hostName, HostEventType.HOST_REGISTRATION_REQUEST);
     this.registrationTime = registrationTime;
     this.hostInfo = hostInfo;
     this.agentVersion = agentVersion;
     this.publicHostName = (null == publicName) ? hostName : publicName;
     this.agentEnv = env;
+    this.agentStartTime = agentStartTime;
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
@@ -547,7 +547,7 @@ public class ClusterTest {
     long currentTime = 1001;
 
     clusters.getHost("h1").handleEvent(new HostRegistrationRequestEvent(
-        "h1", agentVersion, currentTime, hostInfo, agentEnv));
+        "h1", agentVersion, currentTime, hostInfo, agentEnv, currentTime));
 
     Assert.assertEquals(HostState.WAITING_FOR_HOST_STATUS_UPDATES,
         clusters.getHost("h1").getState());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
@@ -540,10 +540,11 @@ public class ClustersTest {
     addHostToCluster(hostName, clusterName);
     Host host = clusters.getHost(hostName);
     Assert.assertNotNull(host);
+    long currentTime = System.currentTimeMillis();
 
     HostRegistrationRequestEvent registrationEvent = new HostRegistrationRequestEvent(
         host.getHostName(),
-        new AgentVersion(""), System.currentTimeMillis(), new HostInfo(), new AgentEnv());
+        new AgentVersion(""), currentTime, new HostInfo(), new AgentEnv(), currentTime);
 
     host.handleEvent(registrationEvent);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/host/HostTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/host/HostTest.java
@@ -161,7 +161,7 @@ public class HostTest {
 
     HostRegistrationRequestEvent e =
         new HostRegistrationRequestEvent("foo", agentVersion, currentTime,
-            info, agentEnv);
+            info, agentEnv, currentTime);
 
     if (!firstReg) {
       Assert.assertNotNull(host.getHostId());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Server is now aware of agent start time.
Task timeout check was changed to use agent start time instead of registration time. 
This will allow request to be continued after agent accidential connection drop and re-registeration.

## How was this patch tested?

Manual check