### PR TITLE
[AMBARI-23238] Incorrect property for NN namespace value is used

### DIFF
--- a/ambari-web/app/app.js
+++ b/ambari-web/app/app.js
@@ -244,7 +244,7 @@ module.exports = Em.Application.create({
 
   hasNameNodeFederation: function () {
     return App.HDFSService.find().objectAt(0).get('masterComponentGroups.length') > 1;
-  }.property('router.clusterController.dataLoadList.services', 'router.clusterController.isServiceContentFullyLoaded'),
+  }.property('router.clusterController.isHDFSNameSpacesLoaded'),
 
   /**
    * If ResourceManager High Availability is enabled

--- a/ambari-web/app/controllers/global/cluster_controller.js
+++ b/ambari-web/app/controllers/global/cluster_controller.js
@@ -48,6 +48,8 @@ App.ClusterController = Em.Controller.extend(App.ReloadPopupMixin, {
    */
   isHostComponentMetricsLoaded: false,
 
+  isHDFSNameSpacesLoaded: false,
+
   /**
    * This counter used as event trigger to notify that quick links should be changed.
    */

--- a/ambari-web/app/controllers/global/update_controller.js
+++ b/ambari-web/app/controllers/global/update_controller.js
@@ -196,7 +196,7 @@ App.UpdateController = Em.Controller.extend({
         App.updater.run(this, 'updateUnhealthyAlertInstances', 'updateAlertInstances', App.alertInstancesUpdateInterval, '\/main\/alerts.*');
       }
       App.updater.run(this, 'updateWizardWatcher', 'isWorking', App.bgOperationsUpdateInterval);
-      App.updater.run(this, 'updateHDFSNameSpaces', 'isWorking', App.componentsUpdateInterval, '\/main\/(dashboard|services/HDFS|hosts).*');
+      App.updater.run(this, 'updateHDFSNameSpaces', 'isWorking', App.componentsUpdateInterval, '\/main\/(dashboard|services\/HDFS|hosts).*');
     }
   }.observes('isWorking', 'App.router.mainAlertInstancesController.isUpdating'),
 

--- a/ambari-web/app/mappers/hosts_mapper.js
+++ b/ambari-web/app/mappers/hosts_mapper.js
@@ -68,7 +68,7 @@ App.hostsMapper = App.QuickDataMapper.create({
     host_name: 'host_name',
     public_host_name: 'public_host_name',
     admin_state: 'HostRoles.desired_admin_state',
-    ha_name_space: 'metrics.dfs.namenode.ClusterId'
+    cluster_id_value: 'metrics.dfs.namenode.ClusterId'
   },
   stackVersionConfig: {
     id: 'HostStackVersions.id',
@@ -218,7 +218,11 @@ App.hostsMapper = App.QuickDataMapper.create({
 
       for (var k = 0; k < advancedHostComponents.length; k++) {
         var key = advancedHostComponents[k];
-        if (componentsIdMap[key]) componentsIdMap[key].display_name_advanced = App.HostComponent.find(key).get('displayNameAdvanced');
+        if (componentsIdMap[key]) {
+          var existingRecord = App.HostComponent.find(key);
+          componentsIdMap[key].display_name_advanced = existingRecord.get('displayNameAdvanced');
+          componentsIdMap[key].ha_name_space = existingRecord.get('haNameSpace');
+        }
       }
 
       //"itemTotal" present only for Hosts page request

--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -33,6 +33,7 @@ App.HostComponent = DS.Model.extend({
   service: DS.belongsTo('App.Service'),
   adminState: DS.attr('string'),
   haNameSpace: DS.attr('string'),
+  clusterIdValue: DS.attr('string'),
 
   serviceDisplayName: Em.computed.truncate('service.displayName', 14, 11),
 

--- a/ambari-web/app/models/service/hdfs.js
+++ b/ambari-web/app/models/service/hdfs.js
@@ -84,7 +84,7 @@ App.HDFSService = App.Service.extend({
       }
     });
     return result;
-  }.property('hostComponents.length')
+  }.property('router.clusterController.isHDFSNameSpacesLoaded')
 });
 
 App.HDFSService.FIXTURES = [];

--- a/ambari-web/app/models/service/hdfs.js
+++ b/ambari-web/app/models/service/hdfs.js
@@ -84,7 +84,7 @@ App.HDFSService = App.Service.extend({
       }
     });
     return result;
-  }.property('router.clusterController.isHDFSNameSpacesLoaded')
+  }.property('hostComponents.length')
 });
 
 App.HDFSService.FIXTURES = [];

--- a/ambari-web/test/controllers/global/update_controller_test.js
+++ b/ambari-web/test/controllers/global/update_controller_test.js
@@ -65,7 +65,7 @@ describe('App.UpdateController', function () {
 
     it('isWorking = true', function () {
       controller.set('isWorking', true);
-      expect(App.updater.run.callCount).to.equal(5);
+      expect(App.updater.run.callCount).to.equal(6);
     });
   });
 

--- a/ambari-web/test/controllers/main/service/item_test.js
+++ b/ambari-web/test/controllers/main/service/item_test.js
@@ -865,10 +865,16 @@ describe('App.MainServiceItemController', function () {
 
     beforeEach(function () {
       sinon.stub(App, 'dateTime').returns(1435790048000);
+      sinon.stub(App.HDFSService, 'find').returns([
+        Em.Object.create({
+          hostComponents: []
+        })
+      ]);
     });
 
     afterEach(function () {
       App.dateTime.restore();
+      App.HDFSService.find.restore();
     });
 
     tests.forEach(function (test) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently ClusterId property is used on UI to identify the namespaces. Values from hdfs-site configs should be used instead.

## How was this patch tested?

  21529 passing (23s)
  48 pending