### PR TITLE
[AMBARI-23254] Mpack should have both displayName and description

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/MpackResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/MpackResponse.java
@@ -35,6 +35,7 @@ public class MpackResponse {
   private Long registryId;
   private String stackId;
   private String description;
+  private String displayName;
 
   public MpackResponse(Mpack mpack) {
     this.id = mpack.getResourceId();
@@ -44,6 +45,7 @@ public class MpackResponse {
     this.mpackUri = mpack.getMpackUri();
     this.registryId = mpack.getRegistryId();
     this.description = mpack.getDescription();
+    this.displayName = mpack.getDisplayName();
   }
 
   public Long getId() {
@@ -108,6 +110,14 @@ public class MpackResponse {
 
   public void setStackId(String stackId) {
     this.stackId = stackId;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/RegistryMpackResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/RegistryMpackResponse.java
@@ -30,6 +30,7 @@ public class RegistryMpackResponse {
   private String mpackName;
   private String mpackDescription;
   private String mpackLogoUri;
+  private String mpackDisplayName;
 
   /**
    * Constructor
@@ -39,12 +40,13 @@ public class RegistryMpackResponse {
    * @param mpackDescription  mpack description
    * @param mpackLogoUri      mpack logo uri
    */
-  public RegistryMpackResponse(Long registryId, String mpackId, String mpackName, String mpackDescription, String mpackLogoUri) {
+  public RegistryMpackResponse(Long registryId, String mpackId, String mpackName, String mpackDescription, String mpackLogoUri, String mpackDisplayName) {
     this.registryId = registryId;
     this.mpackName = mpackName;
     this.mpackId = mpackId;
     this.mpackDescription = mpackDescription;
     this.mpackLogoUri = mpackLogoUri;
+    this.mpackDisplayName = mpackDisplayName;
   }
 
   /**
@@ -86,6 +88,14 @@ public class RegistryMpackResponse {
    */
   public String getMpackLogoUri() {
     return mpackLogoUri;
+  }
+
+  /**
+   * Get mpack display name
+   * @return mpack display name
+   */
+  public String getMpackDisplayName() {
+    return mpackDisplayName;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackResourceProvider.java
@@ -73,6 +73,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
   public static final String MPACK_NAME = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_name";
   public static final String MPACK_VERSION = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_version";
   public static final String MPACK_DESCRIPTION = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_description";
+  public static final String MPACK_DISPLAY_NAME = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_display_name";
   public static final String MPACK_URI = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_uri";
   public static final String MODULES = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "modules";
   public static final String STACK_NAME_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "stack_name";
@@ -114,6 +115,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
     PROPERTY_IDS.add(STACK_NAME_PROPERTY_ID);
     PROPERTY_IDS.add(STACK_VERSION_PROPERTY_ID);
     PROPERTY_IDS.add(OS_PROPERTY_ID);
+    PROPERTY_IDS.add(MPACK_DISPLAY_NAME);
 
     // keys
     KEY_PROPERTY_IDS.put(Resource.Type.Mpack, MPACK_RESOURCE_ID);
@@ -155,6 +157,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
         resource.setProperty(MPACK_URI, response.getMpackUri());
         resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
         resource.setProperty(REGISTRY_ID, response.getRegistryId());
+        resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
         associatedResources.add(resource);
         return getRequestStatus(null, associatedResources);
       }
@@ -262,6 +265,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
         resource.setProperty(MPACK_URI, response.getMpackUri());
         resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
         resource.setProperty(REGISTRY_ID, response.getRegistryId());
+        resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
 
         results.add(resource);
       }
@@ -296,6 +300,7 @@ public class MpackResourceProvider extends AbstractControllerResourceProvider {
         resource.setProperty(MPACK_URI, response.getMpackUri());
         resource.setProperty(MPACK_DESCRIPTION, response.getDescription());
         resource.setProperty(REGISTRY_ID, response.getRegistryId());
+        resource.setProperty(MPACK_DISPLAY_NAME, response.getDisplayName());
 
         StackId stackId = new StackId(response.getStackId());
         resource.setProperty(STACK_NAME_PROPERTY_ID, stackId.getStackName());

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RegistryMpackResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RegistryMpackResourceProvider.java
@@ -52,6 +52,7 @@ public class RegistryMpackResourceProvider extends AbstractControllerResourcePro
   public static final String REGISTRY_MPACK_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_id";
   public static final String REGISTRY_MPACK_NAME = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_name";
   public static final String REGISTRY_MPACK_DESC = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_description";
+  public static final String REGISTRY_MPACK_DISPLAY_NAME = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_display_name";
   public static final String REGISTRY_MPACK_LOGO_URI = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "mpack_logo_uri";
 
   private static Set<String> pkPropertyIds = new HashSet<>(
@@ -74,6 +75,7 @@ public class RegistryMpackResourceProvider extends AbstractControllerResourcePro
     PROPERTY_IDS.add(REGISTRY_MPACK_NAME);
     PROPERTY_IDS.add(REGISTRY_MPACK_DESC);
     PROPERTY_IDS.add(REGISTRY_MPACK_LOGO_URI);
+    PROPERTY_IDS.add(REGISTRY_MPACK_DISPLAY_NAME);
 
     // keys
     KEY_PROPERTY_IDS.put(Resource.Type.Registry, REGISTRY_ID);
@@ -134,6 +136,7 @@ public class RegistryMpackResourceProvider extends AbstractControllerResourcePro
       setResourceProperty(resource, REGISTRY_MPACK_NAME, response.getMpackName(), requestedIds);
       setResourceProperty(resource, REGISTRY_MPACK_DESC, response.getMpackDescription(), requestedIds);
       setResourceProperty(resource, REGISTRY_MPACK_LOGO_URI, response.getMpackLogoUri(), requestedIds);
+      setResourceProperty(resource, REGISTRY_MPACK_DISPLAY_NAME, response.getMpackDisplayName(), requestedIds);
       resources.add(resource);
     }
     return resources;
@@ -187,7 +190,8 @@ public class RegistryMpackResourceProvider extends AbstractControllerResourcePro
           registryMpack.getMpackId(),
           registryMpack.getMpackName(),
           registryMpack.getMpackDescription(),
-          registryMpack.getMpackLogoUri());
+          registryMpack.getMpackLogoUri(),
+          registryMpack.getMpackDisplayName());
         responses.add(response);
       }
     } else {
@@ -198,7 +202,8 @@ public class RegistryMpackResourceProvider extends AbstractControllerResourcePro
           registryMpack.getMpackId(),
           registryMpack.getMpackName(),
           registryMpack.getMpackDescription(),
-          registryMpack.getMpackLogoUri());
+          registryMpack.getMpackLogoUri(),
+          registryMpack.getMpackDisplayName());
         responses.add(response);
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/registry/RegistryMpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/registry/RegistryMpack.java
@@ -45,6 +45,12 @@ public interface RegistryMpack {
   public String getMpackDescription();
 
   /**
+   * Get mpack display name
+   * @return
+   */
+  public String getMpackDisplayName();
+
+  /**
    * Get mpack logo uri
    * @return
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/registry/json/JsonRegistryMpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/registry/json/JsonRegistryMpack.java
@@ -41,6 +41,9 @@ public class JsonRegistryMpack implements RegistryMpack {
   @SerializedName("description")
   private String description;
 
+  @SerializedName("displayName")
+  private String displayName;
+
   @SerializedName("logoUri")
   private String logoUri;
 
@@ -55,6 +58,11 @@ public class JsonRegistryMpack implements RegistryMpack {
   @Override
   public String getMpackName() {
     return name;
+  }
+
+  @Override
+  public String getMpackDisplayName() {
+    return displayName;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -65,6 +65,9 @@ public class Mpack {
   @SerializedName("description")
   private String description;
 
+  @SerializedName("displayName")
+  private String displayName;
+
   private String mpackUri;
 
   /**
@@ -144,13 +147,20 @@ public class Mpack {
     this.modules = modules;
   }
 
-
   public String getDefinition() {
     return definition;
   }
 
   public void setDefinition(String definition) {
     this.definition = definition;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
   }
 
   /**
@@ -234,6 +244,7 @@ public class Mpack {
     equalsBuilder.append(definition, that.definition);
     equalsBuilder.append(description, that.description);
     equalsBuilder.append(mpackUri, that.mpackUri);
+    equalsBuilder.append(displayName, that.displayName);
 
     return equalsBuilder.isEquals();
   }
@@ -244,7 +255,7 @@ public class Mpack {
   @Override
   public int hashCode() {
     return Objects.hash(resourceId, registryId, mpackId, name, version, prerequisites, modules,
-        definition, description, mpackUri);
+        definition, description, mpackUri, displayName);
   }
 
   @Override
@@ -260,6 +271,7 @@ public class Mpack {
             ", definition='" + definition + '\'' +
             ", description='" + description + '\'' +
             ", mpackUri='" + mpackUri + '\'' +
+            ", displayName='" + mpackUri + '\'' +
             '}';
   }
 
@@ -290,6 +302,9 @@ public class Mpack {
     }
     if (definition == null) {
       definition = mpack.getDefinition();
+    }
+    if (displayName == null) {
+      displayName = mpack.getDisplayName();
     }
   }
 }


### PR DESCRIPTION
 Add displayName to mpacks API and registry API

(Please fill in changes proposed in this fix)

## How was this patch tested?
GET http://{ambari_server}:8080/api/v1/registries/1/mpacks/<mpackname>
GET http://{{ambari_server}}:8080/api/v1/mpacks/
GET http://{{ambari_server}}:8080/api/v1/mpacks/<mpackid>

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.