### PR TITLE
AMBARI-23594 - LZO Libraries Are Not Installed Correctly During Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
@@ -44,8 +44,6 @@ import org.apache.ambari.server.state.DesiredConfig;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.Service;
 import org.apache.ambari.server.state.ServiceComponent;
-import org.apache.ambari.server.state.StackId;
-import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.UpgradeContext;
 import org.apache.ambari.server.state.UpgradeContext.UpgradeSummary;
 import org.apache.ambari.server.state.UpgradeContextFactory;
@@ -199,10 +197,9 @@ public class ExecutionCommandWrapper {
         final String componentName = executionCommand.getComponentName();
 
         try {
-
           if (null != componentName) {
             ServiceComponent serviceComponent = service.getServiceComponent(componentName);
-            commandRepository = repoVersionHelper.getCommandRepository(null, serviceComponent, host);
+            commandRepository = repoVersionHelper.getCommandRepository(cluster, serviceComponent, host);
           } else {
             RepositoryVersionEntity repoVersion = service.getDesiredRepositoryVersion();
             RepoOsEntity osEntity = repoVersionHelper.getOSEntityForHost(host, repoVersion);
@@ -211,7 +208,8 @@ public class ExecutionCommandWrapper {
           executionCommand.setRepositoryFile(commandRepository);
 
         } catch (SystemException e) {
-          throw new RuntimeException(e);
+          LOG.debug("Unable to find command repository with a correct operating system for host {}",
+              host, e);
         }
       }
 
@@ -265,10 +263,6 @@ public class ExecutionCommandWrapper {
           && executionCommand.getRoleCommand() != RoleCommand.INSTALL) {
           commandParams.put(VERSION, repositoryVersion.getVersion());
         }
-
-        StackId stackId = repositoryVersion.getStackId();
-        StackInfo stackInfo = ambariMetaInfo.getStack(stackId.getStackName(),
-          stackId.getStackVersion());
 
         if (!commandParams.containsKey(HOOKS_FOLDER)) {
           commandParams.put(HOOKS_FOLDER,configuration.getProperty(Configuration.HOOKS_FOLDER));

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
@@ -28,6 +28,7 @@ import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.RoleCommand;
+import org.apache.ambari.server.actionmanager.ExecutionCommandWrapper;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.UpgradeContext.UpgradeSummary;
 import org.apache.ambari.server.utils.StageUtils;
@@ -180,8 +181,7 @@ public class ExecutionCommand extends AgentCommand {
 
 
   /**
-   * Provides information regarding the content of repositories.  This structure replaces
-   * the deprecated use of {@link KeyNames#REPO_INFO}
+   * Provides information regarding the content of repositories.
    */
   @SerializedName("repositoryFile")
   private CommandRepository commandRepository;
@@ -449,14 +449,33 @@ public class ExecutionCommand extends AgentCommand {
   }
 
   /**
+   * Gets the repository file which was set on this command. The repository can
+   * be set either by the creator of the command or by the
+   * {@link ExecutionCommandWrapper} when it is about to execute the command.
+   *
    * @return the repository file that is to be written.
+   * @see #setRepositoryFile(CommandRepository)
    */
   public CommandRepository getRepositoryFile() {
     return commandRepository;
   }
 
   /**
-   * @param repository  the command repository instance.
+   * Sets the {@link CommandRepository} which will be sent down to the agent
+   * instructing it on which repository file to create on the host. In most
+   * cases, it is not necessary to set this file since the
+   * {@link ExecutionCommandWrapper} will set it in the event that it is
+   * missing. In fact, it is only appropriate to set this file in the following
+   * cases:
+   * <ul>
+   * <li>When distributing a repository to hosts in preparation for upgrade.
+   * This is because the service/component desired stack is not pointing to the
+   * new repository yet</li>
+   * <li>If the command does not contain a host or service/component></li>
+   * </ul>
+   *
+   * @param repository
+   *          the command repository instance.
    */
   public void setRepositoryFile(CommandRepository repository) {
     commandRepository = repository;
@@ -521,12 +540,6 @@ public class ExecutionCommand extends AgentCommand {
     String ORACLE_JDBC_URL = "oracle_jdbc_url";
     String DB_DRIVER_FILENAME = "db_driver_filename";
     String CLIENTS_TO_UPDATE_CONFIGS = "clientsToUpdateConfigs";
-    /**
-     * Keep for backward compatibility.
-     */
-    @Deprecated
-    @Experimental(feature=ExperimentalFeature.PATCH_UPGRADES)
-    String REPO_INFO = "repo_info";
 
     String DB_NAME = "db_name";
     String GLOBAL = "global";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -33,7 +33,6 @@ import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.JDK_LOCAT
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.MYSQL_JDBC_URL;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.NOT_MANAGED_HDFS_PATH_LIST;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.ORACLE_JDBC_URL;
-import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.REPO_INFO;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SCRIPT;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SCRIPT_TYPE;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.STACK_NAME;
@@ -61,7 +60,6 @@ import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.actionmanager.Stage;
 import org.apache.ambari.server.agent.AgentCommand.AgentCommandType;
-import org.apache.ambari.server.agent.CommandRepository;
 import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.agent.ExecutionCommand.KeyNames;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
@@ -69,7 +67,6 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.RequestResourceFilter;
 import org.apache.ambari.server.controller.spi.Resource;
-import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.metadata.ActionMetadata;
 import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
 import org.apache.ambari.server.state.Cluster;
@@ -94,8 +91,6 @@ import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.state.stack.OsFamily;
-import org.apache.ambari.server.state.stack.upgrade.RepositoryVersionHelper;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpInProgressEvent;
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.commons.lang.StringUtils;
@@ -163,13 +158,7 @@ public class AmbariCustomCommandExecutionHelper {
   private MaintenanceStateHelper maintenanceStateHelper;
 
   @Inject
-  private OsFamily os_family;
-
-  @Inject
   private HostRoleCommandDAO hostRoleCommandDAO;
-
-  @Inject
-  private RepositoryVersionHelper repoVersionHelper;
 
   private Map<String, Map<String, Map<String, String>>> configCredentialsForService = new HashMap<>();
 
@@ -323,7 +312,6 @@ public class AmbariCustomCommandExecutionHelper {
 
     AmbariMetaInfo ambariMetaInfo = managementController.getAmbariMetaInfo();
     ServiceInfo serviceInfo = ambariMetaInfo.getService(service);
-    StackInfo stackInfo = ambariMetaInfo.getStack(stackId);
 
     CustomCommandDefinition customCommandDefinition = null;
     ComponentInfo ci = serviceInfo.getComponentByName(componentName);
@@ -334,9 +322,6 @@ public class AmbariCustomCommandExecutionHelper {
     long nowTimestamp = System.currentTimeMillis();
 
     for (String hostName : candidateHosts) {
-
-      Host host = clusters.getHost(hostName);
-
       stage.addHostRoleExecutionCommand(hostName, Role.valueOf(componentName),
           RoleCommand.CUSTOM_COMMAND,
           new ServiceComponentHostOpInProgressEvent(componentName, hostName, nowTimestamp),
@@ -389,11 +374,6 @@ public class AmbariCustomCommandExecutionHelper {
       Service clusterService = cluster.getService(serviceName);
       execCmd.setCredentialStoreEnabled(String.valueOf(clusterService.isCredentialStoreEnabled()));
 
-      ServiceComponent component = null;
-      if (StringUtils.isNotBlank(componentName)) {
-        component = clusterService.getServiceComponent(componentName);
-      }
-
       // Get the map of service config type to password properties for the service
       Map<String, Map<String, String>> configCredentials;
       configCredentials = configCredentialsForService.get(clusterService.getName());
@@ -405,15 +385,6 @@ public class AmbariCustomCommandExecutionHelper {
       execCmd.setConfigurationCredentials(configCredentials);
 
       Map<String, String> hostLevelParams = new TreeMap<>();
-
-      // Set parameters required for re-installing clients on restart
-      String repoInfoString;
-      try {
-        repoInfoString = repoVersionHelper.getRepoInfoString(cluster, component, host);
-      } catch (SystemException e) {
-        throw new RuntimeException(e);
-      }
-      hostLevelParams.put(REPO_INFO, repoInfoString);
       hostLevelParams.put(STACK_NAME, stackId.getStackName());
       hostLevelParams.put(STACK_VERSION, stackId.getStackVersion());
 
@@ -521,14 +492,6 @@ public class AmbariCustomCommandExecutionHelper {
 
       execCmd.setCommandParams(commandParams);
       execCmd.setRoleParams(roleParams);
-
-      CommandRepository commandRepository;
-      try {
-        commandRepository = repoVersionHelper.getCommandRepository(cluster, component, host);
-      } catch (SystemException e) {
-        throw new RuntimeException(e);
-      }
-      execCmd.setRepositoryFile(commandRepository);
 
       // perform any server side command related logic - eg - set desired states on restart
       applyCustomCommandBackendLogic(cluster, serviceName, componentName, commandName, hostName);
@@ -732,8 +695,6 @@ public class AmbariCustomCommandExecutionHelper {
     AmbariMetaInfo ambariMetaInfo = managementController.getAmbariMetaInfo();
     ServiceInfo serviceInfo = ambariMetaInfo.getService(stackId.getStackName(),
         stackId.getStackVersion(), serviceName);
-    StackInfo stackInfo = ambariMetaInfo.getStack(stackId.getStackName(),
-        stackId.getStackVersion());
 
     stage.addHostRoleExecutionCommand(hostname, Role.valueOf(smokeTestRole),
         RoleCommand.SERVICE_CHECK,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -45,7 +45,6 @@ import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.MYSQL_JDB
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.NOT_MANAGED_HDFS_PATH_LIST;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.ORACLE_JDBC_URL;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.PACKAGE_LIST;
-import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.REPO_INFO;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SCRIPT;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SCRIPT_TYPE;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SERVICE_PACKAGE_FOLDER;
@@ -361,9 +360,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   private TopologyDeleteFormer topologyDeleteFormer;
 
   @Inject
-  private AmbariCustomCommandExecutionHelper ambariCustomCommandExecutionHelper;
-
-  @Inject
   private Provider<TopologyHolder> m_topologyHolder;
 
   private Provider<MetadataHolder> m_metadataHolder;
@@ -411,6 +407,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
   @Inject
   private AmbariCustomCommandExecutionHelper customCommandExecutionHelper;
+
   @Inject
   private AmbariActionExecutionHelper actionExecutionHelper;
 
@@ -2539,7 +2536,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
 
     Map<String, String> hostParams = new TreeMap<>();
-    hostParams.put(REPO_INFO, repoInfo);
     hostParams.putAll(getRcaParameters());
 
     if (roleCommand.equals(RoleCommand.INSTALL)) {
@@ -5603,6 +5599,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     return metadataUpdateEvent;
   }
 
+  @Override
   public MetadataUpdateEvent getClusterMetadataOnConfigsUpdate(Cluster cl) throws AmbariException {
     TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
     StackId stackId = cl.getDesiredStackVersion();
@@ -5834,7 +5831,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
           serviceStackId.getStackVersion(), service.getName());
       Long statusCommandTimeout = null;
       if (serviceInfo.getCommandScript() != null) {
-        statusCommandTimeout = new Long(ambariCustomCommandExecutionHelper.getStatusCommandTimeout(serviceInfo));
+        statusCommandTimeout = new Long(customCommandExecutionHelper.getStatusCommandTimeout(serviceInfo));
       }
 
       String servicePackageFolder = serviceInfo.getServicePackageFolder();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -455,25 +455,6 @@ public class RepositoryVersionHelper {
       hostLevelParams.put(KeyNames.STACK_NAME, stackId.getStackName());
       hostLevelParams.put(KeyNames.STACK_VERSION, stackId.getStackVersion());
     }
-
-    JsonObject rootJsonObject = new JsonObject();
-    JsonArray repositories = new JsonArray();
-
-    String hostOsFamily = cluster.getHost(hostName).getOsFamily();
-    for (RepoOsEntity operatingSystemEntity : repositoryVersion.getRepoOsEntities()) {
-      if (operatingSystemEntity.getFamily().equals(hostOsFamily)) {
-        for (RepoDefinitionEntity repositoryEntity : operatingSystemEntity.getRepoDefinitionEntities()) {
-          JsonObject repositoryInfo = new JsonObject();
-          repositoryInfo.addProperty("base_url", repositoryEntity.getBaseUrl());
-          repositoryInfo.addProperty("repo_name", repositoryEntity.getRepoName());
-          repositoryInfo.addProperty("repo_id", repositoryEntity.getRepoID());
-
-          repositories.add(repositoryInfo);
-        }
-        rootJsonObject.add("repositories", repositories);
-      }
-    }
-    hostLevelParams.put(KeyNames.REPO_INFO, rootJsonObject.toString());
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapperTest.java
@@ -42,6 +42,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ConfigFactory;
 import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.Service;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStartEvent;
@@ -110,6 +111,13 @@ public class ExecutionCommandWrapperTest {
     clusters = injector.getInstance(Clusters.class);
     clusters.addHost(HOST1);
     clusters.addCluster(CLUSTER1, new StackId("HDP-0.1"));
+    clusters.mapHostToCluster(HOST1, CLUSTER1);
+
+    Map<String, String> hostAttributes = new HashMap<>();
+    hostAttributes.put("os_family", "redhat");
+    hostAttributes.put("os_release_version", "6.4");
+    Host host = clusters.getHost(HOST1);
+    host.setHostAttributes(hostAttributes);
 
     Cluster cluster1 = clusters.getCluster(CLUSTER1);
 
@@ -236,6 +244,7 @@ public class ExecutionCommandWrapperTest {
 
     Assert.assertEquals(serviceSiteKeys.size(), serviceSiteConfig.size());
 
+    Assert.assertNotNull(processedExecutionCommand.getRepositoryFile());
   }
 
   @Test
@@ -285,7 +294,7 @@ public class ExecutionCommandWrapperTest {
     Cluster cluster = clusters.getCluster(CLUSTER1);
 
     StackId stackId = cluster.getDesiredStackVersion();
-    
+
     // set the repo version resolved state to verify that the version is not sent
     RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(stackId, "0.1-0000");
     repositoryVersion.setResolved(false);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -247,6 +247,7 @@ public class AmbariCustomCommandExecutionHelperTest {
     Assert.assertTrue(command.getHostLevelParams().containsKey(ExecutionCommand.KeyNames.USER_GROUPS));
     Assert.assertEquals("{\"zookeeperUser\":[\"zookeeperGroup\"]}", command.getHostLevelParams().get(ExecutionCommand.KeyNames.USER_GROUPS));
     Assert.assertEquals(true, command.getForceRefreshConfigTagsBeforeExecution());
+    Assert.assertNull(command.getRepositoryFile());
   }
 
   @Test
@@ -573,6 +574,7 @@ public class AmbariCustomCommandExecutionHelperTest {
     Assert.assertFalse(MapUtils.isEmpty(command.getComponentVersionMap()));
     Assert.assertEquals(1, command.getComponentVersionMap().size());
     Assert.assertTrue(command.getComponentVersionMap().containsKey("ZOOKEEPER"));
+    Assert.assertNull(command.getRepositoryFile());
   }
 
   /**
@@ -619,6 +621,7 @@ public class AmbariCustomCommandExecutionHelperTest {
     ExecutionCommand command = commands.get(0).getExecutionCommand();
 
     Assert.assertTrue(MapUtils.isEmpty(command.getComponentVersionMap()));
+    Assert.assertNull(command.getRepositoryFile());
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
@@ -214,8 +213,6 @@ public class AmbariManagementControllerTest {
   private ServiceComponentHostFactory serviceComponentHostFactory;
   private static AmbariMetaInfo ambariMetaInfo;
   private EntityManager entityManager;
-  private static Properties backingProperties;
-  private Configuration configuration;
   private ConfigHelper configHelper;
   private ConfigGroupFactory configGroupFactory;
   private OrmTestHelper helper;
@@ -241,7 +238,6 @@ public class AmbariManagementControllerTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     InMemoryDefaultTestModule module = new InMemoryDefaultTestModule();
-    backingProperties = module.getProperties();
     injector = Guice.createInjector(module);
     H2DatabaseCleaner.resetSequences(injector);
     injector.getInstance(GuiceJpaInitializer.class);
@@ -269,7 +265,6 @@ public class AmbariManagementControllerTest {
         ServiceComponentFactory.class);
     serviceComponentHostFactory = injector.getInstance(
         ServiceComponentHostFactory.class);
-    configuration = injector.getInstance(Configuration.class);
     configHelper = injector.getInstance(ConfigHelper.class);
     configGroupFactory = injector.getInstance(ConfigGroupFactory.class);
     helper = injector.getInstance(OrmTestHelper.class);
@@ -2094,8 +2089,7 @@ public class AmbariManagementControllerTest {
 
       for (String host : stage.getHosts()) {
         for (ExecutionCommandWrapper ecw : stage.getExecutionCommands(host)) {
-          Assert.assertFalse(
-              ecw.getExecutionCommand().getHostLevelParams().get("repo_info").isEmpty());
+          Assert.assertNotNull(ecw.getExecutionCommand().getRepositoryFile());
         }
       }
     }
@@ -6499,10 +6493,11 @@ public class AmbariManagementControllerTest {
       Assert.assertNotNull(params.get("oracle_jdbc_url"));
     }
 
-    Map<String, String> paramsCmd = stages.get(0).getOrderedHostRoleCommands().get
-      (0).getExecutionCommandWrapper().getExecutionCommand()
-      .getHostLevelParams();
-    Assert.assertNotNull(paramsCmd.get("repo_info"));
+    ExecutionCommand executionCommand = stages.get(0).getOrderedHostRoleCommands().get(
+        0).getExecutionCommandWrapper().getExecutionCommand();
+
+    Map<String, String> paramsCmd = executionCommand.getHostLevelParams();
+    Assert.assertNotNull(executionCommand.getRepositoryFile());
     Assert.assertNotNull(paramsCmd.get("clientsToUpdateConfigs"));
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/OrmTestHelper.java
@@ -634,8 +634,31 @@ public class OrmTestHelper {
 
     if (repositoryVersion == null) {
       try {
+        List<RepoOsEntity> operatingSystems = new ArrayList<>();
+        RepoDefinitionEntity repoDefinitionEntity1 = new RepoDefinitionEntity();
+        repoDefinitionEntity1.setRepoID("HDP");
+        repoDefinitionEntity1.setBaseUrl("");
+        repoDefinitionEntity1.setRepoName("HDP");
+        RepoDefinitionEntity repoDefinitionEntity2 = new RepoDefinitionEntity();
+        repoDefinitionEntity2.setRepoID("HDP-UTILS");
+        repoDefinitionEntity2.setBaseUrl("");
+        repoDefinitionEntity2.setRepoName("HDP-UTILS");
+        RepoOsEntity repoOsEntityRedHat6 = new RepoOsEntity();
+        repoOsEntityRedHat6.setFamily("redhat6");
+        repoOsEntityRedHat6.setAmbariManaged(true);
+        repoOsEntityRedHat6.addRepoDefinition(repoDefinitionEntity1);
+        repoOsEntityRedHat6.addRepoDefinition(repoDefinitionEntity2);
+        RepoOsEntity repoOsEntityRedHat5 = new RepoOsEntity();
+        repoOsEntityRedHat5.setFamily("redhat5");
+        repoOsEntityRedHat5.setAmbariManaged(true);
+        repoOsEntityRedHat5.addRepoDefinition(repoDefinitionEntity1);
+        repoOsEntityRedHat5.addRepoDefinition(repoDefinitionEntity2);
+        operatingSystems.add(repoOsEntityRedHat6);
+        operatingSystems.add(repoOsEntityRedHat5);
+
         repositoryVersion = repositoryVersionDAO.create(stackEntity, version,
-            String.valueOf(System.currentTimeMillis()) + uniqueCounter.incrementAndGet(), new ArrayList<>());
+            String.valueOf(System.currentTimeMillis()) + uniqueCounter.incrementAndGet(),
+            operatingSystems);
       } catch (Exception ex) {
         LOG.error("Caught exception", ex);
         ex.printStackTrace();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The RCA for this one is that we are trying to install the wrong LZO packages during NameNode 3.0 startup:

```
2018-04-13 18:21:47,999 - Package['lzo'] {'retry_on_repo_unavailability': True, 'retry_count': 5}
2018-04-13 18:21:48,121 - Skipping installation of existing package lzo
2018-04-13 18:21:48,121 - Package['hadooplzo_2_6_1_0_129'] {'retry_on_repo_unavailability': True, 'retry_count': 5}
2018-04-13 18:21:48,136 - Skipping installation of existing package hadooplzo_2_6_1_0_129
2018-04-13 18:21:48,137 - Package['hadooplzo_2_6_1_0_129-native'] {'retry_on_repo_unavailability': True, 'retry_count': 5}
2018-04-13 18:21:48,151 - Skipping installation of existing package hadooplzo_2_6_1_0_129-native
```

Because we're sending down the wrong version here, we never install {{hadooplzo_3_0_0_0_1192.x86_64}}.

```
hadooplzo.noarch : hadooplzo Distro virtual package
hadooplzo-native.noarch : hadooplzo-native Distro virtual package
hadooplzo_2_6_1_0_129.x86_64 : Hadoop-LZO is a project to bring splittable LZO compression to Hadoop
hadooplzo_2_6_1_0_129-native.x86_64 : GPL Compression Libraries for Hadoop (native)
hadooplzo_3_0_0_0_1192.x86_64 : Hadoop-LZO is a project to bring splittable LZO compression to Hadoop
hadooplzo_3_0_0_0_1192-native.x86_64 : GPL Compression Libraries for Hadoop (native)
```

This is an Ambari issue with how we generate commands for the upgrade. When creating commands, we are populating a {{RepositoryFile}} which captures the current state of the component's repository (2.6.1.0-129). When this runs during the upgrade, the wrong {{RepositoryFile}} is being sent down. This is why the version for installing LZO is incorrect.

In general, we shouldn't need to pre-populate {{ExecutionCommand}}s with {{RepositoryFile}} since it can usually be taken at command-runtime. However, there is one case where this is not so:
- During a stack's distribution

The core logic in Ambari states that when a command is about to run, we should populate the {{repositoryFile}} IFF it's not already set on the command. Most times, this is benign, but in the case of upgrades, it's a real problem.

As I see it, we have a couple of options here:
- Remove it from all execution/action command helpers
-- Rely on the {{ExecutionCommandWrapper}} to set it before the command is sent
-- Require that stack distribution code to ensure that they place it on there instead of having the helpers do it

- Have the {{UpgradeResourceProvider}} strip it from all commands that it generates

## How was this patch tested?

`mvn clean test`
- Blueprint-based deployment of HDP 2.6
-- Enabled LZO
- Upgrade to HDP 3.0 
