### PR TITLE
[AMBARI-23622] JWT cookie name and audiences not queried for during ambari-server setup-sso

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -577,8 +577,8 @@ def init_setup_sso_options(parser):
   parser.add_option('--sso-enabled-services', default=None, help="A comma separated list of services that are expected to be configured for SSO (you are allowed to use '*' to indicate ALL services)", dest='sso_enabled_services')
   parser.add_option('--sso-provider-url', default=None, help="The URL of SSO provider; this must be provided when --sso-enabled is set to 'true'", dest="sso_provider_url")
   parser.add_option('--sso-public-cert-file', default=None, help="The path where the public certificate PEM is located; this must be provided when --sso-enabled is set to 'true'", dest="sso_public_cert_file")
-  parser.add_option('--sso-jwt-cookie-name', default="hadoop-jwt", help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
-  parser.add_option('--sso-jwt-audience-list', default="", help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
+  parser.add_option('--sso-jwt-cookie-name', default=None, help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
+  parser.add_option('--sso-jwt-audience-list', default=None, help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
   parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
   parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
 

--- a/ambari-server/src/main/python/ambari_server/setupSso.py
+++ b/ambari-server/src/main/python/ambari_server/setupSso.py
@@ -42,6 +42,7 @@ JWT_COOKIE_NAME = "ambari.sso.jwt.cookieName"
 SSO_PROVIDER_ORIGINAL_URL_QUERY_PARAM_DEFAULT = "originalUrl"
 SSO_PROVIDER_URL_DEFAULT = "https://knox.example.com:8443/gateway/knoxsso/api/v1/websso"
 JWT_COOKIE_NAME_DEFAULT = "hadoop-jwt"
+JWT_AUDIENCES_DEFAULT = ""
 
 CERTIFICATE_HEADER = "-----BEGIN CERTIFICATE-----"
 CERTIFICATE_FOOTER = "-----END CERTIFICATE-----"
@@ -100,23 +101,23 @@ def populate_sso_public_cert(options, properties):
 
 
 def populate_jwt_cookie_name(options, properties):
-  if not options.sso_jwt_cookie_name:
+  if not options.sso_jwt_cookie_name and (not options.sso_provider_url or not options.sso_public_cert_file):
     cookie_name = get_value_from_dictionary(properties, JWT_COOKIE_NAME, JWT_COOKIE_NAME_DEFAULT)
     cookie_name = get_validated_string_input("JWT Cookie name ({0}):".format(cookie_name), cookie_name, REGEX_ANYTHING,
                                          "Invalid cookie name", False)
   else:
-    cookie_name = options.sso_jwt_cookie_name
+    cookie_name = options.sso_jwt_cookie_name if options.sso_jwt_cookie_name else JWT_COOKIE_NAME_DEFAULT
 
   properties[JWT_COOKIE_NAME] = cookie_name
 
 
 def populate_jwt_audiences(options, properties):
-  if options.sso_jwt_audience_list is None:
-    audiences = get_value_from_dictionary(properties, JWT_AUDIENCES)
+  if options.sso_jwt_audience_list is None and (not options.sso_provider_url or not options.sso_public_cert_file):
+    audiences = get_value_from_dictionary(properties, JWT_AUDIENCES, JWT_AUDIENCES_DEFAULT)
     audiences = get_validated_string_input("JWT audiences list (comma-separated), empty for any ({0}):".format(audiences), audiences,
                                         REGEX_ANYTHING, "Invalid value", False)
   else:
-    audiences = options.sso_jwt_audience_list
+    audiences = options.sso_jwt_audience_list if options.sso_jwt_audience_list else JWT_AUDIENCES_DEFAULT
 
   properties[JWT_AUDIENCES] = audiences
   


### PR DESCRIPTION
## What changes were proposed in this pull request?

JWT cookie name and audiences not queried for during ambari-server setup-sso

Example:
```
[root@c7401 ~]# ambari-server setup-sso
Using python  /usr/bin/python
Setting up SSO authentication properties...
Enter Ambari Admin login: admin
Enter Ambari Admin password:

SSO is currently not configured
Do you want to configure SSO authentication [y/n] (y)? y
Provider URL (https://knox.example.com:8443/gateway/knoxsso/api/v1/websso):https://c7401.ambari.apache.org:8443/gateway/knoxsso/api/v1/websso
Public Certificate PEM (empty line to finish input):
MIICVTCCAb6gAwIBAgIILf1Tx+q3QEMwDQYJKoZIhvcNAQEFBQAwbTELMAkGA1UE
...
6crsjbE33yYbJ1mZCpLGtM7mCj0liitItA==

Use SSO for all services [y/n] (n):
Use SSO for AMBARI [y/n] (y):
Use SSO for ATLAS [y/n] (y):
Use SSO for RANGER [y/n] (y): n
Ambari Server 'setup-sso' completed successfully.
```

The following queries are expected before setup is complete:
```
JWT Cookie name (hadoop-jwt):
JWT audiences list (comma-separated), empty for any ():
```

After the fix, the missing prompts are displayed:

```
[root@c7401 ~]# ambari-server setup-sso
Using python  /usr/bin/python
Setting up SSO authentication properties...
Enter Ambari Admin login: admin
Enter Ambari Admin password:

SSO is currently not configured
Do you want to configure SSO authentication [y/n] (y)? y
Provider URL (https://knox.example.com:8443/gateway/knoxsso/api/v1/websso):https://c7401.ambari.apache.org:8443/gateway/knoxsso/api/v1/websso
Public Certificate PEM (empty line to finish input):
MIICVTCCAb6gAwIBAgIILf1Tx+q3QEMwDQYJKoZIhvcNAQEFBQAwbTELMAkGA1UE
...
6crsjbE33yYbJ1mZCpLGtM7mCj0liitItA==

JWT Cookie name (hadoop-jwt):
JWT audiences list (comma-separated), empty for any ():
Use SSO for all services [y/n] (n):
Use SSO for AMBARI [y/n] (y):
Use SSO for ATLAS [y/n] (y):
Use SSO for RANGER [y/n] (y): n
Ambari Server 'setup-sso' completed successfully.
```

## How was this patch tested?

Manually tested.

Unit tests passed:
```
mvn -pl ambari-server -DskipSurefireTests test
...
----------------------------------------------------------------------
Total run:1193
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:36 min
[INFO] Finished at: 2018-04-19T09:16:15-04:00
[INFO] Final Memory: 92M/1137M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.