### PR TITLE
[AMBARI-23719]. hbase.zookeeper.property.clientPort config of AMS is empty after Ambari Upgrade (amagyar)

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-hbase-site.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-hbase-site.xml
@@ -391,9 +391,6 @@
   <property>
     <name>hbase.zookeeper.property.clientPort</name>
     <value>{{zookeeper_clientPort}}</value>
-    <value-attributes>
-      <type>int</type>
-    </value-attributes>
     <depends-on>
       <property>
         <type>zoo.cfg</type>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After upgrading to Ambari 2.7 ams-hbase-site/hbase.zookeeper.property.clientPort becomes empty. The original value of this property is {{zookeeper_clientPort}} but its type is integer. The new UI validates the type and doesn't show the invalid value.

```xml
 <value>{{zookeeper_clientPort}}</value>
 <value-attributes>
      <type>int</type>
 </value-attributes>
```

This was always an invalid property because it was initialized to a string ({{zookeeper_clientPort}}) but its type was int. 


## How was this patch tested?

Manually checked the UI after upgrade.