### PR TITLE
[AMBARI-23388] Selected Host List count becomes zero when navigating …

### DIFF
--- a/ambari-web/app/views/main/host.js
+++ b/ambari-web/app/views/main/host.js
@@ -188,6 +188,7 @@ App.MainHostView = App.TableView.extend(App.TableServerViewMixin, {
     this.set('startIndex', this.get('controller.startIndex'));
     this.set('displayLength', this.get('controller.paginationProps').findProperty('name', 'displayLength').value);
     this.addObserver('pageContent.@each.selected', this, this.selectedHostsObserver);
+    this.selectedHostsObserver();
   },
 
   /**


### PR DESCRIPTION
…back to hosts page.

## What changes were proposed in this pull request?
The "selectedHostsObserver" is not being invoked after adding the observer which is causing the "Selected Host" list to show 0 selected host when a  user is back to the "hosts" tab and checks the selected hosts from the drop down (even if there are few selected hosts present). 


## How was this patch tested?
Manually tested the fix from UI.
The Build was successful locally after this fix.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.