### PR TITLE
[AMBARI-23426] Unable to parse task structured output when disabling Kerberos

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/dummy_files/alert_definitions.json
+++ b/ambari-agent/src/test/python/ambari_agent/dummy_files/alert_definitions.json
@@ -7,9 +7,9 @@
       {
         "name": "namenode_process", 
         "service": "HDFS", 
-        "enabled": true, 
-        "interval": 6, 
         "component": "NAMENODE", 
+        "interval": 6, 
+        "enabled": true, 
         "label": "NameNode process", 
         "source": {
           "reporting": {

--- a/ambari-agent/src/test/python/ambari_agent/dummy_files/alert_definitions.json
+++ b/ambari-agent/src/test/python/ambari_agent/dummy_files/alert_definitions.json
@@ -7,9 +7,9 @@
       {
         "name": "namenode_process", 
         "service": "HDFS", 
-        "component": "NAMENODE", 
-        "interval": 6, 
-        "enabled": true, 
+        "enabled": true,
+        "interval": 6,
+        "component": "NAMENODE",
         "label": "NameNode process", 
         "source": {
           "reporting": {

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -881,7 +881,7 @@ class Script(object):
     """
     To be overridden by subclasses if a custom action is required upon dekerberization (e.g. removing zk ACLs)
     """
-    pass
+    return "{}"
 
   def restart(self, env):
     """


### PR DESCRIPTION

## What changes were proposed in this pull request?

The following error is seen in the log when disabling Kerberos:

```
Unable to parse task structured output: /var/lib/ambari-agent/data/structured-out-5.json
```
This appears to be caused by an empty value being returned from {{resource_management.libraries.script.script.Script#disable_security}}.  Rather then returning an empty value ({{None}}), return {{"\{\}"}} instead. 

Note: This was handing up disabling Kerberos since the command report was incorrect.

## How was this patch tested?

Manually tested in a cluster. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.