### PR TITLE
[AMBARI-23734] Customize Services - Tooltip issues on Accounts Tab an…

### DIFF
--- a/ambari-web/app/styles/bootstrap_overrides.less
+++ b/ambari-web/app/styles/bootstrap_overrides.less
@@ -31,6 +31,7 @@ select.form-control {
 }
 
 .popover {
+  word-wrap: break-word;  
   small {
     font-size: 1.3rem;
   }

--- a/ambari-web/app/templates/wizard/step7/accounts_tab.hbs
+++ b/ambari-web/app/templates/wizard/step7/accounts_tab.hbs
@@ -38,7 +38,7 @@
         <td class="account-title">{{property.displayName}}</td>
         <td>
           <div {{bindAttr class="property.errorMessage:has-error"}}>
-            {{view property.viewClass serviceConfigBinding="property" fullWidth=true}}
+            {{view property.viewClass serviceConfigBinding="property" fullWidth=true isPopoverEnabled="false"}}
           </div>
         </td>
       </tr>

--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -250,6 +250,7 @@ App.ServiceConfigTextFieldUserGroupWithID = Ember.View.extend(App.ServiceConfigP
   valueBinding: 'serviceConfig.value',
   placeholderBinding: 'serviceConfig.savedValue',
   classNamesBindings: 'view.fullWidth::display-inline-block',
+  isPopoverEnabled: 'false',
 
   fullWidth: false,
 


### PR DESCRIPTION
…d All Configuration Tabs

## What changes were proposed in this pull request?
Fixed tooltip/popover issues of Customize Service Step.
1. Tooltips were being seen twice for MISC configs
2. Popover overflowing
After the fix
![screen shot 2018-04-30 at 4 46 07 pm](https://user-images.githubusercontent.com/12506576/39455795-4cab846a-4c97-11e8-9b74-6cb6ad4c8745.png)
![screen shot 2018-04-30 at 4 45 32 pm](https://user-images.githubusercontent.com/12506576/39455796-4cc6013c-4c97-11e8-9d9b-8075c49c7867.png)
![screen shot 2018-04-30 at 4 45 09 pm](https://user-images.githubusercontent.com/12506576/39455797-4ce084bc-4c97-11e8-86af-945b8a23c7bb.png)


## How was this patch tested?
  21526 passing (24s)
  48 pending