### PR TITLE
AMBARI-23373. Fix formatZKFC

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/zkfc_slave.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/zkfc_slave.py
@@ -59,7 +59,7 @@ class ZkfcSlave(Script):
     import params
     env.set_params(params)
 
-    Execute("hdfs zkfc -formatZK",
+    Execute("hdfs zkfc -formatZK -nonInteractive",
             user=params.hdfs_user,
             logoutput=True
     )

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/zkfc_slave.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/zkfc_slave.py
@@ -35,6 +35,7 @@ from resource_management.libraries.script import Script
 from resource_management.core.resources.zkmigrator import ZkMigrator
 from resource_management.core.resources.system import Execute
 from resource_management.core.exceptions import Fail, ComponentIsNotRunning
+from resource_management.core.resources.system import Execute
 
 
 class ZkfcSlave(Script):
@@ -53,6 +54,15 @@ class ZkfcSlave(Script):
     hdfs("zkfc_slave")
     utils.set_up_zkfc_security(params)
     pass
+
+  def format(self, env):
+    import params
+    env.set_params(params)
+
+    Execute("hdfs zkfc -formatZK",
+            user=params.hdfs_user,
+            logoutput=True
+    )
 
 @OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
 class ZkfcSlaveDefault(ZkfcSlave):
@@ -137,19 +147,6 @@ class ZkfcSlaveDefault(ZkfcSlave):
     env.set_params(params)
     if check_stack_feature(StackFeature.ZKFC_VERSION_ADVERTISED, params.version_for_stack_feature_checks):
       stack_select.select_packages(params.version)
-      
-  def format(self, env):
-    import params
-    env.set_params(params)
-
-    try:
-      self.status(env)
-      raise Fail("ZKFC is running. Cannot format it.")
-    except ComponentIsNotRunning:
-      Execute("hdfs zkfc -formatZK",
-              user=params.hdfs_user,
-              logoutput=True
-      )
 
 def initialize_ha_zookeeper(params):
   try:


### PR DESCRIPTION
resource_management.core.exceptions.Fail: Script '/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/zkfc_slave.py' has no method 'format'