### PR TITLE
AMBARI-23710 : Ambari Metrics Service check fails on Ubuntu16.

### DIFF
--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -1106,7 +1106,7 @@
                     <!-- Resolving symlinks-->
                     <move todir="${project.build.directory}/embedded/${hadoop.folder}/lib/native/">
                       <fileset dir="${project.build.directory}/embedded/${hadoop.folder}/lib/native/"/>
-                      <mapper type="regexp" from="libsnappy.so.1.1.*" to="libsnappy.so.1"/>
+                      <mapper type="regexp" from="libsnappy.so.1.*.*" to="libsnappy.so.1"/>
                     </move>
                     <move
                       file="${project.build.directory}/embedded/${hadoop.folder}/lib/native/libhdfs.so.0.0.0"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Increased scope of regex used to find libsnappy library from hadoop tar. In Ubuntu, the libsnappy version is libsnappy.so.1.3.0 and not libsnappy.so.1.1.0.

## How was this patch tested?
mvn clean install on ambari-metrics