### PR TITLE
[AMBARI-23579] Ambari shows invalid passwords as plaintext

### DIFF
--- a/ambari-web/app/mixins/common/serverValidator.js
+++ b/ambari-web/app/mixins/common/serverValidator.js
@@ -244,8 +244,8 @@ App.ServerValidatorMixin = Em.Mixin.create({
    * @returns {{type: String, isError: boolean, isWarn: boolean, isGeneral: boolean, messages: Array}}
    */
   createErrorMessage: function (type, property, messages) {
-    var errorTypes = this.get('errorTypes');
-    var error = {
+    const errorTypes = this.get('errorTypes');
+    let error = {
       type: type,
       isCriticalError: type === errorTypes.CRITICAL_ERROR,
       isError: type === errorTypes.ERROR,
@@ -257,11 +257,12 @@ App.ServerValidatorMixin = Em.Mixin.create({
 
     Em.assert('Unknown config error type ' + type, error.isError || error.isWarn || error.isGeneral || error.isCriticalError);
     if (property) {
+      const value = Em.get(property, 'value');
       error.id = Em.get(property, 'id');
       error.serviceName = Em.get(property, 'serviceDisplayName') || App.StackService.find(Em.get(property, 'serviceName')).get('displayName');
       error.propertyName = Em.get(property, 'name');
       error.filename = Em.get(property, 'filename');
-      error.value = Em.get(property, 'value');
+      error.value = value && Em.get(property, 'displayType') === 'password' ? new Array(value.length + 1).join('*') : value;
       error.description = Em.get(property, 'description');
     }
     return error;

--- a/ambari-web/test/mixins/common/serverValidator_test.js
+++ b/ambari-web/test/mixins/common/serverValidator_test.js
@@ -199,6 +199,12 @@ describe('App.ServerValidatorMixin', function () {
       expect(instanceObject.createErrorMessage.bind(instanceObject, 'WRONG TYPE', null, ['msg3']))
         .to.throw(Error, 'Unknown config error type WRONG TYPE');
     });
+
+    it('password config property', function () {
+      expect(instanceObject.createErrorMessage('ERROR', $.extend({}, property, {
+        displayType: 'password'
+      })).value).to.equal('**');
+    });
   });
 });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

While installing an HDF cluster, if you provide a password which is not valid for NiFi toolkit (eg. it is less than 12 characters) the password you entered is displayed in the error message as plaintext.

## How was this patch tested?

UI unit tests:
  21518 passing (28s)
  48 pending