### PR TITLE
AMBARI-23142 - ADDENDUM Add AMS Metrics publisher to Infra Solr

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-infra-solr-collections.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-infra-solr-collections.json
@@ -1,7 +1,7 @@
 {
-  "id": 49,
-  "title": "Infra Solr Cores",
-  "originalTitle": "Infra Solr Cores",
+  "id": 46,
+  "title": "Infra Solr Collections",
+  "originalTitle": "Infra Solr Collections",
   "tags": [
     "builtin",
     "2.7.0",
@@ -67,12 +67,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.INDEX.sizeInBytes",
+              "metric": "infra.solr.core.*.%.INDEX.sizeInBytes",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.INDEX.sizeInBytes",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.INDEX.sizeInBytes",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.INDEX.sizeInBytes",
+              "seriesAggregator": "sum",
               "transform": "none"
             }
           ],
@@ -140,12 +142,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE.updateHandler.adds",
+              "metric": "infra.solr.core.*.%.UPDATE.updateHandler.adds",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE.updateHandler.adds",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE.updateHandler.adds",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE.updateHandler.adds",
+              "seriesAggregator": "sum",
               "transform": "none"
             }
           ],
@@ -213,12 +217,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE.updateHandler.deletesById",
+              "metric": "infra.solr.core.*.%.UPDATE.updateHandler.deletesById",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE.updateHandler.deletesById",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE.updateHandler.deletesById",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE.updateHandler.deletesById",
+              "seriesAggregator": "sum",
               "transform": "none"
             },
             {
@@ -227,12 +233,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE.updateHandler.deletesByQuery",
+              "metric": "infra.solr.core.*.%.UPDATE.updateHandler.deletesByQuery",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE.updateHandler.deletesByQuery",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE.updateHandler.deletesByQuery",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE.updateHandler.deletesByQuery",
+              "seriesAggregator": "sum",
               "transform": "none"
             }
           ],
@@ -300,12 +308,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE.updateHandler.errors",
+              "metric": "infra.solr.core.*.%.UPDATE.updateHandler.errors",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE.updateHandler.errors",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE.updateHandler.errors",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE.updateHandler.errors",
+              "seriesAggregator": "sum",
               "transform": "none"
             }
           ],
@@ -373,12 +383,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE.updateHandler.docsPending",
+              "metric": "infra.solr.core.*.%.UPDATE.updateHandler.docsPending",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE.updateHandler.docsPending",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE.updateHandler.docsPending",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE.updateHandler.docsPending",
+              "seriesAggregator": "sum",
               "transform": "none"
             }
           ],
@@ -446,12 +458,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./select.requestTimes.avgRequestsPerSecond",
+              "metric": "infra.solr.core.*.%.QUERY./select.requestTimes.avgRequestsPerSecond",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./select.requestTimes.avgRequestsPerSecond",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./select.requestTimes.avgRequestsPerSecond",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./select.requestTimes.avgRequestsPerSecond",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -519,12 +533,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./select.requestTimes.avgTimePerRequest",
+              "metric": "infra.solr.core.*.%.QUERY./select.requestTimes.avgTimePerRequest",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./select.requestTimes.avgTimePerRequest",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./select.requestTimes.avgTimePerRequest",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./select.requestTimes.avgTimePerRequest",
+              "seriesAggregator": "avg",
               "transform": "none"
             },
             {
@@ -533,12 +549,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./select.requestTimes.medianRequestTime",
+              "metric": "infra.solr.core.*.%.QUERY./select.requestTimes.medianRequestTime",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./select.requestTimes.medianRequestTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./select.requestTimes.medianRequestTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./select.requestTimes.medianRequestTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -554,7 +572,7 @@
           "y-axis": true,
           "y_formats": [
             "ns",
-            "short"
+            "none"
           ]
         },
         {
@@ -606,12 +624,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE./update.requestTimes.avgRequestsPerSecond",
+              "metric": "infra.solr.core.*.%.UPDATE./update.requestTimes.avgRequestsPerSecond",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE./update.requestTimes.avgRequestsPerSecond",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE./update.requestTimes.avgRequestsPerSecond",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE./update.requestTimes.avgRequestsPerSecond",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -679,12 +699,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE./update.requestTimes.avgTimePerRequest",
+              "metric": "infra.solr.core.*.%.UPDATE./update.requestTimes.avgTimePerRequest",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE./update.requestTimes.avgTimePerRequest",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE./update.requestTimes.avgTimePerRequest",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE./update.requestTimes.avgTimePerRequest",
+              "seriesAggregator": "avg",
               "transform": "none"
             },
             {
@@ -693,12 +715,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.UPDATE./update.requestTimes.medianRequestTime",
+              "metric": "infra.solr.core.*.%.UPDATE./update.requestTimes.medianRequestTime",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.UPDATE./update.requestTimes.medianRequestTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.UPDATE./update.requestTimes.medianRequestTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.UPDATE./update.requestTimes.medianRequestTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -714,7 +738,7 @@
           "y-axis": true,
           "y_formats": [
             "ns",
-            "short"
+            "none"
           ]
         },
         {
@@ -766,12 +790,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./get.requestTimes.avgRequestsPerSecond",
+              "metric": "infra.solr.core.*.%.QUERY./get.requestTimes.avgRequestsPerSecond",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./get.requestTimes.avgRequestsPerSecond",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./get.requestTimes.avgRequestsPerSecond",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./get.requestTimes.avgRequestsPerSecond",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -839,12 +865,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./get.requestTimes.avgTimePerRequest",
+              "metric": "infra.solr.core.*.%.QUERY./get.requestTimes.avgTimePerRequest",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./get.requestTimes.avgTimePerRequest",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./get.requestTimes.avgTimePerRequest",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./get.requestTimes.avgTimePerRequest",
+              "seriesAggregator": "avg",
               "transform": "none"
             },
             {
@@ -853,12 +881,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./get.requestTimes.medianRequestTime",
+              "metric": "infra.solr.core.*.%.QUERY./get.requestTimes.medianRequestTime",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./get.requestTimes.medianRequestTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./get.requestTimes.medianRequestTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./get.requestTimes.medianRequestTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -874,7 +904,7 @@
           "y-axis": true,
           "y_formats": [
             "ns",
-            "short"
+            "none"
           ]
         },
         {
@@ -928,12 +958,14 @@
               "downsampleAggregator": "avg",
               "errors": {},
               "hosts": "",
-              "metric": "infra.solr.core.*.ADMIN./admin/luke.requestTimes.avgRequestsPerSecond",
+              "metric": "infra.solr.core.*.%.ADMIN./admin/luke.requestTimes.avgRequestsPerSecond",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.ADMIN./admin/luke.requestTimes.avgRequestsPerSecond",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.ADMIN./admin/luke.requestTimes.avgRequestsPerSecond",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.ADMIN./admin/luke.requestTimes.avgRequestsPerSecond",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -996,31 +1028,35 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "average time per request",
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.ADMIN./admin/luke.requestTimes.avgTimePerRequest",
+              "metric": "infra.solr.core.*.%.ADMIN./admin/luke.requestTimes.avgTimePerRequest",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.ADMIN./admin/luke.requestTimes.avgTimePerRequest",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.ADMIN./admin/luke.requestTimes.avgTimePerRequest",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.ADMIN./admin/luke.requestTimes.avgTimePerRequest",
+              "seriesAggregator": "avg",
               "transform": "none"
             },
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "median request time",
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.ADMIN./admin/luke.requestTimes.medianRequestTime",
+              "metric": "infra.solr.core.*.%.ADMIN./admin/luke.requestTimes.medianRequestTime",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.ADMIN./admin/luke.requestTimes.medianRequestTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.ADMIN./admin/luke.requestTimes.medianRequestTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.ADMIN./admin/luke.requestTimes.medianRequestTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1036,7 +1072,7 @@
           "y-axis": true,
           "y_formats": [
             "ns",
-            "short"
+            "none"
           ]
         },
         {
@@ -1088,12 +1124,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.QUERY./get.requestTimes.avgRequestsPerSecond",
+              "metric": "infra.solr.core.*.%.QUERY./get.requestTimes.avgRequestsPerSecond",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./get.requestTimes.avgRequestsPerSecond",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.QUERY./get.requestTimes.avgRequestsPerSecond",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./get.requestTimes.avgRequestsPerSecond",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1164,8 +1202,10 @@
               "metric": "infra.solr.core.*.QUERY./get.requestTimes.avgTimePerRequest",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./get.requestTimes.avgTimePerRequest",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.QUERY./get.requestTimes.avgTimePerRequest",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./get.requestTimes.avgTimePerRequest",
               "seriesAggregator": "none",
               "transform": "none"
             },
@@ -1178,8 +1218,10 @@
               "metric": "infra.solr.core.*.QUERY./get.requestTimes.medianRequestTime",
               "precision": "default",
               "refId": "B",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.QUERY./get.requestTimes.medianRequestTime",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.QUERY./get.requestTimes.medianRequestTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.QUERY./get.requestTimes.medianRequestTime",
               "seriesAggregator": "none",
               "transform": "none"
             }
@@ -1196,7 +1238,7 @@
           "y-axis": true,
           "y_formats": [
             "ns",
-            "short"
+            "none"
           ]
         }
       ],
@@ -1257,12 +1299,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.filterCache.hitratio",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.filterCache.hitratio",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.filterCache.hitratio",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.filterCache.hitratio",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.filterCache.hitratio",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1330,12 +1374,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.filterCache.size",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.filterCache.size",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.filterCache.size",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.filterCache.size",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.filterCache.size",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1403,12 +1449,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.documentCache.warmupTime",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.documentCache.warmupTime",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.documentCache.warmupTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.documentCache.warmupTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.documentCache.warmupTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1476,12 +1524,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.documentCache.hitratio",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.documentCache.hitratio",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.documentCache.hitratio",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.documentCache.hitratio",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.documentCache.hitratio",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1549,12 +1599,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.documentCache.size",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.documentCache.size",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.documentCache.size",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.documentCache.size",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.documentCache.size",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1624,12 +1676,14 @@
               "downsampleAggregator": "avg",
               "errors": {},
               "hosts": "",
-              "metric": "infra.solr.core.*.CACHE.searcher.documentCache.warmupTime",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.documentCache.warmupTime",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.documentCache.warmupTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.documentCache.warmupTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.documentCache.warmupTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1697,12 +1751,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.queryResultCache.hitratio",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.queryResultCache.hitratio",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.queryResultCache.hitratio",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.queryResultCache.hitratio",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.queryResultCache.hitratio",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1770,12 +1826,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.queryResultCache.size",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.queryResultCache.size",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.queryResultCache.size",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.queryResultCache.size",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.queryResultCache.size",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1843,12 +1901,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.searcher.queryResultCache.warmupTime",
+              "metric": "infra.solr.core.*.%.CACHE.searcher.queryResultCache.warmupTime",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.searcher.queryResultCache.warmupTime",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.searcher.queryResultCache.warmupTime",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.searcher.queryResultCache.warmupTime",
+              "seriesAggregator": "avg",
               "transform": "none"
             }
           ],
@@ -1916,12 +1976,14 @@
               "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "infra.solr.core.*.CACHE.core.fieldCache.entries_count",
+              "metric": "infra.solr.core.*.%.CACHE.core.fieldCache.entries_count",
               "precision": "default",
               "refId": "A",
-              "sCore": "history.shard1.replica_n1",
-              "sCoreMetric": "infra.solr.core.history.shard1.replica_n1.CACHE.core.fieldCache.entries_count",
-              "seriesAggregator": "none",
+              "sCollection": "hadoop_logs",
+              "sCollectionMetric": "infra.solr.core.hadoop_logs.%.CACHE.core.fieldCache.entries_count",
+              "sCore": "audit_logs.shard0.replica_n1",
+              "sCoreMetric": "infra.solr.core.audit_logs.shard0.replica_n1.CACHE.core.fieldCache.entries_count",
+              "seriesAggregator": "sum",
               "transform": "none"
             }
           ],
@@ -1980,124 +2042,37 @@
       {
         "allFormat": "glob",
         "current": {
-          "tags": [],
-          "text": "All",
-          "value": "{audit_logs.ADMIN./admin/luke,audit_logs.CACHE.core,audit_logs.CACHE.searcher,audit_logs.INDEX.sizeInBytes,audit_logs.QUERY./get,audit_logs.QUERY./select,audit_logs.UPDATE./update,audit_logs.UPDATE.updateHandler,audit_logs.shard0.replica_n1,audit_logs.shard1.replica_n2,audit_logs.shard2.replica_n4,audit_logs.shard3.replica_n6,audit_logs.shard4.replica_n7,hadoop_logs.QUERY./get,hadoop_logs.shard0.replica_n1,hadoop_logs.shard1.replica_n2,hadoop_logs.shard2.replica_n4,hadoop_logs.shard3.replica_n6,hadoop_logs.shard4.replica_n8,history.shard1.replica_n1}"
+          "text": "hadoop_logs",
+          "value": "hadoop_logs"
         },
         "datasource": null,
         "includeAll": true,
-        "label": "",
         "multi": true,
         "multiFormat": "glob",
-        "name": "Cores",
+        "name": "Collections",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "All",
-            "value": "{audit_logs.ADMIN./admin/luke,audit_logs.CACHE.core,audit_logs.CACHE.searcher,audit_logs.INDEX.sizeInBytes,audit_logs.QUERY./get,audit_logs.QUERY./select,audit_logs.UPDATE./update,audit_logs.UPDATE.updateHandler,audit_logs.shard0.replica_n1,audit_logs.shard1.replica_n2,audit_logs.shard2.replica_n4,audit_logs.shard3.replica_n6,audit_logs.shard4.replica_n7,hadoop_logs.QUERY./get,hadoop_logs.shard0.replica_n1,hadoop_logs.shard1.replica_n2,hadoop_logs.shard2.replica_n4,hadoop_logs.shard3.replica_n6,hadoop_logs.shard4.replica_n8,history.shard1.replica_n1}"
+            "value": "{audit_logs,hadoop_logs,history}"
           },
           {
             "selected": false,
-            "text": "audit_logs.ADMIN./admin/luke",
-            "value": "audit_logs.ADMIN./admin/luke"
+            "text": "audit_logs",
+            "value": "audit_logs"
+          },
+          {
+            "selected": true,
+            "text": "hadoop_logs",
+            "value": "hadoop_logs"
           },
           {
             "selected": false,
-            "text": "audit_logs.CACHE.core",
-            "value": "audit_logs.CACHE.core"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.CACHE.searcher",
-            "value": "audit_logs.CACHE.searcher"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.INDEX.sizeInBytes",
-            "value": "audit_logs.INDEX.sizeInBytes"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.QUERY./get",
-            "value": "audit_logs.QUERY./get"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.QUERY./select",
-            "value": "audit_logs.QUERY./select"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.UPDATE./update",
-            "value": "audit_logs.UPDATE./update"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.UPDATE.updateHandler",
-            "value": "audit_logs.UPDATE.updateHandler"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.shard0.replica_n1",
-            "value": "audit_logs.shard0.replica_n1"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.shard1.replica_n2",
-            "value": "audit_logs.shard1.replica_n2"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.shard2.replica_n4",
-            "value": "audit_logs.shard2.replica_n4"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.shard3.replica_n6",
-            "value": "audit_logs.shard3.replica_n6"
-          },
-          {
-            "selected": false,
-            "text": "audit_logs.shard4.replica_n7",
-            "value": "audit_logs.shard4.replica_n7"
-          },
-          {
-            "selected": false,
-            "text": "hadoop_logs.QUERY./get",
-            "value": "hadoop_logs.QUERY./get"
-          },
-          {
-            "selected": false,
-            "text": "hadoop_logs.shard0.replica_n1",
-            "value": "hadoop_logs.shard0.replica_n1"
-          },
-          {
-            "selected": false,
-            "text": "hadoop_logs.shard1.replica_n2",
-            "value": "hadoop_logs.shard1.replica_n2"
-          },
-          {
-            "selected": false,
-            "text": "hadoop_logs.shard2.replica_n4",
-            "value": "hadoop_logs.shard2.replica_n4"
-          },
-          {
-            "selected": false,
-            "text": "hadoop_logs.shard3.replica_n6",
-            "value": "hadoop_logs.shard3.replica_n6"
-          },
-          {
-            "selected": false,
-            "text": "hadoop_logs.shard4.replica_n8",
-            "value": "hadoop_logs.shard4.replica_n8"
-          },
-          {
-            "selected": false,
-            "text": "history.shard1.replica_n1",
-            "value": "history.shard1.replica_n1"
+            "text": "history",
+            "value": "history"
           }
         ],
-        "query": "infra_solr_core",
+        "query": "infra_solr_collection",
         "refresh": true,
         "type": "query"
       }
@@ -2108,6 +2083,6 @@
   },
   "refresh": false,
   "schemaVersion": 8,
-  "version": 9,
+  "version": 56,
   "links": []
 }

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-infra-solr-hosts.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-infra-solr-hosts.json
@@ -1,5 +1,5 @@
 {
-  "id": 45,
+  "id": 47,
   "title": "Infra Solr Host",
   "originalTitle": "Infra Solr Host",
   "tags": [
@@ -46,7 +46,7 @@
             "max": true,
             "min": false,
             "rightSide": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -79,25 +79,11 @@
               "templatedCluster": "",
               "templatedHost": "%",
               "transform": "none"
-            },
-            {
-              "aggregator": "none",
-              "alias": "OS CPU utilization",
-              "app": "ambari-infra-solr",
-              "downsampleAggregator": "avg",
-              "errors": {},
-              "metric": "infra.solr.jvm.os.systemCpuLoad",
-              "precision": "default",
-              "refId": "B",
-              "seriesAggregator": "none",
-              "templatedCluster": "",
-              "templatedHost": "%",
-              "transform": "none"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Infra Solr CPU Utilization",
+          "title": "Infra Solr Process CPU Utilization",
           "tooltip": {
             "shared": true,
             "value_type": "cumulative"
@@ -129,6 +115,78 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 13,
+          "isNew": true,
+          "legend": {
+            "avg": true,
+            "current": false,
+            "max": true,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "avg",
+              "alias": "OS CPU utilization",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "infra.solr.jvm.os.systemCpuLoad",
+              "precision": "default",
+              "refId": "A",
+              "seriesAggregator": "none",
+              "templatedCluster": "",
+              "templatedHost": "%",
+              "transform": "none"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Infra Solr OS CPU Utilization",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "percent",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 2,
           "isNew": true,
           "legend": {
@@ -136,7 +194,7 @@
             "current": false,
             "max": true,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -166,16 +224,74 @@
               "templatedCluster": "",
               "templatedHost": "%",
               "transform": "none"
-            },
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Infra Solr Heap Memory Utilization",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "bytes",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 14,
+          "isNew": true,
+          "legend": {
+            "avg": true,
+            "current": false,
+            "max": true,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-              "aggregator": "none",
+              "aggregator": "avg",
               "alias": "Non-Heap memory",
-              "app": "ambari-infra-solr",
               "downsampleAggregator": "avg",
               "errors": {},
               "metric": "infra.solr.jvm.memory.non-heap.used",
               "precision": "default",
-              "refId": "B",
+              "refId": "A",
               "seriesAggregator": "none",
               "templatedCluster": "",
               "templatedHost": "%",
@@ -184,7 +300,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Infra Solr Memory Utilization",
+          "title": "Infra Solr Non-Heap Memory Utilization",
           "tooltip": {
             "shared": true,
             "value_type": "cumulative"
@@ -232,7 +348,7 @@
             "current": true,
             "max": true,
             "min": true,
-            "show": true,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -307,6 +423,88 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 8,
+          "isNew": true,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "aggregator": "avg",
+              "alias": "Open file descriptors",
+              "app": "ambari-infra-solr",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "infra.solr.jvm.os.openFileDescriptorCount",
+              "precision": "default",
+              "refId": "A",
+              "seriesAggregator": "none",
+              "templatedCluster": "",
+              "templatedHost": "%",
+              "transform": "none"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Open File Descriptors",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "FILE DESCRIPTORS"
+    },
+    {
+      "collapse": true,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 4,
           "isNew": true,
           "legend": {
@@ -314,7 +512,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -387,7 +585,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -460,7 +658,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -533,7 +731,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -585,7 +783,7 @@
       "title": "JVM - CMS GC STATS"
     },
     {
-      "collapse": false,
+      "collapse": true,
       "editable": true,
       "height": "250px",
       "panels": [
@@ -615,7 +813,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -688,7 +886,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -761,7 +959,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -834,7 +1032,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -886,92 +1084,10 @@
       ],
       "showTitle": true,
       "title": "JVM - G1 GC STATS"
-    },
-    {
-      "collapse": false,
-      "editable": true,
-      "height": "250px",
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "leftLogBase": 1,
-            "leftMax": null,
-            "leftMin": null,
-            "rightLogBase": 1,
-            "rightMax": null,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 8,
-          "isNew": true,
-          "legend": {
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "aggregator": "avg",
-              "alias": "Open file descriptors",
-              "app": "ambari-infra-solr",
-              "downsampleAggregator": "avg",
-              "errors": {},
-              "metric": "infra.solr.jvm.os.openFileDescriptorCount",
-              "precision": "default",
-              "refId": "A",
-              "seriesAggregator": "none",
-              "templatedCluster": "",
-              "templatedHost": "%",
-              "transform": "none"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Open File Descriptors",
-          "tooltip": {
-            "shared": true,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "short"
-          ]
-        }
-      ],
-      "showTitle": true,
-      "title": "FILE DESCRIPTORS"
     }
   ],
   "time": {
-    "from": "now-3h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -1028,7 +1144,7 @@
         "allFormat": "glob",
         "current": {
           "text": "All",
-          "value": "{solr}"
+          "value": "{kkasa-infra-solr-demo-1.c.pramod-thangali.internal,kkasa-infra-solr-demo-2.c.pramod-thangali.internal}"
         },
         "datasource": null,
         "includeAll": true,
@@ -1038,14 +1154,19 @@
         "name": "hosts",
         "options": [
           {
+            "selected": true,
             "text": "All",
-            "value": "{solr}",
-            "selected": true
+            "value": "{kkasa-infra-solr-demo-1.c.pramod-thangali.internal,kkasa-infra-solr-demo-2.c.pramod-thangali.internal}"
           },
           {
-            "text": "solr",
-            "value": "solr",
-            "selected": false
+            "selected": false,
+            "text": "kkasa-infra-solr-demo-1.c.pramod-thangali.internal",
+            "value": "kkasa-infra-solr-demo-1.c.pramod-thangali.internal"
+          },
+          {
+            "selected": false,
+            "text": "kkasa-infra-solr-demo-2.c.pramod-thangali.internal",
+            "value": "kkasa-infra-solr-demo-2.c.pramod-thangali.internal"
           }
         ],
         "query": "hosts.$cluster",
@@ -1058,6 +1179,6 @@
     "list": []
   },
   "schemaVersion": 8,
-  "version": 17,
+  "version": 23,
   "links": []
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove legends from graphs on Infra Solr Grafana Dashboards
- Change the order of graphs: gc related graphs moved to the bottom of the page
- All GC related graphs are hidden by default
- Added Infra Solr Collection dashboard: graphs on Infra Solr Collection are the same as Infra Solr Core but metrics values collected from all shards are grouped by collection name
- Remove request handler counter graphs

## How was this patch tested?

manually using gce vm environment

Please review:
@swagle @oleewere @avijayanhwx 