### PR TITLE
AMBARI-23672: Change the method identifier "extractHeaders" to "getHeaders".

### DIFF
--- a/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/parsers/RowIterator.java
+++ b/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/parsers/RowIterator.java
@@ -71,7 +71,7 @@ public class RowIterator implements Iterator<Row> {
   /**
    * @return : ordered collection of string of headers
    */
-  public LinkedList<String> extractHeaders() {
+  public LinkedList<String> getHeaders() {
     return headers;
   }
 

--- a/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/parsers/json/JSONParser.java
+++ b/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/parsers/json/JSONParser.java
@@ -63,7 +63,7 @@ public class JSONParser extends Parser {
 
   @Override
   public Row extractHeader() {
-    Collection<String> headers = this.iterator.extractHeaders();
+    Collection<String> headers = this.iterator.getHeaders();
     Object[] objs = new Object[headers.size()];
     Iterator<String> iterator = headers.iterator();
     for(int i = 0 ; i < headers.size() ; i++){

--- a/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/parsers/xml/XMLParser.java
+++ b/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/parsers/xml/XMLParser.java
@@ -76,7 +76,7 @@ public class XMLParser extends Parser {
 
   @Override
   public Row extractHeader() {
-    Collection<String> headers = this.iterator.extractHeaders();
+    Collection<String> headers = this.iterator.getHeaders();
     Object[] objs = new Object[headers.size()];
     Iterator<String> iterator = headers.iterator();
     for (int i = 0; i < headers.size(); i++) {

--- a/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/parsers/RowIterator.java
+++ b/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/parsers/RowIterator.java
@@ -71,7 +71,7 @@ public class RowIterator implements Iterator<Row> {
   /**
    * @return : ordered collection of string of headers
    */
-  public LinkedList<String> extractHeaders() {
+  public LinkedList<String> getHeaders() {
     return headers;
   }
 

--- a/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/parsers/json/JSONParser.java
+++ b/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/parsers/json/JSONParser.java
@@ -63,7 +63,7 @@ public class JSONParser extends Parser {
 
   @Override
   public Row extractHeader() {
-    Collection<String> headers = this.iterator.extractHeaders();
+    Collection<String> headers = this.iterator.getHeaders();
     Object[] objs = new Object[headers.size()];
     Iterator<String> iterator = headers.iterator();
     for(int i = 0 ; i < headers.size() ; i++){

--- a/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/parsers/xml/XMLParser.java
+++ b/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/parsers/xml/XMLParser.java
@@ -76,7 +76,7 @@ public class XMLParser extends Parser {
 
   @Override
   public Row extractHeader() {
-    Collection<String> headers = this.iterator.extractHeaders();
+    Collection<String> headers = this.iterator.getHeaders();
     Object[] objs = new Object[headers.size()];
     Iterator<String> iterator = headers.iterator();
     for (int i = 0; i < headers.size(); i++) {


### PR DESCRIPTION
The method just returns the field "headers" of this class, thus method name "getHeaders" should be better than "extractHeaders".

