### PR TITLE
[AMBARI-23646] Include commons-logging library for Infra Solr debian build

### DIFF
--- a/ambari-infra/ambari-infra-assembly/pom.xml
+++ b/ambari-infra/ambari-infra-assembly/pom.xml
@@ -393,6 +393,8 @@
                           toDir="${project.build.directory}/solr/server/solr-webapp/webapp/WEB-INF/lib/"/>
                     <copy file="${infra.solr.plugin.dir}/target/libs/ambari-metrics-common-${project.version}.jar"
                           toDir="${project.build.directory}/solr/server/solr-webapp/webapp/WEB-INF/lib/"/>
+                    <copy file="${infra.solr.plugin.dir}/target/libs/commons-logging-1.1.1.jar"
+                          toDir="${project.build.directory}/solr/server/solr-webapp/webapp/WEB-INF/lib/"/>
                     <chmod file="${project.build.directory}/solr/bin/**" perm="755"/>
                     <chmod file="${project.build.directory}/solr/server/scripts/**" perm="755"/>
                   </target>


### PR DESCRIPTION
## What changes were proposed in this pull request?
commons-logging-1.1.1 is missing from the classpath for infra solr ubuntu package, that causes a classpath exception at startup (required for ambari metrics exporter)
## How was this patch tested?
mvn clean package -Dbuild-deb

the debian package contains the commons-logging-1.1.1 jar after the change

Please review @zeroflag @adoroszlai @swagle @kasakrisz 