### PR TITLE
[AMBARI-23352] During ambari upgrade, DB backup choice default option…

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -124,7 +124,7 @@ def change_objects_owner(args):
 def run_schema_upgrade(args):
   db_title = get_db_type(get_ambari_properties()).title
   confirm = get_YN_input("Ambari Server configured for %s. Confirm "
-                        "you have made a backup of the Ambari Server database [y/n] (y)? " % db_title, True)
+                        "you have made a backup of the Ambari Server database [y/n] (n)? " % db_title, False)
 
   if not confirm:
     print_error_msg("Database backup is not confirmed")

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -128,6 +128,7 @@ def run_schema_upgrade(args):
   default_value = silent
   confirm = get_YN_input("Ambari Server configured for %s. Confirm "
                          "you have made a backup of the Ambari Server database [y/n] (%s)? " % (db_title, default_answer), default_value)
+
   if not confirm:
     print_error_msg("Database backup is not confirmed")
     return 1

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -123,13 +123,11 @@ def change_objects_owner(args):
 
 def run_schema_upgrade(args):
   db_title = get_db_type(get_ambari_properties()).title
-  if not get_silent():
-    confirm = get_YN_input("Ambari Server configured for %s. Confirm "
-                        "you have made a backup of the Ambari Server database [y/n] (n)? " % db_title, False)
-  else:
-    confirm = get_YN_input("Ambari Server configured for %s. Confirm "
-                        "you have made a backup of the Ambari Server database [y/n] (y)? " % db_title, True)
-
+  silent = get_silent()
+  default_answer = 'y' if silent else 'n'
+  default_value = silent
+  confirm = get_YN_input("Ambari Server configured for %s. Confirm "
+                         "you have made a backup of the Ambari Server database [y/n] (%s)? " % (db_title, default_answer), default_value)
   if not confirm:
     print_error_msg("Database backup is not confirmed")
     return 1

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -50,7 +50,7 @@ from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_ba
 from ambari_server.userInput import get_validated_string_input, get_prompt_default, read_password, get_YN_input
 from ambari_server.serverClassPath import ServerClassPath
 from ambari_server.setupMpacks import replay_mpack_logs
-from ambari_commons.logging_utils import get_debug_mode,   set_debug_mode_from_options
+from ambari_commons.logging_utils import get_debug_mode, set_debug_mode_from_options, get_silent
 
 logger = logging.getLogger(__name__)
 
@@ -123,8 +123,12 @@ def change_objects_owner(args):
 
 def run_schema_upgrade(args):
   db_title = get_db_type(get_ambari_properties()).title
-  confirm = get_YN_input("Ambari Server configured for %s. Confirm "
+  if not get_silent():
+    confirm = get_YN_input("Ambari Server configured for %s. Confirm "
                         "you have made a backup of the Ambari Server database [y/n] (n)? " % db_title, False)
+  else:
+    confirm = get_YN_input("Ambari Server configured for %s. Confirm "
+                        "you have made a backup of the Ambari Server database [y/n] (y)? " % db_title, True)
 
   if not confirm:
     print_error_msg("Database backup is not confirmed")


### PR DESCRIPTION
… should be 'n' instead of 'y'

## What changes were proposed in this pull request?
When we run the "ambari-server upgrade" option then at the following point it asks if the user has already taken Database dump or not ?

`
[root@jnode1 ~]# ambari-server upgrade
.
.
INFO: Fixing database objects owner
Ambari Server configured for Embedded Postgres. Confirm you have made a backup of the Ambari Server database [y/n] (y)? 
`

There is a possibility that the user might mistakenly press ENTER (which means 'y') without actually collecting the Ambari DB backup.
So in order to avoid this risk the default option should be "n' so that we can avoid ignorance and user will have to explicitly enter "y' to proceed (to confirm they collected Db dump already).

**Expected option:**
`Ambari Server configured for Embedded Postgres. Confirm you have made a backup of the Ambari Server database [y/n] (n)? `

## How was this patch tested?
Manually tested the fix.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.