### PR TITLE
[AMBARI-23431] Removing hostId condition in order to process AMBARI identities even if there was an agent installed on the server's host

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
@@ -126,10 +126,8 @@ public class ConfigureAmbariIdentitiesServerAction extends KerberosServerAction 
       String hostName = resolvedPrincipal.getHostName();
       for (Map.Entry<String, String> serviceMappingEntry : resolvedPrincipal.getServiceMapping().entries()){
         String serviceName = serviceMappingEntry.getKey();
-        // distribute ambari keytabs only if host id is null, otherwise they will
-        // be distributed by usual process using ambari-agent.
         // TODO check if changes needed for multiple principals in one keytab
-        if (resolvedPrincipal.getHostId() == null && hostName != null && serviceName.equals(RootService.AMBARI.name())) {
+        if (hostName != null && serviceName.equals(RootService.AMBARI.name())) {
           ResolvedKerberosKeytab keytab = resolvedPrincipal.getResolvedKerberosKeytab();
           String destKeytabFilePath = resolvedPrincipal.getResolvedKerberosKeytab().getFile();
           hostName = StageUtils.getHostName();

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
@@ -121,16 +121,14 @@ public class ConfigureAmbariIdentitiesServerAction extends KerberosServerAction 
       throws AmbariException {
     CommandReport commandReport = null;
 
-    if (resolvedPrincipal != null) {
-      String dataDirectory = getDataDirectoryPath();
-      String hostName = resolvedPrincipal.getHostName();
-      for (Map.Entry<String, String> serviceMappingEntry : resolvedPrincipal.getServiceMapping().entries()){
-        String serviceName = serviceMappingEntry.getKey();
+    if (resolvedPrincipal != null && StageUtils.getHostName().equals(resolvedPrincipal.getHostName())) {
+      final String hostName = resolvedPrincipal.getHostName();
+      final String dataDirectory = getDataDirectoryPath();
+      for (Map.Entry<String, String> serviceMappingEntry : resolvedPrincipal.getServiceMapping().entries()) {
         // TODO check if changes needed for multiple principals in one keytab
-        if (hostName != null && serviceName.equals(RootService.AMBARI.name())) {
+        if (RootService.AMBARI.name().equals(serviceMappingEntry.getKey())) {
           ResolvedKerberosKeytab keytab = resolvedPrincipal.getResolvedKerberosKeytab();
           String destKeytabFilePath = resolvedPrincipal.getResolvedKerberosKeytab().getFile();
-          hostName = StageUtils.getHostName();
           File hostDirectory = new File(dataDirectory, hostName);
           File srcKeytabFile = new File(hostDirectory, DigestUtils.sha256Hex(destKeytabFilePath));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After enabling Kerberos, the Ambari JAAS file is not updated. The reason was that we introduced a new condition in
```
org.apache.ambari.server.serveraction.kerberos.ConfigureAmbariIdentitiesServerAction.processIdentity(...)
```
which prevented Ambari identity processing in case there was an agent running on the host where server was installed. Removing that check solved the problem.

Discussing this with the developer who added that condition we agreed that this is safe to do since the only thing could happen is that agent will overwrite the keytab(s) and the JAAS config file with the same content.

## How was this patch tested?

Running unit tests locally (failed with the famous `TestHeartbeatHandler.testComponents:1351 » NullPointerException` error):
```
[ERROR] Errors: 
[ERROR]   TestHeartbeatHandler.testComponents:1351 » NullPointer
[INFO] 
[ERROR] Tests run: 5079, Failures: 0, Errors: 1, Skipped: 84
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 33:13 min
[INFO] Finished at: 2018-04-05T14:08:12+02:00
[INFO] Final Memory: 90M/1612M
[INFO] ------------------------------------------------------------------------
```
As you can see this was the only test which failed.

Running integration tests manually:

1. had a cluster with HDFS, YARN/MR2 and ZK installed
2. removed that condition, built the project, changed the `ambari-server.jar` and restarted the server
3. enabled Kerberos
4. checked if JAAS configuration got updated
```
[root@c7401 ~]# cat /etc/ambari-server/conf/krb5JAASLogin.conf
com.sun.security.jgss.krb5.initiate {
    com.sun.security.auth.module.Krb5LoginModule required
    renewTGT=false
    doNotPrompt=true
    useKeyTab=true
    keyTab="/etc/security/keytabs/ambari.server.keytab"
    principal="ambari-server-cluster1@AMBARI.APACHE.ORG"
    storeKey=true
    useTicketCache=false;
};
```
<img width="1614" alt="screen shot 2018-04-05 at 3 49 10 pm" src="https://user-images.githubusercontent.com/34065904/38369884-102fa47e-38e9-11e8-9bd8-9ab8b5591a12.png">
