### PR TITLE
[AMBARI-23694] Symlinks are not followed when requesting resources from Ambari's resources entry point

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -487,6 +487,12 @@ public class AmbariServer {
       File resourcesDirectory = new File(configs.getResourceDirPath());
       ServletHolder resources = new ServletHolder(DefaultServlet.class);
       resources.setInitParameter("resourceBase", resourcesDirectory.getParent());
+      // Allowing aliases can bypass some security constraints, but allows for following symlinks
+      // which are needed for mpacks. For example:
+      //   /var/lib/ambari-server/resources/stacks/HDP/2.6/services/BEACON ->
+      //   /var/lib/ambari-server/resources/mpacks/beacon-engine.mpack-1.1.0.0/addon-services/BEACON/1.1.0
+      // NOTE: Enabling aliases does not re-introduce the vulnerability described in CVE-2018-8003.
+      resources.setInitParameter("aliases", "true");
       root.addServlet(resources, "/resources/*");
       resources.setInitOrder(5);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Symlinks are not followed when requesting resources from Ambari's resources entry point.

For example if the Beacon mpack is installed, a symlink is made from /var/lib/ambari-server/resources/mpacks/beacon-engine.mpack-1.1.0.0/addon-services/BEACON/1.1.0 to /var/lib/ambari-server/resources/stacks/HDP/2.6/services/BEACON:
```
# ls -ltr /var/lib/ambari-server/resources/stacks/HDP/2.6/services/BEACON
lrwxrwxrwx 1 root root 95 Apr 25 07:03 /var/lib/ambari-server/resources/stacks/HDP/2.6/services/BEACON -> /var/lib/ambari-server/resources/mpacks/beacon-engine.mpack-1.1.0.0/addon-services/BEACON/1.1.0
```

```
# curl -i -X GET http://c7401.ambari.apache.org:8080/resources/stacks/HDP/2.6/services/BEACON/metainfo.xml
HTTP/1.1 404 Not Found
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Pragma: no-cache
Content-Type: text/plain;charset=ISO-8859-1
Content-Length: 45

{
  "status": 404,
  "message": "Not Found"
}
```

When this occurs, the stack definitions from BEACON are not able to be cached by the Ambari agents. 

This as fixed by turning on the Jetty feature to allow `aliases` when finding resources in a servlet context. 


## How was this patch tested?

Manually tested using `curl`.


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.