### PR TITLE
[AMBARI-23583] Fix typo in apt-manager (ambari-common)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -198,7 +198,7 @@ class AptManager(GenericManager):
     r = shell.subprocess_executor(self.properties.verify_dependency_cmd)
     pattern = re.compile("has missing dependency|E:")
 
-    if r.code or (r.outout and pattern.search(r.out)):
+    if r.code or (r.out and pattern.search(r.out)):
       err_msg = Logger.filter_text("Failed to verify package dependencies. Execution of '%s' returned %s. %s" % (VERIFY_DEPENDENCY_CMD, code, out))
       Logger.error(err_msg)
       return False


### PR DESCRIPTION
## What changes were proposed in this pull request?
Typo in apt-manager: "outout" is used instead of "out"
```bash
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 136, in actionexecute
    ret_code = self.install_packages(package_list)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 441, in install_packages
    if not self.repo_mgr.verify_dependencies():
  File "/usr/lib/ambari-agent/lib/ambari_commons/repo_manager/apt_manager.py", line 201, in verify_dependencies
    if r.code or (r.outout and pattern.search(r.out)):
AttributeError: 'SubprocessCallResult' object has no attribute 'outout'
```

## How was this patch tested?
Not yet. but shell.py show that the property should be "out"