### PR TITLE
AMBARI-23386 HSI Jdbc URL should handle HA mode (mgergely)

### DIFF
--- a/ambari-web/app/controllers/main/service/info/summary.js
+++ b/ambari-web/app/controllers/main/service/info/summary.js
@@ -252,23 +252,27 @@ App.MainServiceInfoSummaryController = Em.Controller.extend({
       }
 
       var hiveSiteDynamicDiscovery = configs[0].properties['hive.server2.support.dynamic.service.discovery'];
-      var hiveSiteZkNameSpace =  configs[0].properties['hive.server2.zookeeper.namespace'];
-      var hiveSiteZkQuorom =  configs[0].properties['hive.zookeeper.quorum'];
-
+      var hiveSiteZkQuorom = configs[0].properties['hive.zookeeper.quorum'];
+      var hiveSiteServiceDiscorveryMode = 'zooKeeper';
+      var hiveSiteZkNameSpace = configs[0].properties['hive.server2.zookeeper.namespace'];
 
       configs.forEach(function(_config) {
         var masterComponent = App.MasterComponent.find().findProperty('componentName', siteToComponentMap[_config.type]);
         if (_config.type === 'hive-interactive-site') {
-          hiveSiteDynamicDiscovery =  _config.properties['hive.server2.support.dynamic.service.discovery'] || hiveSiteDynamicDiscovery;
-          hiveSiteZkQuorom =  _config.properties['hive.zookeeper.quorum'] || hiveSiteZkQuorom;
-          hiveSiteZkNameSpace =  _config.properties['hive.server2.zookeeper.namespace'] || hiveSiteZkNameSpace;
+          hiveSiteDynamicDiscovery = _config.properties['hive.server2.support.dynamic.service.discovery'] || hiveSiteDynamicDiscovery;
+          hiveSiteZkQuorom = _config.properties['hive.zookeeper.quorum'] || hiveSiteZkQuorom;
+          hiveSiteZkNameSpace = _config.properties['hive.server2.zookeeper.namespace'] || hiveSiteZkNameSpace;
+          if (_config.properties['hive.server2.active.passive.ha.enable'] === 'true') {
+            hiveSiteServiceDiscorveryMode = 'zooKeeperHA';
+            hiveSiteZkNameSpace = _config.properties['hive.server2.active.passive.ha.registry.namespace'];
+          }
         }
         if (masterComponent && !!masterComponent.get('totalCount')) {
           var hiveEndPoint = {
             isVisible: hiveSiteDynamicDiscovery,
             componentName: masterComponent.get('componentName'),
             label: masterComponent.get('displayName') + Em.I18n.t('services.service.summary.hiveserver2.jdbc.url.text'),
-            value: Em.I18n.t('services.service.summary.hiveserver2.endpoint.value').format(hiveSiteZkQuorom, hiveSiteZkNameSpace),
+            value: Em.I18n.t('services.service.summary.hiveserver2.endpoint.value').format(hiveSiteZkQuorom, hiveSiteServiceDiscorveryMode, hiveSiteZkNameSpace),
             tooltipText: Em.I18n.t('services.service.summary.hiveserver2.endpoint.tooltip.text').format(masterComponent.get('displayName'))
           };
           self.get('hiveServerEndPoints').pushObject(Em.Object.create(hiveEndPoint));

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -2039,7 +2039,7 @@ Em.I18n.translations = {
   'services.service.summary.historyServer': 'History Server Web UI',
   'services.service.summary.hiveserver2.jdbc.url.text': ' JDBC URL',
   'services.service.summary.hiveserver2.endpoint.tooltip.text':'JDBC connection string for {0}',
-  'services.service.summary.hiveserver2.endpoint.value':'jdbc:hive2://{0}/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace={1}',
+  'services.service.summary.hiveserver2.endpoint.value':'jdbc:hive2://{0}/;serviceDiscoveryMode={1};zooKeeperNamespace={2}',
   'services.service.actions.downloadClientConfigs':'Download Client Configs',
   'services.service.actions.downloadClientConfigs.fail.noConfigFile':'No configuration files defined for the component',
   'services.service.actions.downloadClientConfigs.fail.popup.header':'{0} Configs',


### PR DESCRIPTION
## What changes were proposed in this pull request?

To show the HSI Jdbc URL properly even if it is in HA mode

## How was this patch tested?

Tested with both stack supporting HA mode, and not, in the former both in HA mode and without it.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.