### PR TITLE
[AMBARI-23504] Pre-Upgrade Configuration Check for Kafka should only apply to HDP 2.6.5-> HDP 2.6.x (Not HDF) (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/KafkaPropertiesCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/KafkaPropertiesCheck.java
@@ -51,9 +51,7 @@ import com.google.common.collect.Lists;
  * value is not empty (version can vary from current stack version)
  */
 @Singleton
-@UpgradeCheck(
-    group = UpgradeCheckGroup.REPOSITORY_VERSION,
-    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+@UpgradeCheck(group = UpgradeCheckGroup.DEFAULT)
 public class KafkaPropertiesCheck extends AbstractCheckDescriptor {
   private static String KAFKA_BROKER_CONFIG = "kafka-broker";
   private static String KAFKA_SERVICE_NAME = "KAFKA";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Making pre-upgrade check to be fully optional and run as it supposed by instruction from upgrade packs

## How was this patch tested?

live cluster