### PR TITLE
AMBARI-23289. Add SSO integration support information to service information via Ambari's REST API (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceResponse.java
@@ -36,16 +36,22 @@ public class ServiceResponse {
   private String maintenanceState;
   private boolean credentialStoreSupported;
   private boolean credentialStoreEnabled;
+  private final boolean ssoIntegrationSupported;
+  private final boolean ssoIntegrationDesired;
+  private final boolean ssoIntegrationEnabled;
 
   public ServiceResponse(Long clusterId, String clusterName, String serviceName,
-      StackId desiredStackId, String desiredRepositoryVersion,
-      RepositoryVersionState repositoryVersionState, String desiredState,
-      boolean credentialStoreSupported, boolean credentialStoreEnabled) {
+                         StackId desiredStackId, String desiredRepositoryVersion,
+                         RepositoryVersionState repositoryVersionState, String desiredState,
+                         boolean credentialStoreSupported, boolean credentialStoreEnabled, boolean ssoIntegrationSupported, boolean ssoIntegrationDesired, boolean ssoIntegrationEnabled) {
     this.clusterId = clusterId;
     this.clusterName = clusterName;
     this.serviceName = serviceName;
     this.desiredStackId = desiredStackId;
     this.repositoryVersionState = repositoryVersionState;
+    this.ssoIntegrationSupported = ssoIntegrationSupported;
+    this.ssoIntegrationDesired = ssoIntegrationDesired;
+    this.ssoIntegrationEnabled = ssoIntegrationEnabled;
     setDesiredState(desiredState);
     this.desiredRepositoryVersion = desiredRepositoryVersion;
     this.credentialStoreSupported = credentialStoreSupported;
@@ -226,6 +232,30 @@ public class ServiceResponse {
     result = 71 * result + (clusterName != null ? clusterName.hashCode() : 0);
     result = 71 * result + (serviceName != null ? serviceName.hashCode() : 0);
     return result;
+  }
+
+  /**
+   * Indicates if this service supports single sign-on integration.
+   */
+  @ApiModelProperty(name = "sso_integration_supported")
+  public boolean isSsoIntegrationSupported() {
+    return ssoIntegrationSupported;
+  }
+
+  /**
+   * Indicates whether the service is chosen for SSO integration or not
+   */
+  @ApiModelProperty(name = "sso_integration_desired")
+  public boolean isSsoIntegrationDesired() {
+    return ssoIntegrationDesired;
+  }
+
+  /**
+   * Indicates whether the service is configured for SSO integration or not
+   */
+  @ApiModelProperty(name = "sso_integration_enabled")
+  public boolean isSsoIntegrationEnabled() {
+    return ssoIntegrationEnabled;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
@@ -79,6 +79,8 @@ public class StackServiceResponse {
 
   private boolean isSupportDeleteViaUI;
 
+  private final boolean ssoIntegrationSupported;
+
   /**
    * Constructor.
    *
@@ -114,6 +116,7 @@ public class StackServiceResponse {
     credentialStoreSupported = service.isCredentialStoreSupported();
     credentialStoreEnabled = service.isCredentialStoreEnabled();
     isSupportDeleteViaUI = service.isSupportDeleteViaUI();
+    ssoIntegrationSupported = service.isSingleSignOnSupported();
   }
 
   @ApiModelProperty(name = "selection")
@@ -330,6 +333,14 @@ public class StackServiceResponse {
   @ApiModelProperty(hidden = true)
   public boolean isSupportDeleteViaUI(){
     return isSupportDeleteViaUI;
+  }
+
+  /**
+   * Indicates if this service supports single sign-on integration.
+   */
+  @ApiModelProperty(name = "sso_integration_supported")
+  public boolean isSsoIntegrationSupported() {
+    return ssoIntegrationSupported;
   }
 
   public interface StackServiceResponseSwagger extends ApiModel {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -120,6 +120,15 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   public static final String SERVICE_DESIRED_REPO_VERSION_ID_PROPERTY_ID = PropertyHelper.getPropertyId(
       "ServiceInfo", "desired_repository_version_id");
 
+  private static final String SSO_INTEGRATION_SUPPORTED_PROPERTY_ID = PropertyHelper.getPropertyId(
+    "ServiceInfo", "sso_integration_supported");
+
+  private static final String SSO_INTEGRATION_ENABLED_PROPERTY_ID = PropertyHelper.getPropertyId(
+    "ServiceInfo", "sso_integration_enabled");
+
+  private static final String SSO_INTEGRATION_DESIRED_PROPERTY_ID = PropertyHelper.getPropertyId(
+    "ServiceInfo", "sso_integration_desired");
+
   protected static final String SERVICE_REPOSITORY_STATE = "ServiceInfo/repository_state";
 
   //Parameters from the predicate
@@ -158,6 +167,10 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     PROPERTY_IDS.add(QUERY_PARAMETERS_RUN_SMOKE_TEST_ID);
     PROPERTY_IDS.add(QUERY_PARAMETERS_RECONFIGURE_CLIENT);
     PROPERTY_IDS.add(QUERY_PARAMETERS_START_DEPENDENCIES);
+
+    PROPERTY_IDS.add(SSO_INTEGRATION_SUPPORTED_PROPERTY_ID);
+    PROPERTY_IDS.add(SSO_INTEGRATION_ENABLED_PROPERTY_ID);
+    PROPERTY_IDS.add(SSO_INTEGRATION_DESIRED_PROPERTY_ID);
 
     // keys
     KEY_PROPERTY_IDS.put(Resource.Type.Service, SERVICE_SERVICE_NAME_PROPERTY_ID);
@@ -274,6 +287,13 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
 
       setResourceProperty(resource, SERVICE_REPOSITORY_STATE,
           response.getRepositoryVersionState(), requestedIds);
+
+      setResourceProperty(resource, SSO_INTEGRATION_SUPPORTED_PROPERTY_ID,
+        response.isSsoIntegrationSupported(), requestedIds);
+      setResourceProperty(resource, SSO_INTEGRATION_ENABLED_PROPERTY_ID,
+        response.isSsoIntegrationEnabled(), requestedIds);
+      setResourceProperty(resource, SSO_INTEGRATION_DESIRED_PROPERTY_ID,
+        response.isSsoIntegrationDesired(), requestedIds);
 
       Map<String, Object> serviceSpecificProperties = getServiceSpecificProperties(
           response.getClusterName(), response.getServiceName(), requestedIds);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
@@ -102,6 +102,9 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
   private static final String SUPPORT_DELETE_VIA_UI = PropertyHelper.getPropertyId(
       "StackServices", "support_delete_via_ui");
 
+  private static final String SSO_INTEGRATION_SUPPORTED_PROPERTY_ID = PropertyHelper.getPropertyId(
+    "StackServices", "sso_integration_supported");
+
   /**
    * The key property ids for a StackVersion resource.
    */
@@ -132,7 +135,8 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
       CREDENTIAL_STORE_SUPPORTED,
       CREDENTIAL_STORE_REQUIRED,
       CREDENTIAL_STORE_ENABLED,
-      SUPPORT_DELETE_VIA_UI);
+      SUPPORT_DELETE_VIA_UI,
+      SSO_INTEGRATION_SUPPORTED_PROPERTY_ID);
 
   /**
    * KerberosServiceDescriptorFactory used to create KerberosServiceDescriptor instances
@@ -238,6 +242,8 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
 
     setResourceProperty(resource, SUPPORT_DELETE_VIA_UI,
         response.isSupportDeleteViaUI(), requestedIds);
+
+    setResourceProperty(resource, SSO_INTEGRATION_SUPPORTED_PROPERTY_ID, response.isSsoIntegrationSupported(), requestedIds);
 
     return resource;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
@@ -36,6 +36,7 @@ import org.apache.ambari.server.ObjectNotFoundException;
 import org.apache.ambari.server.ServiceComponentNotFoundException;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.ServiceResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
 import org.apache.ambari.server.controller.internal.DeleteHostComponentStatusMetaData;
 import org.apache.ambari.server.events.MaintenanceModeEvent;
 import org.apache.ambari.server.events.ServiceInstalledEvent;
@@ -79,11 +80,19 @@ public class ServiceImpl implements Service {
   private boolean isClientOnlyService;
   private boolean isCredentialStoreSupported;
   private boolean isCredentialStoreRequired;
+  private final boolean ssoIntegrationSupported;
+  private final String ssoEnabledConfiguration;
   private AmbariMetaInfo ambariMetaInfo;
   private AtomicReference<MaintenanceState> maintenanceState = new AtomicReference<>();
 
   @Inject
   private ServiceConfigDAO serviceConfigDAO;
+
+  @Inject
+  private ConfigHelper configHelper;
+
+  @Inject
+  private AmbariServerConfigurationHandler ambariServerConfigurationHandler;
 
   private final ClusterServiceDAO clusterServiceDAO;
   private final ServiceDesiredStateDAO serviceDesiredStateDAO;
@@ -138,6 +147,8 @@ public class ServiceImpl implements Service {
     isClientOnlyService = sInfo.isClientOnlyService();
     isCredentialStoreSupported = sInfo.isCredentialStoreSupported();
     isCredentialStoreRequired = sInfo.isCredentialStoreRequired();
+    ssoIntegrationSupported = sInfo.isSingleSignOnSupported();
+    ssoEnabledConfiguration = sInfo.getSingleSignOnEnabledConfiguration();
 
     persist(serviceEntity);
   }
@@ -185,6 +196,8 @@ public class ServiceImpl implements Service {
     isCredentialStoreSupported = sInfo.isCredentialStoreSupported();
     isCredentialStoreRequired = sInfo.isCredentialStoreRequired();
     displayName = sInfo.getDisplayName();
+    ssoIntegrationSupported = sInfo.isSingleSignOnSupported();
+    ssoEnabledConfiguration = sInfo.getSingleSignOnEnabledConfiguration();
   }
 
 
@@ -362,7 +375,8 @@ public class ServiceImpl implements Service {
 
     ServiceResponse r = new ServiceResponse(cluster.getClusterId(), cluster.getClusterName(),
         getName(), desiredStackId, desiredRespositoryVersion.getVersion(), getRepositoryState(),
-        getDesiredState().toString(), isCredentialStoreSupported(), isCredentialStoreEnabled());
+        getDesiredState().toString(), isCredentialStoreSupported(), isCredentialStoreEnabled(),
+      ssoIntegrationSupported, isSsoIntegrationDesired(), isSsoIntegrationEnabled());
 
     r.setDesiredRepositoryVersionId(desiredRespositoryVersion.getId());
 
@@ -675,5 +689,23 @@ public class ServiceImpl implements Service {
   // Refresh the cached reference on setters
   private ServiceDesiredStateEntity getServiceDesiredStateEntity() {
     return serviceDesiredStateDAO.findByPK(serviceDesiredStateEntityPK);
+  }
+
+  public boolean isSsoIntegrationDesired() {
+    return ambariServerConfigurationHandler.getSsoEnabledSevices().contains(serviceName);
+  }
+
+  public boolean isSsoIntegrationEnabled() {
+    return ssoIntegrationSupported && ssoEnabledConfigValid() && "true".equalsIgnoreCase(ssoEnabledConfigValue());
+  }
+
+  private boolean ssoEnabledConfigValid() {
+    return ssoEnabledConfiguration != null && ssoEnabledConfiguration.split("/").length == 2;
+  }
+
+  private String ssoEnabledConfigValue() {
+    String configType = ssoEnabledConfiguration.split("/")[0];
+    String propertyName = ssoEnabledConfiguration.split("/")[1];
+    return configHelper.getValueFromDesiredConfigurations(cluster, configType, propertyName);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -653,6 +653,10 @@ public class ServiceInfo implements Validable {
     return (singleSignOnInfo != null) && singleSignOnInfo.isSupported();
   }
 
+  public String getSingleSignOnEnabledConfiguration() {
+    return singleSignOnInfo != null ? singleSignOnInfo.getEnabledConfiguration() : null;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import static java.util.Collections.singletonList;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.SSO_CONFIGURATION;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_ENABED_SERVICES;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
+import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
+import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockSupport;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EasyMockRunner.class)
+public class AmbariServerConfigurationHandlerTest extends EasyMockSupport {
+  @Mock
+  private AmbariConfigurationDAO ambariConfigurationDAO;
+  private AmbariServerConfigurationHandler ambariServerConfigurationHandler;
+
+  @Before
+  public void setUp() throws Exception {
+    ambariServerConfigurationHandler = new AmbariServerConfigurationHandler();
+    AmbariServerConfigurationHandler.ambariConfigurationDAO = ambariConfigurationDAO;
+  }
+
+  @Test
+  public void testCheckingIfSsoIsEnabledPerEachService() {
+    expect(ambariConfigurationDAO.findByCategory(SSO_CONFIGURATION.getCategoryName())).andReturn(singletonList(ssoConfig("SERVICE1, SERVICE2"))).anyTimes();
+    replayAll();
+    assertTrue(ambariServerConfigurationHandler.getSsoEnabledSevices().contains("SERVICE1"));
+    assertTrue(ambariServerConfigurationHandler.getSsoEnabledSevices().contains("SERVICE2"));
+    assertFalse(ambariServerConfigurationHandler.getSsoEnabledSevices().contains("SERVICE3"));
+  }
+
+  private AmbariConfigurationEntity ssoConfig(String services) {
+    AmbariConfigurationEntity entity = new AmbariConfigurationEntity();
+    entity.setCategoryName(SSO_CONFIGURATION.getCategoryName());
+    entity.setPropertyName(SSO_ENABED_SERVICES.key());
+    entity.setPropertyValue(services);
+    return entity;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

SSO related information (enabled, supported, desired) was added to the REST output of stack services and installed services.

Fields are calculated as follows:
- _supported_ comes from service metainfo (&lt;sso&gt;&lt;supported&gt;true&lt;/supported&gt;)
- _desired_ comes from ambari configuration called ambari.sso.enabled_services
- _enabled_ comes from service config where the config-type/property-name comes from service metainfo.

## How was this patch tested?

Manually updated metainfo.xml of an existing service

```xml
    <service>
      <name>ZOOKEEPER</name>
      <version>3.4.6</version>
        <sso>
             <supported>true</supported>
             <enabledConfiguration>zoo.cfg/my-sso</enabledConfiguration>
        </sso>
    </service>
```

used the following curl command to update ambari.sso.enabled_services.

```bash
$ curl -i -v -uadmin:admin -H "X-Requested-By: ambari" -X POST --data @sso-conf.json  http://c7401:8080/api/v1/services/AMBARI/components/AMBARI_SERVER/configurations
```

```bash
$ sso-conf.json

{
  "Configuration": {    
    "category" : "sso-configuration",
    "properties": {
        "ambari.sso.enabled_services": "ZOOKEEPER"
     }
  }
}
```

Checked the outout of REST API calls like:

- /api/v1/stacks/HDP/versions/2.6/services/ZOOKEEPER
- /api/v1/clusters/cluster18/services/ZOOKEEPER