### PR TITLE
[AMBARI-23581] Fix permissions of logsarch/logfeeder scripts for debian packages.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/build.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/build.xml
@@ -45,10 +45,10 @@
     <chmod file="target/package/conf/logfeeder-env.sh" perm="755"/>
     <tar compression="gzip" destfile="target/ambari-logsearch-logfeeder.tgz">
       <tarfileset mode="755" dir="target/package">
-        <include name="*.sh"/>
+        <include name="*/*.sh"/>
       </tarfileset>
       <tarfileset mode="664" dir="target/package">
-        <exclude name="*.sh"/>
+        <exclude name="*/*.sh"/>
       </tarfileset>
     </tar>
   </target>

--- a/ambari-logsearch/ambari-logsearch-logfeeder/build.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/build.xml
@@ -45,10 +45,10 @@
     <chmod file="target/package/conf/logfeeder-env.sh" perm="755"/>
     <tar compression="gzip" destfile="target/ambari-logsearch-logfeeder.tgz">
       <tarfileset mode="755" dir="target/package">
-        <include name="*/*.sh"/>
+        <include name="**/*.sh"/>
       </tarfileset>
       <tarfileset mode="664" dir="target/package">
-        <exclude name="*/*.sh"/>
+        <exclude name="**/*.sh"/>
       </tarfileset>
     </tar>
   </target>

--- a/ambari-logsearch/ambari-logsearch-server/build.xml
+++ b/ambari-logsearch/ambari-logsearch-server/build.xml
@@ -60,10 +60,10 @@
     <chmod file="target/package/conf/logsearch-env.sh" perm="755"/>
     <tar compression="gzip" destfile="target/ambari-logsearch-portal.tar.gz">
       <tarfileset mode="755" dir="target/package">
-        <include name="*.sh"/>
+        <include name="*/*.sh"/>
       </tarfileset>
       <tarfileset mode="664" dir="target/package">
-        <exclude name="*.sh"/>
+        <exclude name="*/*.sh"/>
       </tarfileset>
     </tar>
   </target>

--- a/ambari-logsearch/ambari-logsearch-server/build.xml
+++ b/ambari-logsearch/ambari-logsearch-server/build.xml
@@ -60,10 +60,10 @@
     <chmod file="target/package/conf/logsearch-env.sh" perm="755"/>
     <tar compression="gzip" destfile="target/ambari-logsearch-portal.tar.gz">
       <tarfileset mode="755" dir="target/package">
-        <include name="*/*.sh"/>
+        <include name="**/*.sh"/>
       </tarfileset>
       <tarfileset mode="664" dir="target/package">
-        <exclude name="*/*.sh"/>
+        <exclude name="**/*.sh"/>
       </tarfileset>
     </tar>
   </target>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Folders changed for logsearch/logfeeder scripts, update that as it cause problems on Ubuntu. (somehow its different on CentOS)

## How was this patch tested?
Generate deb package then install to an Ubuntu, permissions looked good.

please review @zeroflag @adoroszlai @g-boros @swagle 