### PR TITLE
[AMBARI-23717] Stack installation command didn't fail properly when installed package didn't present in repository (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -215,12 +215,16 @@ class AptManager(GenericManager):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
     from resource_management.core import sudo
 
     apt_sources_list_tmp_dir = None
 
-    if context.is_upgrade or context.use_repos or not self._check_existence(name):
+    if not name:
+      raise ValueError("Installation command were executed with no package name passed")
+    elif context.is_upgrade or context.use_repos or not self._check_existence(name):
       cmd = self.properties.install_cmd[context.log_output]
       copied_sources_files = []
       is_tmp_dir_created = False
@@ -264,6 +268,8 @@ class AptManager(GenericManager):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
     context.is_upgrade = True
     return self.install_package(name, context)
@@ -276,8 +282,12 @@ class AptManager(GenericManager):
     :type name str
     :type context ambari_commons.shell.RepoCallContext
     :type ignore_dependencies bool
+
+    :raise ValueError if name is empty
     """
-    if self._check_existence(name):
+    if not name:
+      raise ValueError("Installation command were executed with no package name passed")
+    elif self._check_existence(name):
       cmd = self.properties.remove_cmd[context.log_output] + [name]
       Logger.info("Removing package {0} ('{1}')".format(name, shell.string_cmd_from_args_list(cmd)))
       shell.repository_manager_executor(cmd, self.properties, context)
@@ -304,8 +314,6 @@ class AptManager(GenericManager):
     apt-get in inconsistant state (locked, used, having invalid repo). Once packages are installed
     we should not rely on that.
     """
-    if not name:
-      raise ValueError("Package name can't be empty")
 
     r = shell.subprocess_executor(self.properties.check_cmd % name)
     return not bool(r.code)

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -304,5 +304,8 @@ class AptManager(GenericManager):
     apt-get in inconsistant state (locked, used, having invalid repo). Once packages are installed
     we should not rely on that.
     """
+    if not name:
+      raise ValueError("Package name can't be empty")
+
     r = shell.subprocess_executor(self.properties.check_cmd % name)
     return not bool(r.code)

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -223,7 +223,7 @@ class AptManager(GenericManager):
     apt_sources_list_tmp_dir = None
 
     if not name:
-      raise ValueError("Installation command were executed with no package name passed")
+      raise ValueError("Installation command was executed with no package name")
     elif context.is_upgrade or context.use_repos or not self._check_existence(name):
       cmd = self.properties.install_cmd[context.log_output]
       copied_sources_files = []

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/generic_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/generic_manager.py
@@ -69,6 +69,8 @@ class GenericManager(object):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
     raise NotImplementedError()
 
@@ -79,6 +81,8 @@ class GenericManager(object):
     :type name str
     :type context ambari_commons.shell.RepoCallContext
     :type ignore_dependencies bool
+
+    :raise ValueError if name is empty
     """
     raise NotImplementedError()
 
@@ -88,6 +92,8 @@ class GenericManager(object):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
     raise NotImplementedError()
 

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
@@ -207,7 +207,7 @@ class YumManager(GenericManager):
     """
 
     if not name:
-      raise ValueError("Installation command were executed with no package name passed")
+      raise ValueError("Installation command was executed with no package name")
     elif context.is_upgrade or context.use_repos or not self._check_existence(name):
       cmd = self.properties.install_cmd[context.log_output]
       if context.use_repos:

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
@@ -263,6 +263,9 @@ class YumManager(GenericManager):
     yum in inconsistant state (locked, used, having invalid repo). Once packages are installed
     we should not rely on that.
     """
+    if not name:
+      raise ValueError("Package name can't be empty")
+
     if os.geteuid() == 0:
       return self.yum_check_package_available(name)
     else:

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
@@ -202,9 +202,13 @@ class YumManager(GenericManager):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
 
-    if context.is_upgrade or context.use_repos or not self._check_existence(name):
+    if not name:
+      raise ValueError("Installation command were executed with no package name passed")
+    elif context.is_upgrade or context.use_repos or not self._check_existence(name):
       cmd = self.properties.install_cmd[context.log_output]
       if context.use_repos:
         enable_repo_option = '--enablerepo=' + ",".join(sorted(context.use_repos.keys()))
@@ -222,6 +226,8 @@ class YumManager(GenericManager):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
     context.is_upgrade = True
     return self.install_package(name, context)
@@ -233,7 +239,11 @@ class YumManager(GenericManager):
     :type name str
     :type context ambari_commons.shell.RepoCallContext
     :type ignore_dependencies bool
+
+    :raise ValueError if name is empty
     """
+    if not name:
+      raise ValueError("Remove command were executed with no package name passed")
     if self._check_existence(name):
       if ignore_dependencies:
         cmd = self.properties.remove_without_dependencies_cmd + [name]
@@ -263,8 +273,6 @@ class YumManager(GenericManager):
     yum in inconsistant state (locked, used, having invalid repo). Once packages are installed
     we should not rely on that.
     """
-    if not name:
-      raise ValueError("Package name can't be empty")
 
     if os.geteuid() == 0:
       return self.yum_check_package_available(name)

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/zypper_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/zypper_manager.py
@@ -282,4 +282,7 @@ class ZypperManager(GenericManager):
     zypper in inconsistant state (locked, used, having invalid repo). Once packages are installed
     we should not rely on that.
     """
+    if not name:
+      raise ValueError("Package name can't be empty")
+
     return self.rpm_check_package_available(name)

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/zypper_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/zypper_manager.py
@@ -178,8 +178,12 @@ class ZypperManager(GenericManager):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
-    if context.is_upgrade or context.use_repos or not self._check_existence(name):
+    if not name:
+      raise ValueError("Installation command were executed with no package name passed")
+    elif context.is_upgrade or context.use_repos or not self._check_existence(name):
       cmd = self.properties.install_cmd[context.log_output]
 
       if context.use_repos:
@@ -206,6 +210,8 @@ class ZypperManager(GenericManager):
 
     :type name str
     :type context ambari_commons.shell.RepoCallContext
+
+    :raise ValueError if name is empty
     """
     context.is_upgrade = True
     return self.install_package(name, context)
@@ -217,8 +223,12 @@ class ZypperManager(GenericManager):
     :type name str
     :type context ambari_commons.shell.RepoCallContext
     :type ignore_dependencies bool
+
+    :raise ValueError if name is empty
     """
-    if self._check_existence(name):
+    if not name:
+      raise ValueError("Installation command were executed with no package name passed")
+    elif self._check_existence(name):
       cmd = self.properties.remove_cmd[context.log_output] + [name]
       Logger.info("Removing package {0} ('{1}')".format(name, shell.string_cmd_from_args_list(cmd)))
       shell.repository_manager_executor(cmd, self.properties, context)

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/zypper_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/zypper_manager.py
@@ -182,7 +182,7 @@ class ZypperManager(GenericManager):
     :raise ValueError if name is empty
     """
     if not name:
-      raise ValueError("Installation command were executed with no package name passed")
+      raise ValueError("Installation command was executed with no package name")
     elif context.is_upgrade or context.use_repos or not self._check_existence(name):
       cmd = self.properties.install_cmd[context.log_output]
 

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -491,24 +491,41 @@ class Script(object):
 
     return Script.stack_version_from_distro_select
 
-
-  def get_package_from_available(self, name, available_packages_in_repos):
+  def get_package_from_available(self, name, available_packages_in_repos=None):
     """
     This function matches package names with ${stack_version} placeholder to actual package names from
     Ambari-managed repository.
     Package names without ${stack_version} placeholder are returned as is.
     """
+
     if STACK_VERSION_PLACEHOLDER not in name:
       return name
+
+    if not available_packages_in_repos:
+      available_packages_in_repos = self.load_available_packages()
+
+    from resource_management.libraries.functions.default import default
+
     package_delimiter = '-' if OSCheck.is_ubuntu_family() else '_'
     package_regex = name.replace(STACK_VERSION_PLACEHOLDER, '(\d|{0})+'.format(package_delimiter)) + "$"
+    repo = default('/repositoryFile', None)
+    name_with_version = None
+
+    if repo:
+      command_repo = CommandRepository(repo)
+      version_str = command_repo.version_string.replace('.', package_delimiter).replace("-", package_delimiter)
+      name_with_version = name.replace(STACK_VERSION_PLACEHOLDER, version_str)
+
     for package in available_packages_in_repos:
       if re.match(package_regex, package):
         return package
-    Logger.warning("No package found for {0}({1})".format(name, package_regex))
 
+    if name_with_version:
+      raise Fail("No package found for {0}(expected name: {1})".format(name, name_with_version))
+    else:
+      raise Fail("Cannot match package for regexp name {0}. Available packages: {1}".format(name, self.available_packages_in_repos))
 
-  def format_package_name(self, name, repo_version=None):
+  def format_package_name(self, name):
     from resource_management.libraries.functions.default import default
     """
     This function replaces ${stack_version} placeholder with actual version.  If the package
@@ -537,11 +554,7 @@ class Script(object):
       package_version = default("hostLevelParams/package_version", None)
 
     if (package_version is None or '-' not in package_version) and default('/repositoryFile', None):
-      self.load_available_packages()
-      package_name = self.get_package_from_available(name, self.available_packages_in_repos)
-      if package_name is None:
-        raise Fail("Cannot match package for regexp name {0}. Available packages: {1}".format(name, self.available_packages_in_repos))
-      return package_name
+      return self.get_package_from_available(name)
 
     if package_version is not None:
       package_version = package_version.replace('.', package_delimiter).replace('-', package_delimiter)

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -783,6 +783,8 @@ class Script(object):
       Logger.exception("Unable to load available packages")
       self.available_packages_in_repos = []
 
+    return self.available_packages_in_repos
+
 
   def install_packages(self, env):
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Properly handle case when repo didn't have required package:

- handle case when installation/removal of package were executed without package name
- Print expected package name we looked for instead of regexp

## How was this patch tested?

Cluster:

```
Stderr:
2018-04-30 14:27:12,134 - Package Manager failed to install packages: No package found for hadoop_${stack_version}(expected name: hadoop_3_0_0_0_1266)
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 487, in <module>
    InstallPackages().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 149, in actionexecute
    raise Fail("Failed to distribute repositories/install packages")
resource_management.core.exceptions.Fail: Failed to distribute repositories/install packages

Stdout:
2018-04-30 14:25:40,113 - Looking for matching packages in the following repositories: HDP-3.0-GPL-repo-2, HDP-UTILS-1.1.0.22-repo-2, HDP-3.0-repo-2
2018-04-30 14:25:51,875 - Installing package gcc ('/usr/bin/yum -y install gcc')
2018-04-30 14:25:55,952 - Installing package python-kerberos ('/usr/bin/yum -y install python-kerberos')
2018-04-30 14:27:12,134 - Package Manager failed to install packages: No package found for hadoop_${stack_version}(expected name: hadoop_3_0_0_0_1266)
2018-04-30 14:27:13,480 - Installation of packages failed. Checking if installation was partially complete
```