### PR TITLE
AMBARI-23279 Integrate HostComponentService with Swagger

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.ambari.annotations.ApiIgnore;
+import org.apache.ambari.annotations.SwaggerPreferredParent;
 import org.apache.ambari.server.api.resources.ResourceInstance;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.HostComponentProcessResponse;
@@ -60,8 +61,8 @@ import io.swagger.annotations.ApiResponses;
 /**
  * Service responsible for host_components resource requests.
  */
-@Path("/hosts")
-@Api(value = "Hosts", description = "Endpoint for host-specific operations")
+@Api(value = "Host Components", description = "Endpoint for host component specific operations")
+@SwaggerPreferredParent(preferredParent = ClusterService.class)
 public class HostComponentService extends BaseService {
 
   public static final String HOST_ROLE_REQUEST_TYPE = "org.apache.ambari.server.controller.ServiceComponentHostResponse";
@@ -101,7 +102,7 @@ public class HostComponentService extends BaseService {
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Get single host component for a host", response = HostComponentSwagger.class)
   @ApiImplicitParams({
-          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
   })
   @ApiResponses({
     @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
@@ -138,10 +139,11 @@ public class HostComponentService extends BaseService {
    * @return host_component collection resource representation
    */
   @GET
+  @Path("") // This is needed if class level path is not present otherwise no Swagger docs will be generated for this method
   @Produces(MediaType.TEXT_PLAIN)
-  @ApiOperation(value = "Get all host components for a host", response = HostComponentSwagger.class, responseContainer = "List")
+  @ApiOperation(value = "Get all host components for a host", response = HostComponentSwagger.class, responseContainer = RESPONSE_CONTAINER_LIST)
   @ApiImplicitParams({
-          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
   })
   @ApiResponses({
     @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
@@ -174,16 +176,16 @@ public class HostComponentService extends BaseService {
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Create new host components")
   @ApiImplicitParams({
-          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY,  allowMultiple = true)
+    @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY,  allowMultiple = true)
   })
   @ApiResponses(value = {
-          @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
-          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
   })
   public Response createHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
 
@@ -207,16 +209,16 @@ public class HostComponentService extends BaseService {
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Create new host component")
   @ApiImplicitParams({
-          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
+    @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
   })
   @ApiResponses(value = {
-          @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
-          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
   })
   public Response createHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
                                    @PathParam("hostComponentName") String hostComponentName) {
@@ -241,16 +243,16 @@ public class HostComponentService extends BaseService {
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Update host component detail")
   @ApiImplicitParams({
-          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
+    @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
   })
   @ApiResponses({
-          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
-          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
   })
   public Response updateHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
                                       @PathParam("hostComponentName") String hostComponentName) {
@@ -273,16 +275,16 @@ public class HostComponentService extends BaseService {
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Update multiple host component details")
   @ApiImplicitParams({
-          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY,  allowMultiple = true)
+    @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY,  allowMultiple = true)
   })
   @ApiResponses({
-          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
-          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
   })
   public Response updateHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
 
@@ -304,12 +306,14 @@ public class HostComponentService extends BaseService {
   @Path("{hostComponentName}")
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Delete host component")
+  @ApiImplicitParams({
+  })
   @ApiResponses({
-          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
   })
   public Response deleteHostComponent(@Context HttpHeaders headers, @Context UriInfo ui,
                                    @PathParam("hostComponentName") String hostComponentName) {
@@ -328,14 +332,17 @@ public class HostComponentService extends BaseService {
    * @return host_component resource representation
    */
   @DELETE
+  @Path("") // This is needed if class level path is not present otherwise no Swagger docs will be generated for this method
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Delete host components")
+  @ApiImplicitParams({
+  })
   @ApiResponses({
-          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
   })
   public Response deleteHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
 
@@ -349,15 +356,15 @@ public class HostComponentService extends BaseService {
   @Produces(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Get processes of a specific host component", response = HostComponentProcessResponse.class)
   @ApiImplicitParams({
-          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
   })
   @ApiResponses({
-          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
-          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
-          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
-          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
-          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
-          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
   })
   public Response getProcesses(@Context HttpHeaders headers, @Context UriInfo ui,
       @PathParam("hostComponentName") String hostComponentName) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostComponentService.java
@@ -35,20 +35,37 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.ambari.annotations.ApiIgnore;
 import org.apache.ambari.server.api.resources.ResourceInstance;
 import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.HostComponentProcessResponse;
+import org.apache.ambari.server.controller.HostComponentSwagger;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 
+import org.apache.http.HttpStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 /**
  * Service responsible for host_components resource requests.
  */
+@Path("/hosts")
+@Api(value = "Hosts", description = "Endpoint for host-specific operations")
 public class HostComponentService extends BaseService {
+
+  public static final String HOST_ROLE_REQUEST_TYPE = "org.apache.ambari.server.controller.ServiceComponentHostResponse";
+
   /**
    * Parent cluster id.
    */
@@ -79,9 +96,21 @@ public class HostComponentService extends BaseService {
    * @param hostComponentName host_component id
    * @return host_component resource representation
    */
-  @GET @ApiIgnore // until documented
+  @GET
   @Path("{hostComponentName}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Get single host component for a host", response = HostComponentSwagger.class)
+  @ApiImplicitParams({
+          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
                                    @PathParam("hostComponentName") String hostComponentName, @QueryParam("format") String format) {
 
@@ -108,8 +137,20 @@ public class HostComponentService extends BaseService {
    * @param ui      uri info
    * @return host_component collection resource representation
    */
-  @GET @ApiIgnore // until documented
-  @Produces("text/plain")
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Get all host components for a host", response = HostComponentSwagger.class, responseContainer = "List")
+  @ApiImplicitParams({
+          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui, @QueryParam("format") String format) {
     if (format != null && format.equals("client_config_tar")) {
       return createClientConfigResource(body, headers, ui, null);
@@ -129,8 +170,21 @@ public class HostComponentService extends BaseService {
    *
    * @return status code only, 201 if successful
    */
-  @POST @ApiIgnore // until documented
-  @Produces("text/plain")
+  @POST @ApiIgnore // ignored as doesnt work as intended, not able to accept multiple HostRoles
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Create new host components")
+  @ApiImplicitParams({
+          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY,  allowMultiple = true)
+  })
+  @ApiResponses(value = {
+          @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response createHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
 
     return handleRequest(headers, body, ui, Request.Type.POST,
@@ -148,9 +202,22 @@ public class HostComponentService extends BaseService {
    *
    * @return host_component resource representation
    */
-  @POST @ApiIgnore // until documented
+  @POST
   @Path("{hostComponentName}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Create new host component")
+  @ApiImplicitParams({
+          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
+  })
+  @ApiResponses(value = {
+          @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response createHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
                                    @PathParam("hostComponentName") String hostComponentName) {
 
@@ -169,9 +236,22 @@ public class HostComponentService extends BaseService {
    *
    * @return information regarding updated host_component
    */
-  @PUT @ApiIgnore // until documented
+  @PUT
   @Path("{hostComponentName}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Update host component detail")
+  @ApiImplicitParams({
+          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response updateHostComponent(String body, @Context HttpHeaders headers, @Context UriInfo ui,
                                       @PathParam("hostComponentName") String hostComponentName) {
 
@@ -189,8 +269,21 @@ public class HostComponentService extends BaseService {
    *
    * @return information regarding updated host_component resources
    */
-  @PUT @ApiIgnore // until documented
-  @Produces("text/plain")
+  @PUT @ApiIgnore // ignored as doesnt work as intended, not able to accept multiple HostRoles
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Update multiple host component details")
+  @ApiImplicitParams({
+          @ApiImplicitParam(dataType = HOST_ROLE_REQUEST_TYPE, paramType = PARAM_TYPE_BODY,  allowMultiple = true)
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response updateHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
 
     return handleRequest(headers, body, ui, Request.Type.PUT,
@@ -207,9 +300,17 @@ public class HostComponentService extends BaseService {
    *
    * @return host_component resource representation
    */
-  @DELETE @ApiIgnore // until documented
+  @DELETE
   @Path("{hostComponentName}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Delete host component")
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response deleteHostComponent(@Context HttpHeaders headers, @Context UriInfo ui,
                                    @PathParam("hostComponentName") String hostComponentName) {
 
@@ -226,17 +327,38 @@ public class HostComponentService extends BaseService {
    *
    * @return host_component resource representation
    */
-  @DELETE @ApiIgnore // until documented
-  @Produces("text/plain")
+  @DELETE
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Delete host components")
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response deleteHostComponents(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
 
     return handleRequest(headers, body, ui, Request.Type.DELETE,
         createHostComponentResource(m_clusterName, m_hostName, null));
   }
 
-  @GET @ApiIgnore // until documented
+
+  @GET
   @Path("{hostComponentName}/processes")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Get processes of a specific host component", response = HostComponentProcessResponse.class)
+  @ApiImplicitParams({
+          @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+          @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_OR_HOST_NOT_FOUND),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+          @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+          @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+          @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getProcesses(@Context HttpHeaders headers, @Context UriInfo ui,
       @PathParam("hostComponentName") String hostComponentName) {
     Map<Resource.Type,String> mapIds = new HashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/request/eventcreator/ComponentEventCreator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/request/eventcreator/ComponentEventCreator.java
@@ -91,7 +91,7 @@ public class ComponentEventCreator implements RequestAuditEventCreator {
       .withOperation(operation)
       .withRemoteIp(request.getRemoteAddress())
       .withTimestamp(System.currentTimeMillis())
-      .withHostname(RequestAuditEventCreatorHelper.getProperty(request, HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID))
+      .withHostname(RequestAuditEventCreatorHelper.getProperty(request, HostComponentResourceProvider.HOST_NAME))
       .withRequestId(String.valueOf(requestId));
 
     if (result.getStatus().isErrorState()) {
@@ -117,8 +117,8 @@ public class ComponentEventCreator implements RequestAuditEventCreator {
       switch (request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_LEVEL_ID)) {
         case "CLUSTER":
           for (Map<String, Object> map : request.getBody().getPropertySets()) {
-            if (map.containsKey(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID)) {
-              operation = String.valueOf(map.get(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID)) + ": all services"
+            if (map.containsKey(HostComponentResourceProvider.CLUSTER_NAME)) {
+              operation = String.valueOf(map.get(HostComponentResourceProvider.STATE)) + ": all services"
                 + " on all hosts"
                 + (request.getBody().getQueryString() != null && request.getBody().getQueryString().length() > 0 ? " that matches " + request.getBody().getQueryString() : "")
                 + " (" + request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_CLUSTER_ID) + ")";
@@ -128,9 +128,9 @@ public class ComponentEventCreator implements RequestAuditEventCreator {
           break;
         case "HOST":
           for (Map<String, Object> map : request.getBody().getPropertySets()) {
-            if (map.containsKey(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID)) {
+            if (map.containsKey(HostComponentResourceProvider.CLUSTER_NAME)) {
               String query = request.getBody().getRequestInfoProperties().get("query");
-              operation = String.valueOf(map.get(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID)) + ": " + query.substring(query.indexOf("(") + 1, query.length() - 1)
+              operation = String.valueOf(map.get(HostComponentResourceProvider.STATE)) + ": " + query.substring(query.indexOf("(") + 1, query.length() - 1)
                 + " on " + request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_HOST_NAME)
                 + " (" + request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_CLUSTER_ID) + ")";
               break;
@@ -139,8 +139,8 @@ public class ComponentEventCreator implements RequestAuditEventCreator {
           break;
         case "HOST_COMPONENT":
           for (Map<String, Object> map : request.getBody().getPropertySets()) {
-            if (map.containsKey(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)) {
-              operation = String.valueOf(map.get(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID)) + ": " + String.valueOf(map.get(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID))
+            if (map.containsKey(HostComponentResourceProvider.COMPONENT_NAME)) {
+              operation = String.valueOf(map.get(HostComponentResourceProvider.STATE)) + ": " + String.valueOf(map.get(HostComponentResourceProvider.COMPONENT_NAME))
                 + "/" + request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_SERVICE_ID)
                 + " on " + request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_HOST_NAME)
                 + " (" + request.getBody().getRequestInfoProperties().get(RequestOperationLevel.OPERATION_CLUSTER_ID) + ")";
@@ -153,8 +153,8 @@ public class ComponentEventCreator implements RequestAuditEventCreator {
     }
 
     for (Map<String, Object> map : request.getBody().getPropertySets()) {
-      if (map.containsKey(HostComponentResourceProvider.HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID)) {
-        return "Turn " + map.get(HostComponentResourceProvider.HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID) + " Maintenance Mode for " + map.get(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+      if (map.containsKey(HostComponentResourceProvider.MAINTENANCE_STATE)) {
+        return "Turn " + map.get(HostComponentResourceProvider.MAINTENANCE_STATE) + " Maintenance Mode for " + map.get(HostComponentResourceProvider.COMPONENT_NAME);
       }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/request/eventcreator/HostEventCreator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/request/eventcreator/HostEventCreator.java
@@ -138,7 +138,7 @@ public class HostEventCreator implements RequestAuditEventCreator {
       Set<Map<String, String>> set = (Set<Map<String, String>>) propertySet.getProperties().get("host_components");
       if (set != null && !set.isEmpty()) {
         for(Map<String, String> element : set) {
-          components.add(element.get(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID));
+          components.add(element.get(HostComponentResourceProvider.COMPONENT_NAME));
         }
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/HostComponentProcessResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/HostComponentProcessResponse.java
@@ -19,6 +19,10 @@ package org.apache.ambari.server.controller;
 
 import java.util.Map;
 
+import org.apache.ambari.server.controller.internal.HostComponentProcessResourceProvider;
+
+import io.swagger.annotations.ApiModelProperty;
+
 /**
  * Response object for HostComponent processes
  */
@@ -47,6 +51,7 @@ public class HostComponentProcessResponse {
   /**
    * @return the cluster
    */
+  @ApiModelProperty(name = HostComponentProcessResourceProvider.CLUSTER_NAME_PROPERTY_ID)
   public String getCluster() {
     return cluster;
   }
@@ -54,6 +59,7 @@ public class HostComponentProcessResponse {
   /**
    * @return the host
    */
+  @ApiModelProperty(name = HostComponentProcessResourceProvider.HOST_NAME_PROPERTY_ID)
   public String getHost() {
     return host;
   }
@@ -61,6 +67,7 @@ public class HostComponentProcessResponse {
   /**
    * @return the component
    */
+  @ApiModelProperty(name = HostComponentProcessResourceProvider.COMPONENT_NAME_PROPERTY_ID)
   public String getComponent() {
     return component;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/HostComponentSwagger.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/HostComponentSwagger.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ambari.server.controller;
 
 import java.util.List;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/HostComponentSwagger.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/HostComponentSwagger.java
@@ -1,0 +1,70 @@
+package org.apache.ambari.server.controller;
+
+import java.util.List;
+
+import org.apache.ambari.server.controller.internal.ComponentResourceProvider;
+import org.apache.ambari.server.controller.internal.HostComponentResourceProvider;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public interface HostComponentSwagger extends ApiModel {
+
+    @ApiModelProperty(name = HostComponentResourceProvider.HOST_ROLES)
+    ServiceComponentHostResponse getHostRole();
+
+    @ApiModelProperty(name = HostComponentResourceProvider.HOST_PROPERTY_ID)
+    HostComponentHost getHost();
+
+    @ApiModelProperty(name = HostComponentResourceProvider.METRICS_PROPERTY_ID)
+    HostComponentMetrics getMetrics();
+
+    @ApiModelProperty(name = HostComponentResourceProvider.PROCESSES_PROPERTY_ID)
+    List<HostComponentProcesses> getProcesses();
+
+    @ApiModelProperty(name = HostComponentResourceProvider.COMPONENT_PROPERTY_ID)
+    List<HostComponentComponent> getComponent();
+
+
+    interface HostComponentHost extends ApiModel {
+
+        @ApiModelProperty(name = HostComponentResourceProvider.HREF_PROPERTY_ID)
+        String getHref();
+    }
+
+    interface HostComponentMetrics extends ApiModel {
+
+
+    }
+
+    interface HostComponentProcesses extends ApiModel {
+
+
+    }
+
+
+    interface HostComponentComponent extends ApiModel {
+
+        @ApiModelProperty(name = HostComponentResourceProvider.HREF_PROPERTY_ID)
+        String getHref();
+
+        @ApiModelProperty(name = HostComponentResourceProvider.SERVICE_COMPONENT_INFO)
+        HostComponentServiceComponentInfo getHostComponentServiceComponentInfo();
+
+
+        interface HostComponentServiceComponentInfo extends ApiModel {
+
+            @ApiModelProperty(name = ComponentResourceProvider.CLUSTER_NAME_PROPERTY_ID)
+            String getClusterName();
+
+            @ApiModelProperty(name = ComponentResourceProvider.COMPONENT_NAME_PROPERTY_ID)
+            String getComponentName();
+
+            @ApiModelProperty(name = ComponentResourceProvider.SERVICE_NAME_PROPERTY_ID)
+            String getServiceName();
+        }
+
+
+    }
+
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostResponse.java
@@ -20,11 +20,14 @@ package org.apache.ambari.server.controller;
 
 import java.util.Map;
 
+import org.apache.ambari.server.controller.internal.HostComponentResourceProvider;
 import org.apache.ambari.server.state.HostComponentAdminState;
 import org.apache.ambari.server.state.HostConfig;
 import org.apache.ambari.server.state.UpgradeState;
 
-public class ServiceComponentHostResponse {
+import io.swagger.annotations.ApiModelProperty;
+
+public class ServiceComponentHostResponse implements ApiModel {
 
   private String clusterName; // REF
   private String serviceName;
@@ -68,6 +71,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the serviceName
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.SERVICE_NAME_PROPERTY_ID)
   public String getServiceName() {
     return serviceName;
   }
@@ -82,6 +86,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the componentName
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.COMPONENT_NAME_PROPERTY_ID)
   public String getComponentName() {
     return componentName;
   }
@@ -96,6 +101,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the displayName
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.DISPLAY_NAME_PROPERTY_ID)
   public String getDisplayName() {
     return displayName;
   }
@@ -103,6 +109,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the hostname
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.HOST_NAME_PROPERTY_ID)
   public String getHostname() {
     return hostname;
   }
@@ -117,6 +124,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the public hostname
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.PUBLIC_HOST_NAME_PROPERTY_ID)
   public String getPublicHostname() {
     return publicHostname;
   }
@@ -131,6 +139,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the liveState
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.STATE_PROPERTY_ID)
   public String getLiveState() {
     return liveState;
   }
@@ -145,6 +154,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the version
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.VERSION_PROPERTY_ID)
   public String getVersion() {
     return version;
   }
@@ -152,6 +162,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the desiredState
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.DESIRED_STATE_PROPERTY_ID)
   public String getDesiredState() {
     return desiredState;
   }
@@ -166,6 +177,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the desiredStackVersion
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.DESIRED_STACK_ID_PROPERTY_ID)
   public String getDesiredStackVersion() {
     return desiredStackVersion;
   }
@@ -182,6 +194,7 @@ public class ServiceComponentHostResponse {
    *
    * @return the desired repository.
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.DESIRED_REPOSITORY_VERSION_PROPERTY_ID)
   public String getDesiredRepositoryVersion() {
     return desiredRepositoryVersion;
   }
@@ -189,6 +202,8 @@ public class ServiceComponentHostResponse {
   /**
    * @return the clusterName
    */
+
+  @ApiModelProperty(name = HostComponentResourceProvider.CLUSTER_NAME_PROPERTY_ID)
   public String getClusterName() {
     return clusterName;
   }
@@ -203,6 +218,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the admin state of the host component
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.DESIRED_ADMIN_STATE_PROPERTY_ID, hidden = true)
   public String getAdminState() {
     return adminState;
   }
@@ -258,6 +274,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the actual configs
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.ACTUAL_CONFIGS_PROPERTY_ID)
   public Map<String, HostConfig> getActualConfigs() {
     return actualConfigs;
   }
@@ -272,6 +289,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return if the configs are stale
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.STALE_CONFIGS_PROPERTY_ID)
   public boolean isStaleConfig() {
     return staleConfig;
   }
@@ -286,6 +304,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return true if configs are reloadable without RESTART command
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.RELOAD_CONFIGS_PROPERTY_ID)
   public boolean isReloadConfig() {
     return reloadConfig;
   }
@@ -300,6 +319,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the maintenance state
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.MAINTENANCE_STATE_PROPERTY_ID)
   public String getMaintenanceState() {
     return maintenanceState;
   }
@@ -321,6 +341,7 @@ public class ServiceComponentHostResponse {
   /**
    * @return the upgrade state
    */
+  @ApiModelProperty(name = HostComponentResourceProvider.UPGRADE_STATE_PROPERTY_ID)
   public UpgradeState getUpgradeState() {
     return upgradeState;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.security.authorization.AuthorizationHelper;
 import org.apache.ambari.server.security.authorization.ResourceType;
@@ -79,37 +80,56 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
   private static final Logger LOG = LoggerFactory.getLogger(ComponentResourceProvider.class);
 
-  // ----- Property ID constants ---------------------------------------------
+  public static final String SERVICE_COMPONENT_INFO = "ServiceComponentInfo";
+
+  public static final String CLUSTER_NAME_PROPERTY_ID = "cluster_name";
+  public static final String SERVICE_NAME_PROPERTY_ID = "service_name";
+  public static final String COMPONENT_NAME_PROPERTY_ID  = "component_name";
+  public static final String DISPLAY_NAME_PROPERTY_ID = "display_name";
+  public static final String STATE_PROPERTY_ID = "state";
+  public static final String CATEGORY_PROPERTY_ID = "category";
+  public static final String TOTAL_COUNT_PROPERTY_ID = "total_count";
+  public static final String STARTED_COUNT_PROPERTY_ID = "started_count";
+  public static final String INSTALLED_COUNT_PROPERTY_ID = "installed_count";
+  public static final String INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID = "installed_and_maintenance_off_count";
+  public static final String INIT_COUNT_PROPERTY_ID = "init_count";
+  public static final String UNKNOWN_COUNT_PROPERTY_ID = "unknown_count";
+  public static final String INSTALL_FAILED_COUNT_PROPERTY_ID = "install_failed_count";
+  public static final String RECOVERY_ENABLED_PROPERTY_ID = "recovery_enabled";
+  public static final String DESIRED_STACK_PROPERTY_ID = "desired_stack";
+  public static final String DESIRED_VERSION_PROPERTY_ID = "desired_version";
+  public static final String REPOSITORY_STATE_PROPERTY_ID = "repository_state";
 
   // Components
-  protected static final String COMPONENT_CLUSTER_NAME_PROPERTY_ID    = "ServiceComponentInfo/cluster_name";
-  protected static final String COMPONENT_SERVICE_NAME_PROPERTY_ID    = "ServiceComponentInfo/service_name";
-  protected static final String COMPONENT_COMPONENT_NAME_PROPERTY_ID  = "ServiceComponentInfo/component_name";
-  protected static final String COMPONENT_DISPLAY_NAME_PROPERTY_ID    = "ServiceComponentInfo/display_name";
-  protected static final String COMPONENT_STATE_PROPERTY_ID           = "ServiceComponentInfo/state";
-  protected static final String COMPONENT_CATEGORY_PROPERTY_ID        = "ServiceComponentInfo/category";
-  protected static final String COMPONENT_TOTAL_COUNT_PROPERTY_ID     = "ServiceComponentInfo/total_count";
-  protected static final String COMPONENT_STARTED_COUNT_PROPERTY_ID   = "ServiceComponentInfo/started_count";
-  protected static final String COMPONENT_INSTALLED_COUNT_PROPERTY_ID = "ServiceComponentInfo/installed_count";
-  protected static final String COMPONENT_INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID
-                                                                      = "ServiceComponentInfo/installed_and_maintenance_off_count";
-  protected static final String COMPONENT_INIT_COUNT_PROPERTY_ID      = "ServiceComponentInfo/init_count";
-  protected static final String COMPONENT_UNKNOWN_COUNT_PROPERTY_ID   = "ServiceComponentInfo/unknown_count";
-  protected static final String COMPONENT_INSTALL_FAILED_COUNT_PROPERTY_ID = "ServiceComponentInfo/install_failed_count";
-  protected static final String COMPONENT_RECOVERY_ENABLED_ID         = "ServiceComponentInfo/recovery_enabled";
-  protected static final String COMPONENT_DESIRED_STACK               = "ServiceComponentInfo/desired_stack";
-  protected static final String COMPONENT_DESIRED_VERSION             = "ServiceComponentInfo/desired_version";
-  protected static final String COMPONENT_REPOSITORY_STATE            = "ServiceComponentInfo/repository_state";
+  public static final String CLUSTER_NAME = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + CLUSTER_NAME_PROPERTY_ID;
+  public static final String SERVICE_NAME = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + SERVICE_NAME_PROPERTY_ID;
+  public static final String COMPONENT_NAME = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + COMPONENT_NAME_PROPERTY_ID;
+  public static final String DISPLAY_NAME = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + DISPLAY_NAME_PROPERTY_ID;
+  public static final String STATE = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + STATE_PROPERTY_ID;
+  public static final String CATEGORY = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + CATEGORY_PROPERTY_ID;
+  public static final String TOTAL_COUNT = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + TOTAL_COUNT_PROPERTY_ID;
+  public static final String STARTED_COUNT = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + STARTED_COUNT_PROPERTY_ID;
+  public static final String INSTALLED_COUNT = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + INSTALLED_COUNT_PROPERTY_ID;
+  public static final String INSTALLED_AND_MAINTENANCE_OFF_COUNT =
+          SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID;
+  public static final String INIT_COUNT = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + INIT_COUNT_PROPERTY_ID;
+  public static final String UNKNOWN_COUNT = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + UNKNOWN_COUNT_PROPERTY_ID;
+  public static final String INSTALL_FAILED_COUNT = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + INSTALL_FAILED_COUNT_PROPERTY_ID;
+  public static final String RECOVERY_ENABLED = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + RECOVERY_ENABLED_PROPERTY_ID;
+  public static final String DESIRED_STACK = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + DESIRED_STACK_PROPERTY_ID;
+  public static final String DESIRED_VERSION = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + DESIRED_VERSION_PROPERTY_ID;
+  public static final String REPOSITORY_STATE = SERVICE_COMPONENT_INFO + PropertyHelper.EXTERNAL_PATH_SEP + REPOSITORY_STATE_PROPERTY_ID;
 
+  
   private static final String TRUE = "true";
 
   //Parameters from the predicate
   private static final String QUERY_PARAMETERS_RUN_SMOKE_TEST_ID = "params/run_smoke_test";
 
   private static Set<String> pkPropertyIds = Sets.newHashSet(
-          COMPONENT_CLUSTER_NAME_PROPERTY_ID,
-          COMPONENT_SERVICE_NAME_PROPERTY_ID,
-          COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+          CLUSTER_NAME,
+          SERVICE_NAME,
+          COMPONENT_NAME);
 
   /**
    * The property ids for an servce resource.
@@ -123,31 +143,29 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
   static {
     // properties
-    PROPERTY_IDS.add(COMPONENT_CLUSTER_NAME_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_SERVICE_NAME_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_COMPONENT_NAME_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_DISPLAY_NAME_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_STATE_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_CATEGORY_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_TOTAL_COUNT_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_STARTED_COUNT_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_INSTALLED_COUNT_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID);
-
-    PROPERTY_IDS.add(COMPONENT_INIT_COUNT_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_UNKNOWN_COUNT_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_INSTALL_FAILED_COUNT_PROPERTY_ID);
-    PROPERTY_IDS.add(COMPONENT_RECOVERY_ENABLED_ID);
-    PROPERTY_IDS.add(COMPONENT_DESIRED_STACK);
-    PROPERTY_IDS.add(COMPONENT_DESIRED_VERSION);
-    PROPERTY_IDS.add(COMPONENT_REPOSITORY_STATE);
-
+    PROPERTY_IDS.add(CLUSTER_NAME);
+    PROPERTY_IDS.add(SERVICE_NAME);
+    PROPERTY_IDS.add(COMPONENT_NAME);
+    PROPERTY_IDS.add(DISPLAY_NAME);
+    PROPERTY_IDS.add(STATE);
+    PROPERTY_IDS.add(CATEGORY);
+    PROPERTY_IDS.add(TOTAL_COUNT);
+    PROPERTY_IDS.add(STARTED_COUNT);
+    PROPERTY_IDS.add(INSTALLED_COUNT);
+    PROPERTY_IDS.add(INSTALLED_AND_MAINTENANCE_OFF_COUNT);
+    PROPERTY_IDS.add(INIT_COUNT);
+    PROPERTY_IDS.add(UNKNOWN_COUNT);
+    PROPERTY_IDS.add(INSTALL_FAILED_COUNT);
+    PROPERTY_IDS.add(RECOVERY_ENABLED);
+    PROPERTY_IDS.add(DESIRED_STACK);
+    PROPERTY_IDS.add(DESIRED_VERSION);
+    PROPERTY_IDS.add(REPOSITORY_STATE);
     PROPERTY_IDS.add(QUERY_PARAMETERS_RUN_SMOKE_TEST_ID);
 
     // keys
-    KEY_PROPERTY_IDS.put(Resource.Type.Component, COMPONENT_COMPONENT_NAME_PROPERTY_ID);
-    KEY_PROPERTY_IDS.put(Resource.Type.Service, COMPONENT_SERVICE_NAME_PROPERTY_ID);
-    KEY_PROPERTY_IDS.put(Resource.Type.Cluster, COMPONENT_CLUSTER_NAME_PROPERTY_ID);
+    KEY_PROPERTY_IDS.put(Resource.Type.Component, COMPONENT_NAME);
+    KEY_PROPERTY_IDS.put(Resource.Type.Service, SERVICE_NAME);
+    KEY_PROPERTY_IDS.put(Resource.Type.Cluster, CLUSTER_NAME);
   }
 
   private MaintenanceStateHelper maintenanceStateHelper;
@@ -223,23 +241,23 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
     for (ServiceComponentResponse response : responses) {
       Resource resource = new ResourceImpl(Resource.Type.Component);
-      setResourceProperty(resource, COMPONENT_CLUSTER_NAME_PROPERTY_ID, response.getClusterName(), requestedIds);
-      setResourceProperty(resource, COMPONENT_SERVICE_NAME_PROPERTY_ID, response.getServiceName(), requestedIds);
-      setResourceProperty(resource, COMPONENT_COMPONENT_NAME_PROPERTY_ID, response.getComponentName(), requestedIds);
-      setResourceProperty(resource, COMPONENT_DISPLAY_NAME_PROPERTY_ID, response.getDisplayName(), requestedIds);
-      setResourceProperty(resource, COMPONENT_STATE_PROPERTY_ID, response.getDesiredState(), requestedIds);
-      setResourceProperty(resource, COMPONENT_CATEGORY_PROPERTY_ID, response.getCategory(), requestedIds);
-      setResourceProperty(resource, COMPONENT_TOTAL_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("totalCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_STARTED_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("startedCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_INSTALLED_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("installedCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("installedAndMaintenanceOffCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_INSTALL_FAILED_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("installFailedCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_INIT_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("initCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_UNKNOWN_COUNT_PROPERTY_ID, response.getServiceComponentStateCount().get("unknownCount"), requestedIds);
-      setResourceProperty(resource, COMPONENT_RECOVERY_ENABLED_ID, String.valueOf(response.isRecoveryEnabled()), requestedIds);
-      setResourceProperty(resource, COMPONENT_DESIRED_STACK, response.getDesiredStackId(), requestedIds);
-      setResourceProperty(resource, COMPONENT_DESIRED_VERSION, response.getDesiredVersion(), requestedIds);
-      setResourceProperty(resource, COMPONENT_REPOSITORY_STATE, response.getRepositoryState(), requestedIds);
+      setResourceProperty(resource, CLUSTER_NAME, response.getClusterName(), requestedIds);
+      setResourceProperty(resource, SERVICE_NAME, response.getServiceName(), requestedIds);
+      setResourceProperty(resource, COMPONENT_NAME, response.getComponentName(), requestedIds);
+      setResourceProperty(resource, DISPLAY_NAME, response.getDisplayName(), requestedIds);
+      setResourceProperty(resource, STATE, response.getDesiredState(), requestedIds);
+      setResourceProperty(resource, CATEGORY, response.getCategory(), requestedIds);
+      setResourceProperty(resource, TOTAL_COUNT, response.getServiceComponentStateCount().get("totalCount"), requestedIds);
+      setResourceProperty(resource, STARTED_COUNT, response.getServiceComponentStateCount().get("startedCount"), requestedIds);
+      setResourceProperty(resource, INSTALLED_COUNT, response.getServiceComponentStateCount().get("installedCount"), requestedIds);
+      setResourceProperty(resource, INSTALLED_AND_MAINTENANCE_OFF_COUNT, response.getServiceComponentStateCount().get("installedAndMaintenanceOffCount"), requestedIds);
+      setResourceProperty(resource, INSTALL_FAILED_COUNT, response.getServiceComponentStateCount().get("installFailedCount"), requestedIds);
+      setResourceProperty(resource, INIT_COUNT, response.getServiceComponentStateCount().get("initCount"), requestedIds);
+      setResourceProperty(resource, UNKNOWN_COUNT, response.getServiceComponentStateCount().get("unknownCount"), requestedIds);
+      setResourceProperty(resource, RECOVERY_ENABLED, String.valueOf(response.isRecoveryEnabled()), requestedIds);
+      setResourceProperty(resource, DESIRED_STACK, response.getDesiredStackId(), requestedIds);
+      setResourceProperty(resource, DESIRED_VERSION, response.getDesiredVersion(), requestedIds);
+      setResourceProperty(resource, REPOSITORY_STATE, response.getRepositoryState(), requestedIds);
 
       resources.add(resource);
     }
@@ -309,12 +327,12 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
    */
   private ServiceComponentRequest getRequest(Map<String, Object> properties) {
     return new ServiceComponentRequest(
-        (String) properties.get(COMPONENT_CLUSTER_NAME_PROPERTY_ID),
-        (String) properties.get(COMPONENT_SERVICE_NAME_PROPERTY_ID),
-        (String) properties.get(COMPONENT_COMPONENT_NAME_PROPERTY_ID),
-        (String) properties.get(COMPONENT_STATE_PROPERTY_ID),
-        (String) properties.get(COMPONENT_RECOVERY_ENABLED_ID),
-        (String) properties.get(COMPONENT_CATEGORY_PROPERTY_ID));
+        (String) properties.get(CLUSTER_NAME),
+        (String) properties.get(SERVICE_NAME),
+        (String) properties.get(COMPONENT_NAME),
+        (String) properties.get(STATE),
+        (String) properties.get(RECOVERY_ENABLED),
+        (String) properties.get(CATEGORY));
   }
 
   // Create the components for the given requests.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentProcessResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentProcessResourceProvider.java
@@ -34,6 +34,7 @@ import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ServiceComponentHost;
@@ -48,34 +49,42 @@ public class HostComponentProcessResourceProvider extends ReadOnlyResourceProvid
 
   // ----- Property ID constants ---------------------------------------------
 
-  // process
-  public static final String HC_PROCESS_NAME_ID = "HostComponentProcess/name";
-  public static final String HC_PROCESS_STATUS_ID = "HostComponentProcess/status";
+  public static final String HOST_COMPONENT_PROCESS = "HostComponentProcess";
+
+  public static final String NAME_PROPERTY_ID = "name";
+  public static final String STATUS_PROPERTY_ID = "status";
+
+  public static final String CLUSTER_NAME_PROPERTY_ID = "cluster_name";
+  public static final String HOST_NAME_PROPERTY_ID = "host_name";
+  public static final String COMPONENT_NAME_PROPERTY_ID = "component_name";
+
+  public static final String NAME = HOST_COMPONENT_PROCESS + PropertyHelper.EXTERNAL_PATH_SEP + NAME_PROPERTY_ID;
+  public static final String STATUS = HOST_COMPONENT_PROCESS + PropertyHelper.EXTERNAL_PATH_SEP + STATUS_PROPERTY_ID;
   
-  public static final String HC_PROCESS_CLUSTER_NAME_ID = "HostComponentProcess/cluster_name";
-  public static final String HC_PROCESS_HOST_NAME_ID = "HostComponentProcess/host_name";
-  public static final String HC_PROCESS_COMPONENT_NAME_ID = "HostComponentProcess/component_name";
+  public static final String CLUSTER_NAME = HOST_COMPONENT_PROCESS + PropertyHelper.EXTERNAL_PATH_SEP + CLUSTER_NAME_PROPERTY_ID;
+  public static final String HOST_NAME = HOST_COMPONENT_PROCESS + PropertyHelper.EXTERNAL_PATH_SEP + HOST_NAME_PROPERTY_ID;
+  public static final String COMPONENT_NAME = HOST_COMPONENT_PROCESS + PropertyHelper.EXTERNAL_PATH_SEP + COMPONENT_NAME_PROPERTY_ID;
 
   /**
    * The key property ids for a HostComponentProcess resource.
    */
   private static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
-      .put(Resource.Type.Cluster, HC_PROCESS_CLUSTER_NAME_ID)
-      .put(Resource.Type.Host, HC_PROCESS_HOST_NAME_ID)
-      .put(Resource.Type.Component, HC_PROCESS_COMPONENT_NAME_ID)
-      .put(Resource.Type.HostComponent, HC_PROCESS_COMPONENT_NAME_ID)
-      .put(Resource.Type.HostComponentProcess, HC_PROCESS_NAME_ID)
+      .put(Resource.Type.Cluster, CLUSTER_NAME)
+      .put(Resource.Type.Host, HOST_NAME)
+      .put(Resource.Type.Component, COMPONENT_NAME)
+      .put(Resource.Type.HostComponent, COMPONENT_NAME)
+      .put(Resource.Type.HostComponentProcess, NAME)
       .build();
 
   /**
    * The property ids for a HostComponentProcess resource.
    */
   private static Set<String> propertyIds = Sets.newHashSet(
-      HC_PROCESS_NAME_ID,
-      HC_PROCESS_STATUS_ID,
-      HC_PROCESS_CLUSTER_NAME_ID,
-      HC_PROCESS_HOST_NAME_ID,
-      HC_PROCESS_COMPONENT_NAME_ID);
+      NAME,
+      STATUS,
+      CLUSTER_NAME,
+      HOST_NAME,
+      COMPONENT_NAME);
 
   // ----- Constructors ----------------------------------------------------
 
@@ -118,15 +127,15 @@ public class HostComponentProcessResourceProvider extends ReadOnlyResourceProvid
     for (HostComponentProcessResponse response : responses) {
       Resource r = new ResourceImpl(Resource.Type.HostComponentProcess);
       
-      setResourceProperty(r, HC_PROCESS_CLUSTER_NAME_ID, response.getCluster(),
+      setResourceProperty(r, CLUSTER_NAME, response.getCluster(),
           requestedIds);
-      setResourceProperty(r, HC_PROCESS_HOST_NAME_ID, response.getHost(),
+      setResourceProperty(r, HOST_NAME, response.getHost(),
           requestedIds);
-      setResourceProperty(r, HC_PROCESS_COMPONENT_NAME_ID, response.getComponent(), requestedIds);
+      setResourceProperty(r, COMPONENT_NAME, response.getComponent(), requestedIds);
       
-      setResourceProperty(r, HC_PROCESS_NAME_ID, response.getValueMap().get("name"),
+      setResourceProperty(r, NAME, response.getValueMap().get("name"),
           requestedIds);
-      setResourceProperty(r, HC_PROCESS_STATUS_ID, response.getValueMap().get("status"),
+      setResourceProperty(r, STATUS, response.getValueMap().get("status"),
           requestedIds);
       
       // set the following even if they aren't defined
@@ -158,9 +167,9 @@ public class HostComponentProcessResourceProvider extends ReadOnlyResourceProvid
 
     for (Map<String, Object> requestMap : requestMaps) {
       
-      String cluster = (String) requestMap.get(HC_PROCESS_CLUSTER_NAME_ID);
-      String component = (String) requestMap.get(HC_PROCESS_COMPONENT_NAME_ID);
-      String host = (String) requestMap.get(HC_PROCESS_HOST_NAME_ID);
+      String cluster = (String) requestMap.get(CLUSTER_NAME);
+      String component = (String) requestMap.get(COMPONENT_NAME);
+      String host = (String) requestMap.get(HOST_NAME);
 
       Cluster c = clusters.getCluster(cluster);
       

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -84,42 +84,52 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
   // ----- Property ID constants ---------------------------------------------
 
-  // Host Components
-  public static final String HOST_COMPONENT_ROLE_ID
-      = PropertyHelper.getPropertyId("HostRoles", "role_id");
-  public static final String HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "cluster_name");
-  public static final String HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "service_name");
-  public static final String HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "component_name");
-  public static final String HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "display_name");
-  public static final String HOST_COMPONENT_HOST_NAME_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "host_name");
-  public static final String HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "public_host_name");
-  public static final String HOST_COMPONENT_STATE_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "state");
-  public static final String HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "desired_state");
-  public static final String HOST_COMPONENT_VERSION_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "version");
-  public static final String HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "desired_stack_id");
-  public static final String HOST_COMPONENT_DESIRED_REPOSITORY_VERSION
-    = PropertyHelper.getPropertyId("HostRoles", "desired_repository_version");
-  public static final String HOST_COMPONENT_ACTUAL_CONFIGS_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "actual_configs");
-  public static final String HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "stale_configs");
-  public static final String HOST_COMPONENT_RELOAD_CONFIGS_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "reload_configs");
-  public static final String HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID
-      = PropertyHelper.getPropertyId("HostRoles", "desired_admin_state");
-  public static final String HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID
-      = "HostRoles/maintenance_state";
-  public static final String HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID = "HostRoles/upgrade_state";
+  public static final String HOST_ROLES = "HostRoles";
+  public static final String HOST = "host";
+  public static final String SERVICE_COMPONENT_INFO = "ServiceComponentInfo";
+
+  public static final String ROLE_ID_PROPERTY_ID = "role_id";
+  public static final String CLUSTER_NAME_PROPERTY_ID = "cluster_name";
+  public static final String SERVICE_NAME_PROPERTY_ID = "service_name";
+  public static final String COMPONENT_NAME_PROPERTY_ID = "component_name";
+  public static final String DISPLAY_NAME_PROPERTY_ID = "display_name";
+  public static final String HOST_NAME_PROPERTY_ID = "host_name";
+  public static final String PUBLIC_HOST_NAME_PROPERTY_ID = "public_host_name";
+  public static final String STATE_PROPERTY_ID = "state";
+  public static final String DESIRED_STATE_PROPERTY_ID = "desired_state";
+  public static final String VERSION_PROPERTY_ID = "version";
+  public static final String DESIRED_STACK_ID_PROPERTY_ID = "desired_stack_id";
+  public static final String DESIRED_REPOSITORY_VERSION_PROPERTY_ID = "desired_repository_version";
+  public static final String ACTUAL_CONFIGS_PROPERTY_ID = "actual_configs";
+  public static final String STALE_CONFIGS_PROPERTY_ID = "stale_configs";
+  public static final String RELOAD_CONFIGS_PROPERTY_ID = "reload_configs";
+  public static final String DESIRED_ADMIN_STATE_PROPERTY_ID = "desired_admin_state";
+  public static final String MAINTENANCE_STATE_PROPERTY_ID = "maintenance_state";
+  public static final String UPGRADE_STATE_PROPERTY_ID = "upgrade_state";
+  public static final String HOST_PROPERTY_ID = "host";
+  public static final String HREF_PROPERTY_ID = "href";
+  public static final String COMPONENT_PROPERTY_ID = "component";
+  public static final String METRICS_PROPERTY_ID = "metrics";
+  public static final String PROCESSES_PROPERTY_ID = "processes";
+
+  public static final String ROLE_ID = PropertyHelper.getPropertyId(HOST_ROLES, ROLE_ID_PROPERTY_ID);
+  public static final String CLUSTER_NAME = PropertyHelper.getPropertyId(HOST_ROLES, CLUSTER_NAME_PROPERTY_ID);
+  public static final String SERVICE_NAME = PropertyHelper.getPropertyId(HOST_ROLES, SERVICE_NAME_PROPERTY_ID);
+  public static final String COMPONENT_NAME = PropertyHelper.getPropertyId(HOST_ROLES, COMPONENT_NAME_PROPERTY_ID);
+  public static final String DISPLAY_NAME = PropertyHelper.getPropertyId(HOST_ROLES, DISPLAY_NAME_PROPERTY_ID);
+  public static final String HOST_NAME = PropertyHelper.getPropertyId(HOST_ROLES, HOST_NAME_PROPERTY_ID);
+  public static final String PUBLIC_HOST_NAME = PropertyHelper.getPropertyId(HOST_ROLES, PUBLIC_HOST_NAME_PROPERTY_ID);
+  public static final String STATE = PropertyHelper.getPropertyId(HOST_ROLES, STATE_PROPERTY_ID);
+  public static final String DESIRED_STATE = PropertyHelper.getPropertyId(HOST_ROLES, DESIRED_STATE_PROPERTY_ID);
+  public static final String VERSION = PropertyHelper.getPropertyId(HOST_ROLES, VERSION_PROPERTY_ID);
+  public static final String DESIRED_STACK_ID = PropertyHelper.getPropertyId(HOST_ROLES, DESIRED_STACK_ID_PROPERTY_ID);
+  public static final String DESIRED_REPOSITORY_VERSION = PropertyHelper.getPropertyId(HOST_ROLES, DESIRED_REPOSITORY_VERSION_PROPERTY_ID);
+  public static final String ACTUAL_CONFIGS = PropertyHelper.getPropertyId(HOST_ROLES, ACTUAL_CONFIGS_PROPERTY_ID);
+  public static final String STALE_CONFIGS = PropertyHelper.getPropertyId(HOST_ROLES, STALE_CONFIGS_PROPERTY_ID);
+  public static final String RELOAD_CONFIGS = PropertyHelper.getPropertyId(HOST_ROLES, RELOAD_CONFIGS_PROPERTY_ID);
+  public static final String DESIRED_ADMIN_STATE = PropertyHelper.getPropertyId(HOST_ROLES, DESIRED_ADMIN_STATE_PROPERTY_ID);
+  public static final String MAINTENANCE_STATE = PropertyHelper.getPropertyId(HOST_ROLES, MAINTENANCE_STATE_PROPERTY_ID);
+  public static final String UPGRADE_STATE = PropertyHelper.getPropertyId(HOST_ROLES, UPGRADE_STATE_PROPERTY_ID);
 
   //Parameters from the predicate
   private static final String QUERY_PARAMETERS_RUN_SMOKE_TEST_ID = "params/run_smoke_test";
@@ -128,34 +138,34 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
    * The key property ids for a HostComponent resource.
    */
   public static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
-      .put(Resource.Type.Cluster, HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID)
-      .put(Resource.Type.Host, HOST_COMPONENT_HOST_NAME_PROPERTY_ID)
-      .put(Resource.Type.HostComponent, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)
-      .put(Resource.Type.Component, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID)
+      .put(Resource.Type.Cluster, CLUSTER_NAME)
+      .put(Resource.Type.Host, HOST_NAME)
+      .put(Resource.Type.HostComponent, COMPONENT_NAME)
+      .put(Resource.Type.Component, COMPONENT_NAME)
       .build();
 
   /**
    * The property ids for a HostComponent resource.
    */
   protected static Set<String> propertyIds = Sets.newHashSet(
-      HOST_COMPONENT_ROLE_ID,
-      HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID,
-      HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID,
-      HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID,
-      HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID,
-      HOST_COMPONENT_HOST_NAME_PROPERTY_ID,
-      HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID,
-      HOST_COMPONENT_STATE_PROPERTY_ID,
-      HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID,
-      HOST_COMPONENT_VERSION_PROPERTY_ID,
-      HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID,
-      HOST_COMPONENT_DESIRED_REPOSITORY_VERSION,
-      HOST_COMPONENT_ACTUAL_CONFIGS_PROPERTY_ID,
-      HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID,
-      HOST_COMPONENT_RELOAD_CONFIGS_PROPERTY_ID,
-      HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID,
-      HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID,
-      HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID,
+      ROLE_ID,
+      CLUSTER_NAME,
+      SERVICE_NAME,
+      COMPONENT_NAME,
+      DISPLAY_NAME,
+      HOST_NAME,
+      PUBLIC_HOST_NAME,
+      STATE,
+      DESIRED_STATE,
+      VERSION,
+      DESIRED_STACK_ID,
+      DESIRED_REPOSITORY_VERSION,
+      ACTUAL_CONFIGS,
+      STALE_CONFIGS,
+      RELOAD_CONFIGS,
+      DESIRED_ADMIN_STATE,
+      MAINTENANCE_STATE,
+      UPGRADE_STATE,
       QUERY_PARAMETERS_RUN_SMOKE_TEST_ID);
 
   /**
@@ -242,7 +252,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Set<Resource> resources = new HashSet<>();
     Set<String> requestedIds = getRequestPropertyIds(request, predicate);
     // We always need host_name for sch
-    requestedIds.add(HOST_COMPONENT_HOST_NAME_PROPERTY_ID);
+    requestedIds.add(HOST_NAME);
 
     Set<ServiceComponentHostResponse> responses = getResources(new Command<Set<ServiceComponentHostResponse>>() {
       @Override
@@ -253,44 +263,44 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
     for (ServiceComponentHostResponse response : responses) {
       Resource resource = new ResourceImpl(Resource.Type.HostComponent);
-      setResourceProperty(resource, HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID,
+      setResourceProperty(resource, CLUSTER_NAME,
               response.getClusterName(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID,
+      setResourceProperty(resource, SERVICE_NAME,
               response.getServiceName(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID,
+      setResourceProperty(resource, COMPONENT_NAME,
               response.getComponentName(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_DISPLAY_NAME_PROPERTY_ID,
+      setResourceProperty(resource, DISPLAY_NAME,
               response.getDisplayName(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_HOST_NAME_PROPERTY_ID,
+      setResourceProperty(resource, HOST_NAME,
               response.getHostname(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID,
+      setResourceProperty(resource, PUBLIC_HOST_NAME,
           response.getPublicHostname(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_STATE_PROPERTY_ID,
+      setResourceProperty(resource, STATE,
               response.getLiveState(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID,
+      setResourceProperty(resource, DESIRED_STATE,
               response.getDesiredState(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_VERSION_PROPERTY_ID, response.getVersion(),
+      setResourceProperty(resource, VERSION, response.getVersion(),
           requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID,
+      setResourceProperty(resource, DESIRED_STACK_ID,
               response.getDesiredStackVersion(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_ACTUAL_CONFIGS_PROPERTY_ID,
+      setResourceProperty(resource, ACTUAL_CONFIGS,
               response.getActualConfigs(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID,
+      setResourceProperty(resource, STALE_CONFIGS,
               response.isStaleConfig(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_RELOAD_CONFIGS_PROPERTY_ID,
+      setResourceProperty(resource, RELOAD_CONFIGS,
               response.isReloadConfig(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID,
+      setResourceProperty(resource, UPGRADE_STATE,
               response.getUpgradeState(), requestedIds);
-      setResourceProperty(resource, HOST_COMPONENT_DESIRED_REPOSITORY_VERSION,
+      setResourceProperty(resource, DESIRED_REPOSITORY_VERSION,
           response.getDesiredRepositoryVersion(), requestedIds);
 
       if (response.getAdminState() != null) {
-        setResourceProperty(resource, HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID,
+        setResourceProperty(resource, DESIRED_ADMIN_STATE,
                 response.getAdminState(), requestedIds);
       }
 
       if (null != response.getMaintenanceState()) {
-        setResourceProperty(resource, HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID,
+        setResourceProperty(resource, MAINTENANCE_STATE,
                 response.getMaintenanceState(), requestedIds);
       }
 
@@ -370,7 +380,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
     Map<String, Object> installProperties = new HashMap<>();
 
-    installProperties.put(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, "INSTALLED");
+    installProperties.put(DESIRED_STATE, "INSTALLED");
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Install components on host %s", hostname));
     requestInfo.put("phase", "INITIAL_INSTALL");
@@ -381,10 +391,10 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
     Request installRequest = PropertyHelper.getUpdateRequest(installProperties, requestInfo);
 
-    Predicate statePredicate = new EqualsPredicate<>(HOST_COMPONENT_STATE_PROPERTY_ID, "INIT");
-    Predicate clusterPredicate = new EqualsPredicate<>(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, cluster);
+    Predicate statePredicate = new EqualsPredicate<>(STATE, "INIT");
+    Predicate clusterPredicate = new EqualsPredicate<>(CLUSTER_NAME, cluster);
     // single host
-    Predicate hostPredicate = new EqualsPredicate<>(HOST_COMPONENT_HOST_NAME_PROPERTY_ID, hostname);
+    Predicate hostPredicate = new EqualsPredicate<>(HOST_NAME, hostname);
     //Predicate hostPredicate = new OrPredicate(hostPredicates.toArray(new Predicate[hostPredicates.size()]));
     Predicate hostAndStatePredicate = new AndPredicate(statePredicate, hostPredicate);
     Predicate installPredicate = new AndPredicate(hostAndStatePredicate, clusterPredicate);
@@ -423,20 +433,20 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     requestInfo.put("phase", "INITIAL_START");
     requestInfo.put(Setting.SETTING_NAME_SKIP_FAILURE, Boolean.toString(skipFailure));
 
-    Predicate clusterPredicate = new EqualsPredicate<>(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, cluster);
-    Predicate hostPredicate = new EqualsPredicate<>(HOST_COMPONENT_HOST_NAME_PROPERTY_ID, hostName);
+    Predicate clusterPredicate = new EqualsPredicate<>(CLUSTER_NAME, cluster);
+    Predicate hostPredicate = new EqualsPredicate<>(HOST_NAME, hostName);
     //Predicate hostPredicate = new OrPredicate(hostPredicates.toArray(new Predicate[hostPredicates.size()]));
 
     RequestStageContainer requestStages;
     try {
       Map<String, Object> startProperties = new HashMap<>();
-      startProperties.put(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, "STARTED");
+      startProperties.put(DESIRED_STATE, "STARTED");
       Request startRequest = PropertyHelper.getUpdateRequest(startProperties, requestInfo);
       // Important to query against desired_state as this has been updated when install stage was created
       // If I query against state, then the getRequest compares predicate prop against desired_state and then when the predicate
       // is later applied explicitly, it gets compared to live_state. Since live_state == INSTALLED == INIT at this point and
       // desired_state == INSTALLED, we will always get 0 matches since both comparisons can't be true :(
-      Predicate installedStatePredicate = new EqualsPredicate<>(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, "INSTALLED");
+      Predicate installedStatePredicate = new EqualsPredicate<>(DESIRED_STATE, "INSTALLED");
       Predicate notClientPredicate = new NotPredicate(new ClientComponentPredicate());
       Predicate clusterAndClientPredicate = new AndPredicate(clusterPredicate, notClientPredicate);
       Predicate hostAndStatePredicate = new AndPredicate(installedStatePredicate, hostPredicate);
@@ -452,7 +462,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
           new ArrayList<>();
 
         for (String installOnlyComponent : installOnlyComponents) {
-          Predicate componentNameEquals = new EqualsPredicate<>(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, installOnlyComponent);
+          Predicate componentNameEquals = new EqualsPredicate<>(COMPONENT_NAME, installOnlyComponent);
           // create predicate to filter out the install only component
           listOfComponentPredicates.add(new NotPredicate(componentNameEquals));
         }
@@ -703,28 +713,28 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
    */
   private ServiceComponentHostRequest getRequest(Map<String, Object> properties) {
     ServiceComponentHostRequest serviceComponentHostRequest = new ServiceComponentHostRequest(
-        (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
-        (String) properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
-    serviceComponentHostRequest.setState((String) properties.get(HOST_COMPONENT_STATE_PROPERTY_ID));
-    if (properties.get(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID) != null) {
+        (String) properties.get(CLUSTER_NAME),
+        (String) properties.get(SERVICE_NAME),
+        (String) properties.get(COMPONENT_NAME),
+        (String) properties.get(HOST_NAME),
+        (String) properties.get(DESIRED_STATE));
+    serviceComponentHostRequest.setState((String) properties.get(STATE));
+    if (properties.get(STALE_CONFIGS) != null) {
       serviceComponentHostRequest.setStaleConfig(
-          properties.get(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID).toString().toLowerCase());
+          properties.get(STALE_CONFIGS).toString().toLowerCase());
     }
 
-    if (properties.get(HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID) != null) {
+    if (properties.get(DESIRED_ADMIN_STATE) != null) {
       serviceComponentHostRequest.setAdminState(
-          properties.get(HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID).toString());
+          properties.get(DESIRED_ADMIN_STATE).toString());
     }
-    if (properties.get(HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID) != null) {
+    if (properties.get(PUBLIC_HOST_NAME) != null) {
       serviceComponentHostRequest.setPublicHostname(
-          properties.get(HOST_COMPONENT_PUBLIC_HOST_NAME_PROPERTY_ID).toString());
+          properties.get(PUBLIC_HOST_NAME).toString());
     }
 
 
-    Object o = properties.get(HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID);
+    Object o = properties.get(MAINTENANCE_STATE);
     if (null != o) {
       serviceComponentHostRequest.setMaintenanceState (o.toString());
     }
@@ -740,25 +750,25 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
    */
   private ServiceComponentHostRequest changeRequest(Map<String, Object> properties) {
     ServiceComponentHostRequest serviceComponentHostRequest = new ServiceComponentHostRequest(
-            (String) properties.get(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID),
-            (String) properties.get(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID),
-            (String) properties.get(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID),
-            (String) properties.get(HOST_COMPONENT_HOST_NAME_PROPERTY_ID),
-            (String) properties.get(HOST_COMPONENT_STATE_PROPERTY_ID));
-    if (properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID) != null) {
-      serviceComponentHostRequest.setDesiredState((String)properties.get(HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID));
+            (String) properties.get(CLUSTER_NAME),
+            (String) properties.get(SERVICE_NAME),
+            (String) properties.get(COMPONENT_NAME),
+            (String) properties.get(HOST_NAME),
+            (String) properties.get(STATE));
+    if (properties.get(DESIRED_STATE) != null) {
+      serviceComponentHostRequest.setDesiredState((String)properties.get(DESIRED_STATE));
     }
-    if (properties.get(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID) != null) {
+    if (properties.get(STALE_CONFIGS) != null) {
       serviceComponentHostRequest.setStaleConfig(
-              properties.get(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID).toString().toLowerCase());
+              properties.get(STALE_CONFIGS).toString().toLowerCase());
     }
 
-    if (properties.get(HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID) != null) {
+    if (properties.get(DESIRED_ADMIN_STATE) != null) {
       serviceComponentHostRequest.setAdminState(
-              properties.get(HOST_COMPONENT_DESIRED_ADMIN_STATE_PROPERTY_ID).toString());
+              properties.get(DESIRED_ADMIN_STATE).toString());
     }
 
-    Object o = properties.get(HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID);
+    Object o = properties.get(MAINTENANCE_STATE);
     if (null != o) {
       serviceComponentHostRequest.setMaintenanceState (o.toString());
     }
@@ -791,7 +801,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     final boolean runSmokeTest = "true".equals(getQueryParameterValue(
         QUERY_PARAMETERS_RUN_SMOKE_TEST_ID, predicate));
 
-    Set<String> queryIds = Collections.singleton(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+    Set<String> queryIds = Collections.singleton(COMPONENT_NAME);
 
     Request queryRequest = PropertyHelper.getReadRequest(queryIds);
     // will take care of 404 exception
@@ -1031,19 +1041,19 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     public boolean evaluate(Resource resource) {
       boolean isClient = false;
 
-      String componentName = (String) resource.getPropertyValue(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+      String componentName = (String) resource.getPropertyValue(COMPONENT_NAME);
       try {
         if (componentName != null && !componentName.isEmpty()) {
           AmbariManagementController managementController = getManagementController();
-          String clusterName = (String) resource.getPropertyValue(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID);
-          String serviceName = (String) resource.getPropertyValue(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID);
+          String clusterName = (String) resource.getPropertyValue(CLUSTER_NAME);
+          String serviceName = (String) resource.getPropertyValue(SERVICE_NAME);
           if (StringUtils.isEmpty(serviceName)) {
             Cluster cluster = managementController.getClusters().getCluster(clusterName);
             serviceName = managementController.findServiceName(cluster, componentName);
           }
 
           ServiceComponent sc = getServiceComponent((String) resource.getPropertyValue(
-              HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID), serviceName, componentName);
+                  CLUSTER_NAME), serviceName, componentName);
           isClient = sc.isClientComponent();
         }
       } catch (AmbariException e) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceProvider.java
@@ -17,10 +17,10 @@
  */
 package org.apache.ambari.server.controller.internal;
 
-import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID;
-import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID;
-import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID;
-import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.CLUSTER_NAME;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.COMPONENT_NAME;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.HOST_NAME;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.SERVICE_NAME;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -539,16 +539,16 @@ public class RequestResourceProvider extends AbstractControllerResourceProvider 
       ResourceProvider resourceProvider = getResourceProvider(Resource.Type.HostComponent);
 
       Set<String> propertyIds = new HashSet<>();
-      propertyIds.add(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID);
-      propertyIds.add(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID);
-      propertyIds.add(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+      propertyIds.add(CLUSTER_NAME);
+      propertyIds.add(SERVICE_NAME);
+      propertyIds.add(COMPONENT_NAME);
 
       Request request = PropertyHelper.getReadRequest(propertyIds);
 
       Predicate finalPredicate = new PredicateBuilder(filterPredicate)
-        .property(HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID).equals(clusterName).and()
-        .property(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID).equals(serviceName).and()
-        .property(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals(componentName)
+        .property(CLUSTER_NAME).equals(clusterName).and()
+        .property(SERVICE_NAME).equals(serviceName).and()
+        .property(COMPONENT_NAME).equals(componentName)
         .toPredicate();
 
       try {
@@ -558,10 +558,10 @@ public class RequestResourceProvider extends AbstractControllerResourceProvider 
           // Allow request to span services / components using just the predicate
           Map<ServiceComponentTuple, List<String>> dupleListMap = new HashMap<>();
           for (Resource resource : resources) {
-            String hostnameStr = (String) resource.getPropertyValue(HOST_COMPONENT_HOST_NAME_PROPERTY_ID);
+            String hostnameStr = (String) resource.getPropertyValue(HOST_NAME);
             if (hostnameStr != null) {
-              String computedServiceName = (String) resource.getPropertyValue(HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID);
-              String computedComponentName = (String) resource.getPropertyValue(HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
+              String computedServiceName = (String) resource.getPropertyValue(SERVICE_NAME);
+              String computedComponentName = (String) resource.getPropertyValue(COMPONENT_NAME);
               ServiceComponentTuple duple =
                 new ServiceComponentTuple(computedServiceName, computedComponentName);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/ComponentEventCreatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/ComponentEventCreatorTest.java
@@ -46,7 +46,7 @@ public class ComponentEventCreatorTest extends AuditEventCreatorTestBase {
     ComponentEventCreator creator = new ComponentEventCreator();
 
     Map<String,Object> properties = new HashMap<>();
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "ambari1.example.com");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "ambari1.example.com");
 
     Map<Resource.Type,String> resource = new HashMap<>();
     resource.put(Resource.Type.HostComponent, "MyComponent");
@@ -81,9 +81,9 @@ public class ComponentEventCreatorTest extends AuditEventCreatorTestBase {
     ComponentEventCreator creator = new ComponentEventCreator();
 
     Map<String,Object> properties = new HashMap<>();
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "ambari1.example.com");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "mycluster");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, "STARTED");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "ambari1.example.com");
+    properties.put(HostComponentResourceProvider.CLUSTER_NAME, "mycluster");
+    properties.put(HostComponentResourceProvider.STATE, "STARTED");
 
     Request request = AuditEventCreatorTestHelper.createRequest(type, Resource.Type.HostComponent, properties, null);
     request.getBody().addRequestInfoProperty(RequestOperationLevel.OPERATION_LEVEL_ID, "CLUSTER");
@@ -110,9 +110,9 @@ public class ComponentEventCreatorTest extends AuditEventCreatorTestBase {
     ComponentEventCreator creator = new ComponentEventCreator();
 
     Map<String,Object> properties = new HashMap<>();
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "ambari1.example.com");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "mycluster");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, "STARTED");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "ambari1.example.com");
+    properties.put(HostComponentResourceProvider.CLUSTER_NAME, "mycluster");
+    properties.put(HostComponentResourceProvider.STATE, "STARTED");
 
     Request request = AuditEventCreatorTestHelper.createRequest(Request.Type.PUT, Resource.Type.HostComponent, properties, null);
     request.getBody().addRequestInfoProperty(RequestOperationLevel.OPERATION_LEVEL_ID, "HOST");
@@ -140,10 +140,10 @@ public class ComponentEventCreatorTest extends AuditEventCreatorTestBase {
     ComponentEventCreator creator = new ComponentEventCreator();
 
     Map<String,Object> properties = new HashMap<>();
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "ambari1.example.com");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "mycluster");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, "STARTED");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "MYCOMPONENT");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "ambari1.example.com");
+    properties.put(HostComponentResourceProvider.CLUSTER_NAME, "mycluster");
+    properties.put(HostComponentResourceProvider.STATE, "STARTED");
+    properties.put(HostComponentResourceProvider.COMPONENT_NAME, "MYCOMPONENT");
 
     Request request = AuditEventCreatorTestHelper.createRequest(Request.Type.PUT, Resource.Type.HostComponent, properties, null);
     request.getBody().addRequestInfoProperty(RequestOperationLevel.OPERATION_LEVEL_ID, "HOST_COMPONENT");
@@ -171,9 +171,9 @@ public class ComponentEventCreatorTest extends AuditEventCreatorTestBase {
     ComponentEventCreator creator = new ComponentEventCreator();
 
     Map<String,Object> properties = new HashMap<>();
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "ambari1.example.com");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID, "ON");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "MYCOMPONENT");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "ambari1.example.com");
+    properties.put(HostComponentResourceProvider.MAINTENANCE_STATE, "ON");
+    properties.put(HostComponentResourceProvider.COMPONENT_NAME, "MYCOMPONENT");
 
     Request request = AuditEventCreatorTestHelper.createRequest(Request.Type.PUT, Resource.Type.HostComponent, properties, null);
 
@@ -197,9 +197,9 @@ public class ComponentEventCreatorTest extends AuditEventCreatorTestBase {
     ComponentEventCreator creator = new ComponentEventCreator();
 
     Map<String,Object> properties = new HashMap<>();
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "ambari1.example.com");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_MAINTENANCE_STATE_PROPERTY_ID, "ON");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "MYCOMPONENT");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "ambari1.example.com");
+    properties.put(HostComponentResourceProvider.MAINTENANCE_STATE, "ON");
+    properties.put(HostComponentResourceProvider.COMPONENT_NAME, "MYCOMPONENT");
 
     Request request = AuditEventCreatorTestHelper.createRequest(Request.Type.PUT, Resource.Type.HostComponent, properties, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/HostEventCreatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/HostEventCreatorTest.java
@@ -68,7 +68,7 @@ public class HostEventCreatorTest extends AuditEventCreatorTestBase{
 
     Set<Map<String,String>> set = new HashSet<>();
     Map<String,String> map = new HashMap<>();
-    map.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "MYCOMPONENT");
+    map.put(HostComponentResourceProvider.COMPONENT_NAME, "MYCOMPONENT");
     set.add(map);
 
     properties.put("host_components", set);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -173,9 +173,9 @@ public class ComponentResourceProviderTest {
     Map<String, Object> properties = new LinkedHashMap<>();
 
     // add properties to the request map
-    properties.put(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    properties.put(ComponentResourceProvider.COMPONENT_SERVICE_NAME_PROPERTY_ID, "Service100");
-    properties.put(ComponentResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID, "Component100");
+    properties.put(ComponentResourceProvider.CLUSTER_NAME, "Cluster100");
+    properties.put(ComponentResourceProvider.SERVICE_NAME, "Service100");
+    properties.put(ComponentResourceProvider.COMPONENT_NAME, "Component100");
 
     propertySet.add(properties);
 
@@ -280,25 +280,25 @@ public class ComponentResourceProviderTest {
 
     Set<String> propertyIds = new HashSet<>();
 
-    propertyIds.add(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_CATEGORY_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_TOTAL_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_STARTED_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_INSTALLED_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_INSTALL_FAILED_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_INIT_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_UNKNOWN_COUNT_PROPERTY_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_RECOVERY_ENABLED_ID);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_DESIRED_VERSION);
-    propertyIds.add(ComponentResourceProvider.COMPONENT_REPOSITORY_STATE);
+    propertyIds.add(ComponentResourceProvider.CLUSTER_NAME);
+    propertyIds.add(ComponentResourceProvider.COMPONENT_NAME);
+    propertyIds.add(ComponentResourceProvider.CATEGORY);
+    propertyIds.add(ComponentResourceProvider.TOTAL_COUNT);
+    propertyIds.add(ComponentResourceProvider.STARTED_COUNT);
+    propertyIds.add(ComponentResourceProvider.INSTALLED_COUNT);
+    propertyIds.add(ComponentResourceProvider.INSTALLED_AND_MAINTENANCE_OFF_COUNT);
+    propertyIds.add(ComponentResourceProvider.INSTALL_FAILED_COUNT);
+    propertyIds.add(ComponentResourceProvider.INIT_COUNT);
+    propertyIds.add(ComponentResourceProvider.UNKNOWN_COUNT);
+    propertyIds.add(ComponentResourceProvider.RECOVERY_ENABLED);
+    propertyIds.add(ComponentResourceProvider.DESIRED_VERSION);
+    propertyIds.add(ComponentResourceProvider.REPOSITORY_STATE);
 
     Predicate predicate = new PredicateBuilder()
-      .property(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID)
+      .property(ComponentResourceProvider.CLUSTER_NAME)
       .equals("Cluster100")
       .and()
-      .property(ComponentResourceProvider.COMPONENT_CATEGORY_PROPERTY_ID)
+      .property(ComponentResourceProvider.CATEGORY)
       .equals("MASTER").toPredicate();
 
     Request request = PropertyHelper.getReadRequest(propertyIds);
@@ -307,36 +307,36 @@ public class ComponentResourceProviderTest {
     Assert.assertEquals(2, resources.size());
     for (Resource resource : resources) {
       String clusterName = (String) resource.getPropertyValue(
-          ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID);
+          ComponentResourceProvider.CLUSTER_NAME);
       Assert.assertEquals("Cluster100", clusterName);
       Assert.assertEquals("MASTER", resource.getPropertyValue(
-          ComponentResourceProvider.COMPONENT_CATEGORY_PROPERTY_ID));
+          ComponentResourceProvider.CATEGORY));
       Assert.assertEquals(2, resource.getPropertyValue(
-        ComponentResourceProvider.COMPONENT_TOTAL_COUNT_PROPERTY_ID));
+        ComponentResourceProvider.TOTAL_COUNT));
       Assert.assertEquals(1, resource.getPropertyValue(
-        ComponentResourceProvider.COMPONENT_STARTED_COUNT_PROPERTY_ID));
+        ComponentResourceProvider.STARTED_COUNT));
       Assert.assertEquals(0, resource.getPropertyValue(
-        ComponentResourceProvider.COMPONENT_INSTALLED_COUNT_PROPERTY_ID));
+        ComponentResourceProvider.INSTALLED_COUNT));
       Assert.assertEquals(0, resource.getPropertyValue(
-        ComponentResourceProvider.COMPONENT_INSTALLED_AND_MAINTENANCE_OFF_COUNT_PROPERTY_ID));
+        ComponentResourceProvider.INSTALLED_AND_MAINTENANCE_OFF_COUNT));
       Assert.assertEquals(0, resource.getPropertyValue(
-          ComponentResourceProvider.COMPONENT_INSTALL_FAILED_COUNT_PROPERTY_ID));
+          ComponentResourceProvider.INSTALL_FAILED_COUNT));
       Assert.assertEquals(0, resource.getPropertyValue(
-          ComponentResourceProvider.COMPONENT_INIT_COUNT_PROPERTY_ID));
+          ComponentResourceProvider.INIT_COUNT));
       Assert.assertEquals(1, resource.getPropertyValue(
-          ComponentResourceProvider.COMPONENT_UNKNOWN_COUNT_PROPERTY_ID));
+          ComponentResourceProvider.UNKNOWN_COUNT));
       Assert.assertEquals(String.valueOf(true), resource.getPropertyValue(
-        ComponentResourceProvider.COMPONENT_RECOVERY_ENABLED_ID));
+        ComponentResourceProvider.RECOVERY_ENABLED));
 
       if (resource.getPropertyValue(
-          ComponentResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component102")) {
-        Assert.assertNotNull(resource.getPropertyValue(ComponentResourceProvider.COMPONENT_REPOSITORY_STATE));
-        Assert.assertNotNull(resource.getPropertyValue(ComponentResourceProvider.COMPONENT_DESIRED_VERSION));
-        Assert.assertEquals(RepositoryVersionState.CURRENT, resource.getPropertyValue(ComponentResourceProvider.COMPONENT_REPOSITORY_STATE));
-        Assert.assertEquals("1.1", resource.getPropertyValue(ComponentResourceProvider.COMPONENT_DESIRED_VERSION));
+          ComponentResourceProvider.COMPONENT_NAME).equals("Component102")) {
+        Assert.assertNotNull(resource.getPropertyValue(ComponentResourceProvider.REPOSITORY_STATE));
+        Assert.assertNotNull(resource.getPropertyValue(ComponentResourceProvider.DESIRED_VERSION));
+        Assert.assertEquals(RepositoryVersionState.CURRENT, resource.getPropertyValue(ComponentResourceProvider.REPOSITORY_STATE));
+        Assert.assertEquals("1.1", resource.getPropertyValue(ComponentResourceProvider.DESIRED_VERSION));
       } else {
-        Assert.assertNull(resource.getPropertyValue(ComponentResourceProvider.COMPONENT_REPOSITORY_STATE));
-        Assert.assertNull(resource.getPropertyValue(ComponentResourceProvider.COMPONENT_DESIRED_VERSION));
+        Assert.assertNull(resource.getPropertyValue(ComponentResourceProvider.REPOSITORY_STATE));
+        Assert.assertNull(resource.getPropertyValue(ComponentResourceProvider.DESIRED_VERSION));
       }
     }
 
@@ -477,15 +477,15 @@ public class ComponentResourceProviderTest {
 
     Map<String, Object> properties = new LinkedHashMap<>();
 
-    properties.put(ComponentResourceProvider.COMPONENT_RECOVERY_ENABLED_ID, String.valueOf(true) /* recovery enabled */);
-    properties.put(ComponentResourceProvider.COMPONENT_STATE_PROPERTY_ID, "STARTED");
-    properties.put(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
+    properties.put(ComponentResourceProvider.RECOVERY_ENABLED, String.valueOf(true) /* recovery enabled */);
+    properties.put(ComponentResourceProvider.STATE, "STARTED");
+    properties.put(ComponentResourceProvider.CLUSTER_NAME, "Cluster100");
 
     // create the request
     Request request = PropertyHelper.getUpdateRequest(properties, mapRequestProps);
 
     // update the cluster named Cluster100
-    Predicate predicate = new PredicateBuilder().property(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID).
+    Predicate predicate = new PredicateBuilder().property(ComponentResourceProvider.CLUSTER_NAME).
         equals("Cluster100").toPredicate();
     provider.updateResources(request, predicate);
 
@@ -566,13 +566,13 @@ public class ComponentResourceProviderTest {
 
 
     Predicate predicate = new PredicateBuilder()
-                .property(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.CLUSTER_NAME)
                 .equals("Cluster100")
                 .and()
-                .property(ComponentResourceProvider.COMPONENT_SERVICE_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.SERVICE_NAME)
                 .equals("Service100")
                 .and()
-                .property(ComponentResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.COMPONENT_NAME)
                 .equals("Component100").toPredicate();
 
     provider.deleteResources(new RequestImpl(null, null, null, null), predicate);
@@ -644,10 +644,10 @@ public class ComponentResourceProviderTest {
     ((ObservableResourceProvider)provider).addObserver(observer);
 
     Predicate predicate1 = new PredicateBuilder()
-                .property(ComponentResourceProvider.COMPONENT_SERVICE_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.SERVICE_NAME)
                 .equals("Service100")
                 .and()
-                .property(ComponentResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.COMPONENT_NAME)
                 .equals("Component100").toPredicate();
 
     try {
@@ -658,10 +658,10 @@ public class ComponentResourceProviderTest {
     }
 
     Predicate predicate2 = new PredicateBuilder()
-                .property(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.CLUSTER_NAME)
                 .equals("Cluster100")
                 .and()
-                .property(ComponentResourceProvider.COMPONENT_SERVICE_NAME_PROPERTY_ID)
+                .property(ComponentResourceProvider.SERVICE_NAME)
                 .equals("Service100")
                 .and().toPredicate();
 
@@ -797,13 +797,13 @@ public class ComponentResourceProviderTest {
 
     Map<String, Object> properties = new LinkedHashMap<>();
 
-    properties.put(ComponentResourceProvider.COMPONENT_RECOVERY_ENABLED_ID, String.valueOf(true) /* recovery enabled */);
+    properties.put(ComponentResourceProvider.RECOVERY_ENABLED, String.valueOf(true) /* recovery enabled */);
 
     // create the request
     Request request = PropertyHelper.getUpdateRequest(properties, mapRequestProps);
 
     // update the cluster named Cluster100
-    Predicate predicate = new PredicateBuilder().property(ComponentResourceProvider.COMPONENT_CLUSTER_NAME_PROPERTY_ID).
+    Predicate predicate = new PredicateBuilder().property(ComponentResourceProvider.CLUSTER_NAME).
         equals("Cluster100").toPredicate();
     provider.updateResources(request, predicate);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentProcessResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentProcessResourceProviderTest.java
@@ -61,11 +61,11 @@ public class HostComponentProcessResourceProviderTest {
         }});
 
     PredicateBuilder pb = new PredicateBuilder().property(
-        HostComponentProcessResourceProvider.HC_PROCESS_CLUSTER_NAME_ID).equals("c1").and();
+        HostComponentProcessResourceProvider.CLUSTER_NAME).equals("c1").and();
     pb = pb.property(
-        HostComponentProcessResourceProvider.HC_PROCESS_HOST_NAME_ID).equals("h1").and();
+        HostComponentProcessResourceProvider.HOST_NAME).equals("h1").and();
     Predicate predicate = pb.property(
-        HostComponentProcessResourceProvider.HC_PROCESS_COMPONENT_NAME_ID).equals("comp1").toPredicate();
+        HostComponentProcessResourceProvider.COMPONENT_NAME).equals("comp1").toPredicate();
     
     Request request = PropertyHelper.getReadRequest(Collections.emptySet());
     
@@ -75,9 +75,9 @@ public class HostComponentProcessResourceProviderTest {
     Resource res = resources.iterator().next();
     
     Assert.assertNotNull(res.getPropertyValue(
-        HostComponentProcessResourceProvider.HC_PROCESS_NAME_ID));
+        HostComponentProcessResourceProvider.NAME));
     Assert.assertNotNull(res.getPropertyValue(
-        HostComponentProcessResourceProvider.HC_PROCESS_STATUS_ID));
+        HostComponentProcessResourceProvider.STATUS));
   }
   
   @Test
@@ -87,11 +87,11 @@ public class HostComponentProcessResourceProviderTest {
     ResourceProvider provider = init();
 
     PredicateBuilder pb = new PredicateBuilder().property(
-        HostComponentProcessResourceProvider.HC_PROCESS_CLUSTER_NAME_ID).equals("c1").and();
+        HostComponentProcessResourceProvider.CLUSTER_NAME).equals("c1").and();
     pb = pb.property(
-        HostComponentProcessResourceProvider.HC_PROCESS_HOST_NAME_ID).equals("h1").and();
+        HostComponentProcessResourceProvider.HOST_NAME).equals("h1").and();
     Predicate predicate = pb.property(
-        HostComponentProcessResourceProvider.HC_PROCESS_COMPONENT_NAME_ID).equals("comp1").toPredicate();
+        HostComponentProcessResourceProvider.COMPONENT_NAME).equals("comp1").toPredicate();
     
     Request request = PropertyHelper.getReadRequest(Collections.emptySet());
     
@@ -119,11 +119,11 @@ public class HostComponentProcessResourceProviderTest {
         }});        
 
     PredicateBuilder pb = new PredicateBuilder().property(
-        HostComponentProcessResourceProvider.HC_PROCESS_CLUSTER_NAME_ID).equals("c1").and();
+        HostComponentProcessResourceProvider.CLUSTER_NAME).equals("c1").and();
     pb = pb.property(
-        HostComponentProcessResourceProvider.HC_PROCESS_HOST_NAME_ID).equals("h1").and();
+        HostComponentProcessResourceProvider.HOST_NAME).equals("h1").and();
     Predicate predicate = pb.property(
-        HostComponentProcessResourceProvider.HC_PROCESS_COMPONENT_NAME_ID).equals("comp1").toPredicate();
+        HostComponentProcessResourceProvider.COMPONENT_NAME).equals("comp1").toPredicate();
     
     Request request = PropertyHelper.getReadRequest(Collections.emptySet());
     
@@ -132,8 +132,8 @@ public class HostComponentProcessResourceProviderTest {
     Assert.assertEquals(Integer.valueOf(3), Integer.valueOf(resources.size()));
     
     for (Resource r : resources) {
-      Assert.assertNotNull(r.getPropertyValue(HostComponentProcessResourceProvider.HC_PROCESS_NAME_ID));
-      Assert.assertNotNull(r.getPropertyValue(HostComponentProcessResourceProvider.HC_PROCESS_STATUS_ID));
+      Assert.assertNotNull(r.getPropertyValue(HostComponentProcessResourceProvider.NAME));
+      Assert.assertNotNull(r.getPropertyValue(HostComponentProcessResourceProvider.STATUS));
     }
   }
   

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
@@ -134,10 +134,10 @@ public class HostComponentResourceProviderTest {
     Map<String, Object> properties = new LinkedHashMap<>();
 
     // add properties to the request map
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID, "Service100");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "Component100");
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "Host100");
+    properties.put(HostComponentResourceProvider.CLUSTER_NAME, "Cluster100");
+    properties.put(HostComponentResourceProvider.SERVICE_NAME, "Service100");
+    properties.put(HostComponentResourceProvider.COMPONENT_NAME, "Component100");
+    properties.put(HostComponentResourceProvider.HOST_NAME, "Host100");
 
     propertySet.add(properties);
 
@@ -197,19 +197,19 @@ public class HostComponentResourceProviderTest {
 
     Map<String, String> expectedNameValues = new HashMap<>();
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
+        HostComponentResourceProvider.CLUSTER_NAME, "Cluster100");
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, State.INSTALLED.toString());
+        HostComponentResourceProvider.STATE, State.INSTALLED.toString());
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_VERSION_PROPERTY_ID, repositoryVersion2);
+        HostComponentResourceProvider.VERSION, repositoryVersion2);
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_DESIRED_REPOSITORY_VERSION, repositoryVersion2);
+        HostComponentResourceProvider.DESIRED_REPOSITORY_VERSION, repositoryVersion2);
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, State.STARTED.toString());
+        HostComponentResourceProvider.DESIRED_STATE, State.STARTED.toString());
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID, stackId2.getStackId());
+        HostComponentResourceProvider.DESIRED_STACK_ID, stackId2.getStackId());
     expectedNameValues.put(
-        HostComponentResourceProvider.HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID, UpgradeState.NONE.name());
+        HostComponentResourceProvider.UPGRADE_STATE, UpgradeState.NONE.name());
 
 
     // set expectations
@@ -219,58 +219,58 @@ public class HostComponentResourceProviderTest {
 
     Set<String> propertyIds = new HashSet<>();
 
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID);
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID);
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID);
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_VERSION_PROPERTY_ID);
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_REPOSITORY_VERSION);
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID);
-    propertyIds.add(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID);
+    propertyIds.add(HostComponentResourceProvider.CLUSTER_NAME);
+    propertyIds.add(HostComponentResourceProvider.COMPONENT_NAME);
+    propertyIds.add(HostComponentResourceProvider.STATE);
+    propertyIds.add(HostComponentResourceProvider.VERSION);
+    propertyIds.add(HostComponentResourceProvider.DESIRED_REPOSITORY_VERSION);
+    propertyIds.add(HostComponentResourceProvider.DESIRED_STATE);
+    propertyIds.add(HostComponentResourceProvider.DESIRED_STACK_ID);
 
     Predicate predicate = new PredicateBuilder().property(
-        HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").toPredicate();
+        HostComponentResourceProvider.CLUSTER_NAME).equals("Cluster100").toPredicate();
     Request request = PropertyHelper.getReadRequest(propertyIds);
 
     Set<Resource> hostsComponentResources = new HashSet<>();
 
     Resource hostsComponentResource1 = new ResourceImpl(Resource.Type.HostComponent);
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "Host100");
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID, "Service100");
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "Component100");
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, State.INSTALLED.name());
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, State.STARTED.name());
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.CLUSTER_NAME, "Cluster100");
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_NAME, "Host100");
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.SERVICE_NAME, "Service100");
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.COMPONENT_NAME, "Component100");
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.STATE, State.INSTALLED.name());
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.DESIRED_STATE, State.STARTED.name());
     hostsComponentResource1.setProperty(
-        HostComponentResourceProvider.HOST_COMPONENT_VERSION_PROPERTY_ID, repositoryVersion2);
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID, stackId2.getStackId());
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID, UpgradeState.NONE.name());
-    hostsComponentResource1.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_REPOSITORY_VERSION, repositoryVersion2);
+        HostComponentResourceProvider.VERSION, repositoryVersion2);
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.DESIRED_STACK_ID, stackId2.getStackId());
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.UPGRADE_STATE, UpgradeState.NONE.name());
+    hostsComponentResource1.setProperty(HostComponentResourceProvider.DESIRED_REPOSITORY_VERSION, repositoryVersion2);
 
     Resource hostsComponentResource2 = new ResourceImpl(Resource.Type.HostComponent);
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "Host100");
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID, "Service100");
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "Component101");
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, State.INSTALLED.name());
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, State.STARTED.name());
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.CLUSTER_NAME, "Cluster100");
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_NAME, "Host100");
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.SERVICE_NAME, "Service100");
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.COMPONENT_NAME, "Component101");
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.STATE, State.INSTALLED.name());
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.DESIRED_STATE, State.STARTED.name());
     hostsComponentResource2.setProperty(
-        HostComponentResourceProvider.HOST_COMPONENT_VERSION_PROPERTY_ID, repositoryVersion2);
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID, stackId2.getStackId());
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID, UpgradeState.NONE.name());
-    hostsComponentResource2.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_REPOSITORY_VERSION, repositoryVersion2);
+        HostComponentResourceProvider.VERSION, repositoryVersion2);
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.DESIRED_STACK_ID, stackId2.getStackId());
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.UPGRADE_STATE, UpgradeState.NONE.name());
+    hostsComponentResource2.setProperty(HostComponentResourceProvider.DESIRED_REPOSITORY_VERSION, repositoryVersion2);
 
     Resource hostsComponentResource3 = new ResourceImpl(Resource.Type.HostComponent);
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID, "Host100");
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_SERVICE_NAME_PROPERTY_ID, "Service100");
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID, "Component102");
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, State.INSTALLED.name());
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STATE_PROPERTY_ID, State.STARTED.name());
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.CLUSTER_NAME, "Cluster100");
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_NAME, "Host100");
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.SERVICE_NAME, "Service100");
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.COMPONENT_NAME, "Component102");
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.STATE, State.INSTALLED.name());
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.DESIRED_STATE, State.STARTED.name());
     hostsComponentResource3.setProperty(
-        HostComponentResourceProvider.HOST_COMPONENT_VERSION_PROPERTY_ID, repositoryVersion2);
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_STACK_ID_PROPERTY_ID, stackId2.getStackId());
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_UPGRADE_STATE_PROPERTY_ID, UpgradeState.NONE.name());
-    hostsComponentResource3.setProperty(HostComponentResourceProvider.HOST_COMPONENT_DESIRED_REPOSITORY_VERSION, repositoryVersion2);
+        HostComponentResourceProvider.VERSION, repositoryVersion2);
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.DESIRED_STACK_ID, stackId2.getStackId());
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.UPGRADE_STATE, UpgradeState.NONE.name());
+    hostsComponentResource3.setProperty(HostComponentResourceProvider.DESIRED_REPOSITORY_VERSION, repositoryVersion2);
 
     hostsComponentResources.add(hostsComponentResource1);
     hostsComponentResources.add(hostsComponentResource2);
@@ -297,7 +297,7 @@ public class HostComponentResourceProviderTest {
         Assert.assertEquals(expectedNameValues.get(key), resource.getPropertyValue(key));
       }
       names.add((String) resource.getPropertyValue(
-          HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID));
+          HostComponentResourceProvider.COMPONENT_NAME));
     }
     // Make sure that all of the response objects got moved into resources
     for (ServiceComponentHostResponse response : allResponse) {
@@ -397,16 +397,16 @@ public class HostComponentResourceProviderTest {
 
     Map<String, Object> properties = new LinkedHashMap<>();
 
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, "STARTED");
+    properties.put(HostComponentResourceProvider.STATE, "STARTED");
 
     // create the request
     Request request = PropertyHelper.getUpdateRequest(properties, mapRequestProps);
 
     // update the cluster named Cluster102
     Predicate predicate = new PredicateBuilder().property(
-        HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID).equals("Cluster102").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID).equals("INSTALLED").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component100").toPredicate();
+        HostComponentResourceProvider.CLUSTER_NAME).equals("Cluster102").and().
+        property(HostComponentResourceProvider.STATE).equals("INSTALLED").and().
+        property(HostComponentResourceProvider.COMPONENT_NAME).equals("Component100").toPredicate();
     RequestStatus requestStatus = provider.updateResources(request, predicate);
     Resource responseResource = requestStatus.getRequestResource();
     assertEquals("response msg", responseResource.getPropertyValue(PropertyHelper.getPropertyId("Requests", "message")));
@@ -459,8 +459,8 @@ public class HostComponentResourceProviderTest {
     provider.addObserver(observer);
 
     Predicate predicate = new PredicateBuilder().
-        property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component100").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_HOST_NAME_PROPERTY_ID).equals("Host100").toPredicate();
+        property(HostComponentResourceProvider.COMPONENT_NAME).equals("Component100").and().
+        property(HostComponentResourceProvider.HOST_NAME).equals("Host100").toPredicate();
     provider.deleteResources(new RequestImpl(null, null, null, null), predicate);
 
 
@@ -575,16 +575,16 @@ public class HostComponentResourceProviderTest {
 
     Map<String, Object> properties = new LinkedHashMap<>();
 
-    properties.put(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID, "STARTED");
+    properties.put(HostComponentResourceProvider.STATE, "STARTED");
 
     // create the request
     Request request = PropertyHelper.getUpdateRequest(properties, mapRequestProps);
 
     // update the cluster named Cluster102
     Predicate predicate = new PredicateBuilder().property(
-        HostComponentResourceProvider.HOST_COMPONENT_CLUSTER_NAME_PROPERTY_ID).equals("Cluster102").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_STATE_PROPERTY_ID).equals("INSTALLED").and().
-        property(HostComponentResourceProvider.HOST_COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("Component100").toPredicate();
+        HostComponentResourceProvider.CLUSTER_NAME).equals("Cluster102").and().
+        property(HostComponentResourceProvider.STATE).equals("INSTALLED").and().
+        property(HostComponentResourceProvider.COMPONENT_NAME).equals("Component100").toPredicate();
 
 
     try {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RequestResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RequestResourceProviderTest.java
@@ -19,7 +19,7 @@
 package org.apache.ambari.server.controller.internal;
 
 
-import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.STALE_CONFIGS;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.eq;
@@ -1178,7 +1178,7 @@ public class RequestResourceProviderTest {
     properties.put(RequestResourceProvider.REQUEST_CLUSTER_NAME_PROPERTY_ID, "c1");
 
     Set<Map<String, Object>> filterSet = new HashSet<>();
-    String predicateProperty = HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID + "=true";
+    String predicateProperty = STALE_CONFIGS + "=true";
     Map<String, Object> filterMap = new HashMap<>();
     filterMap.put(RequestResourceProvider.HOSTS_PREDICATE, predicateProperty);
     filterSet.add(filterMap);
@@ -1206,7 +1206,7 @@ public class RequestResourceProviderTest {
     String propertyIdToAssert = null;
     Object propertyValueToAssert = null;
     for (Map.Entry<String, Object> predicateEntry : predicateProperties.entrySet()) {
-      if (predicateEntry.getKey().equals(HOST_COMPONENT_STALE_CONFIGS_PROPERTY_ID)) {
+      if (predicateEntry.getKey().equals(STALE_CONFIGS)) {
         propertyIdToAssert = predicateEntry.getKey();
         propertyValueToAssert = predicateEntry.getValue();
       }

--- a/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java
+++ b/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ambari.annotations;
 
 import java.lang.annotation.ElementType;

--- a/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java
+++ b/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java
@@ -1,0 +1,22 @@
+package org.apache.ambari.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@link SwaggerPreferredParent} is used to add information
+ * to help {@link org.apache.ambari.swagger.AmbariSwaggerReader} decide how
+ * to handle nested API resources which have multiple top level API parents.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SwaggerPreferredParent {
+
+    /**
+     * Class name of preferred parent object
+     * @return
+     */
+    Class preferredParent();
+}

--- a/ambari-utility/src/main/java/org/apache/ambari/swagger/AmbariSwaggerReader.java
+++ b/ambari-utility/src/main/java/org/apache/ambari/swagger/AmbariSwaggerReader.java
@@ -93,7 +93,7 @@ public class AmbariSwaggerReader extends JaxrsReader {
                   returnType.getName());
             }
             else {
-              Boolean skipAdd = false;
+              boolean skipAdd = false;
               Class<?> preferredParentClass = cls;
 
               // API is a nested API of multiple top level APIs

--- a/ambari-utility/src/main/java/org/apache/ambari/swagger/AmbariSwaggerReader.java
+++ b/ambari-utility/src/main/java/org/apache/ambari/swagger/AmbariSwaggerReader.java
@@ -126,12 +126,11 @@ public class AmbariSwaggerReader extends JaxrsReader {
                 continue;
               } else {
                 nestedAPIs.remove(returnType);
-                cls = preferredParentClass;
               }
 
               logger.info("Registering nested API: {}", returnType);
-              NestedApiRecord nar = new NestedApiRecord(returnType, cls, validateParentApiPath(cls), method,
-                      methodPath.value());
+              NestedApiRecord nar = new NestedApiRecord(returnType, preferredParentClass,
+                      validateParentApiPath(preferredParentClass), method, methodPath.value());
               nestedAPIs.put(returnType, nar);
             }
           }

--- a/ambari-utility/src/test/java/org/apache/ambari/swagger/AmbariSwaggerReaderTest.java
+++ b/ambari-utility/src/test/java/org/apache/ambari/swagger/AmbariSwaggerReaderTest.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.assertEquals ;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -31,12 +33,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 import org.apache.ambari.annotations.SwaggerPreferredParent;
-import org.apache.commons.collections.set.ListOrderedSet;
 import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import io.swagger.annotations.Api;
@@ -80,8 +80,8 @@ public class AmbariSwaggerReaderTest {
   @Test
   public void swaggerConflictingNestedApis() {
     AmbariSwaggerReader asr = new AmbariSwaggerReader(null, createMock(Log.class));
-    ListOrderedSet classes = ListOrderedSet.decorate(
-        Lists.newArrayList(TopLevelAPI.class, AnotherTopLevelAPI.class, NestedAPI.class));
+    Set<Class<?>> classes = new LinkedHashSet<>(Arrays.asList(TopLevelAPI.class, AnotherTopLevelAPI.class,
+            NestedAPI.class));
     Swagger swagger = asr.read(classes);
     assertEquals(
         ImmutableSet.of("/toplevel/top", "/toplevel/{param}/nested/list", "/toplevel2/anotherTop"),
@@ -97,8 +97,8 @@ public class AmbariSwaggerReaderTest {
   @Test
   public void swaggerConflictingNestedApisWithPreferredParent() {
     AmbariSwaggerReader asr = new AmbariSwaggerReader(null, createMock(Log.class));
-    ListOrderedSet classes = ListOrderedSet.decorate(
-            Lists.newArrayList(TopLevelAPI.class, AnotherTopLevelAPI.class, NestedWithPreferredParentAPI.class));
+    Set<Class<?>> classes = new LinkedHashSet<>(Arrays.asList(TopLevelAPI.class, AnotherTopLevelAPI.class,
+            NestedWithPreferredParentAPI.class));
     Swagger swagger = asr.read(classes);
     assertEquals(
             ImmutableSet.of("/toplevel/top", "/toplevel2/{param}/nestedWithPreferredParent/list",
@@ -115,8 +115,8 @@ public class AmbariSwaggerReaderTest {
   @Test
   public void swaggerConflictingNestedApisWithSamePreferredParent() {
     AmbariSwaggerReader asr = new AmbariSwaggerReader(null, createMock(Log.class));
-    ListOrderedSet classes = ListOrderedSet.decorate(
-            Lists.newArrayList(TopLevelAPI.class, AnotherTopLevelAPI.class, NestedWithSamePreferredParentAPI.class));
+    Set<Class<?>> classes = new LinkedHashSet<>(Arrays.asList(TopLevelAPI.class, AnotherTopLevelAPI.class,
+            NestedWithSamePreferredParentAPI.class));
     Swagger swagger = asr.read(classes);
     assertEquals(
             ImmutableSet.of("/toplevel/top", "/toplevel/{param}/nestedWithSamePreferredParent/list",
@@ -134,8 +134,8 @@ public class AmbariSwaggerReaderTest {
   @Test
   public void swaggerConflictingNestedApisWithBadPreferredParent() {
     AmbariSwaggerReader asr = new AmbariSwaggerReader(null, createMock(Log.class));
-    ListOrderedSet classes = ListOrderedSet.decorate(
-            Lists.newArrayList(TopLevelAPI.class, AnotherTopLevelAPI.class, NestedWithBadPreferredParentAPI.class));
+    Set<Class<?>> classes = new LinkedHashSet<>(Arrays.asList(TopLevelAPI.class, AnotherTopLevelAPI.class,
+            NestedWithBadPreferredParentAPI.class));
     Swagger swagger = asr.read(classes);
     assertEquals(
             ImmutableSet.of("/toplevel/top", "/toplevel2/{param}/nestedWithBadPreferredParent/list",


### PR DESCRIPTION
Change-Id: I6b9964a2cf345f6a2365f2c8b168366ad43cb1bf

## What changes were proposed in this pull request?

Add swagger documentation to HostComponent API endpoints

## How was this patch tested?

Generate swagger docs by

```
mvn process-classes -Dgenerate.swagger.resources -pl ambari-server
```

then manually checking Swagger output at ambari-server/docs/api/generated/index.html

checkstyle using:

```
clean checkstyle:checkstyle -pl ambari-server
```

API endpoints at `api/v1/clusters/{clusterName}/hosts/{hostName}/host_components/` have also been tested manually

_Updates:_

changes in `ambari-utility` have been tested with: 

```
mvn test -Drat.skip -Dtest=AmbariSwaggerReaderTest -pl ambari-utility
mvn checkstyle:checkstyle -pl ambari-utility
```

please review @adoroszlai @benyoka