### PR TITLE
[AMBARI-23689] Installing Packages Fails Silently When Dependencies Are Not Resolved (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/shell.py
+++ b/ambari-common/src/main/python/ambari_commons/shell.py
@@ -739,8 +739,9 @@ def repository_manager_executor(cmd, repo_properties, context=RepoCallContext(),
 
     should_stop_retries = __handle_retries(cmd, repo_properties, context, call_result, is_first_time, is_last_time)
     if (is_last_time or should_stop_retries) and call_result.code != 0:
-      message = "Failed to execute command '{0}', exited with code '{1}' with message: {2}".format(
-        cmd, call_result.code, call_result.error)
+      message = "Failed to execute command '{0}', exited with code '{1}', message: '{2}'".format(
+        cmd if not isinstance(cmd, (list, tuple)) else " ".join(cmd),
+        call_result.code, call_result.error)
 
       if context.ignore_errors:
         _logger.warning(message)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stack installation should fail if something wrong happen with package installation

## How was this patch tested?

Test cluster: 

```
2018-04-27 12:27:08,848 - Installing package gcc ('/usr/bin/yum -y install gcc')
2018-04-27 12:27:09,128 - Installing package python-kerberos ('/usr/bin/yum -y install python-kerberos')
2018-04-27 12:27:09,431 - Installing package hadoop_3_0_0_0_1266 ('/usr/bin/yum -y install hadoop_3_0_0_0_1266')
2018-04-27 12:27:10,211 - Package Manager failed to install packages: Failed to execute command '/usr/bin/yum -y install hadoop_3_0_0_0_1266', exited with code '1', message: 'Error: Package: hadoop_3_0_0_0_1266-3.0.0.3.0.0.0-1266.x86_64 (HDP-3.0-repo-2)

           Requires: system-lsb
'
2018-04-27 12:27:11,412 - Installation of packages failed. Checking if installation was partially complete
2018-04-27 12:27:11,412 - Old versions: ['2.6.5.0-271', '3.0.0.0-1266']
2018-04-27 12:27:11,413 - call[('ambari-python-wrap', u'/usr/bin/hdp-select', 'versions')] {}
2018-04-27 12:27:11,437 - call returned (0, '2.6.5.0-271\n3.0.0.0-1266')
2018-04-27 12:27:11,437 - New versions: ['2.6.5.0-271', '3.0.0.0-1266']
2018-04-27 12:27:11,437 - Deltas: set([])
```