### PR TITLE
AMBARI-23730 When Spark2 is selected in left pane, Spark also gets selected along with it

### DIFF
--- a/ambari-web/vendor/scripts/theme/bootstrap-ambari.js
+++ b/ambari-web/vendor/scripts/theme/bootstrap-ambari.js
@@ -86,10 +86,14 @@ $(document).ready(function () {
 
       function popStateHandler() {
         var path = window.location.pathname + window.location.hash;
+        if (path[path.length - 1] !== '/') {
+          path += '/';
+        }
         $navigationContainer.find('li a').each(function (index, link) {
           var $link = $(link);
           var href = $link.attr('data-href') || $link.attr('href');
-          if (path.indexOf(href) !== -1 && ['', '#'].indexOf(href) === -1) {
+          var hrefWithSlash = href == null || href[href.length - 1] === '/' ? href : href + '/';
+          if (path.indexOf(hrefWithSlash) !== -1 && ['', '#'].indexOf(href) === -1) {
             $link.parent().addClass('active');
           } else {
             $link.parent().removeClass('active');


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Spark2 is selected in services in left pane, Spark gets selected along with it.
The pointer should only point to Spark2 (which is the selected service).

## How was this patch tested?

UI unit tests:
  21524 passing (25s)
  48 pending