### PR TITLE
AMBARI-23713. Handling missing data in 'repositories' JSON

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -439,7 +439,8 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
                 if (rootObject != null) {
                   JsonPrimitive osType = rootObject.getAsJsonPrimitive("OperatingSystems/os_type");
                   JsonPrimitive ambariManaged = rootObject.getAsJsonPrimitive("OperatingSystems/ambari_managed_repositories");
-                  String isAmbariManaged = (ambariManaged != null && ambariManaged.getAsBoolean()) ? "1" : "0";
+                  String isAmbariManaged = ambariManaged == null ? "1" :  (ambariManaged.getAsBoolean() ? "1" : "0"); //the SQL script which creates the DB schema defaults to 1
+
                   JsonArray repositories = rootObject.getAsJsonArray("repositories");
 
                   dbAccessor.insertRowIfMissing(REPO_OS_TABLE,

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -439,12 +439,12 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
                 if (rootObject != null) {
                   JsonPrimitive osType = rootObject.getAsJsonPrimitive("OperatingSystems/os_type");
                   JsonPrimitive ambariManaged = rootObject.getAsJsonPrimitive("OperatingSystems/ambari_managed_repositories");
+                  String isAmbariManaged = (ambariManaged != null && ambariManaged.getAsBoolean()) ? "1" : "0";
                   JsonArray repositories = rootObject.getAsJsonArray("repositories");
-                  String isAmbariManaged = ambariManaged.getAsBoolean() ? "1" : "0";
 
                   dbAccessor.insertRowIfMissing(REPO_OS_TABLE,
                       new String[]{REPO_OS_ID_COLUMN, REPO_OS_REPO_VERSION_ID_COLUMN, REPO_OS_AMBARI_MANAGED_COLUMN, REPO_OS_FAMILY_COLUMN},
-                      new String[]{String.valueOf(++repoOsId), String.valueOf(repoVersionId), isAmbariManaged, String.format("'%s'", osType.getAsString())},
+                      new String[]{String.valueOf(++repoOsId), String.valueOf(repoVersionId), isAmbariManaged, getFormattedJSONPrimitiveString(osType)},
                       false);
 
                   if (repositories != null) {
@@ -461,8 +461,8 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
                             new String[]{REPO_DEFINITION_ID_COLUMN, REPO_DEFINITION_REPO_OS_ID_COLUMN,
                                 REPO_DEFINITION_REPO_NAME_COLUMN, REPO_DEFINITION_REPO_ID_COLUMN, REPO_DEFINITION_BASE_URL_COLUMN},
                             new String[]{String.valueOf(++repoDefinitionId), String.valueOf(repoOsId),
-                                String.format("'%s'", repoName.getAsString()), String.format("'%s'", repoId.getAsString()),
-                                String.format("'%s'", baseUrl.getAsString())},
+                                getFormattedJSONPrimitiveString(repoName), getFormattedJSONPrimitiveString(repoId),
+                                getFormattedJSONPrimitiveString(baseUrl)},
                             false);
 
                         if (tags != null) {
@@ -472,7 +472,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
                             if (tag != null) {
                               dbAccessor.insertRowIfMissing(REPO_TAGS_TABLE,
                                   new String[]{REPO_TAGS_REPO_DEFINITION_ID_COLUMN, REPO_TAGS_TAG_COLUMN},
-                                  new String[]{String.valueOf(repoDefinitionId), String.format("'%s'", tag.getAsString())},
+                                  new String[]{String.valueOf(repoDefinitionId), getFormattedJSONPrimitiveString(tag)},
                                   false);
                             }
                           }
@@ -499,6 +499,10 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
           new String[]{"'repo_definition_id_seq'", String.valueOf(++repoDefinitionId)},
           false);
     }
+  }
+
+  private String getFormattedJSONPrimitiveString(JsonPrimitive jsonValue) {
+    return jsonValue == null ? null : String.format("'%s'", jsonValue.getAsString());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Missing data in `repo_version` table caused failure while upgarding Ambari to 2.7.0.0 (a `NPE` has been thrown). In order to avoid this issue we should use default values in case the data is not there.

## How was this patch tested?

Latest unit test results in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 28:13 min
[INFO] Finished at: 2018-04-27T11:18:49+02:00
[INFO] Final Memory: 207M/842M
[INFO] ------------------------------------------------------------------------
```

In addition to this I executed an E2E test like this:

1. installed Ambari 2.6.2
2. switched to MariaDB (the issue itself is not DB specific but there was MariaDB in the environment we found this issue originally)
3. added sample data into `repo_version` table where `OperatingSystems/ambari_managed_repositories` was missing from `repositories` JSON (using repo data of 2.6.5.0-231)
4. prepared my test environment for Ambari upgrade (using this document)
5. made the changes in the Java codem built the project and replaced `ambari-server-2.7.0.0.284.jar` with the new one
6. executed `ambari-server upgrade -v`; finished without any issue
7. checked if the new tables became populated and the `repositories` column has been removed from 'repo_version' table

```
[root@c7401 ~]# ambari-server upgrade -v
Using python  /usr/bin/python
Upgrading ambari-server
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Upgrade Ambari Server
INFO: Updating Ambari Server properties in ambari.properties ...
INFO: Updating Ambari Server properties in ambari-env.sh ...
INFO: Original file ambari-env.sh kept
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: No mpack replay logs found. Skipping replaying mpack commands
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Fixing database objects owner
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
Ambari Server configured for MySQL. Confirm you have made a backup of the Ambari Server database [y/n] (n)? y
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Upgrading database schema
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: AMBARI_SERVER_LIB is not set, using default /usr/lib/ambari-server
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: about to run command: /usr/jdk64/jdk1.8.0_112/bin/java -cp '/etc/ambari-server/conf:/usr/lib/ambari-server/*:/root/mysql-connector-java-5.1.46/mysql-connector-java-5.1.46.jar:/usr/share/java/mysql-connector-java.jar' org.apache.ambari.server.upgrade.SchemaUpgradeHelper > /var/log/ambari-server/ambari-server.out 2>&1
INFO: 
process_pid=25254
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Return code from schema upgrade command, retcode = 0
INFO: Console output from schema upgrade command:
INFO: {"lzo_enabled":"false"}


INFO: Schema upgrade completed
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Cleaning bootstrap directory (/var/run/ambari-server/bootstrap) contents...
Adjusting ambari-server permissions and ownership...
INFO: Setting file permissions: /var/log/ambari-server/* 644 root True
INFO: File /var/log/ambari-server/* does not exist
INFO: Setting file permissions: /var/log/ambari-server 755 root False
INFO: about to run command: chmod  755 /var/log/ambari-server
...
process_pid=25342
INFO: Setting file permissions: /var/lib/ambari-server/resources/stacks/HDP/2.1/services/SMARTSENSE/package/files/view/smartsense-ambari-view-1.4.0.0.60.jar 644 root False
INFO: File /var/lib/ambari-server/resources/stacks/HDP/2.1/services/SMARTSENSE/package/files/view/smartsense-ambari-view-1.4.0.0.60.jar does not exist
INFO: Setting file permissions: /var/lib/ambari-server/resources/stacks/HDP/3.0/hooks/before-START/files/fast-hdfs-resource.jar 644 root False
INFO: File /var/lib/ambari-server/resources/stacks/HDP/3.0/hooks/before-START/files/fast-hdfs-resource.jar does not exist
INFO: Setting file permissions: /var/lib/ambari-server/resources/jdk-8u112-linux-x64.tar.gz 644 root False
INFO: about to run command: chmod  644 /var/lib/ambari-server/resources/jdk-8u112-linux-x64.tar.gz
...
Ambari Server 'upgrade' completed successfully.


[root@c7401 ~]# mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 30
Server version: 5.5.56-MariaDB MariaDB Server

Copyright (c) 2000, 2017, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> use ambari;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
MariaDB [ambari]> select * from repo_os;
+----+-----------------+---------+----------------+
| id | repo_version_id | family  | ambari_managed |
+----+-----------------+---------+----------------+
|  1 |               1 | redhat7 |              0 |
+----+-----------------+---------+----------------+
1 row in set (0.00 sec)

MariaDB [ambari]> select * from repo_definition;
+----+------------+-----------+--------------------+------------------------------------------------------------------------------------+--------------+------------+-------------+---------+
| id | repo_os_id | repo_name | repo_id            | base_url                                                                           | distribution | components | unique_repo | mirrors |
+----+------------+-----------+--------------------+------------------------------------------------------------------------------------+--------------+------------+-------------+---------+
|  1 |          1 | HDP       | HDP-2.6            | http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/2.x/BUILDS/2.6.5.0-231     | NULL         | NULL       |           1 | NULL    |
|  2 |          1 | HDP-GPL   | HDP-2.6-GPL        | http://s3.amazonaws.com/dev.hortonworks.com/HDP-GPL/centos7/2.x/BUILDS/2.6.5.0-231 | NULL         | NULL       |           1 | NULL    |
|  3 |          1 | HDP-UTILS | HDP-UTILS-1.1.0.22 | http://s3.amazonaws.com/dev.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7       | NULL         | NULL       |           1 | NULL    |
+----+------------+-----------+--------------------+------------------------------------------------------------------------------------+--------------+------------+-------------+---------+
3 rows in set (0.00 sec)

MariaDB [ambari]> select * from repo_tags;
+--------------------+-----+
| repo_definition_id | tag |
+--------------------+-----+
|                  2 | GPL |
+--------------------+-----+
1 row in set (0.00 sec)

MariaDB [ambari]> desc repo_version;
+-----------------+---------------+------+-----+----------+-------+
| Field           | Type          | Null | Key | Default  | Extra |
+-----------------+---------------+------+-----+----------+-------+
| repo_version_id | bigint(20)    | NO   | PRI | NULL     |       |
| stack_id        | bigint(20)    | NO   | MUL | NULL     |       |
| version         | varchar(255)  | NO   |     | NULL     |       |
| display_name    | varchar(128)  | NO   | UNI | NULL     |       |
| repo_type       | varchar(255)  | NO   |     | STANDARD |       |
| hidden          | smallint(6)   | NO   |     | 0        |       |
| resolved        | tinyint(1)    | NO   |     | 0        |       |
| legacy          | tinyint(1)    | NO   |     | 0        |       |
| version_url     | varchar(1024) | YES  |     | NULL     |       |
| version_xml     | mediumtext    | YES  |     | NULL     |       |
| version_xsd     | varchar(512)  | YES  |     | NULL     |       |
| parent_id       | bigint(20)    | YES  |     | NULL     |       |
+-----------------+---------------+------+-----+----------+-------+
12 rows in set (0.00 sec)

MariaDB [ambari]> exit
```