### PR TITLE
AMBARI-23618 : Requesting non-existing metric (including wildcard) to AMS gets HTTP 500 error.

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -262,7 +263,14 @@ public class HBaseTimelineMetricsService extends AbstractService implements Time
     Multimap<String, List<Function>> metricFunctions =
       parseMetricNamesToAggregationFunctions(metricNames);
 
+    TimelineMetrics metrics = new TimelineMetrics();
+
     List<byte[]> uuids = metricMetadataManager.getUuids(metricFunctions.keySet(), hostnames, applicationId, instanceId);
+
+    if (uuids.isEmpty()) {
+      LOG.warn("No metric UUIDs generated for query : " + Arrays.asList(metricNames).toString());
+      return metrics;
+    }
 
     ConditionBuilder conditionBuilder = new ConditionBuilder(new ArrayList<String>(metricFunctions.keySet()))
       .hostnames(hostnames)
@@ -295,8 +303,6 @@ public class HBaseTimelineMetricsService extends AbstractService implements Time
     }
 
     Condition condition = conditionBuilder.build();
-
-    TimelineMetrics metrics;
 
     if (hostnames == null || hostnames.isEmpty()) {
       metrics = hBaseAccessor.getAggregateMetricRecords(condition, metricFunctions);

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/Function.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/Function.java
@@ -24,8 +24,7 @@ import java.util.Arrays;
 /**
  * Is used to determine metrics aggregate table.
  *
- * @see TimelineWebServices#getTimelineMetric
- * @see TimelineWebServices#getTimelineMetrics
+ * @see org.apache.ambari.metrics.webapp.TimelineWebServices#getTimelineMetrics
  */
 public class Function {
   public static Function DEFAULT_VALUE_FUNCTION = new Function(ReadFunction.VALUE, null);

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/discovery/TestMetadataManager.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/discovery/TestMetadataManager.java
@@ -228,6 +228,11 @@ public class TestMetadataManager extends AbstractMiniHBaseClusterTest {
     List<String> hosts = Arrays.asList("dummy_host%", "dummy_3h");
     uuids = metadataManager.getUuids(metrics, hosts, "dummy_app2", null);
     Assert.assertTrue(uuids.size() == 9);
+
+    metrics = Arrays.asList("abc%");
+    hosts = Arrays.asList("dummy_host");
+    uuids = metadataManager.getUuids(metrics, hosts, "dummy_app2", null);
+    Assert.assertTrue(uuids.isEmpty());
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The exception was thrown when both the following are true.
- The metric was non-existing
- The metric name was an expression (i.e with wildcards)

Fixed the underlying bug that caused the 500 error.

## How was this patch tested?
mvn clean install on ambari-metrics.
Manually tested.