### PR TITLE
[AMBARI-23748] - Logout button does not navigate user to login/logged out page

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/app-routing.module.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/app-routing.module.ts
@@ -23,13 +23,15 @@ import {LoginFormComponent} from '@app/components/login-form/login-form.componen
 import {AuthGuardService} from '@app/services/auth-guard.service';
 import {TabGuard} from '@app/services/tab.guard';
 import {LogsBreadcrumbsResolverService} from '@app/services/logs-breadcrumbs-resolver.service';
+import {LoginScreenGuardService} from '@app/services/login-screen-guard.service';
 
 const appRoutes: Routes = [{
     path: 'login',
     component: LoginFormComponent,
     data: {
       breadcrumbs: 'login.title'
-    }
+    },
+    canActivate: [LoginScreenGuardService]
   }, {
     path: 'logs/:activeTab',
     component: LogsContainerComponent,

--- a/ambari-logsearch/ambari-logsearch-web/src/app/app.module.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/app.module.ts
@@ -114,6 +114,7 @@ import {TabGuard} from '@app/services/tab.guard';
 import {LogsBreadcrumbsResolverService} from '@app/services/logs-breadcrumbs-resolver.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
+import {LoginScreenGuardService} from '@app/services/login-screen-guard.service';
 
 export function getXHRBackend(
   injector: Injector, browser: BrowserXhr, xsrf: XSRFStrategy, options: ResponseOptions
@@ -239,7 +240,8 @@ export function getXHRBackend(
     HistoryManagerService,
     ClusterSelectionService,
     LogsFilteringUtilsService,
-    LogsStateService
+    LogsStateService,
+    LoginScreenGuardService
   ],
   bootstrap: [AppComponent],
   entryComponents: [

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/auth.service.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/auth.service.spec.ts
@@ -27,6 +27,8 @@ import {AppStateService, appState} from '@app/services/storage/app-state.service
 import {AuthService} from '@app/services/auth.service';
 import {HttpClientService} from '@app/services/http-client.service';
 import {RouterTestingModule} from '@angular/router/testing';
+import {Routes} from '@angular/router';
+import {Component} from '@angular/core';
 
 describe('AuthService', () => {
 
@@ -61,13 +63,20 @@ describe('AuthService', () => {
   };
 
   beforeEach(() => {
+    const testRoutes: Routes = [{
+      path: 'login',
+      component: Component,
+      data: {
+        breadcrumbs: 'login.title'
+      }
+    }];
     TestBed.configureTestingModule({
       imports: [
         HttpModule,
         StoreModule.provideStore({
           appState
         }),
-        RouterTestingModule
+        RouterTestingModule.withRoutes(testRoutes)
       ],
       providers: [
         AuthService,

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/auth.service.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/auth.service.ts
@@ -55,9 +55,14 @@ export class AuthService {
   }
 
   onAppStateIsAuthorizedChanged = (isAuthorized): void => {
-    if (isAuthorized && this.redirectUrl) {
-      this.router.navigate(Array.isArray(this.redirectUrl) ? this.redirectUrl : [this.redirectUrl]);
+    if (isAuthorized) {
+      const redirectTo = this.redirectUrl || (this.router.routerState.snapshot.url === '/login' ? '/' : null);
+      if (redirectTo) {
+        this.router.navigate(Array.isArray(redirectTo) ? redirectTo : [redirectTo]);
+      }
       this.redirectUrl = '';
+    } else if (!isAuthorized) {
+      this.router.navigate(['/login']);
     }
   }
   /**

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/login-screen-guard.service.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/login-screen-guard.service.ts
@@ -23,20 +23,19 @@ import {Observable} from 'rxjs/Observable';
 import {AuthService} from '@app/services/auth.service';
 
 /**
- * This guard goal is to prevent to display screens where authorization needs.
+ * The goal of this guard service is to prevent to display the login screen when the user is logged in.
  */
 @Injectable()
-export class AuthGuardService implements CanActivate {
+export class LoginScreenGuardService implements CanActivate {
 
   constructor(private authService: AuthService, private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     return this.authService.isAuthorized().map((isAuthorized: boolean) => {
-      this.authService.redirectUrl = state.url;
-      if (!isAuthorized) {
-        this.router.navigate(['/login']);
+      if (isAuthorized && state.url === '/login') {
+        this.router.navigate(['/']);
       }
-      return isAuthorized;
+      return !isAuthorized;
     });
   }
 


### PR DESCRIPTION
Logout button does not navigate user to login/logged out page

## What changes were proposed in this pull request?

Added LoginScreenGuard and the AuthService is more sophisticated now. So when the user logged in it will redirect to the URL from where the user arrived to the login screen or if it is not presented then the root/default route.
When the user is logged out it will redirect to the login page.

## How was this patch tested?

Manually and unit tests.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@aBabiichuk please review it. Thanks