### PR TITLE
[AMBARI-23308] Ticket cache file is delete before balancer access it during rebalance HDFS operation (dsen)

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -314,12 +314,6 @@ class NameNodeDefault(NameNode):
              "operation earlier. The process may take a long time to finish (hours, even days). If the problem persists "
              "please consult with the HDFS administrators if they have triggred or killed the operation.")
 
-    if params.security_enabled:
-      # Delete the kerberos credentials cache (ccache) file
-      File(ccache_file_path,
-           action = "delete",
-      )
-      
   def get_log_folder(self):
     import params
     return params.hdfs_log_dir

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1269,10 +1269,6 @@ class TestNamenode(RMFTestCase):
                               wait_for_finish=False
                               )
 
-    self.assertResourceCalled('File', ccache_path,
-                              action = ['delete'],
-                              )
-
     self.assertNoMoreResources()
 
   @patch("os.path.isfile")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed delete file operation

## How was this patch tested?
manually + UTs