### PR TITLE
[AMBARI-23242] Spark/Spark2 Livy Server alert assume process is running on all interfaces

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/alerts/alert_spark_livy_port.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/alerts/alert_spark_livy_port.py
@@ -35,6 +35,8 @@ CRITICAL_MESSAGE = "Connection failed on host {0}:{1} ({2})"
 
 logger = logging.getLogger('ambari_alerts')
 
+LIVY_SERVER_HOST_KEY = '{{livy-conf/livy.server.host}}'
+
 LIVY_SERVER_PORT_KEY = '{{livy-conf/livy.server.port}}'
 
 LIVYUSER_DEFAULT = 'livy'
@@ -58,7 +60,7 @@ def get_tokens():
     Returns a tuple of tokens in the format {{site/property}} that will be used
     to build the dictionary passed into execute
     """
-    return (LIVY_SERVER_PORT_KEY,LIVYUSER_DEFAULT,SECURITY_ENABLED_KEY,SMOKEUSER_KEYTAB_KEY,SMOKEUSER_PRINCIPAL_KEY,SMOKEUSER_KEY,LIVY_SSL_ENABLED_KEY)
+    return (LIVY_SERVER_HOST_KEY,LIVY_SERVER_PORT_KEY,LIVYUSER_DEFAULT,SECURITY_ENABLED_KEY,SMOKEUSER_KEYTAB_KEY,SMOKEUSER_PRINCIPAL_KEY,SMOKEUSER_KEY,LIVY_SSL_ENABLED_KEY)
 
 @OsFamilyFuncImpl(os_family=OsFamilyImpl.DEFAULT)
 def execute(configurations={}, parameters={}, host_name=None):
@@ -92,6 +94,9 @@ def execute(configurations={}, parameters={}, host_name=None):
     smokeuser_kerberos_keytab = None
     if SMOKEUSER_KEYTAB_KEY in configurations:
         smokeuser_kerberos_keytab = configurations[SMOKEUSER_KEYTAB_KEY]
+
+    if LIVY_SERVER_HOST_KEY in configurations:
+        host_name = str(configurations[LIVY_SERVER_HOST_KEY])
 
     if host_name is None:
         host_name = socket.getfqdn()

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_livy_port.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_livy_port.py
@@ -35,6 +35,8 @@ CRITICAL_MESSAGE = "Connection failed on host {0}:{1} ({2})"
 
 logger = logging.getLogger('ambari_alerts')
 
+LIVY_SERVER_HOST_KEY = '{{livy2-conf/livy.server.host}}'
+
 LIVY_SERVER_PORT_KEY = '{{livy2-conf/livy.server.port}}'
 
 LIVYUSER_DEFAULT = 'livy'
@@ -58,7 +60,7 @@ def get_tokens():
     Returns a tuple of tokens in the format {{site/property}} that will be used
     to build the dictionary passed into execute
     """
-    return (LIVY_SERVER_PORT_KEY,LIVYUSER_DEFAULT,SECURITY_ENABLED_KEY,SMOKEUSER_KEYTAB_KEY,SMOKEUSER_PRINCIPAL_KEY,SMOKEUSER_KEY,LIVY_SSL_ENABLED_KEY)
+    return (LIVY_SERVER_HOST_KEY,LIVY_SERVER_PORT_KEY,LIVYUSER_DEFAULT,SECURITY_ENABLED_KEY,SMOKEUSER_KEYTAB_KEY,SMOKEUSER_PRINCIPAL_KEY,SMOKEUSER_KEY,LIVY_SSL_ENABLED_KEY)
 
 @OsFamilyFuncImpl(os_family=OsFamilyImpl.DEFAULT)
 def execute(configurations={}, parameters={}, host_name=None):
@@ -79,6 +81,9 @@ def execute(configurations={}, parameters={}, host_name=None):
     port = LIVY_PORT_DEFAULT
     if LIVY_SERVER_PORT_KEY in configurations:
         port = int(configurations[LIVY_SERVER_PORT_KEY])
+    
+    if LIVY_SERVER_HOST_KEY in configurations:
+        host_name = str(configurations[LIVY_SERVER_HOST_KEY])
 
     if host_name is None:
         host_name = socket.getfqdn()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added logic to read hostname from livy.server.host if present.

## How was this patch tested?

Manually tested the changes by deploying livy with livy.server.host set to internal host.

Alert is working fine with and without livy.server.host configuration.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.