### PR TITLE
[AMBARI-23389]. Install Packages button on the versions screen fails if  there is a service installed which was removed (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
@@ -31,7 +31,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
@@ -78,7 +77,6 @@ import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.RepositoryType;
 import org.apache.ambari.server.state.RepositoryVersionState;
 import org.apache.ambari.server.state.ServiceComponentHost;
-import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.ServiceOsSpecific;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
@@ -628,7 +626,7 @@ public class ClusterStackVersionResourceProvider extends AbstractControllerResou
         ClusterVersionSummary clusterSummary = desiredVersionDefinition.getClusterSummary(cluster);
         serviceNames.addAll(clusterSummary.getAvailableServiceNames());
       } else {
-        serviceNames.addAll(ami.getStack(stackId).getServices().stream().map(ServiceInfo::getName).collect(Collectors.toList()));
+        serviceNames.addAll(ami.getStack(stackId).getServiceNames());
       }
 
       // Populate with commands for host

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
@@ -77,6 +78,7 @@ import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.RepositoryType;
 import org.apache.ambari.server.state.RepositoryVersionState;
 import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.ServiceOsSpecific;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
@@ -625,6 +627,8 @@ public class ClusterStackVersionResourceProvider extends AbstractControllerResou
       if (RepositoryType.STANDARD != repoVersionEnt.getType()) {
         ClusterVersionSummary clusterSummary = desiredVersionDefinition.getClusterSummary(cluster);
         serviceNames.addAll(clusterSummary.getAvailableServiceNames());
+      } else {
+        serviceNames.addAll(ami.getStack(stackId).getServices().stream().map(ServiceInfo::getName).collect(Collectors.toList()));
       }
 
       // Populate with commands for host

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.controller.StackVersionResponse;
 import org.apache.ambari.server.stack.Validable;
@@ -613,5 +614,12 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
 
   public void setRefreshCommandConfiguration(RefreshCommandConfiguration refreshCommandConfiguration) {
     this.refreshCommandConfiguration = refreshCommandConfiguration;
+  }
+
+  /**
+   * @return names of each service in the stack
+   */
+  public List<String> getServiceNames() {
+    return getServices().stream().map(ServiceInfo::getName).collect(Collectors.toList());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
@@ -619,7 +619,7 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
   /**
    * @return names of each service in the stack
    */
-  public List<String> getServiceNames() {
-    return getServices().stream().map(ServiceInfo::getName).collect(Collectors.toList());
+  public Set<String> getServiceNames() {
+    return getServices().stream().map(ServiceInfo::getName).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install packages fails after adding new repository if there is an already installed service in the cluster which is not in the new stack.

E.g.: 
 1. Install HDP 2.6 with SLIDER
 2. Add HDP 3.0 which doesn't have SLIDER
 3. Press Install Packages.

## How was this patch tested?

manually with SLIDER (see above)