### PR TITLE
AMBARI-23510:FluentPropertyBeanIntrospector from CLI operation log ou…

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/hdfs-log4j.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/hdfs-log4j.xml
@@ -236,6 +236,9 @@ log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
 
 # Removes "deprecated" messages
 log4j.logger.org.apache.hadoop.conf.Configuration.deprecation=WARN
+
+# Adding logging for 3rd party library
+log4j.logger.org.apache.commons.beanutils=WARN
     </value>
     <value-attributes>
       <type>content</type>


### PR DESCRIPTION
…tput, when running hdfs commands

## What changes were proposed in this pull request?

Adding logging for 3rd party library for beanutils to WARN, to avoid bean introspection appears, which are logged at INFO Level.
log4j.logger.org.apache.commons.beanutils=WARN

Added the above setting to custom hdfs-log4j, and ran hdfs client commands, the error has not appeared.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.