### PR TITLE
Clearing security context in AuditEventCreatorTestBase helps pass many tests

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/AuditEventCreatorTestBase.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/AuditEventCreatorTestBase.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.audit.request.creator;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;

--- a/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/AuditEventCreatorTestBase.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/audit/request/creator/AuditEventCreatorTestBase.java
@@ -81,4 +81,8 @@ public class AuditEventCreatorTestBase {
       }
     });
   }
+  @AfterClass
+  public static void afterClass(){
+    SecurityContextHolder.clearContext();
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request? 
Test classes that extend AuditEventCreatorTestBase (i.e. ViewPrivilegeEventCreatorTest) invoke a beforeclass that sets up a security context for these tests. The uncleared security context affected numerous following tests that used method isAuthorized from the AuthorizationHelper class. I have added an afterclass that clears the security context so that those tests are no longer effected. 

## How was this patch tested?
Patch was tested manually. 