### PR TITLE
[AMBARI-23486] Move SSO-related properties from ambari.properties into the Ambari DB

### DIFF
--- a/ambari-server/docs/configuration/index.md
+++ b/ambari-server/docs/configuration/index.md
@@ -78,12 +78,6 @@ The following are the properties which can be used to configure Ambari.
 | api.ssl | Determines whether SSL is used in for secure connections to Ambari. When enabled, ambari-server setup-https must be run in order to properly configure keystores. |`false` | 
 | auditlog.enabled | Determines whether audit logging is enabled. |`true` | 
 | auditlog.logger.capacity | The size of the worker queue for audit logger events.<br/><br/> This property is related to `auditlog.enabled`. |`10000` | 
-| authentication.jwt.audiences | A list of the JWT audiences expected. Leaving this blank will allow for any audience.<br/><br/> This property is related to `authentication.jwt.enabled`. | | 
-| authentication.jwt.cookieName | The name of the cookie which will be used to extract the JWT token from the request.<br/><br/> This property is related to `authentication.jwt.enabled`. |`hadoop-jwt` | 
-| authentication.jwt.enabled | Determines whether to use JWT authentication when connecting to remote Hadoop resources. |`false` | 
-| authentication.jwt.originalUrlParamName | The original URL to use when constructing the logic URL for JWT.<br/><br/> This property is related to `authentication.jwt.enabled`. |`originalUrl` | 
-| authentication.jwt.providerUrl | The URL for authentication of the user in the absence of a JWT token when handling a JWT request.<br/><br/> This property is related to `authentication.jwt.enabled`. | | 
-| authentication.jwt.publicKey | The public key to use when verifying the authenticity of a JWT token.<br/><br/> This property is related to `authentication.jwt.enabled`. | | 
 | authentication.kerberos.auth_to_local.rules | The auth-to-local rules set to use when translating a user's principal name to a local user name during authentication via SPNEGO. |`DEFAULT` | 
 | authentication.kerberos.enabled | Determines whether to use Kerberos (SPNEGO) authentication when connecting Ambari. |`false` | 
 | authentication.kerberos.spnego.keytab.file | The Kerberos keytab file to use when verifying user-supplied Kerberos tokens for authentication via SPNEGO |`/etc/security/keytabs/spnego.service.keytab` | 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
@@ -78,7 +78,17 @@ public enum AmbariServerConfigurationKey {
    * SSO Configuration Keys
    * ******************************************************** */
   SSO_MANAGE_SERVICES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.manage_services", PLAINTEXT, "false", "A Boolean value indicating whether Ambari is to manage the SSO configuration for services or not."),
-  SSO_ENABLED_SERVICES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.enabled_services", PLAINTEXT, null, "A comma-delimited list of services that are expected to be configured for SSO.  A \"*\" indicates all services.");
+  SSO_ENABLED_SERVICES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.enabled_services", PLAINTEXT, null, "A comma-delimited list of services that are expected to be configured for SSO.  A \"*\" indicates all services."),
+
+  SSO_PROVIDER_URL(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.provider.url", PLAINTEXT, null, "The URL for SSO provider to use in the absence of a JWT token when handling a JWT request."),
+  SSO_PROVIDER_CERTIFICATE(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.provider.certificate", PLAINTEXT, null, "The x509 certificate containing the public key to use when verifying the authenticity of a JWT token from the SSO provider."),
+  SSO_PROVIDER_ORIGINAL_URL_PARAM_NAME(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.provider.originalUrlParamName", PLAINTEXT, "originalUrl", "The original URL to use when constructing the URL for SSO provider."),
+
+  SSO_JWT_AUDIENCES(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.jwt.audiences", PLAINTEXT, null, "A list of the JWT audiences expected. Leaving this blank will allow for any audience."),
+  SSO_JWT_COOKIE_NAME(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.jwt.cookieName", PLAINTEXT, "hadoop-jwt", "The name of the cookie which will be used to extract the JWT token from the request."),
+
+  SSO_AUTHENTICATION_ENABLED(AmbariServerConfigurationCategory.SSO_CONFIGURATION, "ambari.sso.authentication.enabled", PLAINTEXT, "false", "Determines whether to use JWT authentication when logging into Ambari.");
+
 
   private final AmbariServerConfigurationCategory configurationCategory;
   private final String propertyName;

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/GuiceBeansConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/GuiceBeansConfig.java
@@ -22,6 +22,7 @@ import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.security.authentication.AmbariAuthenticationEventHandlerImpl;
 import org.apache.ambari.server.security.authentication.AmbariLocalAuthenticationProvider;
 import org.apache.ambari.server.security.authentication.jwt.AmbariJwtAuthenticationProvider;
+import org.apache.ambari.server.security.authentication.jwt.JwtAuthenticationPropertiesProvider;
 import org.apache.ambari.server.security.authentication.pam.AmbariPamAuthenticationProvider;
 import org.apache.ambari.server.security.authorization.AmbariLdapAuthenticationProvider;
 import org.apache.ambari.server.security.authorization.AmbariUserAuthorizationFilter;
@@ -84,6 +85,11 @@ public class GuiceBeansConfig {
   @Bean
   public AmbariJwtAuthenticationProvider ambariJwtAuthenticationProvider() {
     return injector.getInstance(AmbariJwtAuthenticationProvider.class);
+  }
+
+  @Bean
+  public JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider() {
+    return injector.getInstance(JwtAuthenticationPropertiesProvider.class);
   }
 
   @Bean

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/AmbariBasicAuthenticationFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/AmbariBasicAuthenticationFilter.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.ambari.server.security.AmbariEntryPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
@@ -44,6 +45,7 @@ import org.springframework.stereotype.Component;
  * @see AmbariDelegatingAuthenticationFilter
  */
 @Component
+@Order(3)
 public class AmbariBasicAuthenticationFilter extends BasicAuthenticationFilter implements AmbariAuthenticationFilter {
   private static final Logger LOG = LoggerFactory.getLogger(AmbariBasicAuthenticationFilter.class);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationProperties.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationProperties.java
@@ -33,6 +33,7 @@ public class JwtAuthenticationProperties {
   private List<String> audiences = null;
   private String cookieName = "hadoop-jwt";
   private String originalUrlQueryParam = null;
+  private boolean enabledForAmbari;
 
   public String getAuthenticationProviderUrl() {
     return authenticationProviderUrl;
@@ -83,5 +84,13 @@ public class JwtAuthenticationProperties {
 
   public void setOriginalUrlQueryParam(String originalUrlQueryParam) {
     this.originalUrlQueryParam = originalUrlQueryParam;
+  }
+
+  public boolean isEnabledForAmbari() {
+    return enabledForAmbari;
+  }
+
+  public void setEnabledForAmbari(boolean enabledForAmbari) {
+    this.enabledForAmbari = enabledForAmbari;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationPropertiesProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationPropertiesProvider.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.security.authentication.jwt;
+
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.SSO_CONFIGURATION;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_AUTHENTICATION_ENABLED;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_JWT_AUDIENCES;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_JWT_COOKIE_NAME;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_PROVIDER_CERTIFICATE;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_PROVIDER_ORIGINAL_URL_PARAM_NAME;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_PROVIDER_URL;
+
+import java.io.UnsupportedEncodingException;
+import java.security.cert.CertificateException;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Map;
+
+import org.apache.ambari.server.EagerSingleton;
+import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.events.AmbariConfigurationChangedEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.security.encryption.CertificateUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Inject;
+
+/**
+ * JwtAuthenticationPropertiesProvider manages a {@link JwtAuthenticationProperties} instance by
+ * lazily loading the properties if needed and refreshing the properties if updates are made to the
+ * sso-configuration category of the Ambari configuration data.
+ * <p>
+ * The {@link JwtAuthenticationProperties} are updated upon events received from the {@link AmbariEventPublisher}.
+ */
+@EagerSingleton
+public class JwtAuthenticationPropertiesProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(JwtAuthenticationPropertiesProvider.class);
+
+  private static final String PEM_CERTIFICATE_HEADER = "-----BEGIN CERTIFICATE-----";
+  private static final String PEM_CERTIFICATE_FOOTER = "-----END CERTIFICATE-----";
+
+  private final AmbariServerConfigurationHandler configurationHandler;
+
+  private JwtAuthenticationProperties properties = null;
+
+  @Inject
+  public JwtAuthenticationPropertiesProvider(AmbariServerConfigurationHandler configurationHandler, AmbariEventPublisher eventPublisher) {
+    this.configurationHandler = configurationHandler;
+
+    eventPublisher.register(this);
+  }
+
+  /**
+   * Retrieves the {@link JwtAuthenticationProperties} data.
+   * <p>
+   * This value is expected to contain the latest data from the Ambari configuration store in the
+   * Ambari DB.
+   * <p>
+   * If the stored reference is <code>null</code>, the properites will be loaded.
+   *
+   * @return a JwtAuthenticationProperties
+   */
+  public JwtAuthenticationProperties getProperties() {
+    if (properties == null) {
+      loadProperties(false);
+    }
+
+    return properties;
+  }
+
+  /**
+   * (Reloads the {@link JwtAuthenticationProperties} when the sso-configuration data is updated
+   * and an {@link AmbariConfigurationChangedEvent} is triggered in the {@link AmbariEventPublisher}.
+   *
+   * @param event an {@link AmbariConfigurationChangedEvent}
+   */
+  @Subscribe
+  public synchronized void reloadProperties(AmbariConfigurationChangedEvent event) {
+    if (SSO_CONFIGURATION.getCategoryName().equalsIgnoreCase(event.getCategoryName())) {
+      loadProperties(true);
+    }
+  }
+
+  /**
+   * If the {@link JwtAuthenticationProperties} reference is <code>null</code> or the caller requests
+   * a force reload (forceReload == <code>true</code>), a new {@link JwtAuthenticationProperties}
+   * is created and this members are set to data retrieved from the Ambari databases.
+   * <p>
+   * This method is synchronzed so that multiple threads cannot step on each other when requesting
+   * the properties to be reloaded.
+   *
+   * @param forceReload <code>true</code> to force the properties to be reloaded; <code>false</code>
+   *                    to only reload the data if the {@link JwtAuthenticationProperties} reference
+   *                    is <code>null</code>
+   */
+  private synchronized void loadProperties(boolean forceReload) {
+    if (forceReload || (properties == null)) {
+      Map<String, String> ssoProperties = configurationHandler.getConfigurationProperties(SSO_CONFIGURATION.getCategoryName());
+      JwtAuthenticationProperties properties = new JwtAuthenticationProperties();
+      properties.setEnabledForAmbari("true".equalsIgnoreCase(getValue(SSO_AUTHENTICATION_ENABLED, ssoProperties)));
+      properties.setAudiencesString(getValue(SSO_JWT_AUDIENCES, ssoProperties));
+      properties.setAuthenticationProviderUrl(getValue(SSO_PROVIDER_URL, ssoProperties));
+      properties.setCookieName(getValue(SSO_JWT_COOKIE_NAME, ssoProperties));
+      properties.setOriginalUrlQueryParam(getValue(SSO_PROVIDER_ORIGINAL_URL_PARAM_NAME, ssoProperties));
+      properties.setPublicKey(createPublicKey(getValue(SSO_PROVIDER_CERTIFICATE, ssoProperties)));
+
+      this.properties = properties;
+    }
+  }
+
+  /**
+   * Given a String containing PEM-encode x509 certificate, an {@link RSAPublicKey} is created and
+   * returned.
+   * <p>
+   * If the certificate data is does not contain the proper PEM-encoded x509 digital certificate
+   * header and footer, they will be added.
+   *
+   * @param certificate a PEM-encode x509 certificate
+   * @return an {@link RSAPublicKey}
+   */
+  private RSAPublicKey createPublicKey(String certificate) {
+    RSAPublicKey publicKey = null;
+    if (certificate != null) {
+      certificate = certificate.trim();
+    }
+    if (!StringUtils.isEmpty(certificate)) {
+      // Ensure the PEM data is properly formatted
+      if (!certificate.startsWith(PEM_CERTIFICATE_HEADER)) {
+        certificate = PEM_CERTIFICATE_HEADER + "/n" + certificate;
+      }
+      if (!certificate.endsWith(PEM_CERTIFICATE_FOOTER)) {
+        certificate = certificate + "/n" + PEM_CERTIFICATE_FOOTER;
+      }
+
+      try {
+        publicKey = CertificateUtils.getPublicKeyFromString(certificate);
+      } catch (CertificateException | UnsupportedEncodingException e) {
+        LOG.error("Unable to parse public certificate file. JTW authentication will fai", e);
+      }
+    }
+
+    return publicKey;
+  }
+
+  /**
+   * A helper method to retrieve the stored value or the default value for a given SSO confogiguration
+   * value.
+   *
+   * @param key        the {@link AmbariServerConfigurationKey} to retrieve the data for
+   * @param properties the map of properties to search
+   * @return the value
+   */
+  private String getValue(AmbariServerConfigurationKey key, Map<String, String> properties) {
+    if ((properties != null) && properties.containsKey(key.key())) {
+      return properties.get(key.key());
+    } else {
+      return key.getDefaultValue();
+    }
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/kerberos/AmbariKerberosAuthenticationFilter.java
@@ -32,6 +32,7 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.security.authentication.AmbariAuthenticationEventHandler;
 import org.apache.ambari.server.security.authentication.AmbariAuthenticationException;
 import org.apache.ambari.server.security.authentication.AmbariAuthenticationFilter;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -48,6 +49,7 @@ import org.springframework.stereotype.Component;
  * If configured, auditing is performed using {@link AuditLogger}.
  */
 @Component
+@Order(2)
 public class AmbariKerberosAuthenticationFilter extends SpnegoAuthenticationProcessingFilter implements AmbariAuthenticationFilter {
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -18,6 +18,10 @@
 package org.apache.ambari.server.upgrade;
 
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -30,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
@@ -854,7 +859,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     List<DBAccessor.DBColumnInfo> columns = new ArrayList<>();
     columns.add(new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN, String.class, 100, null, false));
     columns.add(new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN, String.class, 100, null, false));
-    columns.add(new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN, String.class, 255, null, true));
+    columns.add(new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN, String.class, 2048, null, true));
 
     dbAccessor.createTable(AMBARI_CONFIGURATION_TABLE, columns);
     dbAccessor.addPKConstraint(AMBARI_CONFIGURATION_TABLE, "PK_ambari_configuration", AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN, AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN);
@@ -930,7 +935,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     updateLogSearchConfigs();
     updateKerberosConfigurations();
     updateHostComponentLastStateTable();
-    upgradeLdapConfiguration();
+    moveAmbariPropertiesToAmbariConfiguration();
     createRoleAuthorizations();
     addUserAuthenticationSequence();
     updateSolrConfigurations();
@@ -1339,53 +1344,86 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
   }
 
   /**
-   * Moves LDAP related properties from ambari.properties to ambari_configuration DB table
+   * Moves SSO and LDAP related properties from ambari.properties to ambari_configuration DB table
    *
    * @throws AmbariException if there was any issue when clearing ambari.properties
    */
-  protected void upgradeLdapConfiguration() throws AmbariException {
-    LOG.info("Moving LDAP related properties from ambari.properties to ambari_congiuration DB table...");
-    final AmbariConfigurationDAO ambariConfigurationDao = injector.getInstance(AmbariConfigurationDAO.class);
-    final Map<String, String> propertiesToBeSaved = new HashMap<>();
-    final Map<AmbariServerConfigurationKey, String> ldapConfigurationMap = getLdapConfigurationMap();
-    ldapConfigurationMap.forEach((key, oldPropertyName) -> {
-      String ldapPropertyValue = configuration.getProperty(oldPropertyName);
-      if (StringUtils.isNotBlank(ldapPropertyValue)) {
+  protected void moveAmbariPropertiesToAmbariConfiguration() throws AmbariException {
+    LOG.info("Moving LDAP and SSO related properties from ambari.properties to ambari_configuration DB table...");
+    final AmbariConfigurationDAO ambariConfigurationDAO = injector.getInstance(AmbariConfigurationDAO.class);
+    final Map<AmbariServerConfigurationCategory, Map<String, String>> propertiesToBeMoved = new HashMap<>();
+
+    final Map<AmbariServerConfigurationKey, String> configurationMap = getAmbariConfigurationMap();
+    configurationMap.forEach((key, oldPropertyName) -> {
+      String propertyValue = configuration.getProperty(oldPropertyName);
+      if (propertyValue != null) { // Empty strings are ok
         if (AmbariServerConfigurationKey.SERVER_HOST == key || AmbariServerConfigurationKey.SECONDARY_SERVER_HOST == key) {
-          final HostAndPort hostAndPort = HostAndPort.fromString(ldapPropertyValue);
+          final HostAndPort hostAndPort = HostAndPort.fromString(propertyValue);
           AmbariServerConfigurationKey keyToBesaved = AmbariServerConfigurationKey.SERVER_HOST == key ? AmbariServerConfigurationKey.SERVER_HOST
-            : AmbariServerConfigurationKey.SECONDARY_SERVER_HOST;
-          populateLdapConfigurationToBeUpgraded(propertiesToBeSaved, oldPropertyName, keyToBesaved.key(), hostAndPort.getHostText());
+              : AmbariServerConfigurationKey.SECONDARY_SERVER_HOST;
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, hostAndPort.getHostText());
 
           keyToBesaved = AmbariServerConfigurationKey.SERVER_HOST == key ? AmbariServerConfigurationKey.SERVER_PORT : AmbariServerConfigurationKey.SECONDARY_SERVER_PORT;
-          populateLdapConfigurationToBeUpgraded(propertiesToBeSaved, oldPropertyName, keyToBesaved.key(), String.valueOf(hostAndPort.getPort()));
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, String.valueOf(hostAndPort.getPort()));
+        } else if (AmbariServerConfigurationKey.SSO_PROVIDER_CERTIFICATE == key) {
+          // Read in the PEM file and store the PEM data rather than the file path...
+          StringBuilder contentBuilder = new StringBuilder();
+          try (Stream<String> stream = Files.lines(Paths.get(propertyValue), StandardCharsets.UTF_8)) {
+            stream.forEach(s -> contentBuilder.append(s).append("\n"));
+          } catch (IOException e) {
+            LOG.error(String.format("Failed to read the SSO provider's certificate file, %s: %s", propertyValue, e.getMessage()), e);
+          }
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, key, contentBuilder.toString());
+        } else if (AmbariServerConfigurationKey.SSO_AUTHENTICATION_ENABLED == key) {
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, key, propertyValue);
+
+          if("true".equalsIgnoreCase(propertyValue)) {
+            // Add the new properties to tell Ambari that SSO is enabled:
+            populateConfigurationToBeMoved(propertiesToBeMoved, null, AmbariServerConfigurationKey.SSO_MANAGE_SERVICES, "true");
+            populateConfigurationToBeMoved(propertiesToBeMoved, null, AmbariServerConfigurationKey.SSO_ENABLED_SERVICES, "AMBARI");
+          }
         } else {
-          populateLdapConfigurationToBeUpgraded(propertiesToBeSaved, oldPropertyName, key.key(), ldapPropertyValue);
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, key, propertyValue);
         }
       }
     });
 
-    if (propertiesToBeSaved.isEmpty()) {
-      LOG.info("There was no LDAP related properties in ambari.properties; moved 0 elements");
+    if (propertiesToBeMoved.isEmpty()) {
+      LOG.info("There are no properties to be moved from ambari.properties to the Ambari DB; moved 0 elements");
     } else {
-      ambariConfigurationDao.reconcileCategory(AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName(), propertiesToBeSaved, false);
-      configuration.removePropertiesFromAmbariProperties(ldapConfigurationMap.values());
-      LOG.info(propertiesToBeSaved.size() + " LDAP related properties " + (propertiesToBeSaved.size() == 1 ? "has" : "have") + " been moved to DB");
+      for (Map.Entry<AmbariServerConfigurationCategory, Map<String, String>> entry : propertiesToBeMoved.entrySet()) {
+        Map<String, String> properties = entry.getValue();
+
+        if (properties != null) {
+          String categoryName = entry.getKey().getCategoryName();
+          ambariConfigurationDAO.reconcileCategory(categoryName, entry.getValue(), false);
+          LOG.info("Moved {} properties to the {} Ambari Configuration category", properties.size(), categoryName);
+        }
+      }
+
+      configuration.removePropertiesFromAmbariProperties(configurationMap.values());
     }
   }
 
-  private void populateLdapConfigurationToBeUpgraded(Map<String, String> propertiesToBeSaved, String oldPropertyName, String newPropertyName, String value) {
-    propertiesToBeSaved.put(newPropertyName, value);
-    LOG.info("About to upgrade '" + oldPropertyName + "' as '" + newPropertyName + "' (value=" + value + ")");
+  private void populateConfigurationToBeMoved(Map<AmbariServerConfigurationCategory, Map<String, String>> propertiesToBeSaved, String oldPropertyName, AmbariServerConfigurationKey key, String value) {
+    AmbariServerConfigurationCategory category = key.getConfigurationCategory();
+    String newPropertyName = key.key();
+    Map<String, String> categoryProperties = propertiesToBeSaved.computeIfAbsent(category, k->new HashMap<>());
+    categoryProperties.put(newPropertyName, value);
+
+    if(oldPropertyName != null) {
+      LOG.info("Upgrading '{}' to '{}'", oldPropertyName, newPropertyName);
+    }
   }
 
   /**
    * @return a map describing the new LDAP configuration key to the old ambari.properties property name
    */
   @SuppressWarnings("serial")
-  private Map<AmbariServerConfigurationKey, String> getLdapConfigurationMap() {
+  private Map<AmbariServerConfigurationKey, String> getAmbariConfigurationMap() {
     Map<AmbariServerConfigurationKey, String> map = new HashMap<>();
 
+    // LDAP-related properties
     map.put(AmbariServerConfigurationKey.LDAP_ENABLED, "ambari.ldap.isConfigured");
     map.put(AmbariServerConfigurationKey.SERVER_HOST, "authentication.ldap.primaryUrl");
     map.put(AmbariServerConfigurationKey.SECONDARY_SERVER_HOST, "authentication.ldap.secondaryUrl");
@@ -1416,6 +1454,14 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     map.put(AmbariServerConfigurationKey.REFERRAL_HANDLING, "authentication.ldap.referral");
     map.put(AmbariServerConfigurationKey.PAGINATION_ENABLED, "authentication.ldap.pagination.enabled");
     map.put(AmbariServerConfigurationKey.COLLISION_BEHAVIOR, "ldap.sync.username.collision.behavior");
+
+    // SSO-related properties
+    map.put(AmbariServerConfigurationKey.SSO_PROVIDER_URL, "authentication.jwt.providerUrl");
+    map.put(AmbariServerConfigurationKey.SSO_PROVIDER_CERTIFICATE, "authentication.jwt.publicKey");
+    map.put(AmbariServerConfigurationKey.SSO_PROVIDER_ORIGINAL_URL_PARAM_NAME, "authentication.jwt.originalUrlParamName");
+    map.put(AmbariServerConfigurationKey.SSO_AUTHENTICATION_ENABLED, "authentication.jwt.enabled");
+    map.put(AmbariServerConfigurationKey.SSO_JWT_AUDIENCES, "authentication.jwt.audiences");
+    map.put(AmbariServerConfigurationKey.SSO_JWT_COOKIE_NAME, "authentication.jwt.cookieName");
 
     return map;
   }

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -577,8 +577,8 @@ def init_setup_sso_options(parser):
   parser.add_option('--sso-enabled-services', default=None, help="A comma separated list of services that are expected to be configured for SSO (you are allowed to use '*' to indicate ALL services)", dest='sso_enabled_services')
   parser.add_option('--sso-provider-url', default=None, help="The URL of SSO provider; this must be provided when --sso-enabled is set to 'true'", dest="sso_provider_url")
   parser.add_option('--sso-public-cert-file', default=None, help="The path where the public certificate PEM is located; this must be provided when --sso-enabled is set to 'true'", dest="sso_public_cert_file")
-  parser.add_option('--sso-jwt-cookie-name', default=None, help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
-  parser.add_option('--sso-jwt-audience-list', default=None, help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
+  parser.add_option('--sso-jwt-cookie-name', default="hadoop-jwt", help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
+  parser.add_option('--sso-jwt-audience-list', default="", help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
   parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
   parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 

--- a/ambari-server/src/main/python/ambari_server/serverUtils.py
+++ b/ambari-server/src/main/python/ambari_server/serverUtils.py
@@ -17,29 +17,32 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import ambari_simplejson as json # simplejson is much faster comparing to Python 2.6 json module and has the same functions set.
 import base64
 import os
-import sys
-import time
 import socket
 import urllib2
-from ambari_commons.exceptions import FatalException, NonFatalException
-from ambari_commons.logging_utils import get_verbose
-from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
-from ambari_commons.os_check import OSConst
-from ambari_commons.os_utils import run_os_command
-from ambari_server.resourceFilesKeeper import ResourceFilesKeeper, KeeperException
-from ambari_server.serverConfiguration import configDefaults, PID_NAME, get_resources_location, get_stack_location, \
-  CLIENT_API_PORT, CLIENT_API_PORT_PROPERTY, SSL_API, DEFAULT_SSL_API_PORT, SSL_API_PORT
-from ambari_server.userInput import get_validated_string_input
 from contextlib import closing
 
+import time
+from ambari_commons.exceptions import FatalException, NonFatalException
+from ambari_commons.logging_utils import get_verbose, print_info_msg, get_debug_mode
+from ambari_commons.os_check import OSConst
+from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
+from ambari_commons.os_utils import run_os_command
+
+# simplejson is much faster comparing to Python 2.6 json module and has the same functions set.
+import ambari_simplejson as json
+from ambari_server.resourceFilesKeeper import ResourceFilesKeeper, KeeperException
+from ambari_server.serverConfiguration import configDefaults, PID_NAME, get_resources_location, \
+  get_stack_location, CLIENT_API_PORT, CLIENT_API_PORT_PROPERTY, \
+  SSL_API, DEFAULT_SSL_API_PORT, SSL_API_PORT
+from ambari_server.userInput import get_validated_string_input
 
 # Ambari server API properties
 SERVER_API_HOST = '127.0.0.1'
 SERVER_API_PROTOCOL = 'http'
 SERVER_API_SSL_PROTOCOL = 'https'
+
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def is_server_runing():
@@ -81,12 +84,13 @@ def wait_for_server_to_stop(wait_timeout):
 
 @OsFamilyFuncImpl(OSConst.WINSRV_FAMILY)
 def is_server_runing():
-  from ambari_commons.os_windows import SERVICE_STATUS_STARTING, SERVICE_STATUS_RUNNING, SERVICE_STATUS_STOPPING, \
+  from ambari_commons.os_windows import SERVICE_STATUS_STARTING, SERVICE_STATUS_RUNNING, \
+    SERVICE_STATUS_STOPPING, \
     SERVICE_STATUS_STOPPED, SERVICE_STATUS_NOT_INSTALLED
   from ambari_windows_service import AmbariServerService
 
   statusStr = AmbariServerService.QueryStatus()
-  if statusStr in(SERVICE_STATUS_STARTING, SERVICE_STATUS_RUNNING, SERVICE_STATUS_STOPPING):
+  if statusStr in (SERVICE_STATUS_STARTING, SERVICE_STATUS_RUNNING, SERVICE_STATUS_STOPPING):
     return True, ""
   elif statusStr == SERVICE_STATUS_STOPPED:
     return False, SERVICE_STATUS_STOPPED
@@ -122,7 +126,7 @@ def refresh_stack_hash(properties):
 # or if using ssl https://hostname.domain:8443/api/v1
 #
 def get_ambari_server_api_base(properties):
-  api_host = SERVER_API_HOST  
+  api_host = SERVER_API_HOST
   api_protocol = SERVER_API_PROTOCOL
   api_port = CLIENT_API_PORT
   api_port_prop = properties.get_property(CLIENT_API_PORT_PROPERTY)
@@ -165,50 +169,54 @@ def get_cluster_name(properties, admin_login, admin_password):
   Fetches the name of the first cluster (in case there are more)
   from the response of host:port/api/v1/clusters call
   """
-  url = get_ambari_server_api_base(properties) + 'clusters'
+  print_info_msg('Fetching cluster name')
+
+  cluster_name = None
+  response_code, json_data = get_json_via_rest_api(properties, admin_login, admin_password,
+                                                   "clusters")
+
+  if json_data and 'items' in json_data:
+    items = json_data['items']
+    if len(items) > 0:
+      cluster_name = items[0]['Clusters']['cluster_name']
+      print_info_msg('Found cluster name: %s' % cluster_name)
+
+  return cluster_name
+
+
+def get_json_via_rest_api(properties, admin_login, admin_password, entry_point):
+  """
+  Fetches the data from a given REST API entry point
+
+  :param properties: the properties from the ambari.properties file
+  :param admin_login: an administrator's username used to log in to Ambari
+  :param admin_password: an administrator's password used to log in to Ambari
+  :param entry_point: the relative entry point to query (the base URL will be generated using the ambari.properties data)
+  :return: HTTP status, JSON data
+  """
+  url = get_ambari_server_api_base(properties) + entry_point
   admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
   request = urllib2.Request(url)
   request.add_header('Authorization', 'Basic %s' % admin_auth)
   request.add_header('X-Requested-By', 'ambari')
   request.get_method = lambda: 'GET'
 
-  request_in_progress = True
-  cluster_name = None
-  sys.stdout.write('\nFetching cluster name')
-  numOfTries = 0
-  while request_in_progress:
-    numOfTries += 1
-    if (numOfTries == 60):
-      raise FatalException(1, "Could not fetch cluster name within a minute; giving up!")
-    sys.stdout.write('.')
-    sys.stdout.flush()
+  print_info_msg("Fetching information from Ambari's REST API")
 
-    try:
-      with closing(urllib2.urlopen(request)) as response:
-        response_status_code = response.getcode()
-        if response_status_code != 200:
-          request_in_progress = False
-          err = 'Error while fetching cluster name. Http status code - ' + str(response_status_code)
-          raise FatalException(1, err)
-        else:
-            response_body = json.loads(response.read())
-            items = response_body['items']
-            if len(items) > 0:
-               cluster_name = items[0]['Clusters']['cluster_name']
-               sys.stdout.write('\nFound cluster name: {0}'.format(cluster_name))
-            if not cluster_name:
-              time.sleep(1)
-            else:
-              request_in_progress = False
-    except Exception as e:
-      request_in_progress = False
-      err = 'Error while fetching cluster name. Error details: %s' % e
-      raise FatalException(1, err)
-
-    return cluster_name
+  with closing(urllib2.urlopen(request)) as response:
+    response_status_code = response.getcode()
+    json_data = None
+    print_info_msg(
+      "Received HTTP %s while fetching information from Ambari's REST API" % response_status_code)
+    if response_status_code == 200:
+      json_data = json.loads(response.read())
+      if (get_debug_mode()):
+        print_info_msg("Received JSON:\n" + json_data)
+    return response_status_code, json_data
 
 
-def perform_changes_via_rest_api(properties, admin_login, admin_password, url_postfix, get_method, request_data = None):
+def perform_changes_via_rest_api(properties, admin_login, admin_password, url_postfix, get_method,
+                                 request_data=None):
   url = get_ambari_server_api_base(properties) + url_postfix
   admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
   request = urllib2.Request(url)
@@ -221,6 +229,6 @@ def perform_changes_via_rest_api(properties, admin_login, admin_password, url_po
   with closing(urllib2.urlopen(request)) as response:
     response_status_code = response.getcode()
     if response_status_code not in (200, 201):
-      err = 'Error while performing changes via Ambari REST API. Http status code - ' + str(response_status_code)
+      err = 'Error while performing changes via Ambari REST API. Http status code - ' + str(
+        response_status_code)
       raise FatalException(1, err)
-

--- a/ambari-server/src/main/python/ambari_server/setupSso.py
+++ b/ambari-server/src/main/python/ambari_server/setupSso.py
@@ -94,8 +94,8 @@ def populate_sso_public_cert(options, properties):
       properties[SSO_CERTIFICATE] = ensure_complete_cert(cert_string) if cert_string else ""
   else:
     cert_path = options.sso_public_cert_file
-    with open(cert_path) as file:
-      cert_string = file.read()
+    with open(cert_path) as cert_file:
+      cert_string = cert_file.read()
     properties[SSO_CERTIFICATE] = ensure_complete_cert(cert_string) if cert_string else ""
 
 

--- a/ambari-server/src/main/python/ambari_server/setupSso.py
+++ b/ambari-server/src/main/python/ambari_server/setupSso.py
@@ -17,52 +17,43 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import ambari_simplejson as json
-import base64
-import logging
 import re
-import sys
-import time
 import urllib2
 
-from ambari_commons.os_utils import is_root, run_os_command, copy_file, set_file_permissions, remove_file
+import sys
 from ambari_commons.exceptions import FatalException, NonFatalException
-from ambari_commons.logging_utils import get_silent
-from ambari_server.userInput import get_validated_string_input, get_YN_input, get_multi_line_input
-from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base, get_ambari_admin_username_password_pair, get_cluster_name, perform_changes_via_rest_api
+from ambari_commons.logging_utils import get_silent, print_info_msg
+
+from ambari_server.serverConfiguration import get_ambari_properties
+from ambari_server.serverUtils import is_server_runing, get_ambari_admin_username_password_pair, \
+  get_cluster_name, perform_changes_via_rest_api, get_json_via_rest_api
 from ambari_server.setupSecurity import REGEX_TRUE_FALSE
-from ambari_server.serverConfiguration import get_ambari_properties, get_value_from_properties, update_properties, \
-  store_password_file
-from contextlib import closing
+from ambari_server.userInput import get_validated_string_input, get_YN_input, get_multi_line_input
 
-logger = logging.getLogger(__name__)
-
-JWT_AUTH_ENBABLED = "authentication.jwt.enabled"
-JWT_AUTH_PROVIDER_URL = "authentication.jwt.providerUrl"
-JWT_PUBLIC_KEY = "authentication.jwt.publicKey"
-JWT_AUDIENCES = "authentication.jwt.audiences"
-JWT_COOKIE_NAME = "authentication.jwt.cookieName"
-JWT_ORIGINAL_URL_QUERY_PARAM = "authentication.jwt.originalUrlParamName"
-
-JWT_COOKIE_NAME_DEFAULT = "hadoop-jwt"
-JWT_ORIGINAL_URL_QUERY_PARAM_DEFAULT = "originalUrl"
-JWT_AUTH_PROVIDER_URL_DEFAULT = "http://example.com"
-
-REGEX_ANYTHING = ".*"
-
-JWT_PUBLIC_KEY_FILENAME = "jwt-cert.pem"
-JWT_PUBLIC_KEY_HEADER = "-----BEGIN CERTIFICATE-----\n"
-JWT_PUBLIC_KEY_FOOTER = "\n-----END CERTIFICATE-----\n"
-
-REGEX_URL = "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+\S*$"
-
+AMBARI_JWT_AUTH_ENBABLED = "ambari.sso.authentication.enabled"
 SSO_MANAGE_SERVICES = "ambari.sso.manage_services"
 SSO_ENABLED_SERVICES = "ambari.sso.enabled_services"
-WILDCARD_FOR_ALL_SERVICES = "*"
-SERVICE_NAME_AMBARI = 'Ambari'
+SSO_PROVIDER_URL = "ambari.sso.provider.url"
+SSO_CERTIFICATE = "ambari.sso.provider.certificate"
+SSO_PROVIDER_ORIGINAL_URL_QUERY_PARAM = "ambari.sso.provider.originalUrlParamName"
+JWT_AUDIENCES = "ambari.sso.jwt.audiences"
+JWT_COOKIE_NAME = "ambari.sso.jwt.cookieName"
 
-URL_TO_FETCH_SERVICES_ELIGIBLE_FOR_SSO = "clusters/:CLUSTER_NAME/services?ServiceInfo/sso_integration_supported=true" ## :CLUSTER_NAME should be replaced
-SETUP_SSO_CONFIG_URL = 'services/AMBARI/components/AMBARI_SERVER/configurations/sso-configuration'
+SSO_PROVIDER_ORIGINAL_URL_QUERY_PARAM_DEFAULT = "originalUrl"
+SSO_PROVIDER_URL_DEFAULT = "https://knox.example.com:8443/gateway/knoxsso/api/v1/websso"
+JWT_COOKIE_NAME_DEFAULT = "hadoop-jwt"
+
+CERTIFICATE_HEADER = "-----BEGIN CERTIFICATE-----"
+CERTIFICATE_FOOTER = "-----END CERTIFICATE-----"
+
+REGEX_ANYTHING = ".*"
+REGEX_URL = "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+\S*$"
+
+WILDCARD_FOR_ALL_SERVICES = "*"
+SERVICE_NAME_AMBARI = 'AMBARI'
+
+FETCH_SERVICES_FOR_SSO_ENTRYPOINT = "clusters/%s/services?ServiceInfo/sso_integration_supported=true"
+SSO_CONFIG_API_ENTRYPOINT = 'services/AMBARI/components/AMBARI_SERVER/configurations/sso-configuration'
 
 
 def validate_options(options):
@@ -85,174 +76,111 @@ def validate_options(options):
 
 def populate_sso_provider_url(options, properties):
   if not options.sso_provider_url:
-      provider_url = get_value_from_properties(properties, JWT_AUTH_PROVIDER_URL, JWT_AUTH_PROVIDER_URL_DEFAULT)
-      provider_url = get_validated_string_input("Provider URL [URL] ({0}):".format(provider_url), provider_url, REGEX_URL,
+      provider_url = get_value_from_dictionary(properties, SSO_PROVIDER_URL, SSO_PROVIDER_URL_DEFAULT)
+      provider_url = get_validated_string_input("Provider URL ({0}):".format(provider_url), provider_url, REGEX_URL,
                                                 "Invalid provider URL", False)
   else:
     provider_url = options.sso_provider_url
 
-  properties.process_pair(JWT_AUTH_PROVIDER_URL, provider_url)
-
+  properties[SSO_PROVIDER_URL] = provider_url
 
 def populate_sso_public_cert(options, properties):
   if not options.sso_public_cert_file:
-    cert_path = properties.get_property(JWT_PUBLIC_KEY)
-    cert_string = get_multi_line_input("Public Certificate pem ({0})".format('stored' if cert_path else 'empty'))
-    store_new_cert = False
-    if cert_string is not None:
-        store_new_cert = True
-    if store_new_cert:
-      full_cert = JWT_PUBLIC_KEY_HEADER + cert_string + JWT_PUBLIC_KEY_FOOTER
-      cert_path = store_password_file(full_cert, JWT_PUBLIC_KEY_FILENAME)
+    cert = get_value_from_dictionary(properties, SSO_CERTIFICATE)
+    get_cert = True if not cert else get_YN_input("The SSO provider's public certificate has already set. Do you want to change it [y/n] (n): ", False)
+
+    if get_cert:
+      cert_string = get_multi_line_input("Public Certificate PEM")
+      properties[SSO_CERTIFICATE] = ensure_complete_cert(cert_string) if cert_string else ""
   else:
     cert_path = options.sso_public_cert_file
-
-  properties.process_pair(JWT_PUBLIC_KEY, cert_path)
+    with open(cert_path) as file:
+      cert_string = file.read()
+    properties[SSO_CERTIFICATE] = ensure_complete_cert(cert_string) if cert_string else ""
 
 
 def populate_jwt_cookie_name(options, properties):
   if not options.sso_jwt_cookie_name:
-    cookie_name = get_value_from_properties(properties, JWT_COOKIE_NAME, JWT_COOKIE_NAME_DEFAULT)
+    cookie_name = get_value_from_dictionary(properties, JWT_COOKIE_NAME, JWT_COOKIE_NAME_DEFAULT)
     cookie_name = get_validated_string_input("JWT Cookie name ({0}):".format(cookie_name), cookie_name, REGEX_ANYTHING,
                                          "Invalid cookie name", False)
   else:
     cookie_name = options.sso_jwt_cookie_name
 
-  properties.process_pair(JWT_COOKIE_NAME, cookie_name)
+  properties[JWT_COOKIE_NAME] = cookie_name
 
 
 def populate_jwt_audiences(options, properties):
-  if not options.sso_jwt_audience_list:
-    audiences = properties.get_property(JWT_AUDIENCES)
+  if options.sso_jwt_audience_list is None:
+    audiences = get_value_from_dictionary(properties, JWT_AUDIENCES)
     audiences = get_validated_string_input("JWT audiences list (comma-separated), empty for any ({0}):".format(audiences), audiences,
                                         REGEX_ANYTHING, "Invalid value", False)
   else:
     audiences = options.sso_jwt_audience_list
 
-  properties.process_pair(JWT_AUDIENCES, audiences)
+  properties[JWT_AUDIENCES] = audiences
   
 def get_eligible_services(properties, admin_login, admin_password, cluster_name):
+  print_info_msg("Fetching SSO enabled services")
+
   safe_cluster_name = urllib2.quote(cluster_name)
-  url = get_ambari_server_api_base(properties) + URL_TO_FETCH_SERVICES_ELIGIBLE_FOR_SSO.replace(":CLUSTER_NAME", safe_cluster_name)
-  admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
-  request = urllib2.Request(url)
-  request.add_header('Authorization', 'Basic %s' % admin_auth)
-  request.add_header('X-Requested-By', 'ambari')
-  request.get_method = lambda: 'GET'
+
+  response_code, json_data = get_json_via_rest_api(properties, admin_login, admin_password,
+                                                   FETCH_SERVICES_FOR_SSO_ENTRYPOINT % safe_cluster_name)
 
   services = [SERVICE_NAME_AMBARI]
-  sys.stdout.write('\nFetching SSO enabled services')
-  numOfTries = 0
-  request_in_progress = True
-  while request_in_progress:
-    numOfTries += 1
-    if (numOfTries == 60):
-      raise FatalException(1, "Could not fetch eligible services within a minute; giving up!")
-    sys.stdout.write('.')
-    sys.stdout.flush()
 
-    try:
-      with closing(urllib2.urlopen(request)) as response:
-        response_status_code = response.getcode()
-        if response_status_code != 200:
-          request_in_progress = False
-          err = 'Error while fetching eligible services. Http status code - ' + str(response_status_code)
-          raise FatalException(1, err)
-        else:
-            response_body = json.loads(response.read())
-            items = response_body['items']
-            if len(items) > 0:
-              for item in items:
-                services.append(item['ServiceInfo']['service_name'])
-              if not services:
-                time.sleep(1)
-              else:
-                request_in_progress = False
-            else:
-              request_in_progress = False
+  if json_data and 'items' in json_data:
+    items = json_data['items']
+    if len(items) > 0:
+      for item in items:
+        services.append(item['ServiceInfo']['service_name'])
 
-    except Exception as e:
-      request_in_progress = False
-      err = 'Error while fetching eligible services. Error details: %s' % e
-      raise FatalException(1, err)
-  if (len(services) == 0):
-    sys.stdout.write('\nThere is no SSO enabled services found\n')
-  else:
-    sys.stdout.write('\nFound SSO enabled services: {0}\n'.format(', '.join(str(s) for s in services)))
+    print_info_msg('Found SSO enabled services: %s' % ', '.join(services))
+
   return services
 
-def get_services_requires_sso(options, properties, admin_login, admin_password):
+
+def get_services_requires_sso(options, ambari_properties, admin_login, admin_password):
   if not options.sso_enabled_services:
     configure_for_all_services = get_YN_input("Use SSO for all services [y/n] (n): ", False)
     if configure_for_all_services:
-      services = WILDCARD_FOR_ALL_SERVICES
+      services = [WILDCARD_FOR_ALL_SERVICES]
     else:
-      cluster_name = get_cluster_name(properties, admin_login, admin_password)
-      eligible_services = get_eligible_services(properties, admin_login, admin_password, cluster_name)
-      services = ''
-      for service in eligible_services:
-        question = "Use SSO for {0} [y/n] (y): ".format(service)
-        if get_YN_input(question, True):
-          if len(services) > 0:
-            services = services + ", "
-          services = services + service
+      services = []
+      cluster_name = get_cluster_name(ambari_properties, admin_login, admin_password)
+
+      if cluster_name:
+        eligible_services = get_eligible_services(ambari_properties, admin_login, admin_password, cluster_name)
+        if eligible_services:
+          for service in eligible_services:
+            question = "Use SSO for {0} [y/n] (y): ".format(service)
+            if get_YN_input(question, True):
+              services.append(service)
   else:
-    services = options.sso_enabled_services
+    services = options.sso_enabled_services.upper().split(',') if options.sso_enabled_services else []
 
   return services
 
-def get_sso_property_from_db(properties, admin_login, admin_password, property_name):
-  sso_property = None
-  url = get_ambari_server_api_base(properties) + SETUP_SSO_CONFIG_URL
-  admin_auth = base64.encodestring('%s:%s' % (admin_login, admin_password)).replace('\n', '')
-  request = urllib2.Request(url)
-  request.add_header('Authorization', 'Basic %s' % admin_auth)
-  request.add_header('X-Requested-By', 'ambari')
-  request.get_method = lambda: 'GET'
-  request_in_progress = True
+def get_sso_properties(properties, admin_login, admin_password):
+  print_info_msg("Fetching SSO configuration from DB")
 
-  sys.stdout.write('\nFetching SSO configuration from DB')
-  numOfTries = 0
-  while request_in_progress:
-    numOfTries += 1
-    if (numOfTries == 60):
-      raise FatalException(1, "Could not fetch SSO configuration within a minute; giving up!")
-    sys.stdout.write('.')
-    sys.stdout.flush()
+  try:
+    response_code, json_data = get_json_via_rest_api(properties, admin_login, admin_password, SSO_CONFIG_API_ENTRYPOINT)
+  except urllib2.HTTPError as http_error:
+    if http_error.code == 404:
+      # This means that there is no SSO configuration in the database yet -> we can not fetch the
+      # property (but this is NOT an error)
+      json_data = None
+    else:
+      raise http_error
 
-    try:
-      with closing(urllib2.urlopen(request)) as response:
-        response_status_code = response.getcode()
-        if response_status_code != 200:
-          request_in_progress = False
-          err = 'Error while fetching SSO configuration. Http status code - ' + str(response_status_code)
-          raise FatalException(1, err)
-        else:
-          response_body = json.loads(response.read())
-          sso_properties = response_body['Configuration']['properties']
-          sso_property = sso_properties[property_name]
-          if not sso_property:
-            time.sleep(1)
-          else:
-            request_in_progress = False
-    except urllib2.HTTPError as http_error:
-      if http_error.code == 404:
-        # This means that there is no SSO configuration in the database yet -> we can not fetch the property (but this is NOT an error)
-        request_in_progress = False
-        sso_property = None
-      else:
-        raise http_error
-    except Exception as e:
-      request_in_progress = False
-      err = 'Error while fetching SSO configuration. Error details: %s' % e
-      raise FatalException(1, err)
+  if json_data and 'Configuration' in json_data and 'properties' in json_data['Configuration']:
+    return json_data['Configuration']['properties']
+  else:
+    return {}
 
-  return sso_property
-
-def update_sso_conf(properties, enable_sso, services, admin_login, admin_password):
-  sso_configuration_properties = {}
-  sso_configuration_properties[SSO_MANAGE_SERVICES] = "true" if enable_sso else "false"
-  sso_configuration_properties[SSO_ENABLED_SERVICES] = services
+def update_sso_conf(ambari_properties, sso_configuration_properties, admin_login, admin_password):
   request_data = {
     "Configuration": {
       "category": "sso-configuration",
@@ -261,13 +189,11 @@ def update_sso_conf(properties, enable_sso, services, admin_login, admin_passwor
     }
   }
   request_data['Configuration']['properties'] = sso_configuration_properties
-  perform_changes_via_rest_api(properties, admin_login, admin_password, SETUP_SSO_CONFIG_URL, 'PUT', request_data)
+  perform_changes_via_rest_api(ambari_properties, admin_login, admin_password, SSO_CONFIG_API_ENTRYPOINT, 'PUT', request_data)
 
 
 def setup_sso(options):
-  logger.info("Setup SSO.")
-  if not is_root():
-    raise FatalException(4, 'ambari-server setup-sso should be run with root-level privileges')
+  print_info_msg("Setup SSO.")
 
   server_status, pid = is_server_runing()
   if not server_status:
@@ -277,15 +203,20 @@ def setup_sso(options):
   if not get_silent():
     validate_options(options)
 
-    properties = get_ambari_properties()
+    ambari_properties = get_ambari_properties()
 
     admin_login, admin_password = get_ambari_admin_username_password_pair(options)
+    properties = get_sso_properties(ambari_properties, admin_login, admin_password)
 
     if not options.sso_enabled:
-      sso_enabled_from_db = get_sso_property_from_db(properties, admin_login, admin_password, SSO_MANAGE_SERVICES)
-      sso_enabled = sso_enabled_from_db == None or sso_enabled_from_db in ['true']
-      sys.stdout.write("\nSSO is currently {0}\n".format("not configured" if sso_enabled_from_db == None else ("enabled" if sso_enabled else "disabled")))
+      sso_enabled = get_value_from_dictionary(properties, SSO_MANAGE_SERVICES, None)
       if sso_enabled:
+        sso_status = "enabled" if sso_enabled == "true" else "disabled"
+      else:
+        sso_status = "not configured"
+      sys.stdout.write("\nSSO is currently %s\n" % sso_status)
+
+      if sso_status == "enabled":
         enable_sso = not get_YN_input("Do you want to disable SSO authentication [y/n] (n)? ", False)
       else:
         if get_YN_input("Do you want to configure SSO authentication [y/n] (y)? ", True):
@@ -295,23 +226,39 @@ def setup_sso(options):
     else:
       enable_sso = options.sso_enabled == 'true'
 
-    services = ''
+    services = None
     if enable_sso:
       populate_sso_provider_url(options, properties)
       populate_sso_public_cert(options, properties)
       populate_jwt_cookie_name(options, properties)
       populate_jwt_audiences(options, properties)
-      services = get_services_requires_sso(options, properties, admin_login, admin_password)
+      services = get_services_requires_sso(options, ambari_properties, admin_login, admin_password)
 
-    update_sso_conf(properties, enable_sso, services, admin_login, admin_password)
+    enable_jwt_auth = services and (WILDCARD_FOR_ALL_SERVICES in services or SERVICE_NAME_AMBARI in services)
+    properties[AMBARI_JWT_AUTH_ENBABLED]  = "true" if enable_jwt_auth else "false"
+    properties[SSO_MANAGE_SERVICES] = "true" if enable_sso else "false"
+    properties[SSO_ENABLED_SERVICES] = ','.join(services) if services else ""
 
-    enable_jwt_auth = WILDCARD_FOR_ALL_SERVICES == services or SERVICE_NAME_AMBARI in services
-    properties.process_pair(JWT_AUTH_ENBABLED, "true" if enable_jwt_auth else "false")
-    update_properties(properties)
-
+    update_sso_conf(ambari_properties, properties, admin_login, admin_password)
     pass
   else:
     warning = "setup-sso is not enabled in silent mode."
     raise NonFatalException(warning)
-
   pass
+
+
+def ensure_complete_cert(cert_string):
+  if cert_string:
+    cert_string = cert_string.lstrip().rstrip()
+
+    # Ensure the header and footer are in the string
+    if not cert_string.startswith(CERTIFICATE_HEADER):
+      cert_string = CERTIFICATE_HEADER + '\n' + cert_string
+
+    if not cert_string.endswith(CERTIFICATE_FOOTER):
+      cert_string = cert_string + '\n' + CERTIFICATE_FOOTER
+
+  return cert_string
+
+def get_value_from_dictionary(properties, key, default_value=None):
+  return properties[key] if properties and key in properties else default_value

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -87,7 +87,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value VARCHAR(255) NOT NULL,
+  property_value VARCHAR(2048),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -107,7 +107,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value MEDUIMTEXT,
+  property_value VARCHAR(2048),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -107,7 +107,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value VARCHAR(255) NOT NULL,
+  property_value MEDUIMTEXT,
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -87,7 +87,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR2(100) NOT NULL,
   property_name VARCHAR2(100) NOT NULL,
-  property_value CLOB,
+  property_value VARCHAR2(2048),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -87,7 +87,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR2(100) NOT NULL,
   property_name VARCHAR2(100) NOT NULL,
-  property_value VARCHAR2(255) NOT NULL,
+  property_value CLOB,
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -69,7 +69,7 @@ CREATE TABLE clusters (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value VARCHAR(255) NOT NULL,
+  property_value VARCHAR(2048),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name)
 );
 

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -86,7 +86,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value TEXT,
+  property_value VARCHAR(2048),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -86,7 +86,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value VARCHAR(255) NOT NULL,
+  property_value TEXT,
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name));
 
 CREATE TABLE serviceconfig (

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -100,7 +100,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value VARCHAR(255) NOT NULL,
+  property_value VARCHAR(MAX),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name)
 );
 

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -100,7 +100,7 @@ CREATE TABLE clusterconfig (
 CREATE TABLE ambari_configuration (
   category_name VARCHAR(100) NOT NULL,
   property_name VARCHAR(100) NOT NULL,
-  property_value VARCHAR(MAX),
+  property_value VARCHAR(2048),
   CONSTRAINT PK_ambari_configuration PRIMARY KEY (category_name, property_name)
 );
 

--- a/ambari-server/src/main/resources/stacks/ambari_configuration.py
+++ b/ambari-server/src/main/resources/stacks/ambari_configuration.py
@@ -79,17 +79,6 @@ class AmbariConfiguration(object):
     """
     return _get_from_dictionary(self.services, "ambari-server-configuration")
 
-  def get_ambari_server_properties(self):
-    """
-    Safely returns the "ambari-server-properties" dictionary from the services dictionary.
-
-    if the services dictionary is None or does not contain "ambari-server-configuration",
-    None is returned
-
-    :return: a dictionary
-    """
-    return _get_from_dictionary(self.services, "ambari-server-properties")
-
   def get_ambari_server_configuration_category(self, category):
     """
     Safely returns a dictionary of the properties for the requested category from the
@@ -103,16 +92,6 @@ class AmbariConfiguration(object):
     """
     return _get_from_dictionary(self.get_ambari_server_configuration(), category)
 
-  def get_category_property_value(self, properties, property_name):
-    """
-    Safely gets the value of a property from a supplied dictionary of properties.
-
-    :param properties: a dictionary of properties
-    :param property_name: the name of a property to retrieve the value for
-    :return: a value or None, if the property does not exist
-    """
-    return _get_from_dictionary(properties, property_name)
-
   def get_ambari_sso_configuration(self):
     """
     Safely gets a dictionary of properties for the "sso-configuration" category.
@@ -121,14 +100,21 @@ class AmbariConfiguration(object):
     """
     return self.get_ambari_server_configuration_category("sso-configuration")
 
-  def get_ambari_sso_configuration_value(self, property_name):
+  def get_ambari_sso_details(self):
     """
-    Safely gets a value for a "sso-configuration" property
+    Gets a dictionary of properties that may be used to configure a service for SSO integration.
+    :return: a dictionary
+    """
+    return AmbariSSODetails(self.get_ambari_sso_configuration())
 
-    :param property_name: the name of a property to retrieve the value for
-    :return: a value or None, if the property does not exist
-    """
-    return self.get_category_property_value(self.get_ambari_sso_configuration(), property_name)
+
+class AmbariSSODetails(object):
+  """
+  AmbariSSODetails encapsulates the SSO configuration data specified in the ambari-server-configuration data
+  """
+
+  def __init__(self, sso_properties):
+    self.sso_properties = sso_properties
 
   def is_managing_services(self):
     """
@@ -139,7 +125,7 @@ class AmbariConfiguration(object):
 
     :return: True, if Ambari should manage services' SSO configurations
     """
-    return "true" == self.get_ambari_sso_configuration_value("ambari.sso.manage_services")
+    return "true" == _get_from_dictionary(self.sso_properties, "ambari.sso.manage_services")
 
   def get_services_to_enable(self):
     """
@@ -149,7 +135,7 @@ class AmbariConfiguration(object):
 
     :return: a list of service names converted to lowercase
     """
-    sso_enabled_services = self.get_ambari_sso_configuration_value("ambari.sso.enabled_services")
+    sso_enabled_services = _get_from_dictionary(self.sso_properties, "ambari.sso.enabled_services")
 
     return [x.strip().lower() for x in sso_enabled_services.strip().split(",")] \
       if sso_enabled_services \
@@ -189,86 +175,67 @@ class AmbariConfiguration(object):
     else:
       return False
 
-  def get_ambari_sso_details(self):
-    """
-    Gets a dictionary of properties that may be used to configure a service for SSO integration.
-    :return: a dictionary
-    """
-    return AmbariSSODetails(self.get_ambari_server_properties())
-
-
-class AmbariSSODetails(object):
-  """
-  AmbariSSODetails encapsulates the SSO configiuration data specified in the ambari-server-properties
-  """
-
-  def __init__(self, ambari_server_properties):
-    self.jwt_enabled = _get_from_dictionary(ambari_server_properties,
-                                            'authentication.jwt.enabled')
-    self.jwt_audiences = _get_from_dictionary(ambari_server_properties,
-                                              'authentication.jwt.audiences')
-    self.jwt_cookie_name = _get_from_dictionary(ambari_server_properties,
-                                                'authentication.jwt.cookieName')
-    self.jwt_provider_url = _get_from_dictionary(ambari_server_properties,
-                                                 'authentication.jwt.providerUrl')
-    self.jwt_public_key_file = _get_from_dictionary(ambari_server_properties,
-                                                    'authentication.jwt.publicKey')
-
-  def is_jwt_enabled(self):
-    """
-    Test is SSO/JWT authentication is enabled for Ambari
-    :return: True if JWT authentication is enabled for Ambari; False, otherwise
-    """
-    return "true" == self.jwt_enabled
-
   def get_jwt_audiences(self):
     """
     Gets the configured JWT audiences list
+
+    The relevant property is "sso-configuration/ambari.sso.jwt.audiences", which is expected
+    to be a comma-delimited list of audience names.
+
     :return the configured JWT audiences list:
     """
-    return self.jwt_audiences
+    return _get_from_dictionary(self.sso_properties, 'ambari.sso.jwt.audiences')
 
   def get_jwt_cookie_name(self):
     """
     Gets the configured JWT cookie name
+
+    The relevant property is "sso-configuration/ambari.sso.jwt.cookieName", which is expected
+    to be a string.
+
     :return: the configured JWT cookie name
     """
-    return self.jwt_cookie_name
+    return _get_from_dictionary(self.sso_properties, 'ambari.sso.jwt.cookieName')
 
-  def get_jwt_provider_url(self):
+  def get_sso_provider_url(self):
     """
     Gets the configured SSO provider URL
+
+    The relevant property is "sso-configuration/ambari.sso.provider.url", which is expected
+    to be a string.
+
     :return: the configured SSO provider URL
     """
-    return self.jwt_provider_url
+    return _get_from_dictionary(self.sso_properties, 'ambari.sso.provider.url')
 
-  def get_jwt_public_key_file(self):
+  def get_sso_provider_original_parameter_name(self):
     """
-    Gets the configured path to the public key file
-    :return: the configured path to the public key file
-    """
-    return self.jwt_public_key_file
+    Gets the configured SSO provider's original URL parameter name
 
-  def get_jwt_public_key(self, include_header_and_footer=False, remove_line_breaks=True):
-    """
-    Retrieves, formats, and returns the PEM data from the configured 509 certificate file.
+    The relevant property is "sso-configuration/ambari.sso.provider.originalUrlParamName", which is
+    expected to be a string.
 
-    Attempts to read in the file specified by the value in ambari-server-properties/authentication.jwt.publicKey.
-    If the file exists and is readable, the content is read.  If the header and foooter need to exists, and
-    do not, the will be added. If they need to be removed, they will be removed if they exist.  Any line
-    break characters will be leave alone unles the caller specifies them to be removed. Line break
-    characters will not be added if missing.
+    :return: the configured SSO provider's original URL parameter name
+    """
+    return _get_from_dictionary(self.sso_properties, 'ambari.sso.provider.originalUrlParamName')
+
+  def get_sso_provider_certificate(self, include_header_and_footer=False, remove_line_breaks=True):
+    """
+    Retrieves, formats, and returns the PEM data from the stored 509 certificate.
+
+    The relevant property is "sso-configuration/ambari.sso.provider.certificate", which is expected
+    to be a PEM-encoded x509 certificate, including the header and footer.
+
+    If the header and footer need to exist, and do not, the will be added. If they need to be removed,
+    they will be removed if they exist.  Any line break characters will be left alone unless the
+    caller specifies them to be removed. Line break characters will not be added if missing.
 
     :param include_header_and_footer: True, to include the standard header and footer; False to remove
     the standard header and footer
     :param remove_line_breaks: True, remove and line breaks from PEM data; False to leave any existing line break as-is
-    :return:  formats, and returns the PEM data from an x509 certificate file
+    :return:  formats, and returns the PEM data from an x509 certificate
     """
-    public_cert = None
-
-    if (self.jwt_public_key_file) and os.path.isfile(self.jwt_public_key_file):
-      with open(self.jwt_public_key_file, "r") as f:
-        public_cert = f.read()
+    public_cert = _get_from_dictionary(self.sso_properties, 'ambari.sso.provider.certificate')
 
     if public_cert:
       public_cert = public_cert.lstrip().rstrip()

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/AmbariErrorHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/AmbariErrorHandlerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.api;
 
+import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -30,7 +31,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.security.authentication.jwt.JwtAuthenticationPropertiesProvider;
+import org.easymock.EasyMockSupport;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -43,7 +45,7 @@ import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
-public class AmbariErrorHandlerTest {
+public class AmbariErrorHandlerTest extends EasyMockSupport {
   Gson gson = new Gson();
 
 
@@ -55,14 +57,17 @@ public class AmbariErrorHandlerTest {
   @Test
   public void testErrorWithJetty() throws Exception {
     Server server = new Server(0);
-    Configuration configuration = new Configuration();
+    JwtAuthenticationPropertiesProvider propertiesProvider = createNiceMock(JwtAuthenticationPropertiesProvider.class);
+    expect(propertiesProvider.getProperties()).andReturn(null).anyTimes();
+
+    replayAll();
 
     ServletContextHandler root = new ServletContextHandler(server, "/",
       ServletContextHandler.SECURITY | ServletContextHandler.SESSIONS);
 
     root.addServlet(HelloServlet.class, "/hello");
     root.addServlet(DefaultServlet.class, "/");
-    root.setErrorHandler(new AmbariErrorHandler(gson, configuration));
+    root.setErrorHandler(new AmbariErrorHandler(gson, propertiesProvider));
 
     server.start();
 
@@ -91,8 +96,9 @@ public class AmbariErrorHandlerTest {
       fail("Incorrect response");
     }
 
+     server.stop();
 
-    server.stop();
+    verifyAll();
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
@@ -61,7 +61,6 @@ import org.easymock.EasyMockSupport;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -105,6 +104,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
     properties.setCookieName("non-default");
     properties.setPublicKey(publicKey);
     properties.setAudiences(audiences);
+    properties.setEnabledForAmbari(true);
 
     return properties;
   }
@@ -173,14 +173,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     expect(request.getCookies()).andReturn(new Cookie[]{cookie});
 
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     String jwtFromCookie = filter.getJWTFromCookie(request);
 
     verifyAll();
@@ -190,14 +190,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testValidateSignature() throws Exception {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertTrue(filter.validateSignature(getSignedToken()));
     assertFalse(filter.validateSignature(getInvalidToken()));
 
@@ -206,14 +206,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testValidateAudiences() throws Exception {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
 
     assertTrue(filter.validateAudiences(getSignedToken()));
     assertFalse(filter.validateAudiences(getInvalidToken()));
@@ -223,14 +223,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testValidateNullAudiences() throws Exception {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties(null)).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties(null)).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertTrue(filter.validateAudiences(getSignedToken()));
     assertTrue(filter.validateAudiences(getInvalidToken()));
 
@@ -239,14 +239,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testValidateTokenWithoutAudiences() throws Exception {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertFalse(filter.validateAudiences(getSignedToken(null)));
 
     verifyAll();
@@ -254,14 +254,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testValidateExpiration() throws Exception {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertTrue(filter.validateExpiration(getSignedToken()));
     assertFalse(filter.validateExpiration(getInvalidToken()));
 
@@ -270,14 +270,14 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testValidateNoExpiration() throws Exception {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     AmbariAuthenticationEventHandler eventHandler = createNiceMock(AmbariAuthenticationEventHandler.class);
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
 
     assertTrue(filter.validateExpiration(getSignedToken(null, "test-audience")));
     assertFalse(filter.validateExpiration(getInvalidToken()));
@@ -287,8 +287,8 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testShouldApplyTrue() throws JOSEException {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     SignedJWT token = getInvalidToken();
 
@@ -303,7 +303,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertTrue(filter.shouldApply(request));
 
     verifyAll();
@@ -311,8 +311,8 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testShouldApplyTrueBadToken() throws JOSEException {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     Cookie cookie = createMock(Cookie.class);
     expect(cookie.getName()).andReturn("non-default").atLeastOnce();
@@ -325,7 +325,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertTrue(filter.shouldApply(request));
 
     verifyAll();
@@ -333,8 +333,8 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testShouldApplyFalseMissingCookie() throws JOSEException {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     Cookie cookie = createMock(Cookie.class);
     expect(cookie.getName()).andReturn("some-other-cookie").atLeastOnce();
@@ -346,7 +346,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertFalse(filter.shouldApply(request));
 
     verifyAll();
@@ -354,8 +354,8 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test
   public void testShouldApplyFalseNotEnabled() throws JOSEException {
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(null).anyTimes();
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(null).anyTimes();
 
     HttpServletRequest request = createMock(HttpServletRequest.class);
 
@@ -363,7 +363,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, configuration, null, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(null, jwtAuthenticationPropertiesProvider, null, eventHandler);
     assertFalse(filter.shouldApply(request));
 
     verify(request);
@@ -371,7 +371,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
   @Test(expected = IllegalArgumentException.class)
   public void ensureNonNullEventHandler() {
-    new AmbariJwtAuthenticationFilter(createNiceMock(AmbariEntryPoint.class), createNiceMock(Configuration.class), createNiceMock(AuthenticationProvider.class), null);
+    new AmbariJwtAuthenticationFilter(createNiceMock(AmbariEntryPoint.class), createNiceMock(JwtAuthenticationPropertiesProvider.class), createNiceMock(AmbariJwtAuthenticationProvider.class), null);
   }
 
   @Test
@@ -380,8 +380,10 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     SignedJWT token = getSignedToken();
 
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
+
     Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
     expect(configuration.getMaxAuthenticationFailures()).andReturn(10).anyTimes();
 
     HttpServletRequest request = createMock(HttpServletRequest.class);
@@ -431,7 +433,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
     replayAll();
 
     AmbariJwtAuthenticationProvider provider = new AmbariJwtAuthenticationProvider(users, configuration);
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(entryPoint, configuration, provider, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(entryPoint, jwtAuthenticationPropertiesProvider, provider, eventHandler);
     filter.doFilter(request, response, filterChain);
 
     verifyAll();
@@ -449,8 +451,10 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     SignedJWT token = getSignedToken();
 
-    Configuration configuration = createNiceMock(Configuration.class);
-    expect(configuration.getJwtProperties()).andReturn(createTestProperties()).anyTimes();
+    Configuration configuration = createMock(Configuration.class);
+
+    JwtAuthenticationPropertiesProvider jwtAuthenticationPropertiesProvider = createMock(JwtAuthenticationPropertiesProvider.class);
+    expect(jwtAuthenticationPropertiesProvider.getProperties()).andReturn(createTestProperties()).anyTimes();
 
     HttpServletRequest request = createMock(HttpServletRequest.class);
     HttpServletResponse response = createMock(HttpServletResponse.class);
@@ -479,7 +483,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
     replayAll();
 
     AmbariJwtAuthenticationProvider provider = new AmbariJwtAuthenticationProvider(users, configuration);
-    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(entryPoint, configuration, provider, eventHandler);
+    AmbariJwtAuthenticationFilter filter = new AmbariJwtAuthenticationFilter(entryPoint, jwtAuthenticationPropertiesProvider, provider, eventHandler);
     filter.doFilter(request, response, filterChain);
 
     verifyAll();

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -307,7 +307,7 @@ public class UpgradeCatalog270Test {
     Method updateLogSearchConfigs = UpgradeCatalog270.class.getDeclaredMethod("updateLogSearchConfigs");
     Method updateKerberosConfigurations = UpgradeCatalog270.class.getDeclaredMethod("updateKerberosConfigurations");
     Method updateHostComponentLastStateTable = UpgradeCatalog270.class.getDeclaredMethod("updateHostComponentLastStateTable");
-    Method upgradeLdapConfiguration = UpgradeCatalog270.class.getDeclaredMethod("upgradeLdapConfiguration");
+    Method upgradeLdapConfiguration = UpgradeCatalog270.class.getDeclaredMethod("moveAmbariPropertiesToAmbariConfiguration");
     Method createRoleAuthorizations = UpgradeCatalog270.class.getDeclaredMethod("createRoleAuthorizations");
     Method addUserAuthenticationSequence = UpgradeCatalog270.class.getDeclaredMethod("addUserAuthenticationSequence");
     Method renameAmbariInfra = UpgradeCatalog270.class.getDeclaredMethod("renameAmbariInfra");
@@ -348,7 +348,7 @@ public class UpgradeCatalog270Test {
     upgradeCatalog270.updateKerberosConfigurations();
     expectLastCall().once();
 
-    upgradeCatalog270.upgradeLdapConfiguration();
+    upgradeCatalog270.moveAmbariPropertiesToAmbariConfiguration();
     expectLastCall().once();
 
     upgradeCatalog270.addUserAuthenticationSequence();
@@ -507,7 +507,7 @@ public class UpgradeCatalog270Test {
         Arrays.asList(
             new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN, String.class, 100, null, false),
             new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN, String.class, 100, null, false),
-            new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN, String.class, 255, null, true))
+            new DBAccessor.DBColumnInfo(AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN, String.class, 2048, null, true))
     );
 
     List<DBAccessor.DBColumnInfo> columns = ambariConfigurationTableColumns.getValue();
@@ -528,7 +528,7 @@ public class UpgradeCatalog270Test {
         Assert.assertFalse(column.isNullable());
       } else if (AMBARI_CONFIGURATION_PROPERTY_VALUE_COLUMN.equals(columnName)) {
         Assert.assertEquals(String.class, column.getType());
-        Assert.assertEquals(Integer.valueOf(255), column.getLength());
+        Assert.assertEquals(Integer.valueOf(2048), column.getLength());
         Assert.assertEquals(null, column.getDefaultValue());
         Assert.assertTrue(column.isNullable());
       } else {
@@ -1175,7 +1175,7 @@ public class UpgradeCatalog270Test {
     final Injector injector = Guice.createInjector(module);
     injector.getInstance(Configuration.class).setProperty("ambari.ldap.isConfigured", "true");
     final UpgradeCatalog270 upgradeCatalog270 = new UpgradeCatalog270(injector);
-    upgradeCatalog270.upgradeLdapConfiguration();
+    upgradeCatalog270.moveAmbariPropertiesToAmbariConfiguration();
     verify(entityManager, ambariConfigurationDao);
   }
 
@@ -1190,7 +1190,7 @@ public class UpgradeCatalog270Test {
 
     final Injector injector = Guice.createInjector(module);
     final UpgradeCatalog270 upgradeCatalog270 = new UpgradeCatalog270(injector);
-    upgradeCatalog270.upgradeLdapConfiguration();
+    upgradeCatalog270.moveAmbariPropertiesToAmbariConfiguration();
 
     expectedException.expect(AssertionError.class);
     expectedException.expectMessage("Expectation failure on verify");

--- a/ambari-server/src/test/python/stacks/test_ambari_configuration.py
+++ b/ambari-server/src/test/python/stacks/test_ambari_configuration.py
@@ -18,23 +18,7 @@ limitations under the License.
 
 import os
 
-from mock.mock import MagicMock, patch
 from unittest import TestCase
-
-# Mock classes for reading from a file
-class MagicFile(object):
-  def __init__(self, data):
-    self.data = data
-
-  def read(self):
-    return self.data
-
-  def __exit__(self, exc_type, exc_val, exc_tb):
-    pass
-
-  def __enter__(self):
-    return self
-pass
 
 class TestAmbariConfiguration(TestCase):
 
@@ -56,7 +40,7 @@ class TestAmbariConfiguration(TestCase):
   def testMissingData(self):
     ambari_configuration = self.ambari_configuration_class('{}')
     self.assertIsNone(ambari_configuration.get_ambari_server_configuration())
-    self.assertIsNone(ambari_configuration.get_ambari_server_properties())
+    self.assertIsNone(ambari_configuration.get_ambari_sso_configuration())
 
   def testMissingSSOConfiguration(self):
     services_json = {
@@ -66,23 +50,15 @@ class TestAmbariConfiguration(TestCase):
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertIsNone(ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.property"))
-    self.assertFalse(ambari_configuration.should_enable_sso("AMBARI"))
+    self.assertIsNone(ambari_configuration.get_ambari_sso_configuration())
 
-  def testMissingAmbariProperties(self):
-    services_json = {
-      "ambari-server-configuration": {
-      }
-    }
-
-    ambari_configuration = self.ambari_configuration_class(services_json)
     ambari_sso_details = ambari_configuration.get_ambari_sso_details()
-    self.assertFalse(ambari_sso_details.is_jwt_enabled())
+    self.assertIsNotNone(ambari_sso_details)
     self.assertIsNone(ambari_sso_details.get_jwt_audiences())
     self.assertIsNone(ambari_sso_details.get_jwt_cookie_name())
-    self.assertIsNone(ambari_sso_details.get_jwt_provider_url())
-    self.assertIsNone(ambari_sso_details.get_jwt_public_key_file())
-    self.assertIsNone(ambari_sso_details.get_jwt_public_key())
+    self.assertIsNone(ambari_sso_details.get_sso_provider_url())
+    self.assertIsNone(ambari_sso_details.get_sso_provider_original_parameter_name())
+    self.assertFalse(ambari_sso_details.should_enable_sso("AMBARI"))
 
   def testAmbariSSOConfigurationNotManagingServices(self):
     services_json = {
@@ -95,52 +71,58 @@ class TestAmbariConfiguration(TestCase):
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertEquals("AMBARI", ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.enabled_services"))
-    self.assertFalse(ambari_configuration.is_managing_services())
-    self.assertFalse(ambari_configuration.should_enable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_disable_sso("AMBARI"))
+
+    ambari_sso_details = ambari_configuration.get_ambari_sso_details()
+    self.assertIsNotNone(ambari_sso_details)
+    self.assertFalse(ambari_sso_details.is_managing_services())
+    self.assertFalse(ambari_sso_details.should_enable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("AMBARI"))
 
     services_json = {
       "ambari-server-configuration": {
         "sso-configuration": {
-          "ambari.sso.manage_services" : "false",
-          "ambari.sso.enabled_services" : "AMBARI, RANGER"
+          "ambari.sso.manage_services": "false",
+          "ambari.sso.enabled_services": "AMBARI, RANGER"
         }
       }
     }
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertEquals("AMBARI, RANGER", ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.enabled_services"))
-    self.assertFalse(ambari_configuration.is_managing_services())
-    self.assertFalse(ambari_configuration.should_enable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_disable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_enable_sso("RANGER"))
-    self.assertFalse(ambari_configuration.should_disable_sso("RANGER"))
+
+    ambari_sso_details = ambari_configuration.get_ambari_sso_details()
+    self.assertIsNotNone(ambari_sso_details)
+    self.assertFalse(ambari_sso_details.is_managing_services())
+    self.assertFalse(ambari_sso_details.should_enable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_enable_sso("RANGER"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("RANGER"))
 
     services_json = {
       "ambari-server-configuration": {
         "sso-configuration": {
-          "ambari.sso.manage_services" : "false",
-          "ambari.sso.enabled_services" : "*"
+          "ambari.sso.manage_services": "false",
+          "ambari.sso.enabled_services": "*"
         }
       }
     }
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertEquals("*", ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.enabled_services"))
-    self.assertFalse(ambari_configuration.is_managing_services())
-    self.assertFalse(ambari_configuration.should_enable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_disable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_enable_sso("RANGER"))
-    self.assertFalse(ambari_configuration.should_disable_sso("RANGER"))
+
+    ambari_sso_details = ambari_configuration.get_ambari_sso_details()
+    self.assertIsNotNone(ambari_sso_details)
+    self.assertFalse(ambari_sso_details.is_managing_services())
+    self.assertFalse(ambari_sso_details.should_enable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_enable_sso("RANGER"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("RANGER"))
 
   def testAmbariSSOConfigurationManagingServices(self):
     services_json = {
       "ambari-server-configuration": {
         "sso-configuration": {
-          "ambari.sso.manage_services" : "true",
+          "ambari.sso.manage_services": "true",
           "ambari.sso.enabled_services": "AMBARI"
         }
       }
@@ -148,92 +130,89 @@ class TestAmbariConfiguration(TestCase):
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertEquals("AMBARI", ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.enabled_services"))
-    self.assertTrue(ambari_configuration.is_managing_services())
-    self.assertTrue(ambari_configuration.should_enable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_disable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_enable_sso("RANGER"))
-    self.assertTrue(ambari_configuration.should_disable_sso("RANGER"))
+
+    ambari_sso_details = ambari_configuration.get_ambari_sso_details()
+    self.assertIsNotNone(ambari_sso_details)
+    self.assertTrue(ambari_sso_details.is_managing_services())
+    self.assertTrue(ambari_sso_details.should_enable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_enable_sso("RANGER"))
+    self.assertTrue(ambari_sso_details.should_disable_sso("RANGER"))
 
     services_json = {
       "ambari-server-configuration": {
         "sso-configuration": {
-          "ambari.sso.manage_services" : "true",
-          "ambari.sso.enabled_services" : "AMBARI, RANGER"
+          "ambari.sso.manage_services": "true",
+          "ambari.sso.enabled_services": "AMBARI, RANGER"
         }
       }
     }
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertEquals("AMBARI, RANGER", ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.enabled_services"))
-    self.assertTrue(ambari_configuration.is_managing_services())
-    self.assertTrue(ambari_configuration.should_enable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_disable_sso("AMBARI"))
-    self.assertTrue(ambari_configuration.should_enable_sso("RANGER"))
-    self.assertFalse(ambari_configuration.should_disable_sso("RANGER"))
+
+    ambari_sso_details = ambari_configuration.get_ambari_sso_details()
+    self.assertIsNotNone(ambari_sso_details)
+    self.assertTrue(ambari_sso_details.is_managing_services())
+    self.assertTrue(ambari_sso_details.should_enable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("AMBARI"))
+    self.assertTrue(ambari_sso_details.should_enable_sso("RANGER"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("RANGER"))
 
     services_json = {
       "ambari-server-configuration": {
         "sso-configuration": {
-          "ambari.sso.manage_services" : "true",
-          "ambari.sso.enabled_services" : "*"
+          "ambari.sso.manage_services": "true",
+          "ambari.sso.enabled_services": "*"
         }
       }
     }
 
     ambari_configuration = self.ambari_configuration_class(services_json)
     self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
-    self.assertEquals("*", ambari_configuration.get_ambari_sso_configuration_value("ambari.sso.enabled_services"))
-    self.assertTrue(ambari_configuration.is_managing_services())
-    self.assertTrue(ambari_configuration.should_enable_sso("AMBARI"))
-    self.assertFalse(ambari_configuration.should_disable_sso("AMBARI"))
-    self.assertTrue(ambari_configuration.should_enable_sso("RANGER"))
-    self.assertFalse(ambari_configuration.should_disable_sso("RANGER"))
+
+    ambari_sso_details = ambari_configuration.get_ambari_sso_details()
+    self.assertIsNotNone(ambari_sso_details)
+    self.assertTrue(ambari_sso_details.is_managing_services())
+    self.assertTrue(ambari_sso_details.should_enable_sso("AMBARI"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("AMBARI"))
+    self.assertTrue(ambari_sso_details.should_enable_sso("RANGER"))
+    self.assertFalse(ambari_sso_details.should_disable_sso("RANGER"))
 
   def testAmbariJWTProperties(self):
     services_json = {
-      "ambari-server-properties": {
-        "authentication.jwt.publicKey": "/etc/ambari-server/conf/jwt-cert.pem",
-        "authentication.jwt.enabled": "true",
-        "authentication.jwt.providerUrl": "https://knox.ambari.apache.org",
-        "authentication.jwt.cookieName": "hadoop-jwt",
-        "authentication.jwt.audiences": ""
-      },
       "ambari-server-configuration": {
+        "sso-configuration": {
+          "ambari.sso.provider.certificate": "-----BEGIN CERTIFICATE-----\nMIICVTCCAb6gAwIBAg...2G2Vhj8vTYptEVg==\n-----END CERTIFICATE-----",
+          "ambari.sso.authentication.enabled": "true",
+          "ambari.sso.provider.url": "https://knox.ambari.apache.org",
+          "ambari.sso.jwt.cookieName": "hadoop-jwt",
+          "ambari.sso.jwt.audiences": ""
+        }
       }
     }
 
     ambari_configuration = self.ambari_configuration_class(services_json)
+    self.assertIsNotNone(ambari_configuration.get_ambari_sso_configuration())
+
     ambari_sso_details = ambari_configuration.get_ambari_sso_details()
-    self.assertTrue(ambari_sso_details.is_jwt_enabled())
+    self.assertIsNotNone(ambari_sso_details)
     self.assertEquals('', ambari_sso_details.get_jwt_audiences())
     self.assertEquals('hadoop-jwt', ambari_sso_details.get_jwt_cookie_name())
-    self.assertEquals('https://knox.ambari.apache.org', ambari_sso_details.get_jwt_provider_url())
-    self.assertEquals('/etc/ambari-server/conf/jwt-cert.pem', ambari_sso_details.get_jwt_public_key_file())
-    self.assertIsNone(ambari_sso_details.get_jwt_public_key())  # This is none since the file does not exist for unit tests.
+    self.assertEquals('https://knox.ambari.apache.org', ambari_sso_details.get_sso_provider_url())
+    self.assertEquals('MIICVTCCAb6gAwIBAg...2G2Vhj8vTYptEVg==',
+                      ambari_sso_details.get_sso_provider_certificate())
 
-
-  @patch("os.path.isfile", new=MagicMock(return_value=True))
-  @patch('__builtin__.open')
-  def testReadCertFileWithHeaderAndFooter(self, open_mock):
-    mock_file = MagicFile(
-      '-----BEGIN CERTIFICATE-----\n'
-      'MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD\n'
-      '................................................................\n'
-      'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy\n'
-      '-----END CERTIFICATE-----\n')
-    open_mock.side_effect = [mock_file, mock_file, mock_file, mock_file]
-
+  def testCertWithHeaderAndFooter(self):
     services_json = {
-      "ambari-server-properties": {
-        "authentication.jwt.publicKey": "/etc/ambari-server/conf/jwt-cert.pem",
-        "authentication.jwt.enabled": "true",
-        "authentication.jwt.providerUrl": "https://knox.ambari.apache.org",
-        "authentication.jwt.cookieName": "hadoop-jwt",
-        "authentication.jwt.audiences": ""
-      },
       "ambari-server-configuration": {
+        "sso-configuration": {
+          "ambari.sso.provider.certificate": '-----BEGIN CERTIFICATE-----\n'
+                                             'MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD\n'
+                                             '................................................................\n'
+                                             'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy\n'
+                                             '-----END CERTIFICATE-----\n'
+        }
       }
     }
 
@@ -245,43 +224,33 @@ class TestAmbariConfiguration(TestCase):
                       '................................................................\n'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy\n'
                       '-----END CERTIFICATE-----',
-                      ambari_sso_details.get_jwt_public_key(True, False))
+                      ambari_sso_details.get_sso_provider_certificate(True, False))
 
     self.assertEquals('-----BEGIN CERTIFICATE-----'
                       'MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD'
                       '................................................................'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy'
                       '-----END CERTIFICATE-----',
-                      ambari_sso_details.get_jwt_public_key(True, True))
+                      ambari_sso_details.get_sso_provider_certificate(True, True))
 
     self.assertEquals('MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD\n'
                       '................................................................\n'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy',
-                      ambari_sso_details.get_jwt_public_key(False, False))
+                      ambari_sso_details.get_sso_provider_certificate(False, False))
 
     self.assertEquals('MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD'
                       '................................................................'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy',
-                      ambari_sso_details.get_jwt_public_key(False, True))
+                      ambari_sso_details.get_sso_provider_certificate(False, True))
 
-  @patch("os.path.isfile", new=MagicMock(return_value=True))
-  @patch('__builtin__.open')
-  def testReadCertFileWithoutHeaderAndFooter(self, open_mock):
-    mock_file = MagicFile(
-      'MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD\n'
-      '................................................................\n'
-      'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy\n')
-    open_mock.side_effect = [mock_file, mock_file, mock_file, mock_file]
-
+  def testCertWithoutHeaderAndFooter(self):
     services_json = {
-      "ambari-server-properties": {
-        "authentication.jwt.publicKey": "/etc/ambari-server/conf/jwt-cert.pem",
-        "authentication.jwt.enabled": "true",
-        "authentication.jwt.providerUrl": "https://knox.ambari.apache.org",
-        "authentication.jwt.cookieName": "hadoop-jwt",
-        "authentication.jwt.audiences": ""
-      },
       "ambari-server-configuration": {
+        "sso-configuration": {
+          "ambari.sso.provider.certificate": 'MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD\n'
+                                             '................................................................\n'
+                                             'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy\n',
+        }
       }
     }
 
@@ -293,22 +262,21 @@ class TestAmbariConfiguration(TestCase):
                       '................................................................\n'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy\n'
                       '-----END CERTIFICATE-----',
-                      ambari_sso_details.get_jwt_public_key(True, False))
+                      ambari_sso_details.get_sso_provider_certificate(True, False))
 
     self.assertEquals('-----BEGIN CERTIFICATE-----'
                       'MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD'
                       '................................................................'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy'
                       '-----END CERTIFICATE-----',
-                      ambari_sso_details.get_jwt_public_key(True, True))
+                      ambari_sso_details.get_sso_provider_certificate(True, True))
 
     self.assertEquals('MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD\n'
                       '................................................................\n'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy',
-                      ambari_sso_details.get_jwt_public_key(False, False))
+                      ambari_sso_details.get_sso_provider_certificate(False, False))
 
     self.assertEquals('MIIE3DCCA8SgAwIBAgIJAKfbOMmFyOlNMA0GCSqGSIb3DQEBBQUAMIGkMQswCQYD'
                       '................................................................'
                       'dXRpbmcxFzAVBgNVBAMTDmNsb3VkYnJlYWstcmdsMSUwIwYJKoZIhvcNAQkBFhZy',
-                      ambari_sso_details.get_jwt_public_key(False, True))
-
+                      ambari_sso_details.get_sso_provider_certificate(False, True))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move SSO-related properties from ambari.properties into the Ambari DB so that Ambari is able to use the SSO-related properties without needing to be restarted.

The following properties should be moved:

|Original Name|New Name|
|--------------|-----------|
|authentication.jwt.providerUrl|ambari.sso.provider.url|
|authentication.jwt.publicKey|ambari.sso.provider.publicKey|
|authentication.jwt.originalUrlParamName|ambari.sso.provider.originalUrlParamName|
|authentication.jwt.enabled|ambari.sso.authentication.enabled|
|authentication.jwt.audiences|ambari.sso.jwt.audiences|
|authentication.jwt.cookieName|ambari.sso.jwt.cookieName|

Also updated the ambari-server CLI to read and write to this data set via the Ambari REST API. 

## How was this patch tested?

Manually tested in a fresh and an upgrade cluster.

Updated and ran unit tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.