### PR TITLE
AMBARI-23230 ADDENDUM - Upgrade Solr configuration while upgrading Am…

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -441,7 +441,7 @@ def find_and_copy_custom_services(resources_dir, services_search_path, old_dir_n
     if os.path.isdir(service) and not os.path.basename(service) in managed_services:
       managed_services.append(os.path.basename(service))
   # add deprecated managed services
-  managed_services.extend(["NAGIOS","GANGLIA","MAPREDUCE","WEBHCAT"])
+  managed_services.extend(["NAGIOS","GANGLIA","MAPREDUCE","WEBHCAT","AMBARI_INFRA"])
 
   stack_backup_dirs = glob.glob(os.path.join(resources_dir, old_dir_name))
   if stack_backup_dirs:


### PR DESCRIPTION
…bari 2.6.1 -> 2.7.0

## What changes were proposed in this pull request?

- When upgrading Ambari the "yum upgrade ambari-server" command creates a backup from the common-services stack definitions. Than "ambari-server upgrade" copy back the missing services from the backup to the just installed common-services folder. Since we rename AMBARI-INFRA we do not want to copy it back because a new AMBARI-INFRA-SOLR service definition exists as a replacement. So AMBARI-INFRA service added to the deprecated services list. 
- Renaming AMBARI_INFRA must be the first DML Update. After than the following DML updates operates on the renamed service. Also when the installed service names are loaded in ClusterImpl AMBARI-INFRA-SOLR should be included instead of AMBARI-INFRA.

## How was this patch tested?

Manually using vagrant:

- Install Ambari 2.6.2 and deploy a HDP 2.6 cluster: zookeeper, logsearch, ambari-infra
- Kerberize the cluster
- Add service ranger
- Stop logsearch
- Delete collections from Infra Solr
- upgrade Ambari to 2.7.0
- upgrade Infra Solr and Logsearch in each host manually.
- Start Logsearch
- Check all collections are created
- Check all the solrconfig.xmls are upgraded

Please review
@oleewere @zeroflag @g-boros 