### PR TITLE
AMBARI-23247. Ambari Setup with external postgres db failed on configuring database.

### DIFF
--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -168,6 +168,9 @@ class LinuxDBMSConfig(DBMSConfig):
       if not retcode == 0:
         err = 'Error while configuring connection properties. Exiting'
         raise FatalException(retcode, err)
+    else:
+      err = 'Error while configuring connection properties. Exiting'
+      raise FatalException(-1, err)
 
   def _reset_remote_database(self):
     client_usage_cmd_drop = self._get_remote_script_line(self.drop_tables_script_file)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Jdbc driver search for postgres DB was removed, now server is always using default built-in driver. 
For other DBs driver path input suggestion in silent mode was removed.

## How was this patch tested?

Manual check