### PR TITLE
[AMBARI-23311] Use Ambari CLI to specify which services should be setup for SSO integration

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -574,6 +574,7 @@ def init_ldap_setup_parser_options(parser):
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_setup_sso_options(parser):
   parser.add_option('--sso-enabled', default=None, help="Indicates whether to enable/disable SSO", dest="sso_enabled")
+  parser.add_option('--sso-enabled-services', default=None, help="A comma separated list of services that are expected to be configured for SSO (you are allowed to use '*' to indicate ALL services)", dest='sso_enabled_services')
   parser.add_option('--sso-provider-url', default=None, help="The URL of SSO provider; this must be provided when --sso-enabled is set to 'true'", dest="sso_provider_url")
   parser.add_option('--sso-public-cert-file', default=None, help="The path where the public certificate PEM is located; this must be provided when --sso-enabled is set to 'true'", dest="sso_public_cert_file")
   parser.add_option('--sso-jwt-cookie-name', default=None, help="The name of the JWT cookie", dest="sso_jwt_cookie_name")

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -579,6 +579,8 @@ def init_setup_sso_options(parser):
   parser.add_option('--sso-public-cert-file', default=None, help="The path where the public certificate PEM is located; this must be provided when --sso-enabled is set to 'true'", dest="sso_public_cert_file")
   parser.add_option('--sso-jwt-cookie-name', default=None, help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
   parser.add_option('--sso-jwt-audience-list', default=None, help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
+  parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
+  parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_pam_setup_parser_options(parser):

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -50,7 +50,7 @@ from ambari_server.serverConfiguration import configDefaults, parse_properties_f
   SSL_TRUSTSTORE_PASSWORD_PROPERTY, SSL_TRUSTSTORE_PATH_PROPERTY, SSL_TRUSTSTORE_TYPE_PROPERTY, \
   SSL_API, SSL_API_PORT, DEFAULT_SSL_API_PORT, CLIENT_API_PORT, JDK_NAME_PROPERTY, JCE_NAME_PROPERTY, JAVA_HOME_PROPERTY, \
   get_resources_location, SECURITY_MASTER_KEY_LOCATION, SETUP_OR_UPGRADE_MSG, CHECK_AMBARI_KRB_JAAS_CONFIGURATION_PROPERTY
-from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base
+from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base, get_ambari_admin_username_password_pair, perform_changes_via_rest_api
 from ambari_server.setupActions import SETUP_ACTION, LDAP_SETUP_ACTION
 from ambari_server.userInput import get_validated_string_input, get_prompt_default, read_password, get_YN_input, quit_if_has_answer
 from ambari_server.serverClassPath import ServerClassPath
@@ -349,6 +349,7 @@ def sync_ldap(options):
     err = 'Must specify a sync option (all, existing, users or groups).  Please invoke ambari-server.py --help to print the options.'
     raise FatalException(1, err)
 
+  #TODO: use serverUtils.get_ambari_admin_username_password_pair (requires changes in ambari-server.py too to modify option names)
   admin_login = ldap_sync_options.ldap_sync_admin_name\
     if ldap_sync_options.ldap_sync_admin_name is not None and ldap_sync_options.ldap_sync_admin_name \
     else get_validated_string_input(prompt="Enter Ambari Admin login: ", default=None,
@@ -673,39 +674,17 @@ def init_ldap_properties_list_reqd(properties, options):
   ]
   return ldap_properties
 
-def get_ambari_admin_username_password_pair(options):
-  admin_login = options.ambari_admin_username if options.ambari_admin_username is not None else get_validated_string_input("Enter Ambari Admin login: ", None, None, None, False, False)
-  admin_password = options.ambari_admin_password if options.ambari_admin_password is not None else get_validated_string_input("Enter Ambari Admin password: ", None, None, None, True, False)
-
-  return admin_login, admin_password
-
 def update_ldap_configuration(options, properties, ldap_property_value_map):
   admin_login, admin_password = get_ambari_admin_username_password_pair(options)
-  url = get_ambari_server_api_base(properties) + SETUP_LDAP_CONFIG_URL
-  admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
-  request = urllib2.Request(url)
-  request.add_header('Authorization', 'Basic %s' % admin_auth)
-  request.add_header('X-Requested-By', 'ambari')
-  data = {
+  request_data = {
     "Configuration": {
       "category": "ldap-configuration",
       "properties": {
       }
     }
   }
-  data['Configuration']['properties'] = ldap_property_value_map
-  request.add_data(json.dumps(data))
-  request.get_method = lambda: 'PUT'
-
-  try:
-    with closing(urllib2.urlopen(request)) as response:
-      response_status_code = response.getcode()
-      if response_status_code != 200:
-        err = 'Error during setup-ldap. Http status code - ' + str(response_status_code)
-        raise FatalException(1, err)
-  except Exception as e:
-    err = 'Updating LDAP configuration failed. Error details: %s' % e
-    raise FatalException(1, err)
+  request_data['Configuration']['properties'] = ldap_property_value_map
+  perform_changes_via_rest_api(properties, admin_login, admin_password, SETUP_LDAP_CONFIG_URL, 'PUT', request_data)
 
 def setup_ldap(options):
   logger.info("Setup LDAP.")

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7332,6 +7332,8 @@ class TestAmbariServer(TestCase):
     sys.stdout = out
 
     options = self._create_empty_options_mock()
+    options.ambari_admin_username = 'admin'
+    options.ambari_admin_password = 'admin'
     is_server_runing_method.return_value = (True, 0)
 
     search_file_message.return_value = "filepath"
@@ -7362,8 +7364,6 @@ class TestAmbariServer(TestCase):
         return 'skip'
       if 'URL Port' in args[0]:
         return '1'
-      if 'Ambari Admin' in args[0]:
-        return 'admin'
       if args[1] == "true" or args[1] == "false":
         return args[1]
       else:
@@ -7419,8 +7419,6 @@ class TestAmbariServer(TestCase):
           return "valid"
       if 'URL Port' in args[0]:
         return '1'
-      if 'Ambari Admin' in args[0]:
-        return 'admin'
       if args[1] == "true" or args[1] == "false":
         return args[1]
       else:
@@ -7502,8 +7500,6 @@ class TestAmbariServer(TestCase):
         return 'skip'
       if 'URL Port' in args[0]:
         return '1'
-      if 'Ambari Admin' in args[0]:
-        return 'admin'
       if 'Primary URL' in args[0]:
         return kwargs['answer']
       if args[1] == "true" or args[1] == "false":
@@ -7518,6 +7514,8 @@ class TestAmbariServer(TestCase):
     urlopen_method.return_value = response
 
     options =  self._create_empty_options_mock()
+    options.ambari_admin_username = 'admin'
+    options.ambari_admin_password = 'admin'
     options.ldap_url = "a:1"
 
     setup_ldap(options)
@@ -7621,8 +7619,6 @@ class TestAmbariServer(TestCase):
         return 'skip'
       if 'URL Port' in args[0]:
         return '1'
-      if 'Ambari Admin' in args[0]:
-        return 'admin'
       if 'Primary URL' in args[0]:
         return kwargs['answer']
       if args[1] == "true" or args[1] == "false":
@@ -7637,6 +7633,8 @@ class TestAmbariServer(TestCase):
     urlopen_method.return_value = response
 
     options = self._create_empty_options_mock()
+    options.ambari_admin_username = 'admin'
+    options.ambari_admin_password = 'admin'
     options.ldap_force_setup = True
 
     setup_ldap(options)

--- a/ambari-server/src/test/python/TestServerUtils.py
+++ b/ambari-server/src/test/python/TestServerUtils.py
@@ -33,7 +33,7 @@ with patch.object(platform, "linux_distribution", return_value = MagicMock(retur
   with patch("os.path.isdir", return_value = MagicMock(return_value=True)):
     with patch("os.access", return_value = MagicMock(return_value=True)):
       with patch.object(os_utils, "parse_log4j_file", return_value={'ambari.log.dir': '/var/log/ambari-server'}):
-        from ambari_server.serverUtils import get_ambari_server_api_base
+        from ambari_server.serverUtils import get_ambari_server_api_base, get_ambari_admin_username_password_pair
         from ambari_server.serverConfiguration import CLIENT_API_PORT, CLIENT_API_PORT_PROPERTY, SSL_API, DEFAULT_SSL_API_PORT, SSL_API_PORT
 
 @patch.object(platform, "linux_distribution", new = MagicMock(return_value=('Redhat', '6.4', 'Final')))
@@ -67,6 +67,32 @@ class TestServerUtils(TestCase):
     self.assertEquals(result, 'https://127.0.0.1:8443/api/v1/')
 
 
+  def test_get_ambari_admin_credentials_from_cli_options(self):
+    user_name = "admin"
+    password = "s#perS3cr3tP4ssw0d!"
+    options = MagicMock()
+    options.ambari_admin_username = user_name
+    options.ambari_admin_password = password
+    user, pw = get_ambari_admin_username_password_pair(options)
+    self.assertEquals(user, user_name)
+    self.assertEquals(pw, password)
+    
+  @patch("ambari_server.serverUtils.get_validated_string_input")
+  def test_get_ambari_admin_credentials_from_user_input(self, get_validated_string_input_mock):
+    user_name = "admin"
+    password = "s#perS3cr3tP4ssw0d!"
+    options = MagicMock()
+    options.ambari_admin_username = None
+    options.ambari_admin_password = None
+
+    def valid_input_side_effect(*args, **kwargs):
+      return user_name if 'Ambari Admin login' in args[0] else password
+
+    get_validated_string_input_mock.side_effect = valid_input_side_effect
+
+    user, pw = get_ambari_admin_username_password_pair(options)
+    self.assertEquals(user, user_name)
+    self.assertEquals(pw, password)
 
 class FakeProperties(object):
   def __init__(self, prop_map):

--- a/ambari-server/src/test/python/TestSetupSso.py
+++ b/ambari-server/src/test/python/TestSetupSso.py
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+import operator
 import os
 import platform
 import sys
@@ -75,14 +76,35 @@ class TestSetupSso(unittest.TestCase):
     pass
 
 
-
-  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_silent_mode_is_not_allowed(self, is_root_mock, get_silent_mock):
+  def test_sso_setup_should_fail_if_server_is_not_running(self, is_root_mock, is_server_runing_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (False, 0)
+    options = self._create_empty_options_mock()
+
+    try:
+      setup_sso(options)
+      self.fail("Should fail with non-fatal exception")
+    except FatalException as e:
+      self.assertTrue("Ambari Server is not running" in e.reason)
+      pass
+
+    sys.stdout = sys.__stdout__
+    pass
+
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
+  @patch("ambari_server.setupSso.is_root")
+  def test_silent_mode_is_not_allowed(self, is_root_mock, is_server_runing_mock, get_silent_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = True
     options = self._create_empty_options_mock()
 
@@ -99,12 +121,14 @@ class TestSetupSso(unittest.TestCase):
 
 
   @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_invalid_sso_enabled_cli_option_should_result_in_error(self, is_root_mock, get_silent_mock):
+  def test_invalid_sso_enabled_cli_option_should_result_in_error(self, is_root_mock, is_server_runing_mock, get_silent_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = False
     options = self._create_empty_options_mock()
     options.sso_enabled = 'not_true_or_false'
@@ -122,12 +146,14 @@ class TestSetupSso(unittest.TestCase):
 
 
   @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_missing_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, get_silent_mock):
+  def test_missing_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, is_server_runing_mock, get_silent_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = False
     options = self._create_empty_options_mock()
     options.sso_enabled = 'true'
@@ -146,12 +172,14 @@ class TestSetupSso(unittest.TestCase):
 
 
   @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_missing_sso_public_cert_file_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, get_silent_mock):
+  def test_missing_sso_public_cert_file_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, is_server_runing_mock, get_silent_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = False
     options = self._create_empty_options_mock()
     options.sso_enabled = 'true'
@@ -170,12 +198,14 @@ class TestSetupSso(unittest.TestCase):
 
 
   @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_invalid_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, get_silent_mock):
+  def test_invalid_sso_provider_url_cli_option_when_enabling_sso_should_result_in_error(self, is_root_mock, is_server_runing_mock, get_silent_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = False
     options = self._create_empty_options_mock()
     options.sso_enabled = 'true'
@@ -193,21 +223,25 @@ class TestSetupSso(unittest.TestCase):
 
 
 
+  @patch("ambari_server.setupSso.perform_changes_via_rest_api")
   @patch("ambari_server.setupSso.update_properties")
   @patch("ambari_server.setupSso.get_ambari_properties")
   @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_all_cli_options_are_collected_when_enabling_sso(self, is_root_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock):
+  def test_all_cli_options_are_collected_when_enabling_sso(self, is_root_mock, is_server_runing_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock, perform_changes_via_rest_api_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = False
 
     properties = Properties();
     get_ambari_properties_mock.return_value = properties
 
     sso_enabled = 'true'
+    sso_enabled_services = 'SERVICE1, SERVICE2'
     sso_provider_url = 'http://testHost:8080'
     sso_public_cert_file = '/test/file/path'
     sso_jwt_cookie_name = 'test_cookie'
@@ -218,6 +252,7 @@ class TestSetupSso(unittest.TestCase):
     options.sso_public_cert_file = sso_public_cert_file
     options.sso_jwt_cookie_name = sso_jwt_cookie_name
     options.sso_jwt_audience_list = sso_jwt_audience_list
+    options.sso_enabled_services = sso_enabled_services
 
     setup_sso(options)
 
@@ -227,6 +262,7 @@ class TestSetupSso(unittest.TestCase):
     self.assertEqual(properties.get_property(JWT_PUBLIC_KEY), sso_public_cert_file)
     self.assertEqual(properties.get_property(JWT_COOKIE_NAME), sso_jwt_cookie_name)
     self.assertEqual(properties.get_property(JWT_AUDIENCES), sso_jwt_audience_list)
+    self.assertTrue(perform_changes_via_rest_api_mock.called)
 
     sys.stdout = sys.__stdout__
     pass
@@ -236,12 +272,14 @@ class TestSetupSso(unittest.TestCase):
   @patch("ambari_server.setupSso.update_properties")
   @patch("ambari_server.setupSso.get_ambari_properties")
   @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_only_sso_enabled_cli_option_is_collected_when_disabling_sso(self, is_root_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock):
+  def test_only_sso_enabled_cli_option_is_collected_when_disabling_sso(self, is_root_mock, is_server_runing_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
     is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
     get_silent_mock.return_value = False
 
     properties = Properties();
@@ -268,6 +306,130 @@ class TestSetupSso(unittest.TestCase):
     self.assertTrue(JWT_COOKIE_NAME not in properties.propertyNames())
     self.assertTrue(JWT_AUDIENCES not in properties.propertyNames())
 
+    sys.stdout = sys.__stdout__
+    pass
+
+
+  @patch("ambari_server.setupSso.perform_changes_via_rest_api")
+  @patch("ambari_server.setupSso.get_YN_input")
+  @patch("ambari_server.setupSso.update_properties")
+  @patch("ambari_server.setupSso.get_ambari_properties")
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
+  @patch("ambari_server.setupSso.is_root")
+  def test_sso_is_enabled_for_all_services_via_user_input(self, is_root_mock, is_server_runing_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock, get_YN_input_mock,
+                                                             perform_changes_via_rest_api_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
+    get_silent_mock.return_value = False
+    get_ambari_properties_mock.return_value = Properties()
+
+    def yn_input_side_effect(*args, **kwargs):
+      if 'all services' in args[0]:
+        return True
+      else:
+        raise Exception("ShouldNotBeInvoked") # only the 'Use SSO for all services' question should be asked for now
+
+    get_YN_input_mock.side_effect = yn_input_side_effect
+
+    options = self._create_empty_options_mock()
+    options.sso_enabled = 'true'
+    options.sso_provider_url = 'http://testHost:8080'
+    options.sso_public_cert_file = '/test/file/path'
+    options.sso_jwt_cookie_name = 'test_cookie'
+    options.sso_jwt_audience_list = 'test, audience, list'
+
+    setup_sso(options)
+
+    requestCall = perform_changes_via_rest_api_mock.call_args_list[0]
+    args, kwargs = requestCall
+    requestData = args[5]
+    self.assertTrue(isinstance(requestData, dict))
+    ssoProperties = requestData['Configuration']['properties'];
+    properties_updated_in_ambari_db = sorted(ssoProperties.iteritems(), key=operator.itemgetter(0))
+    properties_should_be_updated_in_ambari_db = sorted({"ambari.sso.enabled_services": "*"}.iteritems(), key=operator.itemgetter(0))
+    self.assertEqual(properties_should_be_updated_in_ambari_db, properties_updated_in_ambari_db)
+
+    sys.stdout = sys.__stdout__
+    pass
+
+
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSso.perform_changes_via_rest_api")
+  @patch("ambari_server.setupSso.get_cluster_name")
+  @patch("ambari_server.setupSso.get_YN_input")
+  @patch("ambari_server.setupSso.update_properties")
+  @patch("ambari_server.setupSso.get_ambari_properties")
+  @patch("ambari_server.setupSso.get_silent")
+  @patch("ambari_server.setupSso.is_server_runing")
+  @patch("ambari_server.setupSso.is_root")
+  def test_sso_enabled_services_are_collected_via_user_input(self, is_root_mock, is_server_runing_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock, get_YN_input_mock,
+                                                             get_cluster_name_mock, perform_changes_via_rest_api_mock, urlopen_mock):
+    out = StringIO.StringIO()
+    sys.stdout = out
+
+    is_root_mock.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
+    get_silent_mock.return_value = False
+    get_ambari_properties_mock.return_value = Properties()
+    get_cluster_name_mock.return_value = 'cluster1'
+
+    def yn_input_side_effect(*args, **kwargs):
+      if 'all services' in args[0]:
+        return False
+      else:
+        return True
+
+    get_YN_input_mock.side_effect = yn_input_side_effect
+
+    eligible_services = \
+    """
+        {
+          "href": "http://c7401:8080/api/v1/clusters/cluster1/services?ServiceInfo/sso_integration_supported=true",
+          "items": [
+            {
+                "href": "http://c7401:8080/api/v1/clusters/cluster1/services/HDFS",
+                "ServiceInfo": {
+                    "cluster_name": "cluster1",
+                    "service_name": "HDFS"
+                }
+            },
+            {
+                "href": "http://c7401:8080/api/v1/clusters/cluster1/services/ZOOKEPER",
+                "ServiceInfo": {
+                    "cluster_name": "cluster1",
+                    "service_name": "ZOOKEPER"
+                }
+            }
+          ]
+        }
+    """
+
+    response = MagicMock()
+    response.getcode.return_value = 200
+    response.read.return_value = eligible_services
+    urlopen_mock.return_value = response
+
+    options = self._create_empty_options_mock()
+    options.sso_enabled = 'true'
+    options.sso_provider_url = 'http://testHost:8080'
+    options.sso_public_cert_file = '/test/file/path'
+    options.sso_jwt_cookie_name = 'test_cookie'
+    options.sso_jwt_audience_list = 'test, audience, list'
+
+    setup_sso(options)
+
+    requestCall = perform_changes_via_rest_api_mock.call_args_list[0]
+    args, kwargs = requestCall
+    requestData = args[5]
+    self.assertTrue(isinstance(requestData, dict))
+    ssoProperties = requestData['Configuration']['properties'];
+    properties_updated_in_ambari_db = sorted(ssoProperties.iteritems(), key=operator.itemgetter(0))
+    properties_should_be_updated_in_ambari_db = sorted({"ambari.sso.enabled_services": "HDFS, ZOOKEPER"}.iteritems(), key=operator.itemgetter(0))
+    self.assertEqual(properties_should_be_updated_in_ambari_db, properties_updated_in_ambari_db)
 
     sys.stdout = sys.__stdout__
     pass
@@ -275,9 +437,10 @@ class TestSetupSso(unittest.TestCase):
   def _create_empty_options_mock(self):
     options = MagicMock()
     options.sso_enabled = None
+    options.sso_enabled_services = None
     options.sso_provider_url = None
     options.sso_public_cert_file = None
     options.sso_jwt_cookie_name = None
-    options.sso__jwt_audience_list = None
+    options.sso_jwt_audience_list = None
     return options
     

--- a/ambari-server/src/test/python/TestSetupSso.py
+++ b/ambari-server/src/test/python/TestSetupSso.py
@@ -241,7 +241,7 @@ class TestSetupSso(unittest.TestCase):
     get_ambari_properties_mock.return_value = properties
 
     sso_enabled = 'true'
-    sso_enabled_services = 'SERVICE1, SERVICE2'
+    sso_enabled_services = 'Ambari, SERVICE1, SERVICE2'
     sso_provider_url = 'http://testHost:8080'
     sso_public_cert_file = '/test/file/path'
     sso_jwt_cookie_name = 'test_cookie'
@@ -268,13 +268,13 @@ class TestSetupSso(unittest.TestCase):
     pass
 
 
-
+  @patch("urllib2.urlopen")
   @patch("ambari_server.setupSso.update_properties")
   @patch("ambari_server.setupSso.get_ambari_properties")
   @patch("ambari_server.setupSso.get_silent")
   @patch("ambari_server.setupSso.is_server_runing")
   @patch("ambari_server.setupSso.is_root")
-  def test_only_sso_enabled_cli_option_is_collected_when_disabling_sso(self, is_root_mock, is_server_runing_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock):
+  def test_only_sso_enabled_cli_option_is_collected_when_disabling_sso(self, is_root_mock, is_server_runing_mock, get_silent_mock, get_ambari_properties_mock, update_properties_mock, urlopen_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
@@ -296,6 +296,10 @@ class TestSetupSso(unittest.TestCase):
     options.sso_public_cert_file = sso_public_cert_file
     options.sso_jwt_cookie_name = sso_jwt_cookie_name
     options.sso_jwt_audience_list = sso_jwt_audience_list
+
+    response = MagicMock()
+    response.getcode.return_value = 200
+    urlopen_mock.return_value = response
 
     setup_sso(options)
 
@@ -350,7 +354,7 @@ class TestSetupSso(unittest.TestCase):
     self.assertTrue(isinstance(requestData, dict))
     ssoProperties = requestData['Configuration']['properties'];
     properties_updated_in_ambari_db = sorted(ssoProperties.iteritems(), key=operator.itemgetter(0))
-    properties_should_be_updated_in_ambari_db = sorted({"ambari.sso.enabled_services": "*"}.iteritems(), key=operator.itemgetter(0))
+    properties_should_be_updated_in_ambari_db = sorted({"ambari.sso.enabled_services": "*", "ambari.sso.manage_services": "true"}.iteritems(), key=operator.itemgetter(0))
     self.assertEqual(properties_should_be_updated_in_ambari_db, properties_updated_in_ambari_db)
 
     sys.stdout = sys.__stdout__
@@ -428,7 +432,7 @@ class TestSetupSso(unittest.TestCase):
     self.assertTrue(isinstance(requestData, dict))
     ssoProperties = requestData['Configuration']['properties'];
     properties_updated_in_ambari_db = sorted(ssoProperties.iteritems(), key=operator.itemgetter(0))
-    properties_should_be_updated_in_ambari_db = sorted({"ambari.sso.enabled_services": "HDFS, ZOOKEPER"}.iteritems(), key=operator.itemgetter(0))
+    properties_should_be_updated_in_ambari_db = sorted({"ambari.sso.enabled_services": "Ambari, HDFS, ZOOKEPER", "ambari.sso.manage_services": "true"}.iteritems(), key=operator.itemgetter(0))
     self.assertEqual(properties_should_be_updated_in_ambari_db, properties_updated_in_ambari_db)
 
     sys.stdout = sys.__stdout__


### PR DESCRIPTION
## What changes were proposed in this pull request?

Give the option to the end users to indicate which services they want to enable SSO for. To allow this the end users have two options:

- either providing this information as a command-line option with`--sso-enabled-services` (for instance: `--sso-enabled-services=*`
- or we ask them the appropriate questions when running the `setup-sso` tool

If the above mentioned command line option is blank we use Ambari's REST API to fetch eligible services. There is a special service - `Ambari` - that is never returned by the API but we need to ask the same question since we set `authentication.jwt.enabled` in `ambari.properties` based on the response for that question.

An additional check must be added too: since the tool now uses the REST API to save/fetch data we need `ambari-server` to be up&running; so that the tool will check this as one of the first steps and fail if this was not the case.

## How was this patch tested?

Unit tests were extended to cover the new functionality; latest Python test results in `ambari-server`:
```
Total run:1184
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:39 min
[INFO] Finished at: 2018-03-27T14:35:49+02:00
[INFO] Final Memory: 125M/1622M
[INFO] ------------------------------------------------------------------------
```

Manual E2E tests were running in my local test environment:
```
#################
# Disable SSO
#################

[root@c7401 ~]# ambari-server setup-sso --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...

Fetching SSO configuration from DB.INFO: SSO is currently enabled
Do you want to disable SSO authentication [y/n] (n)? y
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        | property_value 
-------------------+-----------------------------+----------------
 sso-configuration | ambari.sso.enabled_services | 
 sso-configuration | ambari.sso.manage_services  | false
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=false
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem


###############################
# Enable SSO for all services
###############################

[root@c7401 ~]# ambari-server setup-sso --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...

Fetching SSO configuration from DB.INFO: SSO is currently disabled
Do you want to configure SSO authentication [y/n] (y)? 
Provider URL [URL] (https://knox.ambari.apache.org:8443):
Public Certificate pem (stored) (empty line to finish input):

JWT Cookie name (ambari-jtw):
JWT audiences list (comma-separated), empty for any (ambari):
Use SSO for all services [y/n] (n): y
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        | property_value 
-------------------+-----------------------------+----------------
 sso-configuration | ambari.sso.enabled_services | *
 sso-configuration | ambari.sso.manage_services  | true
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem


###############################
# Enable SSO for Ambari only
###############################

[root@c7401 ~]# ambari-server setup-sso --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...

Fetching SSO configuration from DB.INFO: SSO is currently enabled
Do you want to disable SSO authentication [y/n] (n)? n
Provider URL [URL] (https://knox.ambari.apache.org:8443):
Public Certificate pem (stored) (empty line to finish input):

JWT Cookie name (ambari-jtw):
JWT audiences list (comma-separated), empty for any (ambari):
Use SSO for all services [y/n] (n): n

Fetching cluster name.
Found cluster name: cluster1
Fetching SSO enabled services.
Found SSO enabled services: Ambari, HDFS
Use SSO for Ambari [y/n] (y): y
Use SSO for HDFS [y/n] (y): n
Ambari Server 'setup-sso' completed successfully.
[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        | property_value 
-------------------+-----------------------------+----------------
 sso-configuration | ambari.sso.enabled_services | Ambari
 sso-configuration | ambari.sso.manage_services  | true
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem


###############################
# Enable SSO for HDFS only
###############################

[root@c7401 ~]# ambari-server setup-sso --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...

Fetching SSO configuration from DB.INFO: SSO is currently enabled
Do you want to disable SSO authentication [y/n] (n)? n
Provider URL [URL] (https://knox.ambari.apache.org:8443):
Public Certificate pem (stored) (empty line to finish input):

JWT Cookie name (ambari-jtw):
JWT audiences list (comma-separated), empty for any (ambari):
Use SSO for all services [y/n] (n): n

Fetching cluster name.
Found cluster name: cluster1
Fetching SSO enabled services.
Found SSO enabled services: Ambari, HDFS
Use SSO for Ambari [y/n] (y): n
Use SSO for HDFS [y/n] (y): y
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        | property_value 
-------------------+-----------------------------+----------------
 sso-configuration | ambari.sso.enabled_services | HDFS
 sso-configuration | ambari.sso.manage_services  | true
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=false
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem


###############################
# Enable SSO for Ambari + HDFS
###############################

[root@c7401 ~]# ambari-server setup-sso --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...

Fetching SSO configuration from DB.INFO: SSO is currently enabled
Do you want to disable SSO authentication [y/n] (n)? n
Provider URL [URL] (https://knox.ambari.apache.org:8443):
Public Certificate pem (stored) (empty line to finish input):

JWT Cookie name (ambari-jtw):
JWT audiences list (comma-separated), empty for any (ambari):
Use SSO for all services [y/n] (n): n

Fetching cluster name.
Found cluster name: cluster1
Fetching SSO enabled services.
Found SSO enabled services: Ambari, HDFS
Use SSO for Ambari [y/n] (y): y
Use SSO for HDFS [y/n] (y): y
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        | property_value 
-------------------+-----------------------------+----------------
 sso-configuration | ambari.sso.enabled_services | Ambari, HDFS
 sso-configuration | ambari.sso.manage_services  | true
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem


#####################
# CLI - Disable SSO
#####################

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=false --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        | property_value 
-------------------+-----------------------------+----------------
 sso-configuration | ambari.sso.enabled_services | 
 sso-configuration | ambari.sso.manage_services  | false
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=ambari
authentication.jwt.cookieName=ambari-jtw
authentication.jwt.enabled=false
authentication.jwt.providerUrl=https://knox.ambari.apache.org:8443
authentication.jwt.publicKey=/tmp/sso.pem


#############################################
# CLI - Enable SSO for Ambari and SERVICE_X
#############################################

[root@c7401 ~]# ambari-server setup-sso --sso-enabled=true --sso-provider-url=https://host:8443 --sso-public-cert-file=/tmp/new.sso.pem --sso-jwt-cookie-name=cookieName-jtw --sso-jwt-audience-list=audienceList --sso-enabled-services=Ambari,SERVICE_X --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
Setting up SSO authentication properties...
Ambari Server 'setup-sso' completed successfully.

[root@c7401 ~]# PGPASSWORD=bigdata psql -U ambari -c "select * from ambari_configuration where category_name = 'sso-configuration'"
   category_name   |        property_name        |  property_value  
-------------------+-----------------------------+------------------
 sso-configuration | ambari.sso.enabled_services | Ambari,SERVICE_X
 sso-configuration | ambari.sso.manage_services  | true
(2 rows)

[root@c7401 ~]# less /etc/ambari-server/conf/ambari.properties | grep jwt
authentication.jwt.audiences=audienceList
authentication.jwt.cookieName=cookieName-jtw
authentication.jwt.enabled=true
authentication.jwt.providerUrl=https://host:8443
authentication.jwt.publicKey=/tmp/new.sso.pem
```