### PR TITLE
AMBARI-23492. Server should acknowledge api endpoint about host-component state before deletion.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/TopologyHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/TopologyHolder.java
@@ -176,6 +176,7 @@ public class TopologyHolder extends AgentClusterDataHolder<TopologyUpdateEvent> 
         for (TopologyComponent topologyComponent : topologyCluster.getTopologyComponents()) {
           topologyComponent.setHostNames(new HashSet<>());
           topologyComponent.setPublicHostNames(new HashSet<>());
+          topologyComponent.setLastComponentState(null);
         }
         if (topologyUpdateEvent.getEventType().equals(TopologyUpdateEvent.EventType.DELETE)) {
           for (TopologyHost topologyHost : topologyCluster.getTopologyHosts()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/TopologyComponent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/TopologyComponent.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.ambari.server.state.State;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
@@ -40,6 +41,7 @@ public class TopologyComponent {
   private Set<String> publicHostNames = new HashSet<>();
   private TreeMap<String, String> componentLevelParams = new TreeMap<>();
   private TreeMap<String, String> commandParams = new TreeMap<>();
+  private State lastComponentState;
 
   private TopologyComponent() {
   }
@@ -95,6 +97,11 @@ public class TopologyComponent {
 
     public Builder setCommandParams(TreeMap<String, String> commandParams) {
       TopologyComponent.this.setCommandParams(commandParams);
+      return this;
+    }
+
+    public Builder setLastComponentState(State lastComponentState) {
+      TopologyComponent.this.setLastComponentState(lastComponentState);
       return this;
     }
 
@@ -267,6 +274,14 @@ public class TopologyComponent {
 
   public void setCommandParams(TreeMap<String, String> commandParams) {
     this.commandParams = commandParams;
+  }
+
+  public State getLastComponentState() {
+    return lastComponentState;
+  }
+
+  public void setLastComponentState(State lastComponentState) {
+    this.lastComponentState = lastComponentState;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/DeleteHostComponentStatusMetaData.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/DeleteHostComponentStatusMetaData.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.state.State;
 
 @NotThreadSafe
 public class DeleteHostComponentStatusMetaData extends DeleteStatusMetaData {
@@ -33,9 +34,9 @@ public class DeleteHostComponentStatusMetaData extends DeleteStatusMetaData {
   }
 
   public void addDeletedHostComponent(String componentName, String serviceName, String hostName, Long hostId,
-                                      String clusterId, String version) {
+                                      String clusterId, String version, State lastComponentState) {
     removedHostComponents.add(new HostComponent(componentName, serviceName, hostId,
-        hostName, clusterId, version));
+        hostName, clusterId, version, lastComponentState));
     addDeletedKey(componentName + "/" + hostName);
   }
 
@@ -58,15 +59,17 @@ public class DeleteHostComponentStatusMetaData extends DeleteStatusMetaData {
     private String hostName;
     private String clusterId;
     private String version;
+    private State lastComponentState;
 
     public HostComponent(String componentName, String serviceName, Long hostId, String hostName,
-                         String clusterId, String version) {
+                         String clusterId, String version, State lastComponentState) {
       this.componentName = componentName;
       this.serviceName = serviceName;
       this.hostId = hostId;
       this.hostName = hostName;
       this.clusterId = clusterId;
       this.version = version;
+      this.lastComponentState = lastComponentState;
     }
 
     public String getComponentName() {
@@ -115,6 +118,14 @@ public class DeleteHostComponentStatusMetaData extends DeleteStatusMetaData {
 
     public void setHostId(Long hostId) {
       this.hostId = hostId;
+    }
+
+    public State getLastComponentState() {
+      return lastComponentState;
+    }
+
+    public void setLastComponentState(State lastComponentState) {
+      this.lastComponentState = lastComponentState;
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -1387,6 +1387,7 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
       String serviceName = getServiceName();
       String componentName = getServiceComponentName();
       String hostName = getHostName();
+      State lastComponentState = getState();
       boolean recoveryEnabled = isRecoveryEnabled();
       boolean masterComponent = serviceComponent.isMasterComponent();
 
@@ -1400,7 +1401,8 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
           hostName,
           getHost().getHostId(),
           Long.toString(clusterId),
-          version);
+          version,
+          lastComponentState);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyDeleteFormer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyDeleteFormer.java
@@ -78,6 +78,7 @@ public class TopologyDeleteFormer {
           .setVersion(hostComponent.getVersion())
           .setHostIds(new HashSet<>(Arrays.asList(hostComponent.getHostId())))
           .setHostNames(new HashSet<>(Arrays.asList(hostComponent.getHostName())))
+          .setLastComponentState(hostComponent.getLastComponentState())
           .build();
 
       String clusterId = hostComponent.getClusterId();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Server now is sending last host-component state with DELETE event to api topology endpoint.

## How was this patch tested?

Manual testing.