### PR TITLE
[AMBARI-23714] Log Feeder: use info level log instead of warn when a l…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
@@ -121,11 +121,11 @@ public class FileUtil {
             return files;
           }
         } catch (Exception e) {
-          LOG.warn("Input file has not found by pattern (exception thrown); {}, message: {}", searchPath, e.getMessage());
+          LOG.warn("Input file was not found by pattern (exception thrown); {}, message: {}", searchPath, e.getMessage());
         }
 
       } else {
-        LOG.info("Input file config has not found by pattern; {}", searchPath);
+        LOG.info("Input file config was not found by pattern; {}", searchPath);
       }
       return new File[]{};
     }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
@@ -121,11 +121,11 @@ public class FileUtil {
             return files;
           }
         } catch (Exception e) {
-          LOG.warn("Input file not found by pattern (exception thrown); {}, message: {}", searchPath, e.getMessage());
+          LOG.warn("Input file has not found by pattern (exception thrown); {}, message: {}", searchPath, e.getMessage());
         }
 
       } else {
-        LOG.warn("Input file config not found by pattern; {}", searchPath);
+        LOG.info("Input file config has not found by pattern; {}", searchPath);
       }
       return new File[]{};
     }


### PR DESCRIPTION
…ogfile does not exist.

## What changes were proposed in this pull request?
Change log level to info about missing log files, as logfeeder logs are processed from warn level (most of the times), and its possible that many logs can be missing on a host if the log configs are centralized. 
## How was this patch tested?
not required

Please review @g-boros @zeroflag @adoroszlai @kasakrisz 