### PR TITLE
[AMBARI-23464]. Debian9 is not shown on UI Install Wizard Select Version page (amagyar)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/resources/os_family.json
+++ b/ambari-common/src/main/python/ambari_commons/resources/os_family.json
@@ -39,7 +39,8 @@
           "debian"
         ],
         "versions": [
-          7
+          7,
+          9
         ]
       },
       "ubuntu": {

--- a/ambari-server/src/main/resources/version_definition.xsd
+++ b/ambari-server/src/main/resources/version_definition.xsd
@@ -56,6 +56,7 @@
       <xs:enumeration value="redhat-ppc7" />
       <xs:enumeration value="debian6" />
       <xs:enumeration value="debian7" />
+      <xs:enumeration value="debian9" />
       <xs:enumeration value="ubuntu12" />
       <xs:enumeration value="ubuntu14" />
       <xs:enumeration value="ubuntu16" />

--- a/contrib/version-builder/version_builder.py
+++ b/contrib/version-builder/version_builder.py
@@ -445,7 +445,7 @@ def main(argv):
   parser.add_option('--repo', action='store_true', dest='repo',
     help="Add repository data with options: --repo-os, --repo-url, --repo-id, --repo-name, --repo-unique")
   parser.add_option('--repo-os', dest='repo_os',
-    help="The operating system type: i.e. redhat6, redhat7, debian7, ubuntu12, ubuntu14, ubuntu16, suse11, suse12")
+    help="The operating system type: i.e. redhat6, redhat7, debian7, debian9, ubuntu12, ubuntu14, ubuntu16, suse11, suse12")
   parser.add_option('--repo-url', dest='repo_url',
     help="The base url for the repository data")
   parser.add_option('--repo-unique', dest='unique', type='choice', choices=['true', 'false'],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Debian9 repo is not visible on UI install wizard select version page.

This patch only updates a subset of the files. The repoinfo.xml and metainfo.xmls files in HDP3 stack also need to be updated. But those files are not in this repo therefore I'll update them in a different patch.

## How was this patch tested?

Manually checked the UI.