### PR TITLE
[AMBARI-23652] LogFeeder: lowercase cluster name (writing solr docs & znode generation)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/LogSearchConfigFactory.java
+++ b/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/LogSearchConfigFactory.java
@@ -98,7 +98,7 @@ public class LogSearchConfigFactory {
         logSearchConfig = defaultClass.newInstance();
       }
       if (init) {
-        logSearchConfig.init(properties, clusterName);
+        logSearchConfig.init(properties, clusterName == null ? "null" : clusterName.toLowerCase());
       }
       return logSearchConfig;
     } catch (Exception e) {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
@@ -50,7 +50,7 @@ public class LogFeederProps implements LogFeederProperties {
     examples = {"cl1"},
     sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}
   )
-  @Value("${" + LogFeederConstants.CLUSTER_NAME_PROPERTY + "}")
+  @Value("#{'${" + LogFeederConstants.CLUSTER_NAME_PROPERTY + "}'.toLowerCase()}")
   private String clusterName;
 
   @LogSearchPropertyDescription(

--- a/ambari-logsearch/docker/test-config/logfeeder/logfeeder.properties
+++ b/ambari-logsearch/docker/test-config/logfeeder/logfeeder.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cluster.name=cl1
+cluster.name=CL1
 logfeeder.checkpoint.folder=/root/checkpoints
 logfeeder.metrics.collector.hosts=
 logfeeder.config.dir=/root/config/logfeeder/shipper-conf/


### PR DESCRIPTION
## What changes were proposed in this pull request?
Lowercase cluster name for logfeeder (cluster name is lowercase in solr anyway), it's required as logfeeder will create the cluster znode with the cluster name, and if it is with uppercase we cannot get the right logs with cluster filter

for now, if its not set, null string will be used

## How was this patch tested?
manually with docker-env

please review @swagle @miklosgergely @kasakrisz @adoroszlai 