### PR TITLE
Ambari 23644

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -6015,6 +6015,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         }
       }
 
+      m_metadataHolder.get().updateData(getClusterMetadataOnConfigsUpdate(cluster));
+      m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
+
       if (request.getVersion() != null) {
         if (!AuthorizationHelper.isAuthorized(ResourceType.CLUSTER, cluster.getResourceId(), EnumSet.of(RoleAuthorization.SERVICE_MODIFY_CONFIGS))) {
           throw new AuthorizationException("The authenticated user does not have authorization to modify service configurations");

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -217,6 +217,7 @@ public class MpackManager {
       mpackTarPath = downloadMpack(mpackRequest.getMpackUri(), mpack.getDefinition());
 
       LOG.info("Custom Mpack Registration :" + mpackRequest.getMpackUri());
+      createMpackDirectory(mpack);
       mpackDirectory = mpacksStaging + File.separator + mpack.getName() + File.separator + mpack.getVersion();
     }
 
@@ -319,7 +320,7 @@ public class MpackManager {
    */
   private void extractMpackTar(Mpack mpack, Path mpackTarPath, String mpackDirectory) throws IOException {
 
-    if(!Files.exists(mpackTarPath)) {
+    if(!Files.exists(Paths.get(mpackDirectory))) {
       extractTar(mpackTarPath, mpacksStaging);
 
       String mpackTarDirectory = mpackTarPath.toString();


### PR DESCRIPTION
With perf merge/optimization. Configurations are sent over to the agent to be cached when certain events occur. One such event is creation of configs for which we have AgentConfigUpdateEvent. This was being triggered in the "updateCluster" code flow but with new APIs we no longer use it. We use a new function called createServiceConfigVerison so need to add the code to trigger the events.

(Please fill in changes proposed in this fix)

Deploy a cluster

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.