### PR TITLE
[AMBARI-23472] NameNode HA: QuickLinks section issues

### DIFF
--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -97,7 +97,7 @@
                     </h5>
                   {{/if}}
                   {{#each quickLinks in group.links}}
-                    <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
+                    <h6>{{quickLinks.publicHostNameLabel}}</h6>
                     {{#each quickLinks}}
                       <a {{bindAttr href="url"}} target="_blank">{{label}}</a>
                     {{/each}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When NameNode HA is enabled, the QuickLink section shows the hostname of each NameNode as a hyperlink.  This is confusing since these are not meant to be clickable; they should be displayed as labels, not hyperlinks.

## How was this patch tested?

UI unit tests:
  21533 passing (24s)
  48 pending