### PR TITLE
[AMBARI-23266] Fix failure in TestFileCache

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/FileCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/FileCache.py
@@ -74,12 +74,15 @@ class FileCache():
     """
     Returns a base directory for service
     """
-    if 'service_package_folder' in command['commandParams']:
-      service_subpath = command['commandParams']['service_package_folder']
-    else:
-      service_subpath = command['serviceLevelParams']['service_package_folder']
-    return self.provide_directory(self.cache_dir, service_subpath,
-                                  server_url_prefix)
+    key = 'service_package_folder'
+    service_subpath = None
+    for param_type in ('commandParams', 'serviceLevelParams'):
+      if param_type in command and key in command[param_type]:
+        service_subpath = command[param_type][key]
+        break
+
+    if service_subpath:
+      return self.provide_directory(self.cache_dir, service_subpath, server_url_prefix)
 
 
   def get_hook_base_dir(self, command, server_url_prefix):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix unit test failure introduced by 576449879d.

```
ERROR: test_get_service_base_dir (TestFileCache.TestFileCache)
----------------------------------------------------------------------
ERROR 2018-03-20 06:58:54,744 - Python unit tests failed
Traceback (most recent call last):
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-common/src/test/python/mock/mock.py", line 1199, in patched
    return func(*args, **keywargs)
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/test/python/ambari_agent/TestFileCache.py", line 72, in test_get_service_base_dir
    res = fileCache.get_service_base_dir(command, "server_url_pref")
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/main/python/ambari_agent/FileCache.py", line 77, in get_service_base_dir
    if 'service_package_folder' in command['commandParams']:
KeyError: 'commandParams'
```

## How was this patch tested?

Unit test:

```
test_build_download_url (TestFileCache.TestFileCache) ... ok
test_fetch_url (TestFileCache.TestFileCache) ... ok
test_get_custom_actions_base_dir (TestFileCache.TestFileCache) ... ok
test_get_custom_resources_subdir (TestFileCache.TestFileCache) ... ok
test_get_hook_base_dir (TestFileCache.TestFileCache) ... ok
test_get_service_base_dir_absent (TestFileCache.TestFileCache) ... ok
test_get_service_base_dir_both (TestFileCache.TestFileCache) ... ok
test_get_service_base_dir_command_param (TestFileCache.TestFileCache) ... ok
test_get_service_base_dir_service_level_param (TestFileCache.TestFileCache) ... ok
test_invalidate_directory (TestFileCache.TestFileCache) ... ok
test_provide_directory (TestFileCache.TestFileCache) ... ok
test_provide_directory_no_update (TestFileCache.TestFileCache) ... ok
test_read_write_hash_sum (TestFileCache.TestFileCache) ... ok
test_reset (TestFileCache.TestFileCache) ... ok
test_unpack_archive (TestFileCache.TestFileCache) ... ok

----------------------------------------------------------------------
Ran 15 tests in 0.031s

OK
```