### PR TITLE
AMBARI-23761. Add organization / license data to ambari-infra and ambari-logsearch.

### DIFF
--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -37,6 +37,22 @@
     <skipSurefireTests>false</skipSurefireTests>
   </properties>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <organization>
+    <name>Apache Software Foundation</name>
+    <url>http://www.apache.org</url>
+  </organization>
+  <issueManagement>
+    <system>jira</system>
+    <url>https://issues.apache.org/jira/browse/AMBARI</url>
+  </issueManagement>
+
   <repositories>
     <repository>
       <id>apache-hadoop</id>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -50,6 +50,23 @@
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
     <skipSurefireTests>false</skipSurefireTests>
   </properties>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <organization>
+    <name>Apache Software Foundation</name>
+    <url>http://www.apache.org</url>
+  </organization>
+  <issueManagement>
+    <system>jira</system>
+    <url>https://issues.apache.org/jira/browse/AMBARI</url>
+  </issueManagement>
+
   <repositories>
     <repository>
       <id>apache-hadoop</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Organization / vendor data is missing from rpm details, which can cause that rpms cannot be upgraded as the vendor is different.

Cause of this issue could be that ambari-logsearch and ambari-infra are not extended from ambari-project module anymore

## How was this patch tested?
done manually. output after generating rpm with the changes:
```bash
Name        : ambari-logsearch-logfeeder
Version     : 2.0.0.0
Release     : SNAPSHOT
Architecture: noarch
Install Date: (not installed)
Group       : Development
Size        : 59901382
License     : (c) Apache Software Foundation
Signature   : (none)
Source RPM  : ambari-logsearch-logfeeder-2.0.0.0-SNAPSHOT.src.rpm
Build Date  : Fri May  4 14:01:17 2018
Build Host  : Olivers-MacBook-Pro.local
Relocations : /
Packager    : Apache Software Foundation
Vendor      : Apache Software Foundation
URL         : http://www.apache.org
Summary     : Ambari Logsearch Assembly
Description :
Maven Recipe: RPM Package.
```

please review @adoroszlai @smolnar82 @kasakrisz 
