### PR TITLE
[AMBARI-23673] Available packages reader speed is to slow for ubuntu systems (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -95,7 +95,8 @@ class AptManager(GenericManager):
     packages = []
     available_packages = self._available_packages_dict(pkg_names, repo_filter)
 
-    with shell.process_executor(self.properties.installed_packages_cmd, error_callback=self._executor_error_handler) as output:
+    with shell.process_executor(self.properties.installed_packages_cmd, error_callback=self._executor_error_handler,
+                                strategy=shell.ReaderStrategy.BufferedChunks) as output:
       for package, version in AptParser.packages_installed_reader(output):
         if package in available_packages:
           packages.append(available_packages[package])
@@ -113,7 +114,9 @@ class AptManager(GenericManager):
     :type repo_filter str|None
     """
 
-    with shell.process_executor(self.properties.available_packages_cmd, error_callback=self._executor_error_handler) as output:
+    with shell.process_executor(self.properties.available_packages_cmd, error_callback=self._executor_error_handler,
+                                strategy=shell.ReaderStrategy.BufferedChunks) as output:
+
       for pkg_item in AptParser.packages_reader(output):
         if repo_filter and repo_filter not in pkg_item[2]:
           continue


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change output reader strategy for ubuntu repo manager functions available and installed packages reader

## How was this patch tested?

On live cluster: 

Test code:
```
import sys
sys.path.append("/usr/lib/ambari-agent/lib/")

from resource_management.core.logger import Logger
Logger.initialize_logger()

from ambari_commons.repo_manager import ManagerFactory
from ambari_commons import shell
f = ManagerFactory.get()



with shell.process_executor(f.properties.available_packages_cmd, error_callback=f._executor_error_handler, strategy=shell.ReaderStrategy.BufferedChunks) as output:
  for l in output:
    print l
```
where strategy could be set to desired reader. Run it on ubuntu to test, code will run different implementation of repo manager, depends on os family


Before:

> real    1m48.893s
> user    0m34.380s
> sys     1m38.843s

After:

> real    0m4.027s
> user    0m2.243s
> sys     0m1.767s