### PR TITLE
[AMBARI-23346] Fixed Python unit test after changing default timeout to 90 seconds

### DIFF
--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -8694,11 +8694,11 @@ class TestAmbariServer(TestCase):
 
     properties = Properties()
     timeout = get_web_server_startup_timeout(properties)
-    self.assertEquals(50, timeout)
+    self.assertEquals(90, timeout)
 
     properties.process_pair(WEB_SERVER_STARTUP_TIMEOUT, "")
     timeout = get_web_server_startup_timeout(properties)
-    self.assertEquals(50, timeout)
+    self.assertEquals(90, timeout)
 
     properties.process_pair(WEB_SERVER_STARTUP_TIMEOUT, "120")
     timeout = get_web_server_startup_timeout(properties)


### PR DESCRIPTION
## What changes were proposed in this pull request?

We forgot to update unit tests when changing the default timeout for web server startup from 50 to 90 seconds (see PR #767)

## How was this patch tested?

Unit testing:
```
mvn -Del.log=WARN -Dcheckstyle.skip -Dfindbugs.skip -Drat.skip -DskipSurefireTests=true -Dpython.test.mask=TestAmbariServer.py clean test

...

Total run:125
Total errors:0
Total failures:0
OK
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 51.217 s
[INFO] Finished at: 2018-03-27T16:03:41+02:00
[INFO] Final Memory: 125M/1598M
[INFO] ------------------------------------------------------------------------
```