### PR TITLE
[AMBARI-23620] Moving DB configuration related code to common Service Advisor so that both Hive and Oozie can reuse it

### DIFF
--- a/ambari-server/src/main/resources/stacks/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/service_advisor.py
@@ -114,3 +114,51 @@ class ServiceAdvisor(DefaultStackAdvisor):
     such as validateHDFSConfigurations.
     """
     return []
+
+  def getDBDriver(self, databaseType):
+    driverDict = {
+      "NEW MYSQL DATABASE": "com.mysql.jdbc.Driver",
+      "NEW DERBY DATABASE": "org.apache.derby.jdbc.EmbeddedDriver",
+      "EXISTING MYSQL DATABASE": "com.mysql.jdbc.Driver",
+      "EXISTING MYSQL / MARIADB DATABASE": "com.mysql.jdbc.Driver",
+      "EXISTING POSTGRESQL DATABASE": "org.postgresql.Driver",
+      "EXISTING ORACLE DATABASE": "oracle.jdbc.driver.OracleDriver",
+      "EXISTING SQL ANYWHERE DATABASE": "sap.jdbc4.sqlanywhere.IDriver"
+    }
+    return driverDict.get(databaseType.upper())
+
+  def getDBConnectionString(self, databaseType):
+    driverDict = {
+      "NEW MYSQL DATABASE": "jdbc:mysql://{0}/{1}?createDatabaseIfNotExist=true",
+      "NEW DERBY DATABASE": "jdbc:derby:${{oozie.data.dir}}/${{oozie.db.schema.name}}-db;create=true",
+      "EXISTING MYSQL DATABASE": "jdbc:mysql://{0}/{1}",
+      "EXISTING MYSQL / MARIADB DATABASE": "jdbc:mysql://{0}/{1}",
+      "EXISTING POSTGRESQL DATABASE": "jdbc:postgresql://{0}:5432/{1}",
+      "EXISTING ORACLE DATABASE": "jdbc:oracle:thin:@//{0}:1521/{1}",
+      "EXISTING SQL ANYWHERE DATABASE": "jdbc:sqlanywhere:host={0};database={1}"
+    }
+    return driverDict.get(databaseType.upper())
+
+  def getProtocol(self, databaseType):
+    first_parts_of_connection_string = {
+      "NEW MYSQL DATABASE": "jdbc:mysql",
+      "NEW DERBY DATABASE": "jdbc:derby",
+      "EXISTING MYSQL DATABASE": "jdbc:mysql",
+      "EXISTING MYSQL / MARIADB DATABASE": "jdbc:mysql",
+      "EXISTING POSTGRESQL DATABASE": "jdbc:postgresql",
+      "EXISTING ORACLE DATABASE": "jdbc:oracle",
+      "EXISTING SQL ANYWHERE DATABASE": "jdbc:sqlanywhere"
+    }
+    return first_parts_of_connection_string.get(databaseType.upper())
+
+  def getDBTypeAlias(self, databaseType):
+    driverDict = {
+      "NEW MYSQL DATABASE": "mysql",
+      "NEW DERBY DATABASE": "derby",
+      "EXISTING MYSQL / MARIADB DATABASE": "mysql",
+      "EXISTING MYSQL DATABASE": "mysql",
+      "EXISTING POSTGRESQL DATABASE": "postgres",
+      "EXISTING ORACLE DATABASE": "oracle",
+      "EXISTING SQL ANYWHERE DATABASE": "sqla"
+    }
+    return driverDict.get(databaseType.upper())


### PR DESCRIPTION
## What changes were proposed in this pull request?

To allow better code reuse I moved DB configuration code into a common place where all services can see those methods.

Please note that this is required for another change coming on a different project that actually changes Hive's and Oozie's `service_advisor.py`

## How was this patch tested?
Uni testing; latest Python unit test result in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:20 min
[INFO] Finished at: 2018-04-23T14:31:32+02:00
[INFO] Final Memory: 114M/1773M
[INFO] ------------------------------------------------------------------------
```

While I was testing [AMBARI-23620](https://issues.apache.org/jira/browse/AMBARI-23620) I modified the affected Python files and was able to proceed without any issue.