### PR TITLE
AMBARI-23322. Missing tooltips for two fields in 'Add User' page

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/i18n.config.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/i18n.config.js
@@ -314,6 +314,8 @@ angular.module('ambariAdminConsole')
     'users.showAdmin': 'Show only admin users',
     'users.groupMembership': 'Group Membership',
     'users.userNameTip': 'Maximum length is 80 characters. \\, &, |, <, >, ` are not allowed.',
+    'users.adminTip': 'An Ambari Admin can create new clusters and other Ambari Admin Users.',
+    'users.deactivateTip': 'Active Users can log in to Ambari. Inactive Users cannot.',
 
     'users.changeStatusConfirmation.title': 'Change Status',
     'users.changeStatusConfirmation.message': 'Are you sure you want to change status for user "{{userName}}" to {{status}}?',

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/modals/userCreate.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/modals/userCreate.html
@@ -124,7 +124,11 @@
     <div class="form-group">
       <label>
         {{'users.isAmbariAdmin' | translate}}<span>&nbsp;*</span>
-        <i class="fa fa-question-circle" aria-hidden="true"></i>
+        <i class="fa fa-question-circle"
+           aria-hidden="true"
+           tooltip="{{'users.adminTip' | translate}}"
+           tooltip-trigger="click"
+           tooltip-placement="top"></i>
       </label>
       <div>
         <toggle-switch model="formData.isAdmin" class="switch-success" data-off-color="danger"></toggle-switch>
@@ -136,7 +140,11 @@
     <div class="form-group">
       <label>
         {{'users.isActive' | translate}}<span>&nbsp;*</span>
-        <i class="fa fa-question-circle" aria-hidden="true"></i>
+        <i class="fa fa-question-circle"
+           aria-hidden="true"
+           tooltip="{{'users.deactivateTip' | translate}}"
+           tooltip-trigger="click"
+           tooltip-placement="top"></i>
       </label>
       <div>
         <toggle-switch model="formData.isActive" class="switch-success" data-off-color="danger"></toggle-switch>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Missing tooltips for two fields in 'Add User' page

## How was this patch tested?
manually


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.