### PR TITLE
[AMBARI-23458] Creating component instances shouldn't fail if instance already exists when called from the agent (dsen)

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
@@ -72,13 +72,13 @@ def get_component_home_path(mpack_name, instance_name, module_name, components_i
 
 
 def create_component_instance(mpack_name, mpack_version, instance_name, module_name, components_instance_type,
-                              subgroup_name='default', component_instance_name='default'):
+                              subgroup_name='default', component_instance_name='default', fail_if_exists=False):
   """
   creates the single component instance according to the parameters
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
   create_mpack(mpack_name, mpack_version, instance_name, subgroup_name, module_name,
-               None, {components_instance_type: [component_instance_name]})
+               None, {components_instance_type: [component_instance_name]}, fail_if_exists)
 
 
 def set_component_instance_version(mpack_name, mpack_version, instance_name, module_name, components_instance_type,

--- a/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
+++ b/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
@@ -413,12 +413,24 @@ class TestInstanceManager(TestCase):
                         " subgroup_name:default, module_name:hdfs, components:None,"
                         " components_map:{'hdfs_server': ['non-existing-instance']}")
 
+  def test_create_mpack_fail_if_exists(self):
+    create_mpack_with_defaults()
+    try:
+      # should throw exception
+      create_mpack_with_defaults()
+      self.assertTrue(False)
+    except ValueError as e:
+      self.assertTrue("already exist" in e.message)
+
+    # this call shouldn't throw exception
+    create_mpack_with_defaults(fail_if_exists=False)
+
 
 def create_mpack_with_defaults(mpack_name=MPACK_NAME, mpack_version=MPACK_VERSION_1, mpack_instance=INSTANCE_NAME_1,
                                subgroup_name=SUBGROUP_NAME, module_name=SERVER_MODULE_NAME, components='*',
-                               components_map=None):
+                               components_map=None, fail_if_exists=True):
   instance_manager.create_mpack(mpack_name, mpack_version, mpack_instance,
-                                subgroup_name, module_name, components, components_map)
+                                subgroup_name, module_name, components, components_map, fail_if_exists)
 
 
 def build_rpm_structure(mpack_name=MPACK_NAME, mpack_version=MPACK_VERSION_1, mpack_json=MPACK_JSON,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added flag to determine if the method should fail

## How was this patch tested?
manual + UT
