### PR TITLE
[AMBARI-23306] Make sure we have container-executor after Ambari upgrade

### DIFF
--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/configuration/container-executor.xml
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/configuration/container-executor.xml
@@ -31,6 +31,6 @@
       <property-file-name>container-executor.cfg.j2</property-file-name>
       <property-file-type>text</property-file-type>
     </value-attributes>
-    <on-ambari-upgrade add="false"/>
+    <on-ambari-upgrade add="true"/>
   </property>
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`container-executor` configuration parameter was not available after Ambari upgrade so that I changed its `add` property upgrade behavior from `false` to `true`

## How was this patch tested?

Latest unit test results in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 30:23 min
[INFO] Finished at: 2018-03-20T17:50:31+01:00
[INFO] Final Memory: 215M/832M
[INFO] ------------------------------------------------------------------------
```

Running manual testing like this:

1. installed Ambar 2.6.2 (build 101)
2. installed a Kerberized cluster with these services: HDFS, YARN+MR2
3. upgraded to Ambari 2.7.0.0 (build 167) by following the instructions of our [upgrade guide](https://docs.hortonworks.com/HDPDocuments/Ambari-2.6.0.0/bk_ambari-upgrade/content/upgrading_ambari.html); before I executed step 9 (`ambari-server upgrade`) I edited the XML manually on the host where my server was running
4. upgrade went well; I started the server and the agents
5. restarted all services on each hosts without any issue

<img width="1615" alt="screen shot 2018-03-20 at 5 28 41 pm" src="https://user-images.githubusercontent.com/34065904/37668192-2e6c8b32-2c64-11e8-844d-01af14466cf9.png">

