### PR TITLE
[AMBARI-23732] Increase default java stack size and make it configurable for Infra Solr

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -184,9 +184,16 @@
   </property>
   <property>
     <name>infra_solr_java_stack_size</name>
-    <value>1024k</value>
+    <value>1</value>
     <display-name>Infra Solr Java Stack Size</display-name>
-    <description>Java Stack Size of Infra Solr (-Xss)</description>
+    <description>Java Stack Size of Infra Solr (-Xss) in MB.</description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>128</maximum>
+      <unit>MB</unit>
+      <increment-step>1</increment-step>
+    </value-attributes>
     <on-ambari-upgrade add="true"/>
   </property>
   <property>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -183,6 +183,13 @@
     <on-ambari-upgrade add="false"/>
   </property>
   <property>
+    <name>infra_solr_java_stack_size</name>
+    <value>1024k</value>
+    <display-name>Infra Solr Java Stack Size</display-name>
+    <description>Java Stack Size of Infra Solr (-Xss)</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>infra_solr_jmx_enabled</name>
     <value>false</value>
     <display-name>Enable JMX</display-name>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -102,6 +102,7 @@ if "infra-solr-env" in config['configurations']:
   infra_solr_znode = config['configurations']['infra-solr-env']['infra_solr_znode']
   infra_solr_min_mem = format(config['configurations']['infra-solr-env']['infra_solr_minmem'])
   infra_solr_max_mem = format(config['configurations']['infra-solr-env']['infra_solr_maxmem'])
+  infra_solr_java_stack_size = format(config['configurations']['infra-solr-env']['infra_solr_java_stack_size'])
   infra_solr_instance_count = len(config['clusterHostInfo']['infra_solr_hosts'])
   infra_solr_datadir = format(config['configurations']['infra-solr-env']['infra_solr_datadir'])
   infra_solr_data_resources_dir = os.path.join(infra_solr_datadir, 'resources')

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
@@ -71,7 +71,8 @@ RMI_PORT={{infra_solr_jmx_port}}
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoSoftCommit.maxTime=3000"
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.clustering.enabled=true"
-SOLR_OPTS="$SOLR_OPTS -Djava.rmi.server.hostname={{hostname}}"
+SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}"
+SOLR_OPTS="$SOLR_OPTS $SOLR_JAVA_STACK_SIZE -Djava.rmi.server.hostname={{hostname}}"
 
 # Location where the bin/solr script will save PID files for running instances
 # If not set, the script will create PID files in $SOLR_TIP/bin

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
@@ -22,7 +22,7 @@ SOLR_JAVA_HOME={{java64_home}}
 # Increase Java Min/Max Heap as needed to support your indexing / query needs
 SOLR_JAVA_MEM="-Xms{{infra_solr_min_mem}}m -Xmx{{infra_solr_max_mem}}m"
 
-SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}"
+SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}m"
 
 # Enable verbose GC logging
 GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
@@ -22,6 +22,8 @@ SOLR_JAVA_HOME={{java64_home}}
 # Increase Java Min/Max Heap as needed to support your indexing / query needs
 SOLR_JAVA_MEM="-Xms{{infra_solr_min_mem}}m -Xmx{{infra_solr_max_mem}}m"
 
+SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}"
+
 # Enable verbose GC logging
 GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
 -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
@@ -71,8 +73,7 @@ RMI_PORT={{infra_solr_jmx_port}}
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoSoftCommit.maxTime=3000"
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.clustering.enabled=true"
-SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}"
-SOLR_OPTS="$SOLR_OPTS $SOLR_JAVA_STACK_SIZE -Djava.rmi.server.hostname={{hostname}}"
+SOLR_OPTS="$SOLR_OPTS -Djava.rmi.server.hostname={{hostname}}"
 
 # Location where the bin/solr script will save PID files for running instances
 # If not set, the script will create PID files in $SOLR_TIP/bin

--- a/ambari-server/src/test/python/stacks/2.4/configs/default.json
+++ b/ambari-server/src/test/python/stacks/2.4/configs/default.json
@@ -391,6 +391,7 @@
         "infra_solr_port": "8886",
         "infra_solr_minmem": "512",
         "infra_solr_maxmem": "512",
+        "infra_solr_java_stack_size" : "1024",
         "infra_solr_znode": "/infra-solr",
         "infra_solr_conf": "/etc/ambari-infra-solr",
         "infra_solr_pid_dir": "/var/run/ambari-infra-solr",

--- a/ambari-server/src/test/python/stacks/2.4/configs/default.json
+++ b/ambari-server/src/test/python/stacks/2.4/configs/default.json
@@ -391,7 +391,7 @@
         "infra_solr_port": "8886",
         "infra_solr_minmem": "512",
         "infra_solr_maxmem": "512",
-        "infra_solr_java_stack_size" : "1024",
+        "infra_solr_java_stack_size" : "1",
         "infra_solr_znode": "/infra-solr",
         "infra_solr_conf": "/etc/ambari-infra-solr",
         "infra_solr_pid_dir": "/var/run/ambari-infra-solr",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default java stack size is 256k for infra-solr, it causes some problems during solr startup on centos-ppc clusters

## How was this patch tested?
with: mvn clean test -DskipSurefireTests -Dpython.test.mask="*infra_solr*"

Total run:3
Total errors:0
Total failures:0
OK
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:22 min
[INFO] Finished at: 2018-04-30T20:25:42+02:00
[INFO] Final Memory: 113M/1778M
[INFO] ------------------------------------------------------------------------

Please review @swagle @adoroszlai 