### PR TITLE
Creation of service, servicecomponents and host components during multimpack deployment has issues

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -709,7 +709,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         hostComponentNames.put(request.getClusterName(), new HashMap<>());
       }
       if (!hostComponentNames.get(request.getClusterName())
-          .containsKey(request.getServiceName())) {
+          .containsKey(request.getServiceGroupName())) {
         hostComponentNames.get(request.getClusterName()).put(
             request.getServiceGroupName(), new HashMap<>());
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -663,7 +663,8 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
 
     // do all validation checks
-    Map<String, Map<String, Map<String, Set<String>>>> hostComponentNames = new HashMap<>();
+    Map<String, Map<String, Map<String, Map<String, Set<String>>>>> hostComponentNames =
+            new HashMap<>();
     Set<String> duplicates = new HashSet<>();
     for (ServiceComponentHostRequest request : requests) {
       validateServiceComponentHostRequest(request);
@@ -710,16 +711,25 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       if (!hostComponentNames.get(request.getClusterName())
           .containsKey(request.getServiceName())) {
         hostComponentNames.get(request.getClusterName()).put(
+            request.getServiceGroupName(), new HashMap<>());
+      }
+      if (!hostComponentNames.get(request.getClusterName())
+          .get(request.getServiceGroupName())
+          .containsKey(request.getServiceName())) {
+        hostComponentNames.get(request.getClusterName()).get(request.getServiceGroupName()).put(
             request.getServiceName(), new HashMap<String, Set<String>>());
       }
       if (!hostComponentNames.get(request.getClusterName())
+          .get(request.getServiceGroupName())
           .get(request.getServiceName())
           .containsKey(request.getComponentName())) {
         hostComponentNames.get(request.getClusterName())
+            .get(request.getServiceGroupName())
             .get(request.getServiceName()).put(request.getComponentName(),
                 new HashSet<String>());
       }
       if (hostComponentNames.get(request.getClusterName())
+          .get(request.getServiceGroupName())
           .get(request.getServiceName())
           .get(request.getComponentName())
           .contains(request.getHostname())) {
@@ -728,6 +738,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         continue;
       }
       hostComponentNames.get(request.getClusterName())
+          .get(request.getServiceGroupName())
           .get(request.getServiceName()).get(request.getComponentName())
           .add(request.getHostname());
 
@@ -852,7 +863,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     for (ServiceComponentHostRequest request : requests) {
       Cluster cluster = clusters.getCluster(request.getClusterName());
-      Service s = cluster.getService(request.getServiceName());
+      Service s = cluster.getService(request.getServiceGroupName(), request.getServiceName());
       ServiceComponent sc = s.getServiceComponent(
           request.getComponentName());
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -438,7 +438,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
       try {
         ServiceComponent sc = s.getServiceComponent(request.getComponentName());
-        if (sc != null) {
+        if (sc != null && (sc.getServiceId().equals(cluster.getService(request.getServiceName()).getServiceId()))) {
           // throw error later for dup
           duplicates.add(request.toString());
           continue;
@@ -470,7 +470,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     // now doing actual work
     for (ServiceComponentRequest request : requests) {
       Cluster cluster = clusters.getCluster(request.getClusterName());
-      Service s = cluster.getService(request.getServiceName());
+      Service s = cluster.getService(request.getServiceGroupName(), request.getServiceName());
       ServiceComponent sc = serviceComponentFactory.createNew(s, request.getComponentName(), request.getComponentType());
 
       if (StringUtils.isNotEmpty(request.getDesiredState())) {
@@ -903,7 +903,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
   private Service getServiceFromCluster(final ServiceComponentRequest request, final Cluster cluster) throws AmbariException {
     try {
-      return cluster.getService(request.getServiceName());
+      return cluster.getService(request.getServiceGroupName(), request.getServiceName());
     } catch (ServiceNotFoundException e) {
       throw new ParentObjectNotFoundException("Parent Service resource doesn't exist.", e);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -438,7 +438,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
       try {
         ServiceComponent sc = s.getServiceComponent(request.getComponentName());
-        if (sc != null && (sc.getServiceId().equals(cluster.getService(request.getServiceName()).getServiceId()))) {
+        if (sc != null && (sc.getServiceId().equals(cluster.getService(request.getServiceGroupName(), request.getServiceName()).getServiceId()))) {
           // throw error later for dup
           duplicates.add(request.toString());
           continue;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -1108,7 +1108,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
       }
       try {
         Service s = cluster.getService(serviceName);
-        if (s != null) {
+        if (s != null && (s.getServiceGroupName() == serviceGroupName)) {
           // throw error later for dup
           duplicates.add(serviceName);
           continue;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -1108,7 +1108,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
       }
       try {
         Service s = cluster.getService(serviceName);
-        if (s != null && (s.getServiceGroupName() == serviceGroupName)) {
+        if (s != null && (s.getServiceGroupName().equals(serviceGroupName))) {
           // throw error later for dup
           duplicates.add(serviceName);
           continue;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
@@ -309,7 +309,7 @@ public class ServiceComponentImpl implements ServiceComponent {
       }
 
       if (hostComponents.containsKey(hostComponent.getHostName())) {
-        if (hostComponents.get(hostComponent.getHostName()).getServiceGroupName().equalsIgnoreCase(hostComponent.getServiceGroupName())) {
+        if (hostComponents.get(hostComponent.getHostName()).getServiceGroupName().equals(hostComponent.getServiceGroupName())) {
           throw new AmbariException("Cannot add duplicate ServiceComponentHost" + ", clusterName="
                   + service.getCluster().getClusterName() + ", clusterId="
                   + service.getCluster().getClusterId() + ", serviceName=" + service.getName()

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
@@ -309,11 +309,13 @@ public class ServiceComponentImpl implements ServiceComponent {
       }
 
       if (hostComponents.containsKey(hostComponent.getHostName())) {
-        throw new AmbariException("Cannot add duplicate ServiceComponentHost" + ", clusterName="
-            + service.getCluster().getClusterName() + ", clusterId="
-            + service.getCluster().getClusterId() + ", serviceName=" + service.getName()
-            + ", serviceComponentName=" + getName() + ", hostname=" + hostComponent.getHostName()
-            + ", recoveryEnabled=" + isRecoveryEnabled());
+        if (hostComponents.get(hostComponent.getHostName()).getServiceGroupName().equalsIgnoreCase(hostComponent.getServiceGroupName())) {
+          throw new AmbariException("Cannot add duplicate ServiceComponentHost" + ", clusterName="
+                  + service.getCluster().getClusterName() + ", clusterId="
+                  + service.getCluster().getClusterId() + ", serviceName=" + service.getName()
+                  + ", serviceComponentName=" + getName() + ", hostname=" + hostComponent.getHostName()
+                  + ", recoveryEnabled=" + isRecoveryEnabled());
+        }
       }
       // FIXME need a better approach of caching components by host
       ClusterImpl clusterImpl = (ClusterImpl) service.getCluster();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -750,9 +750,11 @@ public class ClusterImpl implements Cluster {
 
     if (serviceComponentHosts.get(serviceName).get(componentName).containsKey(
       hostname)) {
-      throw new AmbariException("Duplicate entry for ServiceComponentHost"
-        + ", serviceName=" + serviceName + ", serviceComponentName"
-        + componentName + ", hostname= " + hostname);
+      if(serviceComponentHosts.get(serviceName).get(componentName).get(hostname).getServiceGroupName().equalsIgnoreCase(svcCompHost.getServiceGroupName())) {
+        throw new AmbariException("Duplicate entry for ServiceComponentHost"
+                + ", serviceName=" + serviceName + ", serviceComponentName"
+                + componentName + ", hostname= " + hostname);
+      }
     }
 
     if (!serviceComponentHostsByHost.containsKey(hostname)) {
@@ -946,10 +948,12 @@ public class ClusterImpl implements Cluster {
   public Service addService(ServiceGroup serviceGroup, String serviceName, String serviceType)
       throws AmbariException {
     if (services.containsKey(serviceName)) {
-      String message = MessageFormat.format("The {0} service already exists in {1}", serviceName,
-        getClusterName());
+      if (services.get(serviceName).getServiceGroupName().equalsIgnoreCase(serviceGroup.getServiceGroupName())) {
+        String message = MessageFormat.format("The {0} service already exists in {1}", serviceName,
+                getClusterName());
 
-      throw new AmbariException(message);
+        throw new AmbariException(message);
+      }
     }
 
     @Experimental(feature = ExperimentalFeature.PATCH_UPGRADES)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -750,7 +750,7 @@ public class ClusterImpl implements Cluster {
 
     if (serviceComponentHosts.get(serviceName).get(componentName).containsKey(
       hostname)) {
-      if(serviceComponentHosts.get(serviceName).get(componentName).get(hostname).getServiceGroupName().equalsIgnoreCase(svcCompHost.getServiceGroupName())) {
+      if(serviceComponentHosts.get(serviceName).get(componentName).get(hostname).getServiceGroupName().equals(svcCompHost.getServiceGroupName())) {
         throw new AmbariException("Duplicate entry for ServiceComponentHost"
                 + ", serviceName=" + serviceName + ", serviceComponentName"
                 + componentName + ", hostname= " + hostname);
@@ -948,7 +948,7 @@ public class ClusterImpl implements Cluster {
   public Service addService(ServiceGroup serviceGroup, String serviceName, String serviceType)
       throws AmbariException {
     if (services.containsKey(serviceName)) {
-      if (services.get(serviceName).getServiceGroupName().equalsIgnoreCase(serviceGroup.getServiceGroupName())) {
+      if (services.get(serviceName).getServiceGroupName().equals(serviceGroup.getServiceGroupName())) {
         String message = MessageFormat.format("The {0} service already exists in {1}", serviceName,
                 getClusterName());
 


### PR DESCRIPTION
Update the in memory map comparisons to add service groups as a distinguishing factor. This helps to add same component type/name from different service groups.

(Please fill in changes proposed in this fix)

POST /services
POST /services/ /components
POST /hosts

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.