### PR TITLE
[AMBARI-23716] Kafka Quick Links Shows all Views links

### DIFF
--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -128,20 +128,21 @@
           {{/if}}
         </div>
       {{/view}}
-      <div class="panel-heading">
+      {{! TODO implement display of views related to the current service}}
+      <!--div class="panel-heading">
          <div class="row col-md-8 col-lg-12">
-           <h4 class="panel-title">{{t common.views}}</h4>
+           <h4 class="panel-title">{{!t common.views}}</h4>
          </div>
       </div>
       <div class="panel-body">
-       {{#if view.views.length}}
-         {{#each item in view.views}}
-           <a href="#" {{action "setView" item target="App.router.mainViewsController"}}>{{item.label}}</a>
-         {{/each}}
-       {{else}}
-         <span>{{t menu.item.views.noViews}}</span>
-       {{/if}}
-      </div>
+       {{!#if view.views.length}}
+         {{!#each item in view.views}}
+           <a href="#" {{!action "setView" item target="App.router.mainViewsController"}}>{{!item.label}}</a>
+         {{!/each}}
+       {{!else}}
+         <span>{{!t menu.item.views.noViews}}</span>
+       {{!/if}}
+      </div-->
     </div>
   </div>
 </div>

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -63,12 +63,14 @@ App.MainServiceInfoSummaryView = Em.View.extend({
    */
   serviceSummaryView: null,
 
-  /**
-   * @type {App.ViewInstance}
-   */
-  views: function () {
+
+  // TODO implement filtering of views related to current service
+  ///**
+  // * @type {App.ViewInstance}
+  // */
+  /*views: function () {
     return App.router.get('loggedIn') ? App.router.get('mainViewsController.visibleAmbariViews') : [];
-  }.property('App.router.mainViewsController.visibleAmbariViews.[]', 'App.router.loggedIn'),
+  }.property('App.router.mainViewsController.visibleAmbariViews.[]', 'App.router.loggedIn'),*/
 
   /**
    * @property {Object} serviceCustomViewsMap - custom views to embed


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Kafka Service Summary screen shows all Ambari View instances under the "Views" Quick Link.

## How was this patch tested?

UI unit tests:
  21521 passing (23s)
  48 pending