### PR TITLE
AMBARI-23319: Part 2: Provide for mpack definition tarballs crc32 or …

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -67,6 +67,9 @@ public class Mpack {
   @SerializedName("displayName")
   private String displayName;
 
+  @SerializedName("checksum")
+  private String checksum;
+
   private String mpackUri;
 
   /**
@@ -162,6 +165,14 @@ public class Mpack {
     this.displayName = displayName;
   }
 
+  public String getChecksum() {
+    return checksum;
+  }
+
+  public void setChecksum(String checksum) {
+    this.checksum = checksum;
+  }
+
   /**
    * Gets the repository XML representation.
    *
@@ -244,6 +255,7 @@ public class Mpack {
     equalsBuilder.append(description, that.description);
     equalsBuilder.append(mpackUri, that.mpackUri);
     equalsBuilder.append(displayName, that.displayName);
+    equalsBuilder.append(checksum, that.checksum);
 
     return equalsBuilder.isEquals();
   }
@@ -254,7 +266,7 @@ public class Mpack {
   @Override
   public int hashCode() {
     return Objects.hash(resourceId, registryId, mpackId, name, version, prerequisites, modules,
-        definition, description, mpackUri, displayName);
+        definition, description, mpackUri, displayName, checksum);
   }
 
   @Override
@@ -271,6 +283,7 @@ public class Mpack {
             ", description='" + description + '\'' +
             ", mpackUri='" + mpackUri + '\'' +
             ", displayName='" + mpackUri + '\'' +
+            ", checksum='" + checksum + '\'' +
             '}';
   }
 
@@ -304,6 +317,9 @@ public class Mpack {
     }
     if (displayName == null) {
       displayName = mpack.getDisplayName();
+    }
+    if (checksum == null) {
+      checksum = mpack.getChecksum();
     }
   }
 }


### PR DESCRIPTION
…md5 checksums, to validate downloaded files

## What changes were proposed in this pull request?

Downloaded mpack.json will contain md5 checksum for mpack tarball, this PR adds new code to verify the mpack tarball integrity with md5 checksum comparison.

## How was this patch tested?
Manually tested:
Within live debugging session, set checksum value in mpack checksum field, then the new code should calculate the md5 for the downloaded mpack tarball, then these two md5 checksums value should be identical.
