### PR TITLE
AMBARI-23460. Ambari web modification for HSI HA Ambari integration

### DIFF
--- a/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
+++ b/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
@@ -146,9 +146,9 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
     } else {
       this.set('mastersToCreate', [hostComponent.componentName]);
       this.showAssignComponentPopup();
-    }  
+    }
   },
-  
+
   /**
    * Used to set showAddControl/showRemoveControl flag
    * @param componentName
@@ -384,7 +384,7 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
     var recommendationsHostGroups = this.get('content.recommendationsHostGroups');
     var mastersToCreate = this.get('mastersToCreate');
     mastersToCreate.forEach(function(componentName) {
-      var hostName = this.getSelectedHostName(componentName);
+      var hostName = this.getSelectedHostNames(componentName)[0];
       if (hostName && recommendationsHostGroups) {
         var hostGroups = recommendationsHostGroups.blueprint_cluster_binding.host_groups;
         var isHostPresent = false;
@@ -409,25 +409,25 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
   },
 
   /**
-   * Get the fqdn hostname as selected by the user for the component.
+   * Get the fqdn hostnames as selected by the user for the component.
    * @param componentName
-   * @return {String}
+   * @return {String[]}
    */
-  getSelectedHostName: function(componentName) {
+  getSelectedHostNames: function(componentName) {
     var selectedServicesMasters = this.get('selectedServicesMasters');
-    return selectedServicesMasters.findProperty('component_name', componentName).selectedHost;
+    return selectedServicesMasters.filterProperty('component_name', componentName).mapProperty('selectedHost');
   },
 
   /**
    * set App.componentToBeAdded to use it on subsequent validation call while saving configuration
    * @param componentName {String}
-   * @param hostName {String}
+   * @param hostNames {String[]}
    * @method {setGlobalComponentToBeAdded}
    */
-  setGlobalComponentToBeAdded: function(componentName, hostName) {
+  setGlobalComponentToBeAdded: function(componentName, hostNames) {
     var componentToBeAdded = Em.Object.create({
        componentName: componentName,
-       hostNames: [hostName]
+       hostNames: hostNames
     });
     App.set('componentToBeAdded', componentToBeAdded);
   },
@@ -467,7 +467,7 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
       var context = self.get('configWidgetContext');
       context.toggleProperty('controller.forceUpdateBoundaries');
       var configActionComponent = self.get('configActionComponent');
-      var componentHostName = self.getSelectedHostName(configActionComponent.componentName);
+      var componentHostNames = self.getSelectedHostNames(configActionComponent.componentName);
       var config = self.get('configWidgetContext.config');
 
       // TODO remove after stack advisor is able to handle this case
@@ -484,11 +484,11 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
         var miscConfigs = context.get('controller.stepConfigs').findProperty('serviceName', 'MISC').get('configs');
         serviceConfigs = serviceConfigs.concat(miscConfigs);
       } else {
-        self.setGlobalComponentToBeAdded(configActionComponent.componentName, componentHostName);
+        self.setGlobalComponentToBeAdded(configActionComponent.componentName, componentHostNames);
         self.clearComponentsToBeDeleted(configActionComponent.componentName);
       }
 
-      configActionComponent.hostName = componentHostName;
+      configActionComponent.hostNames = componentHostNames;
       config.set('configActionComponent', configActionComponent);
       /* TODO uncomment after stack advisor is able to handle this case
        var oldValueKey = context.get('controller.wizardController.name') === 'installerController' ? 'initialValue' : 'savedValue';

--- a/ambari-web/app/views/common/configs/widgets/config_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/config_widget_view.js
@@ -456,19 +456,19 @@ App.ConfigWidgetView = Em.View.extend(App.SupportsDependentConfigs, App.WidgetPo
     var hostComponent = {
       componentName:configAction.get('componentName'),
       isClient: '',
-      hostName: '',
+      hostNames: [],
       action: ''
     };
 
-    var hostComponentObj = App.HostComponent.find().findProperty('componentName', hostComponent.componentName);
+    var hostComponentRecords = App.HostComponent.find().filterProperty('componentName', hostComponent.componentName);
     var stackComponentObj = App.StackServiceComponent.find(configAction.get('componentName'));
 
     if (stackComponentObj) {
       hostComponent.isClient = stackComponentObj.get('isClient');
     }
 
-    if (hostComponentObj) {
-      hostComponent.hostName = hostComponentObj.get('hostName');
+    if (hostComponentRecords.length) {
+      hostComponent.hostNames = hostComponentRecords.mapProperty('hostName');
     }
 
     var isConditionTrue = App.configTheme.calculateConfigCondition(configAction.get("if"), serviceConfigs);
@@ -482,7 +482,7 @@ App.ConfigWidgetView = Em.View.extend(App.SupportsDependentConfigs, App.WidgetPo
           this.set('controller.saveInProgress', true);
           assignMasterOnStep7Controller.execute(this, 'ADD', hostComponent);
         } else {
-          if(hostComponent.componentName == "HIVE_SERVER_INTERACTIVE") {
+          if(hostComponent.componentName === "HIVE_SERVER_INTERACTIVE") {
             assignMasterOnStep7Controller.execute(this, 'ADD', hostComponent);
           }
           assignMasterOnStep7Controller.clearComponentsToBeDeleted(hostComponent.componentName);

--- a/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
+++ b/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
@@ -18,7 +18,6 @@
 
 var App = require('app');
 var stringUtils = require('utils/string_utils');
-var numberUtils = require('utils/number_utils');
 var blueprintUtils = require('utils/blueprint');
 var testHelpers = require('test/helpers');
 require('models/stack_service_component');
@@ -523,10 +522,10 @@ describe('App.AssignMasterOnStep7Controller', function () {
 
   describe('#saveRecommendationsHostGroups', function() {
     beforeEach(function() {
-      sinon.stub(view, 'getSelectedHostName').returns('host1');
+      sinon.stub(view, 'getSelectedHostNames').returns(['host1']);
     });
     afterEach(function() {
-      view.getSelectedHostName.restore();
+      view.getSelectedHostNames.restore();
     });
 
     it('should add component to recommendations', function() {
@@ -575,7 +574,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
   describe('#setGlobalComponentToBeAdded', function() {
 
     it('should set componentToBeAdded', function() {
-      view.setGlobalComponentToBeAdded('C1', 'host1');
+      view.setGlobalComponentToBeAdded('C1', ['host1']);
       expect(App.get('componentToBeAdded')).to.be.eql(Em.Object.create({
         componentName: 'C1',
         hostNames: ['host1']
@@ -667,7 +666,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
       sinon.stub(App, 'get').returns({
         getKDCSessionState: Em.clb
       });
-      sinon.stub(view, 'getSelectedHostName').returns('host1');
+      sinon.stub(view, 'getSelectedHostNames').returns(['host1']);
       view.setProperties({
         configWidgetContext: configWidgetContext,
         configActionComponent: { componentName: 'C1'},
@@ -683,7 +682,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
       view.setGlobalComponentToBeAdded.restore();
       view.saveRecommendationsHostGroups.restore();
       view.saveMasterComponentHosts.restore();
-      view.getSelectedHostName.restore();
+      view.getSelectedHostNames.restore();
     });
 
     it('saveMasterComponentHosts should be called when controllerName defined', function() {
@@ -711,7 +710,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
         }
       });
       view.submit();
-      expect(view.setGlobalComponentToBeAdded.calledWith('C1', 'host1')).to.be.true;
+      expect(view.setGlobalComponentToBeAdded.calledWith('C1', ['host1'])).to.be.true;
     });
     it('clearComponentsToBeDeleted should be called when controllerName undefined', function() {
       view.reopen({
@@ -734,7 +733,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
       view.submit();
       expect(view.get('configWidgetContext.config.configActionComponent')).to.be.eql({
         componentName: 'C1',
-        hostName: 'host1'
+        hostNames: ['host1']
       });
     });
   });
@@ -861,7 +860,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
     });
   });
 
-  describe('#getSelectedHostName', function() {
+  describe('#getSelectedHostNames', function() {
 
     it('should return host of component', function() {
       view.set('selectedServicesMasters', [
@@ -870,7 +869,7 @@ describe('App.AssignMasterOnStep7Controller', function () {
           selectedHost: 'host1'
         }
       ]);
-      expect(view.getSelectedHostName('C1')).to.be.equal('host1');
+      expect(view.getSelectedHostNames('C1')).to.be.eql(['host1']);
     });
   });
 

--- a/ambari-web/test/mixins/main/service/configs/component_actions_by_configs_test.js
+++ b/ambari-web/test/mixins/main/service/configs/component_actions_by_configs_test.js
@@ -127,14 +127,15 @@ describe('App.ComponentActionsByConfigs', function () {
           configActionComponent: {
             action: 'delete',
             componentName: 'C1',
-            hostName: 'host1'
+            hostNames: ['host1'],
+            isClient: false
           }
         }
       ];
       expect(mixin.getComponentsToDelete(configActionComponents)).to.be.eql([{
-        action: 'delete',
         componentName: 'C1',
-        hostName: 'host1'
+        hostName: 'host1',
+        isClient: false
       }]);
     });
   });
@@ -142,23 +143,19 @@ describe('App.ComponentActionsByConfigs', function () {
   describe("#getComponentsToAdd()", function () {
 
     beforeEach(function() {
-      sinon.stub(App.StackServiceComponent, 'find').returns([
-        Em.Object.create({
-          componentName: 'C1',
-          serviceName: 'S1'
-        })
-      ]);
-      sinon.stub(App.Service, 'find').returns([
-        Em.Object.create({
-          serviceName: 'S1',
-          hostComponents: [
-            Em.Object.create({
-              componentName: 'C1',
-              hostName: 'host2'
-            })
-          ]
-        })
-      ]);
+      sinon.stub(App.StackServiceComponent, 'find').returns(Em.Object.create({
+        componentName: 'C1',
+        serviceName: 'S1'
+      }));
+      sinon.stub(App.Service, 'find').returns(Em.Object.create({
+        serviceName: 'S1',
+        hostComponents: [
+          Em.Object.create({
+            componentName: 'C1',
+            hostName: 'host2'
+          })
+        ]
+      }));
     });
 
     afterEach(function() {
@@ -172,14 +169,15 @@ describe('App.ComponentActionsByConfigs', function () {
           configActionComponent: {
             action: 'add',
             componentName: 'C1',
-            hostName: 'host1'
+            hostNames: ['host1'],
+            isClient: false
           }
         }
       ];
       expect(mixin.getComponentsToAdd(configActionComponents)).to.be.eql([{
-        action: 'add',
         componentName: 'C1',
-        hostName: 'host1'
+        hostName: 'host1',
+        isClient: false
       }]);
     });
   });


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ambari Web should handle the case if not one but two hosts are selected for HSI install. Currently it fails. Right after the hosts are selected the service advisor needs to be invoked, and the configuration sent to the service advisor should contain the selected hosts as HSI hosts.

## How was this patch tested?
manually, unit
  21533 passing (33s)
  48 pending


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.