### PR TITLE
[AMBARI-23513] Fix logsearch-performance.json file path.

### DIFF
--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/templates/input.config-logsearch.json.j2
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/templates/input.config-logsearch.json.j2
@@ -30,7 +30,7 @@
     {
       "type":"logsearch_perf",
       "rowtype":"service",
-      "path":"{{default('/configurations/logfeeder-env/logfeeder_log_dir', '/var/log/ambari-logsearch-logfeeder')}}/logsearch-performance.json"
+      "path":"{{default('/configurations/logsearch-env/logsearch_log_dir', '/var/log/ambari-logsearch-portal')}}/logsearch-performance.json"
     }
   ],
   "filter":[


### PR DESCRIPTION
## What changes were proposed in this pull request?
Logfeeder continously check agains some files, logsearch-performance.json never found, because it searches in logfeeder log folder not in logsearch portal folder
## How was this patch tested?
FT: manually
UT: not needed
please review @g-boros @kasakrisz @adoroszlai 