### PR TITLE
AMBARI-23294: Ambari files view throws 500 ERROR while trying to upload/download to/from HDFS encrypted zone (nitirajrathore)

### DIFF
--- a/contrib/views/files/src/main/resources/ui/app/adapters/application.js
+++ b/contrib/views/files/src/main/resources/ui/app/adapters/application.js
@@ -18,6 +18,7 @@
 
 import DS from 'ember-data';
 import Ember from 'ember';
+import ENV from 'files-view/config/environment';
 
 export default DS.RESTAdapter.extend({
   init: function () {
@@ -38,10 +39,26 @@ export default DS.RESTAdapter.extend({
       instance = parts[parts.length - 2];
       version = '';
     }
+
+    if (ENV.environment === 'development') {
+      return '/resources/files/fileops';
+    }
+
     return 'api/v1/views/' + view + version + '/instances/' + instance + '/resources/files/fileops';
   }),
 
-  headers: {
-    'X-Requested-By': 'ambari'
-  }
+ headers: Ember.computed(function () {
+    let headers = {
+      'X-Requested-By': 'ambari',
+      'Content-Type': 'application/json'
+    };
+
+    if (ENV.environment === 'development') {
+      // In development mode when the UI is served using ember serve the xhr requests are proxied to ambari server
+      // by setting the proxyurl parameter in ember serve and for ambari to authenticate the requests, it needs this
+      // basic authorization. This is for default admin/admin username/password combination.
+      headers['Authorization'] = 'Basic YWRtaW46YWRtaW4=';
+    }
+    return headers;
+  })
 });

--- a/contrib/views/files/src/main/resources/ui/app/services/file-preview.js
+++ b/contrib/views/files/src/main/resources/ui/app/services/file-preview.js
@@ -21,6 +21,7 @@ import FileOperationMixin from '../mixins/file-operation';
 
 export default Ember.Service.extend(FileOperationMixin, {
   fileSelectionService: Ember.inject.service('files-selection'),
+  logger: Ember.inject.service('alert-messages'),
   selectedFiles: Ember.computed.alias('fileSelectionService.files'),
   selected: Ember.computed('selectedFiles', function () {
     return this.get('selectedFiles').objectAt(0);
@@ -83,7 +84,9 @@ export default Ember.Service.extend(FileOperationMixin, {
           return resolve(response);
         }, (responseError) => {
           _self.set('isLoading', false);
-          return reject(error);
+          var error = this.extractError(responseError);
+          this.get('logger').danger("Failed to preview file.", error);
+          return reject(responseError);
         });
     });
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

After minor code modification below is what happens.
1. User will always be able to list files inside the encrypted zone whether he/she has permission on it or not.
2. User will be able to preview and download the file if he/she has encrypted key permission on the folder transparently.
3. If user does not have encrypted zone key permission and he tries to see content he will get a pop up with error and on error details page he will see complete error message from HDFS

## How was this patch tested?

Manual testing was done in files view and cross checked behaviour against the output of HDFS cli.
