### PR TITLE
AMBARI-23369 Livy server fails to start after Ambari upgrade due to m…

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/livy_server.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/livy_server.py
@@ -32,6 +32,7 @@ from resource_management.libraries.functions.decorator import retry
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions import stack_select
+from resource_management.libraries.functions import namenode_ha_utils
 
 from livy_service import livy_service
 from setup_livy import setup_livy
@@ -110,10 +111,12 @@ class LivyServer(Script):
       Logger.info("Verifying if DFS directory '" + dir_path + "' exists.")
 
       dir_exists = None
+      nameservices = namenode_ha_utils.get_nameservices(params.hdfs_site)
+      nameservice = None if not nameservices else nameservices[-1]
 
       if WebHDFSUtil.is_webhdfs_available(params.is_webhdfs_enabled, params.default_fs):
         # check with webhdfs is much faster than executing hdfs dfs -test
-        util = WebHDFSUtil(params.hdfs_site, params.hdfs_user, params.security_enabled)
+        util = WebHDFSUtil(params.hdfs_site, nameservice, params.hdfs_user, params.security_enabled)
         list_status = util.run_command(dir_path, 'GETFILESTATUS', method='GET', ignore_status_codes=['404'], assertable_result=False)
         dir_exists = ('FileStatus' in list_status)
       else:

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/livy2_server.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/livy2_server.py
@@ -32,6 +32,7 @@ from resource_management.libraries.functions.decorator import retry
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions import stack_select
+from resource_management.libraries.functions import namenode_ha_utils
 
 from livy2_service import livy2_service
 from setup_livy2 import setup_livy
@@ -109,10 +110,12 @@ class LivyServer(Script):
       Logger.info("Verifying if DFS directory '" + dir_path + "' exists.")
 
       dir_exists = None
+      nameservices = namenode_ha_utils.get_nameservices(params.hdfs_site)
+      nameservice = None if not nameservices else nameservices[-1]
 
       if WebHDFSUtil.is_webhdfs_available(params.is_webhdfs_enabled, params.default_fs):
         # check with webhdfs is much faster than executing hdfs dfs -test
-        util = WebHDFSUtil(params.hdfs_site, params.hdfs_user, params.security_enabled)
+        util = WebHDFSUtil(params.hdfs_site, nameservice, params.hdfs_user, params.security_enabled)
         list_status = util.run_command(dir_path, 'GETFILESTATUS', method='GET', ignore_status_codes=['404'], assertable_result=False)
         dir_exists = ('FileStatus' in list_status)
       else:


### PR DESCRIPTION
…issing argument for nameservice

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

Ran all python unit tests, except one: test_web_server_startup_timeout in TestAmbariServer.py (which fails due to a known issue and not my change)

====================
Ran 235 tests in 9.325s

OK
----------------------------------------------------------------------
Total run:1178
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 06:58 min
[INFO] Finished at: 2018-03-27T19:29:43+05:30
[INFO] Final Memory: 110M/988M
[INFO] ------------------------------------------------------------------------

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.