### PR TITLE
[AMBARI-23415] Remove unwanted trailing slash at the end of hbase_pid…

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-hbase-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-hbase-env.xml
@@ -39,7 +39,7 @@
   <property>
     <name>hbase_pid_dir</name>
     <display-name>HBase PID Dir</display-name>
-    <value>/var/run/ambari-metrics-collector/</value>
+    <value>/var/run/ambari-metrics-collector</value>
     <description>Pid Directory for HBase.</description>
     <value-attributes>
       <type>directory</type>


### PR DESCRIPTION
…_dir path in ams-hbase-env

## What changes were proposed in this pull request?
While starting the AMS collector we can see that it has two slash in the PID file path 

`/var/run/ambari-metrics-collector//hbase-ams-regionserver.pid` 
`/var/run/ambari-metrics-collector//hbase-ams-master.pid`

It  does not look good and seems error prone. It should be removed.

## How was this patch tested?
Tested the fix manually.
Build was successful.
