### PR TITLE
[AMBARI-23590] Fix issue where mpackDirectory does not get created at…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -217,6 +217,7 @@ public class MpackManager {
       mpackTarPath = downloadMpack(mpackRequest.getMpackUri(), mpack.getDefinition());
 
       LOG.info("Custom Mpack Registration :" + mpackRequest.getMpackUri());
+      createMpackDirectory(mpack);
       mpackDirectory = mpacksStaging + File.separator + mpack.getName() + File.separator + mpack.getVersion();
     }
 
@@ -319,7 +320,7 @@ public class MpackManager {
    */
   private void extractMpackTar(Mpack mpack, Path mpackTarPath, String mpackDirectory) throws IOException {
 
-    if(!Files.exists(mpackTarPath)) {
+    if(!Files.exists(Paths.get(mpackDirectory))) {
       extractTar(mpackTarPath, mpacksStaging);
 
       String mpackTarDirectory = mpackTarPath.toString();


### PR DESCRIPTION
… first mpack registration

Mpack Directories should be created only if not already present. The conditional check for this scenario was incorrect. It was checking for the tar.gz file existence instead of the mpack directory existence
mpackTarPath -> /var/lib/ambari-server/resources/mpacks-v2/staging/hdpcore-1.0.0-b253.tar.gz
mpack
mpackDirectory -> /var/lib/ambari-server/resources/mpacks-v2/HDPCORE/1.0.0-b253
The extractMpackTar function was checking for mpackTarPath instead of mpackDirectory hence the registration was failing.

(Please fill in changes proposed in this fix)

POST mpacks

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.