### PR TITLE
AMBARI-23567 : Add ability to skip in memory cluster aggregation on certain metrics.

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/PhoenixHBaseAccessor.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/PhoenixHBaseAccessor.java
@@ -47,6 +47,7 @@ import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.ti
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.TimelineMetricConfiguration.TIMELINE_METRICS_PRECISION_TABLE_DURABILITY;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.TimelineMetricConfiguration.TIMELINE_METRICS_PRECISION_TABLE_HBASE_BLOCKING_STORE_FILES;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.TimelineMetricConfiguration.TIMELINE_METRIC_AGGREGATOR_SINK_CLASS;
+import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.aggregators.AggregatorUtils.getJavaRegexFromSqlRegex;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.query.PhoenixTransactSQL.ALTER_METRICS_METADATA_TABLE;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.query.PhoenixTransactSQL.CONTAINER_METRICS_TABLE_NAME;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.query.PhoenixTransactSQL.CREATE_CONTAINER_METRICS_TABLE_SQL;
@@ -1273,20 +1274,6 @@ public class PhoenixHBaseAccessor {
     }
 
     return null;
-  }
-
-  public String getJavaRegexFromSqlRegex(String sqlRegex) {
-    String javaRegEx;
-    if (sqlRegex.contains("*") || sqlRegex.contains("__%")) {
-      //Special case handling for metric name with * and __%.
-      //For example, dfs.NNTopUserOpCounts.windowMs=300000.op=*.user=%.count
-      // or dfs.NNTopUserOpCounts.windowMs=300000.op=__%.user=%.count
-      String metricNameWithEscSeq = sqlRegex.replace("*", "\\*").replace("__%", "..%");
-      javaRegEx = metricNameWithEscSeq.replace("%", ".*");
-    } else {
-      javaRegEx = sqlRegex.replace("%", ".*");
-    }
-    return javaRegEx;
   }
 
   public void saveHostAggregateRecords(Map<TimelineMetric, MetricHostAggregate> hostAggregateMap,

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/aggregators/AggregatorUtils.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/aggregators/AggregatorUtils.java
@@ -251,4 +251,18 @@ public class AggregatorUtils {
     long currentTime = System.currentTimeMillis();
     return currentTime - (currentTime % aggregatorPeriod);
   }
+
+  public static String getJavaRegexFromSqlRegex(String sqlRegex) {
+    String javaRegEx;
+    if (sqlRegex.contains("*") || sqlRegex.contains("__%")) {
+      //Special case handling for metric name with * and __%.
+      //For example, dfs.NNTopUserOpCounts.windowMs=300000.op=*.user=%.count
+      // or dfs.NNTopUserOpCounts.windowMs=300000.op=__%.user=%.count
+      String metricNameWithEscSeq = sqlRegex.replace("*", "\\*").replace("__%", "..%");
+      javaRegEx = metricNameWithEscSeq.replace("%", ".*");
+    } else {
+      javaRegEx = sqlRegex.replace("%", ".*");
+    }
+    return javaRegEx;
+  }
 }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/aggregators/TimelineMetricClusterAggregatorSecond.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/metrics/timeline/aggregators/TimelineMetricClusterAggregatorSecond.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.ti
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.TimelineMetricConfiguration.TIMELINE_METRICS_CLUSTER_AGGREGATOR_INTERPOLATION_ENABLED;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.TimelineMetricConfiguration.TIMELINE_METRICS_EVENT_METRIC_PATTERNS;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.TimelineMetricConfiguration.TIMELINE_METRIC_AGGREGATION_SQL_FILTERS;
+import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.aggregators.AggregatorUtils.getJavaRegexFromSqlRegex;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.aggregators.AggregatorUtils.getTimeSlices;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.aggregators.AggregatorUtils.sliceFromTimelineMetric;
 import static org.apache.hadoop.yarn.server.applicationhistoryservice.metrics.timeline.query.PhoenixTransactSQL.GET_METRIC_SQL;
@@ -68,7 +69,6 @@ public class TimelineMetricClusterAggregatorSecond extends AbstractTimelineAggre
   protected final boolean interpolationEnabled;
   private TimelineMetricMetadataManager metadataManagerInstance;
   private String skipAggrPatternStrings;
-  private String skipInterpolationMetricPatternStrings;
   private Set<Pattern> skipInterpolationMetricPatterns = new HashSet<>();
   private final static String liveHostsMetricName = "live_hosts";
 
@@ -95,11 +95,11 @@ public class TimelineMetricClusterAggregatorSecond extends AbstractTimelineAggre
     this.serverTimeShiftAdjustment = Long.parseLong(metricsConf.get(SERVER_SIDE_TIMESIFT_ADJUSTMENT, "90000"));
     this.interpolationEnabled = Boolean.parseBoolean(metricsConf.get(TIMELINE_METRICS_CLUSTER_AGGREGATOR_INTERPOLATION_ENABLED, "true"));
     this.skipAggrPatternStrings = metricsConf.get(TIMELINE_METRIC_AGGREGATION_SQL_FILTERS);
-    this.skipInterpolationMetricPatternStrings = metricsConf.get(TIMELINE_METRICS_EVENT_METRIC_PATTERNS, "");
+    String skipInterpolationMetricPatternStrings = metricsConf.get(TIMELINE_METRICS_EVENT_METRIC_PATTERNS, "");
 
     if (StringUtils.isNotEmpty(skipInterpolationMetricPatternStrings)) {
       for (String patternString : skipInterpolationMetricPatternStrings.split(",")) {
-        String javaPatternString = hBaseAccessor.getJavaRegexFromSqlRegex(patternString);
+        String javaPatternString = getJavaRegexFromSqlRegex(patternString);
         LOG.info("SQL pattern " + patternString + " converted to Java pattern : " + javaPatternString);
         skipInterpolationMetricPatterns.add(Pattern.compile(javaPatternString));
       }

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-site.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-site.xml
@@ -750,7 +750,7 @@
   </property>
   <property>
     <name>timeline.metrics.cluster.aggregation.sql.filters</name>
-    <value>sdisk\_%,boottime</value>
+    <value>sdisk\_%,boottime,topology%,</value>
     <description>
       Commas separated list of Metric names or Phoenix 'LIKE' class expressions that match metric names
       which prevents certain metrics from being aggregated across hosts.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use the 'timeline.metrics.cluster.aggregation.sql.filters' config to specify aggregation filters for the in memory cluster aggregation method as well. 

## How was this patch tested?
mvn clean test on ambari-metrics.