### PR TITLE
[AMBARI-23461] Fix TestHeartbeatHandler.testComponents NPE

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
@@ -38,6 +38,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1341,12 +1342,15 @@ public class TestHeartbeatHandler {
 
     expect(service.getServiceComponents()).andReturn(componentMap);
 
-    replay(service, nnComponent);
+    ActionManager am = actionManagerTestHelper.getMockActionManager();
+
+    replay(service, nnComponent, am);
 
     cluster.addService(service);
 
-    HeartBeatHandler handler = heartbeatTestHelper.getHeartBeatHandler(
-        actionManagerTestHelper.getMockActionManager());
+    HeartBeatHandler handler = heartbeatTestHelper.getHeartBeatHandler(am);
+    // Make sure handler is not null, this has possibly been an intermittent problem in the past
+    assertNotNull(handler);
 
     ComponentsResponse actual = handler.handleComponents(DummyCluster);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This issue is intermittent:

```
ERROR] testComponents(org.apache.ambari.server.agent.TestHeartbeatHandler)  Time elapsed: 1.116 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.ambari.server.agent.TestHeartbeatHandler.testComponents(TestHeartbeatHandler.java:1351)
```

## How was this patch tested?

```
mvn clean test -Dtest=TestHeartbeatHandler -pl ambari-server
...
----------------------------------------------------------------------
Ran 241 tests in 7.079s

OK
----------------------------------------------------------------------
Total run:1186
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:20 min
[INFO] Finished at: 2018-04-04T11:33:11-04:00
[INFO] Final Memory: 119M/1080M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.