### PR TITLE
AMBARI-23454 - Integrate ConfigGroup Service to Swagger

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/ConfigGroupService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/ConfigGroupService.java
@@ -29,17 +29,31 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.ambari.annotations.ApiIgnore;
 import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.controller.ConfigGroupResponse;
 import org.apache.ambari.server.controller.spi.Resource;
+
+import org.apache.http.HttpStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * Service responsible for management of Config Groups
  */
+@Api(value = "Config Groups", description = "Endpoint for config-group-specific operations")
 public class ConfigGroupService extends BaseService {
+
+  private static final String CONFIG_GROUP_REQUEST_TYPE = "org.apache.ambari.server.controller.ConfigGroupRequest";
+
   /**
    * Parent cluster name.
    */
@@ -61,8 +75,26 @@ public class ConfigGroupService extends BaseService {
    * @param ui
    * @return
    */
-  @GET @ApiIgnore // until documented
-  @Produces("text/plain")
+  @GET
+  @Path("") // This is needed if class level path is not present otherwise no Swagger docs will be generated for this method
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Returns all config groups", response = ConfigGroupResponse.ConfigGroupWrapper.class, responseContainer =
+          RESPONSE_CONTAINER_LIST)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, defaultValue = "ConfigGroup/*", dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_SORT, value = QUERY_SORT_DESCRIPTION, dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_PAGE_SIZE, value = QUERY_PAGE_SIZE_DESCRIPTION, defaultValue = DEFAULT_PAGE_SIZE, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_FROM, value = QUERY_FROM_DESCRIPTION, allowableValues = QUERY_FROM_VALUES, defaultValue = DEFAULT_FROM, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+    @ApiImplicitParam(name = QUERY_TO, value = QUERY_TO_DESCRIPTION, allowableValues = QUERY_TO_VALUES, dataType = DATA_TYPE_INT, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getConfigGroups(String body, @Context HttpHeaders headers,
                                   @Context UriInfo ui) {
     return handleRequest(headers, body, ui, Request.Type.GET,
@@ -75,9 +107,21 @@ public class ConfigGroupService extends BaseService {
    *
    * @return
    */
-  @GET @ApiIgnore // until documented
+  @GET
   @Path("{groupId}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Returns a single config group", response = ConfigGroupResponse.ConfigGroupWrapper.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = QUERY_FIELDS, value = QUERY_FILTER_DESCRIPTION, defaultValue = "ConfigGroup/*", dataType = DATA_TYPE_STRING, paramType = PARAM_TYPE_QUERY),
+  })
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = MSG_CLUSTER_NOT_FOUND),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+  })
   public Response getConfigGroup(String body, @Context HttpHeaders headers,
           @Context UriInfo ui, @PathParam("groupId") String groupId) {
     return handleRequest(headers, body, ui, Request.Type.GET,
@@ -93,8 +137,19 @@ public class ConfigGroupService extends BaseService {
    * @param ui
    * @return
    */
-  @POST @ApiIgnore // until documented
-  @Produces("text/plain")
+  @POST
+  @Path("") // This is needed if class level path is not present otherwise no Swagger docs will be generated for this method
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Creates a config group")
+  @ApiImplicitParams({
+    @ApiImplicitParam(dataType = CONFIG_GROUP_REQUEST_TYPE, paramType = PARAM_TYPE_BODY),
+  })
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_CREATED, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response createConfigGroup(String body, @Context HttpHeaders headers,
                                     @Context UriInfo ui) {
     return handleRequest(headers, body, ui, Request.Type.POST,
@@ -111,9 +166,21 @@ public class ConfigGroupService extends BaseService {
    * @param groupId
    * @return
    */
-  @PUT @ApiIgnore // until documented
+  @PUT
   @Path("{groupId}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Updates a config group")
+  @ApiImplicitParams({
+    @ApiImplicitParam(dataType = CONFIG_GROUP_REQUEST_TYPE, paramType = PARAM_TYPE_BODY)
+  })
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_ACCEPTED, message = MSG_REQUEST_ACCEPTED),
+    @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = MSG_INVALID_ARGUMENTS),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response updateConfigGroup(String body, @Context HttpHeaders
     headers, @Context UriInfo ui, @PathParam("groupId") String groupId) {
     return handleRequest(headers, body, ui, Request.Type.PUT,
@@ -129,9 +196,16 @@ public class ConfigGroupService extends BaseService {
    * @param groupId
    * @return
    */
-  @DELETE @ApiIgnore // until documented
+  @DELETE
   @Path("{groupId}")
-  @Produces("text/plain")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Deletes a config group")
+  @ApiResponses({
+    @ApiResponse(code = HttpStatus.SC_OK, message = MSG_SUCCESSFUL_OPERATION),
+    @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = MSG_NOT_AUTHENTICATED),
+    @ApiResponse(code = HttpStatus.SC_FORBIDDEN, message = MSG_PERMISSION_DENIED),
+    @ApiResponse(code = HttpStatus.SC_INTERNAL_SERVER_ERROR, message = MSG_SERVER_ERROR),
+  })
   public Response deleteConfigGroup(@Context HttpHeaders headers,
                                     @Context UriInfo ui,
                                     @PathParam("groupId") String groupId) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ConfigGroupRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ConfigGroupRequest.java
@@ -20,7 +20,10 @@ package org.apache.ambari.server.controller;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.controller.internal.ConfigGroupResourceProvider;
 import org.apache.ambari.server.state.Config;
+
+import io.swagger.annotations.ApiModelProperty;
 
 public class ConfigGroupRequest {
   private Long id;
@@ -46,6 +49,7 @@ public class ConfigGroupRequest {
     this.configs = configs;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.CLUSTER_NAME_PROPERTY_ID)
   public String getClusterName() {
     return clusterName;
   }
@@ -54,6 +58,7 @@ public class ConfigGroupRequest {
     this.clusterName = clusterName;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.GROUP_NAME_PROPERTY_ID)
   public String getGroupName() {
     return groupName;
   }
@@ -62,6 +67,7 @@ public class ConfigGroupRequest {
     this.groupName = groupName;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.TAG_PROPERTY_ID)
   public String getTag() {
     return tag;
   }
@@ -70,6 +76,7 @@ public class ConfigGroupRequest {
     this.tag = tag;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.SERVICE_NAME_PROPERTY_ID)
   public String getServiceName() {
     return serviceName;
   }
@@ -78,6 +85,7 @@ public class ConfigGroupRequest {
     this.serviceName = serviceName;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.DESCRIPTION_PROPERTY_ID)
   public String getDescription() {
     return description;
   }
@@ -86,6 +94,7 @@ public class ConfigGroupRequest {
     this.description = description;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.HOSTS_PROPERTY_ID)
   public Set<String> getHosts() {
     return hosts;
   }
@@ -94,6 +103,7 @@ public class ConfigGroupRequest {
     this.hosts = hosts;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.DESIRED_CONFIGS_PROPERTY_ID)
   public Map<String, Config> getConfigs() {
     return configs;
   }
@@ -102,6 +112,7 @@ public class ConfigGroupRequest {
     this.configs = configs;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.ID_PROPERTY_ID)
   public Long getId() {
     return id;
   }
@@ -110,6 +121,7 @@ public class ConfigGroupRequest {
     this.id = id;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.SERVICE_CONFIG_VERSION_NOTE_PROPERTY_ID)
   public String getServiceConfigVersionNote() {
     return serviceConfigVersionNote;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ConfigGroupResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ConfigGroupResponse.java
@@ -17,9 +17,14 @@
  */
 package org.apache.ambari.server.controller;
 
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.ambari.server.controller.internal.ConfigGroupResourceProvider;
+
+import io.swagger.annotations.ApiModelProperty;
 
 public class ConfigGroupResponse {
   private Long id;
@@ -44,6 +49,7 @@ public class ConfigGroupResponse {
     this.configVersions = configVersions;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.ID_PROPERTY_ID)
   public Long getId() {
     return id;
   }
@@ -52,6 +58,7 @@ public class ConfigGroupResponse {
     this.id = id;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.CLUSTER_NAME_PROPERTY_ID)
   public String getClusterName() {
     return clusterName;
   }
@@ -60,6 +67,7 @@ public class ConfigGroupResponse {
     this.clusterName = clusterName;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.GROUP_NAME_PROPERTY_ID)
   public String getGroupName() {
     return groupName;
   }
@@ -68,6 +76,7 @@ public class ConfigGroupResponse {
     this.groupName = groupName;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.TAG_PROPERTY_ID)
   public String getTag() {
     return tag;
   }
@@ -76,6 +85,7 @@ public class ConfigGroupResponse {
     this.tag = tag;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.DESCRIPTION_PROPERTY_ID)
   public String getDescription() {
     return description;
   }
@@ -84,6 +94,7 @@ public class ConfigGroupResponse {
     this.description = description;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.HOSTS_PROPERTY_ID)
   public Set<Map<String, Object>> getHosts() {
     return hosts;
   }
@@ -92,6 +103,7 @@ public class ConfigGroupResponse {
     this.hosts = hosts;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.DESIRED_CONFIGS_PROPERTY_ID)
   public Set<Map<String, Object>> getConfigurations() {
     return configVersions;
   }
@@ -100,11 +112,17 @@ public class ConfigGroupResponse {
     this.configVersions = configurations;
   }
 
+  @ApiModelProperty(name = ConfigGroupResourceProvider.VERSION_TAGS_PROPERTY_ID)
   public Set<Map<String, Object>> getVersionTags() {
     return versionTags;
   }
 
   public void setVersionTags(Set<Map<String, Object>> versionTags) {
     this.versionTags = versionTags;
+  }
+
+  public interface ConfigGroupWrapper extends ApiModel {
+    @ApiModelProperty(name = ConfigGroupResourceProvider.CONFIG_GROUP)
+    ConfigGroupResponse getConfigGroup();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
@@ -78,55 +78,59 @@ public class ConfigGroupResourceProvider extends
   private static final Logger LOG = LoggerFactory.getLogger
     (ConfigGroupResourceProvider.class);
 
-  protected static final String CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID =
-    PropertyHelper.getPropertyId("ConfigGroup", "cluster_name");
-  protected static final String CONFIGGROUP_ID_PROPERTY_ID = PropertyHelper
-    .getPropertyId("ConfigGroup", "id");
-  protected static final String CONFIGGROUP_NAME_PROPERTY_ID = PropertyHelper
-    .getPropertyId("ConfigGroup", "group_name");
-  protected static final String CONFIGGROUP_TAG_PROPERTY_ID = PropertyHelper
-    .getPropertyId("ConfigGroup", "tag");
-  protected static final String CONFIGGROUP_SERVICENAME_PROPERTY_ID = PropertyHelper
-    .getPropertyId("ConfigGroup", "service_name");
-  protected static final String CONFIGGROUP_DESC_PROPERTY_ID = PropertyHelper
-    .getPropertyId("ConfigGroup", "description");
-  protected static final String CONFIGGROUP_SCV_NOTE_ID = PropertyHelper
-      .getPropertyId("ConfigGroup", "service_config_version_note");
-  protected static final String CONFIGGROUP_HOSTNAME_PROPERTY_ID =
-    PropertyHelper.getPropertyId(null, "host_name");
-  protected static final String CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID =
-    PropertyHelper.getPropertyId("ConfigGroup", "hosts/host_name");
-  public static final String CONFIGGROUP_HOSTS_PROPERTY_ID = PropertyHelper
-    .getPropertyId("ConfigGroup", "hosts");
-  public static final String CONFIGGROUP_CONFIGS_PROPERTY_ID =
-    PropertyHelper.getPropertyId("ConfigGroup", "desired_configs");
-  public static final String CONFIGGROUP_VERSION_TAGS_PROPERTY_ID =
-    PropertyHelper.getPropertyId("ConfigGroup", "version_tags");
+  public static final String CONFIG_GROUP = "ConfigGroup";
+
+  public static final String CLUSTER_NAME_PROPERTY_ID = "cluster_name";
+  public static final String ID_PROPERTY_ID =  "id";
+  public static final String GROUP_NAME_PROPERTY_ID =  "group_name";
+  public static final String TAG_PROPERTY_ID =  "tag";
+  public static final String SERVICE_NAME_PROPERTY_ID =  "service_name";
+  public static final String DESCRIPTION_PROPERTY_ID =  "description";
+  public static final String SERVICE_CONFIG_VERSION_NOTE_PROPERTY_ID =  "service_config_version_note";
+  public static final String HOST_NAME_PROPERTY_ID = "host_name";
+  public static final String HOSTS_HOSTNAME_PROPERTY_ID = "hosts/host_name";
+  public static final String HOSTS_PROPERTY_ID =  "hosts";
+  public static final String DESIRED_CONFIGS_PROPERTY_ID = "desired_configs";
+  public static final String VERSION_TAGS_PROPERTY_ID = "version_tags";
+
+  public static final String CLUSTER_NAME = PropertyHelper.getPropertyId(CONFIG_GROUP, CLUSTER_NAME_PROPERTY_ID);
+  public static final String ID = PropertyHelper.getPropertyId(CONFIG_GROUP, ID_PROPERTY_ID);
+  public static final String GROUP_NAME = PropertyHelper.getPropertyId(CONFIG_GROUP, GROUP_NAME_PROPERTY_ID);
+  public static final String TAG = PropertyHelper.getPropertyId(CONFIG_GROUP, TAG_PROPERTY_ID);
+  public static final String SERVICE_NAME = PropertyHelper.getPropertyId(CONFIG_GROUP, SERVICE_NAME_PROPERTY_ID);
+  public static final String DESCRIPTION = PropertyHelper.getPropertyId(CONFIG_GROUP, DESCRIPTION_PROPERTY_ID);
+  public static final String SERVICE_CONFIG_VERSION_NOTE = PropertyHelper
+      .getPropertyId(CONFIG_GROUP, SERVICE_CONFIG_VERSION_NOTE_PROPERTY_ID);
+  public static final String HOST_NAME = PropertyHelper.getPropertyId(null, HOST_NAME_PROPERTY_ID);
+  public static final String HOSTS_HOST_NAME = PropertyHelper.getPropertyId(CONFIG_GROUP, HOSTS_HOSTNAME_PROPERTY_ID);
+  public static final String HOSTS = PropertyHelper.getPropertyId(CONFIG_GROUP, HOSTS_PROPERTY_ID);
+  public static final String DESIRED_CONFIGS = PropertyHelper.getPropertyId(CONFIG_GROUP, DESIRED_CONFIGS_PROPERTY_ID);
+  public static final String VERSION_TAGS = PropertyHelper.getPropertyId(CONFIG_GROUP, VERSION_TAGS_PROPERTY_ID);
 
   /**
    * The key property ids for a ConfigGroup resource.
    */
   private static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
-      .put(Resource.Type.Cluster, CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID)
-      .put(Resource.Type.ConfigGroup, CONFIGGROUP_ID_PROPERTY_ID)
+      .put(Resource.Type.Cluster, CLUSTER_NAME)
+      .put(Resource.Type.ConfigGroup, ID)
       .build();
 
   /**
    * The property ids for a ConfigGroup resource.
    */
   private static Set<String> propertyIds = Sets.newHashSet(
-      CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID,
-      CONFIGGROUP_ID_PROPERTY_ID,
-      CONFIGGROUP_NAME_PROPERTY_ID,
-      CONFIGGROUP_TAG_PROPERTY_ID,
-      CONFIGGROUP_SERVICENAME_PROPERTY_ID,
-      CONFIGGROUP_DESC_PROPERTY_ID,
-      CONFIGGROUP_SCV_NOTE_ID,
-      CONFIGGROUP_HOSTNAME_PROPERTY_ID,
-      CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID,
-      CONFIGGROUP_HOSTS_PROPERTY_ID,
-      CONFIGGROUP_CONFIGS_PROPERTY_ID,
-      CONFIGGROUP_VERSION_TAGS_PROPERTY_ID);
+    CLUSTER_NAME,
+    ID,
+    GROUP_NAME,
+    TAG,
+    SERVICE_NAME,
+    DESCRIPTION,
+    SERVICE_CONFIG_VERSION_NOTE,
+    HOST_NAME,
+    HOSTS_HOST_NAME,
+    HOSTS,
+    DESIRED_CONFIGS,
+    VERSION_TAGS);
 
   @Inject
   private static HostDAO hostDAO;
@@ -197,26 +201,26 @@ public class ConfigGroupResourceProvider extends
     Set<String>   requestedIds = getRequestPropertyIds(request, predicate);
     Set<Resource> resources    = new HashSet<>();
 
-    if (requestedIds.contains(CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID)) {
-      requestedIds.add(CONFIGGROUP_HOSTS_PROPERTY_ID);
+    if (requestedIds.contains(HOSTS_HOST_NAME)) {
+      requestedIds.add(HOSTS);
     }
 
     for (ConfigGroupResponse response : responses) {
       Resource resource = new ResourceImpl(Resource.Type.ConfigGroup);
 
-      setResourceProperty(resource, CONFIGGROUP_ID_PROPERTY_ID,
+      setResourceProperty(resource, ID,
         response.getId(), requestedIds);
-      setResourceProperty(resource, CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID,
+      setResourceProperty(resource, CLUSTER_NAME,
         response.getClusterName(), requestedIds);
-      setResourceProperty(resource, CONFIGGROUP_NAME_PROPERTY_ID,
+      setResourceProperty(resource, GROUP_NAME,
         response.getGroupName(), requestedIds);
-      setResourceProperty(resource, CONFIGGROUP_TAG_PROPERTY_ID,
+      setResourceProperty(resource, TAG,
         response.getTag(), requestedIds);
-      setResourceProperty(resource, CONFIGGROUP_DESC_PROPERTY_ID,
+      setResourceProperty(resource, DESCRIPTION,
         response.getDescription(), requestedIds);
-      setResourceProperty(resource, CONFIGGROUP_HOSTS_PROPERTY_ID,
+      setResourceProperty(resource, HOSTS,
         response.getHosts(), requestedIds);
-      setResourceProperty(resource, CONFIGGROUP_CONFIGS_PROPERTY_ID,
+      setResourceProperty(resource, DESIRED_CONFIGS,
         response.getConfigurations(), requestedIds);
 
       resources.add(resource);
@@ -246,11 +250,11 @@ public class ConfigGroupResourceProvider extends
       ConfigGroupResponse configGroupResponse = getManagementController().getConfigGroupUpdateResults(configGroupRequest);
       Resource resource = new ResourceImpl(Resource.Type.ConfigGroup);
 
-      resource.setProperty(CONFIGGROUP_ID_PROPERTY_ID, configGroupResponse.getId());
-      resource.setProperty(CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID, configGroupResponse.getClusterName());
-      resource.setProperty(CONFIGGROUP_NAME_PROPERTY_ID, configGroupResponse.getGroupName());
-      resource.setProperty(CONFIGGROUP_TAG_PROPERTY_ID, configGroupResponse.getTag());
-      resource.setProperty(CONFIGGROUP_VERSION_TAGS_PROPERTY_ID, configGroupResponse.getVersionTags());
+      resource.setProperty(ID, configGroupResponse.getId());
+      resource.setProperty(CLUSTER_NAME, configGroupResponse.getClusterName());
+      resource.setProperty(GROUP_NAME, configGroupResponse.getGroupName());
+      resource.setProperty(TAG, configGroupResponse.getTag());
+      resource.setProperty(VERSION_TAGS, configGroupResponse.getVersionTags());
 
       associatedResources.add(resource);
     }
@@ -323,7 +327,7 @@ public class ConfigGroupResourceProvider extends
     Set<Resource> associatedResources = new HashSet<>();
     for (ConfigGroupResponse response : responses) {
       Resource resource = new ResourceImpl(Resource.Type.ConfigGroup);
-      resource.setProperty(CONFIGGROUP_ID_PROPERTY_ID, response.getId());
+      resource.setProperty(ID, response.getId());
       associatedResources.add(resource);
     }
 
@@ -761,7 +765,7 @@ public class ConfigGroupResourceProvider extends
 
   @SuppressWarnings("unchecked")
   ConfigGroupRequest getConfigGroupRequest(Map<String, Object> properties) {
-    Object groupIdObj = properties.get(CONFIGGROUP_ID_PROPERTY_ID);
+    Object groupIdObj = properties.get(ID);
     Long groupId = null;
     if (groupIdObj != null)  {
       groupId = groupIdObj instanceof Long ? (Long) groupIdObj :
@@ -770,24 +774,24 @@ public class ConfigGroupResourceProvider extends
 
     ConfigGroupRequest request = new ConfigGroupRequest(
       groupId,
-      (String) properties.get(CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID),
-      (String) properties.get(CONFIGGROUP_NAME_PROPERTY_ID),
-      (String) properties.get(CONFIGGROUP_TAG_PROPERTY_ID),
-      (String) properties.get(CONFIGGROUP_SERVICENAME_PROPERTY_ID),
-      (String) properties.get(CONFIGGROUP_DESC_PROPERTY_ID),
+      (String) properties.get(CLUSTER_NAME),
+      (String) properties.get(GROUP_NAME),
+      (String) properties.get(TAG),
+      (String) properties.get(SERVICE_NAME),
+      (String) properties.get(DESCRIPTION),
       null,
       null);
 
-    request.setServiceConfigVersionNote((String) properties.get(CONFIGGROUP_SCV_NOTE_ID));
+    request.setServiceConfigVersionNote((String) properties.get(SERVICE_CONFIG_VERSION_NOTE));
 
     Map<String, Config> configurations = new HashMap<>();
     Set<String> hosts = new HashSet<>();
 
-    String hostnameKey = CONFIGGROUP_HOSTNAME_PROPERTY_ID;
-    Object hostObj = properties.get(CONFIGGROUP_HOSTS_PROPERTY_ID);
+    String hostnameKey = HOST_NAME;
+    Object hostObj = properties.get(HOSTS);
     if (hostObj == null) {
-      hostnameKey = CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID;
-      hostObj = properties.get(CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID);
+      hostnameKey = HOSTS_HOST_NAME;
+      hostObj = properties.get(HOSTS_HOST_NAME);
     }
     if (hostObj != null) {
       if (hostObj instanceof HashSet<?>) {
@@ -809,7 +813,7 @@ public class ConfigGroupResourceProvider extends
       }
     }
 
-    Object configObj = properties.get(CONFIGGROUP_CONFIGS_PROPERTY_ID);
+    Object configObj = properties.get(DESIRED_CONFIGS);
     if (configObj != null && configObj instanceof HashSet<?>) {
       try {
         Set<Map<String, Object>> configSet = (Set<Map<String, Object>>) configObj;

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProviderTest.java
@@ -191,10 +191,10 @@ public class ConfigGroupResourceProviderTest {
 
     Set<Map<String, Object>> hostSet = new HashSet<>();
     Map<String, Object> host1 = new HashMap<>();
-    host1.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID, "h1");
+    host1.put(ConfigGroupResourceProvider.HOST_NAME, "h1");
     hostSet.add(host1);
     Map<String, Object> host2 = new HashMap<>();
-    host2.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID, "h2");
+    host2.put(ConfigGroupResourceProvider.HOST_NAME, "h2");
     hostSet.add(host2);
 
     Set<Map<String, Object>> configSet = new HashSet<>();
@@ -207,14 +207,14 @@ public class ConfigGroupResourceProviderTest {
     configSet.add(configs);
 
     properties.put(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_NAME_PROPERTY_ID,
+        .CLUSTER_NAME, "Cluster100");
+    properties.put(ConfigGroupResourceProvider.GROUP_NAME,
         "test-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.TAG,
         "tag-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTS_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.HOSTS,
         hostSet);
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_CONFIGS_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.DESIRED_CONFIGS,
         configSet);
 
     propertySet.add(properties);
@@ -299,10 +299,10 @@ public class ConfigGroupResourceProviderTest {
     Set<Map<String, Object>> propertySet = new LinkedHashSet<>();
 
     properties.put(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_NAME_PROPERTY_ID,
+        .CLUSTER_NAME, "Cluster100");
+    properties.put(ConfigGroupResourceProvider.GROUP_NAME,
         "test-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.TAG,
         "tag-1");
 
     propertySet.add(properties);
@@ -384,10 +384,10 @@ public class ConfigGroupResourceProviderTest {
 
     Set<Map<String, Object>> hostSet = new HashSet<>();
     Map<String, Object> host1 = new HashMap<>();
-    host1.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID, "h1");
+    host1.put(ConfigGroupResourceProvider.HOST_NAME, "h1");
     hostSet.add(host1);
     Map<String, Object> host2 = new HashMap<>();
-    host2.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID, "h2");
+    host2.put(ConfigGroupResourceProvider.HOST_NAME, "h2");
     hostSet.add(host2);
 
     Set<Map<String, Object>> configSet = new HashSet<>();
@@ -400,14 +400,14 @@ public class ConfigGroupResourceProviderTest {
     configSet.add(configs);
 
     properties.put(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_NAME_PROPERTY_ID,
+        .CLUSTER_NAME, "Cluster100");
+    properties.put(ConfigGroupResourceProvider.GROUP_NAME,
         "test-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.TAG,
         "tag-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTS_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.HOSTS,
         hostSet);
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_CONFIGS_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.DESIRED_CONFIGS,
         configSet);
 
     Map<String, String> mapRequestProps = new HashMap<>();
@@ -416,9 +416,9 @@ public class ConfigGroupResourceProviderTest {
     Request request = PropertyHelper.getUpdateRequest(properties, mapRequestProps);
 
     Predicate predicate = new PredicateBuilder().property
-        (ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals
+        (ConfigGroupResourceProvider.CLUSTER_NAME).equals
         ("Cluster100").and().
-        property(ConfigGroupResourceProvider.CONFIGGROUP_ID_PROPERTY_ID).equals
+        property(ConfigGroupResourceProvider.ID).equals
         (25L).toPredicate();
 
     SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
@@ -523,10 +523,10 @@ public class ConfigGroupResourceProviderTest {
 
     Set<Map<String, Object>> hostSet = new HashSet<>();
     Map<String, Object> host1 = new HashMap<>();
-    host1.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID, "h1");
+    host1.put(ConfigGroupResourceProvider.HOST_NAME, "h1");
     hostSet.add(host1);
     Map<String, Object> host2 = new HashMap<>();
-    host2.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID, "h2");
+    host2.put(ConfigGroupResourceProvider.HOST_NAME, "h2");
     hostSet.add(host2);
 
     Set<Map<String, Object>> configSet = new HashSet<>();
@@ -539,14 +539,14 @@ public class ConfigGroupResourceProviderTest {
     configSet.add(configs);
 
     properties.put(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID, "Cluster100");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_NAME_PROPERTY_ID,
+        .CLUSTER_NAME, "Cluster100");
+    properties.put(ConfigGroupResourceProvider.GROUP_NAME,
         "test-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.TAG,
         "tag-1");
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_HOSTS_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.HOSTS,
         hostSet);
-    properties.put(ConfigGroupResourceProvider.CONFIGGROUP_CONFIGS_PROPERTY_ID,
+    properties.put(ConfigGroupResourceProvider.DESIRED_CONFIGS,
         configSet);
 
     Map<String, String> mapRequestProps = new HashMap<>();
@@ -555,9 +555,9 @@ public class ConfigGroupResourceProviderTest {
     Request request = PropertyHelper.getUpdateRequest(properties, mapRequestProps);
 
     Predicate predicate = new PredicateBuilder().property
-        (ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals
+        (ConfigGroupResourceProvider.CLUSTER_NAME).equals
         ("Cluster100").and().
-        property(ConfigGroupResourceProvider.CONFIGGROUP_ID_PROPERTY_ID).equals
+        property(ConfigGroupResourceProvider.ID).equals
         (25L).toPredicate();
 
     SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -686,12 +686,12 @@ public class ConfigGroupResourceProviderTest {
 
     Set<String> propertyIds = new HashSet<>();
 
-    propertyIds.add(ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID);
-    propertyIds.add(ConfigGroupResourceProvider.CONFIGGROUP_ID_PROPERTY_ID);
+    propertyIds.add(ConfigGroupResourceProvider.CLUSTER_NAME);
+    propertyIds.add(ConfigGroupResourceProvider.ID);
 
     // Read all
     Predicate predicate = new PredicateBuilder().property
-        (ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID)
+        (ConfigGroupResourceProvider.CLUSTER_NAME)
         .equals("Cluster100").toPredicate();
     Request request = PropertyHelper.getReadRequest(propertyIds);
 
@@ -701,44 +701,44 @@ public class ConfigGroupResourceProviderTest {
 
     // Read by id
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_ID_PROPERTY_ID).equals(1L).and().property
-        (ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID)
+        .ID).equals(1L).and().property
+        (ConfigGroupResourceProvider.CLUSTER_NAME)
         .equals("Cluster100").toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
 
     assertEquals(1, resources.size());
     assertEquals(1L, resources.iterator().next().getPropertyValue
-        (ConfigGroupResourceProvider.CONFIGGROUP_ID_PROPERTY_ID));
+        (ConfigGroupResourceProvider.ID));
 
     // Read by Name
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
-        .property(ConfigGroupResourceProvider.CONFIGGROUP_NAME_PROPERTY_ID)
+        .CLUSTER_NAME).equals("Cluster100").and()
+        .property(ConfigGroupResourceProvider.GROUP_NAME)
         .equals("g2").toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
 
     assertEquals(1, resources.size());
     assertEquals("g2", resources.iterator().next().getPropertyValue
-        (ConfigGroupResourceProvider.CONFIGGROUP_NAME_PROPERTY_ID));
+        (ConfigGroupResourceProvider.GROUP_NAME));
 
     // Read by tag
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
-        .property(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID)
+        .CLUSTER_NAME).equals("Cluster100").and()
+        .property(ConfigGroupResourceProvider.TAG)
         .equals("t3").toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
 
     assertEquals(1, resources.size());
     assertEquals("t3", resources.iterator().next().getPropertyValue
-        (ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID));
+        (ConfigGroupResourceProvider.TAG));
 
     // Read by hostname (hosts=h1)
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
-        .property(ConfigGroupResourceProvider.CONFIGGROUP_HOSTS_PROPERTY_ID)
+        .CLUSTER_NAME).equals("Cluster100").and()
+        .property(ConfigGroupResourceProvider.HOSTS)
         .equals("h1").toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
@@ -747,14 +747,14 @@ public class ConfigGroupResourceProviderTest {
     Set<Map<String, Object>> hostSet = (Set<Map<String, Object>>)
         resources.iterator().next()
             .getPropertyValue(ConfigGroupResourceProvider
-                .CONFIGGROUP_HOSTS_PROPERTY_ID);
+                .HOSTS);
     assertEquals("h1", hostSet.iterator().next().get
-        (ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID));
+        (ConfigGroupResourceProvider.HOST_NAME));
 
     // Read by hostname (hosts/host_name=h1)
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
-        .property(ConfigGroupResourceProvider.CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID)
+        .CLUSTER_NAME).equals("Cluster100").and()
+        .property(ConfigGroupResourceProvider.HOSTS_HOST_NAME)
         .equals("h1").toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
@@ -763,17 +763,17 @@ public class ConfigGroupResourceProviderTest {
     hostSet = (Set<Map<String, Object>>)
         resources.iterator().next()
             .getPropertyValue(ConfigGroupResourceProvider
-                .CONFIGGROUP_HOSTS_PROPERTY_ID);
+                .HOSTS);
     assertEquals("h1", hostSet.iterator().next().get
-        (ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID));
+        (ConfigGroupResourceProvider.HOST_NAME));
 
 
     // Read by tag and hostname (hosts=h1) - Positive
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
-        .property(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID)
+        .CLUSTER_NAME).equals("Cluster100").and()
+        .property(ConfigGroupResourceProvider.TAG)
         .equals("t4").and().property(ConfigGroupResourceProvider
-            .CONFIGGROUP_HOSTS_PROPERTY_ID).equals(host1Id).toPredicate();
+            .HOSTS).equals(host1Id).toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
 
@@ -781,16 +781,16 @@ public class ConfigGroupResourceProviderTest {
     hostSet = (Set<Map<String, Object>>)
         resources.iterator().next()
             .getPropertyValue(ConfigGroupResourceProvider
-                .CONFIGGROUP_HOSTS_PROPERTY_ID);
+                .HOSTS);
     assertEquals("h1", hostSet.iterator().next().get
-        (ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID));
+        (ConfigGroupResourceProvider.HOST_NAME));
 
     // Read by tag and hostname (hosts/host_name=h1) - Positive
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID).equals("Cluster100").and()
-        .property(ConfigGroupResourceProvider.CONFIGGROUP_TAG_PROPERTY_ID)
+        .CLUSTER_NAME).equals("Cluster100").and()
+        .property(ConfigGroupResourceProvider.TAG)
         .equals("t4").and().property(ConfigGroupResourceProvider
-            .CONFIGGROUP_HOSTS_HOSTNAME_PROPERTY_ID).equals("h1").toPredicate();
+            .HOSTS_HOST_NAME).equals("h1").toPredicate();
 
     resources = resourceProvider.getResources(request, predicate);
 
@@ -798,14 +798,14 @@ public class ConfigGroupResourceProviderTest {
     hostSet = (Set<Map<String, Object>>)
         resources.iterator().next()
             .getPropertyValue(ConfigGroupResourceProvider
-                .CONFIGGROUP_HOSTS_PROPERTY_ID);
+                .HOSTS);
     assertEquals("h1", hostSet.iterator().next().get
-        (ConfigGroupResourceProvider.CONFIGGROUP_HOSTNAME_PROPERTY_ID));
+        (ConfigGroupResourceProvider.HOST_NAME));
 
     // Read by id
     predicate = new PredicateBuilder().property(ConfigGroupResourceProvider
-        .CONFIGGROUP_ID_PROPERTY_ID).equals(11L).and().property
-        (ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID)
+        .ID).equals(11L).and().property
+        (ConfigGroupResourceProvider.CLUSTER_NAME)
         .equals("Cluster100").toPredicate();
 
     NoSuchResourceException resourceException = null;
@@ -873,9 +873,9 @@ public class ConfigGroupResourceProviderTest {
     ((ObservableResourceProvider) resourceProvider).addObserver(observer);
 
     Predicate predicate = new PredicateBuilder().property
-        (ConfigGroupResourceProvider.CONFIGGROUP_CLUSTER_NAME_PROPERTY_ID)
+        (ConfigGroupResourceProvider.CLUSTER_NAME)
         .equals("Cluster100").and().property(ConfigGroupResourceProvider
-            .CONFIGGROUP_ID_PROPERTY_ID).equals(1L).toPredicate();
+            .ID).equals(1L).toPredicate();
 
     SecurityContextHolder.getContext().setAuthentication(authentication);
 


### PR DESCRIPTION
Change-Id: I3fd97fa13aecfb53ec55fd49e8b700f6aa3e90e2

## What changes were proposed in this pull request?

Integrate ConfigGroup Service to Swagger

## How was this patch tested?

```
mvn clean checkstyle:checkstyle -pl ambari-server
mvn clean test -Dtest=ConfigGroupResourceProviderTest -DskipPythonTests -am -Drat.skip -DfailIfNoTests=false --fail-at-end -pl ambari-server
```

generate new Swagger docs by:

`mvn process-classes -Dgenerate.swagger.resources -pl ambari-server | grep -v "\[EL*"`

check JSON and HTML files generated at: `ambari-server/docs/api/generated/index.html` and `ambari-server/docs/api/generated/swagger.json`

please review @adoroszlai, @benyoka