### PR TITLE
AMBARI-23368. Initialize 'topologyHolder', 'hostLevelParamsHolder', 'recoveryConfigHelper' in HostResourceProvider.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -39,7 +39,10 @@ import org.apache.ambari.server.StaticallyInject;
 import org.apache.ambari.server.actionmanager.ActionManager;
 import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
 import org.apache.ambari.server.agent.HeartBeatHandler;
+import org.apache.ambari.server.agent.RecoveryConfigHelper;
 import org.apache.ambari.server.agent.rest.AgentResource;
+import org.apache.ambari.server.agent.stomp.HostLevelParamsHolder;
+import org.apache.ambari.server.agent.stomp.TopologyHolder;
 import org.apache.ambari.server.api.AmbariErrorHandler;
 import org.apache.ambari.server.api.AmbariPersistFilter;
 import org.apache.ambari.server.api.MethodOverrideFilter;
@@ -912,6 +915,10 @@ public class AmbariServer {
 
     StageUtils.setGson(injector.getInstance(Gson.class));
     StageUtils.setTopologyManager(injector.getInstance(TopologyManager.class));
+    HostResourceProvider.setRecoveryConfigHelper(injector.getInstance(RecoveryConfigHelper.class));
+    HostResourceProvider.setHostLevelParamsHolder(injector.getInstance(HostLevelParamsHolder.class));
+    HostResourceProvider.setTopologyHolder(injector.getInstance(TopologyHolder.class));
+
     StageUtils.setConfiguration(injector.getInstance(Configuration.class));
     SecurityFilter.init(injector.getInstance(Configuration.class));
     StackDefinedPropertyProvider.init(injector);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -206,13 +206,13 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
   private static TopologyManager topologyManager;
 
   @Inject
-  private TopologyHolder topologyHolder;
+  private static TopologyHolder topologyHolder;
 
   @Inject
-  private HostLevelParamsHolder hostLevelParamsHolder;
+  private static HostLevelParamsHolder hostLevelParamsHolder;
 
   @Inject
-  private RecoveryConfigHelper recoveryConfigHelper;
+  private static RecoveryConfigHelper recoveryConfigHelper;
 
   @Inject
   private AmbariMetaInfo ambariMetaInfo;
@@ -1181,5 +1181,17 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
   //todo: proper static injection of topology manager
   public static void setTopologyManager(TopologyManager topologyManager) {
     HostResourceProvider.topologyManager = topologyManager;
+  }
+
+  public static void setRecoveryConfigHelper(RecoveryConfigHelper recoveryConfigHelper) {
+      HostResourceProvider.recoveryConfigHelper = recoveryConfigHelper;
+  }
+
+  public static void setTopologyHolder(TopologyHolder topologyHolder) {
+      HostResourceProvider.topologyHolder = topologyHolder;
+  }
+
+  public static void setHostLevelParamsHolder(HostLevelParamsHolder hostLevelParamsHolder) {
+      HostResourceProvider.hostLevelParamsHolder = hostLevelParamsHolder;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- After **trunk** merge into **branch-feature-AMBARI-14714**


```
commit 65f010cfce4af4eeffc72a125bf2307f7fbc1e87
Merge: 8e5b0de 0ed3485
Author: Swapan Shridhar <sshridhar@hortonworks.com>
Date:   Mon Mar 26 16:32:54 2018 -0700

    Merging Trunk to branch : 'branch-feature-AMBARI-14714'.

```

- POST hosts started failing with NPE at https://github.com/apache/ambari/blob/branch-feature-AMBARI-14714/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java#L585

Stack Trace : ambari-server.log: 

```

27 Mar 2018 03:03:08,284  WARN [ambari-client-thread-95] HttpChannel:507 - /api/v1/clusters/c1/hosts
java.lang.NullPointerException
        at org.apache.ambari.server.controller.internal.HostResourceProvider.createHosts(HostResourceProvider.java:585)
        at org.apache.ambari.server.controller.internal.HostResourceProvider$1.invoke(HostResourceProvider.java:255)
        at org.apache.ambari.server.controller.internal.HostResourceProvider$1.invoke(HostResourceProvider.java:252)
        at org.apache.ambari.server.controller.internal.AbstractResourceProvider.invokeWithRetry(AbstractResourceProvider.java:465)
        at org.apache.ambari.server.controller.internal.AbstractResourceProvider.createResources(AbstractResourceProvider.java:288)
        at org.apache.ambari.server.controller.internal.HostResourceProvider.createResourcesAuthorized(HostResourceProvider.java:252)
        at org.apache.ambari.server.controller.internal.AbstractAuthorizedResourceProvider.createResources(AbstractAuthorizedResourceProvider.java:231)

```

**Code Line:**

File: https://github.com/apache/ambari/blob/branch-feature-AMBARI-14714/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java#L585}

```
   for (HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent : hostLevelParamsUpdateEvents) {
      hostLevelParamsHolder.updateData(hostLevelParamsUpdateEvent);
    }

```

**Reason :** With perf->trunk->feature branch merge, we have started using *hostLevelParamsHolder*, which has not been initialized/injected. Similarly for others : 'topologyHolder' and 'recoveryConfigHelper'.

**Fix :** Added initialization code for them.

## How was this patch tested?

Tested on live cluster.