### PR TITLE
AMBARI-23429 Added missing imports

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py
@@ -20,6 +20,7 @@ limitations under the License.
 
 import ConfigParser
 import os
+import re
 
 from ambari_commons import OSCheck
 from ambari_commons.ambari_metrics_helper import select_metric_collector_hosts_from_hostnames


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the imports in the python script due to which Ambari Metrics Monitor installation is failing when **hbase.wal.dir** configuration is being [set](https://github.com/apache/ambari/blob/trunk/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py#L376)

## How was this patch tested?

  21533 passing (28s)
  48 pending