### PR TITLE
[AMBARI-23074] Change the default datadir for Infra Solr.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -75,7 +75,7 @@
   </property>
   <property>
     <name>infra_solr_datadir</name>
-    <value>/opt/ambari_infra_solr/data</value>
+    <value>/var/lib/ambari-infra-solr/data</value>
     <display-name>Infra Solr data dir</display-name>
     <description>Directory for storting Solr index. Make sure you have enough disk space</description>
     <value-attributes>

--- a/ambari-server/src/test/python/stacks/2.4/AMBARI_INFRA/test_infra_solr.py
+++ b/ambari-server/src/test/python/stacks/2.4/AMBARI_INFRA/test_infra_solr.py
@@ -44,14 +44,14 @@ class TestInfraSolr(RMFTestCase):
                                 cd_access = 'a',
                                 mode = 0755
       )
-      self.assertResourceCalled('Directory', '/opt/ambari_infra_solr/data',
+      self.assertResourceCalled('Directory', '/var/lib/ambari-infra-solr/data',
                                 owner = 'solr',
                                 group = 'hadoop',
                                 create_parents = True,
                                 cd_access = 'a',
                                 mode = 0755
       )
-      self.assertResourceCalled('Directory', '/opt/ambari_infra_solr/data/resources',
+      self.assertResourceCalled('Directory', '/var/lib/ambari-infra-solr/data/resources',
                                 owner = 'solr',
                                 group = 'hadoop',
                                 create_parents = True,
@@ -87,7 +87,7 @@ class TestInfraSolr(RMFTestCase):
                                 mode = 0755,
                                 content = InlineTemplate(self.getConfig()['configurations']['infra-solr-env']['content'])
       )
-      self.assertResourceCalled('File', '/opt/ambari_infra_solr/data/solr.xml',
+      self.assertResourceCalled('File', '/var/lib/ambari-infra-solr/data/solr.xml',
                                 owner = 'solr',
                                 group='hadoop',
                                 content = InlineTemplate(self.getConfig()['configurations']['infra-solr-xml']['content'])
@@ -143,7 +143,7 @@ class TestInfraSolr(RMFTestCase):
     )
     
     self.configureResourcesCalled()
-    self.assertResourceCalled('Execute', "/usr/lib/ambari-infra-solr/bin/solr start -cloud -noprompt -s /opt/ambari_infra_solr/data >> /var/log/ambari-infra-solr/solr-install.log 2>&1",
+    self.assertResourceCalled('Execute', "/usr/lib/ambari-infra-solr/bin/solr start -cloud -noprompt -s /var/lib/ambari-infra-solr/data >> /var/log/ambari-infra-solr/solr-install.log 2>&1",
                               environment = {'SOLR_INCLUDE': '/etc/ambari-infra-solr/conf/infra-solr-env.sh'},
                               user = "solr"
     )

--- a/ambari-server/src/test/python/stacks/2.4/configs/default.json
+++ b/ambari-server/src/test/python/stacks/2.4/configs/default.json
@@ -394,7 +394,7 @@
         "infra_solr_znode": "/infra-solr",
         "infra_solr_conf": "/etc/ambari-infra-solr",
         "infra_solr_pid_dir": "/var/run/ambari-infra-solr",
-        "infra_solr_datadir": "/opt/ambari_infra_solr/data",
+        "infra_solr_datadir": "/var/lib/ambari-infra-solr/data",
         "infra_solr_log_dir": "/var/log/ambari-infra-solr",
         "infra_solr_client_log_dir": "/var/log/ambari-infra-solr-client",
         "infra_solr_jmx_port" : "1",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the default solr data directory, as /opt folder is not really for storing a large amount of data

## How was this patch tested?
mvn clean test -DskipSurefireTests -Dpython.test.mask="*test_infra_solr*"
```bash
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:36 min
[INFO] Finished at: 2018-04-03T13:52:47+02:00
[INFO] Final Memory: 111M/1590M
[INFO] ------------------------------------------------------------------------
```

Please review @kasakrisz @g-boros @zeroflag 