### PR TITLE
[AMBARI-23739] Namespace names are converted to uppercase after selecting from dropdown

### DIFF
--- a/ambari-web/app/templates/main/dashboard/widgets.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets.hbs
@@ -60,13 +60,15 @@
               <div class="col-md-6">
                 <h5 class="widgets-group-title">{{group.title}}</h5>
                 {{#if group.subGroups.length}}
-                  <div class="btn-group">
+                  <div class="btn-group dropdown">
                     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                      {{#if group.activeSubGroup}}
-                        {{group.activeSubGroup.title}}
-                      {{else}}
-                        {{t common.all}}
-                      {{/if}}
+                      <span class="selected-item">
+                        {{#if group.activeSubGroup}}
+                          {{group.activeSubGroup.title}}
+                        {{else}}
+                          {{t common.all}}
+                        {{/if}}
+                      </span>
                       <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu">

--- a/ambari-web/app/templates/main/service/info/metrics.hbs
+++ b/ambari-web/app/templates/main/service/info/metrics.hbs
@@ -100,9 +100,9 @@
         {{#if controller.selectedNSWidgetLayout}}
           <div class="widgets-group-select-wrapper">
             <h5 class="widgets-group-title">{{t dashboard.widgets.nameSpace}}</h5>
-            <div class="btn-group">
+            <div class="btn-group dropdown">
               <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                {{controller.selectedNSWidgetLayout.displayName}}
+                <span class="selected-item">{{controller.selectedNSWidgetLayout.displayName}}</span>
                 <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Selected namespace names are shown in uppercase where as they are actually created in lowercase and in dropdown it's in lowercase

## How was this patch tested?

UI unit tests:
  21528 passing (27s)
  48 pending
