### PR TITLE
AMBARI-23321. Move SOLR znode opertations out from configure

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/infra_solr.py
@@ -29,7 +29,7 @@ from resource_management.libraries.script.script import Script
 
 from collection import backup_collection, restore_collection
 from migrate import migrate_index
-from setup_infra_solr import setup_infra_solr
+from setup_infra_solr import setup_infra_solr, setup_solr_znode_env
 
 class InfraSolr(Script):
   def install(self, env):
@@ -48,6 +48,7 @@ class InfraSolr(Script):
     env.set_params(params)
     self.configure(env)
 
+    setup_solr_znode_env()
     start_cmd = format('{solr_bindir}/solr start -cloud -noprompt -s {infra_solr_datadir} -Dsolr.kerberos.name.rules=\'{infra_solr_kerberos_name_rules}\' >> {infra_solr_log} 2>&1') \
             if params.security_enabled else format('{solr_bindir}/solr start -cloud -noprompt -s {infra_solr_datadir} >> {infra_solr_log} 2>&1')
     Execute(

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
@@ -81,16 +81,6 @@ def setup_infra_solr(name = None):
          mode=0640
          )
 
-    jaas_file = params.infra_solr_jaas_file if params.security_enabled else None
-    java_opts = params.zk_security_opts if params.security_enabled else None
-    url_scheme = 'https' if params.infra_solr_ssl_enabled else 'http'
-
-    create_ambari_solr_znode(java_opts)
-
-    security_json_file_location = custom_security_json_location \
-      if params.infra_solr_security_json_content and str(params.infra_solr_security_json_content).strip() \
-      else format("{infra_solr_conf}/security.json") # security.json file to upload
-
     if params.security_enabled:
       File(format("{infra_solr_jaas_file}"),
            content=Template("infra_solr_jaas.conf.j2"),
@@ -102,42 +92,59 @@ def setup_infra_solr(name = None):
            group=params.user_group,
            mode=0640)
 
-    solr_cloud_util.set_cluster_prop(
-      zookeeper_quorum=params.zk_quorum,
-      solr_znode=params.infra_solr_znode,
-      java64_home=params.java64_home,
-      prop_name="urlScheme",
-      prop_value=url_scheme,
-      jaas_file=jaas_file,
-      java_opts=java_opts
-    )
-
-    solr_cloud_util.setup_kerberos_plugin(
-      zookeeper_quorum=params.zk_quorum,
-      solr_znode=params.infra_solr_znode,
-      jaas_file=jaas_file,
-      java64_home=params.java64_home,
-      secure=params.security_enabled,
-      security_json_location=security_json_file_location,
-      java_opts=java_opts
-    )
-
-    if params.security_enabled:
-      solr_cloud_util.secure_solr_znode(
-        zookeeper_quorum=params.zk_quorum,
-        solr_znode=params.infra_solr_znode,
-        jaas_file=jaas_file,
-        java64_home=params.java64_home,
-        sasl_users_str=params.infra_solr_sasl_user,
-        java_opts=java_opts
-      )
-
-
   elif name == 'client':
     solr_cloud_util.setup_solr_client(params.config)
 
   else :
     raise Fail('Nor client or server were selected to install.')
+
+def setup_solr_znode_env():
+  """
+  Setup SSL, ACL and authentication / authorization related Zookeeper settings for Solr (checkout: /clustersprops.json and /security.json)
+  """
+  import params
+
+  custom_security_json_location = format("{infra_solr_conf}/custom-security.json")
+  jaas_file = params.infra_solr_jaas_file if params.security_enabled else None
+  java_opts = params.zk_security_opts if params.security_enabled else None
+  url_scheme = 'https' if params.infra_solr_ssl_enabled else 'http'
+
+  security_json_file_location = custom_security_json_location \
+    if params.infra_solr_security_json_content and str(params.infra_solr_security_json_content).strip() \
+    else format("{infra_solr_conf}/security.json") # security.json file to upload
+
+  create_ambari_solr_znode(java_opts)
+
+  solr_cloud_util.set_cluster_prop(
+    zookeeper_quorum=params.zk_quorum,
+    solr_znode=params.infra_solr_znode,
+    java64_home=params.java64_home,
+    prop_name="urlScheme",
+    prop_value=url_scheme,
+    jaas_file=jaas_file,
+    java_opts=java_opts
+  )
+
+  solr_cloud_util.setup_kerberos_plugin(
+    zookeeper_quorum=params.zk_quorum,
+    solr_znode=params.infra_solr_znode,
+    jaas_file=jaas_file,
+    java64_home=params.java64_home,
+    secure=params.security_enabled,
+    security_json_location=security_json_file_location,
+    java_opts=java_opts
+  )
+
+  if params.security_enabled:
+    solr_cloud_util.secure_solr_znode(
+      zookeeper_quorum=params.zk_quorum,
+      solr_znode=params.infra_solr_znode,
+      jaas_file=jaas_file,
+      java64_home=params.java64_home,
+      sasl_users_str=params.infra_solr_sasl_user,
+      java_opts=java_opts
+    )
+
 
 @retry(times=30, sleep_time=5, err_class=Fail)
 def create_ambari_solr_znode(java_opts):
@@ -147,14 +154,3 @@ def create_ambari_solr_znode(java_opts):
     solr_znode=params.infra_solr_znode,
     java64_home=params.java64_home,
     retry=30, interval=5, java_opts=java_opts)
-
-def cleanup_logsearch_collections(collection, jaas_file, java_opts):
-  import params
-  solr_cloud_util.remove_admin_handlers(
-    zookeeper_quorum=params.zk_quorum,
-    solr_znode=params.infra_solr_znode,
-    java64_home=params.java64_home,
-    jaas_file=jaas_file,
-    collection=collection,
-    java_opts=java_opts
-  )


### PR DESCRIPTION
## What changes were proposed in this pull request?
Moving znode operations to start, as it wont wont generate lock for ambari-agent

## How was this patch tested?
UT: done, no test against secure env
FT: manually

please review @zeroflag @adoroszlai 

