### PR TITLE
[AMBARI-23223] Stack Mpack link broken in stacks api

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -4659,14 +4659,24 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     String stackName = request.getStackName();
     String stackVersion = request.getStackVersion();
     String propertyName = request.getPropertyName();
+    Set<PropertyInfo> configs;
 
-    Set<PropertyInfo> properties;
+    //properties : cluster-env
+    //TODO: Remove after getting rid of cluster-env
     if (propertyName != null) {
-      properties = ambariMetaInfo.getStackPropertiesByName(stackName, stackVersion, propertyName);
+      configs = ambariMetaInfo.getStackPropertiesByName(stackName, stackVersion, propertyName);
     } else {
-      properties = ambariMetaInfo.getStackProperties(stackName, stackVersion);
+      configs = ambariMetaInfo.getStackProperties(stackName, stackVersion);
     }
-    for (PropertyInfo property: properties) {
+
+    //settings : stackSettings
+    if(configs.size() == 0){
+      if (propertyName != null) {
+        configs = ambariMetaInfo.getStackSettingsByName(stackName, stackVersion, propertyName);
+      } else
+        configs = ambariMetaInfo.getStackSettings(stackName, stackVersion);
+    }
+    for (PropertyInfo property: configs) {
       response.add(property.convertToResponse());
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
@@ -259,16 +259,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
       }
 
       for (MpackResponse response : responses) {
-        Resource resource = new ResourceImpl(Resource.Type.Mpack);
-        resource.setProperty(MPACK_RESOURCE_ID, response.getId());
-        resource.setProperty(MPACK_ID, response.getMpackId());
-        resource.setProperty(MPACK_NAME, response.getMpackName());
-        resource.setProperty(MPACK_VERSION, response.getMpackVersion());
-        resource.setProperty(MPACK_URI, response.getMpackUri());
-        resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
-        resource.setProperty(REGISTRY_ID, response.getRegistryId());
-        resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
-
+        Resource resource = setResources(response);
         results.add(resource);
       }
     } else {
@@ -280,16 +271,9 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
           mpackId = Long.valueOf((String) objMpackId);
         }
         MpackResponse response = getManagementController().getMpack(mpackId);
-        Resource resource = new ResourceImpl(Resource.Type.Mpack);
+
         if (null != response) {
-          resource.setProperty(MPACK_RESOURCE_ID, response.getId());
-          resource.setProperty(MPACK_ID, response.getMpackId());
-          resource.setProperty(MPACK_NAME, response.getMpackName());
-          resource.setProperty(MPACK_VERSION, response.getMpackVersion());
-          resource.setProperty(MPACK_URI, response.getMpackUri());
-          resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
-          resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
-          resource.setProperty(REGISTRY_ID, response.getRegistryId());
+          Resource resource = setResources(response);
           List<Module> modules = getManagementController().getModules(response.getId());
           resource.setProperty(MODULES, modules);
           results.add(resource);
@@ -302,16 +286,9 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
         StackEntity stackEntity = stackDAO.find(stackName, stackVersion);
         mpackId = stackEntity.getMpackId();
         MpackResponse response = getManagementController().getMpack(mpackId);
-        Resource resource = new ResourceImpl(Resource.Type.Mpack);
+
         if (null != response) {
-          resource.setProperty(MPACK_RESOURCE_ID, response.getId());
-          resource.setProperty(MPACK_ID, response.getMpackId());
-          resource.setProperty(MPACK_NAME, response.getMpackName());
-          resource.setProperty(MPACK_VERSION, response.getMpackVersion());
-          resource.setProperty(MPACK_URI, response.getMpackUri());
-          resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
-          resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
-          resource.setProperty(REGISTRY_ID, response.getRegistryId());
+          Resource resource = setResources(response);
           resource.setProperty(STACK_NAME_PROPERTY_ID, stackName);
           resource.setProperty(STACK_VERSION_PROPERTY_ID, stackVersion);
           results.add(resource);
@@ -328,6 +305,19 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
     }
 
     return results;
+  }
+
+  private Resource setResources(MpackResponse response) {
+    Resource resource = new ResourceImpl(Resource.Type.Mpack);
+    resource.setProperty(MPACK_RESOURCE_ID, response.getId());
+    resource.setProperty(MPACK_ID, response.getMpackId());
+    resource.setProperty(MPACK_NAME, response.getMpackName());
+    resource.setProperty(MPACK_VERSION, response.getMpackVersion());
+    resource.setProperty(MPACK_URI, response.getMpackUri());
+    resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
+    resource.setProperty(REGISTRY_ID, response.getRegistryId());
+    resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
+    return resource;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,6 +55,7 @@ import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.registry.Registry;
 import org.apache.ambari.server.registry.RegistryMpack;
 import org.apache.ambari.server.registry.RegistryMpackVersion;
+import org.apache.ambari.server.state.Module;
 import org.apache.ambari.server.state.StackId;
 import org.apache.commons.lang.Validate;
 
@@ -268,39 +270,50 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
     } else {
       // Fetch a particular mpack based on id
       Map<String, Object> propertyMap = new HashMap<>(PredicateHelper.getProperties(predicate));
-      if (propertyMap.containsKey(STACK_NAME_PROPERTY_ID)
+      if (propertyMap.containsKey(MPACK_RESOURCE_ID)) {
+        Object objMpackId = propertyMap.get(MPACK_RESOURCE_ID);
+        if (objMpackId != null) {
+          mpackId = Long.valueOf((String) objMpackId);
+        }
+        MpackResponse response = getManagementController().getMpack(mpackId);
+        Resource resource = new ResourceImpl(Resource.Type.Mpack);
+        if (null != response) {
+          resource.setProperty(MPACK_RESOURCE_ID, response.getId());
+          resource.setProperty(MPACK_ID, response.getMpackId());
+          resource.setProperty(MPACK_NAME, response.getMpackName());
+          resource.setProperty(MPACK_VERSION, response.getMpackVersion());
+          resource.setProperty(MPACK_URI, response.getMpackUri());
+          resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
+          resource.setProperty(REGISTRY_ID, response.getRegistryId());
+          List<Module> modules = getManagementController().getModules(response.getId());
+          resource.setProperty(MODULES, modules);
+          results.add(resource);
+        }
+      } //Fetch an mpack based on a stackVersion query
+      else if (propertyMap.containsKey(STACK_NAME_PROPERTY_ID)
           && propertyMap.containsKey(STACK_VERSION_PROPERTY_ID)) {
         String stackName = (String) propertyMap.get(STACK_NAME_PROPERTY_ID);
         String stackVersion = (String) propertyMap.get(STACK_VERSION_PROPERTY_ID);
         StackEntity stackEntity = stackDAO.find(stackName, stackVersion);
         mpackId = stackEntity.getMpackId();
-      } else if (propertyMap.containsKey(MPACK_RESOURCE_ID)) {
-        Object objMpackId = propertyMap.get(MPACK_RESOURCE_ID);
-        if (objMpackId != null) {
-          mpackId = Long.valueOf((String) objMpackId);
+        MpackResponse response = getManagementController().getMpack(mpackId);
+        Resource resource = new ResourceImpl(Resource.Type.Mpack);
+        if (null != response) {
+          resource.setProperty(MPACK_RESOURCE_ID, response.getId());
+          resource.setProperty(MPACK_ID, response.getMpackId());
+          resource.setProperty(MPACK_NAME, response.getMpackName());
+          resource.setProperty(MPACK_VERSION, response.getMpackVersion());
+          resource.setProperty(MPACK_URI, response.getMpackUri());
+          resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
+          resource.setProperty(REGISTRY_ID, response.getRegistryId());
+          resource.setProperty(STACK_NAME_PROPERTY_ID, stackName);
+          resource.setProperty(STACK_VERSION_PROPERTY_ID, stackVersion);
+          results.add(resource);
         }
       }
-
       if (null == mpackId) {
         throw new IllegalArgumentException(
             "Either the management pack ID or the stack name and version are required when searching");
-      }
-
-      MpackResponse response = getManagementController().getMpack(mpackId);
-      Resource resource = new ResourceImpl(Resource.Type.Mpack);
-      if (null != response) {
-        resource.setProperty(MPACK_RESOURCE_ID, response.getId());
-        resource.setProperty(MPACK_ID, response.getMpackId());
-        resource.setProperty(MPACK_NAME, response.getMpackName());
-        resource.setProperty(MPACK_VERSION, response.getMpackVersion());
-        resource.setProperty(MPACK_URI, response.getMpackUri());
-        resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
-        resource.setProperty(REGISTRY_ID, response.getRegistryId());
-
-        StackId stackId = new StackId(response.getStackId());
-        resource.setProperty(STACK_NAME_PROPERTY_ID, stackId.getStackName());
-        resource.setProperty(STACK_VERSION_PROPERTY_ID, stackId.getStackVersion());
-        results.add(resource);
       }
 
       if (results.isEmpty()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackVersionResourceProvider.java
@@ -61,7 +61,7 @@ public class StackVersionResourceProvider extends ReadOnlyResourceProvider {
   public static final String UPGRADE_PACKS_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "upgrade_packs";
   public static final String STACK_MIN_JDK     = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "min_jdk";
   public static final String STACK_MAX_JDK     = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "max_jdk";
-  public static final String MPACK_ID     = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_id";
+  public static final String MPACK_RESOURCE_ID     = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "id";
 
   public static final Set<String> PROPERTY_IDS = new HashSet<>();
 
@@ -69,7 +69,7 @@ public class StackVersionResourceProvider extends ReadOnlyResourceProvider {
   protected static StackDAO stackDAO;
 
   private static Set<String> pkPropertyIds = new HashSet<>(
-    Arrays.asList(new String[]{STACK_NAME_PROPERTY_ID, STACK_VERSION_PROPERTY_ID, MPACK_ID}));
+    Arrays.asList(new String[]{STACK_NAME_PROPERTY_ID, STACK_VERSION_PROPERTY_ID, MPACK_RESOURCE_ID}));
 
   /**
    * The key property ids for a mpack resource.
@@ -78,7 +78,7 @@ public class StackVersionResourceProvider extends ReadOnlyResourceProvider {
 
   static {
     // properties
-    PROPERTY_IDS.add(MPACK_ID);
+    PROPERTY_IDS.add(MPACK_RESOURCE_ID);
     PROPERTY_IDS.add(STACK_VERSION_PROPERTY_ID);
     PROPERTY_IDS.add(STACK_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(STACK_MIN_VERSION_PROPERTY_ID);
@@ -92,7 +92,7 @@ public class StackVersionResourceProvider extends ReadOnlyResourceProvider {
     PROPERTY_IDS.add(STACK_MAX_JDK);
 
     // keys
-    KEY_PROPERTY_IDS.put(Resource.Type.Mpack, MPACK_ID);
+    KEY_PROPERTY_IDS.put(Resource.Type.Mpack, MPACK_RESOURCE_ID);
     KEY_PROPERTY_IDS.put(Resource.Type.Stack, STACK_NAME_PROPERTY_ID);
     KEY_PROPERTY_IDS.put(Resource.Type.StackVersion, STACK_VERSION_PROPERTY_ID);
 
@@ -115,9 +115,9 @@ public class StackVersionResourceProvider extends ReadOnlyResourceProvider {
       requests.add(getRequest(Collections.emptyMap()));
     } else {
       Map<String, Object> propertyMap = new HashMap<>(PredicateHelper.getProperties(predicate));
-      if (propertyMap.containsKey(MPACK_ID)) {
+      if (propertyMap.containsKey(MPACK_RESOURCE_ID)) {
         Resource resource = new ResourceImpl(Resource.Type.StackVersion);
-        Long mpackId = Long.valueOf((String) propertyMap.get(MPACK_ID));
+        Long mpackId = Long.valueOf((String) propertyMap.get(MPACK_RESOURCE_ID));
         StackEntity stackEntity = stackDAO.findByMpack(mpackId);
         requests.add(new StackVersionRequest(stackEntity.getStackName(), stackEntity.getStackVersion()));
         resource.setProperty(STACK_NAME_PROPERTY_ID,
@@ -126,7 +126,7 @@ public class StackVersionResourceProvider extends ReadOnlyResourceProvider {
         resource.setProperty(STACK_VERSION_PROPERTY_ID,
                 (String)stackEntity.getStackVersion());
 
-        resource.setProperty(MPACK_ID, mpackId);
+        resource.setProperty(MPACK_RESOURCE_ID, mpackId);
 
         resources.add(resource);
 


### PR DESCRIPTION
Fixed the following issues:
1. /stacks/<stackname>/versions/<stackversion> has mpack object empty
2. /mpacks/<mpackid>/ has version object empty
3. Remove stackname and stackversion from /mpacks/<mpackid> API call
4. /stacks/<stackname>/versions/<stackversion> has configuration object empty

(Please fill in changes proposed in this fix)

## How was this patch tested?
GET http://{ambari_server}:8080/api/v1/stacks/<stackname>/versions/<stackversion>
GET http://{ambari_server}:8080/api/v1/mpacks/<mpackid>


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.