### PR TITLE
AMBARI-23551. Disable system out for Logfeeder log (logfeeder.out)

### DIFF
--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/logfeeder-log4j.xml.j2
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/logfeeder-log4j.xml.j2
@@ -47,25 +47,24 @@ limitations under the License.
   <!-- Logs to suppress BEGIN -->
   <category name="org.apache.solr.common.cloud.ZkStateReader" additivity="false">
     <priority value="error" />
-    <appender-ref ref="daily_rolling_file" />
+    <appender-ref ref="rolling_file" />
   </category>
 
   <category name="apache.solr.client.solrj.impl.CloudSolrClient" additivity="false">
     <priority value="fatal" />
-    <appender-ref ref="daily_rolling_file" />
+    <appender-ref ref="rolling_file" />
   </category>
   <!-- Logs to suppress END -->
 
   <category name="org.apache.ambari.logfeeder" additivity="false">
     <priority value="INFO" />
-    <appender-ref ref="console" />
-    <!-- <appender-ref ref="daily_rolling_file" /> -->
+    <!-- <appender-ref ref="console" /> -->
+    <appender-ref ref="rolling_file" />
     <appender-ref ref="rolling_file_json"/>
   </category>
 
   <root>
     <priority value="warn"/>
     <!-- <appender-ref ref="rolling_file"/> -->
-    <!-- <appender-ref ref="daily_rolling_file" /> -->
   </root>
 </log4j:configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
logfeeder.out file is not rotated, but we do not even need it. we can disable sysout console appender by default. (but keep appender there in a comment)

Also fix some bad references in the log4j file

## How was this patch tested?
UTs: not needed
FT: manually change the config and use these values.

please review @swagle @adoroszlai @zeroflag @kasakrisz 