### PR TITLE
[AMBARI-23367] XMLConfig files written by setup_ranger_plugin_xml.py …

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
@@ -148,7 +148,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
       configuration_attributes=plugin_audit_attributes,
       owner = component_user,
       group = component_group,
-      mode=0744)
+      mode=0644)
 
     XmlConfig(format('ranger-{service_name}-security.xml'),
       conf_dir=component_conf_dir,
@@ -156,7 +156,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
       configuration_attributes=plugin_security_attributes,
       owner = component_user,
       group = component_group,
-      mode=0744)
+      mode=0644)
 
     # remove plain-text password from xml configs
     plugin_password_properties = ['xasecure.policymgr.clientssl.keystore.password', 'xasecure.policymgr.clientssl.truststore.password']
@@ -174,7 +174,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
         configuration_attributes=plugin_policymgr_ssl_attributes,
         owner = component_user,
         group = component_group,
-        mode=0744) 
+        mode=0644)
     else:
       XmlConfig("ranger-policymgr-ssl.xml",
         conf_dir=component_conf_dir,
@@ -182,7 +182,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
         configuration_attributes=plugin_policymgr_ssl_attributes,
         owner = component_user,
         group = component_group,
-        mode=0744) 
+        mode=0644)
 
     # creating symblink should be done by rpm package
     # setup_ranger_plugin_jar_symblink(stack_version, service_name, component_list)


### PR DESCRIPTION
…should use 0644 instead of 0744 for XML files

## What changes were proposed in this pull request?
XML configuration files do not need 0744 permission (execute permission) so suggesting a change to make it 0644. This is observed that when we enabled ranger plugins (like for knox) then we see that it creates those config files (ranger-knox-audit.xml, ranger-knox-security.xml, ranger-policymgr-ssl.xml) with 744 permissions.


## How was this patch tested?
Manually tested.
Build was successful locally.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.