### PR TITLE
[AMBARI-23658] No widgets displayed on dashboard after adding third NameNode namespace

### DIFF
--- a/ambari-web/app/views/main/dashboard/widgets.js
+++ b/ambari-web/app/views/main/dashboard/widgets.js
@@ -547,6 +547,10 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
                 subGroup
               });
             }
+            if (!preferences.threshold[subGroup]) {
+              isChanged = true;
+              preferences.threshold[subGroup] = defaultPreferences.groups[groupName]['*'].threshold[subGroup];
+            }
           });
         }
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?

After enabling NameNode federation and adding two additional namespaces, dashboards has no widgets displayed, with infinite spinner instead of them. Also, JS error is thrown: `Uncaught TypeError: Cannot read property '1' of undefined`

## How was this patch tested?

UI unit tests:
  21521 passing (26s)
  48 pending