### PR TITLE
[AMBARI-23624] Additional realm config change not working

### DIFF
--- a/ambari-web/app/controllers/main/admin/kerberos.js
+++ b/ambari-web/app/controllers/main/admin/kerberos.js
@@ -562,7 +562,8 @@ App.MainAdminKerberosController = App.KerberosWizardStep4Controller.extend({
             artifact_data: kerberosDescriptor
           }
         },
-        success: '_updateConfigs'
+        success: '_updateConfigs',
+        error: 'createKerberosDescriptor'
       });
     };
     this.updateKerberosDescriptor(kerberosDescriptor, configs);
@@ -572,6 +573,21 @@ App.MainAdminKerberosController = App.KerberosWizardStep4Controller.extend({
       });
     } else {
       this.restartServicesAfterRegenerate(false, callback);
+    }
+  },
+
+  createKerberosDescriptor: function (requestData, ajaxOptions, error, opt, params) {
+    if (requestData && requestData.status === 404) {
+      const {artifactName, data} = params;
+      App.ajax.send({
+        name: 'admin.kerberos.cluster.artifact.create',
+        sender: self,
+        data: {
+          artifactName,
+          data
+        },
+        success: '_updateConfigs'
+      });
     }
   },
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) go to https://<host_name>/#/main/admin/kerberos
2) click edit
3) add Additional Realms config in ambari kerberos config tab
4) click save
5) Click OK from the popup which ask for the restart of the components
In network tab we got this error:
Request URL:https://<host_name>/api/v1/clusters/<cluster_name>/artifacts/kerberos_descriptor
Request Method:PUT
Status Code:404 Not Found
{ "status" : 404, "message" : "org.apache.ambari.server.controller.spi.NoSuchResourceException: The requested resource doesn't exist: Artifact not found, Artifacts/cluster_name=<cluster_name> AND Artifacts/artifact_name=kerberos_descriptor" }

## How was this patch tested?

UI unit tests:
  21520 passing (23s)
  48 pending