### PR TITLE
[AMBARI-23544] NameNode namespaces aren't displayed after HDFS page refresh

### DIFF
--- a/ambari-web/app/mixins/main/dashboard/widgets/namenode_widget.js
+++ b/ambari-web/app/mixins/main/dashboard/widgets/namenode_widget.js
@@ -31,7 +31,7 @@ App.NameNodeWidgetMixin = Em.Mixin.create({
   clusterId: Em.computed.alias('componentGroup.clusterId'),
 
   hostName: function () {
-    const allHostNames = this.get('componentGroup.hosts'),
+    const allHostNames = this.get('componentGroup.hosts') || [],
       hostComponents = App.HostComponent.find().filter(component => {
         return component.get('componentName') === 'NAMENODE' && allHostNames.contains(component.get('hostName'));
       }),

--- a/ambari-web/app/models/service/hdfs.js
+++ b/ambari-web/app/models/service/hdfs.js
@@ -120,7 +120,7 @@ App.HDFSService = App.Service.extend({
       }
     });
     return result;
-  }.property('hostComponents.length')
+  }.property('hostComponents.length', 'App.router.clusterController.isHDFSNameSpacesLoaded')
 });
 
 App.HDFSService.FIXTURES = [];

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -166,7 +166,7 @@ App.MainServiceInfoSummaryView = Em.View.extend({
     var self = this;
     if (!this.get('service') || this.get('service.deleteInProgress')) return;
     Em.run.once(self, 'setComponentsContent');
-  }.observes('service.hostComponents.length', 'service.slaveComponents.@each.totalCount', 'service.clientComponents.@each.totalCount'),
+  }.observes('service.hostComponents.length', 'service.slaveComponents.@each.totalCount', 'service.clientComponents.@each.totalCount', 'svc.masterComponentGroups.length'),
 
   loadServiceSummary: function () {
     var serviceName = this.get('serviceName');
@@ -214,12 +214,13 @@ App.MainServiceInfoSummaryView = Em.View.extend({
       if (Em.isNone(this.get('service'))) {
         return;
       }
-      var masters = this.get('service.hostComponents').filterProperty('isMaster');
-      var slaves = this.get('service.slaveComponents').toArray();
-      var clients = this.get('service.clientComponents').toArray();
+      const masters = this.get('service.hostComponents').filterProperty('isMaster'),
+        slaves = this.get('service.slaveComponents').toArray(),
+        clients = this.get('service.clientComponents').toArray(),
+        masterGroups = this.get('svc') ? this.get('svc.masterComponentGroups').toArray() : [];
 
-      if (this.get('mastersLength') !== masters.length) {
-        const mastersInit = this.get('mastersObj').mapProperty('components').reduce((acc, group) => {
+      if (this.get('mastersLength') !== masters.length || this.get('mastersObj.length') !== masterGroups.length) {
+        let mastersInit = this.get('mastersObj').mapProperty('components').reduce((acc, group) => {
           return [...acc, ...group];
         }, []);
         this.updateComponentList(mastersInit, masters);
@@ -286,8 +287,8 @@ App.MainServiceInfoSummaryView = Em.View.extend({
   service: null,
 
   svc: function () {
-    var svc = this.get('controller.content');
-    var svcName = svc.get('serviceName');
+    let svc = this.get('controller.content');
+    const svcName = svc ? svc.get('serviceName') : null;
     if (svcName) {
       switch (svcName.toLowerCase()) {
         case 'hdfs':


### PR DESCRIPTION
## What changes were proposed in this pull request?

*STR*
1. Enable NameNode federation
2. Go to HDFS section (summary or any other tab)
3. Refresh page

*Expected result*
Namespaces data is displayed (sections on summary page, items of Service actions dropdown)

*Actual result*
- No namespaces data is displayed
- Service actions dropdown is empty
- JS error thrown: {{app.js:68529 Uncaught TypeError: Cannot read property 'contains' of undefined}}

## How was this patch tested?

UI unit tests:
  21529 passing (22s)
  48 pending