### PR TITLE
AMBARI-23371. Update Log Search integration test framework to work with Solr7 API.

### DIFF
--- a/ambari-logsearch/README.md
+++ b/ambari-logsearch/README.md
@@ -59,7 +59,7 @@ By default integration tests are not a part of the build process, you need to se
 # from ambari-logsearch folder
 mvn clean integration-test -Dbackend-tests failsafe:verify
 # or run selenium tests with docker for mac, but before that you nedd to start xquartz
-xquartz
+open -a XQuartz
 # then in an another window you can start ui tests
 mvn clean integration-test -Dselenium-tests failsafe:verify
 # you can specify story file folde location with -Dbackend.stories.location and -Dui.stories.location (absolute file path) in the commands

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/StoryDataRegistry.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/StoryDataRegistry.java
@@ -29,6 +29,7 @@ public class StoryDataRegistry {
   private String dockerHost;
   private String ambariFolder;
   private String shellScriptLocation;
+  private String shellScriptFolder;
   private final int solrPort = 8886;
   private final int logsearchPort = 61888;
   private final int zookeeperPort = 9983;
@@ -105,5 +106,13 @@ public class StoryDataRegistry {
 
   public void setWebDriverProvider(WebDriverProvider webDriverProvider) {
     this.webDriverProvider = webDriverProvider;
+  }
+
+  public String getShellScriptFolder() {
+    return shellScriptFolder;
+  }
+
+  public void setShellScriptFolder(String shellScriptFolder) {
+    this.shellScriptFolder = shellScriptFolder;
   }
 }

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchDockerSteps.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchDockerSteps.java
@@ -62,6 +62,6 @@ public class LogSearchDockerSteps extends AbstractLogSearchSteps {
 
   @AfterStories
   public void removeLogSearchContainer() {
-    runCommand(new String[]{StoryDataRegistry.INSTANCE.getShellScriptLocation(), "stop"});
+    runCommand(StoryDataRegistry.INSTANCE.getShellScriptFolder(), new String[]{StoryDataRegistry.INSTANCE.getShellScriptLocation(), "stop"});
   }
 }

--- a/ambari-logsearch/docker/all.yml
+++ b/ambari-logsearch/docker/all.yml
@@ -30,7 +30,7 @@ services:
           - 4444:4444
           - 9983:9983
         environment:
-          DISPLAY: $DOCKERIP:0
+          DISPLAY: $DISPLAY_MAC:0
         volumes:
           - $MAVEN_REPOSITORY_LOCATION:/root/.m2
           - $AMBARI_LOCATION:/root/ambari

--- a/ambari-logsearch/docker/all.yml
+++ b/ambari-logsearch/docker/all.yml
@@ -30,7 +30,7 @@ services:
           - 4444:4444
           - 9983:9983
         environment:
-          DISPLAY: $DISPLAY_MAC:0
+          DISPLAY: $DISPLAY_MAC
         volumes:
           - $MAVEN_REPOSITORY_LOCATION:/root/.m2
           - $AMBARI_LOCATION:/root/ambari

--- a/ambari-logsearch/docker/logsearch-docker.sh
+++ b/ambari-logsearch/docker/logsearch-docker.sh
@@ -100,9 +100,9 @@ function setup_env() {
     pushd $sdir/../../
     local AMBARI_LOCATION=$(pwd)
     popd
-    local docker_ip=$(get_docker_ip)
+    local display_ip=$(get_docker_ip)
     cat << EOF > $sdir/.env
-DOCKERIP=$docker_ip
+DISPLAY_MAC=$display_ip:0
 MAVEN_REPOSITORY_LOCATION=$HOME/.m2
 AMBARI_LOCATION=$AMBARI_LOCATION
 
@@ -119,6 +119,11 @@ EOF
 function kill_logsearch_container() {
   echo "Try to remove logsearch container if exists..."
   docker rm -f logsearch
+}
+
+function setup_x11() {
+  local display_ip=$(get_docker_ip)
+  xhost + $display_ip
 }
 
 case $command in
@@ -151,7 +156,10 @@ case $command in
   "stop")
      kill_logsearch_container
      ;;
+  "setup-x11")
+     setup_x11
+     ;;
    *)
-   echo "Available commands: (start|stop|build-and-run|build|build-docker-and-run|build-mvn-and-run|build-docker-only|build-mvn-only)"
+   echo "Available commands: (start|stop|build-and-run|build|build-docker-and-run|build-mvn-and-run|build-docker-only|build-mvn-only|setup-x11)"
    ;;
 esac


### PR DESCRIPTION
## What changes were proposed in this pull request?
Solr7 replica naming changed so we need to update this in the IT source code as well.
Also added a change to pass proper directory as env where we are using logsearch-docker.sh script (right now it has no any effect, but long term its more clear if we are trying to access that file from the right directory)

## How was this patch tested?
UT Not required. Manually. 

Please review @g-boros @zeroflag @adoroszlai 