### PR TITLE
[AMBARI-23480]. Error encountered while disabling Kerberos on HDF 3.2 using Ambari 2.7.0.0 (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/DestroyPrincipalsServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/DestroyPrincipalsServerAction.java
@@ -139,6 +139,7 @@ public class DestroyPrincipalsServerAction extends KerberosServerAction {
           if (principalEntity != null) {
             String cachedKeytabPath = principalEntity.getCachedKeytabPath();
             KerberosKeytabEntity kke = kerberosKeytabDAO.find(resolvedPrincipal.getResolvedKerberosKeytab().getFile());
+            kerberosKeytabPrincipalDAO.remove(kerberosKeytabPrincipalDAO.findByPrincipal(principalEntity.getPrincipalName()));
             kerberosKeytabDAO.remove(kke);
             kerberosPrincipalDAO.remove(principalEntity);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

 Disabling Kerberos throws following exception

```text
Internal Exception: org.postgresql.util.PSQLException: ERROR: update or delete on table "kerberos_principal" violates foreign key constraint "fk_kkp_principal_name" on table "kerberos_keytab_principal"
Detail: Key (principal_name)=(amshbase/priyank-3-2-2.openstacklocal@EXAMPLE.COM) is still referenced from table "kerberos_keytab_principal".
```

The issue happens if the same principal is stored in multiple keytabs. For example:

```text
amshbase/c7403.ambari.apache.org@EXAMPLE.COM |  /etc/security/keytabs/ams-hbase.regionserver.keytab
amshbase/c7403.ambari.apache.org@EXAMPLE.COM |  /etc/security/keytabs/ams-hbase.master.keytab 
```

## How was this patch tested?

Disabling kerberos on a HDF cluster.