### PR TITLE
AMBARI-23206 - Use Agent Command Response To Update Mpack Install State

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py
@@ -148,6 +148,16 @@ class CommandRepository(object):
        for repo_def in repos_def:
          self.items.append(CommandRepositoryItem(self, repo_def))
 
+  def __str__(self):
+    inner = []
+    if self.mpack_id:
+      inner.append("mpack_id: %s" % str(self.mpack_id))
+    elif self.mpack_name:
+      inner.append("mpack_name: %s" % str(self.mpack_name))
+    elif self.version_string:
+      inner.append("mpack_version: %s" % str(self.version_string))
+    return "CommandRepository{%s}" % ", ".join(inner)
+
 
 class CommandRepositoryItem(object):
   """

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -210,6 +210,25 @@ class Script(object):
       return os.path.realpath(config_path)
     return None
 
+
+  def save_mpack_to_structured_out(self, command_name):
+    """
+    Writes out information about the managment pack which was installed if this is an installation command.
+    :param command_name: command name
+    :return: None
+    """
+    is_install_command = command_name is not None and command_name.lower() == "install"
+    if not is_install_command:
+      return
+
+    command_repository = CommandRepository(self.get_config()['repositoryFile'])
+
+    Logger.info("Reporting installation state for {0}".format(command_repository))
+
+    self.put_structured_out({"mpackId": command_repository.mpack_id})
+    self.put_structured_out({"mpackName":command_repository.mpack_id})
+
+
   def save_component_version_to_structured_out(self, command_name):
     """
     Saves the version of the component for this command to the structured out file. If the
@@ -224,51 +243,16 @@ class Script(object):
     :param command_name: command name
     :return: None
     """
-    from resource_management.libraries.functions.default import default
     from resource_management.libraries.functions import stack_select
-
-    repository_resolved = default("repositoryFile/resolved", False)
-    repository_version = default("repositoryFile/repoVersion", None)
-    is_install_command = command_name is not None and command_name.lower() == "install"
-
-    # start out with no version
-    component_version = None
-
-    # install command + trusted repo means use the repo version and don't consult stack-select
-    # this is needed in cases where an existing symlink is on the system and stack-select can't
-    # change it on installation (because it's scared to in order to support parallel installs)
-    if is_install_command and repository_resolved and repository_version is not None:
-      Logger.info("The repository with version {0} for this command has been marked as resolved."\
-        " It will be used to report the version of the component which was installed".format(repository_version))
-
-      component_version = repository_version
 
     stack_name = Script.get_stack_name()
     stack_select_package_name = stack_select.get_package_name()
 
     if stack_select_package_name and stack_name:
-      # only query for the component version from stack-select if we can't trust the repository yet
-      if component_version is None:
-        component_version = version_select_util.get_component_version_from_symlink(stack_name, stack_select_package_name)
-
-      # last ditch effort - should cover the edge case where the package failed to setup its
-      # link and we have to try to see if <stack-select> can help
-      if component_version is None:
-        output, code, versions = stack_select.unsafe_get_stack_versions()
-        if len(versions) == 1:
-          component_version = versions[0]
-          Logger.error("The '{0}' component did not advertise a version. This may indicate a problem with the component packaging. " \
-                         "However, the stack-select tool was able to report a single version installed ({1}). " \
-                         "This is the version that will be reported.".format(stack_select_package_name, component_version))
+      component_version = version_select_util.get_component_version_from_symlink(stack_name, stack_select_package_name)
 
       if component_version:
         self.put_structured_out({"version": component_version})
-
-        # if repository_version_id is passed, pass it back with the version
-        from resource_management.libraries.functions.default import default
-        repo_version_id = default("/hostLevelParams/repository_version_id", None)
-        if repo_version_id:
-          self.put_structured_out({"repository_version_id": repo_version_id})
       else:
         if not self.is_hook():
           Logger.error("The '{0}' component did not advertise a version. This may indicate a problem with the component packaging.".format(stack_select_package_name))
@@ -384,6 +368,8 @@ class Script(object):
       ex.pre_raise()
       raise
     finally:
+      self.save_mpack_to_structured_out(self.command_name)
+
       if self.should_expose_component_version(self.command_name):
         self.save_component_version_to_structured_out(self.command_name)
 
@@ -1018,8 +1004,8 @@ class Script(object):
         else:
           self.post_rolling_restart(env)
 
-    if self.should_expose_component_version("restart"):
-      self.save_component_version_to_structured_out("restart")
+    if self.should_expose_component_version(self.command_name):
+      self.save_component_version_to_structured_out(self.command_name)
 
 
   # TODO, remove after all services have switched to post_upgrade_restart

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -226,7 +226,8 @@ class Script(object):
     Logger.info("Reporting installation state for {0}".format(command_repository))
 
     self.put_structured_out({"mpackId": command_repository.mpack_id})
-    self.put_structured_out({"mpackName":command_repository.mpack_id})
+    self.put_structured_out({"mpackName":command_repository.mpack_name})
+    self.put_structured_out({"mpackVersion":command_repository.version_string})
 
 
   def save_component_version_to_structured_out(self, command_name):

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
@@ -247,17 +247,20 @@ public class ExecutionCommandWrapper {
         executionCommand.setUpgradeSummary(upgradeSummary);
       }
 
+      ServiceGroupEntity serviceGroupEntity = serviceGroupDAO.find(clusterId,
+          executionCommand.getServiceGroupName());
+
+      long mpackId = serviceGroupEntity.getStack().getMpackId();
+      Mpack mpack = ambariMetaInfo.getMpack(mpackId);
+      MpackEntity mpackEntity = mpackDAO.findById(mpackId);
+
+      executionCommand.setMpackId(mpackId);
+
       // setting repositoryFile
       final Host host = cluster.getHost(executionCommand.getHostname());  // can be null on internal commands
 
       if (null == executionCommand.getRepositoryFile() && null != host) {
         final CommandRepository commandRepository;
-
-        ServiceGroupEntity serviceGroupEntity = serviceGroupDAO.find(clusterId, executionCommand.getServiceGroupName());
-        long mpackId = serviceGroupEntity.getStack().getMpackId();
-        Mpack mpack = ambariMetaInfo.getMpack(mpackId);
-        MpackEntity mpackEntity = mpackDAO.findById(mpackId);
-
         RepoOsEntity osEntity = repoVersionHelper.getOSEntityForHost(mpackEntity, host);
         commandRepository = repoVersionHelper.getCommandRepository(mpack, osEntity);
         executionCommand.setRepositoryFile(commandRepository);

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandReport.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandReport.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import com.google.common.base.Objects;
 
 public class CommandReport {
 
@@ -37,6 +38,7 @@ public class CommandReport {
   private String roleCommand;
   private String customCommand;
   private Map<String, Map<String, String>> configurationTags;
+  private Long mpackId;
 
   @JsonProperty("customCommand")
   public String getCustomCommand() {
@@ -52,57 +54,57 @@ public class CommandReport {
   public long getTaskId() {
     return taskId;
   }
-  
+
   @JsonProperty("taskId")
   public void setTaskId(long taskId) {
     this.taskId = taskId;
   }
-  
+
   @JsonProperty("clusterName")
   public void setClusterName(String clusterName) {
     this.clusterName = clusterName;
   }
-  
+
   @JsonProperty("clusterName")
   public String getClusterName() {
-    return this.clusterName;
+    return clusterName;
   }
 
   @JsonProperty("actionId")
   public String getActionId() {
-    return this.actionId;
+    return actionId;
   }
-  
+
   @JsonProperty("actionId")
   public void setActionId(String actionId) {
     this.actionId = actionId;
   }
-  
+
   @JsonProperty("stderr")
   public String getStdErr() {
-    return this.stderr;
+    return stderr;
   }
-  
+
   @JsonProperty("stderr")
   public void setStdErr(String stderr) {
     this.stderr = stderr;
   }
-  
+
   @JsonProperty("exitcode")
   public int getExitCode() {
-    return this.exitCode;
+    return exitCode;
   }
-  
+
   @JsonProperty("exitcode")
   public void setExitCode(int exitCode) {
     this.exitCode = exitCode;
   }
-  
+
   @JsonProperty("stdout")
   public String getStdOut() {
-    return this.stdout;
+    return stdout;
   }
-  
+
   @JsonProperty("stdout")
   public void setStdOut(String stdout) {
     this.stdout = stdout;
@@ -110,7 +112,7 @@ public class CommandReport {
 
   @JsonProperty("structuredOut")
   public String getStructuredOut() {
-    return this.structuredOut;
+    return structuredOut;
   }
 
 
@@ -121,7 +123,7 @@ public class CommandReport {
 
   @JsonProperty("roleCommand")
   public String getRoleCommand() {
-    return this.roleCommand;
+    return roleCommand;
   }
 
   @JsonProperty("roleCommand")
@@ -133,27 +135,27 @@ public class CommandReport {
   public String getRole() {
     return role;
   }
-  
+
   @JsonProperty("role")
   public void setRole(String role) {
     this.role = role;
   }
-  
+
   @JsonProperty("status")
   public String getStatus() {
     return status;
   }
-  
+
   @JsonProperty("status")
   public void setStatus(String status) {
     this.status = status;
   }
-  
+
   @JsonProperty("serviceName")
   public String getServiceName() {
     return serviceName;
   }
-  
+
   @JsonProperty("serviceName")
   public void setServiceName(String serviceName) {
     this.serviceName = serviceName;
@@ -166,7 +168,7 @@ public class CommandReport {
   public void setConfigurationTags(Map<String, Map<String,String>> tags) {
     configurationTags = tags;
   }
-  
+
   /**
    * @return the config tags that match this command, or <code>null</code>
    * if none are present
@@ -176,19 +178,45 @@ public class CommandReport {
     return configurationTags;
   }
 
+  /**
+   * Gets the management pack ID associated with this command report, or
+   * {@code null} for none.
+   *
+   * @return the mpackId the ID of the management pack, or {@code null} for
+   *         none.
+   */
+  @JsonProperty("mpackId")
+  public Long getMpackId() {
+    return mpackId;
+  }
+
+  /**
+   * Sets the management pack ID associated with this command report.
+   *
+   * @param mpackId
+   *          the mpackId to set
+   */
+  @JsonProperty("mpackId")
+  public void setMpackId(Long mpackId) {
+    this.mpackId = mpackId;
+  }
+
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public String toString() {
-    return "CommandReport{" +
-            "role='" + role + '\'' +
-            ", actionId='" + actionId + '\'' +
-            ", status='" + status + '\'' +
-            ", exitCode=" + exitCode +
-            ", clusterName='" + clusterName + '\'' +
-            ", serviceName='" + serviceName + '\'' +
-            ", taskId=" + taskId +
-            ", roleCommand=" + roleCommand +
-            ", configurationTags=" + configurationTags +
-            ", customCommand=" + customCommand +
-            '}';
+    return Objects.toStringHelper(this).add("role", role)
+        .add("actionId", actionId)
+        .add("status", status)
+        .add("exitCode", exitCode)
+        .add("clusterName", clusterName)
+        .add("serviceName", serviceName)
+        .add("mpackId", mpackId)
+        .add("taskId", taskId)
+        .add("roleCommand", roleCommand)
+        .add("configurationTags", configurationTags)
+        .add("customCommand", customCommand).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandRepository.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandRepository.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.ambari.annotations.Experimental;
-import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.orm.entities.RepoDefinitionEntity;
 import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.stack.RepoTag;
@@ -63,13 +61,6 @@ public class CommandRepository {
   public CommandRepositoryFeature getFeature(){
     return feature;
   }
-
-  /**
-   * {@code true} if Ambari believes that this repository has reported back it's
-   * version after distribution.
-   */
-  @SerializedName("resolved")
-  private final boolean m_resolved = true;
 
   /**
    * @param id
@@ -145,42 +136,6 @@ public class CommandRepository {
       repo.m_mirrorsList = null;
       repo.m_ambariManaged = false;
     }
-  }
-
-  /**
-   * Gets whether this repository has been marked as having its version
-   * resolved.
-   *
-   * @return {@code true} if this repository has been confirmed to have the
-   *         right version.
-   */
-  public boolean isResolved() {
-    return m_resolved;
-  }
-
-  /**
-   * Update repository id to be consistent with old format
-   *
-   * @param repoVersion
-   */
-  @Deprecated
-  @Experimental(feature= ExperimentalFeature.PATCH_UPGRADES)
-  public void setLegacyRepoId(String repoVersion){
-    for (Repository repo : m_repositories) {
-      repo.m_repoId = String.format("%s-%s", repo.getRepoName(), repoVersion);
-    }
-  }
-
-  /**
-   * Sets filename for the repo
-   *
-   * @param stackName  name of the stack
-   * @param repoVersion repository version
-   */
-  @Deprecated
-  @Experimental(feature= ExperimentalFeature.PATCH_UPGRADES)
-  public void setLegacyRepoFileName(String stackName, String repoVersion) {
-    m_repoFileName = String.format("%s-%s", stackName, repoVersion);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
@@ -170,6 +170,12 @@ public class ExecutionCommand extends AgentCommand {
   @SerializedName("roleParameters")
   private Map<String, Object> roleParameters;
 
+  /**
+   * If set, the management pack associated with this command.
+   */
+  @SerializedName("mpackId")
+  private Long mpackId;
+
   public void setConfigurationCredentials(Map<String, Map<String, String>> configurationCredentials) {
     this.configurationCredentials = configurationCredentials;
   }
@@ -596,5 +602,26 @@ public class ExecutionCommand extends AgentCommand {
    */
   public UpgradeSummary getUpgradeSummary() {
     return upgradeSummary;
+  }
+
+  /**
+   * Gets the ID of the management pack associated with this command, or
+   * {@code null} if none.
+   *
+   * @return the mpackId the ID of the mpack or {@code null}.
+   */
+  public Long getMpackId() {
+    return mpackId;
+  }
+
+  /**
+   * Sets the ID of the management pack associated with this command, or
+   * {@code null} if none.
+   *
+   * @param mpackId
+   *          the mpackId to set
+   */
+  public void setMpackId(Long mpackId) {
+    this.mpackId = mpackId;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatProcessor.java
@@ -43,12 +43,12 @@ import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.ExecutionCommand.KeyNames;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.MaintenanceStateHelper;
-import org.apache.ambari.server.events.ActionFinalReportReceivedEvent;
 import org.apache.ambari.server.events.AlertEvent;
 import org.apache.ambari.server.events.AlertReceivedEvent;
+import org.apache.ambari.server.events.CommandReportReceivedEvent;
 import org.apache.ambari.server.events.HostComponentVersionAdvertisedEvent;
 import org.apache.ambari.server.events.publishers.AlertEventPublisher;
-import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.events.publishers.CommandReportEventPublisher;
 import org.apache.ambari.server.events.publishers.VersionEventPublisher;
 import org.apache.ambari.server.metadata.ActionMetadata;
 import org.apache.ambari.server.orm.dao.KerberosKeytabDAO;
@@ -117,7 +117,7 @@ public class HeartbeatProcessor extends AbstractService{
   AlertEventPublisher alertEventPublisher;
 
   @Inject
-  AmbariEventPublisher ambariEventPublisher;
+  CommandReportEventPublisher commandReportEventPublisher;
 
   @Inject
   VersionEventPublisher versionEventPublisher;
@@ -392,11 +392,11 @@ public class HeartbeatProcessor extends AbstractService{
       }
 
       // Send event for final command reports for actions
-      if (RoleCommand.valueOf(report.getRoleCommand()) == RoleCommand.ACTIONEXECUTE &&
-          HostRoleStatus.valueOf(report.getStatus()).isCompletedState()) {
-        ActionFinalReportReceivedEvent event = new ActionFinalReportReceivedEvent(
-            clusterId, hostname, report, false);
-        ambariEventPublisher.publish(event);
+      if (HostRoleStatus.valueOf(report.getStatus()).isCompletedState()) {
+        CommandReportReceivedEvent event = new CommandReportReceivedEvent(
+            clusterId, hostname, report);
+
+        commandReportEventPublisher.publish(event);
       }
 
       // Fetch HostRoleCommand that corresponds to a given task ID

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
@@ -30,7 +30,6 @@ import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.RequestResourceFilter;
 import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
-import org.apache.ambari.server.state.Mpack;
 
 /**
  * The context required to create tasks and stages for a custom action
@@ -49,8 +48,6 @@ public class ActionExecutionContext {
   private boolean hostsInMaintenanceModeExcluded = true;
   private boolean allowRetry = false;
   private RepositoryVersionEntity repositoryVersion;
-  private Mpack mpack = null;
-
   private List<ExecutionCommandVisitor> m_visitors = new ArrayList<>();
 
   /**
@@ -212,24 +209,6 @@ public class ActionExecutionContext {
   @Experimental(feature = ExperimentalFeature.REPO_VERSION_REMOVAL)
   public void setRepositoryVersion(RepositoryVersionEntity repositoryVersion) {
     this.repositoryVersion = repositoryVersion;
-  }
-
-  /**
-   * Sets the management pack for this command. This can be used to version and
-   * stack information.
-   *
-   * @param mpack
-   */
-  public void setMpack(Mpack mpack) {
-    this.mpack = mpack;
-  }
-
-  /**
-   * Gets the management pack associated with this command. This can be used for
-   * version and stack information.
-   */
-  public Mpack getMpack() {
-    return mpack;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariEvent.java
@@ -109,11 +109,6 @@ public abstract class AmbariEvent {
     MAINTENANCE_MODE,
 
     /**
-     * Received a final command report for some action
-     */
-    ACTION_EXECUTION_FINISHED,
-
-    /**
      * Sent when request finishes
      */
     REQUEST_FINISHED,

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/CommandReportReceivedEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/CommandReportReceivedEvent.java
@@ -19,18 +19,18 @@ package org.apache.ambari.server.events;
 
 import org.apache.ambari.server.agent.CommandReport;
 
+import com.google.common.base.Objects;
+
 /**
- * The {@link ActionFinalReportReceivedEvent} is fired when a
- * command report action is received. Event is fired only if command state
- * is COMPLETED/FAILED/ABORTED.
+ * The {@link CommandReportReceivedEvent} is fired when a command report is
+ * received. Event is fired only if command state is COMPLETED/FAILED/ABORTED.
  */
-public final class ActionFinalReportReceivedEvent extends AmbariEvent {
+public final class CommandReportReceivedEvent {
 
   private Long clusterId;
   private String hostname;
   private CommandReport commandReport;
   private String role;
-  private Boolean emulated;
 
   /**
    * Constructor.
@@ -38,24 +38,17 @@ public final class ActionFinalReportReceivedEvent extends AmbariEvent {
    * @param clusterId (beware, may be null if action is not bound to cluster)
    * @param hostname host that is an origin for a command report
    * @param report full command report (may be null if action has been cancelled)
-   * @param emulated true, if event was generated without actually receiving
-   * data from agent (e.g. if we did not perform action, or action timed out,
-   * but we want to trigger event listener anyway). More loose checks against
-   * data will be performed in this case.
    */
-  public ActionFinalReportReceivedEvent(Long clusterId, String hostname,
-                                        CommandReport report,
-                                        Boolean emulated) {
-    super(AmbariEventType.ACTION_EXECUTION_FINISHED);
+  public CommandReportReceivedEvent(Long clusterId, String hostname,
+      CommandReport report) {
     this.clusterId = clusterId;
     this.hostname = hostname;
-    this.commandReport = report;
+    commandReport = report;
     if (report.getRole() != null) {
-      this.role = report.getRole();
+      role = report.getRole();
     } else {
-      this.role = null;
+      role = null;
     }
-    this.emulated = emulated;
   }
 
   public Long getClusterId() {
@@ -74,17 +67,11 @@ public final class ActionFinalReportReceivedEvent extends AmbariEvent {
     return role;
   }
 
-  public Boolean isEmulated() {
-    return emulated;
-  }
-
   @Override
   public String toString() {
-    return "ActionFinalReportReceivedEvent{" +
-            "clusterId=" + clusterId +
-            ", hostname='" + hostname + '\'' +
-            ", commandReportStatus=" + commandReport.getStatus() +
-            ", commandReportRole=" + role +
-            '}';
+    return Objects.toStringHelper(this).add("clusterId", clusterId)
+        .add("hostname", hostname)
+        .add("status", commandReport.getStatus())
+        .add("role", role).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/MpackInstallStateListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/MpackInstallStateListener.java
@@ -20,12 +20,19 @@ package org.apache.ambari.server.events.listeners.upgrade;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 
+import javax.annotation.Nullable;
+
 import org.apache.ambari.server.EagerSingleton;
+import org.apache.ambari.server.Role;
+import org.apache.ambari.server.RoleCommand;
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
+import org.apache.ambari.server.agent.CommandReport;
+import org.apache.ambari.server.events.CommandReportReceivedEvent;
 import org.apache.ambari.server.events.HostsAddedEvent;
 import org.apache.ambari.server.events.HostsRemovedEvent;
 import org.apache.ambari.server.events.MpackRegisteredEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
-import org.apache.ambari.server.logging.LockFactory;
+import org.apache.ambari.server.events.publishers.CommandReportEventPublisher;
 import org.apache.ambari.server.orm.dao.HostDAO;
 import org.apache.ambari.server.orm.dao.MpackDAO;
 import org.apache.ambari.server.orm.dao.MpackHostStateDAO;
@@ -33,11 +40,15 @@ import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.MpackEntity;
 import org.apache.ambari.server.orm.entities.MpackHostStateEntity;
 import org.apache.ambari.server.state.MpackInstallState;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.Striped;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -58,13 +69,19 @@ public class MpackInstallStateListener {
   private static final Logger LOG = LoggerFactory.getLogger(MpackInstallStateListener.class);
 
   @Inject
-  private Provider<HostDAO> m_hostDAO;
+  private Provider<HostDAO> m_hostDAOProvider;
 
   @Inject
-  private Provider<MpackHostStateDAO> m_mpackHostStateDAO;
+  private Provider<MpackHostStateDAO> m_mpackHostStateDAOProvider;
 
   @Inject
   private Provider<MpackDAO> m_mpackDAOProvider;
+
+  /**
+   * For deserializing installation command structured output.
+   */
+  @Inject
+  private Gson m_gson;
 
   /**
    * Used for ensuring that the concurrent nature of the event handler methods
@@ -80,8 +97,10 @@ public class MpackInstallStateListener {
    * @param lockFactory
    */
   @Inject
-  public MpackInstallStateListener(AmbariEventPublisher ambariEventPublisher, LockFactory lockFactory) {
+  public MpackInstallStateListener(AmbariEventPublisher ambariEventPublisher,
+      CommandReportEventPublisher commandReportEventPublisher) {
     ambariEventPublisher.register(this);
+    commandReportEventPublisher.register(this);
   }
 
   /**
@@ -93,28 +112,24 @@ public class MpackInstallStateListener {
    * orphans.
    */
   @Subscribe
-  @Transactional
   public void onHostEvent(HostsAddedEvent event) {
     if (LOG.isDebugEnabled()) {
       LOG.debug(event.toString());
     }
 
-    HostDAO hostDAO = m_hostDAO.get();
-    MpackHostStateDAO mpackHostStateDAO = m_mpackHostStateDAO.get();
+    HostDAO hostDAO = m_hostDAOProvider.get();
+    MpackHostStateDAO mpackHostStateDAO = m_mpackHostStateDAOProvider.get();
     List<MpackEntity> mpackEntities = m_mpackDAOProvider.get().findAll();
 
     for (String hostName : event.getHostNames()) {
       Lock lock = m_locksByHost.get(hostName);
       lock.lock();
       try {
-        // find and remove and mpack install states for the host being added
-        List<MpackHostStateEntity> mpackHostStates = mpackHostStateDAO.findByHost(hostName);
-        for( MpackHostStateEntity mpackHostState : mpackHostStates ) {
-          mpackHostStateDAO.remove(mpackHostState);
-        }
+        HostEntity hostEntity = hostDAO.findByName(hostName);
+        hostEntity.getMpackInstallStates().clear();
+        hostEntity = hostDAO.merge(hostEntity);
 
         // add a host state for every mpack
-        HostEntity hostEntity = hostDAO.findByName(hostName);
         for (MpackEntity mpackEntity : mpackEntities) {
           MpackHostStateEntity mpackHostStateEntity = new MpackHostStateEntity(mpackEntity,
               hostEntity, MpackInstallState.NOT_INSTALLED);
@@ -124,6 +139,8 @@ public class MpackInstallStateListener {
           hostEntity.getMpackInstallStates().add(mpackHostStateEntity);
           hostEntity = hostDAO.merge(hostEntity);
         }
+      } catch (Throwable throwable) {
+        LOG.error(throwable.getMessage(), throwable);
       } finally {
         lock.unlock();
       }
@@ -141,8 +158,8 @@ public class MpackInstallStateListener {
       LOG.debug(event.toString());
     }
 
-    HostDAO hostDAO = m_hostDAO.get();
-    MpackHostStateDAO mpackHostStateDAO = m_mpackHostStateDAO.get();
+    HostDAO hostDAO = m_hostDAOProvider.get();
+    MpackHostStateDAO mpackHostStateDAO = m_mpackHostStateDAOProvider.get();
 
     List<HostEntity> hosts = hostDAO.findAll();
     MpackEntity mpackEntity = m_mpackDAOProvider.get().findById(event.getMpackIdId());
@@ -159,10 +176,150 @@ public class MpackInstallStateListener {
 
         hostEntity.getMpackInstallStates().add(mpackHostStateEntity);
         hostEntity = hostDAO.merge(hostEntity);
-        }
+      } catch (Throwable throwable) {
+        LOG.error(throwable.getMessage(), throwable);
+      }
       finally {
         lock.unlock();
       }
     }
+  }
+
+  /**
+   * Handles the {@link CommandReportReceivedEvent} which is sent when a
+   * command finishes. This will determine if the command was an installation
+   * command and then update the appropriate mpack install states.
+   *
+   * @param event
+   */
+  @Subscribe
+  public void onCommandFinished(CommandReportReceivedEvent event) {
+    CommandReport commandReport = event.getCommandReport();
+    if (null == commandReport) {
+      LOG.error(
+          "There is no command report for {} on {}. The management pack installation state cannot be updated.",
+          event.getRole(), event.getHostname());
+      return;
+    }
+
+    String hostName = event.getHostname();
+    if (StringUtils.isEmpty(hostName)) {
+      LOG.error("The installation command does not contain a host name");
+      return;
+    }
+
+    // determine if this is an installation command of some type
+    String role = event.getRole();
+    String roleCommand = commandReport.getRoleCommand();
+
+    if (!StringUtils.equals(role, Role.INSTALL_PACKAGES.name())
+        && !StringUtils.equals(roleCommand, RoleCommand.INSTALL.name())) {
+      return;
+    }
+
+    LOG.debug("Received event {}", event);
+
+    MpackHostStateDAO mpackHostStateDAO = m_mpackHostStateDAOProvider.get();
+
+    // start out with FAILED
+    MpackInstallState mpackInstallState = MpackInstallState.INSTALL_FAILED;
+
+    @Nullable
+    InstallCommandStructuredOutput structuredOutput = null;
+
+    @Nullable
+    Long mpackId = null;
+
+    try {
+      // try to parse the structured output of the install command
+      structuredOutput = m_gson.fromJson(commandReport.getStructuredOut(),
+          InstallCommandStructuredOutput.class);
+    } catch (JsonSyntaxException jsonException) {
+      LOG.error(
+          "Unable to parse the installation structured output for command {} for {} on host {}",
+          commandReport.getTaskId(), event.getRole(), hostName, jsonException);
+    }
+
+    if (null == structuredOutput || null == structuredOutput.mpackId) {
+      LOG.error("The structured output for command {} for {} on {} did not contain an mpack ID",
+          commandReport.getTaskId(), event.getRole(), hostName);
+    } else {
+      mpackId = structuredOutput.mpackId;
+    }
+
+    if (!StringUtils.equals(HostRoleStatus.COMPLETED.name(), commandReport.getStatus())) {
+      LOG.warn(
+          "Command {} for {} did not complete on {}. The management pack installation state will be updated to {}.",
+          commandReport.getTaskId(), event.getRole(), hostName, mpackInstallState);
+    } else {
+      mpackInstallState = MpackInstallState.INSTALLED;
+    }
+
+    Lock lock = m_locksByHost.get(hostName);
+    lock.lock();
+    try {
+      // if no mpack ID, then find all INSTALLING and set them to failed
+      if (null == mpackId) {
+        List<MpackHostStateEntity> mpackHostStateEntities = mpackHostStateDAO.findByHostAndInstallState(
+            hostName, MpackInstallState.INSTALLING);
+
+        for (MpackHostStateEntity mpackHostStateEntity : mpackHostStateEntities) {
+          mpackHostStateEntity.setState(MpackInstallState.INSTALL_FAILED);
+          mpackHostStateDAO.merge(mpackHostStateEntity);
+        }
+      } else {
+        // find the mpack for the host and update the state
+        MpackHostStateEntity mpackHostStateEntity = mpackHostStateDAO.findByMpackAndHost(
+            mpackId, hostName);
+
+        // an odd case, but we'll plan for it
+        if( null == mpackHostStateEntity ) {
+          HostDAO hostDAO = m_hostDAOProvider.get();
+          MpackDAO mpackDAO = m_mpackDAOProvider.get();
+
+          MpackEntity mpackEntity = mpackDAO.findById(mpackId);
+          HostEntity hostEntity = hostDAO.findByName(hostName);
+
+          mpackHostStateEntity = new MpackHostStateEntity(mpackEntity, hostEntity, mpackInstallState);
+          mpackHostStateDAO.create(mpackHostStateEntity);
+
+          hostEntity.getMpackInstallStates().add(mpackHostStateEntity);
+          hostEntity = hostDAO.merge(hostEntity);
+        } else {
+          // don't set it if it's already marked as installed
+          if (mpackHostStateEntity.getState() != MpackInstallState.INSTALLED) {
+            mpackHostStateEntity.setState(mpackInstallState);
+            mpackHostStateEntity = mpackHostStateDAO.merge(mpackHostStateEntity);
+          }
+        }
+      }
+    } catch (Throwable throwable) {
+      LOG.error(throwable.getMessage(), throwable);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Used only to parse the structured output when installing mpacks.
+   */
+  private static class InstallCommandStructuredOutput {
+    /**
+     * Either SUCCESS or FAIL
+     */
+    @SerializedName("package_installation_result")
+    private String packageInstallationResult;
+
+    /**
+     * The actual version returned, even when a failure during install occurs.
+     */
+    @SerializedName("mpackName")
+    private String mpackName;
+
+    /**
+     * The repository id that is returned in structured output.
+     */
+    @SerializedName("mpackId")
+    private Long mpackId = null;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/CommandReportEventPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/CommandReportEventPublisher.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.events.publishers;
+
+import java.util.concurrent.Executors;
+
+import org.apache.ambari.server.Role;
+import org.apache.ambari.server.RoleCommand;
+import org.apache.ambari.server.agent.CommandReport;
+import org.apache.ambari.server.events.CommandReportReceivedEvent;
+import org.apache.commons.lang.StringUtils;
+
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Singleton;
+
+/**
+ * The {@link CommandReportEventPublisher} is used to publish instances of
+ * {@link CommandReportReceivedEvent} to any {@link Subscribe} methods
+ * interested. It uses a single-threaded {@link AsyncEventBus}.
+ */
+@Singleton
+public class CommandReportEventPublisher {
+
+  /**
+   * A single threaded event bus for processing command report events in serial.
+   */
+  private final EventBus m_eventBus;
+
+  /**
+   * The string representation of {@link Role#INSTALL_PACKAGES}
+   */
+  private final String ROLE_INSTALL_PACKAGES = Role.INSTALL_PACKAGES.name();
+
+  /**
+   * The string representation of {@code RoleCommand#INSTALL}
+   */
+  private final String ROLE_COMMAND_INSTALL = RoleCommand.INSTALL.name();
+
+  /**
+   * Constructor.
+   */
+  public CommandReportEventPublisher() {
+    m_eventBus = new AsyncEventBus("command-report-event-bus",
+        Executors.newSingleThreadExecutor());
+  }
+
+  /**
+   * Publishes the specified event to all registered listeners that
+   * {@link Subscribe} to any of the {@link CommandReportReceivedEvent}
+   * instances.
+   * <p/>
+   * The event will only be published for installation reports.
+   *
+   * @param event
+   */
+  public void publish(CommandReportReceivedEvent event) {
+    CommandReport commandReport = event.getCommandReport();
+    if (!StringUtils.equals(event.getRole(), ROLE_INSTALL_PACKAGES)
+        && !StringUtils.equals(commandReport.getRoleCommand(), ROLE_COMMAND_INSTALL)) {
+      return;
+    }
+
+    m_eventBus.post(event);
+  }
+
+  /**
+   * Register a listener to receive events. The listener should use the
+   * {@link Subscribe} annotation.
+   *
+   * @param object
+   *          the listener to receive events.
+   */
+  public void register(Object object) {
+    m_eventBus.register(object);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/MpackHostStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/MpackHostStateDAO.java
@@ -26,6 +26,7 @@ import javax.persistence.TypedQuery;
 
 import org.apache.ambari.server.orm.RequiresSession;
 import org.apache.ambari.server.orm.entities.MpackHostStateEntity;
+import org.apache.ambari.server.state.MpackInstallState;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -71,14 +72,14 @@ public class MpackHostStateDAO extends CrudDAO<MpackHostStateEntity, Long> {
   @RequiresSession
   public List<MpackHostStateEntity> findByHost(String hostName) {
     final TypedQuery<MpackHostStateEntity> query = entityManagerProvider.get().createNamedQuery(
-        "mpackHostStateForHost", MpackHostStateEntity.class);
+        "findInstallStateByHost", MpackHostStateEntity.class);
     query.setParameter("hostName", hostName);
 
     return daoUtils.selectList(query);
   }
 
   /**
-   * Retrieve all of the host versions for the given management pack.
+   * Retrieve all of the install states for the given management pack.
    *
    * @param mpackId
    *          the ID of the mpack
@@ -88,8 +89,48 @@ public class MpackHostStateDAO extends CrudDAO<MpackHostStateEntity, Long> {
   @RequiresSession
   public List<MpackHostStateEntity> findByMpack(Long mpackId) {
     final TypedQuery<MpackHostStateEntity> query = entityManagerProvider.get().createNamedQuery(
-        "mpackHostStateForMpack", MpackHostStateEntity.class);
+        "findInstallStateByMpack", MpackHostStateEntity.class);
     query.setParameter("mpackId", mpackId);
+
+    return daoUtils.selectList(query);
+  }
+
+  /**
+   * Retrieve the installation state for a specific mpack on a host.
+   *
+   * @param mpackId
+   *          the ID of the mpack
+   * @param hostName
+   *          FQDN of host
+   * @return Return all of the mpack install states that match the criteria.
+   */
+  @RequiresSession
+  public MpackHostStateEntity findByMpackAndHost(Long mpackId, String hostName) {
+    final TypedQuery<MpackHostStateEntity> query = entityManagerProvider.get().createNamedQuery(
+        "findInstallStateByMpackAndHost", MpackHostStateEntity.class);
+    query.setParameter("mpackId", mpackId);
+    query.setParameter("hostName", hostName);
+
+    return daoUtils.selectOne(query);
+  }
+
+  /**
+   * Retrieve all of the matching install states for any mpack on the given
+   * host.
+   *
+   * @param mpackId
+   *          the ID of the mpack
+   * @param hostName
+   *          FQDN of host
+   * @return all of the hosts in the cluster which have entries for the
+   *         specified mpack.
+   */
+  @RequiresSession
+  public List<MpackHostStateEntity> findByHostAndInstallState(String hostName, MpackInstallState state) {
+    final TypedQuery<MpackHostStateEntity> query = entityManagerProvider.get().createNamedQuery(
+        "findInstallStateByStateAndHost", MpackHostStateEntity.class);
+    query.setParameter("hostName", hostName);
+    query.setParameter("mpackInstallState", state);
 
     return daoUtils.selectList(query);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostEntity.java
@@ -22,6 +22,7 @@ import static org.apache.commons.lang.StringUtils.defaultString;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
@@ -134,7 +135,7 @@ public class HostEntity implements Comparable<HostEntity> {
       cascade = CascadeType.ALL,
       fetch = FetchType.LAZY,
       orphanRemoval = true)
-  private Collection<MpackHostStateEntity> mpackHostInstallStates;
+  private List<MpackHostStateEntity> mpackHostInstallStates;
 
   @ManyToMany
   @JoinTable(name = "ClusterHostMapping",
@@ -396,11 +397,11 @@ public class HostEntity implements Comparable<HostEntity> {
     this.hostRoleCommandEntities = hostRoleCommandEntities;
   }
 
-  public Collection<MpackHostStateEntity> getMpackInstallStates() {
+  public List<MpackHostStateEntity> getMpackInstallStates() {
     return mpackHostInstallStates;
   }
 
-  public void setMpackInstallStates(Collection<MpackHostStateEntity> mpackHostInstallStates) {
+  public void setMpackInstallStates(List<MpackHostStateEntity> mpackHostInstallStates) {
     this.mpackHostInstallStates = mpackHostInstallStates;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/MpackHostStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/MpackHostStateEntity.java
@@ -57,12 +57,17 @@ import org.apache.ambari.server.state.MpackInstallState;
     initialValue = 0)
 @NamedQueries({
     @NamedQuery(
-        name = "mpackHostStateForHost",
-        query = "SELECT mpackHostState FROM MpackHostStateEntity mpackHostState JOIN mpackHostState.hostEntity host "
-            + "WHERE mpackHostState.hostEntity.hostName=:hostName"),
+        name = "findInstallStateByHost",
+        query = "SELECT mpackHostState FROM MpackHostStateEntity mpackHostState WHERE mpackHostState.hostEntity.hostName=:hostName"),
     @NamedQuery(
-        name = "mpackHostStateForMpack",
-        query = "SELECT mpackHostState FROM MpackHostStateEntity mpackHostState WHERE mpackHostState.mpackId = :mpackId") })
+        name = "findInstallStateByMpack",
+        query = "SELECT mpackHostState FROM MpackHostStateEntity mpackHostState WHERE mpackHostState.mpackId = :mpackId"),
+    @NamedQuery(
+        name = "findInstallStateByMpackAndHost",
+        query = "SELECT mpackHostState FROM MpackHostStateEntity mpackHostState WHERE mpackHostState.mpackId = :mpackId AND mpackHostState.hostEntity.hostName=:hostName"),
+    @NamedQuery(
+        name = "findInstallStateByStateAndHost",
+        query = "SELECT mpackHostState FROM MpackHostStateEntity mpackHostState WHERE mpackHostState.hostEntity.hostName=:hostName AND mpackHostState.state = :mpackInstallState") })
 
 public class MpackHostStateEntity {
 
@@ -184,7 +189,7 @@ public class MpackHostStateEntity {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(id, mpackId, hostId, state);
+    return Objects.hash(mpackId, hostId, state);
   }
 
   @Override
@@ -200,7 +205,7 @@ public class MpackHostStateEntity {
     }
 
     MpackHostStateEntity other = (MpackHostStateEntity) obj;
-    return Objects.equals(id, other.id) && Objects.equals(mpackId, other.mpackId)
+    return Objects.equals(mpackId, other.mpackId)
         && Objects.equals(hostId, other.hostId) && Objects.equals(state, other.state);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
@@ -61,7 +61,7 @@ public abstract class AbstractServerAction implements ServerAction {
 
   @Override
   public ExecutionCommand getExecutionCommand() {
-    return this.executionCommand;
+    return executionCommand;
   }
 
   @Override
@@ -71,7 +71,7 @@ public abstract class AbstractServerAction implements ServerAction {
 
   @Override
   public HostRoleCommand getHostRoleCommand() {
-    return this.hostRoleCommand;
+    return hostRoleCommand;
   }
 
   @Override
@@ -115,6 +115,7 @@ public abstract class AbstractServerAction implements ServerAction {
 
         report.setActionId(StageUtils.getActionId(hostRoleCommand.getRequestId(), hostRoleCommand.getStageId()));
         report.setClusterName(executionCommand.getClusterName());
+        report.setMpackId(executionCommand.getMpackId());
         report.setConfigurationTags(executionCommand.getConfigurationTags());
         report.setRole(executionCommand.getRole());
         report.setRoleCommand((roleCommand == null) ? null : roleCommand.toString());

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -434,13 +434,10 @@ public class RepositoryVersionHelper {
     AmbariMetaInfo ambariMetaInfo = ambariMetainfoProvider.get();
 
     try {
-      Mpack mpack = context.getMpack();
-      if (null == mpack) {
-        final Cluster cluster = clusters.get().getCluster(context.getClusterName());
-        ServiceGroup serviceGroup = cluster.getServiceGroup(context.getExpectedServiceGroupName());
-        long mpackId = serviceGroup.getMpackId();
-        mpack = ambariMetaInfo.getMpack(mpackId);
-      }
+      final Cluster cluster = clusters.get().getCluster(context.getClusterName());
+      ServiceGroup serviceGroup = cluster.getServiceGroup(context.getExpectedServiceGroupName());
+      long mpackId = serviceGroup.getMpackId();
+      Mpack mpack = ambariMetaInfo.getMpack(mpackId);
 
       final CommandRepository commandRepo = getCommandRepository(mpack, osEntity);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/EventBusSynchronizer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/EventBusSynchronizer.java
@@ -28,6 +28,7 @@ import org.apache.ambari.server.events.listeners.alerts.AlertStateChangedListene
 import org.apache.ambari.server.events.listeners.upgrade.MpackInstallStateListener;
 import org.apache.ambari.server.events.publishers.AlertEventPublisher;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.events.publishers.CommandReportEventPublisher;
 
 import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
@@ -70,6 +71,25 @@ public class EventBusSynchronizer {
     AmbariEventPublisher publisher = injector.getInstance(AmbariEventPublisher.class);
 
     replaceEventBus(AmbariEventPublisher.class, publisher, synchronizedBus);
+
+    // register common ambari event listeners
+    registerAmbariListeners(injector, synchronizedBus);
+
+    return synchronizedBus;
+  }
+
+  /**
+   * Force the {@link EventBus} from {@link AlertEventPublisher} to be serial
+   * and synchronous. Also register the known listeners. Registering known
+   * listeners is necessary since the event bus was replaced.
+   *
+   * @param injector
+   */
+  public static EventBus synchronizeCommandReportEventPublisher(Injector injector) {
+    EventBus synchronizedBus = new EventBus();
+    CommandReportEventPublisher publisher = injector.getInstance(CommandReportEventPublisher.class);
+
+    replaceEventBus(CommandReportEventPublisher.class, publisher, synchronizedBus);
 
     // register common ambari event listeners
     registerAmbariListeners(injector, synchronizedBus);

--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/TestActionScheduler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/TestActionScheduler.java
@@ -75,6 +75,7 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.HostsMap;
 import org.apache.ambari.server.events.AmbariEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.events.publishers.CommandReportEventPublisher;
 import org.apache.ambari.server.metadata.RoleCommandOrder;
 import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
 import org.apache.ambari.server.metadata.RoleCommandPair;
@@ -849,7 +850,7 @@ public class TestActionScheduler {
     Configuration conf = new Configuration(properties);
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
         new HostsMap((String) null),
-        unitOfWork, EasyMock.createNiceMock(AmbariEventPublisher.class), conf,
+        unitOfWork, EasyMock.createNiceMock(CommandReportEventPublisher.class), conf,
         entityManagerProviderMock, hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     scheduler.doWork();

--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/TestActionScheduler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/TestActionScheduler.java
@@ -73,8 +73,7 @@ import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.HostsMap;
-import org.apache.ambari.server.events.AmbariEvent;
-import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.events.CommandReportReceivedEvent;
 import org.apache.ambari.server.events.publishers.CommandReportEventPublisher;
 import org.apache.ambari.server.metadata.RoleCommandOrder;
 import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
@@ -153,6 +152,10 @@ public class TestActionScheduler {
 
   private Provider<EntityManager> entityManagerProviderMock = EasyMock.niceMock(Provider.class);
 
+  /**
+   *
+   */
+  private CommandReportEventPublisher eventPublisher = EasyMock.createNiceMock(CommandReportEventPublisher.class);
 
   public  TestActionScheduler(){
     injector = Guice.createInjector(new InMemoryDefaultTestModule());
@@ -231,7 +234,7 @@ public class TestActionScheduler {
     //Keep large number of attempts so that the task is not expired finally
     //Small action timeout to test rescheduling
     ActionScheduler scheduler = new ActionScheduler(100, 5, db, aq, fsm,
-        10000, new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock, hostRoleCommandDAOMock, null);
+        10000, new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock, hostRoleCommandDAOMock, null);
     scheduler.setTaskTimeoutAdjustment(false);
 
     List<AgentCommand> ac = waitForQueueSize(hostname, aq, 1, scheduler);
@@ -330,7 +333,7 @@ public class TestActionScheduler {
     //Keep large number of attempts so that the task is not expired finally
     //Small action timeout to test rescheduling
     ActionScheduler scheduler = new ActionScheduler(100, 5, db, aq, fsm,
-            10000, new HostsMap((String) null), unitOfWork, null, conf,
+            10000, new HostsMap((String) null), unitOfWork, eventPublisher, conf,
             entityManagerProviderMock, hostRoleCommandDAOMock, null, rcoProvider);
     scheduler.setTaskTimeoutAdjustment(false);
 
@@ -446,7 +449,7 @@ public class TestActionScheduler {
 
     //Small action timeout to test rescheduling
     ActionScheduler scheduler = new ActionScheduler(100, 0, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock, hostRoleCommandDAOMock, null);
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock, hostRoleCommandDAOMock, null);
     scheduler.setTaskTimeoutAdjustment(false);
     // Start the thread
 
@@ -530,10 +533,9 @@ public class TestActionScheduler {
       }
     }).when(db).timeoutHostRole(anyString(), anyLong(), anyLong(), anyString(), anyBoolean(), eq(true));
 
-    //Small action timeout to test rescheduling
-    AmbariEventPublisher aep = EasyMock.createNiceMock(AmbariEventPublisher.class);
+    // Small action timeout to test rescheduling
     ActionScheduler scheduler = new ActionScheduler(100, 0, db, aq, fsm, 3,
-      new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock, hostRoleCommandDAOMock, null);
+      new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock, hostRoleCommandDAOMock, null);
     scheduler.setTaskTimeoutAdjustment(false);
 
     int cycleCount=0;
@@ -653,7 +655,7 @@ public class TestActionScheduler {
 
     // Make sure the NN install doesn't timeout
     ActionScheduler scheduler = new ActionScheduler(100, 50000, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
     scheduler.setTaskTimeoutAdjustment(false);
 
@@ -770,7 +772,7 @@ public class TestActionScheduler {
 
     ServerActionExecutor.init(injector);
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     int cycleCount = 0;
@@ -933,7 +935,7 @@ public class TestActionScheduler {
 
     ServerActionExecutor.init(injector);
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     int cycleCount = 0;
@@ -954,9 +956,9 @@ public class TestActionScheduler {
 
     ActionScheduler scheduler = EasyMock.createMockBuilder(ActionScheduler.class)
       .withConstructor(long.class, long.class, ActionDBAccessor.class, ActionQueue.class, Clusters.class, int.class,
-            HostsMap.class, UnitOfWork.class, AmbariEventPublisher.class, Configuration.class,
+            HostsMap.class, UnitOfWork.class, CommandReportEventPublisher.class, Configuration.class,
             Provider.class, HostRoleCommandDAO.class, HostRoleCommandFactory.class)
-      .withArgs(100L, 50L, null, null, null, -1, null, null, null, null, entityManagerProviderMock,
+      .withArgs(100L, 50L, null, null, null, -1, null, null, eventPublisher, null, entityManagerProviderMock,
             mock(HostRoleCommandDAO.class), mock(HostRoleCommandFactory.class))
       .createNiceMock();
 
@@ -1022,21 +1024,21 @@ public class TestActionScheduler {
     ServiceComponentHost serviceComponentHost = EasyMock.createMock(ServiceComponentHost.class);
     Host host = EasyMock.createMock(Host.class);
     ActionDBAccessor db = EasyMock.createMock(ActionDBAccessor.class);
-    AmbariEventPublisher ambariEventPublisher = EasyMock.createMock(AmbariEventPublisher.class);
+    CommandReportEventPublisher CommandReportEventPublisher = EasyMock.createMock(
+        CommandReportEventPublisher.class);
 
     EasyMock.expect(fsm.getCluster(EasyMock.anyString())).andReturn(cluster).anyTimes();
     EasyMock.expect(fsm.getHost(EasyMock.anyString())).andReturn(host);
     EasyMock.expect(cluster.getService(EasyMock.anyString())).andReturn(null);
     EasyMock.expect(host.getHostName()).andReturn(Stage.INTERNAL_HOSTNAME).anyTimes();
 
-    if (RoleCommand.ACTIONEXECUTE.equals(roleCommand)) {
-      EasyMock.expect(cluster.getClusterName()).andReturn("clusterName").anyTimes();
-      EasyMock.expect(cluster.getClusterId()).andReturn(1L);
+    EasyMock.expect(cluster.getClusterName()).andReturn("clusterName").anyTimes();
+    EasyMock.expect(cluster.getClusterId()).andReturn(1L);
 
-      ambariEventPublisher.publish(EasyMock.anyObject(AmbariEvent.class));
-      EasyMock.expectLastCall();
-    } else if (RoleCommand.EXECUTE.equals(roleCommand)) {
-      EasyMock.expect(cluster.getClusterName()).andReturn("clusterName");
+    CommandReportEventPublisher.publish(EasyMock.anyObject(CommandReportReceivedEvent.class));
+    EasyMock.expectLastCall();
+
+    if (RoleCommand.EXECUTE.equals(roleCommand)) {
       EasyMock.expect(cluster.getService(EasyMock.anyString())).andReturn(service);
       EasyMock.expect(service.getServiceComponent(EasyMock.anyString())).andReturn(serviceComponent);
       EasyMock.expect(serviceComponent.getServiceComponentHost(EasyMock.anyString())).andReturn(serviceComponentHost);
@@ -1063,18 +1065,21 @@ public class TestActionScheduler {
 
     ActionScheduler scheduler = EasyMock.createMockBuilder(ActionScheduler.class)
       .withConstructor(long.class, long.class, ActionDBAccessor.class, ActionQueue.class, Clusters.class, int.class,
-            HostsMap.class, UnitOfWork.class, AmbariEventPublisher.class, Configuration.class,
+            HostsMap.class, UnitOfWork.class, CommandReportEventPublisher.class,
+            Configuration.class,
             Provider.class, HostRoleCommandDAO.class, HostRoleCommandFactory.class)
-        .withArgs(100L, 50L, db, aq, fsm, -1, null, null, ambariEventPublisher, null,
+        .withArgs(100L, 50L, db, aq, fsm, -1, null, null, CommandReportEventPublisher, null,
             entityManagerProviderMock, mock(HostRoleCommandDAO.class),
             mock(HostRoleCommandFactory.class))
       .createNiceMock();
 
-    EasyMock.replay(scheduler, fsm, host, db, cluster, ambariEventPublisher, service, serviceComponent, serviceComponentHost);
+    EasyMock.replay(scheduler, fsm, host, db, cluster, CommandReportEventPublisher, service,
+        serviceComponent, serviceComponentHost);
 
     scheduler.processInProgressStage(s, commandsToSchedule, commandsToEnqueue);
 
-    EasyMock.verify(scheduler, fsm, host, db, cluster, ambariEventPublisher, service, serviceComponent, serviceComponentHost);
+    EasyMock.verify(scheduler, fsm, host, db, cluster, CommandReportEventPublisher, service,
+        serviceComponent, serviceComponentHost);
 
     Assert.assertTrue("ActionQueue should be empty after request was timeout", aq.size(Stage.INTERNAL_HOSTNAME) == 0);
   }
@@ -1147,7 +1152,7 @@ public class TestActionScheduler {
     }).when(db).getTasksByRoleAndStatus(anyString(), any(HostRoleStatus.class));
 
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     int cycleCount = 0;
@@ -1262,7 +1267,7 @@ public class TestActionScheduler {
     Properties properties = new Properties();
     Configuration conf = new Configuration(properties);
     ActionScheduler scheduler = spy(new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null));
 
     doReturn(false).when(scheduler).wasAgentRestartedDuringOperation(any(Host.class), any(Stage.class), anyString());
@@ -1356,7 +1361,7 @@ public class TestActionScheduler {
     Configuration conf = new Configuration(properties);
     ActionScheduler scheduler = spy(new ActionScheduler(100, 50, db, aq, fsm, 3,
             new HostsMap((String) null),
-        unitOfWork, null, conf, entityManagerProviderMock,
+        unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null));
 
 
@@ -1434,7 +1439,7 @@ public class TestActionScheduler {
     Configuration conf = new Configuration(properties);
     ActionScheduler scheduler = spy(new ActionScheduler(100, 50, db, aq, fsm, 3,
         new HostsMap((String) null),
-        unitOfWork, null, conf, entityManagerProviderMock,
+        unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null));
 
     doReturn(false).when(scheduler).wasAgentRestartedDuringOperation(any(Host.class), any(Stage.class), anyString());
@@ -1568,7 +1573,7 @@ public class TestActionScheduler {
     ActionScheduler scheduler = EasyMock.createMockBuilder(ActionScheduler.class).
         withConstructor((long)100, (long)50, db, aq, fsm, 3,
           new HostsMap((String) null),
-            unitOfWork, EasyMock.createNiceMock(AmbariEventPublisher.class), conf,
+            unitOfWork, EasyMock.createNiceMock(CommandReportEventPublisher.class), conf,
             entityManagerProviderMock, mock(HostRoleCommandDAO.class),
             mock(HostRoleCommandFactory.class)).
           addMockedMethod("cancelHostRoleCommands").
@@ -1752,7 +1757,7 @@ public class TestActionScheduler {
     Configuration conf = new Configuration(properties);
     ActionScheduler scheduler = new ActionScheduler(100, 10000, db, aq, fsm, 3,
         new HostsMap((String) null),
-        unitOfWork, null, conf, entityManagerProviderMock,
+        unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     scheduler.doWork();
@@ -1948,7 +1953,7 @@ public class TestActionScheduler {
     Configuration conf = new Configuration(properties);
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
         new HostsMap((String) null),
-        unitOfWork, null, conf, entityManagerProviderMock,
+        unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     ActionManager am = new ActionManager(db, requestFactory, scheduler);
@@ -2135,7 +2140,7 @@ public class TestActionScheduler {
     //Keep large number of attempts so that the task is not expired finally
     //Small action timeout to test rescheduling
     ActionScheduler scheduler = new ActionScheduler(100, 100, db, aq, fsm,
-        10000, new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        10000, new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
     scheduler.setTaskTimeoutAdjustment(false);
 
@@ -2220,7 +2225,7 @@ public class TestActionScheduler {
     when(db.getFirstStageInProgressPerRequest()).thenReturn(stages);
 
     ActionScheduler scheduler = new ActionScheduler(100, 50000, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAO, (HostRoleCommandFactory) null);
 
     final CountDownLatch abortCalls = new CountDownLatch(2);
@@ -2332,7 +2337,7 @@ public class TestActionScheduler {
 
     ServerActionExecutor.init(injector);
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null);
 
     int cycleCount = 0;
@@ -2527,7 +2532,7 @@ public class TestActionScheduler {
         HostRoleStatus.NOT_COMPLETED_STATUSES)).thenReturn(hrcEntitiesInProgress);
 
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAO, hostRoleCommandFactory);
 
     scheduler.doWork();
@@ -2703,7 +2708,7 @@ public class TestActionScheduler {
     Configuration conf = new Configuration(properties);
 
     ActionScheduler scheduler = spy(new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null));
 
     doReturn(false).when(scheduler).wasAgentRestartedDuringOperation(any(Host.class), any(Stage.class), anyString());
@@ -2773,7 +2778,7 @@ public class TestActionScheduler {
 
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
         new HostsMap((String) null),
-        unitOfWork, null, conf, entityManagerProviderMock,
+        unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         (HostRoleCommandDAO)null, (HostRoleCommandFactory)null);
 
     HostRoleCommand hrc1 = hostRoleCommandFactory.create("h1", Role.NAMENODE, null, RoleCommand.EXECUTE);
@@ -2806,7 +2811,7 @@ public class TestActionScheduler {
 
     ActionScheduler scheduler = new ActionScheduler(100, 50, db, aq, fsm, 3,
         new HostsMap((String) null),
-        unitOfWork, null, conf, entityManagerProviderMock,
+        unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         (HostRoleCommandDAO)null, (HostRoleCommandFactory)null);
 
     HostRoleCommand hrc1 = hostRoleCommandFactory.create("h1", Role.NAMENODE, null, RoleCommand.EXECUTE);
@@ -2953,7 +2958,7 @@ public class TestActionScheduler {
     }).when(db).abortOperation(anyLong());
 
     ActionScheduler scheduler = spy(new ActionScheduler(100, 50, db, aq, fsm, 3,
-        new HostsMap((String) null), unitOfWork, null, conf, entityManagerProviderMock,
+        new HostsMap((String) null), unitOfWork, eventPublisher, conf, entityManagerProviderMock,
         hostRoleCommandDAOMock, (HostRoleCommandFactory)null));
 
     doReturn(false).when(scheduler).wasAgentRestartedDuringOperation(any(Host.class), any(Stage.class), anyString());

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRendererTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRendererTest.java
@@ -133,8 +133,10 @@ public class ClusterBlueprintRendererTest {
   @Before
   public void setup() throws Exception {
     PowerMock.mockStatic(AmbariContext.class);
+    PowerMock.mockStatic(AmbariServer.class);
     expect(AmbariContext.getClusterController()).andReturn(clusterController).anyTimes();
     expect(AmbariContext.getController()).andReturn(controller).anyTimes();
+    expect(AmbariServer.getController()).andReturn(controller).anyTimes();
 
     Map<String, String> clusterTypeProps = new HashMap<>();
     clusterProps.put("test-type-one", clusterTypeProps);
@@ -201,6 +203,7 @@ public class ClusterBlueprintRendererTest {
     setupKerberosDescriptorArtifact();
 
     PowerMock.replay(AmbariContext.class);
+    PowerMock.replay(AmbariServer.class);
     replay(topology, topologyWithKerberos, blueprint, stack, group1, group2, ambariContext, clusters, controller, kerberosHelper, cluster, kerberosDescriptor, clusterController, artifactResource, artifactResourceProvider);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -306,6 +306,11 @@ public class AmbariManagementControllerTest {
     repositoryVersion120 = helper.getOrCreateRepositoryVersion(
         new StackId("HDP-1.2.0"), "1.2.0-1234");
 
+    helper.getOrCreateRepositoryVersion(new StackId("HDP-1.3.1"), "1.3.1");
+    helper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.5"), "2.0.5");
+    helper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.6"), "2.0.6");
+    helper.getOrCreateRepositoryVersion(new StackId("HDP-2.0.7"), "2.0.7");
+
     repositoryVersion201 = helper.getOrCreateRepositoryVersion(
         new StackId("HDP-2.0.1"), "2.0.1-1234");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A continuation of AMBARI-23205, this will allow commands (like INSTALL and install_packages) to update the management pack installation state. They currently are stuck at NOT_INSTALLED.

## How was this patch tested?

Manual testing of installation states.