### PR TITLE
[AMBARI-23282] Setting a non-world-readable permission for atlas-application.properties file

### DIFF
--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
@@ -129,7 +129,7 @@ def metadata(type='server'):
     # Needed by both Server and Client
     PropertiesFile(format('{conf_dir}/{conf_file}'),
          properties = params.application_properties,
-         mode=0644,
+         mode=0600,
          owner=params.metadata_user,
          group=params.user_group
     )

--- a/ambari-server/src/test/python/stacks/2.3/ATLAS/test_metadata_server.py
+++ b/ambari-server/src/test/python/stacks/2.3/ATLAS/test_metadata_server.py
@@ -125,7 +125,7 @@ class TestMetadataServer(RMFTestCase):
                                 properties=app_props,
                                 owner=u'atlas',
                                 group=u'hadoop',
-                                mode=0644,
+                                mode=0600,
       )
       self.assertResourceCalled('Directory', '/var/log/ambari-infra-solr-client',
                                 create_parents = True,
@@ -260,7 +260,7 @@ class TestMetadataServer(RMFTestCase):
                               properties=app_props,
                               owner=u'atlas',
                               group=u'hadoop',
-                              mode=0644,
+                              mode=0600,
                               )
 
     self.assertResourceCalled('TemplateConfig', self.conf_dir+"/atlas_jaas.conf",

--- a/ambari-server/src/test/python/stacks/2.5/ATLAS/test_atlas_server.py
+++ b/ambari-server/src/test/python/stacks/2.5/ATLAS/test_atlas_server.py
@@ -122,7 +122,7 @@ class TestAtlasServer(RMFTestCase):
                               properties=app_props,
                               owner=u'atlas',
                               group=u'hadoop',
-                              mode=0644,
+                              mode=0600,
                               )
     self.assertResourceCalled('Directory', '/var/log/ambari-infra-solr-client',
                               create_parents=True,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Only the `atlas` user should be able to read `/etc/atlas/conf/atlas-application.properties` due to security reasons (the file contains a clear-text password)

## How was this patch tested?
Tested manually:

1. had Atlas installed in my cluster
2. the file permissions on the disk looked like this:
```
[root@c7401 ~]# ls -al /etc/atlas/conf/atlas-application.properties
-rw-r--r--. 1 atlas hadoop 3147 Mar 19 13:02 /etc/atlas/conf/atlas-application.properties
```
3. changed the `metadata.py` to set permissions of this file to `600`
4. restarted `ambari-server`
5. restarted `Atlas Metadata Server`
6. the file permissions on the disk looked like this:
```
[root@c7401 ~]# ls -al /etc/atlas/conf/atlas-application.properties
-rw-------. 1 atlas hadoop 3147 Mar 19 13:02 /etc/atlas/conf/atlas-application.properties
```
