### PR TITLE
[AMBARI-23313] JS error on service stop/restart after config changes

### DIFF
--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -423,8 +423,12 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
   },
 
   pullNnCheckPointTime: function (haNameSpace) {
-    const correspondingComponent = App.HDFSService.find().objectAt(0).get('hostComponents').findProperty('haNameSpace', haNameSpace),
-      clusterIdValue = correspondingComponent.get('clusterIdValue');
+    let clusterIdValue;
+    if (haNameSpace) {
+      const hostComponents = App.HDFSService.find().objectAt(0).get('hostComponents'),
+        correspondingComponent = hostComponents && hostComponents.findProperty('haNameSpace', haNameSpace);
+      clusterIdValue = correspondingComponent && correspondingComponent.get('clusterIdValue');
+    }
     return App.ajax.send({
       name: 'common.service.hdfs.getNnCheckPointTime',
       sender: this,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Steps:
1. Change the value of fs.trash.interval for HDFS service.
2. Save configs
3. Notice Restart required icon
4. Try to apply 'Restart All Affected'

No op was triggered. Could see js error error in console:
`
Uncaught TypeError: Cannot read property 'get' of undefined
pullNnCheckPointTime @ app.js:27950
checkNnLastCheckpointTime @ app.js:27905
restartAllStaleConfigComponents @ app.js:26478
ActionHelper.registeredActions.(anonymous function).handler @ vendor.js:31554
(anonymous function) @ vendor.js:23346
jQuery.event.dispatch @ vendor.js:3178
elemData.handle @ vendor.js:2854
app.js:56248 
`

Also for 'Stop' service operation:
`
Uncaught TypeError: Cannot read property 'get' of undefined
pullNnCheckPointTime @ app.js:27950
checkNnLastCheckpointTime @ app.js:27905
startStopPopup @ app.js:27842
stopService @ app.js:28176
doAction @ app.js:28662
ActionHelper.registeredActions.(anonymous function).handler @ vendor.js:31554
(anonymous function) @ vendor.js:23346
jQuery.event.dispatch @ vendor.js:3178
elemData.handle @ vendor.js:2854
app.js:56248 
`

## How was this patch tested?

UI unit tests:
  21512 passing (29s)
  48 pending