### PR TITLE
AMBARI-23657. Ambari-agent should handle delivery status responses from server

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
+++ b/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
@@ -58,7 +58,7 @@ class HeartbeatThread(threading.Thread):
     self.config = initializer_module.config
 
     # listeners
-    self.server_responses_listener = ServerResponsesListener()
+    self.server_responses_listener = initializer_module.server_responses_listener
     self.commands_events_listener = CommandsEventListener(initializer_module.action_queue)
     self.metadata_events_listener = MetadataEventListener(initializer_module.metadata_cache)
     self.topology_events_listener = TopologyEventListener(initializer_module.topology_cache)
@@ -243,7 +243,7 @@ class HeartbeatThread(threading.Thread):
     """
     def presend_hook(correlation_id):
       if log_handler:
-        self.server_responses_listener.logging_handlers[str(correlation_id)] = log_handler 
+        self.server_responses_listener.logging_handlers[correlation_id] = log_handler
            
     try:
       correlation_id = self.connection.send(message=message, destination=destination, presend_hook=presend_hook)
@@ -253,6 +253,6 @@ class HeartbeatThread(threading.Thread):
       raise
 
     try:
-      return self.server_responses_listener.responses.blocking_pop(str(correlation_id), timeout=timeout)
+      return self.server_responses_listener.responses.blocking_pop(correlation_id, timeout=timeout)
     except BlockingDictionary.DictionaryPopTimeout:
       raise Exception("{0} seconds timeout expired waiting for response from server at {1} to message from {2}".format(timeout, Constants.SERVER_RESPONSES_TOPIC, destination))

--- a/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
+++ b/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
@@ -36,6 +36,7 @@ from ambari_agent.AlertSchedulerHandler import AlertSchedulerHandler
 from ambari_agent.ConfigurationBuilder import ConfigurationBuilder
 from ambari_agent.StaleAlertsMonitor import StaleAlertsMonitor
 from ambari_stomp.adapter.websocket import ConnectionIsAlreadyClosed
+from ambari_agent.listeners.ServerResponsesListener import ServerResponsesListener
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,8 @@ class InitializerModule:
     self.alert_definitions_cache = ClusterAlertDefinitionsCache(self.config.cluster_cache_dir)
     self.configuration_builder = ConfigurationBuilder(self)
     self.stale_alerts_monitor = StaleAlertsMonitor(self)
+
+    self.server_responses_listener = ServerResponsesListener()
 
     self.file_cache = FileCache(self.config)
 

--- a/ambari-agent/src/main/python/ambari_agent/listeners/ServerResponsesListener.py
+++ b/ambari-agent/src/main/python/ambari_agent/listeners/ServerResponsesListener.py
@@ -31,9 +31,10 @@ class ServerResponsesListener(EventListener):
   """
   Listener of Constants.SERVER_RESPONSES_TOPIC events from server.
   """
+  RESPONSE_STATUS_STRING = 'status'
+  RESPONSE_STATUS_SUCCESS = 'OK'
+
   def __init__(self):
-    self.listener_functions = {}
-    self.logging_handlers = {}
     self.reset_responses()
 
   def on_event(self, headers, message):
@@ -46,12 +47,21 @@ class ServerResponsesListener(EventListener):
     @param message: message payload dictionary
     """
     if Constants.CORRELATION_ID_STRING in headers:
-      correlation_id = headers[Constants.CORRELATION_ID_STRING]
+      correlation_id = int(headers[Constants.CORRELATION_ID_STRING])
       self.responses.put(correlation_id, message)
 
       if correlation_id in self.listener_functions:
         self.listener_functions[correlation_id](headers, message)
         del self.listener_functions[correlation_id]
+
+      if self.RESPONSE_STATUS_STRING in message and message[self.RESPONSE_STATUS_STRING] == self.RESPONSE_STATUS_SUCCESS:
+        if correlation_id in self.listener_functions_on_success:
+          self.listener_functions_on_success[correlation_id](headers, message)
+          del self.listener_functions_on_success[correlation_id]
+      else:
+        if correlation_id in self.listener_functions_on_error:
+          self.listener_functions_on_error[correlation_id](headers, message)
+          del self.listener_functions_on_error[correlation_id]
     else:
       logger.warn("Received a message from server without a '{0}' header. Ignoring the message".format(Constants.CORRELATION_ID_STRING))
 
@@ -76,8 +86,13 @@ class ServerResponsesListener(EventListener):
 
   def reset_responses(self):
     """
-    Clear responses dictionary
+    Resets data saved on per-response basis.
+    Should be called when correlactionIds are reset to 0 aka. re-registration case.
     """
     self.responses = Utils.BlockingDictionary()
+    self.listener_functions_on_success = {}
+    self.listener_functions_on_error = {}
+    self.listener_functions = {}
+    self.logging_handlers = {}
 
 


### PR DESCRIPTION
This is required so that if connection between agent and server is lost, agent knows what was lost and can resend it.

