### PR TITLE
[AMBARI-23521] dfs.journalnode.edits.dir nameservice property being d…

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step3_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step3_controller.js
@@ -115,7 +115,7 @@ App.NameNodeFederationWizardStep3Controller = Em.Controller.extend(App.Blueprint
     var dfsRpcA = hdfsSiteConfigs['dfs.namenode.rpc-address'];
     ret.nnRpcPort = dfsRpcA ? dfsRpcA.split(':')[1] : 8020;
 
-    ret.journalnode_edits_dir = hdfsSiteConfigs['dfs.journalnode.edits.dir'];
+    ret.journalnode_edits_dir = hdfsSiteConfigs['dfs.journalnode.edits.dir.' + ret.nameservice1];
 
     if (App.Service.find().someProperty('serviceName', 'RANGER')) {
       var hdfsRangerConfigs = configsFromServer.findProperty('type', 'ranger-hdfs-security').properties;


### PR DESCRIPTION
…isplayed UNDEFINED

## What changes were proposed in this pull request?
Updated code to access the journalnode.edits property correctly
Issue
<img width="990" alt="screen shot 2018-04-09 at 11 13 52 am" src="https://user-images.githubusercontent.com/12506576/38525264-785c47ee-3c06-11e8-8280-6599edc96eef.png">
After the fix 
![screen shot 2018-04-09 at 2 57 45 pm](https://user-images.githubusercontent.com/12506576/38525334-b570dafa-3c06-11e8-9422-1768f34b4199.png)

## How was this patch tested?
  21529 passing (24s)
  48 pending