### PR TITLE
AMBARI-23314 - Prevent Multiple OS Entries For a Single Mpack

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/OperatingSystemService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/OperatingSystemService.java
@@ -29,6 +29,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -58,7 +59,7 @@ public class OperatingSystemService extends BaseService {
 
   /**
    * Constructor.
-   * 
+   *
    * @param mpackId
    *          the ID of the mpack to get operating system resources for.
    */
@@ -93,7 +94,7 @@ public class OperatingSystemService extends BaseService {
    */
   @GET
   @ApiIgnore
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
   public Response getOperatingSystems(@Context HttpHeaders headers, @Context UriInfo ui) {
     return handleRequest(headers, null, ui, Request.Type.GET, createResource(null));
   }
@@ -113,7 +114,7 @@ public class OperatingSystemService extends BaseService {
   @GET
   @ApiIgnore
   @Path("{osType}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
   public Response getOperatingSystem(@Context HttpHeaders headers, @Context UriInfo ui,
       @PathParam("osType") String osType) {
     return handleRequest(headers, null, ui, Request.Type.GET, createResource(osType));
@@ -133,10 +134,27 @@ public class OperatingSystemService extends BaseService {
   @POST
   @ApiIgnore
   @Path("{osType}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
   public Response createOperatingSystem(String body, @Context HttpHeaders headers,
       @Context UriInfo ui, @PathParam("osType") String osType) {
     return handleRequest(headers, body, ui, Request.Type.POST, createResource(osType));
+  }
+
+  /**
+   * Creates the repositories and properties of all specified operating systems.
+   *
+   * @param headers
+   *          http headers
+   * @param ui
+   *          uri info
+   * @return information regarding the specified operating system
+   */
+  @POST
+  @ApiIgnore
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response createOperatingSystem(String body, @Context HttpHeaders headers,
+      @Context UriInfo ui) {
+    return handleRequest(headers, body, ui, Request.Type.POST, createResource(null));
   }
 
   /**
@@ -153,7 +171,7 @@ public class OperatingSystemService extends BaseService {
   @PUT
   @ApiIgnore
   @Path("{osType}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
   public Response updateOperatingSystem(String body, @Context HttpHeaders headers,
       @Context UriInfo ui,
       @PathParam("osType") String osType) {
@@ -174,7 +192,7 @@ public class OperatingSystemService extends BaseService {
   @DELETE
   @ApiIgnore
   @Path("{osType}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
   public Response deleteOperatingSystem(@Context HttpHeaders headers, @Context UriInfo ui,
       @PathParam("osType") String osType) {
     return handleRequest(headers, null, ui, Request.Type.DELETE, createResource(osType));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/DefaultProviderModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/DefaultProviderModule.java
@@ -127,7 +127,7 @@ public class DefaultProviderModule extends AbstractProviderModule {
       case DefaultOperatingSystem:
         return new DefaultOperatingSystemResourceProvider(managementController);
       case OperatingSystem:
-        return new OperatingSystemResourceProvider(managementController);
+        return new OperatingSystemResourceProvider();
       case OperatingSystemReadOnly:
         return new OperatingSystemReadOnlyResourceProvider(managementController);
       case Repository:

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RepositoryDefinitionDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RepositoryDefinitionDAO.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.orm.dao;
+
+import org.apache.ambari.server.orm.entities.RepoDefinitionEntity;
+
+import com.google.inject.Singleton;
+
+/**
+ * The {@link RepositoryDefinitionDAO} manages {@link RepoDefinitionEntity}
+ * instances.
+ */
+@Singleton
+public class RepositoryDefinitionDAO
+    extends CrudDAO<RepoDefinitionEntity, Long> {
+
+  /**
+   * Constructor.
+   *
+   * @param entityClass
+   */
+  public RepositoryDefinitionDAO() {
+    super(RepoDefinitionEntity.class);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoDefinitionEntity.java
@@ -34,17 +34,23 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
+import javax.persistence.UniqueConstraint;
 
 import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.stack.RepoTag;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
  * Represents a Repository definition type.
  */
 @Entity
-@Table(name = "repo_definition")
+@Table(
+    name = "repo_definition",
+    uniqueConstraints = @UniqueConstraint(
+        name = "UQ_repo_def_os_id_repo_id",
+        columnNames = { "repo_os_id", "repo_id" }))
 @TableGenerator(name = "repo_definition_id_generator",
     table = "ambari_sequences",
     pkColumnName = "sequence_name",
@@ -210,18 +216,18 @@ public class RepoDefinitionEntity {
         && Objects.equal(distribution, that.distribution)
         && Objects.equal(components, that.components);
   }
-  
+
   /**
    * {@inheritDoc}
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("id", repoID)
       .add("name", repoName)
       .add("tags", repoTags)
       .toString();
-  }  
+  }
 
   /**
    * Builds a {@link RepoDefinitionEntity} from a {@link RepositoryInfo} instance.

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepoOsEntity.java
@@ -32,6 +32,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
+import javax.persistence.UniqueConstraint;
 
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
@@ -46,7 +47,11 @@ import com.google.common.base.Objects;
  * Represents a Repository operation system type.
  */
 @Entity
-@Table(name = "repo_os")
+@Table(
+    name = "repo_os",
+    uniqueConstraints = @UniqueConstraint(
+        name = "UQ_repo_os_family_mpack_id",
+        columnNames = { "mpack_id", "family" }))
 @TableGenerator(name = "repo_os_id_generator",
     table = "ambari_sequences",
     pkColumnName = "sequence_name",
@@ -98,9 +103,17 @@ public class RepoOsEntity {
   }
 
   /**
+   * @return repoDefinitionEntities
+   */
+  public void setRepoDefinitionEntities(List<RepoDefinitionEntity> repoDefinitionEntities) {
+    this.repoDefinitionEntities = repoDefinitionEntities;
+  }
+
+  /**
    * Update one-to-many relation without rebuilding the whole entity
    *
-   * @param repoDefinitionEntities list of many-to-one entities
+   * @param repoDefinitionEntities
+   *          list of many-to-one entities
    */
   public void addRepoDefinitionEntities(List<RepoDefinitionEntity> repoDefinitionEntities) {
     this.repoDefinitionEntities.addAll(repoDefinitionEntities);
@@ -226,7 +239,7 @@ public class RepoOsEntity {
    */
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return com.google.common.base.MoreObjects.toStringHelper(this)
         .add("mpackId", mpackId)
         .add("family", family)
         .add("isManagedByAmbari", ambariManaged)

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -260,7 +260,8 @@ CREATE TABLE repo_os (
   ambari_managed SMALLINT DEFAULT 1,
   CONSTRAINT PK_repo_os_id PRIMARY KEY (id),
   CONSTRAINT FK_repo_os_id_repo_version_id FOREIGN KEY (repo_version_id) REFERENCES repo_version (repo_version_id),
-  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id));
+  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_repo_os_family_mpack_id UNIQUE (mpack_id, family));
 
 CREATE TABLE repo_definition (
   id BIGINT NOT NULL,
@@ -273,7 +274,8 @@ CREATE TABLE repo_definition (
   unique_repo SMALLINT DEFAULT 1,
   mirrors VARCHAR(2048),
   CONSTRAINT PK_repo_definition_id PRIMARY KEY (id),
-  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id));
+  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id),
+  CONSTRAINT UQ_repo_def_os_id_repo_id UNIQUE (repo_os_id, repo_id));
 
 CREATE TABLE repo_tags (
   repo_definition_id BIGINT NOT NULL,
@@ -1051,8 +1053,8 @@ CREATE TABLE upgrade_plan(
   cluster_id BIGINT NOT NULL,
   upgrade_type VARCHAR(255) DEFAULT 'ROLLING' NOT NULL,
   direction VARCHAR(255) DEFAULT 'UPGRADE' NOT NULL,
-  skip_failures SMALLINT DEFAULT 0 NOT NULL, 
-  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL, 
+  skip_failures SMALLINT DEFAULT 0 NOT NULL,
+  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL,
   skip_prechecks SMALLINT DEFAULT 0 NOT NULL,
   fail_on_precheck_warnings SMALLINT DEFAULT 0 NOT NULL,
   skip_service_checks SMALLINT DEFAULT 0 NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -279,7 +279,8 @@ CREATE TABLE repo_os (
   ambari_managed TINYINT(1) DEFAULT 1,
   CONSTRAINT PK_repo_os_id PRIMARY KEY (id),
   CONSTRAINT FK_repo_os_id_repo_version_id FOREIGN KEY (repo_version_id) REFERENCES repo_version (repo_version_id),
-  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id));
+  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_repo_os_family_mpack_id UNIQUE (mpack_id, family));
 
 CREATE TABLE repo_definition (
   id BIGINT NOT NULL,
@@ -292,7 +293,8 @@ CREATE TABLE repo_definition (
   unique_repo TINYINT(1) DEFAULT 1,
   mirrors MEDIUMTEXT,
   CONSTRAINT PK_repo_definition_id PRIMARY KEY (id),
-  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id));
+  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id),
+  CONSTRAINT UQ_repo_def_os_id_repo_id UNIQUE (repo_os_id, repo_id));
 
 CREATE TABLE repo_tags (
   repo_definition_id BIGINT NOT NULL,
@@ -1068,8 +1070,8 @@ CREATE TABLE upgrade_plan (
   cluster_id BIGINT NOT NULL,
   upgrade_type VARCHAR(255) DEFAULT 'ROLLING' NOT NULL,
   direction VARCHAR(255) DEFAULT 'UPGRADE' NOT NULL,
-  skip_failures SMALLINT DEFAULT 0 NOT NULL, 
-  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL, 
+  skip_failures SMALLINT DEFAULT 0 NOT NULL,
+  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL,
   skip_prechecks SMALLINT DEFAULT 0 NOT NULL,
   fail_on_precheck_warnings SMALLINT DEFAULT 0 NOT NULL,
   skip_service_checks SMALLINT DEFAULT 0 NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -259,7 +259,8 @@ CREATE TABLE repo_os (
   ambari_managed NUMBER(1) DEFAULT 1,
   CONSTRAINT PK_repo_os_id PRIMARY KEY (id),
   CONSTRAINT FK_repo_os_id_repo_version_id FOREIGN KEY (repo_version_id) REFERENCES repo_version (repo_version_id),
-  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id));
+  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_repo_os_family_mpack_id UNIQUE (mpack_id, family));
 
 CREATE TABLE repo_definition (
   id NUMBER(19) NOT NULL,
@@ -272,7 +273,8 @@ CREATE TABLE repo_definition (
   unique_repo NUMBER(1) DEFAULT 1,
   mirrors CLOB,
   CONSTRAINT PK_repo_definition_id PRIMARY KEY (id),
-  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id));
+  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id),
+  CONSTRAINT UQ_repo_def_os_id_repo_id UNIQUE (repo_os_id, repo_id));
 
 CREATE TABLE repo_tags (
   repo_definition_id NUMBER(19) NOT NULL,
@@ -1046,8 +1048,8 @@ CREATE TABLE upgrade_plan (
   cluster_id NUMBER(19) NOT NULL,
   upgrade_type VARCHAR2(255) DEFAULT 'ROLLING' NOT NULL,
   direction VARCHAR2(255) DEFAULT 'UPGRADE' NOT NULL,
-  skip_failures SMALLINT DEFAULT 0 NOT NULL, 
-  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL, 
+  skip_failures SMALLINT DEFAULT 0 NOT NULL,
+  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL,
   skip_prechecks SMALLINT DEFAULT 0 NOT NULL,
   fail_on_precheck_warnings SMALLINT DEFAULT 0 NOT NULL,
   skip_service_checks SMALLINT DEFAULT 0 NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -261,7 +261,8 @@ CREATE TABLE repo_os (
   ambari_managed SMALLINT DEFAULT 1,
   CONSTRAINT PK_repo_os_id PRIMARY KEY (id),
   CONSTRAINT FK_repo_os_id_repo_version_id FOREIGN KEY (repo_version_id) REFERENCES repo_version (repo_version_id),
-  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id));
+  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_repo_os_family_mpack_id UNIQUE (mpack_id, family));
 
 CREATE TABLE repo_definition (
   id BIGINT NOT NULL,
@@ -274,7 +275,8 @@ CREATE TABLE repo_definition (
   unique_repo SMALLINT DEFAULT 1,
   mirrors VARCHAR(2048),
   CONSTRAINT PK_repo_definition_id PRIMARY KEY (id),
-  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id));
+  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id),
+  CONSTRAINT UQ_repo_def_os_id_repo_id UNIQUE (repo_os_id, repo_id));
 
 CREATE TABLE repo_tags (
   repo_definition_id BIGINT NOT NULL,
@@ -1051,8 +1053,8 @@ CREATE TABLE upgrade_plan (
   cluster_id BIGINT NOT NULL,
   upgrade_type VARCHAR(255) DEFAULT 'ROLLING' NOT NULL,
   direction VARCHAR(255) DEFAULT 'UPGRADE' NOT NULL,
-  skip_failures SMALLINT DEFAULT 0 NOT NULL, 
-  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL, 
+  skip_failures SMALLINT DEFAULT 0 NOT NULL,
+  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL,
   skip_prechecks SMALLINT DEFAULT 0 NOT NULL,
   fail_on_precheck_warnings SMALLINT DEFAULT 0 NOT NULL,
   skip_service_checks SMALLINT DEFAULT 0 NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -258,7 +258,8 @@ CREATE TABLE repo_os (
   ambari_managed SMALLINT DEFAULT 1,
   CONSTRAINT PK_repo_os_id PRIMARY KEY (id),
   CONSTRAINT FK_repo_os_id_repo_version_id FOREIGN KEY (repo_version_id) REFERENCES repo_version (repo_version_id),
-  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id));
+  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_repo_os_family_mpack_id UNIQUE (mpack_id, family));
 
 CREATE TABLE repo_definition (
   id NUMERIC(19) NOT NULL,
@@ -271,7 +272,8 @@ CREATE TABLE repo_definition (
   unique_repo SMALLINT DEFAULT 1,
   mirrors TEXT,
   CONSTRAINT PK_repo_definition_id PRIMARY KEY (id),
-  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id));
+  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id),
+  CONSTRAINT UQ_repo_def_os_id_repo_id UNIQUE (repo_os_id, repo_id));
 
 CREATE TABLE repo_tags (
   repo_definition_id NUMERIC(19) NOT NULL,

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -273,7 +273,8 @@ CREATE TABLE repo_os (
   ambari_managed BIT DEFAULT 1,
   CONSTRAINT PK_repo_os_id PRIMARY KEY (id),
   CONSTRAINT FK_repo_os_id_repo_version_id FOREIGN KEY (repo_version_id) REFERENCES repo_version (repo_version_id),
-  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id));
+  CONSTRAINT FK_repo_os_mpack_id FOREIGN KEY (mpack_id) REFERENCES mpacks (id),
+  CONSTRAINT UQ_repo_os_family_mpack_id UNIQUE (mpack_id, family));
 
 CREATE TABLE repo_definition (
   id BIGINT NOT NULL,
@@ -286,7 +287,8 @@ CREATE TABLE repo_definition (
   unique_repo BIT DEFAULT 1,
   mirrors VARCHAR(MAX),
   CONSTRAINT PK_repo_definition_id PRIMARY KEY (id),
-  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id));
+  CONSTRAINT FK_repo_definition_repo_os_id FOREIGN KEY (repo_os_id) REFERENCES repo_os (id),
+  CONSTRAINT UQ_repo_def_os_id_repo_id UNIQUE (repo_os_id, repo_id));
 
 CREATE TABLE repo_tags (
   repo_definition_id BIGINT NOT NULL,
@@ -1069,8 +1071,8 @@ CREATE TABLE upgrade_plan (
   cluster_id BIGINT NOT NULL,
   upgrade_type VARCHAR(255) DEFAULT 'ROLLING' NOT NULL,
   direction VARCHAR(255) DEFAULT 'UPGRADE' NOT NULL,
-  skip_failures SMALLINT DEFAULT 0 NOT NULL, 
-  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL, 
+  skip_failures SMALLINT DEFAULT 0 NOT NULL,
+  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL,
   skip_prechecks SMALLINT DEFAULT 0 NOT NULL,
   fail_on_precheck_warnings SMALLINT DEFAULT 0 NOT NULL,
   skip_service_checks SMALLINT DEFAULT 0 NOT NULL,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The operating systems endpoint allows for creation and deletion of repositories which are associated with a single management pack. However, multiple PUTs causes duplicate entries for the same OS. This should be prevented.

## How was this patch tested?

Manual testing for now.