### PR TITLE
[AMBARI-23584] Pre Upgrade checks look for kafka service validation even when the service is deleted (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/KafkaPropertiesCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/KafkaPropertiesCheck.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.checks;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.ambari.server.AmbariException;
@@ -28,9 +29,9 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.PrerequisiteCheck;
-import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.apache.ambari.server.utils.VersionUtils;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Singleton;
 import com.google.common.collect.Lists;
 
@@ -64,7 +65,7 @@ public class KafkaPropertiesCheck extends AbstractCheckDescriptor {
   }
 
   /**
-   * Constructor.
+   * Constructor
    */
   public KafkaPropertiesCheck() {
     super(CheckDescription.KAFKA_PROPERTIES_VALIDATION);
@@ -76,6 +77,14 @@ public class KafkaPropertiesCheck extends AbstractCheckDescriptor {
   @Override
   public List<CheckQualification> getQualifications() {
     return Lists.<CheckQualification> newArrayList(new KafkaPropertiesMinVersionQualification());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Set<String> getApplicableServices(){
+    return Sets.newHashSet(KAFKA_SERVICE_NAME);
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/KafkaPropertiesCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/KafkaPropertiesCheckTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -158,6 +159,24 @@ public class KafkaPropertiesCheckTest {
     request.setTargetRepositoryVersion(m_repositoryVersion);
 
     assertTrue(m_kafkaPropertiresCheck.isApplicable(request));
+  }
+
+  @Test
+  public void testNotApplicable() throws Exception {
+
+    final Service service = EasyMock.createMock(Service.class);
+    m_services.put("HDFS", service);
+
+    Cluster cluster = m_clusters.getCluster("cluster");
+    EasyMock.reset(cluster);
+    expect(cluster.getServices()).andReturn(m_services).anyTimes();
+    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP-2.3")).anyTimes();
+    replay(cluster);
+
+    PrereqCheckRequest request = new PrereqCheckRequest("cluster");
+    request.setTargetRepositoryVersion(m_repositoryVersion);
+
+    assertFalse(m_kafkaPropertiresCheck.isApplicable(request));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kafka properties check is executed even if no Kafka service present

## How was this patch tested?

Tested via added UT for this case