### PR TITLE
[AMBARI-23731] Restart required services results in restart NN twice

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step4_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step4_controller.js
@@ -163,8 +163,12 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
 
   restartAllServices: function () {
     App.ajax.send({
-      name: 'restart.allServices',
+      name: 'restart.custom.filter',
       sender: this,
+      data: {
+        filter: "HostRoles/component_name!=NAMENODE&HostRoles/cluster_name=" + App.get('clusterName'),
+        context: "Restart Required Services"
+      },
       success: 'startPolling',
       error: 'onTaskError'
     });

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -2467,7 +2467,29 @@ var urls = {
           },
           "Requests/resource_filters": [
             {
-              "hosts_predicate": "HostRoles/stale_configs=true"
+              "hosts_predicate": "HostRoles/stale_configs=true&HostRoles/cluster_name=" + data.clusterName
+            }
+          ]
+        })
+      }
+    }
+  },
+
+  'restart.custom.filter': {
+    'real': "/clusters/{clusterName}/requests",
+    'mock': "",
+    'format': function (data) {
+      return {
+        type: 'POST',
+        data: JSON.stringify({
+          "RequestInfo": {
+            "command": "RESTART",
+            "context": data.context,
+            "operation_level": "host_component"
+          },
+          "Requests/resource_filters": [
+            {
+              "hosts_predicate": data.filter
             }
           ]
         })


### PR DESCRIPTION
## What changes were proposed in this pull request?

On large clusters restart NN can take 40 mins , if we start nn1 and nn2 in Start Namenodes step they should not be Restarted again.

## How was this patch tested?

  21526 passing (32s)
  48 pending