### PR TITLE
[AMBARI-23096]. Ambari needs to call refreshNodes after deleting a host that was running a datanode (amagyar)

### DIFF
--- a/ambari-server/docs/configuration/index.md
+++ b/ambari-server/docs/configuration/index.md
@@ -137,6 +137,7 @@ The following are the properties which can be used to configure Ambari.
 | metrics.retrieval-service.request.ttl | The number of seconds to wait between issuing JMX or REST metric requests to the same endpoint. This property is used to throttle requests to the same URL being made too close together<br/><br/> This property is related to `metrics.retrieval-service.request.ttl.enabled`. |`5` | 
 | metrics.retrieval-service.request.ttl.enabled | Enables throttling requests to the same endpoint within a fixed amount of time. This property will prevent Ambari from making new metric requests to update the cache for URLs which have been recently retrieved.<br/><br/> This property is related to `metrics.retrieval-service.request.ttl`. |`true` | 
 | mpacks.staging.path | The Ambari Management Pack staging directory on the Ambari Server.<br/><br/>The following are examples of valid values:<ul><li>`/var/lib/ambari-server/resources/mpacks`</ul> | | 
+| namenode.refresh.on.datanode.host.delete | Refresh NameNode after deleting host with DataNode |`false` | 
 | notification.dispatch.alert.script.directory | The directory for scripts which are used by the alert notification dispatcher. |`/var/lib/ambari-server/resources/scripts` | 
 | packages.pre.installed | Determines whether Ambari Agent instances have already have the necessary stack software installed |`false` | 
 | pam.configuration | The PAM configuration file. | | 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -2545,6 +2545,15 @@ public class Configuration {
   public static final ConfigurationProperty<Integer> DEFAULT_MAX_DEGREE_OF_PARALLELISM_FOR_UPGRADES = new ConfigurationProperty<>(
     "stack.upgrade.default.parallelism", 100);
 
+
+  /**
+   * Default value of Max number of tasks to schedule in parallel for upgrades.
+   */
+  @Markdown(description = "Refresh NameNode after deleting host with DataNode")
+  public static final ConfigurationProperty<Boolean> REFRESH_NODE_AFTER_DELETE_DN_HOST = new ConfigurationProperty<>(
+    "namenode.refresh.on.datanode.host.delete", false);
+
+
   private static final Logger LOG = LoggerFactory.getLogger(
     Configuration.class);
 
@@ -5923,5 +5932,13 @@ public class Configuration {
 
   public int getAlertServiceCorePoolSize() {
     return Integer.parseInt(getProperty(SERVER_SIDE_ALERTS_CORE_POOL_SIZE));
+  }
+
+  /**
+   * Determines whether to send refreshNodes command to the NameNode after deleting a host with DataNode.
+   * The default value is False.
+   */
+  public boolean refreshNameNodeAfterDataNodeHostDelete() {
+    return Boolean.parseBoolean(getProperty(REFRESH_NODE_AFTER_DELETE_DN_HOST));
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -1270,7 +1270,7 @@ public class AmbariCustomCommandExecutionHelper {
         hostParamsStageJson);
   }
 
-  Map<String, String> createDefaultHostParams(Cluster cluster, StackId stackId) throws AmbariException {
+  public Map<String, String> createDefaultHostParams(Cluster cluster, StackId stackId) throws AmbariException {
     if (null == stackId) {
       stackId = cluster.getDesiredStackVersion();
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -79,6 +79,8 @@ import org.apache.ambari.server.controller.internal.ViewPermissionResourceProvid
 import org.apache.ambari.server.controller.metrics.ThreadPoolEnabledPropertyProvider;
 import org.apache.ambari.server.controller.utilities.KerberosChecker;
 import org.apache.ambari.server.controller.utilities.KerberosIdentityCleaner;
+import org.apache.ambari.server.controller.utilities.NodeRefresher;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.ldap.LdapModule;
 import org.apache.ambari.server.metrics.system.MetricsService;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
@@ -947,6 +949,9 @@ public class AmbariServer {
 
     KerberosIdentityCleaner identityCleaner = injector.getInstance(KerberosIdentityCleaner.class);
     identityCleaner.register();
+
+    NodeRefresher nodeRefresher = injector.getInstance(NodeRefresher.class);
+    nodeRefresher.register(injector.getInstance(AmbariEventPublisher.class));
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -951,7 +951,9 @@ public class AmbariServer {
     identityCleaner.register();
 
     NodeRefresher nodeRefresher = injector.getInstance(NodeRefresher.class);
-    nodeRefresher.register(injector.getInstance(AmbariEventPublisher.class));
+    if (configs.refreshNameNodeAfterDataNodeHostDelete()) {
+      nodeRefresher.register(injector.getInstance(AmbariEventPublisher.class));
+    }
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/NodeRefresher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/NodeRefresher.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.utilities;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.apache.ambari.server.Role.DATANODE;
+import static org.apache.ambari.server.Role.NAMENODE;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.actionmanager.ActionManager;
+import org.apache.ambari.server.actionmanager.RequestFactory;
+import org.apache.ambari.server.actionmanager.Stage;
+import org.apache.ambari.server.actionmanager.StageFactory;
+import org.apache.ambari.server.controller.ActionExecutionContext;
+import org.apache.ambari.server.controller.AmbariCustomCommandExecutionHelper;
+import org.apache.ambari.server.controller.internal.RequestResourceFilter;
+import org.apache.ambari.server.controller.internal.RequestStageContainer;
+import org.apache.ambari.server.events.HostsRemovedEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.ServiceComponent;
+import org.apache.ambari.server.utils.StageUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Sends REFRESH_NODE command to the NAMENODE after deleting a host that was running a DATANODE
+ */
+@Singleton
+public class NodeRefresher {
+  private final static Logger LOG = LoggerFactory.getLogger(NodeRefresher.class);
+  private static final String REFRESH_NODE = "REFRESH_NODES";
+  private static final String REQUEST_CONTEXT = "Refresh NameNode";
+  private final AmbariCustomCommandExecutionHelper executionHelper;
+  private final StageFactory stageFactory;
+  private final ActionManager actionManager;
+  private final RequestFactory requestFactory;
+
+  @Inject
+  public NodeRefresher(AmbariCustomCommandExecutionHelper executionHelper, StageFactory stageFactory, ActionManager actionManager, RequestFactory requestFactory) {
+    this.executionHelper = executionHelper;
+    this.stageFactory = stageFactory;
+    this.actionManager = actionManager;
+    this.requestFactory = requestFactory;
+  }
+
+  public void register(AmbariEventPublisher eventPublisher) {
+    eventPublisher.register(this);
+  }
+
+  @Subscribe
+  public void onHostRemoved(HostsRemovedEvent event) {
+    if (event.hasComponent(DATANODE)) {
+      for (Cluster cluster : event.getClusters()) {
+        try {
+          LOG.info("Sending {} command to NAMENODE after host was removed {}", REFRESH_NODE, event);
+          refresh(nameNode(cluster), cluster);
+        } catch (AmbariException e) {
+          LOG.warn("Could not send " + REFRESH_NODE + " to NAMENODE after deleting host: " + event, e);
+        }
+      }
+    }
+  }
+
+  private ServiceComponent nameNode(Cluster cluster) throws AmbariException {
+    return cluster.getService("HDFS").getServiceComponent(NAMENODE.name());
+  }
+
+  protected void refresh(ServiceComponent namenode, Cluster cluster) throws AmbariException {
+    RequestStageContainer stageContainer = stageContainer(cluster);
+    Stage stage = createNewStage(stageContainer, cluster, REQUEST_CONTEXT);
+    ActionExecutionContext exec = new ActionExecutionContext(cluster.getClusterName(), REFRESH_NODE, filters(namenode), emptyMap());
+    executionHelper.addExecutionCommandsToStage(exec, stage, emptyMap(), null);
+    stageContainer.persist();
+  }
+
+  private RequestStageContainer stageContainer(Cluster cluster) throws AmbariException {
+    RequestStageContainer requestStageContainer = new RequestStageContainer(
+      actionManager.getNextRequestId(),
+      null,
+      requestFactory,
+      actionManager);
+    requestStageContainer.setClusterHostInfo(clusterHostInfo(cluster));
+    return requestStageContainer;
+  }
+
+  private Stage createNewStage(RequestStageContainer stageContainer, Cluster cluster, String requestContext)
+    throws AmbariException
+  {
+    Stage stage = stageFactory.createNew(stageContainer.getId(),
+      "/tmp/ambari",
+      cluster.getClusterName(),
+      cluster.getClusterId(),
+      requestContext,
+      "{}",
+      hostParams(cluster));
+    stageContainer.addStages(singletonList(stage));
+    stage.setStageId(stageContainer.getLastStageId() <= 0 ? 1 : stageContainer.getLastStageId() +1);
+    return stage;
+  }
+
+  private String hostParams(Cluster cluster) throws AmbariException {
+    Map<String, String> params = executionHelper.createDefaultHostParams(cluster, cluster.getDesiredStackVersion());
+    return StageUtils.getGson().toJson(params);
+  }
+
+  private List<RequestResourceFilter> filters(ServiceComponent namenode) {
+    return singletonList(new RequestResourceFilter(namenode.getServiceName(), namenode.getName(), hosts(namenode)));
+  }
+
+  private List<String> hosts(ServiceComponent component) {
+    return component.getServiceComponentsHosts().stream()
+      .findAny()
+      .map(Collections::singletonList)
+      .orElse(emptyList());
+  }
+
+  private String clusterHostInfo(Cluster cluster) throws AmbariException {
+    return StageUtils.getGson().toJson(StageUtils.getClusterHostInfo(cluster));
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/NodeRefresher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/NodeRefresher.java
@@ -72,6 +72,7 @@ public class NodeRefresher {
 
   public void register(AmbariEventPublisher eventPublisher) {
     eventPublisher.register(this);
+    LOG.info("NodeRefresher registered.");
   }
 
   @Subscribe

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/HostsRemovedEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/HostsRemovedEvent.java
@@ -17,9 +17,14 @@
  */
 package org.apache.ambari.server.events;
 
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.Role;
 import org.apache.ambari.server.state.Cluster;
 
 /**
@@ -38,15 +43,19 @@ public class HostsRemovedEvent extends AmbariEvent {
    */
   private final Set<String> m_hosts;
 
+  private final Map<String, Set<String>> componentsPerHost;
+
   /**
    * Constructor.
    * @param hosts
    * @param clusters
+   * @param componentsPerHost
    */
-  public HostsRemovedEvent(Set<String> hosts, Set<Cluster> clusters) {
+  public HostsRemovedEvent(Set<String> hosts, Set<Cluster> clusters, Map<String, Set<String>> componentsPerHost) {
     super(AmbariEventType.HOST_REMOVED);
     m_clusters = clusters;
     m_hosts = hosts;
+    this.componentsPerHost = componentsPerHost;
   }
 
   /**
@@ -84,5 +93,16 @@ public class HostsRemovedEvent extends AmbariEvent {
     sb.append(", m_hosts=").append(m_hosts);
     sb.append('}');
     return sb.toString();
+  }
+
+  /**
+   * @return true if any of the deleted host had the given component
+   */
+  public boolean hasComponent(Role component) {
+    return flatten(componentsPerHost.values()).contains(component.name());
+  }
+
+  private static Set<String> flatten(Collection<Set<String>> values) {
+    return values.stream().flatMap(Collection::stream).collect(toSet());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
@@ -235,9 +235,10 @@ public interface Clusters {
    * Publish event set of hosts were removed
    * @param clusters
    * @param hostNames
+   * @param componentsPerHost
    * @throws AmbariException
    */
-  void publishHostsDeletion(Set<Cluster> clusters, Set<String> hostNames)
+  void publishHostsDeletion(Set<Cluster> clusters, Set<String> hostNames, Map<String, Set<String>> componentsPerHost)
       throws AmbariException;
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -812,10 +812,10 @@ public class ClustersImpl implements Clusters {
   }
 
   @Override
-  public void publishHostsDeletion(Set<Cluster> clusters, Set<String> hostNames) throws AmbariException {
+  public void publishHostsDeletion(Set<Cluster> clusters, Set<String> hostNames, Map<String, Set<String>> componentsPerHost) throws AmbariException {
     // Publish the event, using the original list of clusters that the host
     // belonged to
-    HostsRemovedEvent event = new HostsRemovedEvent(hostNames, clusters);
+    HostsRemovedEvent event = new HostsRemovedEvent(hostNames, clusters, componentsPerHost);
     eventPublisher.publish(event);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
@@ -1084,7 +1084,7 @@ public class HostResourceProviderTest extends EasyMockSupport {
     expect(cluster.getClusterId()).andReturn(100L).anyTimes();
     expect(cluster.getDesiredConfigs()).andReturn(new HashMap<>()).anyTimes();
     clusters.deleteHost("Host100");
-    clusters.publishHostsDeletion(Collections.EMPTY_SET, Collections.singleton("Host100"));
+    clusters.publishHostsDeletion(Collections.EMPTY_SET, Collections.singleton("Host100"), Collections.emptyMap());
     expect(host1.getHostName()).andReturn("Host100").anyTimes();
     expect(healthStatus.getHealthStatus()).andReturn(HostHealthStatus.HealthStatus.HEALTHY).anyTimes();
     expect(healthStatus.getHealthReport()).andReturn("HEALTHY").anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/NodeRefresherTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/NodeRefresherTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.utilities;
+
+import static java.util.Collections.singleton;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.events.HostsRemovedEvent;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Service;
+import org.apache.ambari.server.state.ServiceComponent;
+import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockSupport;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EasyMockRunner.class)
+public class NodeRefresherTest extends EasyMockSupport {
+  private NodeRefresher nodeRefresher;
+  @Mock
+  private Cluster cluster;
+  @Mock
+  private Service hdfs;
+  @Mock
+  private ServiceComponent namenode;
+  private boolean namenodeWasRefreshed = false;
+
+  @Before
+  public void setUp() throws Exception {
+    nodeRefresher = nodeRefresher();
+    expect(cluster.getService("HDFS")).andReturn(hdfs).anyTimes();
+    expect(hdfs.getServiceComponent("NAMENODE")).andReturn(namenode).anyTimes();
+    replay(cluster, hdfs, namenode);
+  }
+
+  private NodeRefresher nodeRefresher() {
+    return new NodeRefresher(null, null, null, null) {
+      @Override
+      protected void refresh(ServiceComponent namenode, Cluster cluster) throws AmbariException {
+        namenodeWasRefreshed = true;
+      }
+    };
+  }
+
+  @Test
+  public void testNotifiesNameNodeIfHostWithDataNodeWasDeleted() {
+    HostsRemovedEvent event = new HostsRemovedEvent(
+      singleton("host1"),
+      singleton(cluster),
+      new HashMap<String, Set<String>>() {{
+        put("host1", singleton("DATANODE"));
+      }});
+    nodeRefresher.onHostRemoved(event);
+    assertTrue(namenodeWasRefreshed);
+  }
+
+  @Test
+  public void testSkipsNotifyingWhenDeletedHostHaveNoDataNode() {
+    HostsRemovedEvent event = new HostsRemovedEvent(
+      singleton("host1"),
+      singleton(cluster),
+      new HashMap<String, Set<String>>() {{
+        put("host1", singleton("ZOOKEEPER_CLIENT"));
+      }});
+    nodeRefresher.onHostRemoved(event);
+    assertFalse(namenodeWasRefreshed);
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
@@ -432,7 +432,7 @@ public class HostVersionOutOfSyncListenerTest {
     // event handle it
     injector.getInstance(UnitOfWork.class).begin();
     clusters.deleteHost("h2");
-    clusters.publishHostsDeletion(Collections.singleton(c1), Collections.singleton("h2"));
+    clusters.publishHostsDeletion(Collections.singleton(c1), Collections.singleton("h2"), Collections.emptyMap());
     injector.getInstance(UnitOfWork.class).end();
     assertRepoVersionState("2.2.0", RepositoryVersionState.CURRENT);
     assertRepoVersionState("2.2.9-9999", RepositoryVersionState.INSTALLED);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when a host(that was running a datanode) is completely deleted from the cluster, refreshnode on HDFS is not called and thus the the deleted datanode continues to show up in the HDFS NN UI. The UI is refreshed when we explicitly run refreshNodes.

Ambari already has the information which slave components a given host is running, if a host being deleted is one among the hosts that was running a datanode, then deleting it should trigger refreshNodes as part of the delete workflow

## How was this patch tested?

- Stopped datanode,
- Delted a host
- Checked if refresh_node command was sent to the namenode
