### PR TITLE
[AMBARI-23735] - Expose Mpack Information As Individual Fields for Service Groups

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupRequest.java
@@ -19,16 +19,25 @@ package org.apache.ambari.server.controller;
 
 import java.util.Objects;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+
+import com.google.common.base.MoreObjects;
+
 public class ServiceGroupRequest {
 
   private String clusterName; // REF
   private String serviceGroupName; // GET/CREATE/UPDATE/DELETE
-  private String version; // Associated stack version info
 
-  public ServiceGroupRequest(String clusterName, String serviceGroupName, String version) {
+  /**
+   * ServiceGroups should be addressed by their StackID and/or Mpack ID
+   */
+  @Deprecated
+  private String stack; // Associated stack version info
+
+  public ServiceGroupRequest(String clusterName, String serviceGroupName, String stack) {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
-    this.version = version;
+    this.stack = stack;
   }
 
   /**
@@ -60,42 +69,65 @@ public class ServiceGroupRequest {
   }
 
   /**
+   * ServiceGroups should be addressed by their StackID and/or Mpack ID
+   *
    * @return the servicegroup version
    */
-  public String getVersion() {
-    return version;
+  @Deprecated
+  public String getStack() {
+    return stack;
   }
 
   /**
-   * @param version the servicegroup version to set
+   * ServiceGroups should be addressed by their StackID and/or Mpack ID
+   *
+   * @param stack
+   *          the servicegroup stack to set
    */
-  public void setVersion(String version) {
-    this.version = version;
+  @Deprecated
+  public void setStack(String stack) {
+    this.stack = stack;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("clusterName=").append(clusterName).append(", serviceGroupName=").append(serviceGroupName).append(", version=").append(version);
-    return sb.toString();
+    return MoreObjects.toStringHelper(this)
+        .add("clusterName", clusterName)
+        .add("serviceGroupName",serviceGroupName)
+        .add("stackId", stack).toString();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
       return true;
     }
+
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
 
-    ServiceGroupRequest other = (ServiceGroupRequest) obj;
+    ServiceGroupRequest that = (ServiceGroupRequest) obj;
+    EqualsBuilder equalsBuilder = new EqualsBuilder();
 
-    return Objects.equals(clusterName, other.clusterName) && Objects.equals(serviceGroupName, other.serviceGroupName) && Objects.equals(version, other.version);
+    equalsBuilder.append(clusterName, that.clusterName);
+    equalsBuilder.append(serviceGroupName, that.serviceGroupName);
+    equalsBuilder.append(stack, that.stack);
+
+    return equalsBuilder.isEquals();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public int hashCode() {
-    return Objects.hash(clusterName, serviceGroupName, version);
+    return Objects.hash(clusterName, serviceGroupName, stack);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceGroupResponse.java
@@ -18,7 +18,10 @@
 
 package org.apache.ambari.server.controller;
 
-import java.util.Objects;
+import org.apache.ambari.server.state.StackId;
+import org.apache.commons.lang.builder.EqualsBuilder;
+
+import com.google.common.base.Objects;
 
 import io.swagger.annotations.ApiModelProperty;
 
@@ -28,15 +31,17 @@ public class ServiceGroupResponse {
   private Long serviceGroupId;
   private String clusterName;
   private String serviceGroupName;
-  private String version;
+  private Long mpackId;
+  private StackId stackId;
 
-  public ServiceGroupResponse(Long clusterId, String clusterName, Long serviceGroupId, String serviceGroupName, String version) {
+  public ServiceGroupResponse(Long clusterId, String clusterName, Long mpackId, StackId stackId,
+      Long serviceGroupId, String serviceGroupName) {
     this.clusterId = clusterId;
     this.serviceGroupId = serviceGroupId;
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
-    this.version = version;
-
+    this.mpackId = mpackId;
+    this.stackId = stackId;
   }
 
   /**
@@ -96,27 +101,68 @@ public class ServiceGroupResponse {
   }
 
   /**
-   * @return the servicegroup version (stackName-stackVersion)
+   * @return the servicegroup stackId (stackName-stackVersion)
    */
-  public String getVersion() {
-    return version;
+  public StackId getStackId() {
+    return stackId;
   }
 
   /**
-   * @param version the servicegroup version (stackName-stackVersion)
+   * @param version
+   *          the servicegroup stackId (stackName-stackVersion)
    */
-  public void setVersion(String version) {
-    this.version = version;
+  public void setStackId(StackId stackId) {
+    this.stackId = stackId;
+  }
+
+  /**
+   * Gets the MpackID for this service group.
+   *
+   * @return the mpackId
+   */
+  public Long getMpackId() {
+    return mpackId;
+  }
+
+  /**
+   * Sets the Mpack ID for this service group.
+   *
+   * @param mpackId
+   *          the mpackId to set
+   */
+  public void setMpackId(Long mpackId) {
+    this.mpackId = mpackId;
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
 
-    ServiceGroupResponse other = (ServiceGroupResponse) o;
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
 
-    return Objects.equals(clusterId, other.clusterId) && Objects.equals(clusterName, other.clusterName) && Objects.equals(serviceGroupName, other.serviceGroupName) && Objects.equals(version, other.version);
+    ServiceGroupResponse that = (ServiceGroupResponse) object;
+    EqualsBuilder equalsBuilder = new EqualsBuilder();
+
+    equalsBuilder.append(clusterId, that.clusterId);
+    equalsBuilder.append(clusterName, that.clusterName);
+    equalsBuilder.append(mpackId, that.mpackId);
+    equalsBuilder.append(stackId, that.stackId);
+    equalsBuilder.append(serviceGroupId, that.serviceGroupId);
+    equalsBuilder.append(serviceGroupName, that.serviceGroupName);
+    return equalsBuilder.isEquals();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(clusterId, clusterName, mpackId, stackId, serviceGroupId,
+        serviceGroupName);
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceGroupResourceProviderTest.java
@@ -111,7 +111,7 @@ public class ServiceGroupResourceProviderTest {
     ClusterController clusterController = createNiceMock(ClusterController.class);
     ServiceGroup coreServiceGroup = createNiceMock(ServiceGroup.class);
     ServiceGroup edmServiceGroup = createNiceMock(ServiceGroup.class);
-    ServiceGroupResponse coreServiceGroupResponse = new ServiceGroupResponse(1l, "c1", 1l, "CORE", STACK_ID);
+    ServiceGroupResponse coreServiceGroupResponse = new ServiceGroupResponse(1l, "c1", 1L, new StackId(STACK_ID), 1l, "CORE");
     expect(ambariManagementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
     expect(ambariManagementController.getClusters()).andReturn(clusters).anyTimes();
     expect(clusters.getCluster(clusterName)).andReturn(cluster).anyTimes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The service group endpoint does not expose the following fields:

- Mpack ID
- Mpack Name
- Mpack Version

Instead, it exposes a single string called {{version}} which represents the full Mpack: {{FOO-1.0.0-b1234}}.

This is not ideal for several reasons:
- It is not easy to determine the mpack associated with a service group without doing string parsing and string comparison.
- When creating a new service group, a string is used to query instead of an mpack ID.

## How was this patch tested?

```
{
  "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/c1/servicegroups/HDPCORE",
  "ServiceGroupInfo" : {
    "cluster_id" : 2,
    "cluster_name" : "c1",
    "mpack_id" : 1,
    "mpack_name" : "HDPCORE",
    "mpack_version" : "1.0.0-b250",
    "service_group_id" : 2,
    "service_group_name" : "HDPCORE",
    "stack" : "HDPCORE-1.0.0-b250"
  },
```