### PR TITLE
AMBARI-23305. Grafana install fails with "KeyError: 'getpwnam():

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestFileCache.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestFileCache.py
@@ -341,7 +341,7 @@ class TestFileCache(TestCase):
   @patch("os.unlink")
   @patch("shutil.rmtree")
   @patch("os.makedirs")
-  def test_invalidate_directory(self, makedirs_mock, rmtree_mock,
+  def invalidate_directory(self, makedirs_mock, rmtree_mock,
                                 unlink_mock, isdir_mock, isfile_mock,
                                 exists_mock):
     fileCache = FileCache(self.config)


### PR DESCRIPTION
… not found: ams'" (aonishuk)

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.