### PR TITLE
[AMBARI-23413] Moving Hive Metastore gets hanged in Ambari due to Uncaught TypeError: Cannot read property 'tag' of undefined

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step3_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step3_controller.js
@@ -318,7 +318,7 @@ App.ReassignMasterWizardStep3Controller = Em.Controller.extend({
 
     this.get('wizardController.serviceToConfigSiteMap')[componentName].forEach(function(site){
       if(site in data.Clusters.desired_configs) {
-      	urlParams.push('(type=' + site + '&tag=' + data.Clusters.desired_configs[site].tag + ')');
+        urlParams.push('(type=' + site + '&tag=' + data.Clusters.desired_configs[site].tag + ')');
       }
     });
 

--- a/ambari-web/app/controllers/main/service/reassign/step3_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step3_controller.js
@@ -317,7 +317,9 @@ App.ReassignMasterWizardStep3Controller = Em.Controller.extend({
     var urlParams = [];
 
     this.get('wizardController.serviceToConfigSiteMap')[componentName].forEach(function(site){
-      urlParams.push('(type=' + site + '&tag=' + data.Clusters.desired_configs[site].tag + ')');
+      if(site in data.Clusters.desired_configs) {
+      	urlParams.push('(type=' + site + '&tag=' + data.Clusters.desired_configs[site].tag + ')');
+      }
     });
 
     // specific cases for certain components


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding a check to make sure that we attempt to read the "tag' information only when the site is present in the  "desired_configs". Controlling it using the "if" check.

Else we see the error in console and UI gets Stuck:
```
app.js:31183 Uncaught TypeError: Cannot read property 'tag' of undefined
    at app.js:31183
    at Array.forEach (<anonymous>)
    at Class.getConfigUrlParams (app.js:31182)
```

## How was this patch tested?
- Tested the fix
- Build was successful.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.