### PR TITLE
[AMBARI-23245] Invalid value for zeppelin.config.fs.dir property

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/configuration/zeppelin-config.xml
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/configuration/zeppelin-config.xml
@@ -86,12 +86,6 @@
     <on-ambari-upgrade add="false"/>
   </property>
   <property>
-    <name>zeppelin.config.fs.dir</name>
-    <value>conf</value>
-    <description>Location where interpreter.json should be installed</description>
-    <on-ambari-upgrade add="false"/>
-  </property>
-  <property>
     <name>zeppelin.interpreter.dir</name>
     <value>interpreter</value>
     <description>Interpreter implementation base directory</description>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/stack_advisor.py
@@ -70,11 +70,16 @@ class HDP26StackAdvisor(HDP25StackAdvisor):
     cluster_env = self.getServicesSiteProperties(services, "cluster-env")
     if cluster_env and "recommendations_full_stack_version" in cluster_env:
       full_stack_version = cluster_env["recommendations_full_stack_version"]
-      if compare_versions(full_stack_version, '2.6.3.0') >= 0:
+      if full_stack_version and compare_versions(full_stack_version, '2.6.3.0', format=True) >= 0:
         zeppelin_config = self.getServicesSiteProperties(services, "zeppelin-config")
-        if zeppelin_config and zeppelin_config.get('zeppelin.notebook.storage', None) == 'org.apache.zeppelin.notebook.repo.VFSNotebookRepo':
+        if zeppelin_config:
           putZeppelinConfigProperty = self.putProperty(configurations, 'zeppelin-config', services)
-          putZeppelinConfigProperty('zeppelin.notebook.storage', 'org.apache.zeppelin.notebook.repo.FileSystemNotebookRepo')
+
+          if zeppelin_config.get('zeppelin.notebook.storage', None) == 'org.apache.zeppelin.notebook.repo.VFSNotebookRepo':
+            putZeppelinConfigProperty('zeppelin.notebook.storage', 'org.apache.zeppelin.notebook.repo.FileSystemNotebookRepo')
+
+          if 'zeppelin.config.fs.dir' not in zeppelin_config:
+            putZeppelinConfigProperty('zeppelin.config.fs.dir', 'conf')
 
     self.__addZeppelinToLivy2SuperUsers(configurations, services)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added some code to HDP 2.6 stack advisor, to add property zeppelin.config.fs.dir only if stack >= HDP-2.6.3.

## How was this patch tested?

Tested for HDP-2.6.2, HDP-2.6.3 and HDP-2.6.4. It works fine.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.