### PR TITLE
[AMBARI-23707] NN Federation Wizard: move out of wizard create widgets operaions

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step4_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step4_controller.js
@@ -22,7 +22,7 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
 
   name: "nameNodeFederationWizardStep4Controller",
 
-  commands: ['stopRequiredServices', 'reconfigureServices', 'installNameNode', 'installZKFC', 'startJournalNodes', 'startNameNodes', 'formatNameNode', 'formatZKFC', 'startZKFC', 'startNameNode', 'bootstrapNameNode', 'createWidgets', 'startZKFC2', 'startNameNode2', 'restartAllServices'],
+  commands: ['stopRequiredServices', 'reconfigureServices', 'installNameNode', 'installZKFC', 'startJournalNodes', 'startNameNodes', 'formatNameNode', 'formatZKFC', 'startZKFC', 'startNameNode', 'bootstrapNameNode', 'startZKFC2', 'startNameNode2', 'restartAllServices'],
 
   tasksMessagesPrefix: 'admin.nameNodeFederation.wizard.step',
 
@@ -130,74 +130,6 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
     });
   },
 
-  createWidgets: function () {
-    var self = this;
-      this.getNameNodeWidgets().done(function (data) {
-        var newWidgetsIds = [];
-        var oldWidgetIds = [];
-        var nameservice1 = App.HDFSService.find().objectAt(0).get('masterComponentGroups')[0].name;
-        var nameservice2 = self.get('content.nameServiceId');
-        var widgetsCount = data.items.length;
-        data.items.forEach(function (widget) {
-          if (!widget.WidgetInfo.tag) {
-            var oldId = widget.WidgetInfo.id;
-            oldWidgetIds.push(oldId);
-          delete widget.href;
-          delete widget.WidgetInfo.id;
-          delete widget.WidgetInfo.cluster_name;
-          delete widget.WidgetInfo.author;
-            widget.WidgetInfo.tag = nameservice1;
-          widget.WidgetInfo.metrics = JSON.parse(widget.WidgetInfo.metrics);
-          widget.WidgetInfo.values = JSON.parse(widget.WidgetInfo.values);
-            self.createWidget(widget).done(function (w) {
-              newWidgetsIds.push(w.resources[0].WidgetInfo.id);
-              widget.WidgetInfo.tag = nameservice2;
-              self.createWidget(widget).done(function (w) {
-                newWidgetsIds.push(w.resources[0].WidgetInfo.id);
-                self.deleteWidget(oldId).done(function () {
-                  if (!--widgetsCount) {
-                    self.getDefaultHDFStWidgetLayout().done(function (layout) {
-                      layout = layout.items[0].WidgetLayoutInfo;
-                      layout.widgets = layout.widgets.filter(function (w) {
-                        return !oldWidgetIds.contains(w.WidgetInfo.id);
-                      }).map(function (w) {
-                        return w.WidgetInfo.id;
-                      }).concat(newWidgetsIds);
-                      self.updateDefaultHDFStWidgetLayout(layout).done(function () {
-                        self.onTaskCompleted();
-                      });
-                    });
-                  }
-                });
-              });
-            });
-          } else {
-            widgetsCount--;
-          }
-        });
-      });
-  },
-
-  createWidget: function (data) {
-    return App.ajax.send({
-      name: 'widgets.wizard.add',
-      sender: this,
-      data: {
-        data: data
-      }
-    });
-  },
-
-  deleteWidget: function (id) {
-    return App.ajax.send({
-      name: 'widget.action.delete',
-      sender: self,
-      data: {
-        id: id
-      }
-    });
-  },
-
   startZKFC2: function () {
     this.updateComponent('ZKFC', this.get('newNameNodeHosts')[1], "HDFS", "Start");
   },
@@ -212,52 +144,6 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
       sender: this,
       success: 'startPolling',
       error: 'onTaskError'
-    });
-  },
-
-  getNameNodeWidgets: function () {
-    return App.ajax.send({
-      name: 'widgets.get',
-      sender: this,
-      data: {
-        urlParams: 'WidgetInfo/widget_type.in(GRAPH,NUMBER,GAUGE)&WidgetInfo/scope=CLUSTER&WidgetInfo/metrics.matches(.*\"component_name\":\"NAMENODE\".*)&fields=*'
-      }
-    });
-  },
-
-  getDefaultHDFStWidgetLayout: function () {
-    return App.ajax.send({
-      name: 'widget.layout.get',
-      sender: this,
-      data: {
-        urlParams: 'WidgetLayoutInfo/layout_name=default_hdfs_dashboard'
-      }
-    });
-  },
-
-  updateDefaultHDFStWidgetLayout: function (widgetLayoutData) {
-    var layout = widgetLayoutData;
-    var data = {
-      "WidgetLayoutInfo": {
-        "display_name": layout.display_name,
-        "layout_name": layout.layout_name,
-        "id": layout.id,
-        "scope": "USER",
-        "section_name": layout.section_name,
-        "widgets": layout.widgets.map(function (id) {
-          return {
-            "id":id
-          }
-        })
-      }
-    };
-    return App.ajax.send({
-      name: 'widget.layout.edit',
-      sender: this,
-      data: {
-        layoutId: layout.id,
-        data: data
-      },
     });
   }
 });

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -1703,10 +1703,9 @@ Em.I18n.translations = {
   'admin.nameNodeFederation.wizard.step4.task8.title': 'Start ZKFC',
   'admin.nameNodeFederation.wizard.step4.task9.title': 'Start NameNode',
   'admin.nameNodeFederation.wizard.step4.task10.title': 'Bootstrap NameNode',
-  'admin.nameNodeFederation.wizard.step4.task11.title': 'Create widgets',
-  'admin.nameNodeFederation.wizard.step4.task12.title': 'Start ZKFC',
-  'admin.nameNodeFederation.wizard.step4.task13.title': 'Start NameNode',
-  'admin.nameNodeFederation.wizard.step4.task14.title': 'Restart Required Services',
+  'admin.nameNodeFederation.wizard.step4.task11.title': 'Start ZKFC',
+  'admin.nameNodeFederation.wizard.step4.task12.title': 'Start NameNode',
+  'admin.nameNodeFederation.wizard.step4.task13.title': 'Restart Required Services',
 
   'admin.security.title':'Kerberos security has not been enabled',
   'admin.security.enabled': 'Kerberos security is enabled',

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -2987,6 +2987,11 @@ var urls = {
     mock: '/data/widget_layouts/{serviceName}/default_dashboard.json'
   },
 
+  'widget.layout.delete': {
+    real: '/clusters/{clusterName}/widget_layouts/{layoutId}',
+    type: 'DELETE'
+  },
+
   'widget.layout.get': {
     real: '/clusters/{clusterName}/widget_layouts?{urlParams}',
     mock: '/data/widget_layouts/{serviceName}/default_dashboard.json'


### PR DESCRIPTION
## What changes were proposed in this pull request?

As we should handle installing Ambari with federation from blueprint, we should move create widgets logic out of wizard and run it on first dashboard page visit.

## How was this patch tested?

  21523 passing (48s)
  48 pending