### PR TITLE
AMBARI-23402. Make nproc and nolimit values configurable through infra-solr-env config

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -265,6 +265,19 @@
     <on-ambari-upgrade add="false"/>
   </property>
 
+  <property>
+    <name>infra_solr_user_nofile_limit</name>
+    <value>128000</value>
+    <description>Max open files limit setting for infra-solr user.</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>infra_solr_user_nproc_limit</name>
+    <value>65536</value>
+    <description>Max number of processes limit setting for infra-solr user.</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+
   <!-- infra-solr-env.sh -->
   <property>
     <name>content</name>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -65,7 +65,7 @@ fetch_nonlocal_groups = config['configurations']['cluster-env']["fetch_nonlocal_
 
 limits_conf_dir = "/etc/security/limits.d"
 infra_solr_user_nofile_limit = default("/configurations/infra-solr-env/infra_solr_user_nofile_limit", "128000")
-infra_solr_user_nproc_limit = default("/configurations/infra-solr-env/infra_solr__user_nproc_limit", "65536")
+infra_solr_user_nproc_limit = default("/configurations/infra-solr-env/infra_solr_user_nproc_limit", "65536")
 
 # shared configs
 java_home = config['ambariLevelParams']['java_home']

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -63,6 +63,10 @@ prev_infra_solr_pidfile = status_params.prev_infra_solr_pidfile
 user_group = config['configurations']['cluster-env']['user_group']
 fetch_nonlocal_groups = config['configurations']['cluster-env']["fetch_nonlocal_groups"]
 
+limits_conf_dir = "/etc/security/limits.d"
+infra_solr_user_nofile_limit = default("/configurations/infra-solr-env/infra_solr_user_nofile_limit", "128000")
+infra_solr_user_nproc_limit = default("/configurations/infra-solr-env/infra_solr__user_nproc_limit", "65536")
+
 # shared configs
 java_home = config['ambariLevelParams']['java_home']
 ambari_java_home = default("/ambariLevelParams/ambari_java_home", None)

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
@@ -17,13 +17,13 @@ limitations under the License.
 
 """
 
+import os
 from resource_management.core.exceptions import Fail
 from resource_management.core.resources.system import Directory, File
 from resource_management.core.source import InlineTemplate, Template
 from resource_management.libraries.functions import solr_cloud_util
 from resource_management.libraries.functions.decorator import retry
 from resource_management.libraries.functions.format import format
-
 
 def setup_infra_solr(name = None):
   import params
@@ -91,6 +91,13 @@ def setup_infra_solr(name = None):
            owner=params.infra_solr_user,
            group=params.user_group,
            mode=0640)
+
+    File(os.path.join(params.limits_conf_dir, 'infra-solr.conf'),
+         owner='root',
+         group='root',
+         mode=0644,
+         content=Template("infra-solr.conf.j2")
+         )
 
   elif name == 'client':
     solr_cloud_util.setup_solr_client(params.config)

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/templates/infra-solr.conf.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/templates/infra-solr.conf.j2
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{infra_solr_user}}   - nofile {{infra_solr_user_nofile_limit}}
+{{infra_solr_user}}   - nproc  {{infra_solr_user_nproc_limit}}

--- a/ambari-server/src/test/python/stacks/2.4/AMBARI_INFRA/test_infra_solr.py
+++ b/ambari-server/src/test/python/stacks/2.4/AMBARI_INFRA/test_infra_solr.py
@@ -104,6 +104,11 @@ class TestInfraSolr(RMFTestCase):
                                 content = InlineTemplate(self.getConfig()['configurations']['infra-solr-security-json']['content']),
                                 mode = 0640
                                 )
+      self.assertResourceCalled('File', '/etc/security/limits.d/infra-solr.conf',
+                                owner = 'root',
+                                group='root',
+                                content = Template('infra-solr.conf.j2')
+                                )
 
       self.assertResourceCalled('Execute', 'ambari-sudo.sh JAVA_HOME=/usr/jdk64/jdk1.7.0_45 /usr/lib/ambari-infra-solr-client/solrCloudCli.sh --zookeeper-connect-string c6401.ambari.apache.org:2181 --znode /infra-solr --create-znode --retry 30 --interval 5')
       self.assertResourceCalled('Execute', 'ambari-sudo.sh JAVA_HOME=/usr/jdk64/jdk1.7.0_45 /usr/lib/ambari-infra-solr-client/solrCloudCli.sh --zookeeper-connect-string c6401.ambari.apache.org:2181/infra-solr --remove-admin-handlers --collection hadoop_logs --retry 5 --interval 10')


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some issues are really often come up with our Infra Solr, OutOfMemory can occur even if you have enough memory (nproc problem) or it cannot open more files, there values by default are low, so from this point we should be able to configure this. (and also use higher default values), the solution is similar that ambari uses for hdfs.

## How was this patch tested?
With `mvn clean test -DskipSurefireTests -Dpython.test.mask="*test_infra_solr*"`
```bash
Total run:3
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
Downloading: https://maven.atlassian.com/repository/public/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading: http://download.java.net/maven/2/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading: https://repository.apache.org/content/repositories/snapshots/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading: http://download.java.net/maven/glassfish/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
Downloading: http://repository.apache.org/snapshots/org/apache/ambari/ambari-utility/1.0.0.0-SNAPSHOT/maven-metadata.xml
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:07 min
[INFO] Finished at: 2018-03-29T14:01:30+02:00
[INFO] Final Memory: 109M/1707M
[INFO] ------------------------------------------------------------------------
```

Please review @g-boros @zeroflag @smolnar82 