### PR TITLE
[AMBARI-23633] Missing tooltip/indicator for unsupported services in Versions page when HDP-3.0 VDF is registered

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -1842,6 +1842,7 @@ Em.I18n.translations = {
   'admin.stackDowngrade.state.paused.fail.body': "Downgrade could not be paused. Try again later.",
 
   'admin.stackVersions.version.service.notUpgradable': "The version of this service included in this repository is already installed in the cluster.",
+  'admin.stackVersions.version.service.notSupported': "This service is unsupported in the current version of the stack.",
 
   'admin.stackVersions.version.upgrade.upgradeOptions.header': "Upgrade Options",
   'admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.version': "You are about to perform an upgrade to <b>{0}</b>.",

--- a/ambari-web/app/styles/stack_versions.less
+++ b/ambari-web/app/styles/stack_versions.less
@@ -17,6 +17,9 @@
  */
 @import 'common.less';
 
+@left-menu-table-z-index: 999;
+@version-line-height: 20px;
+
 #advancedRepoAccordion{
   .panel-heading {
     background-color: #f0f0f0;
@@ -163,7 +166,7 @@
     .border-extended-table {
       width: 100%;
       position: relative;
-      z-index: 999;
+      z-index: @left-menu-table-z-index;
       background: transparent;
       td.service-display-name {
         border-top: 1px solid #d2d9dd;
@@ -244,8 +247,8 @@
       color: #000;
       text-align: center;
       font-weight: 500;
-      font-size: 20px;
-      line-height: 20px;
+      font-size: @version-line-height;
+      line-height: @version-line-height;
       padding: 5px 5px 0 5px;
       margin-bottom: 0;
       span {
@@ -254,7 +257,7 @@
       .pull-right .not-active {
         font-size: 15px;
         color: #0088cc;
-        line-height: 20px;
+        line-height: @version-line-height;
       }
     }
     .repository-name {
@@ -267,7 +270,7 @@
     .patch-icon {
       text-align: center;
       color: #ff4500;
-      height: 20px;
+      height: @version-line-height;
       font-size: 14px;
       margin: 18px 0px -18px 1px;
       padding: 1px;
@@ -305,7 +308,7 @@
     }
     .version-column-display-type{
       text-align: center;
-      height: 20px;
+      height: @version-line-height;
       margin-bottom: 0;
       color: #ff4500;
     }
@@ -321,7 +324,7 @@
     }
     .state {
       margin: 5px 0 15px 0;
-      line-height: 20px;
+      line-height: @version-line-height;
       height: 35px;
       .label-wrapper{
         display: inline-block;
@@ -352,6 +355,7 @@
       }
       .open .dropdown-menu {
         min-width: 90px;
+        z-index: @left-menu-table-z-index + 2;
       }
     }
     .state.installing {
@@ -363,7 +367,7 @@
       padding-bottom: 4px;
       margin-top: -5px;
       .service-version-info {
-        line-height: 20px;
+        line-height: @version-line-height;
         margin-bottom: 9px;
         padding-top: 6px;
         text-align: center;
@@ -378,6 +382,9 @@
   }
   div.version-column {
     .not-upgradable {
+      position: absolute;
+      z-index: @left-menu-table-z-index + 1;
+      line-height: @version-line-height;
       padding-left: 10px;
       margin-right: -20px;
       cursor: pointer;

--- a/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_version_column.hbs
+++ b/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_version_column.hbs
@@ -114,7 +114,7 @@
            {{service.latestVersion}}
        </span>
         {{#if service.notUpgradable}}
-          <i class="icon-info-sign not-upgradable"></i>
+          <i class="icon-info-sign not-upgradable" {{bindAttr data-original-title="service.notUpgradableTitle"}}></i>
         {{/if}}
     </p>
   {{/each}}

--- a/ambari-web/app/views/main/admin/stack_upgrade/upgrade_version_column_view.js
+++ b/ambari-web/app/views/main/admin/stack_upgrade/upgrade_version_column_view.js
@@ -25,7 +25,7 @@ App.UpgradeVersionColumnView = App.UpgradeVersionBoxView.extend({
 
   didInsertElement: function () {
     App.tooltip($('.out-of-sync-badge'), {title: Em.I18n.t('hosts.host.stackVersions.status.out_of_sync')});
-    App.tooltip($('.not-upgradable'), {title: Em.I18n.t('admin.stackVersions.version.service.notUpgradable')});
+    App.tooltip($('.not-upgradable'));
     if (!this.get('content.isCompatible')) {
       App.tooltip(this.$(".repo-version-tooltip"), {
         title: Em.I18n.t('admin.stackVersions.version.noCompatible.tooltip')
@@ -48,19 +48,23 @@ App.UpgradeVersionColumnView = App.UpgradeVersionBoxView.extend({
   }.observes('parentView.repoVersions.@each.isVisible'),
 
   services: function() {
-    var originalServices = this.get('content.stackServices');
+    const originalServices = this.get('content.stackServices');
     // sort the services in the order the same as service menu
-    return App.Service.find().map(function (service) {
+    return App.Service.find().map(service => {
 
-      var stackService = originalServices.findProperty('name', service.get('serviceName'));
-      var isAvailable = this.isStackServiceAvailable(stackService);
-
-      var notUpgradable = false;
+      const stackService = originalServices.findProperty('name', service.get('serviceName')),
+        isAvailable = this.isStackServiceAvailable(stackService);
+      let notUpgradable = false,
+        notUpgradableTitle = '';
       if (!stackService) {
-        console.error(stackService + " definition does not exist in the stack.")
+        console.error(`${stackService} definition does not exist in the stack.`);
         notUpgradable = true;
+        notUpgradableTitle = Em.I18n.t('admin.stackVersions.version.service.notSupported');
       } else {
         notUpgradable = this.getNotUpgradable(isAvailable, stackService.get('isUpgradable'));
+        if (notUpgradable) {
+          notUpgradableTitle = Em.I18n.t('admin.stackVersions.version.service.notUpgradable');
+        }
       }
 
       return Em.Object.create({
@@ -68,10 +72,11 @@ App.UpgradeVersionColumnView = App.UpgradeVersionBoxView.extend({
         name: service.get('serviceName'),
         latestVersion: stackService ? stackService.get('latestVersion') : '',
         isVersionInvisible: !stackService,
-        notUpgradable: notUpgradable,
-        isAvailable: isAvailable
+        notUpgradable,
+        notUpgradableTitle,
+        isAvailable
       });
-    }, this);
+    });
   }.property(),
 
   getNotUpgradable: function(isAvailable, isUpgradable) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

**STR**
1. Deploy HDP-2.6.1.0 cluster with Ambari-2.6.x
2. Upgrade Ambari to 2.7.0.0
3. Register HDP-3.0 VDF
4. Go to Version page and observe the small icon against services that are unsupported in 3.0 like Falcon, Flume, Spark, Mahout, Slider
5. Hover mouse over them - it does not indicate any message

**Expected Result**
It would be good to say something like: This service is unsupported in the current version of the stack

## How was this patch tested?

UI unit tests:
  21520 passing (28s)
  48 pending
