### PR TITLE
AMBARI-23505 - Cluster version is not updated after stack upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/UpdateDesiredRepositoryAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/UpdateDesiredRepositoryAction.java
@@ -36,6 +36,7 @@ import org.apache.ambari.server.serveraction.ServerAction;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.RepositoryType;
 import org.apache.ambari.server.state.RepositoryVersionState;
+import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.UpgradeContext;
 import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.commons.lang.StringUtils;
@@ -136,6 +137,10 @@ public class UpdateDesiredRepositoryAction extends AbstractUpgradeServerAction {
         }
 
         out.append(message).append(System.lineSeparator());
+
+        // move the cluster's desired stack as well
+        StackId targetStackId = targetRepositoryVersion.getStackId();
+        cluster.setDesiredStackVersion(targetStackId);
       }
 
       if( upgradeContext.getDirection() == Direction.DOWNGRADE ){
@@ -169,6 +174,10 @@ public class UpdateDesiredRepositoryAction extends AbstractUpgradeServerAction {
             hostVersion.setState(RepositoryVersionState.INSTALLED);
           }
         }
+
+        // move the cluster's desired stack back to it's current stack on downgrade
+        StackId targetStackId = cluster.getCurrentStackVersion();
+        cluster.setDesiredStackVersion(targetStackId);
       }
 
       return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", out.toString(), err.toString());

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackManager.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -99,7 +100,7 @@ public class StackManager {
   /**
    * Map of stack id to stack info
    */
-  protected TreeMap<String, StackInfo> stackMap = new TreeMap<>();
+  protected NavigableMap<String, StackInfo> stackMap = new TreeMap<>();
   protected Map<String, ServiceModule> commonServiceModules;
   protected Map<String, StackModule> stackModules;
   protected Map<String, ExtensionModule> extensionModules;
@@ -569,8 +570,6 @@ public class StackManager {
           continue;
         }
         for (File serviceFolder : commonService.listFiles(StackDirectory.FILENAME_FILTER)) {
-          serviceFolder.getParentFile().getName();
-          serviceFolder.getName();
           ServiceDirectory serviceDirectory = new CommonServiceDirectory(serviceFolder.getPath());
           ServiceMetainfoXml metaInfoXml = serviceDirectory.getMetaInfoFile();
           if (metaInfoXml != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackManager.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
@@ -90,8 +91,6 @@ public class StackManager {
    */
   private StackContext stackContext;
 
-  private File stackRoot;
-
   /**
    * Logger
    */
@@ -100,7 +99,7 @@ public class StackManager {
   /**
    * Map of stack id to stack info
    */
-  protected Map<String, StackInfo> stackMap = new HashMap<>();
+  protected TreeMap<String, StackInfo> stackMap = new TreeMap<>();
   protected Map<String, ServiceModule> commonServiceModules;
   protected Map<String, StackModule> stackModules;
   protected Map<String, ExtensionModule> extensionModules;
@@ -156,7 +155,7 @@ public class StackManager {
       validateExtensionDirectory(extensionRoot);
     }
 
-    stackMap = new HashMap<>();
+    stackMap = new TreeMap<>();
     stackContext = new StackContext(metaInfoDAO, actionMetadata, osFamily);
     extensionMap = new HashMap<>();
     this.helper = helper;
@@ -536,8 +535,9 @@ public class StackManager {
   private void validateExtensionDirectory(File extensionRoot) throws AmbariException {
     LOG.info("Validating extension directory {} ...", extensionRoot);
 
-    if (extensionRoot == null)
-	return;
+    if (extensionRoot == null) {
+      return;
+    }
 
     String extensionRootAbsPath = extensionRoot.getAbsolutePath();
     if (LOG.isDebugEnabled()) {
@@ -569,8 +569,8 @@ public class StackManager {
           continue;
         }
         for (File serviceFolder : commonService.listFiles(StackDirectory.FILENAME_FILTER)) {
-          String serviceName = serviceFolder.getParentFile().getName();
-          String serviceVersion = serviceFolder.getName();
+          serviceFolder.getParentFile().getName();
+          serviceFolder.getName();
           ServiceDirectory serviceDirectory = new CommonServiceDirectory(serviceFolder.getPath());
           ServiceMetainfoXml metaInfoXml = serviceDirectory.getMetaInfoFile();
           if (metaInfoXml != null) {
@@ -648,8 +648,9 @@ public class StackManager {
    */
   private Map<String, ExtensionModule> parseExtensionDirectory(File extensionRoot) throws AmbariException {
     Map<String, ExtensionModule> extensionModules = new HashMap<>();
-    if (extensionRoot == null || !extensionRoot.exists())
+    if (extensionRoot == null || !extensionRoot.exists()) {
       return extensionModules;
+    }
 
     File[] extensionFiles = extensionRoot.listFiles(StackDirectory.FILENAME_FILTER);
     for (File extensionNameFolder : extensionFiles) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerMock.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerMock.java
@@ -21,7 +21,7 @@ package org.apache.ambari.server.stack;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.NavigableMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -111,10 +111,10 @@ public class StackManagerMock extends StackManager {
     private Map<String, ServiceModule> cachedCommonServiceModules;
     private Map<String, StackModule> cachedStackModules;
     private Map<String, ExtensionModule> cachedExtensionModules;
-    private TreeMap<String, StackInfo> cachedStackMap;
+    private NavigableMap<String, StackInfo> cachedStackMap;
 
     public CachedModules(Map<String, ServiceModule> cachedCommonServiceModules, Map<String, StackModule> cachedStackModules,
-                         Map<String, ExtensionModule> cachedExtensionModules, TreeMap<String, StackInfo> cachedStackMap) {
+                         Map<String, ExtensionModule> cachedExtensionModules, NavigableMap<String, StackInfo> cachedStackMap) {
       this.cachedCommonServiceModules = cachedCommonServiceModules;
       this.cachedStackModules = cachedStackModules;
       this.cachedExtensionModules = cachedExtensionModules;
@@ -133,7 +133,7 @@ public class StackManagerMock extends StackManager {
       return cachedExtensionModules;
     }
 
-    public TreeMap<String, StackInfo> getCachedStackMap() {
+    public NavigableMap<String, StackInfo> getCachedStackMap() {
       return cachedStackMap;
     }
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerMock.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerMock.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.stack;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -78,14 +79,21 @@ public class StackManagerMock extends StackManager {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
 
       ModulesPathsKey that = (ModulesPathsKey) o;
 
-      if (stackRoot != null ? !stackRoot.equals(that.stackRoot) : that.stackRoot != null) return false;
-      if (commonServicesRoot != null ? !commonServicesRoot.equals(that.commonServicesRoot) : that.commonServicesRoot != null)
+      if (stackRoot != null ? !stackRoot.equals(that.stackRoot) : that.stackRoot != null) {
         return false;
+      }
+      if (commonServicesRoot != null ? !commonServicesRoot.equals(that.commonServicesRoot) : that.commonServicesRoot != null) {
+        return false;
+      }
       return !(extensionRoot != null ? !extensionRoot.equals(that.extensionRoot) : that.extensionRoot != null);
 
     }
@@ -103,10 +111,10 @@ public class StackManagerMock extends StackManager {
     private Map<String, ServiceModule> cachedCommonServiceModules;
     private Map<String, StackModule> cachedStackModules;
     private Map<String, ExtensionModule> cachedExtensionModules;
-    private Map<String, StackInfo> cachedStackMap;
+    private TreeMap<String, StackInfo> cachedStackMap;
 
     public CachedModules(Map<String, ServiceModule> cachedCommonServiceModules, Map<String, StackModule> cachedStackModules,
-                         Map<String, ExtensionModule> cachedExtensionModules, Map<String, StackInfo> cachedStackMap) {
+                         Map<String, ExtensionModule> cachedExtensionModules, TreeMap<String, StackInfo> cachedStackMap) {
       this.cachedCommonServiceModules = cachedCommonServiceModules;
       this.cachedStackModules = cachedStackModules;
       this.cachedExtensionModules = cachedExtensionModules;
@@ -125,7 +133,7 @@ public class StackManagerMock extends StackManager {
       return cachedExtensionModules;
     }
 
-    public Map<String, StackInfo> getCachedStackMap() {
+    public TreeMap<String, StackInfo> getCachedStackMap() {
       return cachedStackMap;
     }
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
@@ -474,7 +474,7 @@ public class ClusterTest {
         hostComponentStateDAO.merge(hce);
       }
 
-      RepositoryVersionEntity rv = helper.getOrCreateRepositoryVersion(stackId, version);
+      helper.getOrCreateRepositoryVersion(stackId, version);
 
       // Simulate the StackVersionListener during the installation
       Service svc = cluster.getService(hce.getServiceName());
@@ -605,8 +605,8 @@ public class ClusterTest {
 
     RepositoryVersionEntity repositoryVersion = helper.getOrCreateRepositoryVersion(c1);
 
-    Service s1 = serviceFactory.createNew(c1, "HDFS", repositoryVersion);
-    Service s2 = serviceFactory.createNew(c1, "MAPREDUCE", repositoryVersion);
+    serviceFactory.createNew(c1, "HDFS", repositoryVersion);
+    serviceFactory.createNew(c1, "MAPREDUCE", repositoryVersion);
 
     Service s = c1.getService("HDFS");
     Assert.assertNotNull(s);
@@ -948,7 +948,7 @@ public class ClusterTest {
     Config config2 = configFactory.createNew(c1, "global", "version2",
         new HashMap<String, String>() {{ put("x", "y"); }}, c2PropAttributes);
 
-    Config config3 = configFactory.createNew(c1, "core-site", "version2",
+    configFactory.createNew(c1, "core-site", "version2",
         new HashMap<String, String>() {{ put("x", "y"); }}, new HashMap<>());
 
     c1.addDesiredConfig("_test", Collections.singleton(config1));
@@ -1080,7 +1080,7 @@ public class ClusterTest {
     c1.addService("MAPREDUCE", repositoryVersion);
 
     Service hdfs = c1.addService("HDFS", repositoryVersion);
-    ServiceComponent nameNode = hdfs.addServiceComponent("NAMENODE");
+    hdfs.addServiceComponent("NAMENODE");
 
     assertEquals(2, c1.getServices().size());
     assertEquals(2, injector.getProvider(EntityManager.class).get().
@@ -1888,8 +1888,8 @@ public class ClusterTest {
     String v1 = "2.0.5-1";
     String v2 = "2.0.5-2";
     c1.setDesiredStackVersion(stackId);
-    RepositoryVersionEntity rve1 = helper.getOrCreateRepositoryVersion(stackId, v1);
-    RepositoryVersionEntity rve2 = helper.getOrCreateRepositoryVersion(stackId, v2);
+    helper.getOrCreateRepositoryVersion(stackId, v1);
+    helper.getOrCreateRepositoryVersion(stackId, v2);
 
     c1.setCurrentStackVersion(stackId);
 
@@ -2189,6 +2189,9 @@ public class ClusterTest {
     createDefaultCluster(Sets.newHashSet("host-1"), stackId);
 
     Cluster cluster = clusters.getCluster("c1");
+    cluster.setCurrentStackVersion(stackId);
+    cluster.setDesiredStackVersion(stackId);
+
     RepositoryVersionEntity repoVersion220 = helper.getOrCreateRepositoryVersion(newStackId, "2.2.0-1234");
 
     ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
@@ -2212,8 +2215,9 @@ public class ClusterTest {
     // make v1 "current"
     cluster.addDesiredConfig("admin", Sets.newHashSet(c1), "note-1");
 
-    // bump the repo version
+    // bump the repo version and the desired stack
     service.setDesiredRepositoryVersion(repoVersion220);
+    cluster.setDesiredStackVersion(newStackId);
 
     // save v2
     // config for v2 on new stack


### PR DESCRIPTION
## What changes were proposed in this pull request?

Express upgrades between stack versions were not setting the cluster desired or current stack ID (as they had been set in `branch-2.6`)

## How was this patch tested?

Manual express upgrade.