### PR TITLE
[AMBARI-23178]Repair ams restarting failed while using embedded mode

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/ams_service.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/ams_service.py
@@ -73,6 +73,12 @@ def ams_service(name, action):
              action='delete',
              owner=params.ams_user)
 
+        if os.path.exists(format("{zookeeper_data_dir}")):
+          Directory(params.zookeeper_data_dir,
+                    action='delete'
+          )
+
+
       if params.security_enabled:
         kinit_cmd = format("{kinit_path_local} -kt {ams_collector_keytab_path} {ams_collector_jaas_princ};")
         daemon_cmd = format("{kinit_cmd} {cmd} start")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove ams-hbase zookeeper_data_dir every time ams start while using embedded mode.Details see ams_service.py file.

## How was this patch tested?

Manual tests
