### PR TITLE
AMBARI-23623 Enable NameNode HA fails if Ranger is set up with Ambari-managed Hive MySQL DB instance

### DIFF
--- a/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
@@ -22,19 +22,24 @@ App.HighAvailabilityWizardStep7Controller = App.HighAvailabilityProgressPageCont
 
   name:"highAvailabilityWizardStep7Controller",
 
-  commands: ['startZooKeeperServers', 'startAmbariInfra', 'startRanger', 'startNameNode'],
+  commands: ['startZooKeeperServers', 'startAmbariInfra', 'startMysqlServer', 'startRanger', 'startNameNode'],
 
   initializeTasks: function () {
     this._super();
-    var tasksToRemove = [];
+    const tasksToRemove = [];
 
-    if (!App.Service.find().someProperty('serviceName', 'AMBARI_INFRA_SOLR')) {
+    if (!App.Service.find('AMBARI_INFRA_SOLR').get('isLoaded')) {
       tasksToRemove.push('startAmbariInfra');
     }
 
-    if (!App.Service.find().someProperty('serviceName', 'RANGER')) {
+    if (App.ClientComponent.getModelByComponentName('RANGER_ADMIN').get('installedCount') === 0) {
       tasksToRemove.push('startRanger');
     }
+
+    if (App.ClientComponent.getModelByComponentName('MYSQL_SERVER').get('installedCount') === 0) {
+      tasksToRemove.push('startMysqlServer');
+    }
+
     this.removeTasks(tasksToRemove);
   },
 
@@ -47,6 +52,11 @@ App.HighAvailabilityWizardStep7Controller = App.HighAvailabilityProgressPageCont
     if(hostNames.length) {
       this.updateComponent('RANGER_ADMIN', hostNames, "RANGER", "Start");
     }
+  },
+
+  startMysqlServer: function () {
+    const hostNames = App.MasterComponent.find('MYSQL_SERVER').get('hostNames');
+    this.updateComponent('MYSQL_SERVER', hostNames, "HIVE", "Start");
   },
 
   startZooKeeperServers: function () {

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -1497,8 +1497,9 @@ Em.I18n.translations = {
 
   'admin.highAvailability.wizard.step7.task0.title':'Start ZooKeeper Servers',
   'admin.highAvailability.wizard.step7.task1.title':'Start Ambari Infra',
-  'admin.highAvailability.wizard.step7.task2.title':'Start Ranger',
-  'admin.highAvailability.wizard.step7.task3.title':'Start NameNode',
+  'admin.highAvailability.wizard.step7.task2.title':'Start Mysql Server',
+  'admin.highAvailability.wizard.step7.task3.title':'Start Ranger',
+  'admin.highAvailability.wizard.step7.task4.title':'Start NameNode',
 
   'admin.highAvailability.wizard.step9.task0.title':'Start Additional NameNode',
   'admin.highAvailability.wizard.step9.task1.title':'Install Failover Controllers',

--- a/ambari-web/test/controllers/main/admin/highAvailability/nameNode/step7_controller_test.js
+++ b/ambari-web/test/controllers/main/admin/highAvailability/nameNode/step7_controller_test.js
@@ -30,16 +30,20 @@ describe('App.HighAvailabilityWizardStep7Controller', function() {
   describe('#initializeTasks', function() {
     beforeEach(function() {
       sinon.stub(controller, 'removeTasks');
-      sinon.stub(App.Service, 'find').returns([]);
+      sinon.stub(App.Service, 'find').returns(Em.Object.create({isLoaded: false}));
+      sinon.stub(App.ClientComponent, 'getModelByComponentName').returns(Em.Object.create({
+        installedCount: 0
+      }));
     });
     afterEach(function() {
       controller.removeTasks.restore();
       App.Service.find.restore();
+      App.ClientComponent.getModelByComponentName.restore();
     });
 
     it('removeTasks should be called', function() {
       controller.initializeTasks();
-      expect(controller.removeTasks.calledWith(['startAmbariInfra', 'startRanger'])).to.be.true;
+      expect(controller.removeTasks.calledWith(['startAmbariInfra', 'startRanger', 'startMysqlServer'])).to.be.true;
     });
   });
 
@@ -74,6 +78,24 @@ describe('App.HighAvailabilityWizardStep7Controller', function() {
       ]);
       controller.startRanger();
       expect(controller.updateComponent.calledWith('RANGER_ADMIN', ['host1'], "RANGER", "Start")).to.be.true;
+    });
+  });
+
+  describe('#startMysqlServer', function() {
+    beforeEach(function() {
+      sinon.stub(App.MasterComponent, 'find').returns(Em.Object.create({
+        hostNames: ['host1']
+      }));
+      sinon.stub(controller, 'updateComponent');
+    });
+    afterEach(function() {
+      App.MasterComponent.find.restore();
+      controller.updateComponent.restore();
+    });
+
+    it('updateComponent should be called', function() {
+      controller.startMysqlServer();
+      expect(controller.updateComponent.calledWith('MYSQL_SERVER', ['host1'], "HIVE", "Start")).to.be.true;
     });
   });
 


### PR DESCRIPTION
## How was this patch tested?
 21521 passing (31s)
  48 pending
