### PR TITLE
AMBARI-23525. Customize Services - SNameNodeHost label value is not s…

### DIFF
--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -904,7 +904,7 @@ App.ServiceConfigMasterHostView = Ember.View.extend(App.ServiceConfigHostPopover
   classNames: ['master-host', 'col-md-6'],
   valueBinding: 'serviceConfig.value',
 
-  template: Ember.Handlebars.compile('{{value}}')
+  template: Ember.Handlebars.compile('{{view.value}}')
 
 });
 


### PR DESCRIPTION
…hown in UI under All Configurations -> HDFS -> Advanced Tab

## What changes were proposed in this pull request?
Customize Services - SNameNodeHost label value is not shown in UI under All Configurations -> HDFS -> Advanced Tab

## How was this patch tested?
manually 
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.