### PR TITLE
[AMBARI-23608] Unable to update credentials of a remotely registered cluster

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/remoteClusters/RemoteClustersEditCtrl.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/remoteClusters/RemoteClustersEditCtrl.js
@@ -80,7 +80,7 @@ angular.module('ambariAdminConsole')
 
             RemoteCluster.edit(payload, config).then(function(data) {
                 Alert.success($t('views.alerts.credentialsUpdated'));
-                $scope.form.passwordChangeForm.$setPristine();
+                $scope.form.passwordChangeForm = {};
               })
               .catch(function(data) {
                 console.log(data);


### PR DESCRIPTION
## What changes were proposed in this pull request?

**STR**
1. Register a remote cluster with Ambari server
2. Go to Admin - Remote Cluster page and select the cluster
3. Hit 'Update Credentials' and supply new/existing admin credentials of remote cluster
4. Hit Update

Result: Credentials are not updated and UI shows an error

## How was this patch tested?

Tested manually on the real cluster