### PR TITLE
AMBARI-23080. Log Search: use compositeId instead of implicit routing by default for collections.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
@@ -50,6 +50,7 @@ public class LogFeederConstants {
 
   public static final String LOG_FILTER_ENABLE_PROPERTY = "logfeeder.log.filter.enable";
   public static final String INCLUDE_DEFAULT_LEVEL_PROPERTY = "logfeeder.include.default.level";
+  public static final String SOLR_IMPLICIT_ROUTING_PROPERTY = "logfeeder.solr.implicit.routing";
 
   public static final String CONFIG_DIR_PROPERTY = "logfeeder.config.dir";
   public static final String CONFIG_FILES_PROPERTY = "logfeeder.config.files";

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
@@ -74,6 +74,16 @@ public class LogFeederProps implements LogFeederProperties {
   private boolean logLevelFilterEnabled;
 
   @LogSearchPropertyDescription(
+    name = LogFeederConstants.SOLR_IMPLICIT_ROUTING_PROPERTY,
+    description = "Use implicit routing for Solr Collections.",
+    examples = {"true"},
+    defaultValue = "false",
+    sources = {LogFeederConstants.SOLR_IMPLICIT_ROUTING_PROPERTY}
+  )
+  @Value("${"+ LogFeederConstants.SOLR_IMPLICIT_ROUTING_PROPERTY + ":false}")
+  private boolean solrImplicitRouting;
+
+  @LogSearchPropertyDescription(
     name = LogFeederConstants.INCLUDE_DEFAULT_LEVEL_PROPERTY,
     description = "Comma separated list of the default log levels to be enabled by the filtering.",
     examples = {"FATAL,ERROR,WARN"},
@@ -207,6 +217,14 @@ public class LogFeederProps implements LogFeederProperties {
 
   public void setCheckpointFolder(String checkpointFolder) {
     this.checkpointFolder = checkpointFolder;
+  }
+
+  public boolean isSolrImplicitRouting() {
+    return solrImplicitRouting;
+  }
+
+  public void setSolrImplicitRouting(boolean solrImplicitRouting) {
+    this.solrImplicitRouting = solrImplicitRouting;
   }
 
   @PostConstruct

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
@@ -155,7 +155,7 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
         + getShortDescription(), workers, splitMode, splitInterval));
 
     implicitRouting = logFeederProps.isSolrImplicitRouting(); // TODO: in the future, load it from output config (can be a use case to use different routing for audit/service logs)
-    if (logFeederProps.isSolrImplicitRouting()) {
+    if (implicitRouting) {
       LOG.info("Config: Use implicit routing globally for adding docs to Solr.");
     } else {
       LOG.info("Config: Use compositeId globally for adding docs to Solr.");

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
@@ -81,7 +81,7 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
   private int maxIntervalMS;
   private int workers;
   private int maxBufferSize;
-  private boolean isComputeCurrentCollection = false;
+  private boolean implicitRouting = false;
   private int lastSlotByMin = -1;
   private boolean skipLogtime = false;
 
@@ -115,14 +115,14 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
   @Override
   public void init(LogFeederProps logFeederProps) throws Exception {
     this.logFeederProps = logFeederProps;
-    initParams();
+    initParams(logFeederProps);
     setupSecurity();
     createOutgoingBuffer();
     createSolrStateWatcher();
     createSolrWorkers();
   }
 
-  private void initParams() throws Exception {
+  private void initParams(LogFeederProps logFeederProps) throws Exception {
     type = getStringValue("type");
     while (true) {
       OutputSolrProperties outputSolrProperties = getLogSearchConfig().getOutputSolrProperties(type);
@@ -153,6 +153,13 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
 
     LOG.info(String.format("Config: Number of workers=%d, splitMode=%s, splitInterval=%d."
         + getShortDescription(), workers, splitMode, splitInterval));
+
+    implicitRouting = logFeederProps.isSolrImplicitRouting(); // TODO: in the future, load it from output config (can be a use case to use different routing for audit/service logs)
+    if (logFeederProps.isSolrImplicitRouting()) {
+      LOG.info("Config: Use implicit routing globally for adding docs to Solr.");
+    } else {
+      LOG.info("Config: Use compositeId globally for adding docs to Solr.");
+    }
   }
 
   @Override
@@ -166,7 +173,6 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
       if (!splitMode.equalsIgnoreCase("none")) {
         splitInterval = Integer.parseInt(splitMode);
       }
-      isComputeCurrentCollection = !splitMode.equalsIgnoreCase("none");
 
       // collection can not be overwritten after initialization
       if (init) {
@@ -424,7 +430,7 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
       while (!isDrain()) {
         try {
           synchronized (propertiesLock) {
-            if (isComputeCurrentCollection) {
+            if (implicitRouting) {
               // Compute the current router value
               addRouterField();
             }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrAuditLogPropsConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrAuditLogPropsConfig.java
@@ -136,6 +136,16 @@ public class SolrAuditLogPropsConfig implements SolrPropsConfig {
   )
   private String configSetFolder;
 
+  @LogSearchPropertyDescription(
+    name = "logsearch.solr.implicit.routing",
+    description = "Use implicit routing for Solr Collections.",
+    examples = {"true"},
+    defaultValue = "false",
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  @Value("${logsearch.solr.implicit.routing:false}")
+  private boolean solrImplicitRouting;
+
   @Override
   public String getSolrUrl() {
     return solrUrl;
@@ -240,6 +250,16 @@ public class SolrAuditLogPropsConfig implements SolrPropsConfig {
 
   public void setAliasNameIn(String aliasNameIn) {
     this.aliasNameIn = aliasNameIn;
+  }
+
+  @Override
+  public boolean isSolrImplicitRouting() {
+    return solrImplicitRouting;
+  }
+
+  @Override
+  public void setSolrImplicitRouting(boolean solrImplicitRouting) {
+    this.solrImplicitRouting = solrImplicitRouting;
   }
 
   @Override

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrConnectionPropsConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrConnectionPropsConfig.java
@@ -64,6 +64,16 @@ public abstract class SolrConnectionPropsConfig implements SolrPropsConfig {
   )
   private String configSetFolder;
 
+  @LogSearchPropertyDescription(
+    name = "logsearch.solr.implicit.routing",
+    description = "Use implicit routing for Solr Collections.",
+    examples = {"true"},
+    defaultValue = "false",
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  @Value("${logsearch.solr.implicit.routing:false}")
+  private boolean solrImplicitRouting;
+
   @Override
   public String getSolrUrl() {
     return solrUrl;
@@ -102,5 +112,15 @@ public abstract class SolrConnectionPropsConfig implements SolrPropsConfig {
   @Override
   public void setConfigSetFolder(String configSetFolder) {
     this.configSetFolder = configSetFolder;
+  }
+
+  @Override
+  public boolean isSolrImplicitRouting() {
+    return solrImplicitRouting;
+  }
+
+  @Override
+  public void setSolrImplicitRouting(boolean solrImplicitRouting) {
+    this.solrImplicitRouting = solrImplicitRouting;
   }
 }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrPropsConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrPropsConfig.java
@@ -60,4 +60,8 @@ public interface SolrPropsConfig {
   void setConfigSetFolder(String configSetFolder);
   
   String getLogType();
+
+  boolean isSolrImplicitRouting();
+
+  void setSolrImplicitRouting(boolean solrImplicitRouting);
 }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/handler/CreateCollectionHandler.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/handler/CreateCollectionHandler.java
@@ -71,10 +71,10 @@ public class CreateCollectionHandler implements SolrZkRequestHandler<Boolean> {
     }
 
     boolean result;
-    if (solrPropsConfig.getSplitInterval().equalsIgnoreCase("none")) {
-      result = createCollection(solrClient, solrPropsConfig, this.allCollectionList);
-    } else {
+    if (solrPropsConfig.isSolrImplicitRouting()) {
       result = setupCollectionsWithImplicitRouting(solrClient, solrPropsConfig, this.allCollectionList);
+    } else {
+      result = createCollection(solrClient, solrPropsConfig, this.allCollectionList);
     }
 
     return result;

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logfeeder-properties.xml
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logfeeder-properties.xml
@@ -65,6 +65,18 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>logfeeder.solr.implicit.routing</name>
+    <value>false</value>
+    <description>
+      Use implicit routing for Solr Collections.
+    </description>
+    <display-name>Log Feeder Solr implicit routing</display-name>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>logfeeder.cache.enabled</name>
     <value>false</value>
     <description>

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logsearch-properties.xml
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logsearch-properties.xml
@@ -134,6 +134,18 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>logsearch.solr.implicit.routing</name>
+    <value>false</value>
+    <description>
+      Use implicit routing for Solr Collections.
+    </description>
+    <display-name>Log Search Solr implicit routing</display-name>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>logsearch.solr.audit.logs.use.ranger</name>
     <value>false</value>
     <display-name>Ranger Audit Logs Enabled</display-name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use compositeId by default for logsearch Solr collections (in order for better data balance between shards)
## How was this patch tested?
Related UTs passed.
FT: with docker env (collections were created with shard names: shard1,shard2 and not with shard0,shard1 as with implicit routing)

Please review @zeroflag @adoroszlai @swagle @kasakrisz @g-boros 