### PR TITLE
[AMBARI-23745] - Replace Multiple Matches Using Regex on Upgrades

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
@@ -532,7 +532,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
         newValues.put(insert.key, valueToInsertInto);
 
         updateBufferWithMessage(outputBuffer, MessageFormat.format(
-            "Updated {0}/{1} by inserting {2}", configType, insert.key, insert.value));
+            "Updated {0}/{1} by inserting \"{2}\"", configType, insert.key, insert.value));
       } else {
         updateBufferWithMessage(outputBuffer, MessageFormat.format(
             "Skipping insertion for {0}/{1} because it does not exist or is empty.", configType,

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
@@ -471,9 +471,15 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
 
           newValues.put(replacement.key, replaced);
 
-          updateBufferWithMessage(outputBuffer,
-              MessageFormat.format("Replaced {0}/{1} containing \"{2}\" with \"{3}\"", configType,
-                  replacement.key, replacement.find, replacement.replaceWith));
+          // customize the replacement message if the new value is empty
+          if (StringUtils.isEmpty(replacement.replaceWith)) {
+            updateBufferWithMessage(outputBuffer, MessageFormat.format(
+                "Removed \"{0}\" from {1}/{2}", replacement.find, configType, replacement.key));
+          } else {
+            updateBufferWithMessage(outputBuffer,
+                MessageFormat.format("Replaced {0}/{1} containing \"{2}\" with \"{3}\"", configType,
+                    replacement.key, replacement.find, replacement.replaceWith));
+          }
         }
       } else {
         updateBufferWithMessage(outputBuffer, MessageFormat.format(

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigUpgradeChangeDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigUpgradeChangeDefinition.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigUpgradeChangeDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigUpgradeChangeDefinition.java
@@ -205,7 +205,8 @@ public class ConfigUpgradeChangeDefinition {
 
     List<Replace> list = new ArrayList<>();
     for (Replace r : replacements) {
-      if (null == r.key || null == r.find || null == r.replaceWith) {
+
+      if (StringUtils.isBlank(r.key) || StringUtils.isEmpty(r.find) || null == r.replaceWith) {
         LOG.warn(String.format("Replacement %s is invalid", r));
         continue;
       }
@@ -231,7 +232,7 @@ public class ConfigUpgradeChangeDefinition {
 
     List<Replace> list = new ArrayList<>();
     for (RegexReplace regexReplaceObj : regexReplacements) {
-      if (null == regexReplaceObj.key || null == regexReplaceObj.find
+      if (StringUtils.isBlank(regexReplaceObj.key) || StringUtils.isEmpty(regexReplaceObj.find)
           || null == regexReplaceObj.replaceWith) {
         LOG.warn(String.format("Replacement %s is invalid", regexReplaceObj));
         continue;

--- a/ambari-server/src/main/resources/upgrade-config.xsd
+++ b/ambari-server/src/main/resources/upgrade-config.xsd
@@ -103,6 +103,7 @@
             <xs:attribute name="key" use="required" type="xs:string"/>
             <xs:attribute name="find" use="required" type="xs:string"/>
             <xs:attribute name="replace-with" use="required" type="xs:string"/>
+            <xs:attribute name="match-all" use="optional" type="xs:boolean"/>
             <xs:attribute name="if-key" use="optional" type="xs:string"/>
             <xs:attribute name="if-type" use="optional" type="xs:string"/>
             <xs:attribute name="if-value" use="optional" type="xs:string"/>

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -661,7 +661,7 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     assertEquals(4, groups.get(0).items.size());
     assertEquals(8, groups.get(1).items.size());
-    assertEquals(5, groups.get(2).items.size());
+    assertEquals(6, groups.get(2).items.size());
     assertEquals(7, groups.get(3).items.size());
     assertEquals(8, groups.get(4).items.size());
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -1023,6 +1023,82 @@ public class UpgradeHelperTest extends EasyMockSupport {
     assertEquals("fooValue", keyValuePairs.get(0).value);
   }
 
+  /**
+   * Tests that the regex replacement is working for configurations.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testConfigureRegexTask() throws Exception {
+    Map<String, UpgradePack> upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.1.1");
+    assertTrue(upgrades.containsKey("upgrade_test"));
+    UpgradePack upgrade = upgrades.get("upgrade_test");
+    ConfigUpgradePack cup = ambariMetaInfo.getConfigUpgradePack("HDP", "2.1.1");
+    assertNotNull(upgrade);
+
+    Cluster cluster = makeCluster();
+
+    UpgradeContext context = getMockUpgradeContext(cluster, Direction.UPGRADE, UpgradeType.ROLLING);
+
+    List<UpgradeGroupHolder> groups = m_upgradeHelper.createSequence(upgrade,context);
+    assertEquals(7, groups.size());
+
+    // grab the regex task out of Hive
+    UpgradeGroupHolder hiveGroup = groups.get(4);
+    assertEquals("HIVE", hiveGroup.name);
+    ConfigureTask configureTask = (ConfigureTask) hiveGroup.items.get(5).getTasks().get(0).getTasks().get(0);
+    assertEquals("hdp_2_1_1_regex_replace", configureTask.getId());
+
+    // now set the property in the if-check in the set element so that we have a match
+    Map<String, String> hiveConfigs = new HashMap<>();
+    StringBuilder builder = new StringBuilder();
+    builder.append("1-foo-2");
+    builder.append(System.lineSeparator());
+    builder.append("1-bar-2");
+    builder.append(System.lineSeparator());
+    builder.append("3-foo-4");
+    builder.append(System.lineSeparator());
+    builder.append("1-foobar-2");
+    builder.append(System.lineSeparator());
+    hiveConfigs.put("regex-replace-key-one", builder.toString());
+
+    ConfigurationRequest configurationRequest = new ConfigurationRequest();
+    configurationRequest.setClusterName(cluster.getClusterName());
+    configurationRequest.setType("hive-site");
+    configurationRequest.setVersionTag("version2");
+    configurationRequest.setProperties(hiveConfigs);
+
+    final ClusterRequest clusterRequest = new ClusterRequest(
+        cluster.getClusterId(), cluster.getClusterName(),
+        cluster.getDesiredStackVersion().getStackVersion(), null);
+
+    clusterRequest.setDesiredConfig(singletonList(configurationRequest));
+    m_managementController.updateClusters(new HashSet<ClusterRequest>() {
+      {
+        add(clusterRequest);
+      }
+    }, null);
+
+    // the configure task should now return different properties to set based on
+    // the if-condition checks
+    Map<String, String> configProperties = configureTask.getConfigurationChanges(cluster, cup);
+    assertFalse(configProperties.isEmpty());
+    assertEquals(configProperties.get(ConfigureTask.PARAMETER_CONFIG_TYPE), "hive-site");
+
+    String configurationJson = configProperties.get(ConfigureTask.PARAMETER_REPLACEMENTS);
+    assertNotNull(configurationJson);
+
+    List<ConfigUpgradeChangeDefinition.Replace> replacements = m_gson.fromJson(
+        configurationJson,
+        new TypeToken<List<ConfigUpgradeChangeDefinition.Replace>>() {}.getType());
+
+    assertEquals("1-foo-2\n", replacements.get(0).find);
+    assertEquals("REPLACED", replacements.get(0).replaceWith);
+    assertEquals("3-foo-4\n", replacements.get(1).find);
+    assertEquals("REPLACED", replacements.get(1).replaceWith);
+    assertEquals(2, replacements.size());
+  }
+
   @Test
   public void testConfigureTaskWithMultipleConfigurations() throws Exception {
     Map<String, UpgradePack> upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.1.1");

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/config-upgrade.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/config-upgrade.xml
@@ -199,6 +199,11 @@
             <type>hive-site</type>
             <set key="fooKey" value="fooValue" if-type="hive-site" if-key="ifFooKey" if-value="ifFooValue"/>
           </definition>
+          
+          <definition xsi:type="configure" id="hdp_2_1_1_regex_replace">
+            <type>hive-site</type>
+            <regex-replace key="regex-replace-key-one" find="^\d-foo-\d[\r\n]+" replace-with="REPLACED" match-all="true"/>
+          </definition>          
         </changes>
       </component>
     </service>

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test.xml
@@ -227,6 +227,7 @@
           <task xsi:type="configure" id="hdp_2_1_1_hive_server_conditions"/>
           <task xsi:type="configure" id="hdp_2_1_1_hive_server_conditions_skip"/>
           <task xsi:type="configure" id="hdp_2_1_1_no_conditions_met"/>
+          <task xsi:type="configure" id="hdp_2_1_1_regex_replace"/>
         </pre-upgrade>
         <pre-downgrade copy-upgrade="true" />
         <upgrade />


### PR DESCRIPTION
## What changes were proposed in this pull request?

When upgrading from one stack to another, the {{regex-replace}} key can be used to find and replace a block of text which matches a given regular expression. This works by finding the literal string matching the regex and turning this into a regular find/replace. 

For example: 
```
<regex-replace find="\d-foo-\d" replace="REPLACED"/>
```

on

```
1-foo-1
2-foo-2
3-foo-3
```

Would produce:
```
REPLACED
2-foo-2
3-foo-3
```

In order to replace all of the possible matches, we can extend the XSD of {{RegexReplace}} to create multiple literal {{Replace}} instances for every match.

```
<regex-replace find="\d-foo-\d" replace="" match-all="true"/>
```

Would produce:
```
REPLACED
REPLACED
REPLACED
```

## How was this patch tested?

Ran an upgrade which used the new regex-replace tag. 