### PR TITLE
[AMBARI-23569] Provide Mpack Package Name to Install in mpack.json

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -51,6 +51,7 @@ import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.stack.RepoUtil;
 import org.apache.ambari.server.state.Module;
 import org.apache.ambari.server.state.Mpack;
+import org.apache.ambari.server.state.MpackOsSpecific;
 import org.apache.ambari.server.state.OsSpecific;
 import org.apache.ambari.server.state.stack.RepositoryXml;
 import org.apache.ambari.server.state.stack.StackMetainfoXml;
@@ -365,15 +366,20 @@ public class MpackManager {
     version.setActive(true);
     generatedMetainfo.setVersion(version);
 
-    //Add osSpecifics to the metainfo.xml
-    OsSpecific osSpecific = new OsSpecific("any");
-    OsSpecific.Package pkg = new OsSpecific.Package();
-    pkg.setName(mpack.getName().toLowerCase());
-    ArrayList<OsSpecific.Package> packageArrayList = new ArrayList<>();
-    packageArrayList.add(pkg);
     ArrayList<OsSpecific> osSpecificArrayList = new ArrayList<>();
-    osSpecificArrayList.add(osSpecific);
-    osSpecific.addPackages(packageArrayList);
+    //Add osSpecifics to the metainfo.xml
+    for(MpackOsSpecific mpackOsSpecific : mpack.getOsSpecifics()){
+      OsSpecific osSpecific = new OsSpecific(mpackOsSpecific.getOsFamily());
+      ArrayList<OsSpecific.Package> packageArrayList = new ArrayList<>();
+      for(String packageName : mpackOsSpecific.getPackages()){
+        OsSpecific.Package pkg = new OsSpecific.Package();
+        pkg.setName(packageName);
+        packageArrayList.add(pkg);
+      }
+      osSpecific.addPackages(packageArrayList);
+      osSpecificArrayList.add(osSpecific);
+    }
+
     generatedMetainfo.setOsSpecifics(osSpecificArrayList);
 
     Map<String, String> prerequisites = mpack.getPrerequisites();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
+/* Representation of the modules section in the mpack.json*/
 public class Module {
   public enum Category {
     @SerializedName("SERVER")

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Mpack.java
@@ -67,6 +67,9 @@ public class Mpack {
   @SerializedName("displayName")
   private String displayName;
 
+  @SerializedName("osSpecifics")
+  private List<MpackOsSpecific> osSpecifics;
+
   private String mpackUri;
 
   private HashMap<String, Module> moduleHashMap;
@@ -162,6 +165,15 @@ public class Mpack {
 
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
+  }
+
+
+  public List<MpackOsSpecific> getOsSpecifics() {
+    return osSpecifics;
+  }
+
+  public void setOsSpecifics(List<MpackOsSpecific> osSpecifics) {
+    this.osSpecifics = osSpecifics;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/MpackOsSpecific.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/MpackOsSpecific.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.state;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Representation of the osSpecifics section in the mpack.json file.
+ */
+public class MpackOsSpecific {
+
+  @SerializedName("osFamily")
+  private  String osFamily;
+
+  @SerializedName("packages")
+  private List<String> packages;
+
+  public String getOsFamily() {
+    return osFamily;
+  }
+
+  public void setOsFamily(String osFamily) {
+    this.osFamily = osFamily;
+  }
+
+  public List<String> getPackages() {
+    return packages;
+  }
+
+  public void setPackages(List<String> packages) {
+    this.packages = packages;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MpackOsSpecific that = (MpackOsSpecific) o;
+
+    if (osFamily != null ? !osFamily.equals(that.osFamily) : that.osFamily != null) return false;
+    return packages != null ? packages.equals(that.packages) : that.packages == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(osFamily, packages);
+  }
+}


### PR DESCRIPTION
Use the osSpecifics section in the mpack.json to add it to the metainfo.xml 

## How was this patch tested?
POST /mpacks
cat /var/lib/ambari-server/resources/stacks/HDPCORE/1.0.0-b232/metainfo.xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<metainfo>
    <minJdk>1.8</minJdk>
    <maxJdk>1.8</maxJdk>
    <versions>
        <active>true</active>
    </versions>
    <osSpecifics>
        <osSpecific>
            <osFamily>ubuntu12,ubuntu14</osFamily>
            <packages>
                <package>
                    <name>hdpcore-1-0-0-b232</name>
                    <condition></condition>
                    <skipUpgrade>false</skipUpgrade>
                </package>
            </packages>
        </osSpecific>
        <osSpecific>
            <osFamily>centos7,redhat7</osFamily>
            <packages>
                <package>
                    <name>hdpcore_1_0_0_b232</name>
                    <condition></condition>
                    <skipUpgrade>false</skipUpgrade>
                </package>
            </packages>
        </osSpecific>
    </osSpecifics>
</metainfo>

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.