### PR TITLE
[AMBARI-23615] Header missing in Step2 Select hosts page in NN Federation Wizard

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -1681,6 +1681,7 @@ Em.I18n.translations = {
   'admin.nameNodeFederation.wizard.step1.nameserviceid.existing':'Existing Nameservice ID',
   'admin.nameNodeFederation.wizard.step1.nameserviceid.error':'Must consist of letters, numbers, and hyphens. Cannot begin or end with a hyphen.',
   'admin.nameNodeFederation.wizard.step2.header': 'Select Hosts',
+  'admin.nameNodeFederation.wizard.step2.body': 'Select hosts running the NameNodes for {0}',
   'admin.nameNodeFederation.wizard.step3.header': 'Review',
   'admin.nameNodeFederation.wizard.step3.confirm.config.body': '<div class="alert alert-info">' +
     '<p><b>Review Configuration Changes.</b></p>' +

--- a/ambari-web/app/views/main/admin/federation/step2_view.js
+++ b/ambari-web/app/views/main/admin/federation/step2_view.js
@@ -20,4 +20,6 @@
 var App = require('app');
 
 App.NameNodeFederationWizardStep2View = App.AssignMasterComponentsView.extend({
+  title: Em.I18n.t('admin.nameNodeFederation.wizard.step2.header'),
+  alertMessage: Em.computed.i18nFormat('admin.nameNodeFederation.wizard.step2.body', 'controller.content.nameServiceId')
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Header missing in Step2 Select hosts page in NN Federation Wizard. All other pages have proper headers

## How was this patch tested?

UI unit tests:
  21520 passing (25s)
  48 pending