### PR TITLE
AMBARI-23326. Add custom context root support to quicklink engine (am…

### DIFF
--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -409,9 +409,24 @@ App.QuickLinksView = Em.View.extend({
         newItem.url = template.fmt(protocol, host, linkPort);
       }
       newItem.label = link.label;
+      newItem.url = this.resolvePlaceholders(newItem.url);
       return newItem;
     }
     return null;
+  },
+
+  /**
+   * Replace placeholders like ${config-type/property-name} in the given URL
+   */
+  resolvePlaceholders: function(url) {
+    return url.replace(/\$\{(\S+)\/(\S+)\}/g, function(match, configType, propertyName) {
+      var config = this.get('configProperties').findProperty('type', configType);
+      if (config) {
+        return config.properties[propertyName] ? config.properties[propertyName] : match;
+      } else {
+        return match;
+      }
+    }.bind(this));
   },
 
   /**

--- a/ambari-web/test/views/common/quick_link_view_test.js
+++ b/ambari-web/test/views/common/quick_link_view_test.js
@@ -840,6 +840,28 @@ describe('App.QuickViewLinks', function () {
     });
   });
 
+  describe('#resolvePlaceholders', function() {
+    beforeEach(function() {
+      quickViewLinks.setProperties({
+      configProperties: [{
+          'type': 'config-type1',
+          'properties': {'property1': 'value1'}
+        }],
+        actualTags: [""],
+        quickLinks: [{}]
+      });
+    }),
+    it("replaces placeholders from config", function () {
+      expect(quickViewLinks.resolvePlaceholders('${config-type1/property1}')).to.equal('value1');
+    }),
+    it("leaves url as it is if config-type was not found", function () {
+      expect(quickViewLinks.resolvePlaceholders('${unknown-config-type/property1}')).to.equal('${unknown-config-type/property1}');
+    }),
+    it("leaves url as it is if property was not found", function () {
+      expect(quickViewLinks.resolvePlaceholders('${config-type1/unknown-property}')).to.equal('${config-type1/unknown-property}');
+    })
+  }),
+
   describe('#setPort', function () {
     var testData = [
       Em.Object.create({


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding placeholder replacement ability to quicklink engine.

A placeholder looks like ${config-type/property-name}

For example if an URL contains ${gateway-site/gateway.path} then this pattern will be replaced with the value from config-type=gateway-site, property-name=gateway.path


## How was this patch tested?

Used the following quicklink.json

```json
{
  "name": "default",
  "description": "default quick links configuration",
  "configuration": {
    "protocol": {
      "type": "HTTPS_ONLY"
    },
    "links": [
      {
        "name": "knox_admin_ui",
        "label": "Knox Admin UI",
        "component_name": "KNOX_GATEWAY",
        "url":"%@://%@:%@/${gateway-site/gateway.path}/knoxsso/knoxauth/login.html",
        "port":{
          "https_property": "gateway.port",
          "https_default_port": "8443",
          "regex": "^(\\d+)$",
          "site": "gateway-site"
        }
      }
    ]
  }
}
```