### PR TITLE
AMBARI-23565. Restore configs does not work.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2013,8 +2013,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       }
     }
     if (serviceConfigVersionResponse != null) {
-      configHelper.updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(),
-          Collections.singleton(serviceConfigVersionResponse.getServiceName())));
+      configHelper.updateAgentConfigs(Collections.singleton(cluster.getClusterName()));
     }
 
     if (requestStageContainer != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -1704,6 +1704,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     List<ConfigurationResponse> configurationResponses =
       new LinkedList<>();
     ServiceConfigVersionResponse serviceConfigVersionResponse = null;
+    boolean nonServiceConfigsChanged = false;
 
     if (desiredConfigs != null && request.getServiceConfigVersionRequest() != null) {
       String msg = "Unable to set desired configs and rollback at same time, request = " + request;
@@ -1864,6 +1865,8 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
                 configChangeLog.info("(configchange)    Config type '{}' was modified with the following keys, {}", config.getType(), configOutput);
               }
             }
+          } else {
+            nonServiceConfigsChanged = true;
           }
         }
       }
@@ -2012,7 +2015,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         }
       }
     }
-    if (serviceConfigVersionResponse != null) {
+    if (serviceConfigVersionResponse != null || nonServiceConfigsChanged) {
       configHelper.updateAgentConfigs(Collections.singleton(cluster.getClusterName()));
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -1868,8 +1868,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         }
       }
     }
-    m_metadataHolder.get().updateData(getClusterMetadataOnConfigsUpdate(cluster));
-    m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
 
     StackId currentVersion = cluster.getCurrentStackVersion();
     StackId desiredVersion = cluster.getDesiredStackVersion();
@@ -2013,6 +2011,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
           cluster.setSecurityType(securityType);
         }
       }
+    }
+    if (serviceConfigVersionResponse != null) {
+      configHelper.updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(),
+          Collections.singleton(serviceConfigVersionResponse.getServiceName())));
     }
 
     if (requestStageContainer != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
@@ -520,8 +520,7 @@ public class ConfigGroupResourceProvider extends
 
     cluster.deleteConfigGroup(request.getId());
 
-    m_configHelper.get().updateAgentConfigs(Collections.singletonMap(request.getClusterName(),
-        Collections.singleton(configGroup.getServiceName())));
+    m_configHelper.get().updateAgentConfigs(Collections.singleton(request.getClusterName()));
   }
 
   private void validateRequest(ConfigGroupRequest request) {
@@ -555,7 +554,7 @@ public class ConfigGroupResourceProvider extends
     ConfigGroupFactory configGroupFactory = getManagementController()
       .getConfigGroupFactory();
 
-    Map<String, Set<String>> updatedServices = new HashMap<>();
+    Set<String> updatedClusters = new HashSet<>();
     for (ConfigGroupRequest request : requests) {
 
       Cluster cluster;
@@ -643,11 +642,10 @@ public class ConfigGroupResourceProvider extends
         configGroup.getTag(), configGroup.getDescription(), null, null);
 
       configGroupResponses.add(response);
-      updatedServices.putIfAbsent(cluster.getClusterName(), new HashSet<>());
-      updatedServices.get(cluster.getClusterName()).add(serviceName);
+      updatedClusters.add(cluster.getClusterName());
     }
 
-    m_configHelper.get().updateAgentConfigs(updatedServices);
+    m_configHelper.get().updateAgentConfigs(updatedClusters);
 
     return configGroupResponses;
   }
@@ -660,7 +658,7 @@ public class ConfigGroupResourceProvider extends
 
     Clusters clusters = getManagementController().getClusters();
 
-    Map<String, Set<String>> updatedServices = new HashMap<>();
+    Set<String> updatedClusters = new HashSet<>();
     for (ConfigGroupRequest request : requests) {
 
       Cluster cluster;
@@ -769,15 +767,14 @@ public class ConfigGroupResourceProvider extends
         versionTags.add(tagsMap);
         configGroupResponse.setVersionTags(versionTags);
         getManagementController().saveConfigGroupUpdate(request, configGroupResponse);
-        updatedServices.putIfAbsent(cluster.getClusterName(), new HashSet<>());
-        updatedServices.get(cluster.getClusterName()).add(serviceName);
+        updatedClusters.add(cluster.getClusterName());
       } else {
         LOG.warn("Could not determine service name for config group {}, service config version not created",
             configGroup.getId());
       }
     }
 
-    m_configHelper.get().updateAgentConfigs(updatedServices);
+    m_configHelper.get().updateAgentConfigs(updatedClusters);
   }
 
   @SuppressWarnings("unchecked")

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
@@ -58,6 +58,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.ConfigFactory;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.configgroup.ConfigGroup;
 import org.apache.ambari.server.state.configgroup.ConfigGroupFactory;
@@ -69,6 +70,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 @StaticallyInject
 public class ConfigGroupResourceProvider extends
@@ -140,6 +142,9 @@ public class ConfigGroupResourceProvider extends
    */
   @Inject
   private static ConfigFactory configFactory;
+
+  @Inject
+  private static Provider<ConfigHelper> m_configHelper;
 
   /**
    * Create a  new resource provider for the given management controller.
@@ -514,6 +519,9 @@ public class ConfigGroupResourceProvider extends
         cluster.getClusterName(), getManagementController().getAuthName(), configGroup.getName(), request.getId());
 
     cluster.deleteConfigGroup(request.getId());
+
+    m_configHelper.get().updateAgentConfigs(Collections.singletonMap(request.getClusterName(),
+        Collections.singleton(configGroup.getServiceName())));
   }
 
   private void validateRequest(ConfigGroupRequest request) {
@@ -547,6 +555,7 @@ public class ConfigGroupResourceProvider extends
     ConfigGroupFactory configGroupFactory = getManagementController()
       .getConfigGroupFactory();
 
+    Map<String, Set<String>> updatedServices = new HashMap<>();
     for (ConfigGroupRequest request : requests) {
 
       Cluster cluster;
@@ -634,7 +643,11 @@ public class ConfigGroupResourceProvider extends
         configGroup.getTag(), configGroup.getDescription(), null, null);
 
       configGroupResponses.add(response);
+      updatedServices.putIfAbsent(cluster.getClusterName(), new HashSet<>());
+      updatedServices.get(cluster.getClusterName()).add(serviceName);
     }
+
+    m_configHelper.get().updateAgentConfigs(updatedServices);
 
     return configGroupResponses;
   }
@@ -647,6 +660,7 @@ public class ConfigGroupResourceProvider extends
 
     Clusters clusters = getManagementController().getClusters();
 
+    Map<String, Set<String>> updatedServices = new HashMap<>();
     for (ConfigGroupRequest request : requests) {
 
       Cluster cluster;
@@ -755,12 +769,15 @@ public class ConfigGroupResourceProvider extends
         versionTags.add(tagsMap);
         configGroupResponse.setVersionTags(versionTags);
         getManagementController().saveConfigGroupUpdate(request, configGroupResponse);
+        updatedServices.putIfAbsent(cluster.getClusterName(), new HashSet<>());
+        updatedServices.get(cluster.getClusterName()).add(serviceName);
       } else {
         LOG.warn("Could not determine service name for config group {}, service config version not created",
             configGroup.getId());
       }
     }
 
+    m_configHelper.get().updateAgentConfigs(updatedServices);
   }
 
   @SuppressWarnings("unchecked")

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -1180,8 +1180,9 @@ public class ConfigHelper {
       || !Maps.difference(oldConfigProperties, properties).areEqual()) {
       if (createConfigType(cluster, stackId, controller, configType, properties,
         propertiesAttributes, authenticatedUserName, serviceVersionNote)) {
-        m_metadataHolder.get().updateData(m_ambariManagementController.get().getClusterMetadataOnConfigsUpdate(cluster));
-        m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
+
+        String serviceName = cluster.getServiceForConfigTypes(Collections.singletonList(configType));
+        updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(), Collections.singleton(serviceName)));
       }
     }
   }
@@ -1192,8 +1193,9 @@ public class ConfigHelper {
 
     if (createConfigType(cluster, stackId, controller, configType, properties,
       new HashMap<>(), authenticatedUserName, serviceVersionNote)) {
-      m_metadataHolder.get().updateData(m_ambariManagementController.get().getClusterMetadataOnConfigsUpdate(cluster));
-      m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
+
+      String serviceName = cluster.getServiceForConfigTypes(Collections.singletonList(configType));
+      updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(), Collections.singleton(serviceName)));
     }
   }
 
@@ -1497,16 +1499,93 @@ public class ConfigHelper {
     return stale;
   }
 
+  public void updateAgentConfigs(Map<String, Set<String>> updatedServices) throws AmbariException {
+
+    // get all used clusters in request
+    List<Cluster> clustersInUse = new ArrayList<>();
+    for (String clusterName : updatedServices.keySet()) {
+      Cluster cluster;
+      cluster = clusters.getCluster(clusterName);
+      clustersInUse.add(cluster);
+    }
+
+    // get all current and previous host configs
+    Map<Long, AgentConfigsUpdateEvent> currentConfigEvents = new HashMap<>();
+    Map<Long, AgentConfigsUpdateEvent> previousConfigEvents = new HashMap<>();
+    for (Cluster cluster : clustersInUse) {
+      for (Host host : cluster.getHosts()) {
+        Long hostId = host.getHostId();
+        if (!currentConfigEvents.containsKey(hostId)) {
+          currentConfigEvents.put(host.getHostId(), m_agentConfigsHolder.get().getCurrentData(hostId));
+        }
+        if (!previousConfigEvents.containsKey(host.getHostId())) {
+          previousConfigEvents.put(host.getHostId(), m_agentConfigsHolder.get().getData(hostId));
+        }
+      }
+    }
+
+    for (Cluster cluster : clustersInUse) {
+      Map<Long, Map<String, Collection<String>>> changedConfigs = new HashMap<>();
+      for (Host host : cluster.getHosts()) {
+        AgentConfigsUpdateEvent currentConfigsEvent = currentConfigEvents.get(host.getHostId());
+        AgentConfigsUpdateEvent previousConfigsEvent = previousConfigEvents.get(host.getHostId());
+
+        SortedMap<String, SortedMap<String, String>> currentConfigs =
+            currentConfigsEvent.getClustersConfigs().get(Long.toString(cluster.getClusterId())).getConfigurations();
+        SortedMap<String, SortedMap<String, String>> previousConfigs =
+            previousConfigsEvent.getClustersConfigs().get(Long.toString(cluster.getClusterId())).getConfigurations();
+
+        Map<String, Collection<String>> changedConfigsHost = new HashMap<>();
+        for (String currentConfigType : currentConfigs.keySet()) {
+          if (previousConfigs.containsKey(currentConfigType)) {
+            Set<String> changedKeys = new HashSet<>();
+            Map<String, String> currentTypedConfigs = currentConfigs.get(currentConfigType);
+            Map<String, String> previousTypedConfigs = previousConfigs.get(currentConfigType);
+
+            for (String currentKey : currentTypedConfigs.keySet()) {
+              if (!previousTypedConfigs.containsKey(currentKey)
+                  || !currentTypedConfigs.get(currentKey).equals(previousTypedConfigs.get(currentKey))) {
+                changedKeys.add(currentKey);
+              }
+            }
+            for (String previousKey : previousTypedConfigs.keySet()) {
+              if (!currentTypedConfigs.containsKey(previousKey)) {
+                changedKeys.add(previousKey);
+              }
+            }
+
+            if (!changedKeys.isEmpty()) {
+              changedConfigsHost.put(currentConfigType, changedKeys);
+            }
+          } else {
+            changedConfigsHost.put(currentConfigType, currentConfigs.get(currentConfigType).keySet());
+          }
+        }
+        for (String previousConfigType : previousConfigs.keySet()) {
+          if (!currentConfigs.containsKey(previousConfigType)) {
+            changedConfigsHost.put(previousConfigType, previousConfigs.get(previousConfigType).keySet());
+          }
+        }
+        changedConfigs.put(host.getHostId(), changedConfigsHost);
+      }
+      for (String serviceName : updatedServices.get(cluster.getClusterName())) {
+        checkStaleConfigsStatusOnConfigsUpdate(cluster.getClusterId(), serviceName, changedConfigs);
+      }
+
+      m_metadataHolder.get().updateData(m_ambariManagementController.get().getClusterMetadataOnConfigsUpdate(cluster));
+      m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
+    }
+  }
+
   /**
    * Checks configs are stale after specified config changes for service's components.
    * @param clusterId cluster with changed config
    * @param serviceName service for changed config
-   * @param hostNames hosts with changed config, can be null
    * @param changedConfigs map of config types to collections of changed properties' names.
    * @throws AmbariException
    */
-  public void checkStaleConfigsStatusOnConfigsUpdate(Long clusterId, String serviceName, Collection<String> hostNames,
-                                                     Map<String, Collection<String>> changedConfigs) throws AmbariException {
+  public void checkStaleConfigsStatusOnConfigsUpdate(Long clusterId, String serviceName,
+                                                     Map<Long, Map<String, Collection<String>>> changedConfigs) throws AmbariException {
     if (MapUtils.isEmpty(changedConfigs)) {
       return;
     }
@@ -1517,16 +1596,11 @@ public class ConfigHelper {
     Service service = clusters.getCluster(clusterId).getService(serviceName);
     for (ServiceComponent serviceComponent : service.getServiceComponents().values()) {
       String serviceComponentHostName = serviceComponent.getName();
-      Set<String> hosts;
-      if (CollectionUtils.isNotEmpty(hostNames)) {
-        hosts = new HashSet<>(hostNames);
-      } else {
-        hosts = serviceComponent.getServiceComponentsHosts();
-      }
       for (ServiceComponentHost serviceComponentHost : serviceComponent.getServiceComponentHosts().values()) {
-        if (hosts.contains(serviceComponentHost.getHostName())) {
+        if (changedConfigs.keySet().contains(serviceComponentHost.getHost().getHostId())) {
           boolean staleConfigs = checkStaleConfigsStatusForHostComponent(serviceComponentHost,
-              changedConfigs);
+              changedConfigs.get(serviceComponentHost.getHost().getHostId()));
+
           if (wasStaleConfigsStatusUpdated(clusterId, serviceComponentHost.getHost().getHostId(),
               serviceName, serviceComponentHostName, staleConfigs)) {
             serviceComponentHost.setRestartRequiredWithoutEventPublishing(staleConfigs);

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -1499,6 +1499,13 @@ public class ConfigHelper {
     return stale;
   }
 
+  /**
+   * Checks populated services for staled configs and updates agent configs.
+   * Method retrieves actual agent configs and compares them with just generated to identify stale configs.
+   * Then config updates are sent to agents.
+   * @param updatedServices service names mapped by cluster names
+   * @throws AmbariException
+   */
   public void updateAgentConfigs(Map<String, Set<String>> updatedServices) throws AmbariException {
 
     // get all used clusters in request

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -1534,13 +1534,13 @@ public class ConfigHelper {
     for (Cluster cluster : clustersInUse) {
       Map<Long, Map<String, Collection<String>>> changedConfigs = new HashMap<>();
       for (Host host : cluster.getHosts()) {
-        AgentConfigsUpdateEvent currentConfigsEvent = currentConfigEvents.get(host.getHostId());
-        AgentConfigsUpdateEvent previousConfigsEvent = previousConfigEvents.get(host.getHostId());
+        AgentConfigsUpdateEvent currentConfigData = currentConfigEvents.get(host.getHostId());
+        AgentConfigsUpdateEvent previousConfigsData = previousConfigEvents.get(host.getHostId());
 
         SortedMap<String, SortedMap<String, String>> currentConfigs =
-            currentConfigsEvent.getClustersConfigs().get(Long.toString(cluster.getClusterId())).getConfigurations();
+            currentConfigData.getClustersConfigs().get(Long.toString(cluster.getClusterId())).getConfigurations();
         SortedMap<String, SortedMap<String, String>> previousConfigs =
-            previousConfigsEvent.getClustersConfigs().get(Long.toString(cluster.getClusterId())).getConfigurations();
+            previousConfigsData.getClustersConfigs().get(Long.toString(cluster.getClusterId())).getConfigurations();
 
         Map<String, Collection<String>> changedConfigsHost = new HashMap<>();
         for (String currentConfigType : currentConfigs.keySet()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -1181,8 +1181,7 @@ public class ConfigHelper {
       if (createConfigType(cluster, stackId, controller, configType, properties,
         propertiesAttributes, authenticatedUserName, serviceVersionNote)) {
 
-        String serviceName = cluster.getServiceForConfigTypes(Collections.singletonList(configType));
-        updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(), Collections.singleton(serviceName)));
+        updateAgentConfigs(Collections.singleton(cluster.getClusterName()));
       }
     }
   }
@@ -1194,8 +1193,7 @@ public class ConfigHelper {
     if (createConfigType(cluster, stackId, controller, configType, properties,
       new HashMap<>(), authenticatedUserName, serviceVersionNote)) {
 
-      String serviceName = cluster.getServiceForConfigTypes(Collections.singletonList(configType));
-      updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(), Collections.singleton(serviceName)));
+      updateAgentConfigs(Collections.singleton(cluster.getClusterName()));
     }
   }
 
@@ -1503,14 +1501,14 @@ public class ConfigHelper {
    * Checks populated services for staled configs and updates agent configs.
    * Method retrieves actual agent configs and compares them with just generated to identify stale configs.
    * Then config updates are sent to agents.
-   * @param updatedServices service names mapped by cluster names
+   * @param updatedClusters names of clusters with changed configs
    * @throws AmbariException
    */
-  public void updateAgentConfigs(Map<String, Set<String>> updatedServices) throws AmbariException {
+  public void updateAgentConfigs(Set<String> updatedClusters) throws AmbariException {
 
     // get all used clusters in request
     List<Cluster> clustersInUse = new ArrayList<>();
-    for (String clusterName : updatedServices.keySet()) {
+    for (String clusterName : updatedClusters) {
       Cluster cluster;
       cluster = clusters.getCluster(clusterName);
       clustersInUse.add(cluster);
@@ -1575,7 +1573,7 @@ public class ConfigHelper {
         }
         changedConfigs.put(host.getHostId(), changedConfigsHost);
       }
-      for (String serviceName : updatedServices.get(cluster.getClusterName())) {
+      for (String serviceName : cluster.getServices().keySet()) {
         checkStaleConfigsStatusOnConfigsUpdate(cluster.getClusterId(), serviceName, changedConfigs);
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -950,10 +950,11 @@ public class UpgradeHelper {
 
     Set<String> clusterConfigTypes = new HashSet<>();
     Set<String> processedClusterConfigTypes = new HashSet<>();
-    boolean configsChanged = false;
+    Set<String> servicesWithUpdatedConfigs = new HashSet<>();
 
     // merge or revert configurations for any service that needs it
     for (String serviceName : servicesInUpgrade) {
+      boolean configsChanged = false;
       RepositoryVersionEntity sourceRepositoryVersion = upgradeContext.getSourceRepositoryVersion(serviceName);
       RepositoryVersionEntity targetRepositoryVersion = upgradeContext.getTargetRepositoryVersion(serviceName);
       StackId sourceStackId = sourceRepositoryVersion.getStackId();
@@ -1156,10 +1157,13 @@ public class UpgradeHelper {
             newServiceDefaultConfigsByType, userName, serviceVersionNote);
         configsChanged = true;
       }
+      if (configsChanged) {
+        servicesWithUpdatedConfigs.add(serviceName);
+      }
     }
-    if (configsChanged) {
-      m_metadataHolder.get().updateData(m_controllerProvider.get().getClusterMetadataOnConfigsUpdate(cluster));
-      m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
+    if (!servicesWithUpdatedConfigs.isEmpty()) {
+      m_configHelperProvider.get().updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(),
+          servicesWithUpdatedConfigs));
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -950,11 +950,10 @@ public class UpgradeHelper {
 
     Set<String> clusterConfigTypes = new HashSet<>();
     Set<String> processedClusterConfigTypes = new HashSet<>();
-    Set<String> servicesWithUpdatedConfigs = new HashSet<>();
+    boolean configsChanged = false;
 
     // merge or revert configurations for any service that needs it
     for (String serviceName : servicesInUpgrade) {
-      boolean configsChanged = false;
       RepositoryVersionEntity sourceRepositoryVersion = upgradeContext.getSourceRepositoryVersion(serviceName);
       RepositoryVersionEntity targetRepositoryVersion = upgradeContext.getTargetRepositoryVersion(serviceName);
       StackId sourceStackId = sourceRepositoryVersion.getStackId();
@@ -1157,13 +1156,9 @@ public class UpgradeHelper {
             newServiceDefaultConfigsByType, userName, serviceVersionNote);
         configsChanged = true;
       }
-      if (configsChanged) {
-        servicesWithUpdatedConfigs.add(serviceName);
-      }
     }
-    if (!servicesWithUpdatedConfigs.isEmpty()) {
-      m_configHelperProvider.get().updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(),
-          servicesWithUpdatedConfigs));
+    if (configsChanged) {
+      m_configHelperProvider.get().updateAgentConfigs(Collections.singleton(cluster.getClusterName()));
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1615,7 +1615,6 @@ public class ClusterImpl implements Cluster {
       }
       STOMPUpdatePublisher.publish(new ConfigsUpdateEvent(serviceConfigEntity,
           configGroup == null ? null : configGroup.getName(), groupHostNames, changedConfigs.keySet()));
-      configHelper.checkStaleConfigsStatusOnConfigsUpdate(clusterEntity.getClusterId(), serviceName, groupHostNames, changedConfigs);
     } finally {
       clusterGlobalLock.writeLock().unlock();
     }
@@ -1955,7 +1954,6 @@ public class ClusterImpl implements Cluster {
         configGroupName,
         groupHostNames,
         changedConfigs.keySet()));
-    configHelper.checkStaleConfigsStatusOnConfigsUpdate(clusterEntity.getClusterId(), serviceName, groupHostNames, changedConfigs);
 
     return convertToServiceConfigVersionResponse(serviceConfigEntityClone);
   }
@@ -1963,7 +1961,8 @@ public class ClusterImpl implements Cluster {
   @Transactional
   ServiceConfigVersionResponse applyConfigs(Set<Config> configs, String user, String serviceConfigVersionNote) throws AmbariException{
 
-List<ClusterConfigEntity> appliedConfigs = new ArrayList<>();    String serviceName = getServiceForConfigTypes( configs.stream().map(Config::getType).collect(toList()));
+    List<ClusterConfigEntity> appliedConfigs = new ArrayList<>();
+    String serviceName = getServiceForConfigTypes(configs.stream().map(Config::getType).collect(toList()));
     // update the selected flag for every config type
     ClusterEntity clusterEntity = getClusterEntity();
     Collection<ClusterConfigEntity> clusterConfigs = clusterEntity.getClusterConfigEntities();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -38,6 +38,7 @@ import org.apache.ambari.server.ClusterNotFoundException;
 import org.apache.ambari.server.DuplicateResourceException;
 import org.apache.ambari.server.HostNotFoundException;
 import org.apache.ambari.server.agent.DiskInfo;
+import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.agent.stomp.TopologyHolder;
 import org.apache.ambari.server.agent.stomp.dto.TopologyCluster;
@@ -151,6 +152,9 @@ public class ClustersImpl implements Clusters {
 
   @Inject
   private Provider<TopologyHolder> m_topologyHolder;
+
+  @Inject
+  private Provider<AgentConfigsHolder> m_agentConfigsHolder;
 
   @Inject
   private Provider<MetadataHolder> m_metadataHolder;
@@ -305,6 +309,14 @@ public class ClustersImpl implements Clusters {
       for (ClusterEntity clusterEntity : hostEntity.getClusterEntities()) {
         clusterHostsMap1.get(clusterEntity.getClusterName()).add(host);
         cSet.add(clustersByName.get(clusterEntity.getClusterName()));
+      }
+    }
+    // init host configs
+    for (Long hostId : hostsById.keySet()) {
+      try {
+        m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true);
+      } catch (AmbariException e) {
+        LOG.error("Agent configs initialization was failed", e);
       }
     }
   }
@@ -479,6 +491,12 @@ public class ClustersImpl implements Clusters {
 
     if (null != hostId) {
       getHostsById().put(hostId, host);
+      // init host configs
+      try {
+        m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true);
+      } catch (AmbariException e) {
+        LOG.error("Agent configs initialization was failed for host with id %s", hostId, e);
+      }
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
@@ -638,8 +638,7 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
             }
 
             ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
-            configHelper.updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(),
-                Collections.singleton(serviceName)));
+            configHelper.updateAgentConfigs(Collections.singleton(cluster.getClusterName()));
           }
         } else {
           LOG.info("No changes detected to config " + configType + ". Skipping configuration properties update");

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
@@ -45,8 +45,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
-import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
-import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.configuration.Configuration.DatabaseType;
@@ -638,10 +636,10 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
                 + "tag='" + baseConfig.getTag() + "'"
                 + oldConfigString);
             }
-            MetadataHolder metadataHolder = injector.getInstance(MetadataHolder.class);
-            AgentConfigsHolder agentConfigsHolder = injector.getInstance(AgentConfigsHolder.class);
-            metadataHolder.updateData(controller.getClusterMetadataOnConfigsUpdate(cluster));
-            agentConfigsHolder.updateData(cluster.getClusterId(), null);
+
+            ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
+            configHelper.updateAgentConfigs(Collections.singletonMap(cluster.getClusterName(),
+                Collections.singleton(serviceName)));
           }
         } else {
           LOG.info("No changes detected to config " + configType + ". Skipping configuration properties update");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.H2DatabaseCleaner;
@@ -45,6 +46,7 @@ import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.RequestResourceFilter;
 import org.apache.ambari.server.controller.internal.ServiceResourceProviderTest;
 import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.events.AgentConfigsUpdateEvent;
 import org.apache.ambari.server.metadata.ActionMetadata;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
@@ -143,6 +145,9 @@ public class AmbariCustomCommandExecutionHelperTest {
         EasyMock.anyObject(PropertyInfo.PropertyType.class),
         EasyMock.anyObject(Cluster.class),
         EasyMock.anyObject(Map.class))).andReturn(Collections.EMPTY_SET);
+
+    EasyMock.expect(configHelper.getHostActualConfigs(EasyMock.anyLong())).andReturn(
+        new AgentConfigsUpdateEvent(new TreeMap<>())).anyTimes();
 
     EasyMock.replay(configHelper);
 
@@ -538,7 +543,14 @@ public class AmbariCustomCommandExecutionHelperTest {
   public void testIsTopologyRefreshRequired() throws Exception {
     AmbariCustomCommandExecutionHelper helper = injector.getInstance(AmbariCustomCommandExecutionHelper.class);
 
+    EasyMock.expect(configHelper.getHostActualConfigs(EasyMock.anyLong())).andReturn(
+        new AgentConfigsUpdateEvent(new TreeMap<>())).anyTimes();
+
+    EasyMock.replay(configHelper);
+
     createClusterFixture("c2", new StackId("HDP-2.1.1"), "2.1.1.0-1234", "c2");
+
+    EasyMock.verify(configHelper);
 
     Assert.assertTrue(helper.isTopologyRefreshRequired("START", "c2", "HDFS"));
     Assert.assertTrue(helper.isTopologyRefreshRequired("RESTART", "c2", "HDFS"));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -982,19 +982,11 @@ public class AmbariManagementControllerImplTest {
     constructorInit(injector, controllerCapture, null, null,
         kerberosHelper, m_metadataHolder, m_agentConfigsHolder);
 
-    expect(m_metadataHolder.get()).andReturn(metadataHolder);
-    expect(metadataHolder.updateData(anyObject())).andReturn(true);
-
-    expect(m_agentConfigsHolder.get()).andReturn(agentConfigsHolder);
-    agentConfigsHolder.updateData(anyLong(), anyObject(List.class));
-    expectLastCall();
-
     expect(clusterRequest.getClusterId()).andReturn(1L).times(4);
     expect(clusterRequest.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
     expect(clusters.getClusterById(1L)).andReturn(cluster).times(1);
     expect(cluster.getResourceId()).andReturn(1L).times(3);
     expect(cluster.getClusterName()).andReturn("cluster").times(1);
-    expect(cluster.getClusterId()).andReturn(1L).times(1);
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
     expect(cluster.getCurrentStackVersion()).andReturn(null).anyTimes();
     expect(cluster.getDesiredStackVersion()).andReturn(null).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProviderTest.java
@@ -31,6 +31,7 @@ import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,6 +79,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Module;
+import com.google.inject.Provider;
 import com.google.inject.util.Modules;
 
 public class ConfigGroupResourceProviderTest {
@@ -97,12 +99,24 @@ public class ConfigGroupResourceProviderTest {
   }
 
   private ConfigGroupResourceProvider getConfigGroupResourceProvider
-      (AmbariManagementController managementController) {
+      (AmbariManagementController managementController) throws NoSuchFieldException, IllegalAccessException {
     Resource.Type type = Resource.Type.ConfigGroup;
 
-    return (ConfigGroupResourceProvider) AbstractControllerResourceProvider.getResourceProvider(
+    ConfigGroupResourceProvider configGroupResourceProvider =
+        (ConfigGroupResourceProvider) AbstractControllerResourceProvider.getResourceProvider(
         type,
         managementController);
+
+    Provider<ConfigHelper> configHelperProvider = createNiceMock(Provider.class);
+    expect(configHelperProvider.get()).andReturn(createNiceMock(ConfigHelper.class));
+
+    replay(configHelperProvider);
+
+    Field m_configHelper = ConfigGroupResourceProvider.class.getDeclaredField("m_configHelper");
+    m_configHelper.setAccessible(true);
+    m_configHelper.set(configGroupResourceProvider, configHelperProvider);
+
+    return configGroupResourceProvider;
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
@@ -216,14 +216,6 @@ public class ClusterTest {
       hostEntity.setHostAttributes(gson.toJson(hostAttributes));
 
 
-//      hostDAO.merge(hostEntity);
-
-      HostVersionEntity hostVersionEntity = new HostVersionEntity();
-      hostVersionEntity.setRepositoryVersion(repositoryVersion);
-      hostVersionEntity.setState(RepositoryVersionState.CURRENT);
-      hostVersionEntity.setHostEntity(hostEntity);
-      hostEntity.setHostVersionEntities(Collections.singletonList(hostVersionEntity));
-
       hostDAO.merge(hostEntity);
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog252Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog252Test.java
@@ -258,7 +258,7 @@ public class UpgradeCatalog252Test {
     Injector injector = getInjector(clusters, controller);
 
     final ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
-    configHelper.updateAgentConfigs(anyObject(Map.class));
+    configHelper.updateAgentConfigs(anyObject(Set.class));
     expectLastCall().times(2);
 
     replay(configHelper);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
@@ -657,7 +657,7 @@ public class UpgradeCatalog260Test {
 
     Capture<? extends Map<String, String>> captureCoreSiteConfProperties = newCapture();
 
-    configHelper.updateAgentConfigs(anyObject(Map.class));
+    configHelper.updateAgentConfigs(anyObject(Set.class));
     expectLastCall();
 
     expect(clusters.getClusters()).andReturn(Collections.singletonMap("c1", cluster)).once();
@@ -728,7 +728,7 @@ public class UpgradeCatalog260Test {
 
     ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
 
-    configHelper.updateAgentConfigs(anyObject(Map.class));
+    configHelper.updateAgentConfigs(anyObject(Set.class));
     expectLastCall().once();
 
     ArtifactDAO artifactDAO = createMock(ArtifactDAO.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createMockBuilder;
 import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -74,7 +75,6 @@ import org.apache.ambari.server.controller.MaintenanceStateHelper;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
 import org.apache.ambari.server.controller.ServiceConfigVersionResponse;
 import org.apache.ambari.server.events.AmbariEvent;
-import org.apache.ambari.server.events.MetadataUpdateEvent;
 import org.apache.ambari.server.events.publishers.STOMPUpdatePublisher;
 import org.apache.ambari.server.hooks.AmbariEventFactory;
 import org.apache.ambari.server.hooks.HookContext;
@@ -100,6 +100,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.ConfigFactory;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.ConfigImpl;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.Service;
@@ -647,6 +648,7 @@ public class UpgradeCatalog260Test {
     Injector injector = getInjector();
 
     final Clusters clusters = injector.getInstance(Clusters.class);
+    final ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
     final Cluster cluster = createMock(Cluster.class);
     final Config zeppelinEnvConf = createMock(Config.class);
     final Config coreSiteConf = createMock(Config.class);
@@ -655,10 +657,12 @@ public class UpgradeCatalog260Test {
 
     Capture<? extends Map<String, String>> captureCoreSiteConfProperties = newCapture();
 
+    configHelper.updateAgentConfigs(anyObject(Map.class));
+    expectLastCall();
+
     expect(clusters.getClusters()).andReturn(Collections.singletonMap("c1", cluster)).once();
 
     expect(cluster.getClusterName()).andReturn("c1").atLeastOnce();
-    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.6")).atLeastOnce();
     expect(cluster.getDesiredConfigByType("zeppelin-env")).andReturn(zeppelinEnvConf).atLeastOnce();
     expect(cluster.getDesiredConfigByType("core-site")).andReturn(coreSiteConf).atLeastOnce();
@@ -675,16 +679,13 @@ public class UpgradeCatalog260Test {
     expect(controller.createConfig(eq(cluster), anyObject(StackId.class), eq("core-site"), capture(captureCoreSiteConfProperties), anyString(), anyObject(Map.class)))
         .andReturn(coreSiteConfNew)
         .once();
-    expect(controller.getClusterMetadataOnConfigsUpdate(eq(cluster)))
-        .andReturn(createNiceMock(MetadataUpdateEvent.class))
-        .once();
 
-    replay(clusters, cluster, zeppelinEnvConf, coreSiteConf, coreSiteConfNew, controller);
+    replay(clusters, cluster, zeppelinEnvConf, coreSiteConf, coreSiteConfNew, controller, configHelper);
 
     UpgradeCatalog260 upgradeCatalog260 = injector.getInstance(UpgradeCatalog260.class);
     upgradeCatalog260.ensureZeppelinProxyUserConfigs();
 
-    verify(clusters, cluster, zeppelinEnvConf, coreSiteConf, coreSiteConfNew, controller);
+    verify(clusters, cluster, zeppelinEnvConf, coreSiteConf, coreSiteConfNew, controller, configHelper);
 
     assertTrue(captureCoreSiteConfProperties.hasCaptured());
     Assert.assertEquals("existing_value", captureCoreSiteConfProperties.getValue().get("hadoop.proxyuser.zeppelin_user.hosts"));
@@ -723,6 +724,11 @@ public class UpgradeCatalog260Test {
     Capture<Map<String, Object>> captureMap = newCapture();
     expect(artifactEntity.getForeignKeys()).andReturn(Collections.singletonMap("cluster", "2")).times(2);
     artifactEntity.setArtifactData(capture(captureMap));
+    expectLastCall().once();
+
+    ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
+
+    configHelper.updateAgentConfigs(anyObject(Map.class));
     expectLastCall().once();
 
     ArtifactDAO artifactDAO = createMock(ArtifactDAO.class);
@@ -768,7 +774,6 @@ public class UpgradeCatalog260Test {
     expect(cluster.getConfigsByType("ranger-kms-audit")).andReturn(Collections.singletonMap("version1", config)).anyTimes();
     expect(cluster.getServiceByConfigType("ranger-kms-audit")).andReturn("RANGER").anyTimes();
     expect(cluster.getClusterName()).andReturn("cl1").anyTimes();
-    expect(cluster.getClusterId()).andReturn(1L).atLeastOnce();
     expect(cluster.getConfig(eq("ranger-kms-audit"), anyString())).andReturn(newConfig).once();
     expect(cluster.addDesiredConfig("ambari-upgrade", Collections.singleton(newConfig), "Updated ranger-kms-audit during Ambari Upgrade from 2.5.2 to 2.6.0.")).andReturn(response).once();
 
@@ -795,15 +800,12 @@ public class UpgradeCatalog260Test {
     expect(controller.createConfig(eq(cluster), eq(stackId), eq("hive-interactive-site"), capture(captureHsiProperties), anyString(), anyObject(Map.class)))
             .andReturn(null)
             .anyTimes();
-    expect(controller.getClusterMetadataOnConfigsUpdate(eq(cluster)))
-        .andReturn(createNiceMock(MetadataUpdateEvent.class))
-        .once();
 
-    replay(artifactDAO, artifactEntity, cluster, clusters, config, newConfig, hsiConfig, newHsiConfig, response, response1, controller, stackId);
+    replay(artifactDAO, artifactEntity, cluster, clusters, config, newConfig, hsiConfig, newHsiConfig, response, response1, controller, stackId, configHelper);
 
     UpgradeCatalog260 upgradeCatalog260 = injector.getInstance(UpgradeCatalog260.class);
     upgradeCatalog260.updateKerberosDescriptorArtifact(artifactDAO, artifactEntity);
-    verify(artifactDAO, artifactEntity, cluster, clusters, config, newConfig, response, controller, stackId);
+    verify(artifactDAO, artifactEntity, cluster, clusters, config, newConfig, response, controller, stackId, configHelper);
     KerberosDescriptor kerberosDescriptorUpdated = new KerberosDescriptorFactory().createInstance(captureMap.getValue());
     Assert.assertNotNull(kerberosDescriptorUpdated);
 
@@ -1107,6 +1109,7 @@ public class UpgradeCatalog260Test {
         binder.bind(KerberosHelper.class).toInstance(createNiceMock(KerberosHelperImpl.class));
         binder.bind(MetadataHolder.class).toInstance(createNiceMock(MetadataHolder.class));
         binder.bind(AgentConfigsHolder.class).toInstance(createNiceMock(AgentConfigsHolder.class));
+        binder.bind(ConfigHelper.class).toInstance(createStrictMock(ConfigHelper.class));
 
         binder.install(new FactoryModuleBuilder().build(RequestFactory.class));
         binder.install(new FactoryModuleBuilder().build(ConfigureClusterTaskFactory.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -118,6 +118,7 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createMockBuilder;
 import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -177,7 +178,6 @@ import org.apache.ambari.server.controller.KerberosHelperImpl;
 import org.apache.ambari.server.controller.MaintenanceStateHelper;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
 import org.apache.ambari.server.controller.ServiceConfigVersionResponse;
-import org.apache.ambari.server.events.MetadataUpdateEvent;
 import org.apache.ambari.server.hooks.HookService;
 import org.apache.ambari.server.hooks.users.UserHookService;
 import org.apache.ambari.server.metadata.CachedRoleCommandOrderProvider;
@@ -1082,7 +1082,6 @@ public class UpgradeCatalog270Test {
     expect(cluster1.getConfigsByType("kerberos-env")).andReturn(Collections.singletonMap("v1", configWithGroup)).atLeastOnce();
     expect(cluster1.getServiceByConfigType("kerberos-env")).andReturn("KERBEROS").atLeastOnce();
     expect(cluster1.getClusterName()).andReturn("c1").atLeastOnce();
-    expect(cluster1.getClusterId()).andReturn(1L).atLeastOnce();
     expect(cluster1.getDesiredStackVersion()).andReturn(stackId).atLeastOnce();
     expect(cluster1.getConfig(eq("kerberos-env"), anyString())).andReturn(newConfig).atLeastOnce();
     expect(cluster1.addDesiredConfig("ambari-upgrade", Collections.singleton(newConfig), "Updated kerberos-env during Ambari Upgrade from 2.6.2 to 2.7.0.")).andReturn(response).once();
@@ -1117,19 +1116,23 @@ public class UpgradeCatalog270Test {
         .createMock();
     expect(controller.getClusters()).andReturn(clusters).anyTimes();
     expect(controller.createConfig(eq(cluster1), eq(stackId), eq("kerberos-env"), capture(capturedProperties), anyString(), anyObject(Map.class))).andReturn(newConfig).once();
-    expect(controller.getClusterMetadataOnConfigsUpdate(eq(cluster1))).andReturn(createNiceMock(MetadataUpdateEvent.class)).once();
 
 
     Injector injector = createNiceMock(Injector.class);
+    ConfigHelper configHelper = createStrictMock(ConfigHelper.class);
     expect(injector.getInstance(AmbariManagementController.class)).andReturn(controller).anyTimes();
     expect(injector.getInstance(MetadataHolder.class)).andReturn(createNiceMock(MetadataHolder.class)).anyTimes();
     expect(injector.getInstance(AgentConfigsHolder.class)).andReturn(createNiceMock(AgentConfigsHolder.class)).anyTimes();
     expect(injector.getInstance(AmbariServer.class)).andReturn(createNiceMock(AmbariServer.class)).anyTimes();
+    expect(injector.getInstance(ConfigHelper.class)).andReturn(configHelper).anyTimes();
     KerberosHelper kerberosHelperMock = createNiceMock(KerberosHelper.class);
     expect(kerberosHelperMock.createTemporaryDirectory()).andReturn(new File("/invalid/file/path")).times(2);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(kerberosHelperMock).anyTimes();
 
-    replay(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, kerberosHelperMock);
+    configHelper.updateAgentConfigs(anyObject(Map.class));
+    expectLastCall();
+
+    replay(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, kerberosHelperMock, configHelper);
 
     Field field = AbstractUpgradeCatalog.class.getDeclaredField("configuration");
 
@@ -1145,7 +1148,7 @@ public class UpgradeCatalog270Test {
     field.set(upgradeCatalog270, createNiceMock(Configuration.class));
     upgradeCatalog270.updateKerberosConfigurations();
 
-    verify(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, upgradeCatalog270);
+    verify(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, upgradeCatalog270, configHelper);
 
 
     Assert.assertEquals(1, capturedProperties.getValues().size());

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -149,6 +149,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.EntityManager;
 
@@ -1129,7 +1130,7 @@ public class UpgradeCatalog270Test {
     expect(kerberosHelperMock.createTemporaryDirectory()).andReturn(new File("/invalid/file/path")).times(2);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(kerberosHelperMock).anyTimes();
 
-    configHelper.updateAgentConfigs(anyObject(Map.class));
+    configHelper.updateAgentConfigs(anyObject(Set.class));
     expectLastCall();
 
     replay(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, kerberosHelperMock, configHelper);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server compares actual agent configs with updated to identify configs that were staled. Also server checks non-service configs and all components depended for changed configs.

## How was this patch tested?

Manual testing.