### PR TITLE
[AMBARI-23582] UI reads service versions from base stack repo

### DIFF
--- a/ambari-web/app/views/main/admin/stack_upgrade/services_view.js
+++ b/ambari-web/app/views/main/admin/stack_upgrade/services_view.js
@@ -32,15 +32,14 @@ App.MainAdminStackServicesView = Em.View.extend({
   services: function() {
     var services = App.supports.installGanglia ? App.StackService.find() : App.StackService.find().without(App.StackService.find('GANGLIA'));
     var controller = this.get('controller');
-    controller.loadServiceVersionFromVersionDefinitions().complete(function () {
-      return services.map(function(s) {
-        s.set('serviceVersionDisplay', controller.get('serviceVersionsMap')[s.get('serviceName')]);
-        s.set('isInstalled', App.Service.find().someProperty('serviceName', s.get('serviceName')));
-        return s;
-      });
+
+    services.map(function(s) {
+      s.set('serviceVersionDisplay', controller.get('serviceVersionsMap')[s.get('serviceName')]);
+      s.set('isInstalled', App.Service.find().someProperty('serviceName', s.get('serviceName')));
+      return s;
     });
     return services;
-  }.property('App.router.clusterController.isLoaded'),
+  }.property('App.router.clusterController.isLoaded', 'controller.serviceVersionsMap'),
 
   didInsertElement: function () {
     if (!App.get('stackVersionsAvailable')) {

--- a/ambari-web/test/controllers/main/admin/stack_and_upgrade_controller_test.js
+++ b/ambari-web/test/controllers/main/admin/stack_and_upgrade_controller_test.js
@@ -3382,6 +3382,55 @@ describe('App.MainAdminStackAndUpgradeController', function() {
             'id': '1',
             'stackVersionType': 'HDP',
             'stackVersionNumber': '2.6',
+            'isCurrent': false,
+            'isStandard': true,
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.6.5'
+              })
+            ]
+          }),
+          Em.Object.create({
+            'id': '2',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
+            'isCurrent': false,
+            'isStandard': true,
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.7.3'
+              })
+            ]
+          })
+        ],
+
+        services: [
+          Em.Object.create({
+            'serviceName': 'YARN',
+            'desiredRepositoryVersionId': '2'
+          })
+        ],
+
+        stackServices: [
+          Em.Object.create({
+            'serviceName': 'HDFS',
+            'stackName': 'HDP',
+            'stackVersion': '2.6'
+          })
+        ],
+        title: 'No standard repo in current state - nothing should be returned',
+        expected: {'HDFS': ''}
+      },
+      {
+        currentStackName: 'HDP',
+        currentStackVersionNumber: '2.6',
+        repoVersions : [
+          Em.Object.create({
+            'id': '1',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
             'isCurrent': true,
             'isStandard': true,
             'stackServices': [
@@ -3422,7 +3471,8 @@ describe('App.MainAdminStackAndUpgradeController', function() {
         ],
         title: 'Service not installed - get version from current & standard repo',
         expected: {'HDFS': '2.6.5'}
-      }
+      },
+
     ];
 
     afterEach(function() {

--- a/ambari-web/test/controllers/main/admin/stack_and_upgrade_controller_test.js
+++ b/ambari-web/test/controllers/main/admin/stack_and_upgrade_controller_test.js
@@ -3283,88 +3283,165 @@ describe('App.MainAdminStackAndUpgradeController', function() {
     });
   });
 
-  describe("#loadServiceVersionFromVersionDefinitions()", function () {
+  describe("#getServiceVersionFromRepo()", function () {
 
-    it("App.ajax.send should be called", function() {
-      App.set('clusterName', 'c1');
-      controller.loadServiceVersionFromVersionDefinitions();
-      var args = testHelpers.findAjaxRequest('name', 'cluster.load_current_repo_stack_services');
-      expect(args[0]).to.be.eql({
-        name: 'cluster.load_current_repo_stack_services',
-        sender: controller,
-        data: {
-          clusterName: App.get('clusterName')
-        },
-        success: 'loadServiceVersionFromVersionDefinitionsSuccessCallback',
-        error: 'loadServiceVersionFromVersionDefinitionsErrorCallback'
-      });
-    });
-  });
-
-  describe("#loadServiceVersionFromVersionDefinitionsSuccessCallback()", function () {
-    var cases;
-    beforeEach(function() {
-      this.appGetStub = sinon.stub(App, 'get');
-    });
-
-    afterEach(function() {
-      App.get.restore();
-      controller.set('serviceVersionsMap', {});
-    });
-    cases = [
+    var cases = [
       {
-        jsonData: {
-          items: [
-            {
-              ClusterStackVersions: {
-                version: '2.3',
-                stack: 'HDP',
-                state: 'NOT_REQUIRED'
-              },
-              repository_versions: [
-                {
-                  RepositoryVersions: {
-                    stack_services: [
-                      { name: 'S3', versions: ['v3']}
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              ClusterStackVersions: {
-                version: '2.2',
-                stack: 'HDP',
-                state: 'NOT_REQUIRED'
-              },
-              repository_versions: [
-                {
-                  RepositoryVersions: {
-                    stack_services: [
-                      { name: 'S2', versions: ['v2']}
-                    ]
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        currentStackData: {
-          currentStackVersionNumber: '2.2',
-          currentStackName: 'HDP'
-        },
-        m: 'should add stack services from stack version by current stack name and version number',
-        e: { "S2": "v2"}
+        currentStackName: 'HDP',
+        currentStackVersionNumber: '2.6',
+        repoVersions: [
+          Em.Object.create({
+            'id': '1',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.5',
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.6.2'
+              })
+            ]
+          }),
+          Em.Object.create({
+            'id': '2',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.7.3'
+              })
+            ]
+          })
+        ],
+        services: [
+          Em.Object.create({
+            'serviceName': 'HDFS',
+            'desiredRepositoryVersionId': '2'
+          })
+        ],
+        stackServices: [
+          Em.Object.create({
+            'serviceName': 'HDFS',
+            'stackName': 'HDP',
+            'stackVersion': '2.6'
+          })
+        ],
+        title: 'If multiple stacks should select the repo on the current stack',
+        expected: {'HDFS': '2.7.3'}
+      },
+
+      {
+        currentStackName: 'HDP',
+        currentStackVersionNumber: '2.6',
+        repoVersions : [
+          Em.Object.create({
+            'id': '1',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.6.5'
+              })
+            ]
+          }),
+          Em.Object.create({
+            'id': '2',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.7.3'
+              })
+            ]
+          })
+        ],
+        services: [
+          Em.Object.create({
+            'serviceName': 'HDFS',
+            'desiredRepositoryVersionId': '2'
+          })
+        ],
+        stackServices: [
+          Em.Object.create({
+            'serviceName': 'HDFS',
+            'stackName': 'HDP',
+            'stackVersion': '2.6'
+          })
+        ],
+        title: 'If multiple repositories in the same stack should select by id',
+        expected: {'HDFS': '2.7.3'}
+      },
+
+      {
+        currentStackName: 'HDP',
+        currentStackVersionNumber: '2.6',
+        repoVersions : [
+          Em.Object.create({
+            'id': '1',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
+            'isCurrent': true,
+            'isStandard': true,
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.6.5'
+              })
+            ]
+          }),
+          Em.Object.create({
+            'id': '2',
+            'stackVersionType': 'HDP',
+            'stackVersionNumber': '2.6',
+            'isCurrent': false,
+            'isStandard': true,
+            'stackServices': [
+              Em.Object.create({
+                'name': 'HDFS',
+                'latestVersion': '2.7.3'
+              })
+            ]
+          })
+        ],
+
+        services: [
+          Em.Object.create({
+            'serviceName': 'YARN',
+            'desiredRepositoryVersionId': '2'
+          })
+        ],
+
+        stackServices: [
+          Em.Object.create({
+            'serviceName': 'HDFS',
+            'stackName': 'HDP',
+            'stackVersion': '2.6'
+          })
+        ],
+        title: 'Service not installed - get version from current & standard repo',
+        expected: {'HDFS': '2.6.5'}
       }
     ];
 
-    cases.forEach(function(test) {
-      it(test.m, function() {
-        this.appGetStub.withArgs('currentStackName').returns(test.currentStackData.currentStackName)
-          .withArgs('currentStackVersionNumber').returns(test.currentStackData.currentStackVersionNumber);
-        controller.loadServiceVersionFromVersionDefinitionsSuccessCallback(test.jsonData);
-        expect(controller.get('serviceVersionsMap')).to.be.eql(test.e);
-      })
+    afterEach(function() {
+      App.get.restore();
+      App.Service.find.restore();
+      App.StackService.find.restore();
+      App.RepositoryVersion.find.restore();
+      controller.set('serviceVersionsMap', {});
+    });
+
+    cases.forEach(function(item) {
+      it(item.title, function() {
+        sinon.stub(App, 'get').withArgs('currentStackName').returns(item.currentStackName).withArgs('currentStackVersionNumber').returns(item.currentStackVersionNumber);
+        sinon.stub(App.Service, 'find').returns(item.services);
+        sinon.stub(App.StackService, 'find').returns(item.stackServices);
+        sinon.stub(App.RepositoryVersion, 'find').returns(item.repoVersions);
+        controller.getServiceVersionFromRepo();
+        expect(controller.get('serviceVersionsMap')).to.be.eql(item.expected);
+      });
     });
   });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently UI reads service versions from the base stack repo. This causes an issue where an upgrade has been performed within the same stack version. Eg 2.6.4.0 --> 2.6.5.0

## How was this patch tested?
Modified and added new tests to cover these cases
  30524 passing (19s)
  157 pending