### PR TITLE
[AMBARI-23382]  Ambari-server sync-ldap: Sync event creation failed

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverUtils.py
+++ b/ambari-server/src/main/python/ambari_server/serverUtils.py
@@ -20,6 +20,7 @@ limitations under the License.
 
 import os
 import time
+import socket
 from ambari_commons.exceptions import FatalException, NonFatalException
 from ambari_commons.logging_utils import get_verbose
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
@@ -113,8 +114,10 @@ def refresh_stack_hash(properties):
 # Reads server protocol/port from configuration
 # And returns something like
 # http://127.0.0.1:8080/api/v1/
+# or if using ssl http://hostname.domain:8443/api/v1
 #
 def get_ambari_server_api_base(properties):
+  api_host = SERVER_API_HOST
   api_protocol = SERVER_API_PROTOCOL
   api_port = CLIENT_API_PORT
   api_port_prop = properties.get_property(CLIENT_API_PORT_PROPERTY)
@@ -127,9 +130,10 @@ def get_ambari_server_api_base(properties):
     api_ssl = api_ssl_prop.lower() == "true"
 
   if api_ssl:
+    api_host = socket.getfqdn()
     api_protocol = SERVER_API_SSL_PROTOCOL
     api_port = DEFAULT_SSL_API_PORT
     api_port_prop = properties.get_property(SSL_API_PORT)
     if api_port_prop is not None:
       api_port = api_port_prop
-  return '{0}://{1}:{2!s}/api/v1/'.format(api_protocol, SERVER_API_HOST, api_port)
+  return '{0}://{1}:{2!s}/api/v1/'.format(api_protocol, api_host, api_port)

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -33,6 +33,7 @@ import operator
 from ambari_commons import subprocess32
 from optparse import OptionParser
 import platform
+import socket
 import re
 import shutil
 import signal
@@ -7560,7 +7561,7 @@ class TestAmbariServer:#(TestCase):
 
     sync_ldap(options)
 
-    url = '{0}://{1}:{2!s}{3}'.format('https', '127.0.0.1', '8443', '/api/v1/ldap_sync_events')
+    url = '{0}://{1}:{2!s}{3}'.format('https', socket.getfqdn(), '8443', '/api/v1/ldap_sync_events')
     request = urlopen_mock.call_args_list[0][0][0]
 
     self.assertEquals(url, str(request.get_full_url()))

--- a/ambari-server/src/test/python/TestServerUtils.py
+++ b/ambari-server/src/test/python/TestServerUtils.py
@@ -22,6 +22,7 @@ os.environ["ROOT"] = ""
 from mock.mock import patch, MagicMock
 from unittest import TestCase
 import platform
+import socket
 
 from ambari_commons import os_utils
 os_utils.search_file = MagicMock(return_value="/tmp/ambari.properties")
@@ -58,13 +59,16 @@ class TestServerUtils(TestCase):
     self.assertEquals(result, 'http://127.0.0.1:8033/api/v1/')
 
     # Test case of using https protocol (and ssl port)
+    fqdn = socket.getfqdn()
+    self.assertTrue(len(fqdn)>0)
+
     properties = FakeProperties({
       SSL_API: "true",
       SSL_API_PORT : "8443",
       CLIENT_API_PORT_PROPERTY: None
     })
     result = get_ambari_server_api_base(properties)
-    self.assertEquals(result, 'https://127.0.0.1:8443/api/v1/')
+    self.assertEquals(result, 'https://{0}:8443/api/v1/'.format(fqdn))
 
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In `ambari_server/serverUtils.py` use socket.getfqdn() to obtain the fully qualified domain name of the host. This is needed to pass more recent ssl verification. Behavior in the non-ssl case does not change so kept the 'SERVER_API_HOST=127.0.0.1'

## How was this patch tested?
Currently deployed in our clusters.  

Updated code in `ambari-server/src/test/python/TestServerUtils.py` and ran python unit tests. 
`mvn -am -pl ambari-server -DskipSurefireTests test` 

![virtualbox_centos_04_04_2018_01_51_10](https://user-images.githubusercontent.com/34562546/38299069-eaa65edc-37ad-11e8-8abb-9a23f8829e65.png)
