### PR TITLE
AMBARI-23370 Download client configs fails due to 'clusterLevelParam' missing

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -588,8 +588,6 @@ public class KerberosHelperImpl implements KerberosHelper {
           configurations.put("clusterHostInfo", clusterHostInfoMap);
         }
 
-        Map<String, String> componentToClusterInfoMap = StageUtils.getComponentToClusterInfoKeyMap();
-
         // Iterate through the recommendations to find the recommended host assignments
         for (RecommendationResponse.HostGroup hostGroup : hostGroups) {
           Set<Map<String, String>> components = hostGroup.getComponents();
@@ -607,13 +605,7 @@ public class KerberosHelperImpl implements KerberosHelper {
                   // If the component filter is null or the current component is found in the filter,
                   // include it in the map
                   if ((componentFilter == null) || componentFilter.contains(componentName)) {
-                    String key = componentToClusterInfoMap.get(componentName);
-
-                    if (StringUtils.isEmpty(key)) {
-                      // If not found in the componentToClusterInfoMap, then keys are assumed to be
-                      // in the form of <component_name>_hosts (lowercase)
-                      key = componentName.toLowerCase() + "_hosts";
-                    }
+                    String key = StageUtils.getClusterHostInfoKey(componentName);
 
                     Set<String> fqdns = new TreeSet<>();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
@@ -285,10 +285,7 @@ public class ClusterConfigurationRequest {
       for (String component : components) {
         Collection<String> componentHost = clusterTopology.getHostAssignmentsForComponent(component);
         // retrieve corresponding clusterInfoKey for component using StageUtils
-        String clusterInfoKey = StageUtils.getComponentToClusterInfoKeyMap().get(component);
-        if (clusterInfoKey == null) {
-          clusterInfoKey = component.toLowerCase() + "_hosts";
-        }
+        String clusterInfoKey = StageUtils.getClusterHostInfoKey(component);
         componentHostsMap.put(clusterInfoKey, StringUtils.join(componentHost, ","));
       }
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -1318,7 +1318,7 @@ public class AmbariManagementControllerTest {
     assertTrue(ec.getCommandParams().containsKey("command_retry_enabled"));
     assertEquals("false", ec.getCommandParams().get("command_retry_enabled"));
     Map<String, Set<String>> chInfo = ec.getClusterHostInfo();
-    assertTrue(chInfo.containsKey("namenode_host"));
+    assertTrue(chInfo.containsKey("namenode_hosts"));
     assertFalse(ec.getCommandParams().containsKey("custom_folder"));
 
     ec = controller.getExecutionCommand(cluster,

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -559,19 +559,19 @@ public class StageUtilsTest extends EasyMockSupport {
     assertEquals(StageUtils.getHostName(), serverHost.iterator().next());
 
     // check host role replacing by the projected topology
-    assertTrue(getDecompressedSet(info.get("hbase_rs_hosts")).contains(9));
+    assertTrue(getDecompressedSet(info.get("hbase_regionserver_hosts")).contains(9));
 
     // Validate substitutions...
     info = StageUtils.substituteHostIndexes(info);
 
-    checkServiceHostNames(info, "DATANODE", "slave_hosts", projectedTopology);
-    checkServiceHostNames(info, "NAMENODE", "namenode_host", projectedTopology);
-    checkServiceHostNames(info, "SECONDARY_NAMENODE", "snamenode_host", projectedTopology);
-    checkServiceHostNames(info, "HBASE_MASTER", "hbase_master_hosts", projectedTopology);
-    checkServiceHostNames(info, "HBASE_REGIONSERVER", "hbase_rs_hosts", projectedTopology);
-    checkServiceHostNames(info, "JOBTRACKER", "jtnode_host", projectedTopology);
-    checkServiceHostNames(info, "TASKTRACKER", "mapred_tt_hosts", projectedTopology);
-    checkServiceHostNames(info, "NONAME_SERVER", "noname_server_hosts", projectedTopology);
+    checkServiceHostNames(info, "DATANODE", projectedTopology);
+    checkServiceHostNames(info, "NAMENODE", projectedTopology);
+    checkServiceHostNames(info, "SECONDARY_NAMENODE", projectedTopology);
+    checkServiceHostNames(info, "HBASE_MASTER", projectedTopology);
+    checkServiceHostNames(info, "HBASE_REGIONSERVER", projectedTopology);
+    checkServiceHostNames(info, "JOBTRACKER", projectedTopology);
+    checkServiceHostNames(info, "TASKTRACKER", projectedTopology);
+    checkServiceHostNames(info, "NONAME_SERVER", projectedTopology);
   }
 
   private void insertTopology(Map<String, Collection<String>> projectedTopology, String componentName, Set<String> hostNames) {
@@ -700,7 +700,7 @@ public class StageUtilsTest extends EasyMockSupport {
     }
 
     // Determine the actual hosts for a given component...
-    Set<String> hosts = info.get(mappedComponentName);
+    Set<String> hosts = info.get(StageUtils.getClusterHostInfoKey(componentName));
     if (hosts != null) {
       actualHostsList.addAll(getDecompressedSet(hosts));
     }
@@ -708,7 +708,7 @@ public class StageUtilsTest extends EasyMockSupport {
     assertEquals(expectedHostsList, actualHostsList);
   }
 
-  private void checkServiceHostNames(Map<String, Set<String>> info, String componentName, String mappedComponentName,
+  private void checkServiceHostNames(Map<String, Set<String>> info, String componentName,
                                      Map<String, Collection<String>> serviceTopology) {
     Set<String> expectedHostsList = new HashSet<>();
     Set<String> actualHostsList = new HashSet<>();
@@ -721,7 +721,7 @@ public class StageUtilsTest extends EasyMockSupport {
     }
 
     // Determine the actual hosts for a given component...
-    Set<String> hosts = info.get(mappedComponentName);
+    Set<String> hosts = info.get(StageUtils.getClusterHostInfoKey(componentName));
     if (hosts != null) {
       actualHostsList.addAll(hosts);
     }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Agent json format has changed. This change was not  done in ClientConfigResourceProvider.

## How was this patch tested?

-JUnit
-Deployed an ambari server, deployed all services, downloaded all the  configs.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

