### PR TITLE
[AMBARI-23656] NameNode namespaces aren't sorted by name

### DIFF
--- a/ambari-web/app/models/service/hdfs.js
+++ b/ambari-web/app/models/service/hdfs.js
@@ -119,7 +119,7 @@ App.HDFSService = App.Service.extend({
         }
       }
     });
-    return result;
+    return result.sortProperty('name');
   }.property('hostComponents.length', 'App.router.clusterController.isHDFSNameSpacesLoaded')
 });
 

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -473,7 +473,7 @@ App.MainServiceInfoSummaryView = Em.View.extend({
             }
           }
         });
-        return groups;
+        return groups.sortProperty('name');
       default:
         return [
           {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Namespaces should be displayed in alphabetical order.

## How was this patch tested?

UI unit tests:
  21521 passing (26s)
  48 pending