### PR TITLE
AMBARI-23495. Fix Ambari Infra Solr service advisor class name.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/service_advisor.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/service_advisor.py
@@ -33,10 +33,10 @@ except Exception as e:
   traceback.print_exc()
   print "Failed to load parent"
 
-class Ambari_InfraServiceAdvisor(service_advisor.ServiceAdvisor):
+class Ambari_Infra_SolrServiceAdvisor(service_advisor.ServiceAdvisor):
 
   def __init__(self, *args, **kwargs):
-    self.as_super = super(Ambari_InfraServiceAdvisor, self)
+    self.as_super = super(Ambari_Infra_SolrServiceAdvisor, self)
     self.as_super.__init__(*args, **kwargs)
 
     # Always call these methods


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because of renaming infra solr service, service advisor name should change, otherwise it throws an exception during the stack advisor call.

## How was this patch tested?
in progress..

please review @kasakrisz @adoroszlai @zeroflag 