### PR TITLE
AMBARI-23296. Python UT failure

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestFileCache.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestFileCache.py
@@ -65,6 +65,9 @@ class TestFileCache(TestCase):
     provide_directory_mock.return_value = "dummy value"
     fileCache = FileCache(self.config)
     command = {
+      'commandParams' : {
+        'service_package_folder' : os.path.join('stacks', 'HDP', '2.1.1', 'services', 'ZOOKEEPER', 'package')
+      },
       'serviceLevelParams' : {
         'service_package_folder' : os.path.join('stacks', 'HDP', '2.1.1', 'services', 'ZOOKEEPER', 'package')
       }


### PR DESCRIPTION
ERROR: test_get_service_base_dir (TestFileCache.TestFileCache)
----------------------------------------------------------------------
ERROR 2018-03-20 06:58:54,744 - Python unit tests failed
Traceback (most recent call last):
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-common/src/test/python/mock/mock.py", line 1199, in patched
    return func(*args, **keywargs)
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/test/python/ambari_agent/TestFileCache.py", line 72, in test_get_service_base_dir
    res = fileCache.get_service_base_dir(command, "server_url_pref")
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/main/python/ambari_agent/FileCache.py", line 77, in get_service_base_dir
    if 'service_package_folder' in command['commandParams']:
KeyError: 'commandParams'