### PR TITLE
AMBARI-23293. Fix the following : 1. Host Component deletes are broken 2. Use resourceType for getting resources from Mpack Modules.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
@@ -54,6 +54,7 @@ import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.UpgradeContext;
+import org.apache.ambari.server.state.ServiceComponent;
 import org.apache.ambari.server.state.UpgradeContext.UpgradeSummary;
 import org.apache.ambari.server.state.UpgradeContextFactory;
 import org.apache.ambari.server.state.stack.upgrade.RepositoryVersionHelper;
@@ -299,8 +300,10 @@ public class ExecutionCommandWrapper {
       }
 
       Service service = cluster.getService(serviceGroupName, serviceName);
+      ServiceComponent serviceComponent = null;
       if (null != service) {
         serviceType = service.getServiceType();
+        serviceComponent = service.getServiceComponent(componentName);
       }
 
       ModuleComponent moduleComponent = null;
@@ -309,7 +312,7 @@ public class ExecutionCommandWrapper {
         // only set the version if it's not set and this is NOT an install
         // command
 
-        moduleComponent = mpack.getModuleComponent(serviceName, componentName);
+        moduleComponent = mpack.getModuleComponent(serviceType, serviceComponent.getType());
       }
 
       if (null != moduleComponent) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/alerts/ComponentVersionAlertRunnable.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/alerts/ComponentVersionAlertRunnable.java
@@ -132,8 +132,8 @@ public class ComponentVersionAlertRunnable extends AlertRunnable {
           continue;
         }
 
-        ModuleComponent moduleComponent = mpack.getModuleComponent(hostComponent.getServiceName(),
-            hostComponent.getServiceComponentName());
+        ModuleComponent moduleComponent = mpack.getModuleComponent(hostComponent.getServiceType(),
+            hostComponent.getServiceComponentType());
 
         String version = hostComponent.getVersion();
         if (!StringUtils.equals(version, moduleComponent.getVersion())) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
@@ -507,7 +507,7 @@ public interface AmbariManagementController {
    *
    * @throws  AmbariException if service name is null or empty
    */
-  String findService(Cluster cluster, String componentName) throws AmbariException;
+  String findServiceName(Cluster cluster, String componentName) throws AmbariException;
 
   /**
    * Get service name by cluster instance and component id
@@ -520,7 +520,22 @@ public interface AmbariManagementController {
    * @throws  AmbariException if service name is null or empty
    */
 
-  String findService(Cluster cluster, Long componentId) throws AmbariException;
+  String findServiceName(Cluster cluster, Long componentId) throws AmbariException;
+
+
+  /**
+   * Get Service by cluster instance and component id
+   *
+   * @param cluster the cluster instance
+   * @param componentId the component id in Long type
+   *
+   * @return a service instance
+   *
+   * @throws  AmbariException if service name is null or empty
+   */
+
+  Service findService(Cluster cluster, Long componentId) throws AmbariException;
+
 
   /**
    * Get the clusters for this management controller.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -652,7 +652,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
       if (StringUtils.isEmpty(request.getServiceName())) {
         try {
-          request.setServiceName(findService(cluster, request.getComponentName()));
+          request.setServiceName(findServiceName(cluster, request.getComponentName()));
         } catch (ServiceNotFoundException e) {
           // handled below
         }
@@ -1276,7 +1276,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         // time bomb.  Blueprints are making this assumption.
         String serviceName = "";
         try {
-          serviceName = findService(cluster, request.getComponentName());
+          serviceName = findServiceName(cluster, request.getComponentName());
         } catch (ServiceNotFoundException e) {
           // handled below
         }
@@ -2479,7 +2479,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     execCmd.setConfigurations(configurations);
     execCmd.setConfigurationAttributes(configurationAttributes);
     execCmd.setConfigurationTags(configTags);
-
+    if (execCmd.getComponentName() == null) {
+      execCmd.setComponentName(scHost.getServiceComponentName());
+    }
     // Get the value of credential store enabled from the DB
     Service clusterService = cluster.getService(serviceGroupName, serviceName);
     execCmd.setCredentialStoreEnabled(String.valueOf(clusterService.isCredentialStoreEnabled()));
@@ -3598,13 +3600,18 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   }
 
   @Override
-  public String findService(Cluster cluster, String componentName) throws AmbariException {
+  public String findServiceName(Cluster cluster, String componentName) throws AmbariException {
     return cluster.getServiceByComponentName(componentName).getName();
   }
 
   @Override
-  public String findService(Cluster cluster, Long componentId) throws AmbariException {
+  public String findServiceName(Cluster cluster, Long componentId) throws AmbariException {
     return cluster.getServiceByComponentId(componentId).getName();
+  }
+
+  @Override
+  public Service findService(Cluster cluster, Long componentId) throws AmbariException {
+    return cluster.getServiceByComponentId(componentId);
   }
 
   @Override
@@ -3633,7 +3640,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     // if any request are for the whole host, they need to be expanded
     for (ServiceComponentHostRequest request : requests) {
-      if (null == request.getComponentName()) {
+      if (null == request.getComponentId()) {
         if (null == request.getClusterName() || request.getClusterName().isEmpty() ||
             null == request.getHostname() || request.getHostname().isEmpty()) {
           throw new IllegalArgumentException("Cluster name and hostname must be specified.");
@@ -3662,27 +3669,38 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     for (ServiceComponentHostRequest request : expanded) {
 
-      validateServiceComponentHostRequest(request);
-
       Cluster cluster = clusters.getCluster(request.getClusterName());
 
+      HostComponentStateEntity hostComponentStateEntity = null;
+      Service s = null;
+
       if (StringUtils.isEmpty(request.getServiceName())) {
-        request.setServiceName(findService(cluster, request.getComponentName()));
+        hostComponentStateEntity = hostComponentStateDAO.findById(request.getComponentId());
+        if (hostComponentStateEntity == null) {
+          throw new AmbariException("Could not find Host Component resource for"
+                  + " componentId = "+ request.getComponentId());
+        }
+        s = cluster.getService(hostComponentStateEntity.getServiceId());
+        request.setServiceGroupName(s.getServiceGroupName());
+        request.setServiceName(s.getName());
+        request.setComponentName(hostComponentStateEntity.getComponentName());
+        request.setComponentType(hostComponentStateEntity.getComponentType());
       }
 
       LOG.info("Received a hostComponent DELETE request"
         + ", clusterName=" + request.getClusterName()
+        + ", serviceGroupName=" + request.getServiceGroupName()
         + ", serviceName=" + request.getServiceName()
+        + ", componentId=" + request.getComponentId()     
         + ", componentName=" + request.getComponentName()
         + ", componentType=" + request.getComponentType()
         + ", hostname=" + request.getHostname()
         + ", request=" + request);
 
-      Service service = cluster.getService(request.getServiceName());
-      ServiceComponent component = service.getServiceComponent(request.getComponentName());
+      ServiceComponent component = s.getServiceComponent(request.getComponentName());
       ServiceComponentHost componentHost = component.getServiceComponentHost(request.getHostname());
 
-      setRestartRequiredServices(service, request.getComponentName());
+      setRestartRequiredServices(s, request.getComponentName());
       try {
         checkIfHostComponentsInDeleteFriendlyState(request, cluster);
         if (!safeToRemoveSCHs.containsKey(component)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractProviderModule.java
@@ -478,7 +478,7 @@ public abstract class AbstractProviderModule implements ProviderModule,
     Set<String> hosts = null;
     try {
       Cluster cluster = managementController.getClusters().getCluster(clusterName);
-      String serviceName = managementController.findService(cluster, componentName);
+      String serviceName = managementController.findServiceName(cluster, componentName);
       hosts = cluster.getService(serviceName).getServiceComponent(componentName).getServiceComponentHosts().keySet();
     } catch (Exception e) {
       LOG.warn("Exception in getting host names for jmx metrics: ", e);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -588,7 +588,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
         ServiceComponentResponse serviceComponentResponse = sc.convertToResponse();
         try {
           ComponentInfo componentInfo = ambariMetaInfo.getComponent(stackId.getStackName(),
-              stackId.getStackVersion(), s.getServiceType(), sc.getName());
+              stackId.getStackVersion(), s.getServiceType(), sc.getType());
           category = componentInfo.getCategory();
           if (category != null) {
             serviceComponentResponse.setCategory(category);
@@ -942,7 +942,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
       String componentName = request.getComponentName();
       String componentType = request.getComponentType();
 
-      String serviceName = getManagementController().findService(cluster, componentType);
+      String serviceName = getManagementController().findServiceName(cluster, componentType);
 
       debug("Looking up service name for component, componentType={}, serviceName={}", componentType, serviceName);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -545,7 +545,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       }
 
       if (StringUtils.isEmpty(request.getServiceName())) {
-        request.setServiceName(getManagementController().findService(cluster, request.getComponentName()));
+        request.setServiceName(getManagementController().findServiceName(cluster, request.getComponentName()));
       }
 
       ServiceComponent sc = getServiceComponent(
@@ -1081,7 +1081,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
           String serviceGroupName = (String) resource.getPropertyValue(HOST_COMPONENT_SERVICE_GROUP_NAME_PROPERTY_ID);
           if (StringUtils.isEmpty(serviceName)) {
             Cluster cluster = managementController.getClusters().getCluster(clusterName);
-            serviceName = managementController.findService(cluster, componentName);
+            serviceName = managementController.findServiceName(cluster, componentName);
             //TODO : What if SG name is empty.
           }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingSearchPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingSearchPropertyProvider.java
@@ -188,7 +188,7 @@ public class LoggingSearchPropertyProvider implements PropertyProvider {
     try {
       AmbariMetaInfo metaInfo = controller.getAmbariMetaInfo();
       Cluster cluster = controller.getClusters().getCluster(clusterName);
-      String serviceName = controller.findService(cluster, componentName);
+      String serviceName = controller.findServiceName(cluster, componentName);
       Service service = cluster.getService(serviceName);
       StackId stackId = service.getDesiredStackId();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
@@ -450,10 +450,9 @@ public class ServiceComponentImpl implements ServiceComponent {
     }
 
     String serviceName = service.getName();
-    String componentName = getName();
 
     Mpack mpack = ambariMetaInfo.getMpack(sg.getMpackId());
-    ModuleComponent moduleComponent = mpack.getModuleComponent(serviceName, componentName);
+    ModuleComponent moduleComponent = mpack.getModuleComponent(service.getServiceType(), getType());
 
     ServiceComponentResponse r = new ServiceComponentResponse(getClusterId(),
         cluster.getClusterName(), sg.getServiceGroupId(), sg.getServiceGroupName(), service.getServiceId(),

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
@@ -500,7 +500,7 @@ public class ServiceImpl implements Service {
   public ServiceResponse convertToResponse() {
     RepositoryVersionEntity desiredRespositoryVersion = getDesiredRepositoryVersion();
     Mpack mpack = ambariMetaInfo.getMpack(serviceGroup.getMpackId());
-    Module module = mpack.getModule(getName());
+    Module module = mpack.getModule(getServiceType());
 
     ServiceResponse r = new ServiceResponse(cluster.getClusterId(), cluster.getClusterName(),
         serviceGroup.getServiceGroupId(), serviceGroup.getServiceGroupName(),

--- a/ambari-server/src/test/java/org/apache/ambari/server/alerts/ComponentVersionAlertRunnableTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/alerts/ComponentVersionAlertRunnableTest.java
@@ -143,16 +143,16 @@ public class ComponentVersionAlertRunnableTest extends EasyMockSupport {
     ServiceComponentHost sch2_1 = createNiceMock(ServiceComponentHost.class);
     ServiceComponentHost sch2_2 = createNiceMock(ServiceComponentHost.class);
 
-    expect(sch1_1.getServiceName()).andReturn("FOO").atLeastOnce();
+    expect(sch1_1.getServiceType()).andReturn("FOO").atLeastOnce();
     expect(sch1_1.getServiceComponentName()).andReturn("FOO_COMPONENT").atLeastOnce();
     expect(sch1_1.getVersion()).andReturn(EXPECTED_VERSION).atLeastOnce();
-    expect(sch1_2.getServiceName()).andReturn("BAR").atLeastOnce();
+    expect(sch1_2.getServiceType()).andReturn("BAR").atLeastOnce();
     expect(sch1_2.getServiceComponentName()).andReturn("BAR_COMPONENT").atLeastOnce();
     expect(sch1_2.getVersion()).andReturn(EXPECTED_VERSION).atLeastOnce();
-    expect(sch2_1.getServiceName()).andReturn("FOO").atLeastOnce();
+    expect(sch2_1.getServiceType()).andReturn("FOO").atLeastOnce();
     expect(sch2_1.getServiceComponentName()).andReturn("FOO_COMPONENT").atLeastOnce();
     expect(sch2_1.getVersion()).andReturn(EXPECTED_VERSION).atLeastOnce();
-    expect(sch2_2.getServiceName()).andReturn("BAZ").atLeastOnce();
+    expect(sch2_2.getServiceType()).andReturn("BAZ").atLeastOnce();
     expect(sch2_2.getServiceComponentName()).andReturn("BAZ_COMPONENT").atLeastOnce();
     expect(sch2_2.getVersion()).andReturn(EXPECTED_VERSION).atLeastOnce();
 
@@ -302,7 +302,7 @@ public class ComponentVersionAlertRunnableTest extends EasyMockSupport {
     // reset expectation so that it returns a wrong version
     ServiceComponentHost sch = m_hostComponentMap.get(HOSTNAME_1).get(0);
     EasyMock.reset(sch);
-    expect(sch.getServiceName()).andReturn("FOO").atLeastOnce();
+    expect(sch.getServiceType()).andReturn("FOO").atLeastOnce();
     expect(sch.getServiceComponentName()).andReturn("FOO_COMPONENT").atLeastOnce();
     expect(sch.getVersion()).andReturn(WRONG_VERSION).atLeastOnce();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -241,11 +241,11 @@ public class ComponentResourceProviderTest {
     expect(managementController.getClusters()).andReturn(clusters);
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo);
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
-    expect(serviceComponent1.getName()).andReturn("Component100");
+    expect(serviceComponent1.getType()).andReturn("Component100");
     expect(serviceComponent1.getDesiredStackId()).andReturn(stackId).anyTimes();
-    expect(serviceComponent2.getName()).andReturn("Component101");
+    expect(serviceComponent2.getType()).andReturn("Component101");
     expect(serviceComponent2.getDesiredStackId()).andReturn(stackId).anyTimes();
-    expect(serviceComponent3.getName()).andReturn("Component102");
+    expect(serviceComponent3.getType()).andReturn("Component102");
     expect(serviceComponent3.getDesiredStackId()).andReturn(stackId).anyTimes();
 
     expect(cluster.getServices()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
@@ -413,11 +413,11 @@ public class ComponentResourceProviderTest {
     expect(service.getServiceComponent("Component102")).andReturn(serviceComponent1).anyTimes();
     expect(service.getServiceComponent("Component103")).andReturn(serviceComponent2).anyTimes();
 
-    expect(serviceComponent1.getName()).andReturn("Component101").anyTimes();
+    expect(serviceComponent1.getType()).andReturn("Component101").anyTimes();
     expect(serviceComponent1.getDesiredStackId()).andReturn(stackId).anyTimes();
-    expect(serviceComponent2.getName()).andReturn("Component102").anyTimes();
+    expect(serviceComponent2.getType()).andReturn("Component102").anyTimes();
     expect(serviceComponent2.getDesiredStackId()).andReturn(stackId).anyTimes();
-    expect(serviceComponent3.getName()).andReturn("Component103").anyTimes();
+    expect(serviceComponent3.getType()).andReturn("Component103").anyTimes();
     expect(serviceComponent3.getDesiredStackId()).andReturn(stackId).anyTimes();
 
     expect(cluster.getServices()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
@@ -730,7 +730,7 @@ public class ComponentResourceProviderTest {
     expect(service.getServiceType()).andReturn("Service100").anyTimes();
     expect(service.getServiceComponent("Component101")).andReturn(serviceComponent1).anyTimes();
 
-    expect(serviceComponent1.getName()).andReturn("Component101").atLeastOnce();
+    expect(serviceComponent1.getType()).andReturn("Component101").atLeastOnce();
     expect(serviceComponent1.isRecoveryEnabled()).andReturn(false).atLeastOnce();
     expect(serviceComponent1.getDesiredStackId()).andReturn(stackId).anyTimes();
     serviceComponent1.setRecoveryEnabled(true);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
@@ -354,7 +354,7 @@ public class HostComponentResourceProviderTest {
 
     // set expectations
     expect(managementController.getClusters()).andReturn(clusters).anyTimes();
-    expect(managementController.findService(cluster, "Component100")).andReturn("Service100").anyTimes();
+    expect(managementController.findServiceName(cluster, "Component100")).andReturn("Service100").anyTimes();
     expect(clusters.getCluster("Cluster102")).andReturn(cluster).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
     expect(cluster.getService("Service100")).andReturn(service).anyTimes();
@@ -540,7 +540,7 @@ public class HostComponentResourceProviderTest {
 
     // set expectations
     expect(managementController.getClusters()).andReturn(clusters).anyTimes();
-    expect(managementController.findService(cluster, "Component100")).andReturn("Service100").anyTimes();
+    expect(managementController.findServiceName(cluster, "Component100")).andReturn("Service100").anyTimes();
     expect(clusters.getCluster("Cluster102")).andReturn(cluster).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
     expect(cluster.getService("Service100")).andReturn(service).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/JMXHostProviderTest.java
@@ -472,7 +472,7 @@ public class JMXHostProviderTest {
     hostComponents.put("host1", null);
 
     expect(managementControllerMock.getClusters()).andReturn(clustersMock).anyTimes();
-    expect(managementControllerMock.findService(clusterMock, "DATANODE")).andReturn("HDFS");
+    expect(managementControllerMock.findServiceName(clusterMock, "DATANODE")).andReturn("HDFS");
     expect(clustersMock.getCluster("c1")).andReturn(clusterMock).anyTimes();
     expect(clusterMock.getService("HDFS")).andReturn(serviceMock).anyTimes();
     expect(serviceMock.getServiceComponent("DATANODE")).andReturn(serviceComponentMock).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LoggingSearchPropertyProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LoggingSearchPropertyProviderTest.java
@@ -198,7 +198,7 @@ public class LoggingSearchPropertyProviderTest {
           mockSupport.createMock(LogDefinition.class);
 
       Service serviceMock = mockSupport.createNiceMock(Service.class);
-      expect(controllerMock.findService(clusterMock, expectedComponentName)).andReturn(expectedServiceName).atLeastOnce();
+      expect(controllerMock.findServiceName(clusterMock, expectedComponentName)).andReturn(expectedServiceName).atLeastOnce();
       expect(clusterMock.getService(expectedServiceName)).andReturn(serviceMock).anyTimes();
       expect(serviceMock.getDesiredStackId()).andReturn(stackIdMock).anyTimes();
       expect(serviceMock.getServiceType()).andReturn(expectedServiceName).anyTimes();
@@ -407,7 +407,7 @@ public class LoggingSearchPropertyProviderTest {
           mockSupport.createMock(LoggingRequestHelper.class);
 
       Service serviceMock = mockSupport.createNiceMock(Service.class);
-      expect(controllerMock.findService(clusterMock, expectedComponentName)).andReturn(expectedServiceName).atLeastOnce();
+      expect(controllerMock.findServiceName(clusterMock, expectedComponentName)).andReturn(expectedServiceName).atLeastOnce();
       expect(clusterMock.getService(expectedServiceName)).andReturn(serviceMock).anyTimes();
       expect(serviceMock.getDesiredStackId()).andReturn(stackIdMock).anyTimes();
       expect(serviceMock.getServiceType()).andReturn(expectedServiceName).anyTimes();
@@ -575,7 +575,7 @@ public class LoggingSearchPropertyProviderTest {
           mockSupport.createMock(LoggingRequestHelper.class);
 
       Service serviceMock = mockSupport.createNiceMock(Service.class);
-      expect(controllerMock.findService(clusterMock, expectedComponentName)).andReturn(expectedServiceName).atLeastOnce();
+      expect(controllerMock.findServiceName(clusterMock, expectedComponentName)).andReturn(expectedServiceName).atLeastOnce();
       expect(clusterMock.getService(expectedServiceName)).andReturn(serviceMock).anyTimes();
       expect(serviceMock.getDesiredStackId()).andReturn(stackIdMock).anyTimes();
       expect(serviceMock.getServiceType()).andReturn(expectedServiceName).anyTimes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-23293. Fix the following : 
   1. Host Component deletes are broken 
   2. Use resourceType for getting resources from Mpack Modules.

**1. Host Component deletes after fix:**


DELETE http://<AmbariServer>:8080/api/v1/clusters/c1/hosts/<HostName>/host_components/13}
```
{
  "deleteResult" : [
    {
      "deleted" : {
        "key" : "component_id: 13"
      }
    }
  ]
}
```

**2. Use resource Type in for getting resources from Mpack Modules.**

*Reason:* When we are creating a Service, Host Component and Service Component when **name** provided is not same as the **type**, we need to use the ResourceType to refer the mpack to get the resource component from stack.

Eg: 

```
 {  
      "ServiceInfo":{  
         "service_group_name":"dev",
         "service_type":"ZOOKEEPER",
         "service_name":"ZOOKEEPER_dev"
      }
   }

```

## How was this patch tested?

- Deployed cluster with changes. Worked fine.
- Create Multi SG, Service, Service and Host Components. Worked fine. Used Postman Scripts from : [LINK](https://issues.apache.org/jira/secure/attachment/12913277/12913277_IdBasedHostComponentAPIs.postman_collection1)

