### PR TITLE
[AMBARI-23698] Remove unsecure dependencies from ambari-utility

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -38,7 +38,7 @@
     <slf4j.version>1.7.20</slf4j.version>
     <guice.version>4.1.0</guice.version>
     <spring.version>4.3.7.RELEASE</spring.version>
-    <fasterxml.jackson.version>2.9.4</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -33,14 +33,35 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.kongchen</groupId>
       <artifactId>swagger-maven-plugin</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-xml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed `jackson-dataformat-xml-2.4.5.jar` from `ambari-utility` as it is not needed
Upgraded `jackson-databind-2.9.4.jar` to `jackson-databind-2.9.5.jar` as recommended


## How was this patch tested?

1.) Running unit tests in ambari-utility project:
```
HW15069:ambari-utility smolnar$ mvn clean install
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.swagger.AmbariSwaggerReaderTest
[INFO] Running org.apache.ambari.checkstyle.AvoidTransactionalOnPrivateMethodsCheckTest
[INFO] Running org.apache.ambari.checkstyle.UndocumentedRestApiOperationCheckTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.535 s - in org.apache.ambari.checkstyle.UndocumentedRestApiOperationCheckTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.536 s - in org.apache.ambari.checkstyle.AvoidTransactionalOnPrivateMethodsCheckTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.897 s - in org.apache.ambari.swagger.AmbariSwaggerReaderTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.490 s
[INFO] Finished at: 2018-04-26T00:45:36+02:00
[INFO] Final Memory: 36M/484M
[INFO] ------------------------------------------------------------------------
```

2.) Checking Maven's  dependency resolution:
```
HW15069:ambari-utility smolnar$ mvn dependency:tree -Dincludes=*:*jackson-dataformat-xml*
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building ambari-utility 1.0.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-utility ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.133 s
[INFO] Finished at: 2018-04-26T00:39:56+02:00
[INFO] Final Memory: 18M/309M
[INFO] ------------------------------------------------------------------------

HW15069:ambari-utility smolnar$ mvn dependency:tree -Dincludes=*:*jackson-databind*
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building ambari-utility 1.0.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-utility ---
[INFO] org.apache.ambari:ambari-utility:jar:1.0.0.0-SNAPSHOT
[INFO] \- com.fasterxml.jackson.core:jackson-databind:jar:2.9.5:provided
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.107 s
[INFO] Finished at: 2018-04-26T00:40:05+02:00
[INFO] Final Memory: 18M/309M
[INFO] ------------------------------------------------------------------------
```

3.) In addition to this; I replaced `jackson-databind-2.9.4.jar` with `jackson-databind-2.9.5.jar` and removed `jackson-dataformat-xml-2.4.5.jar` in/from `usr/lib/ambari-server` on my vagrant host and restarted the server; logged in and did some actions (in this case I created a cluster); there were no any issue.