### PR TITLE
[AMBARI-23338] blueprints with installed cluster should be read-only

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -91,6 +91,7 @@ import org.apache.ambari.server.orm.dao.PermissionDAO;
 import org.apache.ambari.server.orm.dao.PrincipalDAO;
 import org.apache.ambari.server.orm.dao.PrivilegeDAO;
 import org.apache.ambari.server.orm.dao.ResourceDAO;
+import org.apache.ambari.server.orm.dao.TopologyRequestDAO;
 import org.apache.ambari.server.orm.dao.UserDAO;
 import org.apache.ambari.server.orm.dao.ViewInstanceDAO;
 import org.apache.ambari.server.orm.entities.MetainfoEntity;
@@ -916,8 +917,8 @@ public class AmbariServer {
     StackDefinedPropertyProvider.init(injector);
     AbstractControllerResourceProvider.init(injector.getInstance(ResourceProviderFactory.class));
     BlueprintResourceProvider.init(injector.getInstance(BlueprintFactory.class),
-        injector.getInstance(BlueprintDAO.class), injector.getInstance(SecurityConfigurationFactory.class),
-        injector.getInstance(Gson.class), ambariMetaInfo);
+        injector.getInstance(BlueprintDAO.class), injector.getInstance(TopologyRequestDAO.class),
+        injector.getInstance(SecurityConfigurationFactory.class), injector.getInstance(Gson.class), ambariMetaInfo);
     StackDependencyResourceProvider.init(ambariMetaInfo);
     ClusterResourceProvider.init(injector.getInstance(TopologyManager.class),
         injector.getInstance(TopologyRequestFactoryImpl.class), injector.getInstance(SecurityConfigurationFactory

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/TopologyRequestDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/TopologyRequestDAO.java
@@ -57,6 +57,12 @@ public class TopologyRequestDAO {
     return daoUtils.selectAll(entityManagerProvider.get(), TopologyRequestEntity.class);
   }
 
+  @RequiresSession
+  public List<TopologyRequestEntity> findAllProvisionRequests() {
+    return daoUtils.selectList(entityManagerProvider.get().createNamedQuery("TopologyRequestEntity.findProvisionRequests",
+      TopologyRequestEntity.class));
+  }
+
   @Transactional
   public void create(TopologyRequestEntity requestEntity) {
     entityManagerProvider.get().persist(requestEntity);

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/TopologyRequestEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/TopologyRequestEntity.java
@@ -45,7 +45,8 @@ import org.apache.ambari.server.controller.internal.ProvisionAction;
                 pkColumnName = "sequence_name", valueColumnName = "sequence_value",
                 pkColumnValue = "topology_request_id_seq", initialValue = 0)
 @NamedQueries({
-  @NamedQuery(name = "TopologyRequestEntity.findByClusterId", query = "SELECT req FROM TopologyRequestEntity req WHERE req.clusterId = :clusterId")
+  @NamedQuery(name = "TopologyRequestEntity.findByClusterId", query = "SELECT req FROM TopologyRequestEntity req WHERE req.clusterId = :clusterId"),
+  @NamedQuery(name = "TopologyRequestEntity.findProvisionRequests", query = "SELECT req FROM TopologyRequestEntity req WHERE req.action = 'PROVISION'"),
 })
 public class TopologyRequestEntity {
   @Id


### PR DESCRIPTION
## What changes were proposed in this pull request?

Deleting a blueprint with a provision request based on it will return error code 400.

## How was this patch tested?
- Tested manually
- Wrote a new unit test
- Unit test run results:

```
[ERROR] Failures:
[ERROR]   BufferedThreadPoolExecutorCompletionServiceTest.testScalingThreadPoolExecutor:181 expected:<10> but was:<8>
[ERROR]   PasswordUtilsTest.shouldReadDefaultPasswordIfPasswordPropertyIsPasswordFilePathButItIsNotReadable:93 expected:<[testPasswordDefaul]t> but was:<[ambariTes]t>
[ERROR] Errors:
[ERROR]   CredentialStoreTest.testInMemoryCredentialStoreService_CredentialExpired:90->getExpiredCredentialTest:169 NullPointer
[INFO]
[ERROR] Tests run: 5069, Failures: 2, Errors: 1, Skipped: 67
```
All failing unit tests succeeded when run individually.