### PR TITLE
[AMBARI-23721] Adding and deleting widgets of NameNode section on dashboard isn't persisted

### DIFF
--- a/ambari-web/app/views/main/dashboard/widgets.js
+++ b/ambari-web/app/views/main/dashboard/widgets.js
@@ -209,10 +209,50 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
     }
     else {
       newSettings.threshold = userPreferences.threshold;
-      newSettings.groups = userPreferences.groups;
       this.get('allWidgets').forEach(widget => {
-        let key = widget.get('isVisible') ? 'visible' : 'hidden';
+        const key = widget.get('isVisible') ? 'visible' : 'hidden';
         newSettings[key].push(widget.get('id'));
+      });
+      this.get('widgetGroups').forEach(group => {
+        const groupName = group.get('name');
+        if (!newSettings.groups[groupName]) {
+          newSettings.groups[groupName] = {};
+        }
+        group.get('allWidgets').forEach(widgetsSubGroup => {
+          const subGroupName = widgetsSubGroup.get('subGroupName'),
+            widgets = widgetsSubGroup.get('widgets'),
+            subGroupSettings = {
+              visible: [],
+              hidden: [],
+              threshold: {}
+            };
+          newSettings.groups[groupName][subGroupName] = subGroupSettings;
+          widgets.forEach(widget => {
+            const key = widget.get('isVisible') ? 'visible' : 'hidden',
+              threshold = widget.get('threshold'),
+              widgetId = widget.get('id'),
+              id = parseInt(widgetId);
+            if (subGroupName === '*') {
+              const regExp = new RegExp(`\\d+\\-${groupName}\\-([\\W\\w]+)\\-\\*`),
+                regExpMatch = widgetId.match(regExp),
+                subGroup = regExpMatch && regExpMatch[1];
+              if (subGroup) {
+                subGroupSettings[key].push({
+                  id,
+                  subGroup
+                });
+                $.extend(true, subGroupSettings.threshold, {
+                  [subGroup]: {
+                    [id]: threshold
+                  }
+                });
+              }
+            } else {
+              subGroupSettings[key].push(id);
+              subGroupSettings.threshold[id] = threshold;
+            }
+          });
+        });
       });
     }
     this.set('userPreferences', newSettings);

--- a/ambari-web/test/views/main/dashboard/widget_test.js
+++ b/ambari-web/test/views/main/dashboard/widget_test.js
@@ -136,14 +136,22 @@ describe('App.DashboardWidgetView', function () {
   describe('#deleteWidget()', function() {
 
     beforeEach(function() {
-      view.get('parentView').set('allWidgets', [Em.Object.create({id: 1, isVisible: true})]);
-      view.set('widget.id', 1);
-      view.set('parentView.userPreferences', {
-        visible: [1],
-        hidden: [],
-        threshold: [],
-        groups: {}
+      view.get('parentView').setProperties({
+        allWidgets: [
+          Em.Object.create({
+            id: 1,
+            isVisible: true
+          })
+        ],
+        userPreferences: {
+          visible: [1],
+          hidden: [],
+          threshold: [],
+          groups: {}
+        },
+        widgetGroups: []
       });
+      view.set('widget.id', 1);
       view.deleteWidget();
     });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**STR**
1. Enable NameNode federation
2. Add or remove some NameNode widgets on dashboard
3. Go to other page and retirn to dashboard, or stay on dashboard and refresh the page

**Expected result**
NameNode widgets are displayed/hidden according to the adding/removing actions described above

**Actual result**
Default set of NameNode widgets is displayed

## How was this patch tested?

UI unit tests:
  21524 passing (24s)
  48 pending
