### PR TITLE
[AMBARI-23302] Ambari Upgrade from 2.6.0.0 - 2.7.0.0 - Dashboard is unable to load and spinner keeps spinning

### DIFF
--- a/ambari-web/app/controllers/global/cluster_controller.js
+++ b/ambari-web/app/controllers/global/cluster_controller.js
@@ -254,6 +254,7 @@ App.ClusterController = Em.Controller.extend(App.ReloadPopupMixin, {
           // make second call, because first is light since it doesn't request host-component metrics
           updater.updateServiceMetric(function() {
             self.set('isHostComponentMetricsLoaded', true);
+            updater.updateHDFSNameSpaces();
           });
           // components config loading doesn't affect overall progress
           self.loadComponentWithStaleConfigs(function () {

--- a/ambari-web/app/controllers/global/update_controller.js
+++ b/ambari-web/app/controllers/global/update_controller.js
@@ -685,7 +685,7 @@ App.UpdateController = Em.Controller.extend({
   },
 
   updateHDFSNameSpaces: function () {
-    if (App.Service.find().someProperty('serviceName', 'HDFS')) {
+    if (App.Service.find().someProperty('serviceName', 'HDFS') && App.get('isHaEnabled')) {
       const siteName = 'hdfs-site',
         storedHdfsSiteconfigs = App.db.getConfigs().findProperty('type', siteName),
         tagName = storedHdfsSiteconfigs && storedHdfsSiteconfigs.tag;

--- a/ambari-web/app/mappers/service_metrics_mapper.js
+++ b/ambari-web/app/mappers/service_metrics_mapper.js
@@ -543,7 +543,7 @@ App.serviceMetricsMapper = App.QuickDataMapper.create({
           });
         } else {
           activeNameNodeConfigKeys.forEach(key => {
-            item[key].default = Em.get(firstHostComponent, activeNameNodeConfigKeys[key]);
+            item[key].default = Em.get(firstHostComponent, activeNameNodeConfig[key]);
           });
         }
 

--- a/ambari-web/app/views/main/dashboard/widgets/namenode_cpu.js
+++ b/ambari-web/app/views/main/dashboard/widgets/namenode_cpu.js
@@ -39,7 +39,7 @@ App.NameNodeCpuPieChartView = App.PieChartDashboardWidgetView.extend(App.NameNod
           this.set('nnHostName', nn.get('hostName'));
         }
       } else {
-        this.set('nnHostName', self.get('model.nameNode.hostName'));
+        this.set('nnHostName', this.get('model.nameNode.hostName'));
       }
       if (this.get('nnHostName')) {
         this.getValue();

--- a/ambari-web/test/views/main/dashboard/widgets_test.js
+++ b/ambari-web/test/views/main/dashboard/widgets_test.js
@@ -34,7 +34,8 @@ describe('App.MainDashboardWidgetsView', function () {
       setDBProperty: Em.K,
       persistKey: 'key',
       widgetGroupsDeferred: {
-        done: Em.clb
+        done: Em.clb,
+        resolve: Em.K
       }
     });
   });


### PR DESCRIPTION
## What changes were proposed in this pull request?

After Ambari Upgrade from 2.6.0.0 to 2.7.0.0 , the Ambari UI Dashboard is unable to load. Spinner keeps spinning,
Seems like Wizard-Data API calls are returning null and not being handled properly on the UI. Ideally, the dashboard should be shown with widgets with No data (if AMS is down)
Additional Information:
Adding few more observed issues. These might be related to the originally raised issue.
1. Quick Links are not shown for services. Spinner keeps spinning.
2. Component information is not shown for some services. e.g. Oozie.
3. For HDFS, YARN -> DataNodes, NodeManagers keep showing Loading and never loads.

## How was this patch tested?

UI unit tests:
  21512 passing (24s)
  48 pending