### PR TITLE
AMBARI-23400. HDFS metrics data missing in Ambari 2.7.0 (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/MetricSource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/MetricSource.java
@@ -30,6 +30,7 @@ import org.apache.ambari.server.state.UriInfo;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
@@ -105,16 +106,17 @@ public class MetricSource extends Source {
    * Represents the {@code jmx} element in a Metric alert.
    */
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
   public static class JmxInfo {
     @SerializedName("property_list")
     private List<String> propertyList;
 
+    @SerializedName("value")
     private String value = "{0}";
 
     @SerializedName("url_suffix")
     private String urlSuffix = "/jmx";
 
-    @JsonProperty("property_list")
     public List<String> getPropertyList() {
       return propertyList;
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/metric/system/impl/MetricsSourceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metric/system/impl/MetricsSourceTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.metric.system.impl;
 
+import static java.util.Collections.singletonList;
+import static junit.framework.Assert.assertEquals;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -35,6 +37,7 @@ import org.apache.ambari.server.metrics.system.impl.AmbariMetricSinkImpl;
 import org.apache.ambari.server.metrics.system.impl.DatabaseMetricsSource;
 import org.apache.ambari.server.metrics.system.impl.JvmMetricsSource;
 import org.apache.ambari.server.metrics.system.impl.MetricsConfiguration;
+import org.apache.ambari.server.state.alert.MetricSource;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
@@ -43,6 +46,9 @@ import org.hamcrest.Description;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 import junit.framework.Assert;
 
@@ -168,4 +174,15 @@ public class MetricsSourceTest {
     Assert.assertTrue(source.acceptMetric("Counter.ReadObjectQuery.MetainfoEntity.readMetainfoEntity.CacheMisses"));
   }
 
+  @Test
+  public void testJmxInfoSerialization() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
+    MetricSource.JmxInfo jmxInfo = new MetricSource.JmxInfo();
+    jmxInfo.setValue("custom");
+    jmxInfo.setPropertyList(singletonList("prop1"));
+    MetricSource.JmxInfo deserialized = mapper.readValue(mapper.writeValueAsString(jmxInfo), MetricSource.JmxInfo.class);
+    assertEquals("custom", deserialized.getValue().toString());
+    assertEquals(singletonList("prop1"), deserialized.getPropertyList());
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The "value" field in JmxInfo was not serialized so ambari-agent didn't receive it. This caused all of the jmx metrics with custom value fields to fail.

## How was this patch tested?

By checking alert reports on the UI