### PR TITLE
[AMBARI-23255] Load modules and components into a map when reading the mpack.json

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -135,6 +135,7 @@ public class MpackManager {
                   existingMpack.setResourceId(mpackEntity.getId());
                   existingMpack.setMpackUri(mpackEntity.getMpackUri());
                   existingMpack.setRegistryId(mpackEntity.getRegistryId());
+                  existingMpack.populateModuleMap();
 
                   RepositoryXml repositoryXml = RepoUtil.getRepositoryXml(file);
                   if (null == repositoryXml) {
@@ -262,6 +263,7 @@ public class MpackManager {
     //Read the mpack.json file into Mpack Object for further use.
     Gson gson = new Gson();
     Mpack mpack = gson.fromJson(new FileReader(targetPath.toString()), Mpack.class);
+    mpack.populateModuleMap();
     return mpack;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -135,6 +135,8 @@ public class MpackManager {
                   existingMpack.setResourceId(mpackEntity.getId());
                   existingMpack.setMpackUri(mpackEntity.getMpackUri());
                   existingMpack.setRegistryId(mpackEntity.getRegistryId());
+                  //Load module and component maps
+                  existingMpack.populateModuleMap();
 
                   RepositoryXml repositoryXml = RepoUtil.getRepositoryXml(file);
                   if (null == repositoryXml) {
@@ -262,6 +264,8 @@ public class MpackManager {
     //Read the mpack.json file into Mpack Object for further use.
     Gson gson = new Gson();
     Mpack mpack = gson.fromJson(new FileReader(targetPath.toString()), Mpack.class);
+    //Load module and component maps
+    mpack.populateModuleMap();
     return mpack;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
@@ -137,10 +137,7 @@ public class Module {
    * @return
    */
   public ModuleComponent getModuleComponent(String moduleComponentName) {
-    if(componentHashMap.containsKey(moduleComponentName)){
-      return componentHashMap.get(moduleComponentName);
-    }
-    return null;
+   return componentHashMap.get(moduleComponentName);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
@@ -17,10 +17,10 @@
  */
 package org.apache.ambari.server.state;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -52,6 +52,8 @@ public class Module {
   private List<ModuleDependency> dependencies;
   @SerializedName("components")
   private List<ModuleComponent> components;
+
+  private HashMap<String, ModuleComponent> componentHashMap;
 
   public Category getCategory() {
     return category;
@@ -129,13 +131,15 @@ public class Module {
     this.components = components;
   }
 
+  /**
+   * Fetch a particular module component by the component name.
+   * @param moduleComponentName
+   * @return
+   */
   public ModuleComponent getModuleComponent(String moduleComponentName) {
-    for (ModuleComponent moduleComponent : components) {
-      if (StringUtils.equals(moduleComponentName, moduleComponent.getName())) {
-        return moduleComponent;
-      }
+    if(componentHashMap.containsKey(moduleComponentName)){
+      return componentHashMap.get(moduleComponentName);
     }
-
     return null;
   }
 
@@ -174,5 +178,15 @@ public class Module {
             ", dependencies=" + dependencies +
             ", components=" + components +
             '}';
+  }
+
+  /**
+   * Loads the components into a map (component name, component) for ease of access.
+   */
+  public void populateComponentMap() {
+    componentHashMap = new HashMap<>();
+    for (ModuleComponent moduleComponent : this.getComponents()){
+      componentHashMap.put(moduleComponent.getName(), moduleComponent);
+    }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
@@ -17,10 +17,10 @@
  */
 package org.apache.ambari.server.state;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -52,6 +52,8 @@ public class Module {
   private List<ModuleDependency> dependencies;
   @SerializedName("components")
   private List<ModuleComponent> components;
+
+  private HashMap<String, ModuleComponent> componentHashMap;
 
   public Category getCategory() {
     return category;
@@ -130,12 +132,9 @@ public class Module {
   }
 
   public ModuleComponent getModuleComponent(String moduleComponentName) {
-    for (ModuleComponent moduleComponent : components) {
-      if (StringUtils.equals(moduleComponentName, moduleComponent.getName())) {
-        return moduleComponent;
-      }
+    if(componentHashMap.containsKey(moduleComponentName)){
+      return componentHashMap.get(moduleComponentName);
     }
-
     return null;
   }
 
@@ -174,5 +173,12 @@ public class Module {
             ", dependencies=" + dependencies +
             ", components=" + components +
             '}';
+  }
+
+  public void populateComponentMap() {
+    componentHashMap = new HashMap<>();
+    for (ModuleComponent mc : this.getComponents()){
+      componentHashMap.put(mc.getName(), mc);
+    }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -17,13 +17,13 @@
  */
 package org.apache.ambari.server.state;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import org.apache.ambari.server.stack.RepoUtil;
 import org.apache.ambari.server.state.stack.RepositoryXml;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 
 import com.google.gson.annotations.SerializedName;
@@ -68,6 +68,8 @@ public class Mpack {
   private String displayName;
 
   private String mpackUri;
+
+  private HashMap<String, Module> moduleHashMap;
 
   /**
    * The {@link RepoUtil#REPOSITORY_FILE_NAME} representation.
@@ -189,12 +191,9 @@ public class Mpack {
    * @return the module or {@code null}.
    */
   public Module getModule(String moduleName) {
-    for (Module module : modules) {
-      if (StringUtils.equals(moduleName, module.getName())) {
-        return module;
-      }
+    if(moduleHashMap.containsKey(moduleName)){
+      return moduleHashMap.get(moduleName);
     }
-
     return null;
   }
 
@@ -208,13 +207,12 @@ public class Mpack {
    * @return the component or {@code null}.
    */
   public ModuleComponent getModuleComponent(String moduleName, String moduleComponentName) {
-    for (Module module : modules) {
-      ModuleComponent moduleComponent = module.getModuleComponent(moduleComponentName);
-      if (null != moduleComponent) {
-        return moduleComponent;
+    if(moduleHashMap.containsKey(moduleName)){
+      Module module = moduleHashMap.get(moduleName);
+      if(module.getModuleComponent(moduleComponentName) != null){
+        return module.getModuleComponent(moduleComponentName);
       }
     }
-
     return null;
   }
 
@@ -304,6 +302,14 @@ public class Mpack {
     }
     if (displayName == null) {
       displayName = mpack.getDisplayName();
+    }
+  }
+
+  public void populateModuleMap() {
+    moduleHashMap = new HashMap<>();
+    for(Module m : this.modules){
+      m.populateComponentMap();
+      moduleHashMap.put(m.getName(), m);
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -207,12 +207,10 @@ public class Mpack {
    * @return the component or {@code null}.
    */
   public ModuleComponent getModuleComponent(String moduleName, String moduleComponentName) {
-    if(moduleHashMap.containsKey(moduleName)){
-      Module module = moduleHashMap.get(moduleName);
-      if(module.getModuleComponent(moduleComponentName) != null){
+   Module module = moduleHashMap.get(moduleName);
+      if(module !=null){
         return module.getModuleComponent(moduleComponentName);
       }
-    }
     return null;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -17,13 +17,13 @@
  */
 package org.apache.ambari.server.state;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import org.apache.ambari.server.stack.RepoUtil;
 import org.apache.ambari.server.state.stack.RepositoryXml;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 
 import com.google.gson.annotations.SerializedName;
@@ -68,6 +68,8 @@ public class Mpack {
   private String displayName;
 
   private String mpackUri;
+
+  private HashMap<String, Module> moduleHashMap;
 
   /**
    * The {@link RepoUtil#REPOSITORY_FILE_NAME} representation.
@@ -189,12 +191,9 @@ public class Mpack {
    * @return the module or {@code null}.
    */
   public Module getModule(String moduleName) {
-    for (Module module : modules) {
-      if (StringUtils.equals(moduleName, module.getName())) {
-        return module;
-      }
+    if(moduleHashMap.containsKey(moduleName)){
+      return moduleHashMap.get(moduleName);
     }
-
     return null;
   }
 
@@ -208,13 +207,12 @@ public class Mpack {
    * @return the component or {@code null}.
    */
   public ModuleComponent getModuleComponent(String moduleName, String moduleComponentName) {
-    for (Module module : modules) {
-      ModuleComponent moduleComponent = module.getModuleComponent(moduleComponentName);
-      if (null != moduleComponent) {
-        return moduleComponent;
+    if(moduleHashMap.containsKey(moduleName)){
+      Module module = moduleHashMap.get(moduleName);
+      if(module.getModuleComponent(moduleComponentName) != null){
+        return module.getModuleComponent(moduleComponentName);
       }
     }
-
     return null;
   }
 
@@ -304,6 +302,19 @@ public class Mpack {
     }
     if (displayName == null) {
       displayName = mpack.getDisplayName();
+    }
+  }
+
+
+  /**
+   * Load modules in an mpack as (modulename, module)
+   * Each module will have a componentMap (componentName, component)
+   */
+  public void populateModuleMap() {
+    moduleHashMap = new HashMap<>();
+    for(Module module : this.modules){
+      module.populateComponentMap();
+      moduleHashMap.put(module.getName(), module);
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -191,10 +191,7 @@ public class Mpack {
    * @return the module or {@code null}.
    */
   public Module getModule(String moduleName) {
-    if(moduleHashMap.containsKey(moduleName)){
-      return moduleHashMap.get(moduleName);
-    }
-    return null;
+     return moduleHashMap.get(moduleName);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
During mpack registration and bootstrap of ambari server, load modules and components into a map which is an attribute of Mpack.java

(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested POST /service which issues a call to mpack.getModule(getServiceType())
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Ambari Server ...................................... SUCCESS [04:21 min]
[INFO] Ambari Functional Tests ............................ SUCCESS [  1.172 s]
[INFO] Ambari Agent ....................................... SUCCESS [ 39.048 s]
[INFO] Mpack instance manager ............................. SUCCESS [  0.218 s]
[INFO] ambari-logsearch ................................... SUCCESS [  5.229 s]
[INFO] Ambari Logsearch Appender .......................... SUCCESS [  0.852 s]
[INFO] Ambari Logsearch Config Api ........................ SUCCESS [  0.257 s]
[INFO] Ambari Logsearch Config Zookeeper .................. SUCCESS [  0.308 s]
[INFO] Ambari Logsearch Log Feeder Plugin Api ............. SUCCESS [  0.200 s]
[INFO] Ambari Logsearch Log Feeder ........................ SUCCESS [  6.524 s]
[INFO] Ambari Logsearch Web ............................... SUCCESS [01:27 min]
[INFO] Ambari Logsearch Server ............................ SUCCESS [  7.155 s]
[INFO] Ambari Logsearch Assembly .......................... SUCCESS [  0.084 s]
[INFO] Ambari Logsearch Integration Test .................. SUCCESS [  0.553 s]
[INFO] ambari-infra ....................................... SUCCESS [  0.107 s]
[INFO] Ambari Infra Solr Client ........................... SUCCESS [  3.716 s]
[INFO] Ambari Infra Solr Plugin ........................... SUCCESS [  0.400 s]
[INFO] Ambari Infra Manager ............................... SUCCESS [  6.338 s]
[INFO] Ambari Infra Assembly .............................. SUCCESS [  0.080 s]
[INFO] Ambari Infra Manager Integration Tests ............. SUCCESS [  0.185 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 07:01 min
[INFO] Finished at: 2018-03-27T15:21:39-07:00
[INFO] Final Memory: 320M/1862M
[INFO] ------------------------------------------------------------------------

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.