### PR TITLE
[AMBARI-22904] Fix mpack-related unit tests

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/MpackResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/MpackResourceDefinitionTest.java
@@ -32,5 +32,6 @@ public class MpackResourceDefinitionTest {
       ResourceDefinition def = new MpackResourceDefinition();
       assertEquals("mpack", def.getSingularName());
       assertEquals("mpacks", def.getPluralName());
+
     }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/MpackResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/MpackResourceProviderTest.java
@@ -25,7 +25,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,9 +39,7 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.controller.utilities.PredicateBuilder;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
-import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
 import org.apache.ambari.server.orm.dao.MpackDAO;
-import org.apache.ambari.server.orm.entities.MpackEntity;
 import org.apache.ambari.server.state.Module;
 import org.apache.ambari.server.state.Mpack;
 import org.easymock.EasyMock;
@@ -51,65 +48,59 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.inject.Binder;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.google.inject.util.Modules;
 
 
 public class MpackResourceProviderTest {
 
   private MpackDAO m_dao;
-  private Injector m_injector;
   private AmbariManagementController m_amc;
 
   @Before
   public void before() throws Exception {
     m_dao = EasyMock.createNiceMock(MpackDAO.class);
     m_amc = EasyMock.createNiceMock(AmbariManagementController.class);
-
-    m_injector = Guice.createInjector(Modules.override(new InMemoryDefaultTestModule()).with(
-            new MockModule()));
-  }
+    }
 
   @Test
   public void testGetResourcesMpacks() throws Exception {
     Resource.Type type = Resource.Type.Mpack;
 
     Resource resourceExpected1 = new ResourceImpl(Resource.Type.Mpack);
-    resourceExpected1.setProperty(MpackResourceProvider.MPACK_RESOURCE_ID, (long)1);
+    resourceExpected1.setProperty(MpackResourceProvider.MPACK_RESOURCE_ID, 1L);
     resourceExpected1.setProperty(MpackResourceProvider.MPACK_NAME, "TestMpack1");
     resourceExpected1.setProperty(MpackResourceProvider.MPACK_VERSION, "3.0");
     resourceExpected1.setProperty(MpackResourceProvider.MPACK_URI, "abcd.tar.gz");
     resourceExpected1.setProperty(MpackResourceProvider.REGISTRY_ID, null);
 
     Resource resourceExpected2 = new ResourceImpl(Resource.Type.Mpack);
-    resourceExpected2.setProperty(MpackResourceProvider.MPACK_RESOURCE_ID, (long)2);
+    resourceExpected2.setProperty(MpackResourceProvider.MPACK_RESOURCE_ID, 2L);
     resourceExpected2.setProperty(MpackResourceProvider.MPACK_NAME, "TestMpack2");
     resourceExpected2.setProperty(MpackResourceProvider.MPACK_VERSION, "3.0");
     resourceExpected2.setProperty(MpackResourceProvider.MPACK_URI, "abc.tar.gz");
-    resourceExpected2.setProperty(MpackResourceProvider.REGISTRY_ID, (long)1);
+    resourceExpected2.setProperty(MpackResourceProvider.REGISTRY_ID, 1L);
 
-    List<MpackEntity> entities = new ArrayList<>();
-    MpackEntity entity = new MpackEntity();
-    entity.setId((long) 1);
-    entity.setMpackUri("abcd.tar.gz");
-    entity.setMpackName("TestMpack1");
-    entity.setMpackVersion("3.0");
-    entities.add(entity);
+    Mpack mpack1 = new Mpack();
+    mpack1.setResourceId(1L);
+    mpack1.setName("TestMpack1");
+    mpack1.setVersion("3.0");
+    mpack1.setMpackUri("abcd.tar.gz");
 
-    entity = new MpackEntity();
-    entity.setId((long) 2);
-    entity.setMpackUri("abc.tar.gz");
-    entity.setMpackName("TestMpack2");
-    entity.setMpackVersion("3.0");
-    entity.setRegistryId(new Long(1));
-    entities.add(entity);
+    Mpack mpack2 = new Mpack();
+    mpack2.setResourceId(2L);
+    mpack2.setName("TestMpack2");
+    mpack2.setVersion("3.0");
+    mpack2.setMpackUri("abc.tar.gz");
+    mpack2.setRegistryId(1L);
+
+    Set<MpackResponse> mpackResponses = new HashSet<>();
+    mpackResponses.add(new MpackResponse(mpack1));
+    mpackResponses.add(new MpackResponse(mpack2));
 
     // set expectations
-    EasyMock.expect(m_dao.findAll()).andReturn(entities).anyTimes();
+    EasyMock.expect(m_amc.getMpacks()).andReturn(mpackResponses).anyTimes();
 
     // replay
-    replay(m_dao);
+    replay(m_amc);
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(type, m_amc);
 
@@ -123,12 +114,12 @@ public class MpackResourceProviderTest {
 
     for (Resource resource : resources) {
       Long mpackId = (Long) resource.getPropertyValue(MpackResourceProvider.MPACK_RESOURCE_ID);
-      if (mpackId == (long) 1) {
+      if (mpackId == 1L) {
         Assert.assertEquals(resourceExpected1.getPropertyValue(MpackResourceProvider.MPACK_NAME), (String) resource.getPropertyValue(MpackResourceProvider.MPACK_NAME));
         Assert.assertEquals(resourceExpected1.getPropertyValue(MpackResourceProvider.MPACK_VERSION), (String) resource.getPropertyValue(MpackResourceProvider.MPACK_VERSION));
         Assert.assertEquals(resourceExpected1.getPropertyValue(MpackResourceProvider.MPACK_URI), (String) resource.getPropertyValue(MpackResourceProvider.MPACK_URI));
         Assert.assertEquals(resourceExpected1.getPropertyValue(MpackResourceProvider.REGISTRY_ID), (Long) resource.getPropertyValue(MpackResourceProvider.REGISTRY_ID));
-      } else if (mpackId == (long) 2) {
+      } else if (mpackId == 2L) {
         Assert.assertEquals(resourceExpected2.getPropertyValue(MpackResourceProvider.MPACK_NAME), (String) resource.getPropertyValue(MpackResourceProvider.MPACK_NAME));
         Assert.assertEquals(resourceExpected2.getPropertyValue(MpackResourceProvider.MPACK_VERSION), (String) resource.getPropertyValue(MpackResourceProvider.MPACK_VERSION));
         Assert.assertEquals(resourceExpected2.getPropertyValue(MpackResourceProvider.MPACK_URI), (String) resource.getPropertyValue(MpackResourceProvider.MPACK_URI));
@@ -139,7 +130,7 @@ public class MpackResourceProviderTest {
     }
 
     // verify
-    verify(m_dao);
+    verify(m_amc);
   }
 
   @Test
@@ -150,20 +141,19 @@ public class MpackResourceProviderTest {
             MpackResourceProvider.MPACK_RESOURCE_ID).equals(
             Long.valueOf(1).toString()).toPredicate();
 
-    MpackEntity entity = new MpackEntity();
-    entity.setId((long) 1);
-    entity.setMpackUri("abcd.tar.gz");
-    entity.setMpackName("TestMpack1");
-    entity.setMpackVersion("3.0");
+    Mpack mpack = new Mpack();
+    mpack.setResourceId(1L);
+    mpack.setMpackUri("abcd.tar.gz");
+    mpack.setName("TestMpack1");
+    mpack.setVersion("3.0");
 
-
-    ArrayList<Module> packletArrayList = new ArrayList<>();
+    ArrayList<Module> moduleArrayList = new ArrayList<>();
     Module module = new Module();
     module.setName("testService");
     //module.setType(Module.PackletType.SERVICE_PACKLET);
     module.setDefinition("testDir");
     module.setVersion("3.0");
-    packletArrayList.add(module);
+    moduleArrayList.add(module);
 
     Resource resourceExpected1 = new ResourceImpl(Resource.Type.Mpack);
     resourceExpected1.setProperty(MpackResourceProvider.MPACK_RESOURCE_ID, (long)1);
@@ -171,14 +161,14 @@ public class MpackResourceProviderTest {
     resourceExpected1.setProperty(MpackResourceProvider.MPACK_VERSION, "3.0");
     resourceExpected1.setProperty(MpackResourceProvider.MPACK_URI, "abcd.tar.gz");
     resourceExpected1.setProperty(MpackResourceProvider.REGISTRY_ID, null);
-    resourceExpected1.setProperty(MpackResourceProvider.MODULES,packletArrayList);
+    resourceExpected1.setProperty(MpackResourceProvider.MODULES,moduleArrayList);
 
     // set expectations
-    EasyMock.expect(m_dao.findById((long)1)).andReturn(entity).anyTimes();
-    EasyMock.expect(m_amc.getModules((long)1)).andReturn(packletArrayList).anyTimes();
+    EasyMock.expect(m_amc.getMpack(1L)).andReturn(new MpackResponse(mpack)).anyTimes();
+    EasyMock.expect(m_amc.getModules(1L)).andReturn(moduleArrayList).anyTimes();
 
     // replay
-    replay(m_dao,m_amc);
+    replay(m_amc);
 
     ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(type, m_amc);
 
@@ -197,7 +187,7 @@ public class MpackResourceProviderTest {
       Assert.assertEquals(resourceExpected1.getPropertyValue(MpackResourceProvider.MODULES),(ArrayList)resource.getPropertyValue(MpackResourceProvider.MODULES));
   }
     // verify
-    verify(m_dao,m_amc);
+    verify(m_amc);
 
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/MpackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/MpackTest.java
@@ -26,6 +26,45 @@ import org.junit.Test;
 import com.google.gson.Gson;
 
 public class MpackTest {
+  String mpackJsonContents = "{\n" +
+          "  \"definition\": \"hdpcore-1.0.0-b16-definition.tar.gz\",\n" +
+          "  \"description\": \"Hortonworks Data Platform Core\",\n" +
+          "  \"id\": \"hdpcore\",\n" +
+          "  \"modules\": [\n" +
+          "    {\n" +
+          "      \"category\": \"SERVER\",\n" +
+          "      \"components\": [\n" +
+          "        {\n" +
+          "          \"id\": \"zookeeper_server\",\n" +
+          "          \"version\": \"3.4.0.0-b17\",\n" +
+          "          \"name\": \"ZOOKEEPER_SERVER\",\n" +
+          "          \"category\": \"MASTER\",\n" +
+          "          \"isExternal\": \"False\"\n" +
+          "        }\n" +
+          "      ],\n" +
+          "      \"definition\": \"zookeeper-3.4.0.0-b17-definition.tar.gz\",\n" +
+          "      \"dependencies\": [\n" +
+          "        {\n" +
+          "          \"id\": \"zookeeper_clients\",\n" +
+          "          \"name\": \"ZOOKEEPER_CLIENTS\",\n" +
+          "          \"type\": \"INSTALL\"\n" +
+          "        }\n" +
+          "      ],\n" +
+          "      \"description\": \"Centralized service which provides highly reliable distributed coordination\",\n" +
+          "      \"displayName\": \"ZooKeeper\",\n" +
+          "      \"id\": \"zookeeper\",\n" +
+          "      \"name\": \"ZOOKEEPER\",\n" +
+          "      \"version\": \"3.4.0.0-b17\"\n" +
+          "    }\n" +
+          "  ],\n" +
+          "  \"name\": \"HDPCORE\",\n" +
+          "  \"prerequisites\": {\n" +
+          "    \"max-ambari-version\": \"3.1.0.0\",\n" +
+          "    \"min-ambari-version\": \"3.0.0.0\"\n" +
+          "  },\n" +
+          "  \"version\": \"1.0.0-b16\"\n" +
+          "}";
+
   @Test
   public void testMpacks() {
     Mpack mpack = new Mpack();
@@ -46,50 +85,11 @@ public class MpackTest {
 
   @Test
   public void testMpacksUsingGson() {
-    String mpackJsonContents = "{\n" +
-            "  \"definition\": \"hdpcore-1.0.0-b16-definition.tar.gz\",\n" +
-            "  \"description\": \"Hortonworks Data Platform Core\",\n" +
-            "  \"id\": \"hdpcore\",\n" +
-            "  \"modules\": [\n" +
-            "    {\n" +
-            "      \"category\": \"SERVER\",\n" +
-            "      \"components\": [\n" +
-            "        {\n" +
-            "          \"id\": \"zookeeper_server\",\n" +
-            "          \"version\": \"3.4.0.0-b17\",\n" +
-            "          \"name\": \"ZOOKEEPER_SERVER\",\n" +
-            "          \"category\": \"MASTER\",\n" +
-            "          \"isExternal\": \"False\"\n" +
-            "        }\n" +
-            "      ],\n" +
-            "      \"definition\": \"zookeeper-3.4.0.0-b17-definition.tar.gz\",\n" +
-            "      \"dependencies\": [\n" +
-            "        {\n" +
-            "          \"id\": \"zookeeper_clients\",\n" +
-            "          \"name\": \"ZOOKEEPER_CLIENTS\",\n" +
-            "          \"dependencyType\": \"INSTALL\"\n" +
-            "        }\n" +
-            "      ],\n" +
-            "      \"description\": \"Centralized service which provides highly reliable distributed coordination\",\n" +
-            "      \"displayName\": \"ZooKeeper\",\n" +
-            "      \"id\": \"zookeeper\",\n" +
-            "      \"name\": \"ZOOKEEPER\",\n" +
-            "      \"version\": \"3.4.0.0-b17\"\n" +
-            "    }\n" +
-            "  ],\n" +
-            "  \"name\": \"HDPCORE\",\n" +
-            "  \"prerequisites\": {\n" +
-            "    \"max-ambari-version\": \"3.1.0.0\",\n" +
-            "    \"min-ambari-version\": \"3.0.0.0\"\n" +
-            "  },\n" +
-            "  \"version\": \"1.0.0-b16\"\n" +
-            "}";
     HashMap<String, String> expectedPrereq = new HashMap<>();
     expectedPrereq.put("min-ambari-version","3.0.0.0");
     expectedPrereq.put("max-ambari-version","3.1.0.0");
     ArrayList<Module> expectedModules = new ArrayList<>();
     Module zkfc = new Module();
-    //nifi.setType(.PackletType.SERVICE_PACKLET);
     zkfc.setVersion("3.4.0.0-b17");
     zkfc.setDefinition("zookeeper-3.4.0.0-b17-definition.tar.gz");
     zkfc.setName("ZOOKEEPER");


### PR DESCRIPTION
 mpack API change - https://github.com/apache/ambari/pull/486 , Fix the remaining mpack-related unit tests?

[ERROR]   MpackResourceProviderTest.testGetResourcesMpacks:122 expected:<2> but was:<0>
[ERROR]   MpackResourceProviderTest.testGetResourcesMpackId:189 » NoSuchResource
(Note these occur after  – before that change, all 3 test methods throw NullPointer instead.)

## How was this patch tested?
Run Mpack Unit Tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.