### PR TITLE
AMBARI-23499. Infra Solr - ambari commons - max_shard calculation can…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
@@ -103,7 +103,7 @@ def create_collection(zookeeper_quorum, solr_znode, collection, config_set, java
   solr_cli_prefix = __create_solr_cloud_cli_prefix(zookeeper_quorum, solr_znode, java64_home, java_opts)
 
   if max_shards == 1: # if max shards is not specified use this strategy
-    max_shards = replication_factor * shards
+    max_shards = int(replication_factor) * int(shards)
 
   create_collection_cmd = format('{solr_cli_prefix} --create-collection --collection {collection} --config-set {config_set} '\
                                  '--shards {shards} --replication {replication_factor} --max-shards {max_shards} --retry {retry} '\


### PR DESCRIPTION
… be wrong if shard or replica value is string.

## What changes were proposed in this pull request?
If shard or replica value is string, max shard calculation is invalid, so we should cast values to integer (safest if we are doing that where we calculating max_shards)
## How was this patch tested?
In progress ...

please review @fimugdha @kasakrisz @zeroflag @adoroszlai @swagle @g-boros 
