### PR TITLE
Fix various DDL errors

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -91,7 +91,7 @@ public class HostComponentStateEntity {
   @Column(name = "id", nullable = false, insertable = true, updatable = false)
   private Long id;
 
-  @Column(name = "host_component_desired_state_id", nullable = false, insertable = false, updatable = false)
+  @Column(name = "host_comp_desired_state_id", nullable = false, insertable = false, updatable = false)
   private Long hostComponentDesiredStateId;
 
   @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
@@ -140,7 +140,7 @@ public class HostComponentStateEntity {
   private HostEntity hostEntity;
 
   @OneToOne
-  @JoinColumn(name = "host_component_desired_state_id", referencedColumnName = "id", nullable = false)
+  @JoinColumn(name = "host_comp_desired_state_id", referencedColumnName = "id", nullable = false)
   private HostComponentDesiredStateEntity hostComponentDesiredStateEntity;
 
   public Long getId() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceGroupDependencyEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ServiceGroupDependencyEntity.java
@@ -55,25 +55,25 @@ public class ServiceGroupDependencyEntity {
   @Column(name = "service_group_id", nullable = false, insertable = false, updatable = false)
   private long serviceGroupId;
 
-  @Column(name = "service_group_cluster_id", nullable = false, insertable = false, updatable = false)
+  @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false)
   private long serviceGroupClusterId;
 
   @Column(name = "dependent_service_group_id", nullable = false, insertable = false, updatable = false)
   private long dependentServiceGroupId;
 
-  @Column(name = "dependent_service_group_cluster_id", nullable = false, insertable = false, updatable = false)
+  @Column(name = "dependent_cluster_id", nullable = false, insertable = false, updatable = false)
   private long dependentServiceGroupClusterId;
 
   @ManyToOne
   @JoinColumns({
           @JoinColumn(name = "service_group_id", referencedColumnName = "id", nullable = false),
-          @JoinColumn(name = "service_group_cluster_id", referencedColumnName = "cluster_id", nullable = false) })
+          @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false) })
   private ServiceGroupEntity serviceGroup;
 
   @ManyToOne
   @JoinColumns({
           @JoinColumn(name = "dependent_service_group_id", referencedColumnName = "id", nullable = false),
-          @JoinColumn(name = "dependent_service_group_cluster_id", referencedColumnName = "cluster_id", nullable = false) })
+          @JoinColumn(name = "dependent_cluster_id", referencedColumnName = "cluster_id", nullable = false) })
   private ServiceGroupEntity serviceGroupDependency;
 
   public ServiceGroupEntity getServiceGroup() {

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -316,7 +316,7 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
-  host_component_desired_state_id BIGINT NOT NULL,
+  host_comp_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
   component_type VARCHAR(255) NOT NULL,
@@ -329,7 +329,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
   CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -142,13 +142,13 @@ CREATE TABLE servicegroups (
 CREATE TABLE servicegroupdependencies (
   id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
-  service_group_cluster_id BIGINT NOT NULL,
+  cluster_id BIGINT NOT NULL,
   dependent_service_group_id BIGINT NOT NULL,
-  dependent_service_group_cluster_id BIGINT NOT NULL,
+  dependent_cluster_id BIGINT NOT NULL,
   CONSTRAINT PK_servicegroupdependencies PRIMARY KEY (id),
-  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, service_group_cluster_id, dependent_service_group_id, dependent_service_group_cluster_id),
-  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, service_group_cluster_id) REFERENCES servicegroups (id, cluster_id),
-  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_service_group_cluster_id) REFERENCES servicegroups (id, cluster_id));
+  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, cluster_id, dependent_service_group_id, dependent_cluster_id),
+  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, cluster_id) REFERENCES servicegroups (id, cluster_id),
+  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_cluster_id) REFERENCES servicegroups (id, cluster_id));
 
 CREATE TABLE clusterservices (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -624,6 +624,18 @@ CREATE TABLE blueprint (
   security_descriptor_reference VARCHAR(255),
   CONSTRAINT PK_blueprint PRIMARY KEY (blueprint_name));
 
+CREATE TABLE topology_request (
+  id BIGINT NOT NULL,
+  action VARCHAR(255) NOT NULL,
+  cluster_id BIGINT NOT NULL,
+  bp_name VARCHAR(100) NOT NULL,
+  cluster_properties VARCHAR(3000),
+  cluster_attributes VARCHAR(3000),
+  description VARCHAR(1024),
+  provision_action VARCHAR(255),
+  CONSTRAINT PK_topology_request PRIMARY KEY (id),
+  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
+
 CREATE TABLE mpack_instance(
   id BIGINT NOT NULL,
   owner VARCHAR (20) NOT NULL,
@@ -880,18 +892,6 @@ CREATE TABLE artifact (
   artifact_data VARCHAR(3000) NOT NULL,
   foreign_keys VARCHAR(255) NOT NULL,
   CONSTRAINT PK_artifact PRIMARY KEY (artifact_name, foreign_keys));
-
-CREATE TABLE topology_request (
-  id BIGINT NOT NULL,
-  action VARCHAR(255) NOT NULL,
-  cluster_id BIGINT NOT NULL,
-  bp_name VARCHAR(100) NOT NULL,
-  cluster_properties VARCHAR(3000),
-  cluster_attributes VARCHAR(3000),
-  description VARCHAR(1024),
-  provision_action VARCHAR(255),
-  CONSTRAINT PK_topology_request PRIMARY KEY (id),
-  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
 
 CREATE TABLE topology_hostgroup (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -63,16 +63,6 @@ CREATE TABLE stack (
   CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
-CREATE TABLE mpack_host_state (
-  id BIGINT NOT NULL,
-  host_id BIGINT NOT NULL,
-  mpack_id BIGINT NOT NULL,
-  state VARCHAR(32) NOT NULL,
-  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
-  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
-  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
-
 CREATE TABLE extension(
   extension_id BIGINT NOT NULL,
   extension_name VARCHAR(100) NOT NULL,
@@ -139,6 +129,16 @@ CREATE TABLE hosts (
   total_mem BIGINT NOT NULL,
   CONSTRAINT PK_hosts PRIMARY KEY (host_id),
   CONSTRAINT UQ_hosts_host_name UNIQUE (host_name));
+
+CREATE TABLE mpack_host_state (
+  id BIGINT NOT NULL,
+  host_id BIGINT NOT NULL,
+  mpack_id BIGINT NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
+  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
 
 CREATE TABLE clustersettings (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -642,6 +642,18 @@ CREATE TABLE blueprint (
   security_descriptor_reference VARCHAR(255),
   CONSTRAINT PK_blueprint PRIMARY KEY (blueprint_name));
 
+CREATE TABLE topology_request (
+  id BIGINT NOT NULL,
+  action VARCHAR(255) NOT NULL,
+  cluster_id BIGINT NOT NULL,
+  bp_name VARCHAR(100) NOT NULL,
+  cluster_properties LONGTEXT,
+  cluster_attributes LONGTEXT,
+  description VARCHAR(1024),
+  provision_action VARCHAR(255),
+  CONSTRAINT PK_topology_request PRIMARY KEY (id),
+  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
+
 CREATE TABLE mpack_instance(
   id BIGINT NOT NULL,
   owner VARCHAR (20) NOT NULL,
@@ -897,18 +909,6 @@ CREATE TABLE artifact (
   foreign_keys VARCHAR(100) NOT NULL,
   artifact_data LONGTEXT NOT NULL,
   CONSTRAINT PK_artifact PRIMARY KEY (artifact_name, foreign_keys));
-
-CREATE TABLE topology_request (
-  id BIGINT NOT NULL,
-  action VARCHAR(255) NOT NULL,
-  cluster_id BIGINT NOT NULL,
-  bp_name VARCHAR(100) NOT NULL,
-  cluster_properties LONGTEXT,
-  cluster_attributes LONGTEXT,
-  description VARCHAR(1024),
-  provision_action VARCHAR(255),
-  CONSTRAINT PK_topology_request PRIMARY KEY (id),
-  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
 
 CREATE TABLE topology_hostgroup (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -335,7 +335,7 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
-  host_component_desired_state_id BIGINT NOT NULL,
+  host_comp_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(100) NOT NULL,
   component_type VARCHAR(100) NOT NULL,
@@ -348,7 +348,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
   CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -161,13 +161,13 @@ CREATE TABLE servicegroups (
 CREATE TABLE servicegroupdependencies (
   id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
-  service_group_cluster_id BIGINT NOT NULL,
+  cluster_id BIGINT NOT NULL,
   dependent_service_group_id BIGINT NOT NULL,
-  dependent_service_group_cluster_id BIGINT NOT NULL,
+  dependent_cluster_id BIGINT NOT NULL,
   CONSTRAINT PK_servicegroupdependencies PRIMARY KEY (id),
-  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, service_group_cluster_id, dependent_service_group_id, dependent_service_group_cluster_id),
-  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, service_group_cluster_id) REFERENCES servicegroups (id, cluster_id),
-  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_service_group_cluster_id) REFERENCES servicegroups (id, cluster_id));
+  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, cluster_id, dependent_service_group_id, dependent_cluster_id),
+  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, cluster_id) REFERENCES servicegroups (id, cluster_id),
+  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_cluster_id) REFERENCES servicegroups (id, cluster_id));
 
 CREATE TABLE clusterservices (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -314,7 +314,7 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id NUMBER(19) NOT NULL,
-  host_component_desired_state_id NUMBER(19) NOT NULL,
+  host_comp_desired_state_id NUMBER(19) NOT NULL,
   cluster_id NUMBER(19) NOT NULL,
   component_name VARCHAR2(255) NOT NULL,
   component_type VARCHAR2(255) NOT NULL,
@@ -327,7 +327,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
   CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -44,16 +44,6 @@ CREATE TABLE stack (
   CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
-CREATE TABLE mpack_host_state (
-  id NUMBER(19) NOT NULL,
-  host_id NUMBER(19) NOT NULL,
-  mpack_id NUMBER(19) NOT NULL,
-  state VARCHAR2(32) NOT NULL,
-  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
-  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
-  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
-
 CREATE TABLE extension(
   extension_id NUMERIC(19) NOT NULL,
   extension_name VARCHAR2(255) NOT NULL,
@@ -120,6 +110,16 @@ CREATE TABLE hosts (
   total_mem INTEGER NOT NULL,
   CONSTRAINT PK_hosts PRIMARY KEY (host_id),
   CONSTRAINT UQ_hosts_host_name UNIQUE (host_name));
+
+CREATE TABLE mpack_host_state (
+  id NUMBER(19) NOT NULL,
+  host_id NUMBER(19) NOT NULL,
+  mpack_id NUMBER(19) NOT NULL,
+  state VARCHAR2(32) NOT NULL,
+  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
+  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
 
 CREATE TABLE clustersettings (
   id NUMBER(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -142,13 +142,13 @@ CREATE TABLE servicegroups (
 CREATE TABLE servicegroupdependencies (
   id NUMBER(19) NOT NULL,
   service_group_id NUMBER(19) NOT NULL,
-  service_group_cluster_id NUMBER(19) NOT NULL,
+  cluster_id NUMBER(19) NOT NULL,
   dependent_service_group_id NUMBER(19) NOT NULL,
-  dependent_service_group_cluster_id NUMBER(19) NOT NULL,
+  dependent_cluster_id NUMBER(19) NOT NULL,
   CONSTRAINT PK_servicegroupdependencies PRIMARY KEY (id),
-  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, service_group_cluster_id, dependent_service_group_id, dependent_service_group_cluster_id),
-  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, service_group_cluster_id) REFERENCES servicegroups (id, cluster_id),
-  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_service_group_cluster_id) REFERENCES servicegroups (id, cluster_id));
+  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, cluster_id, dependent_service_group_id, dependent_cluster_id),
+  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, cluster_id) REFERENCES servicegroups (id, cluster_id),
+  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_cluster_id) REFERENCES servicegroups (id, cluster_id));
 
 CREATE TABLE clusterservices (
   id NUMBER(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -622,6 +622,18 @@ CREATE TABLE blueprint (
   security_descriptor_reference VARCHAR2(255),
   CONSTRAINT PK_blueprint PRIMARY KEY (blueprint_name));
 
+CREATE TABLE topology_request (
+  id NUMBER(19) NOT NULL,
+  action VARCHAR(255) NOT NULL,
+  cluster_id NUMBER(19) NOT NULL,
+  bp_name VARCHAR(100) NOT NULL,
+  cluster_properties CLOB,
+  cluster_attributes CLOB,
+  description VARCHAR(1024),
+  provision_action VARCHAR(255),
+  CONSTRAINT PK_topology_request PRIMARY KEY (id),
+  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
+
 CREATE TABLE mpack_instance(
   id NUMBER(19) NOT NULL,
   owner VARCHAR2 (20) NOT NULL,
@@ -875,18 +887,6 @@ CREATE TABLE artifact (
   foreign_keys VARCHAR2(255) NOT NULL,
   artifact_data CLOB NOT NULL,
   CONSTRAINT PK_artifact PRIMARY KEY (artifact_name, foreign_keys));
-
-CREATE TABLE topology_request (
-  id NUMBER(19) NOT NULL,
-  action VARCHAR(255) NOT NULL,
-  cluster_id NUMBER(19) NOT NULL,
-  bp_name VARCHAR(100) NOT NULL,
-  cluster_properties CLOB,
-  cluster_attributes CLOB,
-  description VARCHAR(1024),
-  provision_action VARCHAR(255),
-  CONSTRAINT PK_topology_request PRIMARY KEY (id),
-  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
 
 CREATE TABLE topology_hostgroup (
   id NUMBER(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -1082,11 +1082,11 @@ CREATE TABLE kerberos_keytab (
 );
 
 CREATE TABLE kerberos_keytab_principal (
-  kkp_id BIGINT NOT NULL DEFAULT 0,
+  kkp_id NUMBER(19) DEFAULT 0 NOT NULL,
   keytab_path VARCHAR2(255) NOT NULL,
   principal_name VARCHAR2(255) NOT NULL,
   host_id NUMBER(19),
-  is_distributed NUMBER(1) NOT NULL DEFAULT 0,
+  is_distributed NUMBER(1) DEFAULT 0 NOT NULL,
   CONSTRAINT PK_kkp PRIMARY KEY (kkp_id),
   CONSTRAINT FK_kkp_keytab_path FOREIGN KEY (keytab_path) REFERENCES kerberos_keytab (keytab_path),
   CONSTRAINT FK_kkp_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
@@ -1095,7 +1095,7 @@ CREATE TABLE kerberos_keytab_principal (
 );
 
 CREATE TABLE kkp_mapping_service (
-  kkp_id BIGINT NOT NULL DEFAULT 0,
+  kkp_id NUMBER(19) DEFAULT 0 NOT NULL,
   service_name VARCHAR(255) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
   CONSTRAINT PK_kkp_mapping_service PRIMARY KEY (kkp_id, service_name, component_name),

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -330,7 +330,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
-CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);
+CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);
 
 CREATE TABLE hoststate (
   agent_version VARCHAR2(255) NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -316,7 +316,7 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
-  host_component_desired_state_id BIGINT NOT NULL,
+  host_comp_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
   component_type VARCHAR(255) NOT NULL,
@@ -329,7 +329,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT pk_hostcomponentstate PRIMARY KEY (id),
   CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -144,13 +144,13 @@ CREATE TABLE servicegroups (
 CREATE TABLE servicegroupdependencies (
   id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
-  service_group_cluster_id BIGINT NOT NULL,
+  cluster_id BIGINT NOT NULL,
   dependent_service_group_id BIGINT NOT NULL,
-  dependent_service_group_cluster_id BIGINT NOT NULL,
+  dependent_cluster_id BIGINT NOT NULL,
   CONSTRAINT PK_servicegroupdependencies PRIMARY KEY (id),
-  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, service_group_cluster_id, dependent_service_group_id, dependent_service_group_cluster_id),
-  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, service_group_cluster_id) REFERENCES servicegroups (id, cluster_id),
-  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_service_group_cluster_id) REFERENCES servicegroups (id, cluster_id));
+  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, cluster_id, dependent_service_group_id, dependent_cluster_id),
+  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, cluster_id) REFERENCES servicegroups (id, cluster_id),
+  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_cluster_id) REFERENCES servicegroups (id, cluster_id));
 
 CREATE TABLE clusterservices (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -624,6 +624,18 @@ CREATE TABLE blueprint (
   security_descriptor_reference VARCHAR(255),
   CONSTRAINT PK_blueprint PRIMARY KEY (blueprint_name));
 
+CREATE TABLE topology_request (
+  id BIGINT NOT NULL,
+  action VARCHAR(255) NOT NULL,
+  cluster_id BIGINT NOT NULL,
+  bp_name VARCHAR(100) NOT NULL,
+  cluster_properties TEXT,
+  cluster_attributes TEXT,
+  description VARCHAR(1024),
+  provision_action VARCHAR(255),
+  CONSTRAINT PK_topology_request PRIMARY KEY (id),
+  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
+
 CREATE TABLE mpack_instance(
   id BIGINT NOT NULL,
   owner VARCHAR (20) NOT NULL,
@@ -881,18 +893,6 @@ CREATE TABLE artifact (
   artifact_data TEXT NOT NULL,
   foreign_keys VARCHAR(255) NOT NULL,
   CONSTRAINT PK_artifact PRIMARY KEY (artifact_name, foreign_keys));
-
-CREATE TABLE topology_request (
-  id BIGINT NOT NULL,
-  action VARCHAR(255) NOT NULL,
-  cluster_id BIGINT NOT NULL,
-  bp_name VARCHAR(100) NOT NULL,
-  cluster_properties TEXT,
-  cluster_attributes TEXT,
-  description VARCHAR(1024),
-  provision_action VARCHAR(255),
-  CONSTRAINT PK_topology_request PRIMARY KEY (id),
-  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
 
 CREATE TABLE topology_hostgroup (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -43,16 +43,6 @@ CREATE TABLE stack (
   CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
-CREATE TABLE mpack_host_state (
-  id NUMERIC(19) NOT NULL,
-  host_id NUMERIC(19) NOT NULL,
-  mpack_id NUMERIC(19) NOT NULL,
-  state VARCHAR(32) NOT NULL,
-  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
-  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
-  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
-
 CREATE TABLE extension(
   extension_id NUMERIC(19) NOT NULL,
   extension_name VARCHAR(255) NOT NULL,
@@ -119,6 +109,16 @@ CREATE TABLE hosts (
   total_mem NUMERIC(19) NOT NULL,
   CONSTRAINT PK_hosts PRIMARY KEY (host_id),
   CONSTRAINT UQ_hosts_host_name UNIQUE (host_name));
+
+CREATE TABLE mpack_host_state (
+  id NUMERIC(19) NOT NULL,
+  host_id NUMERIC(19) NOT NULL,
+  mpack_id NUMERIC(19) NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
+  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
 
 CREATE TABLE clustersettings (
   id NUMERIC(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -620,6 +620,18 @@ CREATE TABLE blueprint (
   security_descriptor_reference VARCHAR(255),
   CONSTRAINT PK_blueprint PRIMARY KEY (blueprint_name));
 
+CREATE TABLE topology_request (
+  id NUMERIC(19) NOT NULL,
+  action VARCHAR(255) NOT NULL,
+  cluster_id NUMERIC(19) NOT NULL,
+  bp_name VARCHAR(100) NOT NULL,
+  cluster_properties TEXT,
+  cluster_attributes TEXT,
+  description VARCHAR(1024),
+  provision_action VARCHAR(255),
+  CONSTRAINT PK_topology_request PRIMARY KEY (id),
+  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
+
 CREATE TABLE mpack_instance(
   id NUMERIC(19) NOT NULL,
   owner VARCHAR (20) NOT NULL,
@@ -875,18 +887,6 @@ CREATE TABLE artifact (
   foreign_keys VARCHAR(255) NOT NULL,
   artifact_data TEXT NOT NULL,
   CONSTRAINT PK_artifact PRIMARY KEY (artifact_name, foreign_keys));
-
-CREATE TABLE topology_request (
-  id NUMERIC(19) NOT NULL,
-  action VARCHAR(255) NOT NULL,
-  cluster_id NUMERIC(19) NOT NULL,
-  bp_name VARCHAR(100) NOT NULL,
-  cluster_properties TEXT,
-  cluster_attributes TEXT,
-  description VARCHAR(1024),
-  provision_action VARCHAR(255),
-  CONSTRAINT PK_topology_request PRIMARY KEY (id),
-  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
 
 CREATE TABLE topology_hostgroup (
   id NUMERIC(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -313,7 +313,7 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id NUMERIC(19) NOT NULL,
-  host_component_desired_state_id NUMERIC(19) NOT NULL,
+  host_comp_desired_state_id NUMERIC(19) NOT NULL,
   cluster_id NUMERIC(19) NOT NULL,
   component_name VARCHAR(255) NOT NULL,
   component_type VARCHAR(255) NOT NULL,
@@ -326,7 +326,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT PK_hostcomponentstate PRIMARY KEY (id),
   CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -141,13 +141,13 @@ CREATE TABLE servicegroups (
 CREATE TABLE servicegroupdependencies (
   id NUMBER(19) NOT NULL,
   service_group_id NUMBER(19) NOT NULL,
-  service_group_cluster_id NUMBER(19) NOT NULL,
+  cluster_id NUMBER(19) NOT NULL,
   dependent_service_group_id NUMBER(19) NOT NULL,
-  dependent_service_group_cluster_id NUMBER(19) NOT NULL,
+  dependent_cluster_id NUMBER(19) NOT NULL,
   CONSTRAINT PK_servicegroupdependencies PRIMARY KEY (id),
-  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, service_group_cluster_id, dependent_service_group_id, dependent_service_group_cluster_id),
-  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, service_group_cluster_id) REFERENCES servicegroups (id, cluster_id),
-  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_service_group_cluster_id) REFERENCES servicegroups (id, cluster_id));
+  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, cluster_id, dependent_service_group_id, dependent_cluster_id),
+  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, cluster_id) REFERENCES servicegroups (id, cluster_id),
+  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_cluster_id) REFERENCES servicegroups (id, cluster_id));
 
 CREATE TABLE clusterservices (
   id NUMERIC(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -329,7 +329,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
-CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);
+CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);
 
 CREATE TABLE hoststate (
   agent_version VARCHAR(255) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -156,13 +156,13 @@ CREATE TABLE servicegroups (
 CREATE TABLE servicegroupdependencies (
   id BIGINT NOT NULL,
   service_group_id BIGINT NOT NULL,
-  service_group_cluster_id BIGINT NOT NULL,
+  cluster_id BIGINT NOT NULL,
   dependent_service_group_id BIGINT NOT NULL,
-  dependent_service_group_cluster_id BIGINT NOT NULL,
+  dependent_cluster_id BIGINT NOT NULL,
   CONSTRAINT PK_servicegroupdependencies PRIMARY KEY (id),
-  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, service_group_cluster_id, dependent_service_group_id, dependent_service_group_cluster_id),
-  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, service_group_cluster_id) REFERENCES servicegroups (id, cluster_id),
-  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_service_group_cluster_id) REFERENCES servicegroups (id, cluster_id));
+  CONSTRAINT UQ_servicegroupdependencies UNIQUE (service_group_id, cluster_id, dependent_service_group_id, dependent_cluster_id),
+  CONSTRAINT FK_svcgrpdep_svcgrp_cl_id FOREIGN KEY (service_group_id, cluster_id) REFERENCES servicegroups (id, cluster_id),
+  CONSTRAINT FK_svcgrpdep_dep_svcgrp_cl_id FOREIGN KEY (dependent_service_group_id, dependent_cluster_id) REFERENCES servicegroups (id, cluster_id));
 
 CREATE TABLE clusterservices (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -56,16 +56,6 @@ CREATE TABLE stack (
   CONSTRAINT FK_mpacks FOREIGN KEY (mpack_id) REFERENCES mpacks(id),
   CONSTRAINT UQ_stack UNIQUE (stack_name, stack_version));
 
-CREATE TABLE mpack_host_state (
-  id BIGINT NOT NULL,
-  host_id BIGINT NOT NULL,
-  mpack_id BIGINT NOT NULL,
-  state VARCHAR(32) NOT NULL,
-  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
-  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
-  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
-
 CREATE TABLE extension(
   extension_id BIGINT NOT NULL,
   extension_name VARCHAR(255) NOT NULL,
@@ -134,6 +124,16 @@ CREATE TABLE hosts (
   total_mem BIGINT NOT NULL,
   CONSTRAINT PK_hosts PRIMARY KEY CLUSTERED (host_id),
   CONSTRAINT UQ_hosts_host_name UNIQUE (host_name));
+
+CREATE TABLE mpack_host_state (
+  id BIGINT NOT NULL,
+  host_id BIGINT NOT NULL,
+  mpack_id BIGINT NOT NULL,
+  state VARCHAR(32) NOT NULL,
+  CONSTRAINT PK_mpack_host_state PRIMARY KEY (id),
+  CONSTRAINT FK_mhs_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
+  CONSTRAINT FK_mhs_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_mpack_host_state UNIQUE(host_id, mpack_id));
 
 CREATE TABLE clustersettings (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -639,6 +639,18 @@ CREATE TABLE blueprint (
   security_descriptor_reference VARCHAR(255),
   CONSTRAINT PK_blueprint PRIMARY KEY CLUSTERED (blueprint_name));
 
+CREATE TABLE topology_request (
+  id BIGINT NOT NULL,
+  action VARCHAR(255) NOT NULL,
+  cluster_id BIGINT NOT NULL,
+  bp_name VARCHAR(100) NOT NULL,
+  cluster_properties TEXT,
+  cluster_attributes TEXT,
+  description VARCHAR(1024),
+  provision_action VARCHAR(255),
+  CONSTRAINT PK_topology_request PRIMARY KEY CLUSTERED (id),
+  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
+
 CREATE TABLE mpack_instance(
   id BIGINT NOT NULL,
   owner VARCHAR (20) NOT NULL,
@@ -898,18 +910,6 @@ CREATE TABLE widget_layout_user_widget (
   CONSTRAINT PK_widget_layout_user_widget PRIMARY KEY CLUSTERED (widget_layout_id, widget_id),
   CONSTRAINT FK_widget_id FOREIGN KEY (widget_id) REFERENCES widget(id),
   CONSTRAINT FK_widget_layout_id FOREIGN KEY (widget_layout_id) REFERENCES widget_layout(id));
-
-CREATE TABLE topology_request (
-  id BIGINT NOT NULL,
-  action VARCHAR(255) NOT NULL,
-  cluster_id BIGINT NOT NULL,
-  bp_name VARCHAR(100) NOT NULL,
-  cluster_properties TEXT,
-  cluster_attributes TEXT,
-  description VARCHAR(1024),
-  provision_action VARCHAR(255),
-  CONSTRAINT PK_topology_request PRIMARY KEY CLUSTERED (id),
-  CONSTRAINT FK_topology_request_cluster_id FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id));
 
 CREATE TABLE topology_hostgroup (
   id BIGINT NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -344,7 +344,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
-CREATE NONCLUSTERED INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);
+CREATE NONCLUSTERED INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_id, cluster_id);
 
 CREATE TABLE hoststate (
   agent_version VARCHAR(255) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -328,7 +328,7 @@ CREATE TABLE hostcomponentdesiredstate (
 
 CREATE TABLE hostcomponentstate (
   id BIGINT NOT NULL,
-  host_component_desired_state_id BIGINT NOT NULL,
+  host_comp_desired_state_id BIGINT NOT NULL,
   cluster_id BIGINT NOT NULL,
   component_name VARCHAR(255) NOT NULL,
   component_type VARCHAR(255) NOT NULL,
@@ -341,7 +341,7 @@ CREATE TABLE hostcomponentstate (
   CONSTRAINT PK_hostcomponentstate PRIMARY KEY CLUSTERED (id),
   CONSTRAINT UQ_hostcomponentstate_name UNIQUE (component_name, service_id, host_id, service_group_id, cluster_id),
   CONSTRAINT FK_hostcomponentstate_host_id FOREIGN KEY (host_id) REFERENCES hosts (host_id),
-  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_component_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
+  CONSTRAINT FK_hostcomponentstate_ds_id FOREIGN KEY (host_comp_desired_state_id) REFERENCES hostcomponentdesiredstate (id),
   CONSTRAINT hstcomponentstatecomponentname FOREIGN KEY (component_name, service_id, service_group_id, cluster_id) REFERENCES servicecomponentdesiredstate (component_name, service_id, service_group_id, cluster_id));
 
 CREATE NONCLUSTERED INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id);


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Forward reference to `topology_request` table in all create scripts.
  ```
  psql:/var/lib/ambari-server/resources/Ambari-DDL-Postgres-CREATE.sql:639: ERROR:  relation "topology_request" does not exist
  ```
2. Forward reference to `hosts` table in most scripts.
  ```
  ERROR 1215 (HY000) at line 66: Cannot add foreign key constraint
  ```
3. Identifier `dependent_service_group_cluster_id ` too long for Oracle.  Replaced in SQL and the entity.
  ```
    dependent_service_group_cluster_id NUMBER(19) NOT NULL,
    *
  ERROR at line 6:
  ORA-00972: identifier is too long
  ```
4. Identifier `host_component_desired_state_id` too long for Oracle.  Replaced in SQL and the entity.
  ```
    host_component_desired_state_id NUMBER(19) NOT NULL,
    *
  ERROR at line 3:
  ORA-00972: identifier is too long
  ```
5. Reference to non-existent `service_name` column (was changed to `service_id` in some DDL scripts, leftover as `service_name` in some others).
  ```
  CREATE INDEX idx_host_component_state on hostcomponentstate(host_id, component_name, service_name, cluster_id)
                                                                                       *
  ERROR at line 1:
  ORA-00904: "SERVICE_NAME": invalid identifier
  ```
6. Wrong order of `NOT NULL` vs `DEFAULT` (part of #657 for trunk).
  ```
    kkp_id BIGINT NOT NULL DEFAULT 0,
                           *
  ERROR at line 2:
  ORA-00907: missing right parenthesis
  ```

## How was this patch tested?

Tested schema creation on Postgres, MySQL and Oracle.
Tested cluster deployment on Postgres.

MySQL script still has a problem that was fixed in #695, but I'm not sure about cherry-picking it to the feature branch, because the fix turned out to have a problem on versions prior to MySQL 5.6.5.