### PR TITLE
[AMBARI-23380] Fix intermittent "No such file or directory" error in TestHostCleanup

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
@@ -511,8 +511,13 @@ class HostCleanup:
     for folder in folders:
       for filename in os.listdir(folder):
         fileToCheck = os.path.join(folder, filename)
-        stat = os.stat(fileToCheck)
-        if stat.st_uid in userIds:
+        try:
+          stat = os.stat(fileToCheck)
+        except OSError:
+          stat = None
+          logger.warn("Cannot stat file, skipping: " + fileToCheck)
+
+        if stat and stat.st_uid in userIds:
           self.do_erase_dir_silent([fileToCheck])
           logger.info("Deleting file/folder: " + fileToCheck)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent "No such file or directory" error in TestHostCleanup

```
======================================================================
ERROR: test_do_cleanup_all (TestHostCleanup.TestHostCleanup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-common/src/test/python/mock/mock.py", line 1199, in patched
    return func(*args, **keywargs)
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/test/python/ambari_agent/TestHostCleanup.py", line 233, in test_do_cleanup_all
    self.hostcleanup.do_cleanup(propertyMap)
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/main/python/ambari_agent/HostCleanup.py", line 168, in do_cleanup
    self.do_delete_by_owner(userIds, FOLDER_LIST)
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-agent/src/main/python/ambari_agent/HostCleanup.py", line 514, in do_delete_by_owner
    stat = os.stat(fileToCheck)
OSError: [Errno 2] No such file or directory: '/tmp/symlink2120964127269148256test_link'
```

The tmp file seems to be unrelated to the unit test and disappears between getting the list of files in `/tmp` and attempting to `stat` it. See https://github.com/apache/ambari/blob/trunk/ambari-agent/src/main/python/ambari_agent/HostCleanup.py#L512.  

To help this issue, the `OSError` is caught when attempting to `stat` the file. If the file goes away and an OSError is thrown, the function will now happily skip the file while logging a warning.

## How was this patch tested?

Unit tests executed:
```
$ mvn -pl ambari-agent -DskipSurefireTests test
...
test_clear_cache (TestHostCleanup.TestHostCleanup) ... ok
test_do_cleanup_all (TestHostCleanup.TestHostCleanup) ... ok
test_do_cleanup_default (TestHostCleanup.TestHostCleanup) ... ok
test_do_cleanup_with_skip (TestHostCleanup.TestHostCleanup) ... ok
test_do_delete_by_owner (TestHostCleanup.TestHostCleanup) ... ok
test_do_delete_users (TestHostCleanup.TestHostCleanup) ... ok
test_do_erase_alternatives (TestHostCleanup.TestHostCleanup) ... ok
test_do_erase_packages (TestHostCleanup.TestHostCleanup) ... ok
test_find_repo_files_for_repos (TestHostCleanup.TestHostCleanup) ... ok
test_options (TestHostCleanup.TestHostCleanup) ... ok
test_options_silent (TestHostCleanup.TestHostCleanup) ... ok
test_read_host_check_file (TestHostCleanup.TestHostCleanup) ... ok
test_read_host_check_file_with_content (TestHostCleanup.TestHostCleanup) ... ok
...
Ran 326 tests in 8.913s
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13.431 s
[INFO] Finished at: 2018-03-27T13:52:28-04:00
[INFO] Final Memory: 24M/491M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.