### PR TITLE
AMBARI-23359. When credential store is enabled status commands should not generate jceks

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -365,7 +365,7 @@ class CustomServiceOrchestrator():
       if 'serviceLevelParams' in command and 'credentialStoreEnabled' in command['serviceLevelParams']:
         credentialStoreEnabled = command['serviceLevelParams']['credentialStoreEnabled']
 
-      if credentialStoreEnabled == True:
+      if credentialStoreEnabled and command_name != self.COMMAND_NAME_STATUS:
         if 'commandBeingRetried' not in command['agentLevelParams'] or command['agentLevelParams']['commandBeingRetried'] != "true":
           self.generateJceks(command)
         else:


### PR DESCRIPTION
Status commands should not generate jceks as they don't need them. This was the behavior in previous release.

Currently jceks are generated for every status command, flooding ambari-agent logs and making status commands run unnecessary longer.