### PR TITLE
[AMBARI-23455] Improve parallel start performance

### DIFF
--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie.py
@@ -28,7 +28,6 @@ from resource_management.core.source import DownloadSource
 from resource_management.core.source import InlineTemplate
 from resource_management.core.source import Template
 from resource_management.libraries.functions.format import format
-from resource_management.libraries.functions.default import default
 from resource_management.libraries.functions import StackFeature
 from resource_management.libraries.functions.version import format_stack_version
 from resource_management.libraries.functions.stack_features import check_stack_feature
@@ -38,12 +37,11 @@ from resource_management.libraries.resources.xml_config import XmlConfig
 from resource_management.libraries.functions.lzo_utils import install_lzo_if_needed
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.security_commons import update_credential_provider_path
-from resource_management.core.resources.packaging import Package
-from resource_management.core.shell import as_user, as_sudo, call
+from resource_management.core.shell import call
 from resource_management.core.exceptions import Fail
 
 from resource_management.libraries.functions.setup_atlas_hook import has_atlas_in_cluster, setup_atlas_hook
-from ambari_commons.constants import SERVICE, UPGRADE_TYPE_NON_ROLLING, UPGRADE_TYPE_ROLLING
+from ambari_commons.constants import SERVICE
 from resource_management.libraries.functions.constants import Direction
 
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
@@ -244,7 +242,7 @@ def get_oozie_ext_zip_source_paths(upgrade_type, params):
 def oozie_server_specific(upgrade_type):
   import params
 
-  no_op_test = as_user(format("ls {pid_file} >/dev/null 2>&1 && ps -p `cat {pid_file}` >/dev/null 2>&1"), user=params.oozie_user)
+  no_op_test = format("ls {pid_file} >/dev/null 2>&1 && ps -p `cat {pid_file}` >/dev/null 2>&1")
 
   File(params.pid_file,
     action="delete",
@@ -270,7 +268,7 @@ def oozie_server_specific(upgrade_type):
   untar_sharelib = ('tar','-xvf',format('{oozie_home}/oozie-sharelib.tar.gz'),'-C',params.oozie_home)
 
   Execute( untar_sharelib,    # time-expensive
-    not_if  = format("{no_op_test} || {skip_recreate_sharelib}"),
+    not_if  = format("({no_op_test}) || ({skip_recreate_sharelib})"),
     sudo = True,
   )
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_client.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_client.py
@@ -18,18 +18,19 @@ limitations under the License.
 
 """
 
-import sys
 from resource_management import *
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions import StackFeature
 from resource_management.libraries.functions.stack_features import check_stack_feature
 from oozie import oozie
-from oozie_service import oozie_service
 from resource_management.core.exceptions import ClientComponentHasNoStatus
 
 class OozieClient(Script):
 
   def install(self, env):
+    import params
+    env.set_params(params)
+
     self.install_packages(env)
     self.configure(env)
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_service.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_service.py
@@ -26,7 +26,6 @@ from oozie import copy_atlas_hive_hook_to_dfs_share_lib
 # Resource Managemente Imports
 from resource_management.core import shell, sudo
 from resource_management import *
-from resource_management.core.shell import as_user
 from resource_management.core.logger import Logger
 from resource_management.libraries.functions.show_logs import show_logs
 from resource_management.libraries.providers.hdfs_resource import WebHDFSUtil
@@ -68,8 +67,8 @@ def oozie_service(action = 'start', upgrade_type=None):
   else:
     kinit_if_needed = ""
 
-  no_op_test = as_user(format("ls {pid_file} >/dev/null 2>&1 && ps -p `cat {pid_file}` >/dev/null 2>&1"), user=params.oozie_user)
-  
+  no_op_test = format("ls {pid_file} >/dev/null 2>&1 && ps -p `cat {pid_file}` >/dev/null 2>&1")
+
   if action == 'start':
     start_cmd = format("cd {oozie_tmp_dir} && {oozie_home}/bin/oozie-start.sh")
     path_to_jdbc = params.target
@@ -103,17 +102,17 @@ def oozie_service(action = 'start', upgrade_type=None):
 
       if db_connection_check_command:
         sudo.chmod(params.check_db_connection_jar, 0755)
-        Execute( db_connection_check_command, 
-                 tries=5, 
+        Execute( db_connection_check_command,
+                 tries=5,
                  try_sleep=10,
                  user=params.oozie_user,
         )
 
-      Execute( format("cd {oozie_tmp_dir} && {oozie_home}/bin/ooziedb.sh create -sqlfile oozie.sql -run"), 
+      Execute( format("cd {oozie_tmp_dir} && {oozie_home}/bin/ooziedb.sh create -sqlfile oozie.sql -run"),
                user = params.oozie_user, not_if = no_op_test,
-               ignore_failures = True 
+               ignore_failures = True
       )
-      
+
       if params.security_enabled:
         Execute(kinit_if_needed,
                 user = params.oozie_user,
@@ -134,7 +133,7 @@ def oozie_service(action = 'start', upgrade_type=None):
 
         hdfs_share_dir_exists = True # skip time-expensive hadoop fs -ls check
       elif WebHDFSUtil.is_webhdfs_available(params.is_webhdfs_enabled, params.default_fs):
-        # check with webhdfs is much faster than executing hadoop fs -ls. 
+        # check with webhdfs is much faster than executing hadoop fs -ls.
         util = WebHDFSUtil(params.hdfs_site, params.oozie_user, params.security_enabled)
         list_status = util.run_command(params.hdfs_share_dir, 'GETFILESTATUS', method='GET', ignore_status_codes=['404'], assertable_result=False)
         hdfs_share_dir_exists = ('FileStatus' in list_status)
@@ -142,11 +141,11 @@ def oozie_service(action = 'start', upgrade_type=None):
         # have to do time expensive hadoop fs -ls check.
         hdfs_share_dir_exists = shell.call(format("{kinit_if_needed} hadoop --config {hadoop_conf_dir} dfs -ls {hdfs_share_dir} | awk 'BEGIN {{count=0;}} /share/ {{count++}} END {{if (count > 0) {{exit 0}} else {{exit 1}}}}'"),
                                  user=params.oozie_user)[0]
-                                 
-      if not hdfs_share_dir_exists:                      
-        Execute( params.put_shared_lib_to_hdfs_cmd, 
+
+      if not hdfs_share_dir_exists:
+        Execute( params.put_shared_lib_to_hdfs_cmd,
                  user = params.oozie_user,
-                 path = params.execute_path 
+                 path = params.execute_path
         )
         params.HdfsResource(format("{oozie_hdfs_user_dir}/share"),
                              type="directory",
@@ -155,7 +154,7 @@ def oozie_service(action = 'start', upgrade_type=None):
                              recursive_chmod=True,
         )
         params.HdfsResource(None, action="execute")
-        
+
 
     try:
       # start oozie

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/spark_client.py
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/scripts/spark_client.py
@@ -19,7 +19,6 @@ limitations under the License.
 """
 # Python imports
 import os
-import sys
 
 # Local imports
 from resource_management.libraries.script.script import Script
@@ -34,6 +33,8 @@ from setup_spark import setup_spark
 
 class SparkClient(Script):
   def install(self, env):
+    import params
+    env.set_params(params)
     self.install_packages(env)
     self.configure(env)
 
@@ -45,12 +46,12 @@ class SparkClient(Script):
     """
     import params
     env.set_params(params)
-    
+
     setup_spark(env, 'client', upgrade_type=upgrade_type, action='config', config_dir=config_dir)
 
   def status(self, env):
     raise ClientComponentHasNoStatus()
-  
+
   def stack_upgrade_save_new_config(self, env):
     """
     Because this gets called during a Rolling Upgrade, the new configs have already been saved, so we must be

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/spark_client.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/spark_client.py
@@ -18,31 +18,31 @@ limitations under the License.
 
 """
 
-import sys
 from resource_management import *
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions.stack_features import check_stack_feature
 from resource_management.libraries.functions import StackFeature
 from resource_management.core.exceptions import ClientComponentHasNoStatus
 from resource_management.core.logger import Logger
-from resource_management.core import shell
 from setup_spark import setup_spark
 
 
 class SparkClient(Script):
   def install(self, env):
+    import params
+    env.set_params(params)
     self.install_packages(env)
     self.configure(env)
 
   def configure(self, env, upgrade_type=None, config_dir=None):
     import params
     env.set_params(params)
-    
+
     setup_spark(env, 'client', upgrade_type=upgrade_type, action = 'config')
 
   def status(self, env):
     raise ClientComponentHasNoStatus()
-  
+
   def pre_upgrade_restart(self, env, upgrade_type=None):
     import params
 

--- a/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.2.0/package/scripts/sqoop_client.py
+++ b/ambari-server/src/main/resources/common-services/SQOOP/1.4.4.2.0/package/scripts/sqoop_client.py
@@ -19,11 +19,8 @@ limitations under the License.
 """
 
 from resource_management.core.exceptions import ClientComponentHasNoStatus
-from resource_management.core.resources.system import Execute
-from resource_management.libraries.functions.default import default
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions import stack_select
-from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions import StackFeature
 from resource_management.libraries.functions.stack_features import check_stack_feature
 from sqoop import sqoop
@@ -32,6 +29,8 @@ from ambari_commons import OSConst
 
 class SqoopClient(Script):
   def install(self, env):
+    import params
+    env.set_params(params)
     self.install_packages(env)
     self.configure(env)
 

--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/yarn_client.py
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/yarn_client.py
@@ -19,7 +19,6 @@ Ambari Agent
 
 """
 
-import sys
 from resource_management import *
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions import StackFeature
@@ -31,6 +30,8 @@ from ambari_commons.os_family_impl import OsFamilyImpl
 
 class YarnClient(Script):
   def install(self, env):
+    import params
+    env.set_params(params)
     self.install_packages(env)
     self.configure(env)
 

--- a/ambari-server/src/main/resources/common-services/ZOOKEEPER/3.4.5/package/scripts/zookeeper_client.py
+++ b/ambari-server/src/main/resources/common-services/ZOOKEEPER/3.4.5/package/scripts/zookeeper_client.py
@@ -19,15 +19,13 @@ Ambari Agent
 
 """
 
-import sys
 from resource_management import *
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions import StackFeature
-from resource_management.libraries.functions.version import compare_versions, format_stack_version
-from resource_management.libraries.functions.format import format
-from resource_management.libraries.functions.stack_features import check_stack_feature 
+from resource_management.libraries.functions.version import format_stack_version
+from resource_management.libraries.functions.stack_features import check_stack_feature
 from ambari_commons import OSConst
-from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
+from ambari_commons.os_family_impl import OsFamilyImpl
 from zookeeper import zookeeper
 from resource_management.core.exceptions import ClientComponentHasNoStatus
 
@@ -56,6 +54,8 @@ class ZookeeperClient(Script):
 class ZookeeperClientLinux(ZookeeperClient):
 
   def install(self, env):
+    import params
+    env.set_params(params)
     self.install_packages(env)
     self.configure(env)
 

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_mysql_server.py
@@ -17,13 +17,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import os
+from ambari_commons.os_check import OSCheck
 from mock.mock import MagicMock, call, patch
 from stacks.utils.RMFTestCase import *
 
-from only_for_platform import not_for_platform, PLATFORM_WINDOWS
+from only_for_platform import not_for_platform, os_distro_value, PLATFORM_WINDOWS
 
 @patch("os.path.exists", MagicMock(return_value=True))
+@patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
 @not_for_platform(PLATFORM_WINDOWS)
 class TestMySqlServer(RMFTestCase):
   COMMON_SERVICES_PACKAGE_DIR = "HIVE/0.12.0.2.0/package"

--- a/ambari-server/src/test/python/stacks/2.0.6/OOZIE/test_oozie_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/OOZIE/test_oozie_server.py
@@ -19,12 +19,10 @@ limitations under the License.
 '''
 
 import json
-from mock.mock import MagicMock, call, patch
+from mock.mock import MagicMock, patch
 from stacks.utils.RMFTestCase import *
 from resource_management.libraries.script.script import Script
 from resource_management.core import shell
-from resource_management.core.exceptions import Fail
-from resource_management.libraries import functions
 from resource_management.libraries.providers.hdfs_resource import WebHDFSUtil
 import tempfile
 
@@ -203,7 +201,7 @@ class TestOozieServer(RMFTestCase):
                               )
     self.assertResourceCalled('File', '/var/run/oozie/oozie.pid',
         action = ['delete'],
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
     self.assertResourceCalled('Directory', '/usr/lib/oozie//var/tmp/oozie',
                               owner = 'oozie',
@@ -272,15 +270,15 @@ class TestOozieServer(RMFTestCase):
                               create_parents = True,
                               )
     self.assertResourceCalled('Execute', ('tar', '-xvf', '/usr/lib/oozie/oozie-sharelib.tar.gz', '-C', '/usr/lib/oozie'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1' || test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share",
+        not_if = "(ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1) || (test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share)",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('cp', '/usr/share/HDP-oozie/ext-2.2.zip', '/usr/lib/oozie/libext'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('chown', 'oozie:hadoop', '/usr/lib/oozie/libext/ext-2.2.zip'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         sudo = True,
     )
     self.assertResourceCalled('Directory', '/var/lib/oozie/oozie-server/conf',
@@ -304,10 +302,10 @@ class TestOozieServer(RMFTestCase):
         group = 'hadoop',
     )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh cp /usr/lib/falcon/oozie/ext/falcon-oozie-el-extension-*.jar /usr/lib/oozie/libext',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh chown oozie:hadoop /usr/lib/oozie/libext/falcon-oozie-el-extension-*.jar',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
 
     self.assertResourceCalled('File', '/usr/lib/oozie/.prepare_war_cmd',
@@ -431,7 +429,7 @@ class TestOozieServer(RMFTestCase):
                               )
     self.assertResourceCalled('File', '/var/run/oozie/oozie.pid',
                               action = ['delete'],
-                              not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+                              not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
                               )
     self.assertResourceCalled('Directory', '/usr/lib/oozie//var/tmp/oozie',
                               owner = 'oozie',
@@ -500,15 +498,15 @@ class TestOozieServer(RMFTestCase):
                               create_parents = True,
                               )
     self.assertResourceCalled('Execute', ('tar', '-xvf', '/usr/lib/oozie/oozie-sharelib.tar.gz', '-C', '/usr/lib/oozie'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1' || test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share",
+        not_if = "(ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1) || (test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share)",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('cp', '/usr/share/HDP-oozie/ext-2.2.zip', '/usr/lib/oozie/libext'),
-                              not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+                              not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
                               sudo = True,
                               )
     self.assertResourceCalled('Execute', ('chown', u'oozie:hadoop', '/usr/lib/oozie/libext/ext-2.2.zip'),
-                              not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+                              not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
                               sudo = True,
                               )
     self.assertResourceCalled('Directory', '/var/lib/oozie/oozie-server/conf',
@@ -534,10 +532,10 @@ class TestOozieServer(RMFTestCase):
                               group = 'hadoop',
                               )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh cp /usr/lib/falcon/oozie/ext/falcon-oozie-el-extension-*.jar /usr/lib/oozie/libext',
-                              not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+                              not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
                               )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh chown oozie:hadoop /usr/lib/oozie/libext/falcon-oozie-el-extension-*.jar',
-                              not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+                              not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
                               )
     self.assertResourceCalled('File', '/usr/lib/oozie/.prepare_war_cmd',
                               content = 'cd /var/tmp/oozie && /usr/lib/oozie/bin/oozie-setup.sh prepare-war',
@@ -576,7 +574,7 @@ class TestOozieServer(RMFTestCase):
         )
     self.assert_configure_default()
     self.assertResourceCalled('Execute', 'cd /var/tmp/oozie && /usr/lib/oozie/bin/ooziedb.sh create -sqlfile oozie.sql -run',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         ignore_failures = True,
         user = 'oozie',
     )
@@ -617,7 +615,7 @@ class TestOozieServer(RMFTestCase):
     )
     self.assertResourceCalled('Execute', 'cd /var/tmp/oozie && /usr/lib/oozie/bin/oozie-start.sh',
         environment = {'OOZIE_CONFIG': '/etc/oozie/conf'},
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         user = 'oozie',
     )
     self.assertNoMoreResources()
@@ -643,7 +641,7 @@ class TestOozieServer(RMFTestCase):
     )
     self.assertResourceCalled('Execute', 'cd /var/tmp/oozie && /usr/lib/oozie/bin/oozied.sh stop 60 -force',
         environment = {'OOZIE_CONFIG': '/etc/oozie/conf'},
-        only_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        only_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         user = 'oozie',
     )
     self.assertResourceCalled('File', '/var/run/oozie/oozie.pid',
@@ -720,7 +718,7 @@ class TestOozieServer(RMFTestCase):
     )
     self.assert_configure_secured()
     self.assertResourceCalled('Execute', 'cd /var/tmp/oozie && /usr/lib/oozie/bin/ooziedb.sh create -sqlfile oozie.sql -run',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         ignore_failures = True,
         user = 'oozie',
     )
@@ -765,7 +763,7 @@ class TestOozieServer(RMFTestCase):
     )
     self.assertResourceCalled('Execute', 'cd /var/tmp/oozie && /usr/lib/oozie/bin/oozie-start.sh',
         environment = {'OOZIE_CONFIG': '/etc/oozie/conf'},
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         user = 'oozie',
     )
     self.assertNoMoreResources()
@@ -784,7 +782,7 @@ class TestOozieServer(RMFTestCase):
     )
     self.assertResourceCalled('Execute', 'cd /var/tmp/oozie && /usr/lib/oozie/bin/oozied.sh stop 60 -force',
         environment = {'OOZIE_CONFIG': '/etc/oozie/conf'},
-        only_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        only_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         user = 'oozie',
     )
     self.assertResourceCalled('File', '/var/run/oozie/oozie.pid',
@@ -875,7 +873,7 @@ class TestOozieServer(RMFTestCase):
                               )
     self.assertResourceCalled('File', '/var/run/oozie/oozie.pid',
         action = ['delete'],
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
     self.assertResourceCalled('Directory', '/usr/lib/oozie//var/tmp/oozie',
         owner = 'oozie',
@@ -944,15 +942,15 @@ class TestOozieServer(RMFTestCase):
         create_parents = True,
     )
     self.assertResourceCalled('Execute', ('tar', '-xvf', '/usr/lib/oozie/oozie-sharelib.tar.gz', '-C', '/usr/lib/oozie'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1' || test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share",
+        not_if = "(ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1) || (test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share)",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('cp', '/usr/share/HDP-oozie/ext-2.2.zip', '/usr/lib/oozie/libext'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('chown', 'oozie:hadoop', '/usr/lib/oozie/libext/ext-2.2.zip'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         sudo = True,
     )
     self.assertResourceCalled('Directory', '/var/lib/oozie/oozie-server/conf',
@@ -962,10 +960,10 @@ class TestOozieServer(RMFTestCase):
                               recursive_ownership = True,
     )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh cp /usr/lib/falcon/oozie/ext/falcon-oozie-el-extension-*.jar /usr/lib/oozie/libext',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh chown oozie:hadoop /usr/lib/oozie/libext/falcon-oozie-el-extension-*.jar',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
 
     self.assertResourceCalled('File', '/usr/lib/oozie/.prepare_war_cmd',
@@ -1074,7 +1072,7 @@ class TestOozieServer(RMFTestCase):
                               )
     self.assertResourceCalled('File', '/var/run/oozie/oozie.pid',
         action = ['delete'],
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
     self.assertResourceCalled('Directory', '/usr/lib/oozie//var/tmp/oozie',
         owner = 'oozie',
@@ -1143,15 +1141,15 @@ class TestOozieServer(RMFTestCase):
         create_parents = True,
     )
     self.assertResourceCalled('Execute', ('tar', '-xvf', '/usr/lib/oozie/oozie-sharelib.tar.gz', '-C', '/usr/lib/oozie'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1' || test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share",
+        not_if = "(ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1) || (test -f /usr/lib/oozie/.hashcode && test -d /usr/lib/oozie/share)",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('cp', '/usr/share/HDP-oozie/ext-2.2.zip', '/usr/lib/oozie/libext'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         sudo = True,
     )
     self.assertResourceCalled('Execute', ('chown', 'oozie:hadoop', '/usr/lib/oozie/libext/ext-2.2.zip'),
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
         sudo = True,
     )
     self.assertResourceCalled('Directory', '/var/lib/oozie/oozie-server/conf',
@@ -1161,10 +1159,10 @@ class TestOozieServer(RMFTestCase):
                               recursive_ownership = True,
     )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh cp /usr/lib/falcon/oozie/ext/falcon-oozie-el-extension-*.jar /usr/lib/oozie/libext',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
     self.assertResourceCalled('Execute', 'ambari-sudo.sh chown oozie:hadoop /usr/lib/oozie/libext/falcon-oozie-el-extension-*.jar',
-        not_if = "ambari-sudo.sh su oozie -l -s /bin/bash -c '[RMF_EXPORT_PLACEHOLDER]ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1'",
+        not_if = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1",
     )
 
     self.assertResourceCalled('File', '/usr/lib/oozie/.prepare_war_cmd',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Few minor tweaks to improve parallel component start performance:

* `import params` outside of critical section
* avoid unnecessary `as_user`
* fix logical operator grouping in `not_if` condition

Plus:

* remove unused imports
* cherry-pick 10a1e8b692, fix for `test_mysql_server` on Mac from trunk

## How was this patch tested?

Deployed cluster via blueprint on sysprepped nodes.

Unit tests:

```
Total run:1051
Total errors:0
Total failures:0
OK
```