### PR TITLE
[AMBARI-23471] Ubuntu16: Install components exited with code '100' with message: debconf: delaying package configuration, since apt-utils is not installed (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/shell.py
+++ b/ambari-common/src/main/python/ambari_commons/shell.py
@@ -25,6 +25,7 @@ import signal
 from ambari_commons import subprocess32 as subprocess
 import threading
 from contextlib import contextmanager
+import copy
 
 import time
 
@@ -282,9 +283,13 @@ def launch_subprocess(command, term_geometry=(42, 255), env=None):
     _logger.debug("Warning, command  \"{0}\" doesn't support sudo appending".format(command))
 
   is_shell = not isinstance(command, (list, tuple))
+  environ = copy.deepcopy(os.environ)
+
+  if env:
+    environ.update(env)
 
   return PopenEx(command, stdout=PIPE_PTY, stderr=subprocess.PIPE,
-                 shell=is_shell, preexec_fn=_geometry_helper, close_fds=True, env=env)
+                 shell=is_shell, preexec_fn=_geometry_helper, close_fds=True, env=environ)
 
 
 def chunks_reader(cmd, kill_timer):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Parent environment were not passed to the child processes, what makes some applications broken.
Issue happen only if we passing custom env variables to the child.

## How was this patch tested?

Life cluster