### PR TITLE
[AMBARI-23449] Agent can not to connect to server during blueprint deploy (dsen)

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
+++ b/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
@@ -319,9 +319,9 @@ class AmbariConfig:
     """
     Get forced https protocol name.
 
-    :return: protocol name, PROTOCOL_TLSv1 by default
+    :return: protocol name, PROTOCOL_TLSv1_2 by default
     """
-    return self.get('security', 'force_https_protocol', default="PROTOCOL_TLSv1")
+    return self.get('security', 'force_https_protocol', default="PROTOCOL_TLSv1_2")
 
   def get_force_https_protocol_value(self):
     """

--- a/ambari-common/src/main/python/ambari_commons/inet_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/inet_utils.py
@@ -228,10 +228,9 @@ def resolve_address(address):
       return '127.0.0.1'
   return address
 
-def ensure_ssl_using_protocol(protocol="PROTOCOL_TLSv1", ca_certs=None):
+def ensure_ssl_using_protocol(protocol="PROTOCOL_TLSv1_2", ca_certs=None):
   """
-  Monkey patching ssl module to force it use tls_v1. Do this in common module to avoid problems with
-  PythonReflectiveExecutor.
+  Patching ssl module to use configured protocol and ca certs
 
   :param protocol: one of ("PROTOCOL_SSLv2", "PROTOCOL_SSLv3", "PROTOCOL_SSLv23", "PROTOCOL_TLSv1", "PROTOCOL_TLSv1_1", "PROTOCOL_TLSv1_2")
   :param ca_certs: path to ca_certs file
@@ -240,21 +239,6 @@ def ensure_ssl_using_protocol(protocol="PROTOCOL_TLSv1", ca_certs=None):
   from functools import wraps
   import ssl
 
-  if not hasattr(ssl.wrap_socket, "_ambari_patched"):
-    def sslwrap(func):
-      @wraps(func)
-      def bar(*args, **kw):
-        import ssl
-        kw['ssl_version'] = getattr(ssl, protocol)
-        if ca_certs and not 'ca_certs' in kw:
-          kw['ca_certs'] = ca_certs
-          kw['cert_reqs'] = ssl.CERT_REQUIRED
-        return func(*args, **kw)
-      bar._ambari_patched = True
-      return bar
-    ssl.wrap_socket = sslwrap(ssl.wrap_socket)
-
-  # python 2.7 stuff goes here
   if hasattr(ssl, "_create_default_https_context"):
     if not hasattr(ssl._create_default_https_context, "_ambari_patched"):
       @wraps(ssl._create_default_https_context)

--- a/ambari-common/src/main/python/ambari_stomp/transport.py
+++ b/ambari-common/src/main/python/ambari_stomp/transport.py
@@ -17,7 +17,7 @@ try:
     import ssl
     from ssl import SSLError
 
-    DEFAULT_SSL_VERSION = ssl.PROTOCOL_TLSv1
+    DEFAULT_SSL_VERSION = ssl.PROTOCOL_TLSv1_2
 except (ImportError, AttributeError):  # python version < 2.6 without the backported ssl module
     ssl = None
 
@@ -814,7 +814,7 @@ class Transport(BaseTransport):
                                where OK is a boolean, and cert is a certificate structure
                                as returned by ssl.SSLSocket.getpeercert()
         :param ssl_version: SSL protocol to use for the connection. This should be one of the PROTOCOL_x
-                            constants provided by the ssl module. The default is ssl.PROTOCOL_TLSv1
+                            constants provided by the ssl module. The default is ssl.PROTOCOL_TLSv1_2
         """
         if not ssl:
             raise Exception("SSL connection requested, but SSL library not found")

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -80,7 +80,7 @@ USAGE = """Usage: {0} <COMMAND> <JSON_CONFIG> <BASEDIR> <STROUTPUT> <LOGGING_LEV
 <STROUTPUT> path to file with structured command output (file will be created). Ex:/tmp/my.txt
 <LOGGING_LEVEL> log level for stdout. Ex:DEBUG,INFO
 <TMP_DIR> temporary directory for executable scripts. Ex: /var/lib/ambari-agent/tmp
-[PROTOCOL] optional protocol to use during https connections. Ex: see python ssl.PROTOCOL_<PROTO> variables, default PROTOCOL_TLSv1
+[PROTOCOL] optional protocol to use during https connections. Ex: see python ssl.PROTOCOL_<PROTO> variables, default PROTOCOL_TLSv1_2
 """
 
 _PASSWORD_MAP = {"/configurations/cluster-env/hadoop.user.name":"/configurations/cluster-env/hadoop.user.password"}
@@ -129,7 +129,7 @@ class Script(object):
 
   # Class variable
   tmp_dir = ""
-  force_https_protocol = "PROTOCOL_TLSv1"
+  force_https_protocol = "PROTOCOL_TLSv1_2"
   ca_cert_file_path = None
 
   def load_structured_out(self):
@@ -597,7 +597,7 @@ class Script(object):
     """
     Get forced https protocol name.
 
-    :return: protocol name, PROTOCOL_TLSv1 by default
+    :return: protocol name, PROTOCOL_TLSv1_2 by default
     """
     return Script.force_https_protocol
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed ssl.wrap_socket method override since min python version is 2.7.5 and it was required for 2.6,
Changed default ssl protocol to TLS 1.2

## How was this patch tested?
With this changes agent successfully connects to server