### PR TITLE
[AMBARI-23477] Utility to parse initial active namenode for blueprint deployment

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/namenode_ha_utils.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/namenode_ha_utils.py
@@ -17,7 +17,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-from resource_management.libraries.functions.is_empty import is_empty
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.jmx import get_value_from_jmx
 from resource_management.core.base import Fail
@@ -164,7 +163,7 @@ def get_active_namenode(hdfs_site, security_enabled, run_user):
     return active_namenodes[0]
 
   raise NoActiveNamenodeException('No active NameNode was found.')
-  
+
 def get_property_for_active_namenodes(hdfs_site, property_name, security_enabled, run_user):
   """
   Return format: {'ns1': 'value1', 'ns2', 'value2'}
@@ -312,3 +311,24 @@ def get_nameservices(hdfs_site):
         return [ns]
     return [name_services_string.split(",")[0]] # default to return the first nameservice
   return []
+
+
+def get_initial_active_namenodes(hadoop_env):
+  """
+  :return: The set of initially active namenode hosts as specified by one of the
+           'hadoop-env/dfs_ha_initial_namenode_active_set' or
+           'hadoop-env/dfs_ha_initial_namenode_active' properties.
+           An empty set if the properties are unspecified or empty.
+  """
+  setting = ''
+
+  if 'dfs_ha_initial_namenode_active_set' in hadoop_env:
+    setting = hadoop_env['dfs_ha_initial_namenode_active_set']
+
+  if 'dfs_ha_initial_namenode_active' in hadoop_env and not setting:
+    setting = hadoop_env['dfs_ha_initial_namenode_active']
+
+  if setting:
+    return frozenset(setting.split(','))
+
+  return frozenset()

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -24,6 +24,7 @@ import tempfile
 import time
 from stacks.utils.RMFTestCase import *
 from mock.mock import MagicMock, patch, call
+from resource_management.libraries.functions import namenode_ha_utils
 from resource_management.libraries.script.script import Script
 from resource_management.core import shell
 from resource_management.core.exceptions import Fail
@@ -835,7 +836,7 @@ class TestNamenode(RMFTestCase):
     active_namenodes = [('nn1', 'c6401.ambari.apache.org:50070')]
     standby_namenodes = [('nn2', 'c6402.ambari.apache.org:50070')]
     unknown_namenodes = []
-    
+
     get_namenode_states_mock.return_value = active_namenodes, standby_namenodes, unknown_namenodes
 
     call_mocks = MagicMock(return_value=(0,""))
@@ -1772,6 +1773,24 @@ class TestNamenode(RMFTestCase):
       #                       logoutput=True
       #                       )
 
+  def test_initial_active_namenode_unspecified(self):
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({}), frozenset())
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': '' }), frozenset())
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active_set': '' }), frozenset())
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': '', 'dfs_ha_initial_namenode_active_set': '' }), frozenset())
+
+  def test_initial_active_namenode_single(self):
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': 'c6401.ambari.apache.org' }), frozenset(['c6401.ambari.apache.org']))
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': 'c6401,c7401' }), frozenset(['c6401', 'c7401']))
+
+  def test_initial_active_namenode_set(self):
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active_set': 'c6401.ambari.apache.org' }), frozenset(['c6401.ambari.apache.org']))
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active_set': 'c6401,c7401' }), frozenset(['c6401', 'c7401']))
+
+  def test_initial_active_namenode_both(self):
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': '', 'dfs_ha_initial_namenode_active_set': 'mult1,mult2' }), frozenset(['mult1', 'mult2']))
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': 'single', 'dfs_ha_initial_namenode_active_set': 'mult1,mult2' }), frozenset(['mult1', 'mult2']))
+    self.assertEqual(namenode_ha_utils.get_initial_active_namenodes({ 'dfs_ha_initial_namenode_active': 'single', 'dfs_ha_initial_namenode_active_set': '' }), frozenset(['single']))
 
 
 class Popen_Mock:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide a utility function to get the set of initially active NameNodes from
the configuration for blueprint deployments.

## How was this patch tested?

Unit tests:

```
test_initial_active_namenode_both (test_namenode.TestNamenode) ... ok
test_initial_active_namenode_set (test_namenode.TestNamenode) ... ok
test_initial_active_namenode_single (test_namenode.TestNamenode) ... ok
test_initial_active_namenode_unspecified (test_namenode.TestNamenode) ... ok

...

Total run:1191
Total errors:0
Total failures:2
```

The 2 failures in `test_alert_metrics_deviation` are due to [AMBARI-23449](https://issues.apache.org/jira/browse/AMBARI-23449).