### PR TITLE
[AMBARI-23756] Ambari Infra Solr Service Check fails after Ambari Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
@@ -285,4 +285,9 @@ public interface Clusters {
    */
   void invalidate(Cluster cluster);
 
+  /**
+   * Invalidates all clusters by retrieving each from the database and refreshing all of its internal
+   * stateful collections.
+   */
+  void invalidateAllClusters();
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -1006,4 +1006,17 @@ public class ClustersImpl implements Clusters {
     getClustersByName().put(clusterEntity.getClusterName(), currentCluster);
     getClustersById().put(currentCluster.getClusterId(), currentCluster);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void invalidateAllClusters() {
+    if(clustersByName != null) {
+      Collection<Cluster> clusters = clustersByName.values();
+      for (Cluster cluster : clusters) {
+        invalidate(cluster);
+      }
+    }
+  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1018,6 +1018,10 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
         alertsDAO.merge(alertHistoryEntity);
       }
     }
+
+    // Force the clusters object to reload to ensure the renamed service is accounted for
+    getEntityManagerProvider().get().getEntityManagerFactory().getCache().evictAll();
+    clusters.invalidateAllClusters();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

**STR**
1) Upgrade Ambari from 2.6.X to 2.7.0.0-435 ( Unkerberized cluster)
2) Upgrade Non Stack Services, like Infra Solr.
3) Restart all required services (which might have stale configs)
4) Run Service check on Ambari Infra Solr . It fails with below error

```
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/service_check.py", line 48, in <module>
    InfraServiceCheck().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/service_check.py", line 27, in service_check
    import params
  File "/var/lib/ambari-agent/cache/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py", line 109, in <module>
    infra_solr_java_stack_size = format(config['configurations']['infra-solr-env']['infra_solr_java_stack_size'])
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/format.py", line 95, in format
    return ConfigurationFormatter().format(format_string, args, **result)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/format.py", line 59, in format
    result_protected = self.vformat(format_string, args, all_params)
  File "/usr/lib64/python2.7/string.py", line 549, in vformat
    result = self._vformat(format_string, args, kwargs, used_args, 2)
  File "/usr/lib64/python2.7/string.py", line 558, in _vformat
    self.parse(format_string):
  File "/usr/lib64/python2.7/string.py", line 621, in parse
    return format_string._formatter_parser()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/config_dictionary.py", line 73, in __getattr__
    raise Fail("Configuration parameter '" + self.name + "' was not found in configurations dictionary!")
resource_management.core.exceptions.Fail: Configuration parameter 'infra_solr_java_stack_size' was not found in configurations dictionary!
```

**Cause**
While upgrading the name of the AMBARI_INFRA service is changed to AMBARI_INFRA_SOLR, but the old name is cached in the JPA entities cause a mismatch on services names at some point. 

**Solution**
Clear the JPA entity cache after changing the AMBARI_INFRA service name. 

## How was this patch tested?

Manually tested.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.