### PR TITLE
[AMBARI-23213] New CLI options for setup-sso tool

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -572,6 +572,14 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
+def init_setup_sso_options(parser):
+  parser.add_option('--sso-enabled', default=None, help="Indicates whether to enable/disable SSO", dest="sso_enabled")
+  parser.add_option('--sso-provider-url', default=None, help="The URL of SSO provider; this must be provided when --sso-enabled is set to 'true'", dest="sso_provider_url")
+  parser.add_option('--sso-public-cert-file', default=None, help="The path where the public certificate PEM is located; this must be provided when --sso-enabled is set to 'true'", dest="sso_public_cert_file")
+  parser.add_option('--sso-jwt-cookie-name', default=None, help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
+  parser.add_option('--sso-jwt-audience-list', default=None, help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
+
+@OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_pam_setup_parser_options(parser):
   parser.add_option('--pam-config-file', default=None, help="Path to the PAM configuration file", dest="pam_config_file")
   parser.add_option('--pam-auto-create-groups', default=None, help="Automatically create groups for authenticated users [true/false]", dest="pam_auto_create_groups")
@@ -846,7 +854,7 @@ def init_action_parser(action, parser):
     UPDATE_HOST_NAMES_ACTION: init_empty_parser_options,
     CHECK_DATABASE_ACTION: init_empty_parser_options,
     ENABLE_STACK_ACTION: init_enable_stack_parser_options,
-    SETUP_SSO_ACTION: init_empty_parser_options,
+    SETUP_SSO_ACTION: init_setup_sso_options,
     DB_PURGE_ACTION: init_db_purge_parser_options,
     INSTALL_MPACK_ACTION: init_install_mpack_parser_options,
     UNINSTALL_MPACK_ACTION: init_uninstall_mpack_parser_options,

--- a/ambari-server/src/test/python/TestSetupSso.py
+++ b/ambari-server/src/test/python/TestSetupSso.py
@@ -1,0 +1,283 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import os
+import platform
+import sys
+import unittest
+import StringIO
+
+from mock.mock import patch, MagicMock
+
+from only_for_platform import os_distro_value
+from ambari_commons import os_utils
+
+import shutil
+project_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)),os.path.normpath("../../../../"))
+shutil.copyfile(project_dir+"/ambari-server/conf/unix/ambari.properties", "/tmp/ambari.properties")
+
+# We have to use this import HACK because the filename contains a dash
+_search_file = os_utils.search_file
+
+def search_file_proxy(filename, searchpatch, pathsep=os.pathsep):
+  global _search_file
+  if "ambari.properties" in filename:
+    return "/tmp/ambari.properties"
+  return _search_file(filename, searchpatch, pathsep)
+
+os_utils.search_file = search_file_proxy
+
+with patch.object(platform, "linux_distribution", return_value = MagicMock(return_value=('Redhat', '6.4', 'Final'))):
+  with patch("os.path.isdir", return_value = MagicMock(return_value=True)):
+    with patch("os.access", return_value = MagicMock(return_value=True)):
+      with patch.object(os_utils, "parse_log4j_file", return_value={'ambari.log.dir': '/var/log/ambari-server'}):
+        with patch("platform.linux_distribution", return_value = os_distro_value):
+          with patch("os.symlink"):
+            with patch("glob.glob", return_value = ['/etc/init.d/postgresql-9.3']):
+              _ambari_server_ = __import__('ambari-server')
+              with patch("__builtin__.open"):
+                from ambari_commons.exceptions import FatalException, NonFatalException
+                from ambari_server.properties import Properties
+                from ambari_server.setupSso import setup_sso, JWT_AUTH_ENBABLED, JWT_AUTH_PROVIDER_URL, JWT_PUBLIC_KEY, JWT_COOKIE_NAME, JWT_AUDIENCES
+
+class TestSetupSso(unittest.TestCase):
+
+  @patch("ambari_server.setupSso.is_root")
+  def test_non_root_user_should_not_be_able_to_setup_sso(self, is_root_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = False
+    options = self._create_empty_options_mock()
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with non-fatal exception")
+    except FatalException as e:
+      self.assertTrue("ambari-server setup-sso should be run with root-level privileges" in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_silent_mode_is_not_allowed(self, is_root_mock, get_silent_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = True
+    options = self._create_empty_options_mock()
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with fatal exception")
+    except NonFatalException as e:
+      self.assertTrue("setup-sso is not enabled in silent mode." in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_invalid_sso_enabled_cli_option_should_result_in_error(self, is_root_mock, get_silent_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = False
+    options = self._create_empty_options_mock()
+    options.sso_enabled = 'not_true_or_false'
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with fatal exception")
+    except FatalException as e:
+      self.assertTrue("--sso-enabled should be to either 'true' or 'false'" in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_missing_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, get_silent_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = False
+    options = self._create_empty_options_mock()
+    options.sso_enabled = 'true'
+    options.sso_provider_url = ''
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with fatal exception")
+    except FatalException as e:
+      self.assertTrue("Missing option: --sso-provider-url" in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_missing_sso_public_cert_file_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, get_silent_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = False
+    options = self._create_empty_options_mock()
+    options.sso_enabled = 'true'
+    options.sso_public_cert_file = ''
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with fatal exception")
+    except FatalException as e:
+      self.assertTrue("Missing option: --sso-public-cert-file" in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_invalid_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, get_silent_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = False
+    options = self._create_empty_options_mock()
+    options.sso_enabled = 'true'
+    options.sso_provider_url = '!invalidHost:invalidPort'
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with fatal exception")
+    except FatalException as e:
+      self.assertTrue("Invalid --sso-provider-url" in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.update_properties")
+  @patch("ambari_server.setupSso.get_ambari_properties")
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_all_cli_options_are_collected_when_enabling_sso(self, is_root_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = False
+
+    properties = Properties();
+    get_ambari_properties_mock.return_value = properties
+
+    sso_enabled = 'true'
+    sso_provider_url = 'http://testHost:8080'
+    sso_public_cert_file = '/test/file/path'
+    sso_jwt_cookie_name = 'test_cookie'
+    sso_jwt_audience_list = 'test, audience, list'
+    options = self._create_empty_options_mock()
+    options.sso_enabled = sso_enabled
+    options.sso_provider_url = sso_provider_url
+    options.sso_public_cert_file = sso_public_cert_file
+    options.sso_jwt_cookie_name = sso_jwt_cookie_name
+    options.sso_jwt_audience_list = sso_jwt_audience_list
+
+    setup_sso(options)
+
+    self.assertTrue(update_properties_mock.called)
+    self.assertEqual(properties.get_property(JWT_AUTH_ENBABLED), sso_enabled)
+    self.assertEqual(properties.get_property(JWT_AUTH_PROVIDER_URL), sso_provider_url)
+    self.assertEqual(properties.get_property(JWT_PUBLIC_KEY), sso_public_cert_file)
+    self.assertEqual(properties.get_property(JWT_COOKIE_NAME), sso_jwt_cookie_name)
+    self.assertEqual(properties.get_property(JWT_AUDIENCES), sso_jwt_audience_list)
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+
+  @patch("ambari_server.setupSso.update_properties")
+  @patch("ambari_server.setupSso.get_ambari_properties")
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_root")
+  def test_only_sso_enabled_cli_option_is_collected_when_disabling_sso(self, is_root_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    get_silent_mock.return_value = False
+
+    properties = Properties();
+    get_ambari_properties_mock.return_value = properties
+
+    sso_enabled = 'false'
+    sso_provider_url = 'http://testHost:8080'
+    sso_public_cert_file = '/test/file/path'
+    sso_jwt_cookie_name = 'test_cookie'
+    sso_jwt_audience_list = 'test, audience, list'
+    options = self._create_empty_options_mock()
+    options.sso_enabled = sso_enabled
+    options.sso_provider_url = sso_provider_url
+    options.sso_public_cert_file = sso_public_cert_file
+    options.sso_jwt_cookie_name = sso_jwt_cookie_name
+    options.sso_jwt_audience_list = sso_jwt_audience_list
+
+    setup_sso(options)
+
+    self.assertTrue(update_properties_mock.called)
+    self.assertEqual(properties.get_property(JWT_AUTH_ENBABLED), sso_enabled)
+    self.assertTrue(JWT_AUTH_PROVIDER_URL not in properties.propertyNames())
+    self.assertTrue(JWT_PUBLIC_KEY not in properties.propertyNames())
+    self.assertTrue(JWT_COOKIE_NAME not in properties.propertyNames())
+    self.assertTrue(JWT_AUDIENCES not in properties.propertyNames())
+
+
+    sys.stdout = sys.__stdout__
+    pass
+
+  def _create_empty_options_mock(self):
+    options = MagicMock()
+    options.sso_enabled = None
+    options.sso_provider_url = None
+    options.sso_public_cert_file = None
+    options.sso_jwt_cookie_name = None
+    options.sso__jwt_audience_list = None
+    return options
+    


### PR DESCRIPTION
## What changes were proposed in this pull request?

To enable or disable SSO using the Ambari CLI, the user needs to answer each prompt. This is not convenient for automated tools. So that we introduced new CLI options for each question to allow scripts to specify inputs without answering those questions. If any of the options is not specified via the command line, the user is prompted for a value.

## How was this patch tested?

Created a new Python test class and covered the use cases described in the JIRA (it was necessary because there was no unit tests at all for `setup-sso`):

```
test_all_cli_options_are_collected_when_enabling_sso (TestSetupSso.TestSetupSso) ... ok
test_invalid_sso_enabled_cli_option_should_result_in_error (TestSetupSso.TestSetupSso) ... ok
test_invalid_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error (TestSetupSso.TestSetupSso) ... ok
test_missing_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error (TestSetupSso.TestSetupSso) ... ok
test_missing_sso_public_cert_file_cli_option_when_enabling_sso_should_result_in_error (TestSetupSso.TestSetupSso) ... ok
test_non_root_user_should_not_be_able_to_setup_sso (TestSetupSso.TestSetupSso) ... ok
test_only_sso_enabled_cli_option_is_collected_when_disabling_sso (TestSetupSso.TestSetupSso) ... ok
test_silent_mode_is_not_allowed (TestSetupSso.TestSetupSso) ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.005s

OK
----------------------------------------------------------------------
Total run:8
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 42.564 s
[INFO] Finished at: 2018-03-15T00:34:42+01:00
[INFO] Final Memory: 128M/1613M
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing I executed integration testing as well (after I overwrote the relevant files in my test environment):

```
[root@c7401 ~]# ambari-server setup-sso --sso-enabled=test
Using python  /usr/bin/python
Setting up SSO authentication properties...
ERROR: Exiting with exit code 1. 
REASON: The following errors occurred while processing your request: ["--sso-enabled should be to either 'true' or 'false'"]

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=true
Using python  /usr/bin/python
Setting up SSO authentication properties...
ERROR: Exiting with exit code 1. 
REASON: The following errors occurred while processing your request: ['Missing option: --sso-provider-url', 'Missing option: --sso-public-cert-file']

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=true --sso-provider-url=notAValidHostAndPort
Using python  /usr/bin/python
Setting up SSO authentication properties...
ERROR: Exiting with exit code 1. 
REASON: The following errors occurred while processing your request: ['Missing option: --sso-public-cert-file', 'Invalid --sso-provider-url']

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=true --sso-provider-url=https://knox.ambari.apache.org:8443 --sso-public-cert-file=/tmp/sso.pem
Using python  /usr/bin/python
Setting up SSO authentication properties...
JWT Cookie name (hadoop-jwt):
JWT audiences list (comma-separated), empty for any ():
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# cat /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=
authentication.jwt.cookieName=hadoop-jwt
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=true --sso-provider-url=https://knox.ambari.apache.org:8443 --sso-public-cert-file=/tmp/sso.pem --sso-jwt-cookie-name=ambari-jtw
Using python  /usr/bin/python
Setting up SSO authentication properties...
JWT audiences list (comma-separated), empty for any ():
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# cat /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=true --sso-provider-url=https://knox.ambari.apache.org:8443 --sso-public-cert-file=/tmp/sso.pem --sso-jwt-cookie-name=ambari-jtw --sso-jwt-audience-list=ambari
Using python  /usr/bin/python
Setting up SSO authentication properties...
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# cat /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=false
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem

[root@c7401 ~]# ambari-server setup-sso --sso-provider-url=https://knox.ambari.apache.org:8443 --sso-public-cert-file=/tmp/sso.pem --sso-jwt-cookie-name=ambari-jtw --sso-jwt-audience-list=ambari
Using python  /usr/bin/python
Setting up SSO authentication properties...
Do you want to disable SSO authentication [y/n] (n)?y
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# cat /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=false
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=false
Using python  /usr/bin/python
Setting up SSO authentication properties...
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# cat /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=false
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem

[root@c7401 ~]# ambari-server setup-sso
Using python  /usr/bin/python
Setting up SSO authentication properties...
Do you want to configure SSO authentication [y/n] (y)?y
Provider URL [URL] (https://knox.ambari.apache.org:8443):
Public Certificate pem (stored) (empty line to finish input):

JWT Cookie name (ambari-jtw):
JWT audiences list (comma-separated), empty for any (ambari):
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# cat /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem
```
