### PR TITLE
[AMBARI-23610] Enable NameNode HA fails after Ambari upgrade

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
+++ b/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
@@ -80,4 +80,4 @@ class ConfigurationBuilder:
 
   @property
   def public_fqdn(self):
-    hostname.public_hostname(self.config)
+    return hostname.public_hostname(self.config)

--- a/ambari-agent/src/test/python/ambari_agent/TestConfigurationBuilder.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestConfigurationBuilder.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+from mock.mock import MagicMock, patch
+from unittest import TestCase
+
+from ambari_agent.ConfigurationBuilder import ConfigurationBuilder
+from ambari_agent.InitializerModule import InitializerModule
+
+class TestConfigurationBuilder(TestCase):
+
+  @patch("ambari_agent.hostname.public_hostname", new = MagicMock(return_value='c6401.ambari.apache.org'))
+  def test_public_fqdn(self):
+    initializer_module = InitializerModule()
+
+    config_builder = ConfigurationBuilder(initializer_module)
+    self.assertEqual('c6401.ambari.apache.org', config_builder.public_fqdn)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable NameNode HA wizard fails due with:

```
  File "/var/lib/ambari-agent/cache/common-services/HDFS/2.1.0.2.0/package/scripts/params_linux.py", line 330, in <module>
    if hostname.lower() in nn_host.lower() or public_hostname.lower() in nn_host.lower():
AttributeError: 'NoneType' object has no attribute 'lower'
```

due to `"public_hostname": null` observed in `command*json`.

## How was this patch tested?

Manually tested NameNode HA wizard.

Unit tests:

```
$ mvn -pl ambari-agent clean test
...
Ran 344 tests in 16.354s

OK
...
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 180 licenses.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```