### PR TITLE
[AMBARI-23677] Fix CVE issues for ambari-logsearch 2.7.0

### DIFF
--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -218,7 +218,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.7.1</version>
+      <version>1.10.3</version>
     </dependency>
     <!-- Exclude jars globally-->
     <dependency>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -44,12 +44,18 @@
     <solr.version>7.3.0</solr.version>
     <hadoop.version>3.0.0</hadoop.version>
     <common.io.version>2.5</common.io.version>
+    <zookeeper.version>3.4.6.2.3.0.0-2557</zookeeper.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
     <skipSurefireTests>false</skipSurefireTests>
   </properties>
   <repositories>
+    <repository>
+      <id>apache-hadoop</id>
+      <name>hdp</name>
+      <url>http://repo.hortonworks.com/content/groups/public/</url>
+    </repository>
     <repository>
       <id>oss.sonatype.org</id>
       <name>OSS Sonatype Staging</name>
@@ -278,6 +284,11 @@
         <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
         <version>3.10.5.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>${zookeeper.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix zookeeper + ant versions. (zookeeper working as expected with that version, although that is an earlier patched version)

log4j not updated as https://nvd.nist.gov/vuln/detail/CVE-2017-5645 tells that log4j2 affected, and as i see 1.2.17 versions are affected with the redhat releases

## How was this patch tested?
FT: manually

please review @smolnar82 @zeroflag @rlevas 