### PR TITLE
AMBARI-23743. Log Feeder: security config bean is duplicated

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederSecurityConfig.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederSecurityConfig.java
@@ -26,15 +26,11 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.nio.charset.Charset;
 
-@Configuration
-@Lazy
 public class LogFeederSecurityConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogFeederSecurityConfig.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?
security config bean is already created for logfeeder, using with Configuration annotation will create again. (removing that annotation is solving that problem)

## How was this patch tested?
I updated a jar on a cluster where that problem caused dependency issues, then my changes fixed it

Please review @kasakrisz @adoroszlai @swagle @zeroflag 