### PR TITLE
AMBARI-23660. Hosts topology can be incomplete for components install during blueprint deploy

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -485,6 +485,8 @@ class CustomServiceOrchestrator():
     required_config_timestamp = command_header['requiredConfigTimestamp'] if 'requiredConfigTimestamp' in command_header else None
 
     command_dict = self.configuration_builder.get_configuration(cluster_id, service_name, component_name, required_config_timestamp)
+    if 'clusterHostInfo' in command_header:
+      del command_dict['clusterHostInfo']
     command = Utils.update_nested(Utils.get_mutable_copy(command_dict), command_header)
     return command
 

--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -485,6 +485,8 @@ class CustomServiceOrchestrator():
     required_config_timestamp = command_header['requiredConfigTimestamp'] if 'requiredConfigTimestamp' in command_header else None
 
     command_dict = self.configuration_builder.get_configuration(cluster_id, service_name, component_name, required_config_timestamp)
+
+    # remove data populated from topology to avoid merge and just override
     if 'clusterHostInfo' in command_header:
       del command_dict['clusterHostInfo']
     command = Utils.update_nested(Utils.get_mutable_copy(command_dict), command_header)

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -373,7 +373,7 @@ public class StageUtils {
           // a higher priority lookup
           for (Service service : cluster.getServices().values()) {
             for (ServiceComponent sc : service.getServiceComponents().values()) {
-              if (!sc.isClientComponent() && sc.getName().equals(hostComponent)) {
+              if (sc.getName().equals(hostComponent)) {
                 roleName = hostComponent.toLowerCase() + "_hosts";
                 additionalComponentToClusterInfoKeyMap.put(hostComponent, roleName);
               }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Additional fix.
Now server sends commands with topology for all components (including clients). Agent uses topology from command only when it is available and from topology cache otherwise.

## How was this patch tested?

Manual testing.