### PR TITLE
[AMBARI-23741] - Starting JHS Takes Too Long Due To Tarball Extraction

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/copy_tarball.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/copy_tarball.py
@@ -70,7 +70,7 @@ def _prepare_tez_tarball():
   sudo.chmod(tez_temp_dir, 0777)
 
   Logger.info("Extracting {0} to {1}".format(mapreduce_source_file, mapreduce_temp_dir))
-  tar_archive.extract_archive(mapreduce_source_file, mapreduce_temp_dir)
+  tar_archive.untar_archive(mapreduce_source_file, mapreduce_temp_dir)
 
   Logger.info("Extracting {0} to {1}".format(tez_source_file, tez_temp_dir))
   tar_archive.untar_archive(tez_source_file, tez_temp_dir)
@@ -169,7 +169,7 @@ def _prepare_mapreduce_tarball():
     raise Fail("Unable to seed the mapreduce tarball with native LZO libraries since the source Hadoop native lib directory {0} does not exist".format(hadoop_lib_native_source_dir))
 
   Logger.info("Extracting {0} to {1}".format(mapreduce_source_file, mapreduce_temp_dir))
-  tar_archive.extract_archive(mapreduce_source_file, mapreduce_temp_dir)
+  tar_archive.untar_archive(mapreduce_source_file, mapreduce_temp_dir)
 
   mapreduce_lib_dir = os.path.join(mapreduce_temp_dir, "hadoop", "lib")
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
@@ -64,10 +64,6 @@ def untar_archive(archive, directory, silent=True):
     try_sleep = 1,
   )
 
-def extract_archive(archive, directory):
-  with closing(tarfile.open(archive, mode(archive))) as tar:
-    tar.extractall(directory)
-
 def get_archive_root_dir(archive):
   root_dir = None
   with closing(tarfile.open(archive, mode(archive))) as tar:

--- a/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
@@ -48,7 +48,13 @@ def archive_directory_dereference(archive, directory):
 
 def untar_archive(archive, directory, silent=True):
   """
+  Extracts a tarball using the system's tar utility. This is more
+  efficient than Python 2.x's tarfile module.
+
   :param directory:   can be a symlink and is followed
+  :param silent:  True if the output should be suppressed. This is a good
+  idea in most cases as the streamed output of a huge tarball can cause
+  a performance degredation
   """
   options = "-xf" if silent else "-xvf"
 

--- a/ambari-server/src/main/python/ambari_server/setupMpacks.py
+++ b/ambari-server/src/main/python/ambari_server/setupMpacks.py
@@ -39,7 +39,7 @@ from ambari_server.userInput import get_YN_input
 from ambari_server.dbConfiguration import ensure_jdbc_driver_is_installed, LINUX_DBMS_KEYS_LIST
 
 from resource_management.core import sudo
-from resource_management.libraries.functions.tar_archive import extract_archive, get_archive_root_dir
+from resource_management.libraries.functions.tar_archive import untar_archive, get_archive_root_dir
 from resource_management.libraries.functions.version import compare_versions
 
 
@@ -157,7 +157,8 @@ def expand_mpack(archive_path):
   print_info_msg("Expand management pack at temp location {0}".format(tmp_root_dir))
   if os.path.exists(tmp_root_dir):
     sudo.rmtree(tmp_root_dir)
-  extract_archive(archive_path, tmpdir)
+
+  untar_archive(archive_path, tmpdir)
 
   if not os.path.exists(tmp_root_dir):
     print_error_msg("Malformed management pack. Failed to expand management pack!")

--- a/ambari-server/src/test/python/TestMpacks.py
+++ b/ambari-server/src/test/python/TestMpacks.py
@@ -215,11 +215,11 @@ class TestMpacks(TestCase):
     os_path_exists_mock.assert_has_calls(os_path_exists_calls)
 
   @patch("os.path.exists")
-  @patch("ambari_server.setupMpacks.extract_archive")
+  @patch("ambari_server.setupMpacks.untar_archive")
   @patch("ambari_server.setupMpacks.get_archive_root_dir")
   @patch("ambari_server.setupMpacks.download_mpack")
   @patch("ambari_server.setupMpacks.get_ambari_properties")
-  def test_install_mpack_with_malformed_mpack(self, get_ambari_properties_mock, download_mpack_mock, get_archive_root_dir_mock, extract_archive_mock, os_path_exists_mock):
+  def test_install_mpack_with_malformed_mpack(self, get_ambari_properties_mock, download_mpack_mock, get_archive_root_dir_mock, untar_archive_mock, os_path_exists_mock):
     options = self._create_empty_options_mock()
     options.mpack_path = "/path/to/mpack.tar.gz"
     download_mpack_mock.return_value = "/tmp/mpack.tar.gz"
@@ -237,7 +237,7 @@ class TestMpacks(TestCase):
 
     get_archive_root_dir_mock.return_value = "mpack"
     os_path_exists_mock.side_effect = [True, True, False, False]
-    extract_archive_mock.return_value = None
+    untar_archive_mock.return_value = None
     fail = False
     try:
       install_mpack(options)
@@ -248,7 +248,7 @@ class TestMpacks(TestCase):
 
     get_archive_root_dir_mock.return_value = "mpack"
     os_path_exists_mock.side_effect = [True, True, False, True, False]
-    extract_archive_mock.return_value = None
+    untar_archive_mock.return_value = None
     fail = False
     try:
       install_mpack(options)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Starting the Job History Server might time out on systems due to the use of Python's {{tarfile}} module. Instead, calling {{tar}} directly is much faster.

```
2018-05-01 17:28:44,102 - Extracting /usr/hdp/2.6.3.0-235/hadoop/mapreduce.tar.gz to /var/lib/ambari-agent/tmp/mapreduce-tarball-nqNJdx
2018-05-01 17:53:12,992 - Extracting /usr/hdp/2.6.3.0-235/tez/lib/tez.tar.gz to /var/lib/ambari-agent/tmp/tez-tarball-9CbDSh
2018-05-01 17:53:12,993 - Execute[('tar', '-xf', '/usr/hdp/2.6.3.0-235/tez/lib/tez.tar.gz', '-C', '/var/lib/ambari-agent/tmp/tez-tarball-9CbDSh/')] {'tries': 3, 'sudo': True, 'try_sleep': 1}
```

## How was this patch tested?

- Installed a new cluster and verified that the tarballs are properly created and extracted using the new function.

```
Total run:1194
Total errors:0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:13 min
[INFO] Finished at: 2018-05-02T11:23:34-04:00
[INFO] Final Memory: 19M/491M
[INFO] ------------------------------------------------------------------------
```