### PR TITLE
[AMBARI-23531]. Debian9: Atlas client installation failed due to unsupported OS family error (amagyar)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/__init__.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/__init__.py
@@ -59,14 +59,13 @@ class ManagerFactory(object):
     if not os_family:
       os_family = OSCheck.get_os_family()
 
-    construct_rules = {
-      OSConst.UBUNTU_FAMILY: AptManager,
-      OSConst.DEBIAN_FAMILY: AptManager,
-      OSConst.SUSE_FAMILY: ZypperManager,
-      OSConst.REDHAT_FAMILY: YumManager,
-      OSConst.WINSRV_FAMILY: ChocoManager
-    }
-    if os_family in construct_rules:
-      return construct_rules[os_family]()
+    if OSCheck.is_in_family(os_family, OSConst.UBUNTU_FAMILY):
+      return AptManager()
+    if OSCheck.is_in_family(os_family, OSConst.SUSE_FAMILY):
+      return ZypperManager()
+    if OSCheck.is_in_family(os_family, OSConst.REDHAT_FAMILY):
+      return YumManager()
+    if OSCheck.is_in_family(os_family, OSConst.WINSRV_FAMILY):
+      return ChocoManager()
 
     raise RuntimeError("Not able to create Repository Manager object for unsupported OS family {0}".format(os_family))

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/__init__.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/__init__.py
@@ -61,6 +61,7 @@ class ManagerFactory(object):
 
     construct_rules = {
       OSConst.UBUNTU_FAMILY: AptManager,
+      OSConst.DEBIAN_FAMILY: AptManager,
       OSConst.SUSE_FAMILY: ZypperManager,
       OSConst.REDHAT_FAMILY: YumManager,
       OSConst.WINSRV_FAMILY: ChocoManager

--- a/ambari-server/src/test/python/custom_actions/TestInstallPackages.py
+++ b/ambari-server/src/test/python/custom_actions/TestInstallPackages.py
@@ -1276,3 +1276,10 @@ class TestInstallPackages(RMFTestCase):
       )
 
       self.assertNoMoreResources()
+
+  def test_os_family_check_with_inheritance(self):
+    from ambari_commons.os_check import OSConst
+    from ambari_commons.repo_manager import ManagerFactory
+    self.assertEquals(
+      ManagerFactory.get_new_instance(OSConst.DEBIAN_FAMILY).__class__,
+      ManagerFactory.get_new_instance(OSConst.UBUNTU_FAMILY).__class__)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Package installation on debian failed "Not able to create Repository Manager object for unsupported OS family" error.

## How was this patch tested?

Installed HDP on debian.