### PR TITLE
[AMBARI-23590] Return mpack info even when attempting to register dup…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -217,26 +217,23 @@ public class MpackManager {
       mpackTarPath = downloadMpack(mpackRequest.getMpackUri(), mpack.getDefinition());
 
       LOG.info("Custom Mpack Registration :" + mpackRequest.getMpackUri());
-
-      if (createMpackDirectory(mpack)) {
-        mpackDirectory = mpacksStaging + File.separator + mpack.getName() + File.separator + mpack.getVersion();
-      }
+      mpackDirectory = mpacksStaging + File.separator + mpack.getName() + File.separator + mpack.getVersion();
     }
 
     extractMpackTar(mpack, mpackTarPath, mpackDirectory);
     mpack.setMpackUri(mpackRequest.getMpackUri());
-    mpackResourceId = populateDB(mpack);
-
-    if (null == mpackResourceId) {
-      String message = "Mpack :" + mpackRequest.getMpackName() + " version: "
-          + mpackRequest.getMpackVersion() + " already exists in server";
-      throw new ResourceAlreadyExistsException(message);
-    }
-
-    mpackMap.put(mpackResourceId, mpack);
+    MpackEntity mpackEntity = populateDB(mpack);
+    mpackResourceId = mpackEntity.getId();
     mpack.setResourceId(mpackResourceId);
-    populateStackDB(mpack);
-
+    if (mpackMap.get(mpackEntity.getId()) != null){
+      String message =
+              "Mpack: " + mpackEntity.getMpackName() + " version: " + mpackEntity.getMpackVersion() + " id: " + mpackResourceId + " already exists in server";
+      LOG.info(message);
+    }
+    else {
+      mpackMap.put(mpackResourceId, mpack);
+      populateStackDB(mpack);
+    }
     MpackRegisteredEvent mpackEvent = new MpackRegisteredEvent(mpackResourceId);
     eventPublisher.publish(mpackEvent);
 
@@ -322,33 +319,35 @@ public class MpackManager {
    */
   private void extractMpackTar(Mpack mpack, Path mpackTarPath, String mpackDirectory) throws IOException {
 
-    extractTar(mpackTarPath, mpacksStaging);
+    if(!Files.exists(mpackTarPath)) {
+      extractTar(mpackTarPath, mpacksStaging);
 
-    String mpackTarDirectory = mpackTarPath.toString();
-    Path extractedMpackDirectory = Files.move
-      (Paths.get(mpacksStaging + File.separator + mpackTarDirectory
-          .substring(mpackTarDirectory.lastIndexOf('/') + 1, mpackTarDirectory.indexOf(".tar")) + File.separator),
-        Paths.get(mpackDirectory), StandardCopyOption.REPLACE_EXISTING);
+      String mpackTarDirectory = mpackTarPath.toString();
+      Path extractedMpackDirectory = Files.move
+              (Paths.get(mpacksStaging + File.separator + mpackTarDirectory
+                              .substring(mpackTarDirectory.lastIndexOf('/') + 1, mpackTarDirectory.indexOf(".tar")) + File.separator),
+                      Paths.get(mpackDirectory), StandardCopyOption.REPLACE_EXISTING);
 
-    LOG.debug("Extracting Mpack definitions into :" + extractedMpackDirectory);
+      LOG.debug("Extracting Mpack definitions into :" + extractedMpackDirectory);
 
-    createServicesDirectory(extractedMpackDirectory, mpack);
+      createServicesDirectory(extractedMpackDirectory, mpack);
 
-    File metainfoFile = new File(extractedMpackDirectory + File.separator + METAINFO_FILE_NAME);
-    // if metainfo.xml doesn't exist in mpack generate it
-    if (!metainfoFile.exists()) {
-      generateMetainfo(metainfoFile, mpack);
+      File metainfoFile = new File(extractedMpackDirectory + File.separator + METAINFO_FILE_NAME);
+      // if metainfo.xml doesn't exist in mpack generate it
+      if (!metainfoFile.exists()) {
+        generateMetainfo(metainfoFile, mpack);
+      }
+
+      RepositoryXml repositoryXml = RepoUtil.getRepositoryXml(extractedMpackDirectory.toFile());
+      if (null == repositoryXml) {
+        throw new IOException("The repository file " + RepoUtil.REPOSITORY_FILE_NAME
+                + " must exist in the management pack");
+      }
+
+      mpack.setRepositoryXml(repositoryXml);
+
+      createSymLinks(mpack);
     }
-
-    RepositoryXml repositoryXml = RepoUtil.getRepositoryXml(extractedMpackDirectory.toFile());
-    if (null == repositoryXml) {
-      throw new IOException("The repository file " + RepoUtil.REPOSITORY_FILE_NAME
-          + " must exist in the management pack");
-    }
-
-    mpack.setRepositoryXml(repositoryXml);
-
-    createSymLinks(mpack);
   }
 
   /**
@@ -448,7 +447,7 @@ public class MpackManager {
    * @throws IOException
    */
   private Boolean createMpackDirectory(Mpack mpack)
-    throws IOException, ResourceAlreadyExistsException {
+    throws IOException {
         //Check if the mpack already exists
         List<MpackEntity> mpackEntities = mpackDAO.findByNameVersion(mpack.getName(), mpack.getVersion());
         if (mpackEntities.size() == 0) {
@@ -461,7 +460,8 @@ public class MpackManager {
         } else {
           String message =
             "Mpack: " + mpack.getName() + " version: " + mpack.getVersion() + " already exists in server";
-          throw new ResourceAlreadyExistsException(message);
+          LOG.info(message);
+          return false;
         }
   }
 
@@ -543,7 +543,7 @@ public class MpackManager {
    * @return
    * @throws IOException
    */
-  protected Long populateDB(Mpack mpack) throws IOException {
+  protected MpackEntity populateDB(Mpack mpack) throws IOException {
 
     String mpackName = mpack.getName();
     String mpackVersion = mpack.getVersion();
@@ -566,15 +566,15 @@ public class MpackManager {
           operatingSystem -> operatingSystem.setMpackEntity(mpackEntity));
 
       mpackEntity.setRepositoryOperatingSystems(repositoryOperatingSystems);
-      return mpackDAO.merge(mpackEntity).getId();
+      return mpackDAO.merge(mpackEntity);
     }
 
     //mpack already exists
-    return null;
+    return resultSet.get(0);
   }
 
   /***
-   * Makes an entry or updates the entry in the stack table to establish a link between the mpack and the
+   * Makes an entry in the entry in the stack table to establish a link between the mpack and the
    * associated stack
    *
    * @param mpack


### PR DESCRIPTION
…licate mpack

Earlier, registering a same mpack twice was returning 409 - ResourceAlreadyExistsException. But we want this operation to be idempotent. Hence, server will now send 201 even if same mpack is trying to be registered and simply send back a complete MpackResponse. This way both FE and BE will be consistent in the behavour, rather than UI converting a server exception into an idempotent operation.

## How was this patch tested?
Issue POST /mpacks on the same mpack multiple times.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:15 min

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.