### PR TITLE
[AMBARI-23441] Escape column name `key` (reserved word)

### DIFF
--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -1086,7 +1086,7 @@ CREATE TABLE upgrade_plan_config (
   id BIGINT NOT NULL,
   upgrade_plan_detail_id BIGINT NOT NULL,
   config_type VARCHAR(255) NOT NULL,
-  key VARCHAR(255) NOT NULL,
+  `key` VARCHAR(255) NOT NULL,
   new_value LONGTEXT,
   remove SMALLINT DEFAULT 0 NOT NULL,
   CONSTRAINT PK_upgrade_plan_config PRIMARY KEY (id),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Escape the column name `key` in `upgrade_plan_config`.  This is required since `key` is a [reserved word](https://dev.mysql.com/doc/refman/5.5/en/keywords.html#keywords-5-5-detailed-K) in MySQL.  Fixes:

```
ERROR 1064 (42000) at line 1085: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'VARCHAR(255) NOT NULL,
  new_value LONGTEXT,
```

## How was this patch tested?

Tested schema creation on MySQL 5.7:

```
$ docker run -it --rm --name mysql \
  --env 'MYSQL_ALLOW_EMPTY_PASSWORD=true' --env 'MYSQL_DATABASE=ambari' \
  -v $PWD/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql:/docker-entrypoint-initdb.d/ambari.sql \
  mysql:5.7
...
/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/ambari.sql
...
MySQL init process done. Ready for start up.
...
2018-04-12T09:29:37.465347Z 0 [Note] mysqld: ready for connections.
```

Verified that `upgrade_plan_config` has the expected columns.

```
$ docker run -it --link mysql --rm mysql:5.7 sh -c 'exec mysql \
  -h"$MYSQL_PORT_3306_TCP_ADDR" -P"$MYSQL_PORT_3306_TCP_PORT" -uroot ambari'
...
mysql> desc upgrade_plan_config;
+------------------------+--------------+------+-----+---------+-------+
| Field                  | Type         | Null | Key | Default | Extra |
+------------------------+--------------+------+-----+---------+-------+
| id                     | bigint(20)   | NO   | PRI | NULL    |       |
| upgrade_plan_detail_id | bigint(20)   | NO   | MUL | NULL    |       |
| config_type            | varchar(255) | NO   |     | NULL    |       |
| key                    | varchar(255) | NO   |     | NULL    |       |
| new_value              | longtext     | YES  |     | NULL    |       |
| remove                 | smallint(6)  | NO   |     | 0       |       |
+------------------------+--------------+------+-----+---------+-------+
6 rows in set (0.00 sec)
```

<!-- [skip ci] since this is not covered by any tests. -->