### PR TITLE
 AMBARI-23348 - service advisor has the option to calculate colocatSe…

### DIFF
--- a/ambari-server/src/main/resources/stacks/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/service_advisor.py
@@ -53,6 +53,23 @@ class ServiceAdvisor(DefaultStackAdvisor):
   Abstract class implemented by all service advisors.
   """
 
+  def colocateServiceWithServicesInfo(self, hostsComponentsMap, serviceComponents, services):
+    """
+    Populate hostsComponentsMap with key = hostname and value = [{"name": "COMP_NAME_1"}, {"name": "COMP_NAME_2"}, ...]
+    of services that must be co-hosted and on which host they should be present.
+    :param hostsComponentsMap: Map from hostname to list of [{"name": "COMP_NAME_1"}, {"name": "COMP_NAME_2"}, ...]
+    present on on that host.
+    :param serviceComponents: Mapping of components
+    :param services: The full list of servies
+
+    If any components of the service should be colocated with other services,
+    and the decision should be based on information that is only available in the services list,
+    such as what are the master components, etc,
+    this is where you should set up that layout.
+
+    Each service should only implement either this method or the colocateService method
+    """
+    pass
 
   def colocateService(self, hostsComponentsMap, serviceComponents):
     """
@@ -62,18 +79,9 @@ class ServiceAdvisor(DefaultStackAdvisor):
     present on on that host.
     :param serviceComponents: Mapping of components
 
-    If any components of the service should be colocated with other services,
-    this is where you should set up that layout.  Example:
+    If any components of the service should be colocated with other services, this is where you should set up that layout.
 
-      # colocate HAWQSEGMENT with DATANODE, if no hosts have been allocated for HAWQSEGMENT
-      hawqSegment = [component for component in serviceComponents if component["StackServiceComponents"]["component_name"] == "HAWQSEGMENT"][0]
-      if not self.isComponentHostsPopulated(hawqSegment):
-        for hostName in hostsComponentsMap.keys():
-          hostComponents = hostsComponentsMap[hostName]
-          if {"name": "DATANODE"} in hostComponents and {"name": "HAWQSEGMENT"} not in hostComponents:
-            hostsComponentsMap[hostName].append( { "name": "HAWQSEGMENT" } )
-          if {"name": "DATANODE"} not in hostComponents and {"name": "HAWQSEGMENT"} in hostComponents:
-            hostComponents.remove({"name": "HAWQSEGMENT"})
+    Each service should only implement either this method or the colocateServiceWithServicesInfo method
     """
     pass
 

--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -809,6 +809,7 @@ class DefaultStackAdvisor(StackAdvisor):
       if serviceAdvisor is not None:
         serviceComponents = [component for component in service["components"]]
         serviceAdvisor.colocateService(hostsComponentsMap, serviceComponents)
+        serviceAdvisor.colocateServiceWithServicesInfo(hostsComponentsMap, serviceComponents. services)
 
     #prepare 'host-group's from 'hostsComponentsMap'
     host_groups = recommendations["blueprint"]["host_groups"]

--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -809,7 +809,7 @@ class DefaultStackAdvisor(StackAdvisor):
       if serviceAdvisor is not None:
         serviceComponents = [component for component in service["components"]]
         serviceAdvisor.colocateService(hostsComponentsMap, serviceComponents)
-        serviceAdvisor.colocateServiceWithServicesInfo(hostsComponentsMap, serviceComponents. services)
+        serviceAdvisor.colocateServiceWithServicesInfo(hostsComponentsMap, serviceComponents, services)
 
     #prepare 'host-group's from 'hostsComponentsMap'
     host_groups = recommendations["blueprint"]["host_groups"]


### PR DESCRIPTION
…rvices with more information from the services list (dili)

## What changes were proposed in this pull request?

Add a new method to the top level service_advisor.py so that each service can either implement colocateService or colocateServiceWithServiceInfo(). The point is to not break existing service advisor implementations in HDP 3.0

## How was this patch tested?

Patch an AMbari 2.7/HDP 3.0 cluster with the changes, add KNox, verify I could add Knox

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.