### PR TITLE
AMBARI-23681 - capitalize API references for Swagger

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/ClusterService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/ClusterService.java
@@ -56,7 +56,7 @@ import io.swagger.annotations.ApiResponses;
  * Service responsible for cluster resource requests.
  */
 @Path("/clusters")
-@Api(value = "/clusters", description = "Endpoint for cluster-specific operations")
+@Api(value = "Clusters", description = "Endpoint for cluster-specific operations")
 public class ClusterService extends BaseService {
 
   private static final String CLUSTER_REQUEST_TYPE = "org.apache.ambari.server.api.services.ClusterRequestSwagger";

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/HostService.java
@@ -50,7 +50,7 @@ import io.swagger.annotations.ApiResponses;
  * Service responsible for hosts resource requests.
  */
 @Path("/hosts")
-@Api(value = "/hosts", description = "Endpoint for host-specific operations")
+@Api(value = "Hosts", description = "Endpoint for host-specific operations")
 public class HostService extends BaseService {
 
   private static final String UNKNOWN_HOSTS = "Attempt to add hosts that have not been registered";

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/RootServiceService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/RootServiceService.java
@@ -57,7 +57,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
 @Path("/services")
-@Api(value = "/services", description = "Endpoint for querying root-level services, ie. Ambari Server and Ambari Agents")
+@Api(value = "Services", description = "Endpoint for querying root-level services, ie. Ambari Server and Ambari Agents")
 public class RootServiceService extends BaseService {
 
   private static final String KEY_COMPONENTS = "components";

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/SettingService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/SettingService.java
@@ -51,7 +51,7 @@ import io.swagger.annotations.ApiResponses;
  * Service responsible for setting resource requests.
  */
 @Path("/settings")
-@Api(value = "/settings", description = "Endpoint for settings-specific operations")
+@Api(value = "Settings", description = "Endpoint for settings-specific operations")
 public class SettingService extends BaseService {
 
   private static final String DEFAULT_FIELDS_GET_SETTINGS = SettingResourceProvider.SETTING_NAME_PROPERTY_ID;


### PR DESCRIPTION
Change-Id: I6e3786183ac55b6bce61f6158e40167acac85aef

## What changes were proposed in this pull request?

Capitalize API resource names to be consistent with existing resource names.

## How was this patch tested?

run `mvn process-classes -Dgenerate.swagger.resources -pl ambari-server | grep -v "\[EL*"` then manually checking `ambari/ambari-server/docs/api/generated/swagger.json`

manually checking output at swagger-ui online editor because our HTML generation automatically makes resource names uppercase therefore hiding this issue.

please review @adoroszlai, @benyoka 