### PR TITLE
AMBARI-23600. cluster name validation issue in ADMIN view

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/clusters/clusterInformation.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/clusters/clusterInformation.html
@@ -51,8 +51,7 @@
                ng-model="edit.clusterName"
                required
                autofocus
-               ng-pattern="/^\w*$/"
-               ng-maxlength="80"
+               ng-maxlength="100"
                tooltip="{{'common.renameClusterTip' | translate}}"
                tooltip-trigger="focus"
                tooltip-placement="bottom"


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Cluster name max-length is setted to 100 symbols, field is required (no other validations)

## How was this patch tested?
manually 

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.