### PR TITLE
[AMBARI-23394] Group_list should also look for properties in cluster …

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2767,19 +2767,22 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     List<OsSpecific.Package> packages =
         getPackagesForStackServiceHost(ambariMetaInfo.getStack(stackId), serviceInfo, hostParams, osFamily);
     String packageList = gson.toJson(packages);
-    hostParams.put(PACKAGE_LIST, packageList);
+    commandParams.put(PACKAGE_LIST, packageList);
 
     Set<PropertyInfo> stackProperties = ambariMetaInfo.getStackProperties(stackInfo.getName(), stackInfo.getVersion());
 
-    Set<String> userSet = configHelper.getPropertyValuesWithPropertyType(PropertyType.USER, cluster, clusterDesiredConfigs, servicesMap, stackProperties);
+    Set<PropertyInfo> clusterProperties = ambariMetaInfo.getClusterProperties();
+
+    Set<String> userSet = configHelper.getPropertyValuesWithPropertyType(PropertyType.USER, cluster, clusterDesiredConfigs, servicesMap, stackProperties, clusterProperties);
     String userList = gson.toJson(userSet);
     hostParams.put(USER_LIST, userList);
 
     //Create a user_group mapping and send it as part of the hostLevelParams
     Map<String, Set<String>> userGroupsMap = configHelper.createUserGroupsMap(
-      cluster, clusterDesiredConfigs, servicesMap, stackProperties);
+      cluster, clusterDesiredConfigs, servicesMap, stackProperties, clusterProperties);
     String userGroups = gson.toJson(userGroupsMap);
     hostParams.put(USER_GROUPS, userGroups);
+
 
     // Set exec command with 'ClusterSettings' map
     execCmd.setClusterSettings(cluster.getClusterSettingsNameValueMap());
@@ -2787,11 +2790,11 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     // Set exec command with 'StackSettings' map
     execCmd.setStackSettings(ambariMetaInfo.getStackSettingsNameValueMap(stackId));
 
-    Set<String> groupSet = configHelper.getPropertyValuesWithPropertyType(PropertyType.GROUP, cluster, clusterDesiredConfigs, servicesMap, stackProperties);
+    Set<String> groupSet = configHelper.getPropertyValuesWithPropertyType(PropertyType.GROUP, cluster, clusterDesiredConfigs, servicesMap, stackProperties, clusterProperties);
     String groupList = gson.toJson(groupSet);
     hostParams.put(GROUP_LIST, groupList);
 
-    Map<PropertyInfo, String> notManagedHdfsPathMap = configHelper.getPropertiesWithPropertyType(PropertyType.NOT_MANAGED_HDFS_PATH, cluster, clusterDesiredConfigs, servicesMap, stackProperties);
+    Map<PropertyInfo, String> notManagedHdfsPathMap = configHelper.getPropertiesWithPropertyType(PropertyType.NOT_MANAGED_HDFS_PATH, cluster, clusterDesiredConfigs, servicesMap, stackProperties, clusterProperties);
     Set<String> notManagedHdfsPathSet = configHelper.filterInvalidPropertyValues(notManagedHdfsPathMap, NOT_MANAGED_HDFS_PATH_LIST);
     String notManagedHdfsPathList = gson.toJson(notManagedHdfsPathSet);
     hostParams.put(NOT_MANAGED_HDFS_PATH_LIST, notManagedHdfsPathList);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2764,11 +2764,12 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     Map<String, String> hostParams = new TreeMap<>();
 
-    List<OsSpecific.Package> packages =
-        getPackagesForStackServiceHost(ambariMetaInfo.getStack(stackId), serviceInfo, hostParams, osFamily);
-    String packageList = gson.toJson(packages);
-    commandParams.put(PACKAGE_LIST, packageList);
-
+    if (roleCommand.equals(RoleCommand.INSTALL)) {
+      List<OsSpecific.Package> packages =
+              getPackagesForStackServiceHost(ambariMetaInfo.getStack(stackId), serviceInfo, hostParams, osFamily);
+      String packageList = gson.toJson(packages);
+      commandParams.put(PACKAGE_LIST, packageList);
+    }
     Set<PropertyInfo> stackProperties = ambariMetaInfo.getStackProperties(stackInfo.getName(), stackInfo.getVersion());
 
     Set<PropertyInfo> clusterProperties = ambariMetaInfo.getClusterProperties();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -934,6 +934,4 @@ public interface Cluster {
    * @return a mapping of service to component version, or an empty map.
    */
   Map<String, Map<String, String>> getComponentVersionMap();
-
-
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -934,4 +934,6 @@ public interface Cluster {
    * @return a mapping of service to component version, or an empty map.
    */
   Map<String, Map<String, String>> getComponentVersionMap();
+
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -3394,6 +3394,4 @@ Long serviceName = getServiceForConfigTypes( configs.stream().map(Config::getTyp
 
     return componentVersionMap;
   }
-
-
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1289,7 +1289,6 @@ public class ClusterImpl implements Cluster {
     return clusterSetting;
   }
 
-
   @Override
   public ClusterSetting getClusterSetting(Long clusterSettingId) throws ClusterSettingNotFoundException {
     ClusterSetting clusterSetting = clusterSettingsById.get(clusterSettingId);
@@ -3395,4 +3394,6 @@ Long serviceName = getServiceForConfigTypes( configs.stream().map(Config::getTyp
 
     return componentVersionMap;
   }
+
+
 }

--- a/ambari-server/src/main/resources/cluster-settings.xml
+++ b/ambari-server/src/main/resources/cluster-settings.xml
@@ -157,6 +157,16 @@
         <value-attributes>
             <type>user</type>
             <overridable>false</overridable>
+            <user-groups>
+                <property>
+                    <type>hadoop-env</type>
+                    <name>proxyuser_group</name>
+                </property>
+                <property>
+                    <type>cluster-settings</type>
+                    <name>user_group</name>
+                </property>
+            </user-groups>
         </value-attributes>
         <on-ambari-upgrade add="true"/>
     </property>


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. User list, group list and user groups are currently fetched only from cluster desired configs which has the service configs. Hence those properties from cluster settings are missed out.
2. PackageList should be set in commandParams instead of hostParams.

## How was this patch tested?
Command.json file
**Issue**
        "group_list": "[\"hdfs\",\"users\"]",
        "user_groups": "{\"zookeeper\":[],\"hdfs\":[\"hdfs\"]}",
        "stack_version": "1.0.0-b140",
        "user_list": "[\"zookeeper\",\"hdfs\"]"

**After fix**
        "group_list": "[\"hdfs\"_,\"hadoop\",_\"users\"]",
        "user_groups": "{\"zookeeper\"_:[\"hadoop\"],_\"hdfs\":[\"hdfs\"]}",
        "stack_version": "1.0.0-b196",
        "user_list": "[\"zookeeper\"_,\"ambari-qa\"_,\"hdfs\"]"
    },
    "commandParams": {
        "service_package_folder": "stacks/HDPCORE/1.0.0-b196/services/HDFS/package",
        "hooks_folder": "stack-hooks",
        "script": "scripts/namenode.py",
        _"package_list": "[{\"name\":\"hdpcore\",\"condition\":\"\",\"skipUpgrade\":false}]",_
        "max_duration_for_retries": "0",
        "command_retry_enabled": "false",
        "command_timeout": "1800",
        "script_type": "PYTHON"
    },

[INFO] Reactor Summary:
[INFO]
[INFO] Ambari Main ........................................ SUCCESS [ 19.067 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.041 s]
[INFO] Ambari Web ......................................... SUCCESS [01:08 min]
[INFO] Ambari Views ....................................... SUCCESS [  1.261 s]
[INFO] Ambari Admin View .................................. SUCCESS [  9.459 s]
[INFO] ambari-utility ..................................... SUCCESS [  1.300 s]
[INFO] ambari-metrics ..................................... SUCCESS [  0.743 s]
[INFO] Ambari Metrics Common .............................. SUCCESS [  5.674 s]
[INFO] Ambari Metrics Hadoop Sink ......................... SUCCESS [  4.427 s]
[INFO] Ambari Metrics Flume Sink .......................... SUCCESS [  2.200 s]
[INFO] Ambari Metrics Kafka Sink .......................... SUCCESS [  2.203 s]
[INFO] Ambari Metrics Storm Sink .......................... SUCCESS [  3.708 s]
[INFO] Ambari Metrics Storm Sink (Legacy) ................. SUCCESS [  2.098 s]
[INFO] Ambari Metrics Collector ........................... SUCCESS [ 17.196 s]
[INFO] Ambari Metrics Monitor ............................. SUCCESS [  2.465 s]
[INFO] Ambari Metrics Grafana ............................. SUCCESS [  4.282 s]
[INFO] Ambari Metrics Host Aggregator ..................... SUCCESS [  7.549 s]
[INFO] Ambari Metrics Assembly ............................ SUCCESS [02:08 min]
[INFO] Ambari Service Advisor ............................. SUCCESS [  0.122 s]
[INFO] Ambari Server ...................................... SUCCESS [04:09 min]
[INFO] Ambari Functional Tests ............................ SUCCESS [  0.979 s]
[INFO] Ambari Agent ....................................... SUCCESS [ 40.262 s]
[INFO] Mpack instance manager ............................. SUCCESS [  0.212 s]
[INFO] ambari-logsearch ................................... SUCCESS [  3.829 s]
[INFO] Ambari Logsearch Appender .......................... SUCCESS [  0.165 s]
[INFO] Ambari Logsearch Config Api ........................ SUCCESS [  0.153 s]
[INFO] Ambari Logsearch Config Zookeeper .................. SUCCESS [  0.177 s]
[INFO] Ambari Logsearch Log Feeder Plugin Api ............. SUCCESS [  0.129 s]
[INFO] Ambari Logsearch Log Feeder ........................ SUCCESS [  4.343 s]
[INFO] Ambari Logsearch Web ............................... SUCCESS [01:14 min]
[INFO] Ambari Logsearch Server ............................ SUCCESS [  6.944 s]
[INFO] Ambari Logsearch Assembly .......................... SUCCESS [  0.080 s]
[INFO] Ambari Logsearch Integration Test .................. SUCCESS [  0.514 s]
[INFO] ambari-infra ....................................... SUCCESS [  0.242 s]
[INFO] Ambari Infra Solr Client ........................... SUCCESS [  2.713 s]
[INFO] Ambari Infra Solr Plugin ........................... SUCCESS [  0.445 s]
[INFO] Ambari Infra Manager ............................... SUCCESS [  6.214 s]
[INFO] Ambari Infra Assembly .............................. SUCCESS [  0.076 s]
[INFO] Ambari Infra Manager Integration Tests ............. SUCCESS [  0.163 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11:18 min
[INFO] Finished at: 2018-03-28T14:09:37-07:00
[INFO] Final Memory: 448M/2043M
[INFO] ------------------------------------------------------------------------

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.