### PR TITLE
Change the method "begin" to "build".

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/PredicateBuilder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/PredicateBuilder.java
@@ -74,6 +74,12 @@ public class PredicateBuilder {
     return this;
   }
 
+  public PredicateBuilder build() {
+	  checkDone();
+	  return new PredicateBuilder(this);
+  }
+  
+  @Deprecated
   public PredicateBuilder begin() {
     checkDone();
     return new PredicateBuilder(this);


### PR DESCRIPTION
The method returns a new PredicateBuilder, so that the method name "build" should be better than "begin".

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.