### PR TITLE
[AMBARI-23556] Fix constraint issue during logfeeder log entry testing.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/ShipperConfigTestRequest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/ShipperConfigTestRequest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.logsearch.model.request.impl;
 
 import org.apache.ambari.logsearch.model.request.ShipperConfigTestParams;
 import org.hibernate.validator.constraints.NotBlank;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.Map;
 
@@ -31,7 +32,7 @@ public class ShipperConfigTestRequest implements ShipperConfigTestParams {
   @NotBlank
   private String testEntry;
 
-  @NotBlank
+  @NotEmpty
   private Map<String, Object> shipperConfig;
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
NotBlank annotation cannot be used for Map types, NotEmpty can be used for constraint validation, so use that

## How was this patch tested?
FT: manually

please review @adoroszlai @zeroflag @kasakrisz 