### PR TITLE
[AMBARI-23688] Multiple versions of asm.jar found in classpath

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1302,6 +1302,12 @@
     <dependency>
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jsp-2.1-glassfish</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
@@ -1545,12 +1551,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>2.2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>3.3.1</version>
+      <version>3.2.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix:

```
WARNING: Multiple versions of asm.jar found in java class path (/usr/lib/ambari-server/asm-5.0.4.jar and /usr/lib/ambari-server/asm-3.3.1.jar).
```

* Remove explicit dependency on `asm`
* Upgrade `cglib`, as it depended on the older version of `asm`
* Exclude `ant` for `jsp-2.1-glassfish` to prevent introduction of multiple versions

## How was this patch tested?

```
$ mvn -pl ambari-server dependency:tree -Dincludes='*asm*'
...
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.0.0.0-SNAPSHOT
[INFO] \- cglib:cglib:jar:3.2.4:compile
[INFO]    \- org.ow2.asm:asm:jar:5.1:compile
[INFO] ------------------------------------------------------------------------
```

Replaced all jars in `/usr/lib/ambari-server` with ones from `ambari-server/target/ambari-server-2.0.0.0-SNAPSHOT-dist/usr/lib/ambari-server`.  Ambari Server started without warnings.  Deployed a simple cluster, ran service check, restarted Ambari Server.