### PR TITLE
[AMBARI-23626] Progress bar is missing in UI during package install

### DIFF
--- a/ambari-web/app/views/main/admin/stack_upgrade/upgrade_version_box_view.js
+++ b/ambari-web/app/views/main/admin/stack_upgrade/upgrade_version_box_view.js
@@ -173,7 +173,7 @@ App.UpgradeVersionBoxView = Em.View.extend({
       element.set('action', 'confirmRevertPatchUpgrade');
       element.set('actionText', Em.I18n.t('common.revert'));
     }
-    else if (['INSTALLING', 'CURRENT'].contains(status) && !this.get('content.isPatch')) {
+    else if (['INSTALLING', 'CURRENT'].contains(status)) {
       element.setProperties(statePropertiesMap[status]);
     }
     else if (status === 'NOT_REQUIRED') {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed the specific condition that excluded Patch Upgrades to show install progress bar.

Issue
![screen shot 2018-03-29 at 1 56 54 pm](https://user-images.githubusercontent.com/12506576/39008565-e61877ee-43bd-11e8-9913-2a234e0b090a.png)

After the patch
![screen shot 2018-04-19 at 10 28 46 am](https://user-images.githubusercontent.com/12506576/39008582-f1a74734-43bd-11e8-9ac5-e39b9e5d0197.png)


## How was this patch tested?
  21520 passing (26s)
  48 pending