### PR TITLE
[AMBARI-23292] livy.superusers is not getting configured correctly wh…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -732,6 +732,25 @@ public class KerberosHelperImpl implements KerberosHelper {
           continue;
         }
 
+        for (Map.Entry<String, Map<String, Map<String, String>>> config : requestConfigurations.entrySet()) {
+          for (Map<String, String> properties : config.getValue().values()) {
+            for (Map.Entry<String, String> property : properties.entrySet()) {
+              String oldValue = property.getValue();
+              String updatedValue = variableReplacementHelper.replaceVariables(property.getValue(), existingConfigurations);
+              if (!StringUtils.equals(oldValue, updatedValue) && !config.getKey().isEmpty()) {
+                property.setValue(updatedValue);
+                if (kerberosConfigurations.containsKey(config.getKey())) {
+                  kerberosConfigurations.get(config.getKey()).put(property.getKey(), updatedValue);
+                } else {
+                  Map kerberosConfigProperties = new HashMap<>();
+                  kerberosConfigProperties.put(property.getKey(), updatedValue);
+                  kerberosConfigurations.put(config.getKey(), kerberosConfigProperties);
+                }
+              }
+            }
+          }
+        }
+
         StackAdvisorRequest request = StackAdvisorRequest.StackAdvisorRequestBuilder
           .forStack(stackId.getStackName(), stackId.getStackVersion())
           .forServices(services)


### PR DESCRIPTION
…en Spark2 and Zeppelin are added as a service later on

Added code which resolving properties in config before we passing it to advisor. 

(Please fill in changes proposed in this fix)

## How was this patch tested?

Installed cluster with ambari 2.7 + HDP 3.0 + kerberos. Then added Zeppelin and Spark via "add service".

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.