### PR TITLE
[AMBARI-23264] Fix TestMySqlServer error while executing unit tests on MacOS/Darwin

### DIFF
--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
@@ -17,13 +17,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import os
+from ambari_commons.os_check import OSCheck
 from mock.mock import MagicMock, call, patch
 from stacks.utils.RMFTestCase import *
 
-from only_for_platform import not_for_platform, PLATFORM_WINDOWS
+from only_for_platform import not_for_platform, os_distro_value, PLATFORM_WINDOWS
 
 @patch("os.path.exists", MagicMock(return_value=True))
+@patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
 @not_for_platform(PLATFORM_WINDOWS)
 class TestMySqlServer(RMFTestCase):
   COMMON_SERVICES_PACKAGE_DIR = "HIVE/0.12.0.2.0/package"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix TestMySqlServer error while executing unit tests on MacOS/Darwin.
 
```
ERROR: test_configure_secured (test_mysql_server.TestMySqlServer)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/Users/rlevas/github/ambari/ambari-common/src/test/python/mock/mock.py", line 1199, in patched
return func(*args, **keywargs)
File "/Users/rlevas/github/ambari/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py", line 84, in test_configure_secured
self.assert_configure_secured()
File "/Users/rlevas/github/ambari/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py", line 168, in assert_configure_secured
mode = 0755,
File "/Users/rlevas/github/ambari/ambari-server/src/test/python/stacks/utils/RMFTestCase.py", line 345, in assertResourceCalled
self.assertEquals(kwargs, resource.arguments)
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 515, in assertEqual
assertion_func(first, second, msg=msg)
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 831, in assertDictEqual
if d1 != d2:
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/resource_management/core/source.py", line 59, in __eq__
and ((self.name.startswith(os.sep) and self.name == other.name) or self.get_content() == other.get_content()))
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/resource_management/core/source.py", line 78, in get_content
return self.read_file(path)
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/ambari_commons/os_family_impl.py", line 84, in thunk
fn_id = fn_id_base + "." + OSCheck.get_os_family()
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/ambari_commons/os_check.py", line 277, in get_os_family
os_family = OSCheck.get_os_type()
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/ambari_commons/os_check.py", line 242, in get_os_type
return OSCheck.get_alias(OSCheck._get_os_type(), OSCheck._get_os_version())[0]
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/ambari_commons/os_check.py", line 248, in _get_os_type
dist = OSCheck.os_distribution()
File "/Users/rlevas/github/ambari/ambari-common/src/main/python/ambari_commons/os_check.py", line 202, in os_distribution
distribution = platform.linux_distribution()
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/platform.py", line 329, in linux_distribution
return _dist_try_harder(distname,version,id)
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/platform.py", line 205, in _dist_try_harder
info = open('/var/adm/inst-log/info').readlines()
IOError: [Errno 2] No such file or directory: '/var/adm/inst-log/info'
```
 **Cause**
This is caused by the following mock
```
@patch("os.path.exists", MagicMock(return_value=True))
```
Which allow a later call on the Python 2.7 library to return `True`, causing `/var/adm/inst-log/info` to appear to exist and then be read. Since `/var/adm/inst-log/info` does not exist, this fails, as seen above. 

**Solution**
Mock the OsCheck function to avoid this.
 
## How was this patch tested?

```
mvn -pl ambari-server -DskipSurefireTests test

...

----------------------------------------------------------------------
Total run:1171
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:37 min
[INFO] Finished at: 2018-03-16T12:26:51-04:00
[INFO] Final Memory: 92M/1172M
[INFO] ------------------------------------------------------------------------
```
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.