### PR TITLE
[AMBARI-23692] Re-enable authorization for Infra Solr.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-security-json.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-security-json.xml
@@ -132,7 +132,7 @@
       (only used if the cluster is secure and this property overrides the security.json which generated during solr
       start).
     </description>
-    <value>{"authentication":{"class": "org.apache.solr.security.KerberosPlugin"}}</value>
+    <value/>
     <value-attributes>
       <type>content</type>
       <show-property-name>false</show-property-name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Earlier authorization was turned off. it could be done by fill the custom-security-json content (then ambari wont fill that with authorization details - use only authentication plugin, as you see), now i set this back.

## How was this patch tested?
Worked with ambari upgrade, so it should work as expected. 

please review @kasakrisz @adoroszlai @zeroflag @g-boros 