### PR TITLE
AMBARI-21858 Not able to enable hive Interactive Query

### DIFF
--- a/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
+++ b/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
@@ -109,12 +109,14 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
     var showAlert = false;
     if (data.hasOwnProperty('items') && data.items.length > 0) {
       data.items.forEach( function(_item) {
-        _item.RequestSchedule.batch.batch_requests.forEach( function(batchRequest) {
-          // Check if a DELETE request on HIVE_SERVER_INTERACTIVE is in progress
-          if (batchRequest.request_type == "DELETE" && batchRequest.request_uri.indexOf("HIVE_SERVER_INTERACTIVE") > -1) {
-            showAlert = true;
-          }
-        });
+        if (_item && _item.RequestSchedule && _item.RequestSchedule.batch && _item.RequestSchedule.batch.batch_requests) {
+          _item.RequestSchedule.batch.batch_requests.forEach(function (batchRequest) {
+            // Check if a DELETE request on HIVE_SERVER_INTERACTIVE is in progress
+            if (batchRequest.request_type == "DELETE" && batchRequest.request_uri.indexOf("HIVE_SERVER_INTERACTIVE") > -1) {
+              showAlert = true;
+            }
+          });
+        }
       });
     }
     if (showAlert) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-21858 Not able to enable hive Interactive Query 

app.js throws a javascript error when request_schedules exists in Database with no batch_requests.

## How was this patch tested?

Tested in UI, works well in all Browsers.

  30525 passing (26s)
  157 pending


[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ ambari-web ---
[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/ambari-web/pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/ambari-web/2.6.1.0.0/ambari-web-2.6.1.0.0.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:29 min
[INFO] Finished at: 2018-04-23T12:59:59+05:30
[INFO] Final Memory: 15M/220M
[INFO] ------------------------------------------------------------------------
