### PR TITLE
[AMBARI-23308] Tgt cache file is delete before balancer access it during rebalance HDFS operation (dsen)

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -213,8 +213,6 @@ class NameNodeDefault(NameNode):
 
     rebalance_env = {'PATH': params.hadoop_bin_dir}
 
-    rebalance_command_suffix = ""
-
     if params.security_enabled:
       # Create the kerberos credentials cache (ccache) file and set it in the environment to use
       # when executing HDFS rebalance command. Use the sha224 hash of the combination of the principal and keytab file
@@ -232,8 +230,6 @@ class NameNodeDefault(NameNode):
       if shell.call(klist_cmd, user=params.hdfs_user)[0] != 0:
         Execute(kinit_cmd, user=params.hdfs_user)
 
-      rebalance_command_suffix = format("; rm -f {ccache_file_path}")
-
     def calculateCompletePercent(first, current):
       # avoid division by zero
       try:
@@ -244,11 +240,11 @@ class NameNodeDefault(NameNode):
       return 1.0 - division_result
 
 
-    def startRebalancingProcess(threshold, rebalance_env, suffix):
-      rebalanceCommand = format('hdfs --config {hadoop_conf_dir} balancer -threshold {threshold}{suffix}')
+    def startRebalancingProcess(threshold, rebalance_env):
+      rebalanceCommand = format('hdfs --config {hadoop_conf_dir} balancer -threshold {threshold}')
       return as_user(rebalanceCommand, params.hdfs_user, env=rebalance_env)
 
-    command = startRebalancingProcess(threshold, rebalance_env, rebalance_command_suffix)
+    command = startRebalancingProcess(threshold, rebalance_env)
 
     basedir = os.path.join(env.config.basedir, 'scripts')
     if(threshold == 'DEBUG'): #FIXME TODO remove this on PROD

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1259,7 +1259,7 @@ class TestNamenode(RMFTestCase):
     tempdir = tempfile.gettempdir()
     ccache_path =  os.path.join(tempfile.gettempdir(), "hdfs_rebalance_cc_676e87466798ee1b4128732da3effe26e7dfc902e2c9ebdfde4331d2")
     kinit_cmd = "/usr/bin/kinit -c {0} -kt /etc/security/keytabs/hdfs.headless.keytab hdfs@EXAMPLE.COM".format(ccache_path)
-    rebalance_cmd = "ambari-sudo.sh su hdfs -l -s /bin/bash -c 'export  PATH=/bin:/usr/bin KRB5CCNAME={0} ; hdfs --config /etc/hadoop/conf balancer -threshold -1; rm -f {0}'".format(ccache_path)
+    rebalance_cmd = "ambari-sudo.sh su hdfs -l -s /bin/bash -c 'export  PATH=/bin:/usr/bin KRB5CCNAME={0} ; hdfs --config /etc/hadoop/conf balancer -threshold -1'".format(ccache_path)
 
     self.assertResourceCalled('Execute', kinit_cmd,
                               user = 'hdfs',

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1259,7 +1259,7 @@ class TestNamenode(RMFTestCase):
     tempdir = tempfile.gettempdir()
     ccache_path =  os.path.join(tempfile.gettempdir(), "hdfs_rebalance_cc_676e87466798ee1b4128732da3effe26e7dfc902e2c9ebdfde4331d2")
     kinit_cmd = "/usr/bin/kinit -c {0} -kt /etc/security/keytabs/hdfs.headless.keytab hdfs@EXAMPLE.COM".format(ccache_path)
-    rebalance_cmd = "ambari-sudo.sh su hdfs -l -s /bin/bash -c 'export  PATH=/bin:/usr/bin KRB5CCNAME={0} ; hdfs --config /etc/hadoop/conf balancer -threshold -1'".format(ccache_path)
+    rebalance_cmd = "ambari-sudo.sh su hdfs -l -s /bin/bash -c 'export  PATH=/bin:/usr/bin KRB5CCNAME={0} ; hdfs --config /etc/hadoop/conf balancer -threshold -1; rm -f {0}'".format(ccache_path)
 
     self.assertResourceCalled('Execute', kinit_cmd,
                               user = 'hdfs',
@@ -1267,10 +1267,6 @@ class TestNamenode(RMFTestCase):
 
     self.assertResourceCalled('Execute', rebalance_cmd,
                               wait_for_finish=False
-                              )
-
-    self.assertResourceCalled('File', ccache_path,
-                              action = ['delete'],
                               )
 
     self.assertNoMoreResources()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Appended rebalance command with the file deletion statement, removed the delete file action

## How was this patch tested?
manually + UT