### PR TITLE
[AMBARI-23684] Overriding 'isComponentUsingCardinalityForLayout' in parent service advisor in order to exclude deployment of certain components upon UI deployment

### DIFF
--- a/ambari-server/src/main/resources/stacks/service_advisor.py
+++ b/ambari-server/src/main/resources/stacks/service_advisor.py
@@ -162,3 +162,6 @@ class ServiceAdvisor(DefaultStackAdvisor):
       "EXISTING SQL ANYWHERE DATABASE": "sqla"
     }
     return driverDict.get(databaseType.upper())
+
+  def isComponentUsingCardinalityForLayout(self, componentName):
+    return componentName in ['NFS_GATEWAY', 'PHOENIX_QUERY_SERVER', 'SPARK_THRIFTSERVER', 'SPARK2_THRIFTSERVER', 'LIVY2_SERVER', 'LIVY_SERVER']


### PR DESCRIPTION
## What changes were proposed in this pull request?

Manually deploying a cluster in Ambari 2.7 UI using HDP 3 resulted in `NFS Gateway` and `Phoenix Query Server` enabled by default when selecting slaves and clients. this was not the case in HDP 2.6 and we need to make sure we do not change this.

~3 years ago a change has been implemented by @aonishuk to provide a mechanism

> when slave-component layout is being determined, it should ask if component-name should use cardinality for layout.

See [AMBARI-9778](https://issues.apache.org/jira/browse/AMBARI-9778) for more details.

The new method has been overwritten in HDP 2.3 and HDP 2.5 with the following components:

- 2.3 - NFS_GATEWAY, PHOENIX_QUERY_SERVER, SPARK_THRIFTSERVER
- 2.5 - SPARK2_THRIFTSERVER, LIVY2_SERVER, LIVY_SERVER

The issue is that upon the stack advisor split into different services this behavior has not been added. The solution is to add this method with the above list into the most top level service advisor.

## How was this patch tested?

Latest Python unit test results in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:01 min
[INFO] Finished at: 2018-04-25T14:16:38+02:00
[INFO] Final Memory: 114M/1781M
[INFO] ------------------------------------------------------------------------
```

Manually tested in my vagrant environment: after applying this change and created a cluster the components in question were not enabled by default:
<img width="1905" alt="screen shot 2018-04-25 at 12 57 15 pm" src="https://user-images.githubusercontent.com/34065904/39245136-271c49b2-4893-11e8-82b3-86479c39ef55.png">
