### PR TITLE
AMBARI-23305. Grafana install fails with "KeyError: 'getpwnam(): name

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestFileCache.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestFileCache.py
@@ -65,7 +65,7 @@ class TestFileCache(TestCase):
     provide_directory_mock.return_value = "dummy value"
     fileCache = FileCache(self.config)
     command = {
-      'serviceLevelParams' : {
+      'commandParams' : {
         'service_package_folder' : os.path.join('stacks', 'HDP', '2.1.1', 'services', 'ZOOKEEPER', 'package')
       }
     }
@@ -341,7 +341,7 @@ class TestFileCache(TestCase):
   @patch("os.unlink")
   @patch("shutil.rmtree")
   @patch("os.makedirs")
-  def invalidate_directory(self, makedirs_mock, rmtree_mock,
+  def test_invalidate_directory(self, makedirs_mock, rmtree_mock,
                                 unlink_mock, isdir_mock, isfile_mock,
                                 exists_mock):
     fileCache = FileCache(self.config)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/system.py", line 51, in _ensure_metadata
    _user_entity = pwd.getpwnam(user)
KeyError: 'getpwnam(): name not found: ams'