### PR TITLE
AMBARI-23385. When Updating A Property in the UI, Both the Old and Ne…

### DIFF
--- a/ambari-web/app/mixins/common/configs/configs_loader.js
+++ b/ambari-web/app/mixins/common/configs/configs_loader.js
@@ -176,7 +176,7 @@ App.ConfigsLoader = Em.Mixin.create(App.GroupsMappingMixin, {
       sender: this,
       data: {
         serviceName: this.get('content.serviceName'),
-        serviceConfigVersions: versions,
+        serviceConfigVersions: [selectedVersion],
         additionalParams: this.get('dependentServiceNames.length') ? '|service_name.in(' + this.get('dependentServiceNames') + ')&is_current=true' : ''
       },
       success: 'loadSelectedVersionsSuccess'

--- a/ambari-web/test/mixins/common/configs/configs_loader_test.js
+++ b/ambari-web/test/mixins/common/configs/configs_loader_test.js
@@ -359,7 +359,7 @@ describe('App.ConfigsLoader', function() {
         sender: mixin,
         data: {
           serviceName: 'S1',
-          serviceConfigVersions: ['v1', 'v2'],
+          serviceConfigVersions: ['v2'],
           additionalParams: ''
         },
         success: 'loadSelectedVersionsSuccess'


### PR DESCRIPTION
…w Properties Are Visible After Saving

## What changes were proposed in this pull request?
When Updating A Property in the UI, Both the Old and New Properties Are Visible After Saving	

## How was this patch tested?
manually, unit

  21515 passing (29s)
  48 pending



Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.