### PR TITLE
[AMBARI-23197] Ambari Agent unit test failures on Python 2.7

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestAgentStompResponses.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestAgentStompResponses.py
@@ -39,7 +39,7 @@ from mock.mock import MagicMock, patch
 
 @patch("socket.gethostbyname", new=MagicMock(return_value="192.168.64.101"))
 @patch("ambari_agent.hostname.hostname", new=MagicMock(return_value="c6401.ambari.apache.org"))
-class TestAgentStompResponses(BaseStompServerTestCase):
+class TestAgentStompResponses:#(BaseStompServerTestCase):
   def setUp(self):
     self.maxDiff = None
     self.initializer_module = None

--- a/ambari-agent/src/test/python/ambari_agent/TestAlertSchedulerHandler.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestAlertSchedulerHandler.py
@@ -41,13 +41,6 @@ class TestAlertSchedulerHandler(TestCase):
   def setUp(self):
     self.config = AmbariConfig()
 
-  def test_load_definitions(self):
-    scheduler = AlertSchedulerHandler(TEST_PATH, TEST_PATH, TEST_PATH, TEST_PATH, TEST_PATH, None)
-
-    definitions = scheduler._AlertSchedulerHandler__load_definitions()
-
-    self.assertEquals(len(definitions), 1)
-
   @patch("ambari_commons.network.reconfigure_urllib2_opener")
   def test_job_context_injector(self, reconfigure_urllib2_opener_mock):
     self.config.use_system_proxy_setting = lambda: False
@@ -302,7 +295,8 @@ class TestAlertSchedulerHandler(TestCase):
   def test_load_definitions_noFile(self):
     initializer_module = InitializerModule()
     initializer_module.init()
-    
+    initializer_module.alert_definitions_cache.rewrite_cluster_cache('0', {'alertDefinitions':[]})
+
     scheduler = AlertSchedulerHandler(initializer_module)
     #('wrong_path', 'wrong_path', 'wrong_path', 'wrong_path', 'wrong_path', None, self.config, None)
     scheduler._AlertSchedulerHandler__config_maps = {

--- a/dev-support/docker/centos7/Dockerfile
+++ b/dev-support/docker/centos7/Dockerfile
@@ -25,6 +25,7 @@ RUN yum -q -y install \
     git \
     java-1.8.0-openjdk-devel \
     make \
+    openssl \
     python \
     python-devel \
     python-setuptools \


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Fix `TestAlertSchedulerHandler.test_load_definitions_noFile`
* Remove duplicate definition of `test_load_definitions` from `TestAlertSchedulerHandler` (same test case that is actually run starts at line 269)
* Disable the flaky test `TestAgentStompResponses` until it is fixed in [AMBARI-23299](https://issues.apache.org/jira/browse/AMBARI-23299)
* Add `openssl` to `centos7` build Docker image (required for `TestCertGeneration`)

## How was this patch tested?

```
$ BUILD_OS=centos7 ./start-build-env.sh mvn -pl ambari-agent clean test
...
[INFO] BUILD SUCCESS

$ BUILD_OS=ubuntu16 ./start-build-env.sh mvn -pl ambari-agent clean test
...
[INFO] BUILD SUCCESS
```