### PR TITLE
[AMBARI-23112] [trunk] Some libraries are not relocated in ambari-metrics-common.

### DIFF
--- a/ambari-metrics/ambari-metrics-common/pom.xml
+++ b/ambari-metrics/ambari-metrics-common/pom.xml
@@ -74,12 +74,8 @@
                   <shadedPattern>org.apache.ambari.metrics.sink.relocated.google</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.commons.io</pattern>
-                  <shadedPattern>org.apache.ambari.metrics.sink.relocated.commons.io</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons.lang</pattern>
-                  <shadedPattern>org.apache.ambari.metrics.relocated.commons.lang</shadedPattern>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>org.apache.ambari.metrics.relocated.commons</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.curator</pattern>
@@ -115,7 +111,11 @@
                 </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
-                  <shadedPattern>org.apache.hadoop.metrics2.sink.relocated.apache.http</shadedPattern>
+                  <shadedPattern>org.apache.ambari.metrics.sink.relocated.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.jackson</pattern>
+                  <shadedPattern>org.apache.ambari.metrics.sink.relocated.jackson</shadedPattern>
                 </relocation>
               </relocations>
               <filters>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed shading to include all of jackson and commons jars.

## How was this patch tested?
Ran 'mvn clean package' and verified the JAR contents.