### PR TITLE
[AMBARI-23727] Predicate evaluation does not work as expected for RequestResourceFilters. (swagle)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceProvider.java
@@ -43,17 +43,18 @@ import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ExecuteActionRequest;
 import org.apache.ambari.server.controller.RequestRequest;
 import org.apache.ambari.server.controller.RequestStatusResponse;
+import org.apache.ambari.server.controller.spi.ClusterController;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.NoSuchResourceException;
 import org.apache.ambari.server.controller.spi.Predicate;
+import org.apache.ambari.server.controller.spi.QueryResponse;
 import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.RequestStatus;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
-import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
-import org.apache.ambari.server.controller.utilities.PredicateBuilder;
+import org.apache.ambari.server.controller.utilities.ClusterControllerHelper;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.customactions.ActionDefinition;
 import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
@@ -536,52 +537,46 @@ public class RequestResourceProvider extends AbstractControllerResourceProvider 
         throw new SystemException(msg, e);
       }
 
-      ResourceProvider resourceProvider = getResourceProvider(Resource.Type.HostComponent);
-
       Set<String> propertyIds = new HashSet<>();
       propertyIds.add(CLUSTER_NAME);
       propertyIds.add(SERVICE_NAME);
       propertyIds.add(COMPONENT_NAME);
 
       Request request = PropertyHelper.getReadRequest(propertyIds);
-
-      Predicate finalPredicate = new PredicateBuilder(filterPredicate)
-        .property(CLUSTER_NAME).equals(clusterName).and()
-        .property(SERVICE_NAME).equals(serviceName).and()
-        .property(COMPONENT_NAME).equals(componentName)
-        .toPredicate();
-
+      
       try {
-        Set<Resource> resources = resourceProvider.getResources(request, finalPredicate);
+        ClusterController clusterController = ClusterControllerHelper.getClusterController();
+        QueryResponse queryResponse = clusterController.getResources(
+          Resource.Type.HostComponent, request, filterPredicate);
+        Iterable<Resource> resourceIterable = clusterController.getIterable(
+          Resource.Type.HostComponent, queryResponse, request,
+          filterPredicate, null, null);
+        
+        // Allow request to span services / components using just the predicate
+        Map<ServiceComponentTuple, List<String>> tupleListMap = new HashMap<>();
+        for (Resource resource : resourceIterable) {
+          String hostnameStr = (String) resource.getPropertyValue(HOST_NAME);
+          if (hostnameStr != null) {
+            String computedServiceName = (String) resource.getPropertyValue(SERVICE_NAME);
+            String computedComponentName = (String) resource.getPropertyValue(COMPONENT_NAME);
+            ServiceComponentTuple tuple = new ServiceComponentTuple(computedServiceName, computedComponentName);
 
-        if (resources != null && !resources.isEmpty()) {
-          // Allow request to span services / components using just the predicate
-          Map<ServiceComponentTuple, List<String>> dupleListMap = new HashMap<>();
-          for (Resource resource : resources) {
-            String hostnameStr = (String) resource.getPropertyValue(HOST_NAME);
-            if (hostnameStr != null) {
-              String computedServiceName = (String) resource.getPropertyValue(SERVICE_NAME);
-              String computedComponentName = (String) resource.getPropertyValue(COMPONENT_NAME);
-              ServiceComponentTuple duple =
-                new ServiceComponentTuple(computedServiceName, computedComponentName);
-
-              if (!dupleListMap.containsKey(duple)) {
-                hostList = new ArrayList<>();
-                hostList.add(hostnameStr);
-                dupleListMap.put(duple, hostList);
-              } else {
-                dupleListMap.get(duple).add(hostnameStr);
-              }
+            if (!tupleListMap.containsKey(tuple)) {
+              hostList = new ArrayList<>();
+              hostList.add(hostnameStr);
+              tupleListMap.put(tuple, hostList);
+            } else {
+              tupleListMap.get(tuple).add(hostnameStr);
             }
           }
-          if (!dupleListMap.isEmpty()) {
-            for (Map.Entry<ServiceComponentTuple, List<String>> entry : dupleListMap.entrySet()) {
-              resourceFilterList.add(new RequestResourceFilter(
-                entry.getKey().getServiceName(),
-                entry.getKey().getComponentName(),
-                entry.getValue()
-              ));
-            }
+        }
+        if (!tupleListMap.isEmpty()) {
+          for (Map.Entry<ServiceComponentTuple, List<String>> entry : tupleListMap.entrySet()) {
+            resourceFilterList.add(new RequestResourceFilter(
+              entry.getKey().getServiceName(),
+              entry.getKey().getComponentName(),
+              entry.getValue()
+            ));
           }
         }
       } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow full predicate evaluation through ClusterController to support more complex predicates.

## How was this patch tested?

Verified manually and unit test fixed.

Verified the 3 API calls work:

`curl -H "X-Requested-By:ambari" -u admin:admin -i -X POST -d '{"RequestInfo":{"command":"RESTART","context":"Restart all services except NN","operation_level":"host_component"},"Requests/resource_filters":[{"hosts_predicate":"HostRoles/component_name!=NAMENODE&HostRoles/cluster_name=c1"}]}' http://localhost:8080/api/v1/clusters/c1/requests`

`curl -H "X-Requested-By:ambari" -u admin:admin -i -X POST -d '{"RequestInfo":{"command":"RESTART","context":"Restart all required services","operation_level":"host_component"},"Requests/resource_filters":[{"hosts_predicate":"HostRoles/stale_configs=true&HostRoles/cluster_name=c1""}]}' http://localhost:8080/api/v1/clusters/c1/requests`

`curl -H "X-Requested-By:ambari" -u admin:admin -i -X POST -d '{"RequestInfo":{"command":"RESTART","context":"Restart all services","operation_level":"host_component"},"Requests/resource_filters":[{"hosts_predicate":"HostRoles/cluster_name=c1"}]}' http://localhost:8080/api/v1/clusters/c1/requests`