### PR TITLE
[AMBARI-23515] : Rearranging configuration file creation for Ranger Plu…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/setup_ranger_plugin_xml.py
@@ -45,7 +45,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
                         cache_service_list, plugin_audit_properties, plugin_audit_attributes,
                         plugin_security_properties, plugin_security_attributes,
                         plugin_policymgr_ssl_properties, plugin_policymgr_ssl_attributes,
-                        component_list, audit_db_is_enabled, credential_file, 
+                        component_list, audit_db_is_enabled, credential_file,
                         xa_audit_db_password, ssl_truststore_password,
                         ssl_keystore_password, api_version=None, stack_version_override = None, skip_if_rangeradmin_down = True,
                         is_security_enabled = False, is_stack_supports_ranger_kerberos = False,
@@ -111,7 +111,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
                                               policy_user)
 
     current_datetime = datetime.now()
-    
+
     File(format('{component_conf_dir}/ranger-security.xml'),
       owner = component_user,
       group = component_group,
@@ -174,7 +174,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
         configuration_attributes=plugin_policymgr_ssl_attributes,
         owner = component_user,
         group = component_group,
-        mode=0744) 
+        mode=0744)
     else:
       XmlConfig("ranger-policymgr-ssl.xml",
         conf_dir=component_conf_dir,
@@ -182,7 +182,7 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
         configuration_attributes=plugin_policymgr_ssl_attributes,
         owner = component_user,
         group = component_group,
-        mode=0744) 
+        mode=0744)
 
     # creating symblink should be done by rpm package
     # setup_ranger_plugin_jar_symblink(stack_version, service_name, component_list)
@@ -193,8 +193,8 @@ def setup_ranger_plugin(component_select_name, service_name, previous_jdbc_jar,
 
   else:
     File(format('{component_conf_dir}/ranger-security.xml'),
-      action="delete"      
-    )    
+      action="delete"
+    )
 
 def setup_ranger_plugin_jar_symblink(stack_version, service_name, component_list):
 
@@ -240,8 +240,8 @@ def setup_ranger_plugin_keystore(service_name, audit_db_is_enabled, stack_versio
     mode = 0640
   )
 
-def setup_core_site_for_required_plugins(component_user, component_group, create_core_site_path, configurations = {}, configuration_attributes = {}):
-  XmlConfig('core-site.xml',
+def setup_configuration_file_for_required_plugins(component_user, component_group, create_core_site_path, configurations = {}, configuration_attributes = {}, file_name='core-site.xml'):
+  XmlConfig(file_name,
     conf_dir = create_core_site_path,
     configurations = configurations,
     configuration_attributes = configuration_attributes,

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/setup_ranger_kafka.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/setup_ranger_kafka.py
@@ -17,7 +17,7 @@ limitations under the License.
 from resource_management.core.logger import Logger
 from resource_management.core.resources import File, Execute
 from resource_management.libraries.functions.format import format
-from resource_management.libraries.functions.setup_ranger_plugin_xml import setup_core_site_for_required_plugins
+from resource_management.libraries.functions.setup_ranger_plugin_xml import setup_configuration_file_for_required_plugins
 
 def setup_ranger_kafka():
   import params
@@ -84,14 +84,14 @@ def setup_ranger_kafka():
     if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_kafka and params.kerberos_security_enabled:
       if params.has_namenode:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
-        setup_core_site_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
+        setup_configuration_file_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
                                              create_core_site_path = params.conf_dir, configurations = params.config['configurations']['core-site'],
-                                             configuration_attributes = params.config['configuration_attributes']['core-site'])
+                                             configuration_attributes = params.config['configuration_attributes']['core-site'], file_name='core-site.xml')
       else:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
-        setup_core_site_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
+        setup_configuration_file_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
                                              create_core_site_path = params.conf_dir, configurations = { 'hadoop.security.authentication' : 'kerberos' if params.kerberos_security_enabled else 'simple' },
-                                             configuration_attributes = {})
+                                             configuration_attributes = {}, file_name='core-site.xml')
 
     else:
       Logger.info("Stack does not support core-site.xml creation for Ranger plugin, skipping core-site.xml configurations")

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/setup_ranger_kafka.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/setup_ranger_kafka.py
@@ -86,7 +86,7 @@ def setup_ranger_kafka():
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
         setup_configuration_file_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,
                                              create_core_site_path = params.conf_dir, configurations = params.config['configurations']['core-site'],
-                                             configuration_attributes = params.config['configuration_attributes']['core-site'], file_name='core-site.xml')
+                                             configuration_attributes = params.config['configurationAttributes']['core-site'], file_name='core-site.xml')
       else:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
         setup_configuration_file_for_required_plugins(component_user = params.kafka_user, component_group = params.user_group,

--- a/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/setup_ranger_knox.py
+++ b/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/setup_ranger_knox.py
@@ -18,7 +18,7 @@ limitations under the License.
 
 """
 from resource_management.core.logger import Logger
-from resource_management.libraries.functions.setup_ranger_plugin_xml import setup_core_site_for_required_plugins
+from resource_management.libraries.functions.setup_ranger_plugin_xml import setup_configuration_file_for_required_plugins
 from resource_management.core.resources import File
 from resource_management.libraries.resources.xml_config import XmlConfig
 from resource_management.libraries.functions.format import format
@@ -114,14 +114,14 @@ def setup_ranger_knox(upgrade_type=None):
     if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_knox and params.security_enabled:
       if params.has_namenode:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
-        setup_core_site_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
+        setup_configuration_file_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
                                              create_core_site_path = params.knox_conf_dir, configurations = params.config['configurations']['core-site'],
-                                             configuration_attributes = params.config['configuration_attributes']['core-site'])
+                                             configuration_attributes = params.config['configuration_attributes']['core-site'], file_name = 'core-site.xml')
       else:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
-        setup_core_site_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
+        setup_configuration_file_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
                                              create_core_site_path = params.knox_conf_dir, configurations = { 'hadoop.security.authentication' : 'kerberos' if params.security_enabled else 'simple' },
-                                             configuration_attributes = {})
+                                             configuration_attributes = {}, file_name = 'core-site.xml')
     else:
       Logger.info("Stack does not support core-site.xml creation for Ranger plugin, skipping core-site.xml configurations")
 

--- a/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/setup_ranger_knox.py
+++ b/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/setup_ranger_knox.py
@@ -116,7 +116,7 @@ def setup_ranger_knox(upgrade_type=None):
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
         setup_configuration_file_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,
                                              create_core_site_path = params.knox_conf_dir, configurations = params.config['configurations']['core-site'],
-                                             configuration_attributes = params.config['configuration_attributes']['core-site'], file_name = 'core-site.xml')
+                                             configuration_attributes = params.config['configurationAttributes']['core-site'], file_name = 'core-site.xml')
       else:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
         setup_configuration_file_for_required_plugins(component_user = params.knox_user, component_group = params.knox_group,

--- a/ambari-server/src/main/resources/common-services/STORM/0.9.1/package/scripts/setup_ranger_storm.py
+++ b/ambari-server/src/main/resources/common-services/STORM/0.9.1/package/scripts/setup_ranger_storm.py
@@ -116,7 +116,7 @@ def setup_ranger_storm(upgrade_type=None):
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
         setup_configuration_file_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
                                              create_core_site_path = site_files_create_path, configurations = params.config['configurations']['core-site'],
-                                             configuration_attributes = params.config['configuration_attributes']['core-site'], file_name='core-site.xml')
+                                             configuration_attributes = params.config['configurationAttributes']['core-site'], file_name='core-site.xml')
       else:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
         setup_configuration_file_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,

--- a/ambari-server/src/main/resources/common-services/STORM/0.9.1/package/scripts/setup_ranger_storm.py
+++ b/ambari-server/src/main/resources/common-services/STORM/0.9.1/package/scripts/setup_ranger_storm.py
@@ -18,7 +18,7 @@ limitations under the License.
 
 """
 from resource_management.core.logger import Logger
-from resource_management.libraries.functions.setup_ranger_plugin_xml import setup_core_site_for_required_plugins
+from resource_management.libraries.functions.setup_ranger_plugin_xml import setup_configuration_file_for_required_plugins
 from resource_management.libraries.resources.xml_config import XmlConfig
 from resource_management.libraries.functions.format import format
 from resource_management.core.resources import File, Directory
@@ -114,25 +114,20 @@ def setup_ranger_storm(upgrade_type=None):
     if params.stack_supports_core_site_for_ranger_plugin and params.enable_ranger_storm and params.security_enabled:
       if params.has_namenode:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is installed, creating create core-site.xml from namenode configurations")
-        setup_core_site_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
+        setup_configuration_file_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
                                              create_core_site_path = site_files_create_path, configurations = params.config['configurations']['core-site'],
-                                             configuration_attributes = params.config['configuration_attributes']['core-site'])
+                                             configuration_attributes = params.config['configuration_attributes']['core-site'], file_name='core-site.xml')
       else:
         Logger.info("Stack supports core-site.xml creation for Ranger plugin and Namenode is not installed, creating create core-site.xml from default configurations")
-        setup_core_site_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
+        setup_configuration_file_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
                                              create_core_site_path = site_files_create_path, configurations = { 'hadoop.security.authentication' : 'kerberos' if params.security_enabled else 'simple' },
-                                             configuration_attributes = {})
+                                             configuration_attributes = {}, file_name = 'core-site.xml')
 
       if len(params.namenode_hosts) > 1:
         Logger.info('Ranger Storm plugin is enabled along with security and NameNode is HA , creating hdfs-site.xml')
-        XmlConfig("hdfs-site.xml",
-          conf_dir=site_files_create_path,
-          configurations=params.config['configurations']['hdfs-site'],
-          configuration_attributes=params.config['configurationAttributes']['hdfs-site'],
-          owner=params.storm_user,
-          group=params.user_group,
-          mode=0644
-        )
+        setup_configuration_file_for_required_plugins(component_user = params.storm_user, component_group = params.user_group,
+                                                      create_core_site_path = site_files_create_path, configurations = params.config['configurations']['hdfs-site'],
+                                                      configuration_attributes = params.config['configurationAttributes']['hdfs-site'], file_name = 'hdfs-site.xml')
       else:
         Logger.info('Ranger Storm plugin is not enabled or security is disabled, removing hdfs-site.xml')
         File(format('{site_files_create_path}/hdfs-site.xml'), action="delete")


### PR DESCRIPTION
…gins.

## What changes were proposed in this pull request?
When enabling Ranger plug-ins for Storm, Knox and Kafka certain configuration files are created for the plug-in enabled components, need to re-arrange logic to create the configuration files to allow better flexibility.

## How was this patch tested?
Verified with fresh installation of services for required files to be created.

@fimugdha / @jayush  / @swagle  / @jonathan-hurley / @aonishuk : Request to kindly review the patch. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.