### PR TITLE
[AMBARI-23243]. Adding missing properties to OneFS mpack (amagyar)

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
@@ -57,9 +57,30 @@
     </depends-on>
   </property>
   <property>
+    <name>dfs.datanode.http.address</name>
+    <value>0.0.0.0:8082</value>
+    <description>The datanode http server address and port.</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>dfs.datanode.https.address</name>
+    <value>0.0.0.0:8080</value>
+    <description>The datanode https server address and port.</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
     <name>dfs.client-write-packet-size</name>
     <value>131072</value>
     <description>Packet size for clients to write</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>dfs.checksum.type</name>
+    <value>NULL</value>
+    <description>The checksum method to be used by default. To maintain
+      compatibility, it is being set to CRC32. Once all migration steps
+      are complete, we can change it to CRC32C and take advantage of the
+      additional performance benefit.</description>
     <on-ambari-upgrade add="false"/>
   </property>
 </configuration>

--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
@@ -26,7 +26,8 @@
           "core-site": {
             "hadoop.security.authentication": "kerberos",
             "hadoop.security.authorization": "true",
-            "hadoop.proxyuser.HTTP.groups": "${hadoop-env/proxyuser_group}"
+            "hadoop.proxyuser.HTTP.groups": "${hadoop-env/proxyuser_group}",
+            "hadoop.security.token.service.use_ip" : "false"
           }
         },
         {

--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/metainfo.xml
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/metainfo.xml
@@ -97,6 +97,7 @@
         <config-type>hdfs-site</config-type>
         <config-type>onefs</config-type>
         <config-type>hadoop-env</config-type>
+        <config-type>capacity-scheduler</config-type>
       </configuration-dependencies>
       <restartRequiredAfterRackChange>true</restartRequiredAfterRackChange>
 

--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -113,6 +113,24 @@ else:
       putCoreSiteProperty("fs.defaultFS", Uri.default_fs(services).fix_host(onefs_host))
       putHdfsSiteProperty("dfs.namenode.http-address", Uri.http_namenode(services).fix_host(onefs_host))
       putHdfsSiteProperty("dfs.namenode.https-address", Uri.https_namenode(services).fix_host(onefs_host))
+      # self.updateYarnConfig(configs, services) TODO doesn't work possibly due to a UI bug (Couldn't retrieve 'capacity-scheduler' from services)
+
+    def updateYarnConfig(self, configs, services):
+      if not 'YARN' in self.installedServices(services): return
+      capacity_scheduler_dict, received_as_key_value_pair = self.getCapacitySchedulerProperties(services)
+      if capacity_scheduler_dict:
+        putCapSchedProperty = self.putProperty(configs, 'capacity-scheduler', services)
+        if received_as_key_value_pair:
+          capacity_scheduler_dict['yarn.scheduler.capacity.node-locality-delay'] = '0'
+          putCapSchedProperty('capacity-scheduler', self.concatenated(capacity_scheduler_dict))
+        else:
+          putCapSchedProperty('yarn.scheduler.capacity.node-locality-delay', '0')
+
+    def concatenated(self, capacity_scheduler_dict):
+      return ''.join('%s=%s\n' % (k,v) for k,v in capacity_scheduler_dict.items())
+
+    def installedServices(self, services):
+      return [service['StackServices']['service_name'] for service in services['services']]
 
     def getServiceConfigurationsValidationItems(self, configs, recommendedDefaults, services, hosts):
       validation_errors = []


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding the following configuration properties:

1. hadoop.security.token.service.use_ip should be false when kerberos is enabled
2. dfs.checksum.type should always be NULL
3. dfs.datanode.http.address/dfs.datanode.https.address = 0.0.0.0:8082/0.0.0.0:8080
4. yarn.scheduler.capacity.node-locality-delay = 0 _(adding this from service advisior doesn't work, needs more investigation, but possibly because of a UI bug, so this is commented out for now)_
5. dfs.client-write-packet-size = 131072 (this was already added)

## How was this patch tested?

1. Installed OneFS service and inspected core-site, hdfs-site
2. Enabled kerberos and checked hadoop.security.token.service.use_ip  under custom core-site