### PR TITLE
[AMBARI-23384]. PQS start fails after Ambari upgrade due to Bad file descriptor (amagyar)

### DIFF
--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/phoenix_queryserver.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/phoenix_queryserver.py
@@ -23,6 +23,8 @@ from resource_management.libraries.functions.stack_features import check_stack_f
 from resource_management.libraries.script import Script
 from phoenix_service import phoenix_service
 from hbase import hbase
+from resource_management.core.exceptions import Fail
+from resource_management.libraries.functions.decorator import retry
 
 # Note: Phoenix Query Server is only applicable to stack version supporting Phoenix.
 class PhoenixQueryServer(Script):
@@ -45,6 +47,9 @@ class PhoenixQueryServer(Script):
     self.configure(env)
     phoenix_service('start')
 
+  @retry(times=3, sleep_time=5, err_class=Fail)
+  def post_start(self, env=None):
+    return super(PhoenixQueryServer, self).post_start(env)
 
   def stop(self, env, upgrade_type=None):
     import params

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/phoenix_queryserver.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/phoenix_queryserver.py
@@ -47,7 +47,7 @@ class PhoenixQueryServer(Script):
     self.configure(env)
     phoenix_service('start')
 
-  @retry(times=3, sleep_time=5, err_class=Fail)
+  @retry(times=3, sleep_time=5, err_class=Fail) # XXX PID file is not always created in time. Should be idempotent.
   def post_start(self, env=None):
     return super(PhoenixQueryServer, self).post_start(env)
 

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/phoenix_service.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/phoenix_service.py
@@ -40,7 +40,7 @@ def phoenix_service(action = 'start'): # 'start', 'stop', 'status'
         Execute(daemon_cmd,
                 user=format("{hbase_user}"),
                 environment=env)
-  
+
       elif action == 'stop':
         Execute(daemon_cmd,
                 user=format("{hbase_user}"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

There was an intermittent failure when restarting PQS from Ambari UI indicating that pid file didn't exist after component was started.

Despite the error message the component always started successfully. It looked like the pid file was not created right away after restart but a bit later, for unknown reasons.

The workaround was to apply the retry decorator on post_restart which check the pid file.

## How was this patch tested?

By doing restarts on PQS many times.