### PR TITLE
[AMBARI-23566] Fix shipper config test entry mechanism

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/ConfigHandler.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/ConfigHandler.java
@@ -442,4 +442,12 @@ public class ConfigHandler implements InputConfigMonitor {
     outputManager.close();
     inputManager.checkInAll();
   }
+
+  public void setInputManager(InputManager inputManager) {
+    this.inputManager = inputManager;
+  }
+
+  public void setOutputManager(OutputManager outputManager) {
+    this.outputManager = outputManager;
+  }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogEntryParseTester.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogEntryParseTester.java
@@ -27,6 +27,9 @@ import java.util.Map;
 
 import org.apache.ambari.logfeeder.conf.LogFeederProps;
 import org.apache.ambari.logfeeder.input.InputFileMarker;
+import org.apache.ambari.logfeeder.input.InputManagerImpl;
+import org.apache.ambari.logfeeder.loglevelfilter.LogLevelFilterHandler;
+import org.apache.ambari.logfeeder.output.OutputManagerImpl;
 import org.apache.ambari.logfeeder.plugin.input.Input;
 import org.apache.ambari.logfeeder.plugin.input.InputMarker;
 import org.apache.ambari.logfeeder.plugin.output.Output;
@@ -77,6 +80,12 @@ public class LogEntryParseTester {
   public Map<String, Object> parse() throws Exception {
     InputConfig inputConfig = getInputConfig();
     ConfigHandler configHandler = new ConfigHandler(null);
+    configHandler.setInputManager(new InputManagerImpl());
+    OutputManagerImpl outputManager = new OutputManagerImpl();
+    LogLevelFilterHandler logLevelFilterHandler = new LogLevelFilterHandler(null);
+    logLevelFilterHandler.setLogFeederProps(new LogFeederProps());
+    outputManager.setLogLevelFilterHandler(logLevelFilterHandler);
+    configHandler.setOutputManager(outputManager);
     Input input = configHandler.getTestInput(inputConfig, logId);
     final Map<String, Object> result = new HashMap<>();
     input.getFirstFilter().init(new LogFeederProps());

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/loglevelfilter/LogLevelFilterHandler.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/loglevelfilter/LogLevelFilterHandler.java
@@ -198,4 +198,8 @@ public class LogLevelFilterHandler implements LogLevelFilterMonitor {
       return false;
     }
   }
+
+  public void setLogFeederProps(LogFeederProps logFeederProps) {
+    this.logFeederProps = logFeederProps;
+  }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputManagerImpl.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputManagerImpl.java
@@ -264,7 +264,6 @@ public class OutputManagerImpl extends OutputManager {
     return logLevelFilterHandler;
   }
 
-  @VisibleForTesting
   public void setLogLevelFilterHandler(LogLevelFilterHandler logLevelFilterHandler) {
     this.logLevelFilterHandler = logLevelFilterHandler;
   }

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -293,6 +293,16 @@
         <groupId>com.google.guava</groupId>
         <version>20.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>1.9.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
+    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/doc/DocConstants.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/doc/DocConstants.java
@@ -46,6 +46,10 @@ public class DocConstants {
     public static final String FORMAT_D = "File Export format, can be 'txt' or 'json'";
     public static final String TOP = "Number that defines how many top element you would like to see.";
     public static final String USER_D = "Filter for users (comma separated list)";
+    public static final String LOG_ID_D = "Id of the log component";
+    public static final String SHIPPER_CONFIG_D = "Input config json for logfeeder shipper";
+    public static final String TEST_ENTRY_D = "Log sample for testing";
+
   }
 
   public class AuditOperationDescriptions {

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ShipperConfigManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ShipperConfigManager.java
@@ -92,17 +92,16 @@ public class ShipperConfigManager extends JsonManagerBase {
     }
   }
 
-  public Response testShipperConfig(Map<String, Object> shipperConfig, String logId, String testEntry, String clusterName) {
+  public Response testShipperConfig(String shipperConfig, String logId, String testEntry, String clusterName) {
     try {
-      String shipperConfigJsonStr = new ObjectMapper().writeValueAsString(shipperConfig);
-      LSServerInputConfig inputConfigValidate = new ObjectMapper().readValue(shipperConfigJsonStr, LSServerInputConfig.class);
+      LSServerInputConfig inputConfigValidate = new ObjectMapper().readValue(shipperConfig, LSServerInputConfig.class);
       Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
       Set<ConstraintViolation<LSServerInputConfig>> violations = validator.validate(inputConfigValidate);
       if (!violations.isEmpty()) {
         throw new IllegalArgumentException("Error validating shipper config:\n" + violations);
       }
       String globalConfigs = logSearchConfigConfigurer.getConfig().getGlobalConfigs(clusterName);
-      LogEntryParseTester tester = new LogEntryParseTester(testEntry, shipperConfigJsonStr, globalConfigs, logId);
+      LogEntryParseTester tester = new LogEntryParseTester(testEntry, shipperConfig, globalConfigs, logId);
       Map<String, Object> resultEntrty = tester.parse();
       return Response.ok().entity(resultEntrty).build();
     } catch (Exception e) {

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/ShipperConfigTestParams.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/ShipperConfigTestParams.java
@@ -21,25 +21,25 @@ package org.apache.ambari.logsearch.model.request;
 import io.swagger.annotations.ApiParam;
 import org.apache.ambari.logsearch.common.LogSearchConstants;
 
-import java.util.Map;
-
-import static org.apache.ambari.logsearch.doc.DocConstants.CommonDescriptions.TOP;
+import static org.apache.ambari.logsearch.doc.DocConstants.CommonDescriptions.LOG_ID_D;
+import static org.apache.ambari.logsearch.doc.DocConstants.CommonDescriptions.SHIPPER_CONFIG_D;
+import static org.apache.ambari.logsearch.doc.DocConstants.CommonDescriptions.TEST_ENTRY_D;
 
 public interface ShipperConfigTestParams {
 
-  Map<String, Object> getShipperConfig();
+  String getShipperConfig();
 
-  @ApiParam(value = TOP, name = LogSearchConstants.REQUEST_PARAM_SHIPPER_CONFIG, required = true)
-  void setShipperConfig(Map<String, Object> shipperConfig);
+  @ApiParam(value = SHIPPER_CONFIG_D, name = LogSearchConstants.REQUEST_PARAM_SHIPPER_CONFIG, required = true)
+  void setShipperConfig(String shipperConfig);
 
   String getLogId();
 
-  @ApiParam(value = TOP, name = LogSearchConstants.REQUEST_PARAM_LOG_ID, required = true)
+  @ApiParam(value = LOG_ID_D, name = LogSearchConstants.REQUEST_PARAM_LOG_ID, required = true)
   void setLogId(String logId);
 
   String getTestEntry();
 
-  @ApiParam(value = TOP, name = LogSearchConstants.REQUEST_PARAM_TEST_ENTRY, required = true)
+  @ApiParam(value = TEST_ENTRY_D, name = LogSearchConstants.REQUEST_PARAM_TEST_ENTRY, required = true)
   void setTestEntry(String testEntry);
 
 }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/ShipperConfigTestRequest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/request/impl/ShipperConfigTestRequest.java
@@ -22,18 +22,25 @@ import org.apache.ambari.logsearch.model.request.ShipperConfigTestParams;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
 
-import java.util.Map;
+import javax.ws.rs.FormParam;
+
+import static org.apache.ambari.logsearch.common.LogSearchConstants.REQUEST_PARAM_LOG_ID;
+import static org.apache.ambari.logsearch.common.LogSearchConstants.REQUEST_PARAM_SHIPPER_CONFIG;
+import static org.apache.ambari.logsearch.common.LogSearchConstants.REQUEST_PARAM_TEST_ENTRY;
 
 public class ShipperConfigTestRequest implements ShipperConfigTestParams {
 
   @NotBlank
+  @FormParam(REQUEST_PARAM_LOG_ID)
   private String logId;
 
   @NotBlank
+  @FormParam(REQUEST_PARAM_TEST_ENTRY)
   private String testEntry;
 
   @NotEmpty
-  private Map<String, Object> shipperConfig;
+  @FormParam(REQUEST_PARAM_SHIPPER_CONFIG)
+  private String shipperConfig;
 
   @Override
   public String getLogId() {
@@ -46,12 +53,12 @@ public class ShipperConfigTestRequest implements ShipperConfigTestParams {
   }
 
   @Override
-  public Map<String, Object> getShipperConfig() {
+  public String getShipperConfig() {
     return shipperConfig;
   }
 
   @Override
-  public void setShipperConfig(Map<String, Object> shipperConfig) {
+  public void setShipperConfig(String shipperConfig) {
     this.shipperConfig = shipperConfig;
   }
 

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ShipperConfigResource.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ShipperConfigResource.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.validation.Valid;
 import javax.validation.executable.ValidateOnExecution;
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -41,6 +42,7 @@ import org.apache.ambari.logsearch.model.request.impl.ShipperConfigTestRequest;
 import org.springframework.context.annotation.Scope;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.ambari.logsearch.doc.DocConstants.ShipperConfigOperationDescriptions.GET_LOG_LEVEL_FILTER_OD;
 import static org.apache.ambari.logsearch.doc.DocConstants.ShipperConfigOperationDescriptions.GET_SERVICE_NAMES_OD;
@@ -99,7 +101,7 @@ public class ShipperConfigResource {
   @Path("/input/{clusterName}/test")
   @Produces({"application/json"})
   @ApiOperation(TEST_SHIPPER_CONFIG_OD)
-  public Response testShipperConfig(@Valid ShipperConfigTestRequest request, @PathParam("clusterName") String clusterName) {
+  public Response testShipperConfig(@Valid @BeanParam ShipperConfigTestRequest request, @PathParam("clusterName") String clusterName) {
     return shipperConfigManager.testShipperConfig(request.getShipperConfig(), request.getLogId(), request.getTestEntry(), clusterName);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change endpoint to use form params.
Also add some fixes (required libraries for logsearch for jakson parsing + set some objects that was null) to make log entry testing work after refactor changes (where i included spring DI)

## How was this patch tested?
UTs: passed
FTs: manually with swagger api

please review @swagle @kasakrisz @g-boros 