### PR TITLE
AMBARI-23691 : Fix CVE security issues in AMS dependencies.

### DIFF
--- a/ambari-metrics/ambari-metrics-common/pom.xml
+++ b/ambari-metrics/ambari-metrics-common/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
-      <version>2.12.0</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>

--- a/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
@@ -31,7 +31,6 @@ limitations under the License.
   <packaging>jar</packaging>
   <properties>
     <sinkJarName>${project.artifactId}-with-common-${project.version}.jar</sinkJarName>
-    <hadoopVersion>3.0.0-beta1</hadoopVersion>
   </properties>
 
 
@@ -142,7 +141,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoopVersion}</version>
+      <version>3.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -171,7 +170,7 @@ limitations under the License.
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
-      <version>1.6</version>
+      <version>1.10</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/ambari-metrics/ambari-metrics-host-aggregator/pom.xml
+++ b/ambari-metrics/ambari-metrics-host-aggregator/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.1.2.3.4.0-3347</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey.jersey-test-framework</groupId>

--- a/ambari-metrics/ambari-metrics-kafka-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-kafka-sink/pom.xml
@@ -144,7 +144,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.10</artifactId>
-      <version>0.10.1.0</version>
+      <version>0.10.2.1</version>
       <exclusions>
         <exclusion>
           <groupId>com.sun.jdmk</groupId>

--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -311,6 +311,10 @@
           <artifactId>zkclient</artifactId>
           <groupId>com.101tec</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>zookeeper</artifactId>
+          <groupId>org.apache.zookeeper</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- zkclient is helix-core dependency but it need to be 0.9 in order for AMS HA to work on secure cluster-->
@@ -318,6 +322,11 @@
       <groupId>com.101tec</groupId>
       <artifactId>zkclient</artifactId>
       <version>0.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.5.1.3.0.0-107</version>
     </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgraded the following
ambari-metrics-host-aggregator -> hadoop-common
ambari-metrics-common -> hadoop-common, curator-framework, commons-configuration
ambari-metrics-timelineservice -> zookeeper
ambari-metrics-kafka-sink -> kafka_2.10

## How was this patch tested?
mvn clean install on ambari-metrics.