### PR TITLE
[AMBARI-23470] Duplicate `X-Frame-Options` headers

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiSecurityConfig.java
@@ -89,6 +89,7 @@ public class ApiSecurityConfig extends WebSecurityConfigurerAdapter{
     http.csrf().disable()
         .authorizeRequests().anyRequest().authenticated()
         .and()
+        .headers().frameOptions().disable().and()
         .exceptionHandling().authenticationEntryPoint(ambariEntryPoint)
         .and()
         .addFilterBefore(guiceBeansConfig.ambariUserAuthorizationFilter(), BasicAuthenticationFilter.class)


### PR DESCRIPTION
## What changes were proposed in this pull request?

HTTP responses from Ambari include duplicate `X-Frame-Options` headers.  For views, the headers are conflicting, and prevent normal behavior, as `SAMEORIGIN` should be allowed:

```
X-Frame-Options: SAMEORIGIN
...
X-Frame-Options: DENY
```

## How was this patch tested?

Verified that response has only one `X-Frame-Options` header, and it is as expected for both views and non-views paths (`SAMEORIGIN` and `DENY` respectively).

```
$ curl --include http://${AMBARI_SERVER}:8080/api/v1/views
HTTP/1.1 200 OK
Date: Thu, 12 Apr 2018 18:34:37 GMT
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Cache-Control: no-store
Pragma: no-cache
X-Content-Type-Options: nosniff
Set-Cookie: AMBARISESSIONID=node01xv0r1ffn0xxjsgppd49ghr3474.node0;Path=/;HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
User: admin
Content-Type: text/plain;charset=utf-8
Vary: Accept-Encoding, User-Agent
Transfer-Encoding: chunked

{
...

$ curl --include http://${AMBARI_SERVER}:8080/api/v1/clusters
HTTP/1.1 200 OK
Date: Thu, 12 Apr 2018 18:36:12 GMT
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Cache-Control: no-store
Pragma: no-cache
X-Content-Type-Options: nosniff
Set-Cookie: AMBARISESSIONID=node0n6v7uebqviq7lr28a5bv8ty75.node0;Path=/;HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
User: admin
Content-Type: text/plain;charset=utf-8
Vary: Accept-Encoding, User-Agent
Transfer-Encoding: chunked

{
...
```