### PR TITLE
[AMBARI-23688]. Remove unsecure dependencies from ambari-server (amagyar)

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -33,7 +33,7 @@
     <jetty.version>9.4.2.v20170220</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
     <checkstyle.version>6.19</checkstyle.version> <!-- last version that does not require Java 8 -->
-    <swagger.version>1.5.10</swagger.version>
+    <swagger.version>1.5.19</swagger.version>
     <swagger.maven.plugin.version>3.1.4</swagger.maven.plugin.version>
     <slf4j.version>1.7.20</slf4j.version>
     <guice.version>4.1.0</guice.version>
@@ -162,17 +162,17 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>4.2.2.RELEASE</version>
+        <version>4.2.4.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
-        <version>4.2.2.RELEASE</version>
+        <version>4.2.4.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
-        <version>4.2.2.RELEASE</version>
+        <version>4.2.4.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security.kerberos</groupId>
@@ -188,12 +188,12 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-ldap</artifactId>
-        <version>4.0.4.RELEASE</version>
+        <version>4.1.1.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.ldap</groupId>
         <artifactId>spring-ldap-core</artifactId>
-        <version>2.0.4.RELEASE</version>
+        <version>2.3.2.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -329,7 +329,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant-launcher</artifactId>
-        <version>1.7.1</version>
+        <version>1.10.3</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1644,7 +1644,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>3.9</version>
+      <version>5.9</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -1709,7 +1709,16 @@
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.1.45</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
@@ -125,14 +125,13 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
 
     Calendar calendar = Calendar.getInstance();
     calendar.setTimeInMillis(System.currentTimeMillis());
-    JWTClaimsSet claimsSet = new JWTClaimsSet();
-    claimsSet.setSubject("test-user");
-    claimsSet.setIssuer("unit-test");
-    claimsSet.setIssueTime(calendar.getTime());
-
-    claimsSet.setExpirationTime(expirationTime);
-
-    claimsSet.setAudience(audience);
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+      .subject("test-user")
+      .issuer("unit-test")
+      .issueTime(calendar.getTime())
+      .expirationTime(expirationTime)
+      .audience(audience)
+      .build();
 
     SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
     signedJWT.sign(signer);
@@ -143,19 +142,21 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
   private SignedJWT getInvalidToken() throws JOSEException {
     RSASSASigner signer = new RSASSASigner(invalidPrivateKey);
 
-    Calendar calendar = Calendar.getInstance();
-    calendar.setTimeInMillis(System.currentTimeMillis());
-    calendar.add(Calendar.DATE, -2);
+    Calendar issueTime = Calendar.getInstance();
+    issueTime.setTimeInMillis(System.currentTimeMillis());
+    issueTime.add(Calendar.DATE, -2);
 
-    JWTClaimsSet claimsSet = new JWTClaimsSet();
-    claimsSet.setSubject("test-user");
-    claimsSet.setIssuer("unit-test");
-    claimsSet.setIssueTime(calendar.getTime());
+    Calendar expirationTime = Calendar.getInstance();
+    issueTime.setTimeInMillis(System.currentTimeMillis());
+    expirationTime.add(Calendar.DATE, -1);
 
-    calendar.add(Calendar.DATE, 1); //add one day
-    claimsSet.setExpirationTime(calendar.getTime());
-
-    claimsSet.setAudience("test-audience-invalid");
+    JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+      .subject("test-user")
+      .issuer("unit-test")
+      .issueTime(issueTime.getTime())
+      .expirationTime(issueTime.getTime())
+      .audience("test-audience-invalid")
+      .build();
 
     SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), claimsSet);
     signedJWT.sign(signer);


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Remove dependency on org.springframework.security:spring-security-core 4.2.2.RELEASE in Ambari Server
* Remove dependency on org.springframework.ldap:spring-ldap-core 2.0.4.RELEASE in Ambari Server	
* Remove dependency on org.springframework.security:spring-security-config 4.2.2.RELEASE in Ambari Server
* Remove dependency on com.nimbusds:nimbus-jose-jwt 3.9 in Ambari Server
* Remove dependency on org.apache.ant:ant-launcher 1.7.1 in Ambari Server
* Remove dependency on org.springframework.security:spring-security-ldap 4.0.4.RELEASE in Ambari Server
* Remove dependency on org.springframework.security:spring-security-web 4.2.2.RELEASE in Ambari Server
* Remove dependency on com.jcraft:jsch 0.1.42 in Ambari Server
* Remove dependency on com.fasterxml.jackson.dataformat:jackson-dataformat-xml 2.4.5 in Ambari Server

## How was this patch tested?

started ambari-server and checked a functions on the UI