### PR TITLE
[AMBARI-23487] Cannot tell which services are in maintenance mode.

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -2044,6 +2044,7 @@ Em.I18n.translations = {
   'services.service.summary.hiveserver2.jdbc.url.text': ' JDBC URL',
   'services.service.summary.hiveserver2.endpoint.tooltip.text':'JDBC connection string for {0}',
   'services.service.summary.hiveserver2.endpoint.value':'jdbc:hive2://{0}/;serviceDiscoveryMode={1};zooKeeperNamespace={2}',
+  'services.service.summary.inMaintenanceMode.tooltip': 'Service is in maintenance mode',
   'services.service.actions.downloadClientConfigs':'Download Client Configs',
   'services.service.actions.downloadClientConfigs.fail.noConfigFile':'No configuration files defined for the component',
   'services.service.actions.downloadClientConfigs.fail.popup.header':'{0} Configs',

--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -1173,10 +1173,16 @@ a.services-menu-blocks{
     word-break:break-word;
   }
 
-  .glyphicon.glyphicon-refresh {
+  .glyphicon.glyphicon-refresh, .icon-medkit {
     margin-left: 4px;
     margin-right: 4px;
+    top: 0px;
   }
+
+  .icon-medkit {
+    color: @maintenance-grey;
+  }
+
   .menu-item-name.INSTALLED:not(.client-only-service) {
     color: @health-status-red;
   }

--- a/ambari-web/app/styles/common.less
+++ b/ambari-web/app/styles/common.less
@@ -29,6 +29,7 @@
 @health-status-yellow: #FFD13D;
 @health-status-orange: #e98a41;
 @maintenance-black: #000;
+@maintenance-grey: #999999;
 @gray-text: #666;
 /************************************************************************
 * Health status(service/host/host component health)icon colors ends

--- a/ambari-web/app/templates/main/service/menu_item.hbs
+++ b/ambari-web/app/templates/main/service/menu_item.hbs
@@ -20,6 +20,9 @@
   <span class="pull-right">
     <i rel="tooltip" {{action goToConfigs target="view"}} {{bindAttr class=":glyphicon :glyphicon-refresh :restart-required-service view.content.isRestartRequired::hidden" data-original-title="view.restartRequiredMessage"}}></i>
   </span>
+  <span class="pull-right">
+    <i rel="tooltip" {{bindAttr class=":icon-medkit :passive-state-service view.content.isInPassive::hidden" }} {{translateAttr data-original-title="services.service.summary.inMaintenanceMode.tooltip"}}></i>
+  </span>
   {{#if view.content.alertsCount}}
     <span {{bindAttr class=":icon-circle view.hasCriticalAlerts:service-alerts-critical:service-alerts-warning"}}></span>
   {{/if}}

--- a/ambari-web/app/views/main/menu.js
+++ b/ambari-web/app/views/main/menu.js
@@ -176,11 +176,13 @@ App.SideNavServiceMenuView = Em.CollectionView.extend({
     this.renderOnRoute();
     App.tooltip(this.$(".restart-required-service"), {html:true, placement:"right"});
     App.tooltip($("[rel='serviceHealthTooltip']"), {html:true, placement:"right"});
+    App.tooltip(this.$(".passive-state-service"), {html: true, placement: "top"});
   },
 
   willDestroyElement: function() {
     App.router.location.removeObserver('lastSetURL', this, 'renderOnRoute');
     this.$(".restart-required-service").tooltip('destroy');
+    this.$(".passive-state-service").tooltip('destroy');
   },
 
   activeServiceId:null,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add medkit icon to services which are in maintenance mode and apply a tooltip to indicate the same.
<img width="388" alt="screen shot 2018-04-05 at 7 50 35 pm" src="https://user-images.githubusercontent.com/12506576/38401756-85376608-390c-11e8-8d0f-8f8992cd752a.png">

## How was this patch tested?

  21533 passing (24s)
  48 pending
