### PR TITLE
[AMBARI-23459]. ServiceAdvisor KeyError during kerberization of OneFS (amagyar)

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -107,13 +107,16 @@ except Exception as e:
 else:
   class HDP26ONEFSServiceAdvisor(service_advisor.ServiceAdvisor):
     def getServiceConfigurationRecommendations(self, configs, clusterData, services, hosts):
-      putCoreSiteProperty = self.putProperty(configs, "core-site", services)
-      putHdfsSiteProperty = self.putProperty(configs, "hdfs-site", services)
-      onefs_host = Uri.onefs(services)
-      putCoreSiteProperty("fs.defaultFS", Uri.default_fs(services).fix_host(onefs_host))
-      putHdfsSiteProperty("dfs.namenode.http-address", Uri.http_namenode(services).fix_host(onefs_host))
-      putHdfsSiteProperty("dfs.namenode.https-address", Uri.https_namenode(services).fix_host(onefs_host))
-      # self.updateYarnConfig(configs, services) TODO doesn't work possibly due to a UI bug (Couldn't retrieve 'capacity-scheduler' from services)
+      try:
+        putCoreSiteProperty = self.putProperty(configs, "core-site", services)
+        putHdfsSiteProperty = self.putProperty(configs, "hdfs-site", services)
+        onefs_host = Uri.onefs(services)
+        putCoreSiteProperty("fs.defaultFS", Uri.default_fs(services).fix_host(onefs_host))
+        putHdfsSiteProperty("dfs.namenode.http-address", Uri.http_namenode(services).fix_host(onefs_host))
+        putHdfsSiteProperty("dfs.namenode.https-address", Uri.https_namenode(services).fix_host(onefs_host))
+        # self.updateYarnConfig(configs, services) TODO doesn't work possibly due to a UI bug (Couldn't retrieve 'capacity-scheduler' from services)
+      except KeyError as e:
+        self.logger.info('Cannot get OneFS properties from config. KeyError: %s' % e)
 
     def updateYarnConfig(self, configs, services):
       if not 'YARN' in self.installedServices(services): return


### PR DESCRIPTION
## What changes were proposed in this pull request?

There was a key error during kerberization of onefs. Some config types are not passed to the service advisor.

## How was this patch tested?

Started kerberization of onefs