### PR TITLE
AMBARI-23632. Compatibility repository version wrong (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/CompatibleRepositoryVersionDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/CompatibleRepositoryVersionDefinition.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.ambari.server.api.resources;
+
+import static org.apache.ambari.server.controller.internal.CompatibleRepositoryVersionResourceProvider.REPOSITORY_VERSION_ID_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.CompatibleRepositoryVersionResourceProvider.REPOSITORY_VERSION_STACK_VERSION_PROPERTY_ID;
+
+import java.util.List;
+
+import org.apache.ambari.server.api.services.Request;
+import org.apache.ambari.server.api.util.TreeNode;
+import org.apache.ambari.server.controller.spi.Resource;
+
+public class CompatibleRepositoryVersionDefinition extends SimpleResourceDefinition {
+
+  public CompatibleRepositoryVersionDefinition() {
+    super(Resource.Type.CompatibleRepositoryVersion,
+      "compatible_repository_version", "compatible_repository_versions",
+      Resource.Type.OperatingSystem);
+  }
+
+  @Override
+  public List<PostProcessor> getPostProcessors() {
+    List<PostProcessor> listProcessors = super.getPostProcessors();
+    listProcessors.add(new CompatibleRepositoryVersionHrefProcessor());
+    return listProcessors;
+  }
+
+  private class CompatibleRepositoryVersionHrefProcessor extends BaseResourceDefinition.BaseHrefPostProcessor {
+    @Override
+    public void process(Request request, TreeNode<Resource> resultNode, String href) {
+      if (resultNode.getObject().getType() == Resource.Type.CompatibleRepositoryVersion) {
+        Resource node = resultNode.getObject();
+        Object id = node.getPropertyValue(REPOSITORY_VERSION_ID_PROPERTY_ID);
+        Object stackVersion = node.getPropertyValue(REPOSITORY_VERSION_STACK_VERSION_PROPERTY_ID);
+        if (id != null && stackVersion != null) {
+          resultNode.setProperty("href", fixHref(href, id, stackVersion));
+          return;
+        }
+      }
+      super.process(request, resultNode, href);
+    }
+
+    private String fixHref(String href, Object id, Object stackVersion) {
+      href = href.replaceAll("/versions/[^/]+/", "/versions/" + stackVersion + "/");
+      if (!href.endsWith("/" + id)) {
+        href += "/" + id;
+      }
+      return href;
+    }
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/CompatibleRepositoryVersionDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/CompatibleRepositoryVersionDefinition.java
@@ -1,20 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
@@ -29,6 +28,9 @@ import org.apache.ambari.server.api.services.Request;
 import org.apache.ambari.server.api.util.TreeNode;
 import org.apache.ambari.server.controller.spi.Resource;
 
+/**
+ * ResourceDefinition with a custom href post processor which overrides the URL
+ */
 public class CompatibleRepositoryVersionDefinition extends SimpleResourceDefinition {
 
   public CompatibleRepositoryVersionDefinition() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ResourceInstanceFactoryImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ResourceInstanceFactoryImpl.java
@@ -364,9 +364,7 @@ public class ResourceInstanceFactoryImpl implements ResourceInstanceFactory {
         break;
 
       case CompatibleRepositoryVersion:
-        resourceDefinition = new SimpleResourceDefinition(Resource.Type.CompatibleRepositoryVersion,
-            "compatible_repository_version", "compatible_repository_versions",
-            Resource.Type.OperatingSystem);
+        resourceDefinition = new CompatibleRepositoryVersionDefinition();
         break;
 
       case HostStackVersion:

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/CompatibleRepositoryVersionDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/CompatibleRepositoryVersionDefinitionTest.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.ambari.server.api.resources;
+
+import static junit.framework.Assert.assertEquals;
+import static org.apache.ambari.server.controller.internal.CompatibleRepositoryVersionResourceProvider.REPOSITORY_VERSION_ID_PROPERTY_ID;
+import static org.apache.ambari.server.controller.internal.CompatibleRepositoryVersionResourceProvider.REPOSITORY_VERSION_STACK_VERSION_PROPERTY_ID;
+
+import org.apache.ambari.server.api.util.TreeNode;
+import org.apache.ambari.server.api.util.TreeNodeImpl;
+import org.apache.ambari.server.controller.internal.ResourceImpl;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.junit.Test;
+
+public class CompatibleRepositoryVersionDefinitionTest {
+  private static final String ORIGINAL_HREF = "http://host/api/v1/stacks/HDP/versions/2.6/compatible_repository_versions";
+  private CompatibleRepositoryVersionDefinition def = new CompatibleRepositoryVersionDefinition();
+
+  @Test
+  public void testHrefReplace() throws Exception {
+    TreeNode<Resource> repoVersionNode = nodeWithIdAndVersion("42", "3.0");
+    postProcessHref(repoVersionNode);
+    assertEquals(
+      "http://host/api/v1/stacks/HDP/versions/3.0/compatible_repository_versions/42",
+      repoVersionNode.getStringProperty("href"));
+  }
+
+  private TreeNode<Resource> nodeWithIdAndVersion(String id, String version) {
+    ResourceImpl resource = new ResourceImpl(Resource.Type.CompatibleRepositoryVersion);
+    resource.setProperty(REPOSITORY_VERSION_ID_PROPERTY_ID, id);
+    resource.setProperty(REPOSITORY_VERSION_STACK_VERSION_PROPERTY_ID, version);
+    return new TreeNodeImpl<>(null, resource, "any");
+  }
+
+  private void postProcessHref(TreeNode<Resource> repoVersionNode) {
+    ResourceDefinition.PostProcessor hrefProcessor = hrefProcessor();
+    hrefProcessor.process(null, repoVersionNode, ORIGINAL_HREF);
+  }
+
+  private ResourceDefinition.PostProcessor hrefProcessor() {
+    return def.getPostProcessors().get(1);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The href was incorrect in the output of GET http://AMBARI_SERVER/api/v1/stacks/HDP/versions/2.6/compatible_repository_versions

```json
{
  "href" : "http://c7401:8080/api/v1/stacks/HDP/versions/2.6/compatible_repository_versions",
  "items" : [
    {
      "href" : "http://c7401:8080/api/v1/stacks/HDP/versions/2.6/compatible_repository_versions/51",
      "CompatibleRepositoryVersions" : {
        "id" : 51,
        "stack_name" : "HDP",
        "stack_version" : "2.6",
        "upgrade_types" : [
          "NON_ROLLING",
          "ROLLING",
          "HOST_ORDERED"
        ]
      }
    },
    {
      "href" : "http://c7401:8080/api/v1/stacks/HDP/versions/2.6/compatible_repository_versions/1",
      "CompatibleRepositoryVersions" : {
        "id" : 1,
        "stack_name" : "HDP",
        "stack_version" : "3.0",
        "upgrade_types" : [
          "NON_ROLLING"
        ]
      }
    }
  ]
}
```

## How was this patch tested?

checked the response of http://AMBARI_SERVER/api/v1/stacks/HDP/versions/2.6/compatible_repository_versions
