### PR TITLE
AMBARI-23386 HSI ADDENDUM Jdbc URL should handle HA mode (mgergely)

### DIFF
--- a/ambari-web/app/controllers/main/service/info/summary.js
+++ b/ambari-web/app/controllers/main/service/info/summary.js
@@ -262,7 +262,7 @@ App.MainServiceInfoSummaryController = Em.Controller.extend({
           hiveSiteDynamicDiscovery = _config.properties['hive.server2.support.dynamic.service.discovery'] || hiveSiteDynamicDiscovery;
           hiveSiteZkQuorom = _config.properties['hive.zookeeper.quorum'] || hiveSiteZkQuorom;
           hiveSiteZkNameSpace = _config.properties['hive.server2.zookeeper.namespace'] || hiveSiteZkNameSpace;
-          if (App.HostComponent.find().filterProperty('componentName','HIVE_SERVER_INTERACTIVE').length == 2) {
+          if (App.HostComponent.find().filterProperty('componentName','HIVE_SERVER_INTERACTIVE').length > 1) {
             hiveSiteServiceDiscorveryMode = 'zooKeeperHA';
             hiveSiteZkNameSpace = _config.properties['hive.server2.active.passive.ha.registry.namespace'];
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support HSI HA mode for more than 2 HSI instances, Ambari should display the proper JDBC URLs

## How was this patch tested?

Tested on OS cluster, it worked fine.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.