### PR TITLE
[AMBARI-23554] NN federation: switching namespaces for dashboard widgets doesn't work

### DIFF
--- a/ambari-web/app/templates/main/dashboard/widgets.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets.hbs
@@ -102,8 +102,10 @@
               {{#each groupLayout in group.allWidgets}}
                 {{#if groupLayout.isActive}}
                   {{#each widget in groupLayout.widgets}}
-                    {{#if widget.isVisible}}
-                      {{view widget.viewClass widgetBinding="widget"}}
+                    {{#if widget}}
+                      {{#if widget.isVisible}}
+                        {{view widget.viewClass widgetBinding="widget"}}
+                      {{/if}}
                     {{/if}}
                   {{/each}}
                 {{/if}}

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -217,7 +217,7 @@ App.MainServiceInfoSummaryView = Em.View.extend({
       const masters = this.get('service.hostComponents').filterProperty('isMaster'),
         slaves = this.get('service.slaveComponents').toArray(),
         clients = this.get('service.clientComponents').toArray(),
-        masterGroups = this.get('svc') ? this.get('svc.masterComponentGroups').toArray() : [];
+        masterGroups = this.get('svc.masterComponentGroups') ? this.get('svc.masterComponentGroups').toArray() : [];
 
       if (this.get('mastersLength') !== masters.length || this.get('mastersObj.length') !== masterGroups.length) {
         let mastersInit = this.get('mastersObj').mapProperty('components').reduce((acc, group) => {


### PR DESCRIPTION
## What changes were proposed in this pull request?

After switching NN namespace for dashboard widgets nothing happens on UI, and also JS error is thrown:
`
Uncaught Error: assertion failed: Emptying a view in the inBuffer state is not allowed and should not happen under normal circumstances. Most likely there is a bug in your application. This may be due to excessive property change notifications.
`

## How was this patch tested?

UI unit tests:
  21529 passing (25s)
  48 pending