### PR TITLE
[AMBARI-23686] HDFS metrics page: list of namespaces is misaligned

### DIFF
--- a/ambari-web/app/styles/enhanced_service_dashboard.less
+++ b/ambari-web/app/styles/enhanced_service_dashboard.less
@@ -25,6 +25,12 @@
 
   clear: both;
 
+  .widgets-group-select-wrapper {
+    margin-left: 21px;
+    margin-top: 25px;
+    position: relative;
+  }
+
   .service-widgets-box {
     padding: 10px 1.1% 10px 1.1%;
   }

--- a/ambari-web/app/templates/main/service/info/metrics.hbs
+++ b/ambari-web/app/templates/main/service/info/metrics.hbs
@@ -98,16 +98,21 @@
       </div>
       {{#if controller.isHDFSFederatedSummary}}
         {{#if controller.selectedNSWidgetLayout}}
-          <div style="margin-left: 21px; margin-top: 25px; position: relative">
+          <div class="widgets-group-select-wrapper">
             <h5 class="widgets-group-title">{{t dashboard.widgets.nameSpace}}</h5>
-            <button type="button" style="min-width: 200px; text-align: left;" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-              {{controller.selectedNSWidgetLayout.displayName}} &nbsp; <span class="caret pull-right" style="position: relative; top: 6px;"></span>
-            </button>
-            <ul class="dropdown-menu">
-              {{#each option in controller.activeNSWidgetLayouts}}
-                <li><a href="#" {{action switchNameServiceLayout option target="controller"}}>{{option.displayName}}</a></li>
-              {{/each}}
-            </ul>
+            <div class="btn-group">
+              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                {{controller.selectedNSWidgetLayout.displayName}}
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                {{#each option in controller.activeNSWidgetLayouts}}
+                  <li>
+                    <a href="#" {{action switchNameServiceLayout option target="controller"}}>{{option.displayName}}</a>
+                  </li>
+                {{/each}}
+              </ul>
+            </div>
           </div>
           <div class="panel-body service-widgets-box">
             <div id="ns_widget_layout" class="thumbnails">


### PR DESCRIPTION
## What changes were proposed in this pull request?

After enabling NameNode federation, the section with namespace-scoped widgets on HDFS metric page appears. Namespaces list is misaligned relatively to select control.

## How was this patch tested?

UI unit tests:
  21521 passing (28s)
  48 pending
