### PR TITLE
[AMBARI-23550] Ambari Metrics references outdated jars

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -34,9 +34,9 @@
     <!-- Needed for generating FindBugs warnings using parent pom -->
     <!--<yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>-->
     <protobuf.version>2.5.0</protobuf.version>
-    <hadoop.version>3.0.0.3.0.0.2-97</hadoop.version>
-    <phoenix.version>5.0.0.3.0.0.2-97</phoenix.version>
-    <hbase.version>2.0.0.3.0.0.2-97</hbase.version>
+    <hadoop.version>3.0.0.3.0.0.0-1181</hadoop.version>
+    <phoenix.version>5.0.0.3.0.0.0-1181</phoenix.version>
+    <hbase.version>2.0.0.3.0.0.0-1181</hbase.version>
   </properties>
 
   <build>

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/AbstractMiniHBaseClusterTest.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/AbstractMiniHBaseClusterTest.java
@@ -40,6 +40,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.IntegrationTestingUtility;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
@@ -156,7 +157,7 @@ public abstract class AbstractMiniHBaseClusterTest extends BaseTest {
       Boolean.FALSE.toString());
     props.put("java.security.krb5.realm", "");
     props.put("java.security.krb5.kdc", "");
-    props.put("hbase.regionserver.port", String.valueOf(HBaseTestingUtility.randomFreePort()));
+    props.put(HConstants.REGIONSERVER_PORT, String.valueOf(HBaseTestingUtility.randomFreePort()));
     return props;
   }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/AbstractMiniHBaseClusterTest.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/AbstractMiniHBaseClusterTest.java
@@ -39,9 +39,9 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.IntegrationTestingUtility;
 import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.aggregators.AggregatorUtils;
@@ -156,6 +156,7 @@ public abstract class AbstractMiniHBaseClusterTest extends BaseTest {
       Boolean.FALSE.toString());
     props.put("java.security.krb5.realm", "");
     props.put("java.security.krb5.kdc", "");
+    props.put("hbase.regionserver.port", String.valueOf(HBaseTestingUtility.randomFreePort()));
     return props;
   }
 

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -40,14 +40,14 @@
     <python.ver>python &gt;= 2.6</python.ver>
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>
     <!--TODO change to HDP URL-->
-    <hbase.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.2-97/tars/hbase/hbase-2.0.0.3.0.0.2-97-bin.tar.gz</hbase.tar>
-    <hbase.folder>hbase-2.0.0.3.0.0.2-97</hbase.folder>
-    <hadoop.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.2-97/tars/hadoop/hadoop-3.0.0.3.0.0.2-97.tar.gz</hadoop.tar>
-    <hadoop.folder>hadoop-3.0.0.3.0.0.2-97</hadoop.folder>
+    <hbase.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1181/tars/hbase/hbase-2.0.0.3.0.0.0-1181-bin.tar.gz</hbase.tar>
+    <hbase.folder>hbase-2.0.0.3.0.0.0-1181</hbase.folder>
+    <hadoop.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1181/tars/hadoop/hadoop-3.0.0.3.0.0.0-1181.tar.gz</hadoop.tar>
+    <hadoop.folder>hadoop-3.0.0.3.0.0.0-1181</hadoop.folder>
     <grafana.folder>grafana-2.6.0</grafana.folder>
     <grafana.tar>https://grafanarel.s3.amazonaws.com/builds/grafana-2.6.0.linux-x64.tar.gz</grafana.tar>
-    <phoenix.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.2-97/tars/phoenix/phoenix-5.0.0.3.0.0.2-97.tar.gz</phoenix.tar>
-    <phoenix.folder>phoenix-5.0.0.3.0.0.2-97</phoenix.folder>
+    <phoenix.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1181/tars/phoenix/phoenix-5.0.0.3.0.0.0-1181.tar.gz</phoenix.tar>
+    <phoenix.folder>phoenix-5.0.0.3.0.0.0-1181</phoenix.folder>
     <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
     <powermock.version>1.6.2</powermock.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update `hadoop.version`, etc. to reference more recent builds.

https://issues.apache.org/jira/browse/AMBARI-23550

## How was this patch tested?

```
$ cd ambari-metrics && mvn -DskipTests -Drat.skip clean package
...
[INFO] Reactor Summary:
[INFO]
[INFO] ambari-utility ..................................... SUCCESS [  3.038 s]
[INFO] ambari-metrics ..................................... SUCCESS [  0.331 s]
[INFO] Ambari Metrics Common .............................. SUCCESS [  8.219 s]
[INFO] Ambari Metrics Hadoop Sink ......................... SUCCESS [  5.450 s]
[INFO] Ambari Metrics Flume Sink .......................... SUCCESS [  3.440 s]
[INFO] Ambari Metrics Kafka Sink .......................... SUCCESS [  3.606 s]
[INFO] Ambari Metrics Storm Sink .......................... SUCCESS [  3.356 s]
[INFO] Ambari Metrics Storm Sink (Legacy) ................. SUCCESS [  2.761 s]
[INFO] Ambari Metrics Collector ........................... SUCCESS [15:56 min]
[INFO] Ambari Metrics Monitor ............................. SUCCESS [  2.596 s]
[INFO] Ambari Metrics Grafana ............................. SUCCESS [ 46.394 s]
[INFO] Ambari Metrics Host Aggregator ..................... SUCCESS [ 10.882 s]
[INFO] Ambari Metrics Assembly ............................ SUCCESS [06:49 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```