### PR TITLE
AMBARI-23682. Ambari Metrics Service Check Fails Post Ambari Upgarde

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py
@@ -111,7 +111,7 @@ for host in ams_collector_hosts.split(","):
   metric_truststore_alias_list.append(metric_truststore_alias)
 
 agent_cache_dir = config['agentLevelParams']['agentCacheDir']
-service_package_folder = config['commandParams']['service_package_folder']
+service_package_folder = config['serviceLevelParams']['service_package_folder']
 stack_name = default("/clusterLevelParams/stack_name", None)
 dashboards_dirs = []
 # Stack specific

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
@@ -50,7 +50,7 @@ service_name = config['serviceName']
 logsearch_logfeeder_conf = "/usr/lib/ambari-logsearch-logfeeder/conf"
 
 agent_cache_dir = config['agentLevelParams']['agentCacheDir']
-service_package_folder = config['commandParams']['service_package_folder']
+service_package_folder = config['serviceLevelParams']['service_package_folder']
 logsearch_service_name = service_name.lower().replace("_", "-")
 logsearch_config_file_name = 'input.config-' + logsearch_service_name + ".json"
 logsearch_config_file_path = agent_cache_dir + "/" + service_package_folder + "/templates/" + logsearch_config_file_name + ".j2"


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/AMBARI_METRICS/0.1.0/package/scripts/service_check.py", line 304, in <module>
    AMSServiceCheck().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/usr/lib/ambari-agent/lib/ambari_commons/os_family_impl.py", line 89, in thunk
    return fn(*args, **kwargs)
  File "/var/lib/ambari-agent/cache/common-services/AMBARI_METRICS/0.1.0/package/scripts/service_check.py", line 170, in service_check
    import params
  File "/var/lib/ambari-agent/cache/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py", line 119, in <module>
    'files', 'grafana-dashboards', stack_name))
  File "/usr/lib64/python2.7/posixpath.py", line 75, in join
    if b.startswith('/'):
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/config_dictionary.py", line 73, in __getattr__
    raise Fail("Configuration parameter '" + self.name + "' was not found in configurations dictionary!")
resource_management.core.exceptions.Fail: Configuration parameter 'service_package_folder' was not found in configurations dictionary!