### PR TITLE
[AMBARI-23420] Refine pre-check message to remove unsupported services before upgrade to HDP-3.0

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/CheckDescription.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/CheckDescription.java
@@ -279,8 +279,7 @@ public class CheckDescription {
           "After upgrading, %s can be reinstalled")
       .put(ServicePresenceCheck.KEY_SERVICE_REMOVED,
           "The %s service is currently installed on the cluster. " +
-          "This service is removed from the new release and must be removed before the upgrade can continue. " +
-          "After upgrading, %s can be installed").build());
+          "This service is removed from the new release and must be removed before the upgrade can continue.").build());
 
   public static CheckDescription RANGER_SERVICE_AUDIT_DB_CHECK = new CheckDescription("RANGER_SERVICE_AUDIT_DB_CHECK",
     PrereqCheckType.SERVICE,


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
Ran ambari-server unit tests
----------------------------------------------------------------------
Total run:1183
Total errors:0
Total failures:0
OK

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

Also verified the fix by changing the upgrade pack xml and verifying the message as part of EU pre-check:

UpgradeChecks: {
check: "Service Is Not Supported For Upgrades",
check_type: "SERVICE",
cluster_name: "cl1",
failed_detail: [ ],
failed_on: [
"Flume",
"Slider"
],
id: "SERVICE_PRESENCE_CHECK",
reason: "The Flume service is currently installed on the cluster. This service is removed from the new release and must be removed before the upgrade can continue. The Slider service is currently installed on the cluster. This service is removed from the new release and must be removed before the upgrade can continue",
repository_version_id: 51,
status: "FAIL",
upgrade_type: "NON_ROLLING"
}
