### PR TITLE
AMBARI-23350. UI. ServiceConfig API call uses MpackName-Vesion for SG instead of just MpackName.

### DIFF
--- a/ambari-web/app/controllers/wizard/step8_controller.js
+++ b/ambari-web/app/controllers/wizard/step8_controller.js
@@ -1589,7 +1589,7 @@ App.WizardStep8Controller = App.WizardStepController.extend(App.AddSecurityConfi
           name: 'common.service.create.configs',
           data: {
             serviceName: service.get('serviceName'),
-            serviceGroupName: `${service.get('stackName')}-${service.get('stackVersion')}`,
+            serviceGroupName: service.get('stackName'),
             data: serviceConfigData
           }
         });    


### PR DESCRIPTION
## What changes were proposed in this pull request?

**1. ServiceConfig API call uses "MpackName-Vesion" for SG instead of just "MpackName".** 

- With "[AMBARI-23269] Removed mpack version from service group name (#692)" we have started using just the **Mpack** Name to create the SG.
- But we haven't updated the Service Configs API POST calls, which still continue to use **MpackName-Version** for referring SG. This needs to be updated.

Failure : 

POST http://<Server>:8080/api/v1/clusters/c1/servicegroups/HDPCORE-1.0.0-b140/services/HDFS/configurations

**Fix:** Removed appending version while making this call.



## How was this patch tested?

Tested on cluster.