### PR TITLE
[AMBARI-23578] - Log Search UI: open the available search terms list

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
@@ -31,11 +31,13 @@
 <div [ngClass]="{'search-item-container': true, 'active': isActive, 'value': isValueInput}">
   <input #parameterInput [(ngModel)]="currentValue" [typeahead]="items" typeaheadOptionField="value"
          [typeaheadItemTemplate]="listItemTemplate" (typeaheadNoResults)="setParameterNameMatchFlag($event)"
+         [typeaheadMinLength]="0"
          (typeaheadOnSelect)="changeParameterName({item: $event.item, isExclude: false})"
          (focus)="onParameterInputFocus()" (keyup)="onParameterKeyUp($event)"
          class="search-item-input parameter-input form-control">
   <input #valueInput [(ngModel)]="currentValue" [typeahead]="activeItemValueOptions" typeaheadOptionField="value"
          [typeaheadItemTemplate]="listItemTemplate" (typeaheadNoResults)="setParameterValueMatchFlag($event)"
+         [typeaheadMinLength]="0"
          (typeaheadOnSelect)="onParameterValueChange($event.value)" (keydown)="onParameterValueKeyDown($event)"
          (keyup)="onParameterValueKeyUp($event)" class="search-item-input value-input form-control">
 </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the user clicks in to search box field the list of the available search parameters should open up in order to let the user know what kind of parameters he/she can use.

## How was this patch tested?
Manual and unit tests (267/267 success)
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@aBabiichuk please review it
+ @oleewere 