### PR TITLE
[AMBARI-23414] Refreshing Ambari Dashboard or HDFS Dashboard shows co…

### DIFF
--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -301,7 +301,7 @@ App.QuickLinksView = Em.View.extend({
       this.setEmptyLinks();
     } else if (hosts.length === 1 || isMultipleComponentsInLinks || this.hasOverriddenHost()) {
       this.setSingleHostLinks(hosts, response);
-    } else if (this.get('masterGroups.length') > 1 || this.get('shouldSetGroupedLinks')) {
+    } else if (this.get('masterGroups.length') > 1 && this.get('shouldSetGroupedLinks')) {
       this.setMultipleGroupLinks(hosts);
     } else {
       this.setMultipleHostLinks(hosts);

--- a/ambari-web/test/views/common/quick_link_view_test.js
+++ b/ambari-web/test/views/common/quick_link_view_test.js
@@ -308,13 +308,23 @@ describe('App.QuickViewLinks', function () {
         [{hostName: 'host1'}, {hostName: 'host2'}]
       )).to.be.true;
     });
-    it("multiple grouped hosts", function () {
+    it("multiple grouped hosts with shouldSetGroupedLinks", function () {
       this.mock.returns([{hostName: 'host1'}, {hostName: 'host2'}]);
       quickViewLinks.set('masterGroups', [{}, {}]);
+      quickViewLinks.set('shouldSetGroupedLinks', true);
       quickViewLinks.setQuickLinksSuccessCallback();
       expect(quickViewLinks.setMultipleGroupLinks.calledWith(
         [{hostName: 'host1'}, {hostName: 'host2'}]
       )).to.be.true;
+    });
+    it("multiple grouped hosts without shouldSetGroupedLinks", function () {
+      this.mock.returns([{hostName: 'host1'}, {hostName: 'host2'}]);
+      quickViewLinks.set('masterGroups', [{}, {}]);
+      quickViewLinks.set('shouldSetGroupedLinks', false);
+      quickViewLinks.setQuickLinksSuccessCallback();
+      expect(quickViewLinks.setMultipleGroupLinks.calledWith(
+        [{hostName: 'host1'}, {hostName: 'host2'}]
+      )).to.be.false;
     });
   });
 


### PR DESCRIPTION
…nsole error Cannot read property 'hosts' of undefined.

## What changes were proposed in this pull request?
The following error occurs on next refresh of ambari UI.
`Uncaught TypeError: Cannot read property 'hosts' of undefined
`
This happens because the expression "this.get('shouldSetGroupedLinks')" returns "false" first time but next time it returns "true" however there is a possibility is that the expression "this.get('masterGroups.length')" still returns "false". (means the "masterGroups" array is still having no or one element).


## How was this patch tested?
Tested locally the fix works.
Build was successful.