### PR TITLE
[AMBARI-23354] Enable or disable SSO for servces upon setting sso-configuration values

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
@@ -78,7 +78,7 @@ public enum AmbariServerConfigurationKey {
    * SSO Configuration Keys
    * ******************************************************** */
   SSO_MANAGE_SERVICES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.manage_services", PLAINTEXT, "false", "A Boolean value indicating whether Ambari is to manage the SSO configuration for services or not."),
-  SSO_ENABED_SERVICES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.enabled_services", PLAINTEXT, null, "A comma-delimited list of services that are expected to be configured for SSO.  A \"*\" indicates all services.");
+  SSO_ENABLED_SERVICES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.enabled_services", PLAINTEXT, null, "A comma-delimited list of services that are expected to be configured for SSO.  A \"*\" indicates all services.");
 
   private final AmbariServerConfigurationCategory configurationCategory;
   private final String propertyName;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandler.java
@@ -18,25 +18,17 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.SSO_CONFIGURATION;
-import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_ENABED_SERVICES;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
-import org.apache.ambari.server.StaticallyInject;
 import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
-import org.apache.ambari.server.controller.spi.NoSuchResourceException;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.events.AmbariConfigurationChangedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
@@ -49,29 +41,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 
 /**
  * AmbariServerConfigurationHandler handles Ambari server specific configuration properties.
  */
-@StaticallyInject
+@Singleton
 public class AmbariServerConfigurationHandler extends RootServiceComponentConfigurationHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(AmbariServerConfigurationHandler.class);
 
-  @Inject
-  static AmbariConfigurationDAO ambariConfigurationDAO;
-
-  @Inject
-  private static AmbariEventPublisher publisher;
-
-  @Inject
-  private static Configuration ambariConfiguration;
+  private final AmbariConfigurationDAO ambariConfigurationDAO;
+  private final AmbariEventPublisher publisher;
+  private final Configuration ambariConfiguration;
 
   private CredentialProvider credentialProvider;
 
+  @Inject
+  AmbariServerConfigurationHandler(AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher, Configuration ambariConfiguration) {
+    this.ambariConfigurationDAO = ambariConfigurationDAO;
+    this.publisher = publisher;
+    this.ambariConfiguration = ambariConfiguration;
+  }
+
   @Override
-  public Map<String, RootServiceComponentConfiguration> getConfigurations(String categoryName)
-      throws NoSuchResourceException {
+  public Map<String, RootServiceComponentConfiguration> getComponentConfigurations(String categoryName) {
     Map<String, RootServiceComponentConfiguration> configurations = null;
 
     List<AmbariConfigurationEntity> entities = (categoryName == null)
@@ -99,30 +93,26 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
   }
 
   @Override
-  public void removeConfiguration(String categoryName) throws NoSuchResourceException {
+  public void removeComponentConfiguration(String categoryName) {
     if (null == categoryName) {
       LOGGER.debug("No resource id provided in the request");
     } else {
       LOGGER.debug("Deleting Ambari configuration with id: {}", categoryName);
-      try {
-        if (ambariConfigurationDAO.removeByCategory(categoryName) > 0) {
-          publisher.publish(new AmbariConfigurationChangedEvent(categoryName));
-        }
-      } catch (IllegalStateException e) {
-        throw new NoSuchResourceException(e.getMessage());
+      if (ambariConfigurationDAO.removeByCategory(categoryName) > 0) {
+        publisher.publish(new AmbariConfigurationChangedEvent(categoryName));
       }
     }
   }
 
   @Override
-  public void updateCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException {
+  public void updateComponentCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException {
     boolean toBePublished = false;
     final Iterator<Map.Entry<String, String>> propertiesIterator = properties.entrySet().iterator();
     while (propertiesIterator.hasNext()) {
       Map.Entry<String, String> property = propertiesIterator.next();
       if (AmbariServerConfigurationUtils.isPassword(categoryName, property.getKey())) {
-        final String passwordFileOrCredentailStoreAlias = fetchPasswordFileNameOrCredentialStoreAlias(categoryName, property.getKey());
-        if (StringUtils.isNotBlank(passwordFileOrCredentailStoreAlias)) { //if blank -> this is the first time setup; we simply need to store the alias/file name
+        final String passwordFileOrCredentialStoreAlias = fetchPasswordFileNameOrCredentialStoreAlias(categoryName, property.getKey());
+        if (StringUtils.isNotBlank(passwordFileOrCredentialStoreAlias)) { //if blank -> this is the first time setup; we simply need to store the alias/file name
           if (updatePasswordIfNeeded(categoryName, property.getKey(), property.getValue())) {
             toBePublished = true;
           }
@@ -139,6 +129,48 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
       // notify subscribers about the configuration changes
       publisher.publish(new AmbariConfigurationChangedEvent(categoryName));
     }
+  }
+
+  @Override
+  public OperationResult performOperation(String categoryName, Map<String, String> properties,
+                                          boolean mergeExistingProperties, String operation,
+                                          Map<String, Object> operationParameters) throws SystemException {
+    throw new SystemException(String.format("The requested operation is not supported for this category: %s", categoryName));
+  }
+
+  public Map<String, Map<String, String>> getConfigurations() {
+    Map<String, Map<String, String>> configurations = new HashMap<>();
+    List<AmbariConfigurationEntity> entities = ambariConfigurationDAO.findAll();
+
+    if (entities != null) {
+      for (AmbariConfigurationEntity entity : entities) {
+        String category = entity.getCategoryName();
+        Map<String, String> configuration = configurations.computeIfAbsent(category, k -> new HashMap<>());
+        configuration.put(entity.getPropertyName(), entity.getPropertyValue());
+      }
+    }
+
+    return configurations;
+  }
+
+  /**
+   * Get the properties associated with a configuration category
+   *
+   * @param categoryName the name of the requested category
+   * @return a map of property names to values; or null if the data does not exist
+   */
+  public Map<String, String> getConfigurationProperties(String categoryName) {
+    Map<String, String> properties = null;
+
+    List<AmbariConfigurationEntity> entities = ambariConfigurationDAO.findByCategory(categoryName);
+    if (entities != null) {
+      properties = new HashMap<>();
+      for (AmbariConfigurationEntity entity : entities) {
+        properties.put(entity.getPropertyName(), entity.getPropertyValue());
+      }
+    }
+
+    return properties;
   }
 
   private boolean updatePasswordIfNeeded(String categoryName, String propertyName, String newPassword) throws AmbariException {
@@ -185,41 +217,6 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
       }
     } catch (IOException e) {
       throw new AmbariException("Error while updating password file [" + passwordFileName + "]", e);
-    }
-  }
-
-  @Override
-  public OperationResult performOperation(String categoryName, Map<String, String> properties,
-                                          boolean mergeExistingProperties, String operation,
-                                          Map<String, Object> operationParameters) throws SystemException {
-    throw new SystemException(String.format("The requested operation is not supported for this category: %s", categoryName));
-  }
-
-  public SsoEnabledServices getSsoEnabledSevices() {
-    return new SsoEnabledServices(
-      ambariConfigurationDAO.findByCategory(SSO_CONFIGURATION.getCategoryName()).stream()
-      .filter(each -> SSO_ENABED_SERVICES.key().equalsIgnoreCase(each.getPropertyName()))
-      .findFirst()
-      .map(entity -> entity.getPropertyValue())
-      .orElse(""));
-  }
-
-  public static class SsoEnabledServices {
-    private final String commaSeparatedServices;
-
-    SsoEnabledServices(String commaSeparatedServices) {
-      this.commaSeparatedServices = commaSeparatedServices.trim();
-    }
-
-    public boolean contains(String serviceName) {
-      return "*".equals(commaSeparatedServices) || serviceList().contains(serviceName.toUpperCase());
-    }
-
-    private Set<String> serviceList() {
-      return Arrays.asList(commaSeparatedServices.split(",")).stream()
-        .map(String::trim)
-        .map(String::toUpperCase)
-        .collect(Collectors.toSet());
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
@@ -23,30 +23,37 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.ambari.server.StaticallyInject;
-import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
-import org.apache.ambari.server.controller.spi.NoSuchResourceException;
+import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.spi.SystemException;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
 import org.apache.ambari.server.ldap.service.AmbariLdapException;
 import org.apache.ambari.server.ldap.service.LdapFacade;
+import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 /**
  * AmbariServerLDAPConfigurationHandler handles Ambari server LDAP-specific configuration properties.
  */
-@StaticallyInject
-class AmbariServerLDAPConfigurationHandler extends AmbariServerConfigurationHandler {
+@Singleton
+public class AmbariServerLDAPConfigurationHandler extends AmbariServerConfigurationHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(AmbariServerLDAPConfigurationHandler.class);
 
+  private final LdapFacade ldapFacade;
+
   @Inject
-  private static LdapFacade ldapFacade;
-  
+  AmbariServerLDAPConfigurationHandler(LdapFacade ldapFacade, AmbariConfigurationDAO ambariConfigurationDAO,
+                                       AmbariEventPublisher publisher, Configuration ambariConfiguration) {
+    super(ambariConfigurationDAO, publisher, ambariConfiguration);
+    this.ldapFacade = ldapFacade;
+  }
+
   @Override
   public OperationResult performOperation(String categoryName, Map<String, String> properties,
                                           boolean mergeExistingProperties, String operation, Map<String, Object> operationParameters) throws SystemException {
@@ -55,9 +62,14 @@ class AmbariServerLDAPConfigurationHandler extends AmbariServerConfigurationHand
       throw new SystemException(String.format("Unexpected category name for Ambari server LDAP properties: %s", categoryName));
     }
 
-    OperationType operationType = OperationType.translate(operation);
-    if (operation == null) {
-      throw new SystemException("Unexpected operation for Ambari server LDAP properties");
+    OperationType operationType;
+    try {
+      operationType = OperationType.translate(operation);
+      if (operationType == null) {
+        throw new SystemException(String.format("The requested operation is not supported for this category: %s", categoryName));
+      }
+    } catch (IllegalArgumentException e) {
+      throw new SystemException(String.format("The requested operation is not supported for this category: %s", categoryName), e);
     }
 
     Map<String, String> ldapConfigurationProperties = new HashMap<>();
@@ -65,17 +77,9 @@ class AmbariServerLDAPConfigurationHandler extends AmbariServerConfigurationHand
     // If we need to merge with the properties of an existing ldap-configuration property set, attempt
     // to retrieve if. If one does not exist, that is ok.
     if (mergeExistingProperties) {
-      try {
-        Map<String, RootServiceComponentConfiguration> _configurations = getConfigurations(categoryName);
-        if (_configurations != null) {
-          RootServiceComponentConfiguration _ldapProperties = _configurations.get(categoryName);
-
-          if (_ldapProperties != null) {
-            ldapConfigurationProperties.putAll(_ldapProperties.getProperties());
-          }
-        }
-      } catch (NoSuchResourceException e) {
-        // Ignore this. There is no existing ldap-configuration category and that is ok.
+      Map<String, String> _ldapProperties = getConfigurationProperties(categoryName);
+      if (_ldapProperties != null) {
+        ldapConfigurationProperties.putAll(_ldapProperties);
       }
     }
 
@@ -164,7 +168,7 @@ class AmbariServerLDAPConfigurationHandler extends AmbariServerConfigurationHand
         }
       }
 
-      throw new IllegalArgumentException(String.format("Invalid Ambari server configuration category name: %s", operation));
+      throw new IllegalArgumentException(String.format("Invalid operation for %s: %s", AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName(), operation));
     }
 
     public static String translate(OperationType operation) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandler.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import static org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest.StackAdvisorRequestType.SSO_CONFIGURATIONS;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.SSO_CONFIGURATION;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_ENABLED_SERVICES;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_MANAGE_SERVICES;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorException;
+import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
+import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest;
+import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.Host;
+import org.apache.ambari.server.state.Service;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.ValueAttributesInfo;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * AmbariServerSSOConfigurationHandler is an {@link AmbariServerConfigurationHandler} implementation
+ * handing changes to the SSO configuration
+ */
+@Singleton
+public class AmbariServerSSOConfigurationHandler extends AmbariServerConfigurationHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AmbariServerSSOConfigurationHandler.class);
+
+  private final Clusters clusters;
+
+  private final ConfigHelper configHelper;
+
+  private final AmbariManagementController managementController;
+
+  private final StackAdvisorHelper stackAdvisorHelper;
+
+  @Inject
+  public AmbariServerSSOConfigurationHandler(Clusters clusters, ConfigHelper configHelper,
+                                             AmbariManagementController managementController,
+                                             StackAdvisorHelper stackAdvisorHelper,
+                                             AmbariConfigurationDAO ambariConfigurationDAO,
+                                             AmbariEventPublisher publisher,
+                                             Configuration ambariConfiguration) {
+    super(ambariConfigurationDAO, publisher, ambariConfiguration);
+    this.clusters = clusters;
+    this.configHelper = configHelper;
+    this.managementController = managementController;
+    this.stackAdvisorHelper = stackAdvisorHelper;
+  }
+
+  @Override
+  public void updateComponentCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException {
+    // Use the default implementation of #updateComponentCategory; however if Ambari is managing the SSO implementations
+    // always process them, even the of sso-configuration properties have not been changed since we do not
+    // know of the Ambari SSO data has changed in the ambari.properties file.  For example the authentication.jwt.providerUrl
+    // or authentication.jwt.publicKey values.
+    super.updateComponentCategory(categoryName, properties, removePropertiesIfNotSpecified);
+
+    // Determine if Ambari is managing SSO configurations...
+    boolean manageSSOConfigurations;
+
+    Map<String, String> ssoProperties = getConfigurationProperties(SSO_CONFIGURATION.getCategoryName());
+    manageSSOConfigurations = (ssoProperties != null) && "true".equalsIgnoreCase(ssoProperties.get(SSO_MANAGE_SERVICES.key()));
+
+    if (manageSSOConfigurations) {
+      Map<String, Cluster> clusterMap = clusters.getClusters();
+
+      if (clusterMap != null) {
+        for (Cluster cluster : clusterMap.values()) {
+          try {
+            LOGGER.info(String.format("Managing the SSO configuration for the cluster named '%s'", cluster.getClusterName()));
+            processCluster(cluster);
+          } catch (AmbariException | StackAdvisorException e) {
+            LOGGER.warn(String.format("Failed to update the the SSO configuration for the cluster named '%s': ", cluster.getClusterName()), e);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the set of services for which the user declared  Ambari to enable SSO integration.
+   * <p>
+   * If Ambari is not managing SSO integration configuration for services the set of names will be empry.
+   *
+   * @return a set of service names
+   */
+  public Set<String> getSSOEnabledServices() {
+    Map<String, String> ssoProperties = getConfigurationProperties(SSO_CONFIGURATION.getCategoryName());
+    boolean manageSSOConfigurations = (ssoProperties != null) && "true".equalsIgnoreCase(ssoProperties.get(SSO_MANAGE_SERVICES.key()));
+    String ssoEnabledServices = (manageSSOConfigurations) ? ssoProperties.get(SSO_ENABLED_SERVICES.key()) : null;
+
+    if (StringUtils.isEmpty(ssoEnabledServices)) {
+      return Collections.emptySet();
+    } else {
+      return Arrays.stream(ssoEnabledServices.split(","))
+          .map(String::trim)
+          .map(String::toUpperCase)
+          .collect(Collectors.toSet());
+    }
+  }
+
+  /**
+   * Build the stack advisor request, call the stack advisor, then automatically handle the recommendations.
+   * <p>
+   * Any recommendation coming back from the Stack/service advisor is expected to be only SSO-related
+   * configurations.
+   * <p>
+   * If there are no changes to the current configurations, no new configuration versions will be created.
+   *
+   * @param cluster the cluster to process
+   * @throws AmbariException
+   * @throws StackAdvisorException
+   */
+  private void processCluster(Cluster cluster) throws AmbariException, StackAdvisorException {
+    StackId stackVersion = cluster.getCurrentStackVersion();
+    List<String> hosts = cluster.getHosts().stream().map(Host::getHostName).collect(Collectors.toList());
+    Set<String> serviceNames = cluster.getServices().values().stream().map(Service::getName).collect(Collectors.toSet());
+
+    // Build the StackAdvisor request for SSO-related configurations.  it is expected that the stack
+    // advisor will abide by the configurations set in the Ambari sso-configurations to enable and
+    // disable SSO integration for the relevant services.
+    StackAdvisorRequest request = StackAdvisorRequest.StackAdvisorRequestBuilder.
+        forStack(stackVersion.getStackName(), stackVersion.getStackVersion())
+        .ofType(SSO_CONFIGURATIONS)
+        .forHosts(hosts)
+        .forServices(serviceNames)
+        .withComponentHostsMap(cluster.getServiceComponentHostMap(null, null))
+        .withConfigurations(calculateExistingConfigurations(cluster))
+        .build();
+
+    // Execute the stack advisor
+    RecommendationResponse response = stackAdvisorHelper.recommend(request);
+
+    // Process the recommendations and automatically apply them.  Ideally this is what the user wanted
+    RecommendationResponse.Recommendation recommendation = (response == null) ? null : response.getRecommendations();
+    RecommendationResponse.Blueprint blueprint = (recommendation == null) ? null : recommendation.getBlueprint();
+    Map<String, RecommendationResponse.BlueprintConfigurations> configurations = (blueprint == null) ? null : blueprint.getConfigurations();
+
+    if (configurations != null) {
+      for (Map.Entry<String, RecommendationResponse.BlueprintConfigurations> configuration : configurations.entrySet()) {
+        processConfigurationType(cluster, configuration.getKey(), configuration.getValue());
+      }
+    }
+  }
+
+  /**
+   * Process the configuration to add, update, and remove properties as needed.
+   *
+   * @param cluster        the cluster
+   * @param configType     the configuration type
+   * @param configurations the recommended configuration values
+   * @throws AmbariException
+   */
+  private void processConfigurationType(Cluster cluster, String configType,
+                                        RecommendationResponse.BlueprintConfigurations configurations)
+      throws AmbariException {
+
+    Map<String, String> updates = new HashMap<>();
+    Collection<String> removals = new HashSet<>();
+
+    // Gather the updates
+    Map<String, String> recommendedConfigProperties = configurations.getProperties();
+    if (recommendedConfigProperties != null) {
+      updates.putAll(recommendedConfigProperties);
+    }
+
+    // Determine if any properties need to be removed
+    Map<String, ValueAttributesInfo> recommendedConfigPropertyAttributes = configurations.getPropertyAttributes();
+    if (recommendedConfigPropertyAttributes != null) {
+      for (Map.Entry<String, ValueAttributesInfo> entry : recommendedConfigPropertyAttributes.entrySet()) {
+        ValueAttributesInfo info = entry.getValue();
+
+        if ((info != null) && "true".equalsIgnoreCase(info.getDelete())) {
+          updates.remove(entry.getKey());
+          removals.add(entry.getKey());
+        }
+      }
+    }
+
+    configHelper.updateConfigType(cluster, cluster.getCurrentStackVersion(), managementController,
+        configType, updates, removals,
+        "internal", "Ambari-managed single sign-on configurations");
+  }
+
+  /**
+   * Calculate the current configurations for all services
+   *
+   * @param cluster the cluster
+   * @return a map of services and their configurations
+   * @throws AmbariException
+   */
+  private Map<String, Map<String, Map<String, String>>> calculateExistingConfigurations(Cluster cluster) throws AmbariException {
+    Map<String, Map<String, String>> configurationTags = configHelper.getEffectiveDesiredTags(cluster, null);
+    Map<String, Map<String, String>> effectiveConfigs = configHelper.getEffectiveConfigProperties(cluster, configurationTags);
+
+    Map<String, Map<String, Map<String, String>>> requestConfigurations = new HashMap<>();
+    if (effectiveConfigs != null) {
+      for (Map.Entry<String, Map<String, String>> configuration : effectiveConfigs.entrySet()) {
+        Map<String, Map<String, String>> properties = new HashMap<>();
+        String configType = configuration.getKey();
+        Map<String, String> configurationProperties = configuration.getValue();
+
+        if (configurationProperties == null) {
+          configurationProperties = Collections.emptyMap();
+        }
+
+        properties.put("properties", configurationProperties);
+        requestConfigurations.put(configType, properties);
+      }
+    }
+
+    return requestConfigurations;
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationHandler.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
-import org.apache.ambari.server.controller.spi.NoSuchResourceException;
 import org.apache.ambari.server.controller.spi.SystemException;
 
 /**
@@ -31,21 +30,19 @@ import org.apache.ambari.server.controller.spi.SystemException;
  */
 abstract class RootServiceComponentConfigurationHandler {
   /**
-   * Retrieve the request configurations.
+   * Retrieve the requested component configurations.
    *
    * @param categoryName the category name (or <code>null</code> for all)
    * @return a map of category names to properties (name/value pairs).
-   * @throws NoSuchResourceException if the requested data is not found
    */
-  public abstract Map<String, RootServiceComponentConfiguration> getConfigurations(String categoryName) throws NoSuchResourceException;
+  public abstract Map<String, RootServiceComponentConfiguration> getComponentConfigurations(String categoryName);
 
   /**
    * Delete the requested configuration.
    *
    * @param categoryName the category name
-   * @throws NoSuchResourceException if the requested category does not exist
    */
-  public abstract void removeConfiguration(String categoryName) throws NoSuchResourceException;
+  public abstract void removeComponentConfiguration(String categoryName);
 
   /**
    * Set or update a configuration category with the specified properties.
@@ -62,7 +59,7 @@ abstract class RootServiceComponentConfigurationHandler {
    *                                       <code>false</code> to update the set of existing properties with the specified set of properties, adding missing properties but not removing any properties
    * @throws AmbariException in case an error occurred while updating category's properties
    */
-  public abstract void updateCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException;
+  public abstract void updateComponentCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException;
 
   /**
    * Preform some operation on the set of data for a category.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationHandlerFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationHandlerFactory.java
@@ -22,6 +22,7 @@ import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.RootService;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 /**
@@ -30,6 +31,15 @@ import com.google.inject.Singleton;
  */
 @Singleton
 public class RootServiceComponentConfigurationHandlerFactory {
+
+  @Inject
+  private AmbariServerConfigurationHandler defaultConfigurationHandler;
+
+  @Inject
+  private AmbariServerLDAPConfigurationHandler ldapConfigurationHandler;
+
+  @Inject
+  private AmbariServerSSOConfigurationHandler ssoConfigurationHandler;
 
   /**
    * Returns the internal configuration handler used to support various configuration storage facilities.
@@ -43,9 +53,11 @@ public class RootServiceComponentConfigurationHandlerFactory {
     if (RootService.AMBARI.name().equals(serviceName)) {
       if (RootComponent.AMBARI_SERVER.name().equals(componentName)) {
         if (AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName().equals(categoryName)) {
-          return new AmbariServerLDAPConfigurationHandler();
+          return ldapConfigurationHandler;
+        } else if (AmbariServerConfigurationCategory.SSO_CONFIGURATION.getCategoryName().equals(categoryName)) {
+          return ssoConfigurationHandler;
         } else {
-          return new AmbariServerConfigurationHandler();
+          return defaultConfigurationHandler;
         }
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProvider.java
@@ -173,7 +173,7 @@ public class RootServiceComponentConfigurationResourceProvider extends AbstractA
 
     RootServiceComponentConfigurationHandler handler = rootServiceComponentConfigurationHandlerFactory.getInstance(serviceName, componentName, categoryName);
     if (handler != null) {
-      handler.removeConfiguration(categoryName);
+      handler.removeComponentConfiguration(categoryName);
     } else {
       throw new SystemException(String.format("Configurations may not be updated for the %s component of the root service %s", componentName, serviceName));
     }
@@ -243,7 +243,7 @@ public class RootServiceComponentConfigurationResourceProvider extends AbstractA
         RootServiceComponentConfigurationHandler handler = rootServiceComponentConfigurationHandlerFactory.getInstance(requestDetails.serviceName, requestDetails.componentName, requestDetails.categoryName);
         if (handler != null) {
           try {
-            handler.updateCategory(requestDetails.categoryName, requestDetails.properties, removePropertiesIfNotSpecified);
+            handler.updateComponentCategory(requestDetails.categoryName, requestDetails.properties, removePropertiesIfNotSpecified);
           } catch (AmbariException | IllegalArgumentException e) {
             throw new SystemException(e.getMessage(), e.getCause());
           }
@@ -398,9 +398,11 @@ public class RootServiceComponentConfigurationResourceProvider extends AbstractA
     RootServiceComponentConfigurationHandler handler = rootServiceComponentConfigurationHandlerFactory.getInstance(serviceName, componentName, categoryName);
 
     if (handler != null) {
-      Map<String, RootServiceComponentConfiguration> configurations = handler.getConfigurations(categoryName);
+      Map<String, RootServiceComponentConfiguration> configurations = handler.getComponentConfigurations(categoryName);
 
-      if (configurations != null) {
+      if (configurations == null) {
+        throw new NoSuchResourceException(categoryName);
+      } else {
         for (Map.Entry<String, RootServiceComponentConfiguration> entry : configurations.entrySet()) {
           resources.add(toResource(serviceName, componentName, entry.getKey(), entry.getValue().getProperties(), entry.getValue().getPropertyTypes(), requestedIds));
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
@@ -36,7 +36,7 @@ import org.apache.ambari.server.ObjectNotFoundException;
 import org.apache.ambari.server.ServiceComponentNotFoundException;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.ServiceResponse;
-import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.controller.internal.AmbariServerSSOConfigurationHandler;
 import org.apache.ambari.server.controller.internal.DeleteHostComponentStatusMetaData;
 import org.apache.ambari.server.events.MaintenanceModeEvent;
 import org.apache.ambari.server.events.ServiceInstalledEvent;
@@ -92,7 +92,7 @@ public class ServiceImpl implements Service {
   private ConfigHelper configHelper;
 
   @Inject
-  private AmbariServerConfigurationHandler ambariServerConfigurationHandler;
+  private AmbariServerSSOConfigurationHandler ambariServerConfigurationHandler;
 
   private final ClusterServiceDAO clusterServiceDAO;
   private final ServiceDesiredStateDAO serviceDesiredStateDAO;
@@ -692,7 +692,7 @@ public class ServiceImpl implements Service {
   }
 
   public boolean isSsoIntegrationDesired() {
-    return ambariServerConfigurationHandler.getSsoEnabledSevices().contains(serviceName);
+    return ambariServerConfigurationHandler.getSSOEnabledServices().contains(serviceName);
   }
 
   public boolean isSsoIntegrationEnabled() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
@@ -48,7 +48,6 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.ambari.server.api.resources.ResourceInstance;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.api.services.Request;
-import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorException;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest.StackAdvisorRequestBuilder;
@@ -287,11 +286,8 @@ public class StackAdvisorCommandTest {
 
   @Test
   public void testPopulateLdapConfig() throws Exception {
-    Map<String, RootServiceComponentConfiguration> storedConfig = new HashMap<String, RootServiceComponentConfiguration>() {{
-      put("ldap-configuration", new RootServiceComponentConfiguration(new HashMap<String, String>() {{
-        put("authentication.ldap.secondaryUrl", "localhost:333");
-      }}, null));
-    }};
+    Map<String, Map<String, String>> storedConfig = Collections.singletonMap("ldap-configuration",
+        Collections.singletonMap("authentication.ldap.secondaryUrl", "localhost:333"));
     TestStackAdvisorCommand command = new TestStackAdvisorCommand(
       temp.newFolder("recommendationDir"),
       "1w",
@@ -299,7 +295,7 @@ public class StackAdvisorCommandTest {
       0,
       mock(StackAdvisorRunner.class),
       mock(AmbariMetaInfo.class));
-    when(ambariServerConfigurationHandler.getConfigurations(null)).thenReturn(storedConfig);
+    when(ambariServerConfigurationHandler.getConfigurations()).thenReturn(storedConfig);
     JsonNode servicesRootNode = json("{}");
     command.populateAmbariConfiguration((ObjectNode)servicesRootNode);
     JsonNode expectedLdapConfig = json("{\"ambari-server-configuration\":{\"ldap-configuration\":{\"authentication.ldap.secondaryUrl\":\"localhost:333\"}}}");
@@ -315,7 +311,7 @@ public class StackAdvisorCommandTest {
       0,
       mock(StackAdvisorRunner.class),
       mock(AmbariMetaInfo.class));
-    when(ambariServerConfigurationHandler.getConfigurations(null)).thenReturn(emptyMap());
+    when(ambariServerConfigurationHandler.getConfigurations()).thenReturn(emptyMap());
     JsonNode servicesRootNode = json("{}");
     command.populateAmbariConfiguration((ObjectNode)servicesRootNode);
     JsonNode expectedLdapConfig = json("{\"ambari-server-configuration\":{}}");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandlerTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.SSO_CONFIGURATION;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_ENABLED_SERVICES;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_MANAGE_SERVICES;
+import static org.apache.ambari.server.events.AmbariEvent.AmbariEventType.AMBARI_CONFIGURATION_CHANGED;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorException;
+import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
+import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest;
+import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.events.AmbariConfigurationChangedEvent;
+import org.apache.ambari.server.events.AmbariEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
+import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.Host;
+import org.apache.ambari.server.state.Service;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.ValueAttributesInfo;
+import org.easymock.Capture;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
+
+  @Test
+  public void testUpdateCategoryAmbariNotManagingServices() throws AmbariException {
+    Map<String, String> ssoConfigurationProperties = new HashMap<>();
+    ssoConfigurationProperties.put(SSO_MANAGE_SERVICES.key(), "false");
+
+    AmbariConfigurationEntity entity = new AmbariConfigurationEntity();
+    entity.setCategoryName(SSO_CONFIGURATION.getCategoryName());
+    entity.setPropertyName(SSO_MANAGE_SERVICES.key());
+    entity.setPropertyValue("false");
+    List<AmbariConfigurationEntity> entities = Collections.singletonList(entity);
+
+    AmbariConfigurationDAO ambariConfigurationDAO = createMock(AmbariConfigurationDAO.class);
+    expect(ambariConfigurationDAO.reconcileCategory(SSO_CONFIGURATION.getCategoryName(), Collections.singletonMap(SSO_MANAGE_SERVICES.key(), "false"), true)).andReturn(false).once();
+    expect(ambariConfigurationDAO.findByCategory(SSO_CONFIGURATION.getCategoryName())).andReturn(entities).once();
+
+    AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
+    Configuration configuration = createMock(Configuration.class);
+    Clusters clusters = createMock(Clusters.class);
+    ConfigHelper configHelper = createMock(ConfigHelper.class);
+    AmbariManagementController managementController = createMock(AmbariManagementController.class);
+    StackAdvisorHelper stackAdvisorHelper = createMock(StackAdvisorHelper.class);
+
+    replayAll();
+
+    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration);
+    handler.updateComponentCategory(SSO_CONFIGURATION.getCategoryName(), ssoConfigurationProperties, true);
+
+    verifyAll();
+  }
+
+  @Test
+  public void testUpdateCategoryAmbariManagingServices() throws AmbariException, StackAdvisorException {
+    Map<String, String> ssoConfigurationProperties = new HashMap<>();
+    ssoConfigurationProperties.put(SSO_MANAGE_SERVICES.key(), "true");
+
+    AmbariConfigurationEntity entity = new AmbariConfigurationEntity();
+    entity.setCategoryName(SSO_CONFIGURATION.getCategoryName());
+    entity.setPropertyName(SSO_MANAGE_SERVICES.key());
+    entity.setPropertyValue("true");
+    List<AmbariConfigurationEntity> entities = Collections.singletonList(entity);
+
+    StackId stackId = new StackId("HDP-3.0");
+
+    Map<String, Set<String>> serviceComponentHostMap = Collections.singletonMap("ATLAS_COMPONENT", Collections.singleton("host1"));
+
+    Host host = createMock(Host.class);
+    expect(host.getHostName()).andReturn("host1").once();
+
+    Service service = createMock(Service.class);
+    expect(service.getName()).andReturn("SERVICE1").once();
+
+    Map<String, Map<String, String>> tags = Collections.emptyMap();
+    Map<String, Map<String, String>> existing_configurations = Collections.singletonMap("SERVICE1", Collections.singletonMap("service1-property1", "service1-value1"));
+
+    ValueAttributesInfo nonSSOProperty1Attributes = new ValueAttributesInfo();
+    nonSSOProperty1Attributes.setDelete("true");
+
+    RecommendationResponse.BlueprintConfigurations blueprintConfigurations = new RecommendationResponse.BlueprintConfigurations();
+    blueprintConfigurations.setProperties(Collections.singletonMap("service1-sso-property1", "service1-sso-value1"));
+    blueprintConfigurations.setPropertyAttributes(Collections.singletonMap("service1-nonsso-property1", nonSSOProperty1Attributes));
+
+    RecommendationResponse.Blueprint blueprint = new RecommendationResponse.Blueprint();
+    blueprint.setConfigurations(Collections.singletonMap("service-site", blueprintConfigurations));
+
+    RecommendationResponse.Recommendation recommendations = new RecommendationResponse.Recommendation();
+    recommendations.setBlueprint(blueprint);
+
+    RecommendationResponse recommendationResponse = new RecommendationResponse();
+    recommendationResponse.setRecommendations(recommendations);
+
+    Capture<AmbariEvent> capturedEvent = newCapture();
+    Capture<StackAdvisorRequest> capturedRequest = newCapture();
+    Capture<Map<String, String>> capturedUpdates = newCapture();
+    Capture<Collection<String>> capturedRemovals = newCapture();
+
+    Configuration configuration = createMock(Configuration.class);
+    AmbariManagementController managementController = createMock(AmbariManagementController.class);
+
+    AmbariConfigurationDAO ambariConfigurationDAO = createMock(AmbariConfigurationDAO.class);
+    expect(ambariConfigurationDAO.reconcileCategory(SSO_CONFIGURATION.getCategoryName(), Collections.singletonMap(SSO_MANAGE_SERVICES.key(), "true"), true)).andReturn(true).once();
+    expect(ambariConfigurationDAO.findByCategory(SSO_CONFIGURATION.getCategoryName())).andReturn(entities).once();
+
+    AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
+    publisher.publish(capture(capturedEvent));
+    expectLastCall().once();
+
+    Cluster cluster = createMock(Cluster.class);
+    expect(cluster.getClusterName()).andReturn("c1").once();
+    expect(cluster.getCurrentStackVersion()).andReturn(stackId).anyTimes();
+    expect(cluster.getHosts()).andReturn(Collections.singleton(host)).once();
+    expect(cluster.getServices()).andReturn(Collections.singletonMap("SERVICE1", service)).once();
+    expect(cluster.getServiceComponentHostMap(null, null)).andReturn(serviceComponentHostMap).once();
+
+    ConfigHelper configHelper = createMock(ConfigHelper.class);
+    expect(configHelper.getEffectiveDesiredTags(cluster, null)).andReturn(tags).once();
+    expect(configHelper.getEffectiveConfigProperties(cluster, tags)).andReturn(existing_configurations).once();
+    configHelper.updateConfigType(eq(cluster), eq(stackId), eq(managementController), eq("service-site"), capture(capturedUpdates), capture(capturedRemovals),
+        eq("internal"), eq("Ambari-managed single sign-on configurations"));
+    expectLastCall().once();
+
+    Clusters clusters = createMock(Clusters.class);
+    expect(clusters.getClusters()).andReturn(Collections.singletonMap("c1", cluster)).once();
+
+    StackAdvisorHelper stackAdvisorHelper = createMock(StackAdvisorHelper.class);
+    expect(stackAdvisorHelper.recommend(capture(capturedRequest))).andReturn(recommendationResponse).once();
+
+    replayAll();
+
+    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration);
+    handler.updateComponentCategory(SSO_CONFIGURATION.getCategoryName(), ssoConfigurationProperties, true);
+
+    verifyAll();
+
+    Assert.assertTrue(capturedEvent.hasCaptured());
+    Assert.assertEquals(AMBARI_CONFIGURATION_CHANGED, capturedEvent.getValue().getType());
+    Assert.assertEquals(SSO_CONFIGURATION.getCategoryName(), ((AmbariConfigurationChangedEvent) capturedEvent.getValue()).getCategoryName());
+
+    Assert.assertTrue(capturedUpdates.hasCaptured());
+    Assert.assertTrue(capturedUpdates.getValue().containsKey("service1-sso-property1"));
+    Assert.assertEquals("service1-sso-value1", capturedUpdates.getValue().get("service1-sso-property1"));
+
+    Assert.assertTrue(capturedRemovals.hasCaptured());
+    Assert.assertTrue(capturedRemovals.getValue().contains("service1-nonsso-property1"));
+
+    Assert.assertTrue(capturedRequest.hasCaptured());
+  }
+
+  @Test
+  public void testCheckingIfSSOIsEnabledPerEachService() {
+    Clusters clusters = createMock(Clusters.class);
+    ConfigHelper configHelper = createMock(ConfigHelper.class);
+    AmbariManagementController managementController = createMock(AmbariManagementController.class);
+    StackAdvisorHelper stackAdvisorHelper = createMock(StackAdvisorHelper.class);
+    AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
+    Configuration configuration = createMock(Configuration.class);
+
+    List<AmbariConfigurationEntity> entities = new ArrayList<>();
+    AmbariConfigurationEntity entity;
+
+    entity = new AmbariConfigurationEntity();
+    entity.setCategoryName(SSO_CONFIGURATION.getCategoryName());
+    entity.setPropertyName(SSO_MANAGE_SERVICES.key());
+    entity.setPropertyValue("true");
+    entities.add(entity);
+
+    entity = new AmbariConfigurationEntity();
+    entity.setCategoryName(SSO_CONFIGURATION.getCategoryName());
+    entity.setPropertyName(SSO_ENABLED_SERVICES.key());
+    entity.setPropertyValue("SERVICE1,SERVICE2");
+    entities.add(entity);
+
+    AmbariConfigurationDAO ambariConfigurationDAO = createMock(AmbariConfigurationDAO.class);
+    expect(ambariConfigurationDAO.findByCategory(SSO_CONFIGURATION.getCategoryName())).andReturn(entities).anyTimes();
+
+    replayAll();
+
+    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration);
+
+    Assert.assertTrue(handler.getSSOEnabledServices().contains("SERVICE1"));
+    Assert.assertTrue(handler.getSSOEnabledServices().contains("SERVICE2"));
+    Assert.assertFalse(handler.getSSOEnabledServices().contains("SERVICE3"));
+
+    verifyAll();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable or Disable SSO for services upon setting sso-configuration values.

The action performed by the user via the REST API to set value for the Ambari server sso-configuration value should trigger a call to the stack advisor and, using the returned recommendations, set properties needed to enable or disable SSO integration for the relevant services.

* Added `org.apache.ambari.server.controller.internal.AmbariServerSSOConfigurationHandler`
* Added `org.apache.ambari.server.controller.internal.AmbariServerSSOConfigurationHandlerTest`
* refactored `org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler` for better code reuse
* updated `org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandlerTest` to match
* Added logic to turn on and off Ambari's ability to manage SSO configurations using the `sso-configuration/ambari.sso.manage_services` value. 
* While handing SSO configuration changes, relevant services' configurations are automatically updated as needed.  Affected services require a restart. 


## How was this patch tested?

* Updated and executed unit tests.
```
mvn  clean test package install -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 49:48 min
[INFO] Finished at: 2018-03-25T20:12:58-04:00
[INFO] Final Memory: 237M/1138M
[INFO] ------------------------------------------------------------------------
```

* Manually ensured that existing functionality was not broken
* Manually ensure new logic behaved as expected

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.