### PR TITLE
[AMBARI-23562] Updating hadoop.proxyuser.HTTP.hosts in USER Kerberos descriptor when upgrading to 2.7 and make sure the new STACK Kerberos descriptors have the correct value

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
@@ -144,7 +144,7 @@
           "configurations": [
             {
               "core-site": {
-                "hadoop.proxyuser.HTTP.hosts": "${clusterHostInfo/webhcat_server_host|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\,, true)}"
+                "hadoop.proxyuser.HTTP.hosts": "${clusterHostInfo/webhcat_server_hosts|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\,, true)}"
               }
             },
             {

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -1228,14 +1228,14 @@ public class UpgradeCatalog270Test {
 
   @Test
   public void testupdateKerberosDescriptorArtifact() throws Exception {
+    //there is HIVE -> WEBHCAT_SERVER -> configurations -> core-site -> hadoop.proxyuser.HTTP.hosts
     String kerberosDescriptorJson = IOUtils.toString(getClass().getClassLoader().getResourceAsStream("org/apache/ambari/server/upgrade/kerberos_descriptor.json"), "UTF-8");
 
     ArtifactEntity artifactEntity = new ArtifactEntity();
     artifactEntity.setArtifactName("kerberos_descriptor");
     artifactEntity.setArtifactData(GSON.<Map<String, Object>>fromJson(kerberosDescriptorJson, Map.class));
 
-    UpgradeCatalog270 upgradeCatalog270 = createMockBuilder(UpgradeCatalog270.class)
-            .createMock();
+    UpgradeCatalog270 upgradeCatalog270 = createMockBuilder(UpgradeCatalog270.class).createMock();
 
     expect(artifactDAO.merge(artifactEntity)).andReturn(artifactEntity);
 
@@ -1243,9 +1243,13 @@ public class UpgradeCatalog270Test {
 
     upgradeCatalog270.updateKerberosDescriptorArtifact(artifactDAO, artifactEntity);
 
+    final String newKerberosDescriptorJson = GSON.toJson(artifactEntity.getArtifactData());
+
     int oldCount = substringCount(kerberosDescriptorJson, AMBARI_INFRA_OLD_NAME);
-    int newCount = substringCount(GSON.toJson(artifactEntity.getArtifactData()), AMBARI_INFRA_NEW_NAME);
+    int newCount = substringCount(newKerberosDescriptorJson, AMBARI_INFRA_NEW_NAME);
     assertThat(newCount, is(oldCount));
+
+    assertTrue(newKerberosDescriptorJson.contains("webhcat_server_hosts|"));
 
     verify(upgradeCatalog270);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to recent configuration changes the value of `hadoop.proxyuser.HTTP.hosts` was set to a wrong value upon regenerating the keytab and/or enabling/disabling Kerberos in Ambari 2.7 after upgrading from a previous version (`clusterHostInfo/webhcat_server_host` should have been modified to `clusterHostInfo/webhcat_server_hosts`; please note the trailing `s`)
There are two places where we needed to fix this issue:
within HIVE's `kerberos.json` to make sure we have the proper STACK Kerberos descriptor
within the `artifact` DB table upon upgrade (so that the USER Kerberos descriptor will have the appropriate value)

## How was this patch tested?

Unit tests have been modified to cover this case; latest test result from `ambari-server`:
```
HW15069:ambari smolnar$ mvn -Del.log=WARN clean install
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 32:51 min
[INFO] Finished at: 2018-05-03T09:40:55+02:00
[INFO] Final Memory: 206M/617M
[INFO] ------------------------------------------------------------------------
```

The following E2E test were executed:

1. installed Ambari 2.6.1.5-3
2. installed a cluster (HDFS, Hive, YARN/MR2, ZK, Pig, Slider, Tez, AMS)
3. Kerberized the cluster
4. prepared to upgrade to 2.7.0.0-437
5. just before the `ambari-server upgrade step` I implemented my changes in the code; built the new JAR and replaced it in my test environment; I overwrote the `kerberos.json` in questions too
6. upgraded to 2.7.0.0 (w/o any issue) and started the server and agents
7. logged in to Ambari UI and checked HDFS's config; so far so good
8. used Ambari's REST API to check if the USER Kerberos descriptor got overwritten: yes, it did.
9. regenerated the keytabs and checked HDFS's configuration again: the proper value has been shown

Screenshots:
- USER Kerberos descriptor before upgrade:
<img width="1671" alt="screen shot 2018-05-03 at 7 40 47 am" src="https://user-images.githubusercontent.com/34065904/39565986-4bd707b0-4eba-11e8-9ea1-62f1f19af2cc.png">

- USER Kerberos descriptor after the upgrade:
<img width="1528" alt="screen shot 2018-05-03 at 9 02 39 am" src="https://user-images.githubusercontent.com/34065904/39566015-69e5a914-4eba-11e8-846a-6a83fac2de0f.png">

- HDFS's configuration before regenerating the keytabs:
<img width="1342" alt="screen shot 2018-05-03 at 9 03 28 am" src="https://user-images.githubusercontent.com/34065904/39566039-7bb0d204-4eba-11e8-8481-005d20d1247c.png">

- HDFS's configuration after regenerating the keytabs:
<img width="1299" alt="screen shot 2018-05-03 at 9 04 28 am" src="https://user-images.githubusercontent.com/34065904/39566069-912430ae-4eba-11e8-82d9-5279bc6cc673.png">
