### PR TITLE
[AMBARI-23441] API Addition for Upgrade Plan for Config Changes

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
@@ -246,7 +246,7 @@ public class HeartBeatHandler {
         response.setRecoveryConfig(rc);
 
         if (response.getRecoveryConfig() != null) {
-          LOG.info("Recovery configuration set to {}", response.getRecoveryConfig());
+          LOG.debug("Recovery configuration set to {}", response.getRecoveryConfig());
         }
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradePlanConfigEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradePlanConfigEntity.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.orm.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.TableGenerator;
+
+/**
+ * Holds config changes for an entity.
+ */
+@Table(name = "upgrade_plan_config")
+@Entity
+@TableGenerator(name = "upgrade_plan_config_id_generator",
+    table = "ambari_sequences", pkColumnName = "sequence_name", valueColumnName = "sequence_value",
+    pkColumnValue = "upgrade_plan_config_id_seq",
+    initialValue = 0)
+public class UpgradePlanConfigEntity {
+
+  @Id
+  @Column(name = "id", nullable = false, insertable = true, updatable = false)
+  @GeneratedValue(strategy = GenerationType.TABLE, generator = "upgrade_plan_config_id_generator")
+  private Long id;
+
+  @Column(name = "config_type", nullable = false, insertable = true, updatable = false)
+  private String type;
+
+  @Column(name = "key", nullable = false, insertable = true, updatable = false)
+  private String key;
+
+  @Column(name="new_value", insertable = true, updatable = false)
+  private String newValue;
+
+  @Column(name="remove")
+  private short remove = (short) 0;
+
+  @ManyToOne
+  @JoinColumn(name = "upgrade_plan_detail_id", referencedColumnName = "id", nullable = false)
+  private UpgradePlanDetailEntity upgradePlanDetailEntity;
+
+
+  /**
+   * @param detail
+   *          the plan detail
+   */
+  void setPlanDetail(UpgradePlanDetailEntity detail) {
+    upgradePlanDetailEntity = detail;
+  }
+
+  /**
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * @param configType
+   *          the type
+   */
+  public void setType(String configType) {
+    type = configType;
+  }
+
+  /**
+   * @return the key
+   */
+  public String getKey() {
+    return key;
+  }
+
+  /**
+   * @param configKey
+   *          the key
+   */
+  public void setKey(String configKey) {
+    key = configKey;
+  }
+
+  /**
+   * @return the new value
+   */
+  public String getNewValue() {
+    return newValue;
+  }
+
+  /**
+   * @param value
+   *          the new value
+   */
+  public void setNewValue(String value) {
+    newValue = value;
+  }
+
+  /**
+   * @return if the {{@link #getKey()} is to be removed
+   */
+  public boolean isRemove() {
+    return remove != 0;
+  }
+
+  /**
+   * @param toRemove
+   *          {@code true} to remove property of the specified key
+   */
+  public void setRemove(boolean toRemove) {
+    remove = toRemove ? (short) 1 : (short) 0;
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradePlanDetailEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradePlanDetailEntity.java
@@ -17,6 +17,10 @@
  */
 package org.apache.ambari.server.orm.entities;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -24,10 +28,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Models a single upgrade plan that can be used to invoke an Upgrade.
@@ -57,6 +62,9 @@ public class UpgradePlanDetailEntity {
   @ManyToOne
   @JoinColumn(name = "upgrade_plan_id", referencedColumnName = "id", nullable = false)
   private UpgradePlanEntity upgradePlanEntity;
+
+  @OneToMany(mappedBy = "upgradePlanDetailEntity", cascade = { CascadeType.ALL })
+  private List<UpgradePlanConfigEntity> upgradePlanConfigs = new ArrayList<>();
 
   /**
    * @return the id
@@ -107,10 +115,27 @@ public class UpgradePlanDetailEntity {
     upgradePlanEntity = plan;
   }
 
+  /**
+   * @param changes
+   *          the changes for this detail
+   */
+  public void setConfigChanges(List<UpgradePlanConfigEntity> changes) {
+    changes.forEach(change -> change.setPlanDetail(this));
+
+    upgradePlanConfigs = changes;
+  }
+
+  /**
+   * @return the config changes
+   */
+  public List<UpgradePlanConfigEntity> getConfigChanges() {
+    return upgradePlanConfigs;
+  }
+
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).omitNullValues()
+    return MoreObjects.toStringHelper(this).omitNullValues()
         .add("id", id)
         .toString();
   }

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -1066,6 +1066,17 @@ CREATE TABLE upgrade_plan_detail (
   CONSTRAINT FK_upgrade_det_upgrade_plan FOREIGN KEY (upgrade_plan_id) REFERENCES upgrade_plan (id)
 );
 
+CREATE TABLE upgrade_plan_config (
+  id BIGINT NOT NULL,
+  upgrade_plan_detail_id BIGINT NOT NULL,
+  config_type VARCHAR(255) NOT NULL,
+  key VARCHAR(255) NOT NULL,
+  new_value VARCHAR(3000),
+  remove SMALLINT DEFAULT 0 NOT NULL,
+  CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),
+  CONSTRAINT FK_up_conf_up_detail FOREIGN KEY (upgrade_plan_detail_id) REFERENCES upgrade_plan_detail (id)
+);
+
 CREATE TABLE ambari_operation_history(
   id BIGINT NOT NULL,
   from_version VARCHAR(255) NOT NULL,
@@ -1342,6 +1353,8 @@ INSERT INTO ambari_sequences (sequence_name, sequence_value)
   select 'upgrade_item_id_seq', 0 FROM SYSIBM.SYSDUMMY1
   union all
   select 'upgrade_plan_id_seq', 0 FROM SYSIBM.SYSDUMMY1
+  union all
+  select 'upgrade_plan_config_id_seq', 0 FROM SYSIBM.SYSDUMMY1
   union all
   select 'upgrade_plan_detail_id_seq', 0 FROM SYSIBM.SYSDUMMY1
   union all

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -1083,6 +1083,16 @@ CREATE TABLE upgrade_plan_detail (
   CONSTRAINT FK_upgrade_det_upgrade_plan FOREIGN KEY (upgrade_plan_id) REFERENCES upgrade_plan (id)
 );
 
+CREATE TABLE upgrade_plan_config (
+  id BIGINT NOT NULL,
+  upgrade_plan_detail_id BIGINT NOT NULL,
+  config_type VARCHAR(255) NOT NULL,
+  key VARCHAR(255) NOT NULL,
+  new_value LONGTEXT,
+  remove SMALLINT DEFAULT 0 NOT NULL,
+  CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),
+  CONSTRAINT FK_up_conf_up_detail FOREIGN KEY (upgrade_plan_detail_id) REFERENCES upgrade_plan_detail (id)
+);
 
 CREATE TABLE ambari_operation_history(
   id BIGINT NOT NULL,
@@ -1317,6 +1327,7 @@ INSERT INTO ambari_sequences(sequence_name, sequence_value) VALUES
   ('upgrade_group_id_seq', 0),
   ('upgrade_item_id_seq', 0),
   ('upgrade_plan_id_seq', 0),
+  ('upgrade_plan_config_id_seq', 0),
   ('upgrade_plan_detail_id_seq', 0),
   ('stack_id_seq', 0),
   ('mpack_id_seq', 0),

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -1044,11 +1044,11 @@ CREATE TABLE upgrade_plan (
   cluster_id NUMBER(19) NOT NULL,
   upgrade_type VARCHAR2(255) DEFAULT 'ROLLING' NOT NULL,
   direction VARCHAR2(255) DEFAULT 'UPGRADE' NOT NULL,
-  skip_failures SMALLINT DEFAULT 0 NOT NULL,
-  skip_sc_failures SMALLINT DEFAULT 0 NOT NULL,
-  skip_prechecks SMALLINT DEFAULT 0 NOT NULL,
-  fail_on_precheck_warnings SMALLINT DEFAULT 0 NOT NULL,
-  skip_service_checks SMALLINT DEFAULT 0 NOT NULL,
+  skip_failures NUMBER(1) DEFAULT 0 NOT NULL,
+  skip_sc_failures NUMBER(1) DEFAULT 0 NOT NULL,
+  skip_prechecks NUMBER(1) DEFAULT 0 NOT NULL,
+  fail_on_precheck_warnings NUMBER(1) DEFAULT 0 NOT NULL,
+  skip_service_checks NUMBER(1) DEFAULT 0 NOT NULL,
   CONSTRAINT PK_upgrade_plan PRIMARY KEY (id)
 );
 
@@ -1061,6 +1061,16 @@ CREATE TABLE upgrade_plan_detail (
   CONSTRAINT FK_upgrade_det_upgrade_plan FOREIGN KEY (upgrade_plan_id) REFERENCES upgrade_plan (id)
 );
 
+CREATE TABLE upgrade_plan_config (
+  id NUMBER(19) NOT NULL,
+  upgrade_plan_detail_id NUMBER(19) NOT NULL,
+  config_type VARCHAR2(255) NOT NULL,
+  key VARCHAR2(255) NOT NULL,
+  new_value CLOB,
+  remove NUMBER(1) DEFAULT 0 NOT NULL,
+  CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),
+  CONSTRAINT FK_up_conf_up_detail FOREIGN KEY (upgrade_plan_detail_id) REFERENCES upgrade_plan_detail (id)
+);
 
 CREATE TABLE ambari_operation_history(
   id NUMBER(19) NOT NULL,
@@ -1295,6 +1305,7 @@ INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_id_
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_group_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_item_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_plan_id_seq', 0);
+INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_plan_config_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_plan_detail_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('stack_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('mpack_id_seq', 0);

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -1066,6 +1066,18 @@ CREATE TABLE upgrade_plan_detail (
   CONSTRAINT FK_upgrade_det_upgrade_plan FOREIGN KEY (upgrade_plan_id) REFERENCES upgrade_plan (id)
 );
 
+CREATE TABLE upgrade_plan_config (
+  id BIGINT NOT NULL,
+  upgrade_plan_detail_id BIGINT NOT NULL,
+  config_type VARCHAR(255) NOT NULL,
+  key VARCHAR(255) NOT NULL,
+  new_value TEXT,
+  remove SMALLINT DEFAULT 0 NOT NULL,
+  CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),
+  CONSTRAINT FK_up_conf_up_detail FOREIGN KEY (upgrade_plan_detail_id) REFERENCES upgrade_plan_detail (id)
+);
+
+
 CREATE TABLE ambari_operation_history(
   id BIGINT NOT NULL,
   from_version VARCHAR(255) NOT NULL,
@@ -1296,6 +1308,7 @@ INSERT INTO ambari_sequences (sequence_name, sequence_value) VALUES
   ('upgrade_group_id_seq', 0),
   ('upgrade_item_id_seq', 0),
   ('upgrade_plan_id_seq', 0),
+  ('upgrade_plan_config_id_seq', 0),
   ('upgrade_plan_detail_id_seq', 0),
   ('widget_id_seq', 0),
   ('widget_layout_id_seq', 0),

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -1062,6 +1062,17 @@ CREATE TABLE upgrade_plan_detail (
   CONSTRAINT FK_upgrade_det_upgrade_plan FOREIGN KEY (upgrade_plan_id) REFERENCES upgrade_plan (id)
 );
 
+CREATE TABLE upgrade_plan_config (
+  id NUMERIC(19) NOT NULL,
+  upgrade_plan_detail_id NUMERIC(19) NOT NULL,
+  config_type VARCHAR(255) NOT NULL,
+  key VARCHAR(255) NOT NULL,
+  new_value TEXT,
+  remove SMALLINT DEFAULT 0 NOT NULL,
+  CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),
+  CONSTRAINT FK_up_conf_up_detail FOREIGN KEY (upgrade_plan_detail_id) REFERENCES upgrade_plan_detail (id)
+);
+
 
 CREATE TABLE ambari_operation_history(
   id NUMERIC(19) NOT NULL,
@@ -1296,6 +1307,7 @@ INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_id_
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_group_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_item_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_plan_id_seq', 0);
+INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_plan_config_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('upgrade_plan_detail_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('stack_id_seq', 0);
 INSERT INTO ambari_sequences(sequence_name, sequence_value) values ('mpack_id_seq', 0);

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -1084,6 +1084,17 @@ CREATE TABLE upgrade_plan_detail (
   CONSTRAINT FK_upgrade_det_upgrade_plan FOREIGN KEY (upgrade_plan_id) REFERENCES upgrade_plan (id)
 );
 
+CREATE TABLE upgrade_plan_config (
+  id BIGINT NOT NULL,
+  upgrade_plan_detail_id BIGINT NOT NULL,
+  config_type VARCHAR(255) NOT NULL,
+  key VARCHAR(255) NOT NULL,
+  new_value TEXT,
+  remove SMALLINT NOT NULL DEFAULT 0,
+  CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),
+  CONSTRAINT FK_up_conf_up_detail FOREIGN KEY (upgrade_plan_detail_id) REFERENCES upgrade_plan_detail (id)
+);
+
 CREATE TABLE ambari_operation_history(
   id BIGINT NOT NULL,
   from_version VARCHAR(255) NOT NULL,
@@ -1323,6 +1334,7 @@ BEGIN TRANSACTION
     ('upgrade_group_id_seq', 0),
     ('upgrade_item_id_seq', 0),
     ('upgrade_plan_id_seq', 0),
+    ('upgrade_plan_config_id_seq', 0),
     ('upgrade_plan_detail_id_seq', 0),
     ('widget_id_seq', 0),
     ('widget_layout_id_seq', 0),

--- a/ambari-server/src/main/resources/META-INF/persistence.xml
+++ b/ambari-server/src/main/resources/META-INF/persistence.xml
@@ -88,6 +88,7 @@
     <class>org.apache.ambari.server.orm.entities.UpgradeItemEntity</class>
     <class>org.apache.ambari.server.orm.entities.UpgradeHistoryEntity</class>
     <class>org.apache.ambari.server.orm.entities.UpgradePlanEntity</class>
+    <class>org.apache.ambari.server.orm.entities.UpgradePlanConfigEntity</class>
     <class>org.apache.ambari.server.orm.entities.UpgradePlanDetailEntity</class>
     <class>org.apache.ambari.server.orm.entities.UserEntity</class>
     <class>org.apache.ambari.server.orm.entities.UserAuthenticationEntity</class>

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradePlanResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradePlanResourceProviderTest.java
@@ -35,13 +35,18 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
+import org.apache.ambari.server.orm.dao.MpackDAO;
+import org.apache.ambari.server.orm.dao.ServiceGroupDAO;
 import org.apache.ambari.server.orm.dao.UpgradePlanDAO;
+import org.apache.ambari.server.orm.entities.MpackEntity;
+import org.apache.ambari.server.orm.entities.ServiceGroupEntity;
 import org.apache.ambari.server.orm.entities.UpgradePlanDetailEntity;
 import org.apache.ambari.server.orm.entities.UpgradePlanEntity;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
+import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,8 +65,11 @@ import com.google.inject.util.Modules;
 public class UpgradePlanResourceProviderTest {
 
   private Injector injector;
-  private AmbariManagementController amc;
   private UpgradePlanDAO planDAO;
+
+  private AmbariManagementController amc;
+  private MpackDAO mpackDAO;
+  private ServiceGroupDAO serviceGroupDAO;
 
   @Before
   public void before() throws Exception {
@@ -73,6 +81,8 @@ public class UpgradePlanResourceProviderTest {
     expect(clusters.getCluster(anyString())).andReturn(cluster).atLeastOnce();
 
     amc = createNiceMock(AmbariManagementController.class);
+    mpackDAO = createNiceMock(MpackDAO.class);
+    serviceGroupDAO = createNiceMock(ServiceGroupDAO.class);
 
     expect(amc.getClusters()).andReturn(clusters).atLeastOnce();
 
@@ -93,6 +103,14 @@ public class UpgradePlanResourceProviderTest {
 
   @Test
   public void testCreateResources() throws Exception {
+    ServiceGroupEntity randomServiceGroup = createNiceMock(ServiceGroupEntity.class);
+    expect(serviceGroupDAO.findByClusterAndServiceGroupIds(EasyMock.anyLong(),
+        EasyMock.anyLong())).andReturn(randomServiceGroup).atLeastOnce();
+
+    MpackEntity randomMpack = createNiceMock(MpackEntity.class);
+    expect(mpackDAO.findById(EasyMock.anyLong())).andReturn(randomMpack).atLeastOnce();
+
+    replay(serviceGroupDAO, mpackDAO);
 
     UpgradePlanResourceProvider provider = createProvider(amc);
 
@@ -125,6 +143,9 @@ public class UpgradePlanResourceProviderTest {
     UpgradePlanDetailEntity detail = entity.getDetails().iterator().next();
     assertEquals(4L, detail.getServiceGroupId());
     assertEquals(2L, detail.getMpackTargetId());
+    assertNotNull(detail.getConfigChanges());
+    // !!! TODO when more thorough code is added, we'll be able to test more assertions
+    assertEquals(0, detail.getConfigChanges().size());
   }
 
 
@@ -143,6 +164,8 @@ public class UpgradePlanResourceProviderTest {
     @Override
     public void configure(Binder binder) {
       binder.bind(AmbariManagementController.class).toInstance(amc);
+      binder.bind(MpackDAO.class).toInstance(mpackDAO);
+      binder.bind(ServiceGroupDAO.class).toInstance(serviceGroupDAO);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add DDL and resource provider to ability to save config changes.  This commit is largely to get the base in there knowing that the code will likely be evolving.

UpgradeCatalog300 changes are slated for later

## How was this patch tested?

Unit tests.  No more failing than without these changes:
```
[ERROR] Tests run: 4858, Failures: 38, Errors: 353, Skipped: 73
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```
