### PR TITLE
[AMBARI-23666] Hive Summary page does not have the correct 'Go To Vie…

### DIFF
--- a/ambari-web/app/controllers/main/service/info/summary.js
+++ b/ambari-web/app/controllers/main/service/info/summary.js
@@ -407,7 +407,9 @@ App.MainServiceInfoSummaryController = Em.Controller.extend({
   },
 
   goToView: function(event) {
-    App.router.route(event.context.get('internalAmbariUrl'));
+    if (event.context) {
+      window.open(event.context.get('internalAmbariUrl'));
+    }
   }
 
 });


### PR DESCRIPTION
…w' links for Views.

## What changes were proposed in this pull request?
Implementation of "goToView" function should include:
```
    if (event.context) {
      window.open(event.context.get('internalAmbariUrl'));
    }
```
## How was this patch tested?
Manually Tested.
The Build was successful:
```
[INFO] Ambari Main ........................................ SUCCESS [  1.174 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.013 s]
[INFO] Ambari Web ......................................... SUCCESS [01:52 min]
[INFO] Ambari Views ....................................... SUCCESS [  1.921 s]
[INFO] Ambari Admin View .................................. SUCCESS [  7.818 s]
[INFO] ambari-utility ..................................... SUCCESS [  3.477 s]
.
.
[INFO] Ambari Functional Tests ............................ SUCCESS [  0.414 s]
[INFO] Ambari Agent ....................................... SUCCESS [ 50.632 s]
```

