### PR TITLE
AMBARI-23256 Ambari-agent setting permission of .hash files to 666 

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/FileCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/FileCache.py
@@ -247,7 +247,7 @@ class FileCache():
     try:
       with open(hash_file, "w") as fh:
         fh.write(new_hash)
-      os.chmod(hash_file, 0o755)
+      os.chmod(hash_file, 0o644)
     except Exception, err:
       raise CachingException("Can not write to file {0} : {1}".format(hash_file,
                                                                  str(err)))

--- a/ambari-agent/src/main/python/ambari_agent/FileCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/FileCache.py
@@ -247,7 +247,7 @@ class FileCache():
     try:
       with open(hash_file, "w") as fh:
         fh.write(new_hash)
-      os.chmod(hash_file, 0o666)
+      os.chmod(hash_file, 0o755)
     except Exception, err:
       raise CachingException("Can not write to file {0} : {1}".format(hash_file,
                                                                  str(err)))

--- a/ambari-server/src/main/python/ambari_server/resourceFilesKeeper.py
+++ b/ambari-server/src/main/python/ambari_server/resourceFilesKeeper.py
@@ -248,7 +248,7 @@ class ResourceFilesKeeper():
     try:
       with open(hash_file, "w") as fh:
         fh.write(new_hash)
-      os.chmod(hash_file, 0o755)
+      os.chmod(hash_file, 0o644)
     except Exception, err:
       raise KeeperException("Can not write to file {0} : {1}".format(hash_file,
                                                                    str(err)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-23256 Ambari-agent setting permission of .hash files  to 666 (asnaik)

## How was this patch tested?
Please test the permission of var/lib/ambari-agent/cache and .hash files after patch .
