### PR TITLE
AMBARI-23680 Installing hive with "New mysql database" fails

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
@@ -504,7 +504,8 @@ def jdbc_connector(target, hive_previous_jdbc_jar):
 
   else:
     #for default hive db (Mysql)
-    Execute(('cp', '--remove-destination', format('/usr/share/java/{jdbc_jar_name}'), target),
+    File(params.downloaded_custom_connector, content = DownloadSource(params.driver_curl_source))
+    Execute(('cp', '--remove-destination', params.downloaded_custom_connector, target),
             #creates=target, TODO: uncomment after ranger_hive_plugin will not provide jdbc
             path=["/bin", "/usr/bin/"],
             sudo=True

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_metastore.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_metastore.py
@@ -256,10 +256,14 @@ class TestHiveMetastore(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
-    
+
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
                                           '--remove-destination',
-                                          '/usr/share/java/mysql-connector-java.jar',
+                                          '/tmp/mysql-connector-java.jar',
                                           '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
                               path = ['/bin', '/usr/bin/'],
                               sudo = True,
@@ -382,9 +386,13 @@ class TestHiveMetastore(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
                                           '--remove-destination',
-                                          '/usr/share/java/mysql-connector-java.jar',
+                                          '/tmp/mysql-connector-java.jar',
                                           '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
                               path = ['/bin', '/usr/bin/'],
                               sudo = True,
@@ -522,10 +530,14 @@ class TestHiveMetastore(RMFTestCase):
                               mode = 0755,
                               create_parents = True,
                               cd_access = 'a')
-    
+
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
                                           '--remove-destination',
-                                          '/usr/share/java/mysql-connector-java.jar',
+                                          '/tmp/mysql-connector-java.jar',
                                           '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
                               path = ['/bin', '/usr/bin/'],
                               sudo = True)

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_server.py
@@ -429,9 +429,13 @@ class TestHiveServer(RMFTestCase):
                               create_parents = True,
                               cd_access='a',
     )
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
                                           '--remove-destination',
-                                          '/usr/share/java/mysql-connector-java.jar',
+                                          '/tmp/mysql-connector-java.jar',
                                           '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
                               path=['/bin', '/usr/bin/'],
                               sudo=True,
@@ -643,9 +647,13 @@ class TestHiveServer(RMFTestCase):
                               create_parents = True,
                               cd_access='a',
     )
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
                                           '--remove-destination',
-                                          '/usr/share/java/mysql-connector-java.jar',
+                                          '/tmp/mysql-connector-java.jar',
                                           '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
                               path=['/bin', '/usr/bin/'],
                               sudo=True,

--- a/ambari-server/src/test/python/stacks/2.1/HIVE/test_hive_metastore.py
+++ b/ambari-server/src/test/python/stacks/2.1/HIVE/test_hive_metastore.py
@@ -281,9 +281,13 @@ class TestHiveMetastore(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
      '--remove-destination',
-     '/usr/share/java/mysql-connector-java.jar',
+     '/tmp/mysql-connector-java.jar',
      '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
         path = ['/bin', '/usr/bin/'],
         sudo = True,
@@ -394,9 +398,13 @@ class TestHiveMetastore(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
      '--remove-destination',
-     '/usr/share/java/mysql-connector-java.jar',
+     '/tmp/mysql-connector-java.jar',
      '/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar'),
         path = ['/bin', '/usr/bin/'],
         sudo = True,
@@ -685,9 +693,13 @@ class TestHiveMetastore(RMFTestCase):
     self.assertResourceCalledIgnoreEarlier('Directory', '/var/lib/hive', owner = 'hive', group = 'hadoop',
       mode = 0755, create_parents = True, cd_access = 'a')
 
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
      '--remove-destination',
-     '/usr/share/java/mysql-connector-java.jar',
+     '/tmp/mysql-connector-java.jar',
      '/usr/hdp/2.3.2.0-2950/hive/lib/mysql-connector-java.jar'),
         path = ['/bin', '/usr/bin/'],
         sudo = True,
@@ -712,9 +724,13 @@ class TestHiveMetastore(RMFTestCase):
                               mode=0777
                               )
 
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+                              )
     self.assertResourceCalled('Execute', ('cp',
      '--remove-destination',
-     '/usr/share/java/mysql-connector-java.jar',
+     '/tmp/mysql-connector-java.jar',
      u'/usr/hdp/2.3.2.0-2950/hive/lib/mysql-connector-java.jar'),
         path = ['/bin', '/usr/bin/'],
         sudo = True,

--- a/ambari-server/src/test/python/stacks/2.5/HIVE/test_hive_server_int.py
+++ b/ambari-server/src/test/python/stacks/2.5/HIVE/test_hive_server_int.py
@@ -714,9 +714,13 @@ class TestHiveServerInteractive(RMFTestCase):
                               group='root',
                               mode=0644,
     )
+    self.assertResourceCalled('File',
+                              '/tmp/mysql-connector-java.jar',
+                              content=DownloadSource('http://c6401.ambari.apache.org:8080/resources/mysql-connector-java.jar'),
+    )
     self.assertResourceCalled('Execute', ('cp',
                                           '--remove-destination',
-                                          '/usr/share/java/mysql-connector-java.jar',
+                                          '/tmp/mysql-connector-java.jar',
                                           '/usr/hdp/current/hive-server2-hive2/lib/mysql-connector-java.jar'),
                               path=['/bin', '/usr/bin/'],
                               sudo=True,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The whole problem originates from removing mysql-java-connector package install from hive install.
Hive already has a mechanism for downloading drivers from the Ambari Server. Added this to the hive.py for the default path.
I think the 'ambari-server setup --jdbc....' did not work properly. Added a symlink for the installed custom driver. The symlink is named as described in default_connectors_map. This is how the rest of the system is looking for it.

## How was this patch tested?

unit tests, manual testing


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.