### PR TITLE
AMBARI-23561. Ambari (HSI HA): Missing option to add another 'Hiveser…

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -3161,6 +3161,7 @@ Em.I18n.translations = {
   'dashboard.services.hive.client':'Hive Client',
   'dashboard.services.hive.metastore':'Hive Metastore',
   'dashboard.services.hive.server2':'HiveServer2',
+  'dashboard.services.hive.server2interactive':'HiveServer2 Interactive',
 
   'dashboard.services.oozie.clients':'Oozie Clients',
   'dashboard.services.oozie.client':'Oozie Client',

--- a/ambari-web/app/views/main/service/item.js
+++ b/ambari-web/app/views/main/service/item.js
@@ -65,6 +65,12 @@ App.MainServiceItemView = Em.View.extend({
        },
        {
          cssClass: 'glyphicon glyphicon-plus',
+         'label': '{0} {1}'.format(Em.I18n.t('add'), Em.I18n.t('dashboard.services.hive.server2interactive')),
+         service: 'HIVE',
+         component: 'HIVE_SERVER_INTERACTIVE'
+       },
+       {
+         cssClass: 'glyphicon glyphicon-plus',
          'label': '{0} {1}'.format(Em.I18n.t('add'), Em.I18n.t('dashboard.services.zookeeper.server')),
          service: 'ZOOKEEPER',
          component: 'ZOOKEEPER_SERVER'


### PR DESCRIPTION
…ver Interactive' component under actions menu for Active/Passive HSI.

## What changes were proposed in this pull request?
 Missing option to add another 'Hiveserver Interactive' component under actions menu for Active/Passive HSI.

## How was this patch tested?
manually, unit
 30517 passing (27s)
  157 pending


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.