### PR TITLE
[AMBARI-23628] Enable Ambari SSO to be enabled without impacting other service sso configs

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -568,19 +568,21 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-force-lowercase-usernames', default=None, help="Declares whether to force the ldap user name to be lowercase or leave as-is", dest="ldap_force_lowercase_usernames")
   parser.add_option('--ldap-pagination-enabled', default=None, help="Determines whether results from LDAP are paginated when requested", dest="ldap_pagination_enabled")
   parser.add_option('--ldap-force-setup', action="store_true", default=False, help="Forces the use of LDAP even if other (i.e. PAM) authentication method is configured already or if there is no authentication method configured at all", dest="ldap_force_setup")
-  parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
-  parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
+  parser.add_option('--ambari-admin-username', default=None, help="Ambari administrator username for accessing Ambari's REST API", dest="ambari_admin_username")
+  parser.add_option('--ambari-admin-password', default=None, help="Ambari administrator password for accessing Ambari's REST API", dest="ambari_admin_password")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_setup_sso_options(parser):
   parser.add_option('--sso-enabled', default=None, help="Indicates whether to enable/disable SSO", dest="sso_enabled")
+  parser.add_option('--sso-enabled-ambari', default=None, help="Indicates whether to enable/disable SSO authentication for Ambari, itself", dest='sso_enabled_ambari')
+  parser.add_option('--sso-manage-services', default=None, help="Indicates whether Ambari should manage the SSO configurations for specified services", dest='sso_manage_services')
   parser.add_option('--sso-enabled-services', default=None, help="A comma separated list of services that are expected to be configured for SSO (you are allowed to use '*' to indicate ALL services)", dest='sso_enabled_services')
   parser.add_option('--sso-provider-url', default=None, help="The URL of SSO provider; this must be provided when --sso-enabled is set to 'true'", dest="sso_provider_url")
   parser.add_option('--sso-public-cert-file', default=None, help="The path where the public certificate PEM is located; this must be provided when --sso-enabled is set to 'true'", dest="sso_public_cert_file")
   parser.add_option('--sso-jwt-cookie-name', default=None, help="The name of the JWT cookie", dest="sso_jwt_cookie_name")
   parser.add_option('--sso-jwt-audience-list', default=None, help="A comma separated list of JWT audience(s)", dest="sso_jwt_audience_list")
-  parser.add_option('--ambari-admin-username', default=None, help="Ambari Admin username for LDAP setup", dest="ambari_admin_username")
-  parser.add_option('--ambari-admin-password', default=None, help="Ambari Admin password for LDAP setup", dest="ambari_admin_password")
+  parser.add_option('--ambari-admin-username', default=None, help="Ambari administrator username for accessing Ambari's REST API", dest="ambari_admin_username")
+  parser.add_option('--ambari-admin-password', default=None, help="Ambari administrator password for accessing Ambari's REST API", dest="ambari_admin_password")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_pam_setup_parser_options(parser):


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Scenario**
Ranger and Atlas are SSO enabled via BP deploys and Ambari is not SSO enabled. 
Later Ambari SSO has to be enabled without changing existing configs(so restart will not be required) for Atlas and Ranger. 
Now this is not possible with "Enable for the selected services" option. 
This was possible in previous versions but with the latest changes from AMBARI-23253, even if SSO was enabled for services earlier we still have to opt SSO for Ranger and Atlas in the list. When services are specified in the list, this would prompt for service restart.
So,
- If we enable SSO for Ambari and not the other services via the CLI, then any previous SSO setting for those services will be cleared
- If we enable SSO for Ambari and the other services via the CLI, then any previous SSO setting for those services will be potentially updated and this cause services to need to restart. But since data is the same no restart should be needed for those services

**Solution**
Add new prompts to separate Ambari's SSO configuration from the managed service's SSO configs so they can be managed separately:
- Use SSO for Ambari (`--sso-enabled-ambari`)
- Manage SSO configurations for eligible services (`--sso-manage-services`)

```
[root@c7401 ~]# ambari-server setup-sso --help
Using python  /usr/bin/python
Setting up SSO authentication properties...
Usage: ambari-server.py action [options]

Options:
  -h, --help            show this help message and exit
  -v, --verbose         Print verbose status messages
  -s, --silent          Silently accepts default prompt values. For db-cleanup
                        command, silent mode will stop ambari server.
  --sso-enabled=SSO_ENABLED
                        Indicates whether to enable/disable SSO
  --sso-enabled-ambari=SSO_ENABLED_AMBARI
                        Indicates whether to enable/disable SSO authentication
                        for Ambari, itself
  --sso-manage-services=SSO_MANAGE_SERVICES
                        Indicates whether Ambari should manage the SSO
                        configurations for specified services
  --sso-enabled-services=SSO_ENABLED_SERVICES
                        A comma separated list of services that are expected
                        to be configured for SSO (you are allowed to use '*'
                        to indicate ALL services)
  --sso-provider-url=SSO_PROVIDER_URL
                        The URL of SSO provider; this must be provided when
                        --sso-enabled is set to 'true'
  --sso-public-cert-file=SSO_PUBLIC_CERT_FILE
                        The path where the public certificate PEM is located;
                        this must be provided when --sso-enabled is set to
                        'true'
  --sso-jwt-cookie-name=SSO_JWT_COOKIE_NAME
                        The name of the JWT cookie
  --sso-jwt-audience-list=SSO_JWT_AUDIENCE_LIST
                        A comma separated list of JWT audience(s)
  --ambari-admin-username=AMBARI_ADMIN_USERNAME
                        Ambari administrator username for accessing Ambari's REST API
  --ambari-admin-password=AMBARI_ADMIN_PASSWORD
                        Ambari administrator password for accessing Ambari's REST API
```
## How was this patch tested?

Manually tested for different scenarios

Ran Python unit tests:

```
mvn -pl ambari-server -DskipSurefireTests test
...
----------------------------------------------------------------------
Total run:1193
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:49 min
[INFO] Finished at: 2018-04-19T17:33:39-04:00
[INFO] Final Memory: 92M/1087M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.