### PR TITLE
[AMBARI-23722] Ambari allows namespace name to be reused for new namespaces

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step1_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step1_controller.js
@@ -24,12 +24,17 @@ App.NameNodeFederationWizardStep1Controller = Em.Controller.extend({
 
   existingNameServices: function () {
     var isMetricsLoaded = App.router.get('clusterController.isHostComponentMetricsLoaded');
-    return isMetricsLoaded ? App.HDFSService.find().objectAt(0).get('masterComponentGroups').mapProperty('name').join(', ') : '';
-  }.property('App.router.clusterController.isHostComponentMetricsLoaded'),
+    return isMetricsLoaded ? App.HDFSService.find().objectAt(0).get('masterComponentGroups').mapProperty('name') : [];
+  }.property('App.router.clusterController.isHDFSNameSpacesLoaded'),
 
-  isNameServiceIdValid: function () {
-    return validator.isValidNameServiceId(this.get('content.nameServiceId'));
-  }.property('content.nameServiceId'),
+  existingNameServicesString: function () {
+    return this.get('existingNameServices').join(', ');
+  }.property('existingNameServices.length'),
+
+  isNameServiceIdError: function () {
+    var nameServiceId = this.get('content.nameServiceId');
+    return !nameServiceId || this.get('existingNameServices').contains(nameServiceId) || !validator.isValidNameServiceId(nameServiceId);
+  }.property('content.nameServiceId', 'existingNameServices.length'),
 
   next: function () {
     if (this.get('isNameServiceIdValid')) {

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -1675,7 +1675,7 @@ Em.I18n.translations = {
   'admin.nameNodeFederation.wizard.step1.alert':'You should plan a cluster maintenance window and prepare for cluster downtime when adding a new HDFS Namespace as this Wizard will restart all services.',
   'admin.nameNodeFederation.wizard.step1.nameserviceid':'New Nameservice ID',
   'admin.nameNodeFederation.wizard.step1.nameserviceid.existing':'Existing Nameservice ID',
-  'admin.nameNodeFederation.wizard.step1.nameserviceid.error':'Must consist of letters, numbers, and hyphens. Cannot begin or end with a hyphen.',
+  'admin.nameNodeFederation.wizard.step1.nameserviceid.error':'Must be unique and consist of letters, numbers, and hyphens. Cannot begin or end with a hyphen.',
   'admin.nameNodeFederation.wizard.step2.header': 'Select Hosts',
   'admin.nameNodeFederation.wizard.step2.body': 'Select hosts running the NameNodes for {0}',
   'admin.nameNodeFederation.wizard.step3.header': 'Review',

--- a/ambari-web/app/templates/main/admin/federation/step1.hbs
+++ b/ambari-web/app/templates/main/admin/federation/step1.hbs
@@ -25,13 +25,13 @@
   </div>
   <div class="panel panel-default">
     <div class="panel-body">
-      <div {{bindAttr class=":form-group view.showInputError:has-error :form-horizontal"}}>
+      <div {{bindAttr class=":form-group controller.isNameServiceIdError:has-error :form-horizontal"}}>
         <div class="row">
           <div class="col-md-2">
             <label>{{t admin.nameNodeFederation.wizard.step1.nameserviceid.existing}}:</label>
           </div>
           <div class="col-md-10">
-            {{controller.existingNameServices}}
+            {{controller.existingNameServicesString}}
           </div>
         </div>
         <div class="row">
@@ -42,7 +42,7 @@
             {{view Ember.TextField valueBinding="content.nameServiceId" classNames="form-control"}}
           </div>
           <div class="col-md-7">
-            <span {{bindAttr class=":help-block :validation-block view.showInputError::hidden"}}>
+            <span {{bindAttr class=":help-block :validation-block controller.isNameServiceIdError::hidden"}}>
               {{t admin.nameNodeFederation.wizard.step1.nameserviceid.error}}
             </span>
           </div>
@@ -53,7 +53,7 @@
 </div>
 <div class="wizard-footer col-md-12">
   <div class="btn-area">
-    <a {{bindAttr class=":btn controller.isNameServiceIdValid::disabled :btn-success :pull-right"}} {{action next target="controller"}}>{{t common.next}} &rarr;</a>
+    <button {{bindAttr disabled="controller.isNameServiceIdError"}} class="btn btn-success pull-right" {{action next target="controller"}}>{{t common.next}} &rarr;</button>
   </div>
 </div>
 

--- a/ambari-web/app/views/main/admin/federation/step1_view.js
+++ b/ambari-web/app/views/main/admin/federation/step1_view.js
@@ -25,8 +25,6 @@ App.NameNodeFederationWizardStep1View = Em.View.extend({
   didInsertElement: function() {
     //todo: provide tooltip with correct message
     // App.popover($("input[type=text]"), {'placement': 'right', 'trigger': 'hover', 'title': this.t('admin.highAvailability.wizard.step1.nameserviceid.tooltip.title'), 'content': this.t('admin.highAvailability.wizard.step1.nameserviceid.tooltip.content')});
-  },
-
-  showInputError: Em.computed.and('!controller.isNameServiceIdValid', 'controller.content.nameServiceId.length')
+  }
 
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Deployed a cluster with namespaces ns1 and ns2
Try Adding new namespace via UI
Name it ns1
Next button should not be enabled and error message should be displayed to avoid conflicting namespaces

## How was this patch tested?

  21524 passing (31s)
  48 pending