### PR TITLE
[AMBARI-22827] Loading hostTaskIds, hostRequestIds and topologyRequestIds in batches to avoid issues triggered by JDBC limitations on prepared statement parameter list size

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/cleanup/CleanupDriver.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/cleanup/CleanupDriver.java
@@ -23,6 +23,7 @@ import java.util.Date;
 
 import org.apache.ambari.server.audit.AuditLoggerModule;
 import org.apache.ambari.server.controller.ControllerModule;
+import org.apache.ambari.server.ldap.LdapModule;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -80,7 +81,7 @@ public class CleanupDriver {
     CleanupContext cleanupContext = processArguments(args);
 
     // set up the guice context
-    Injector injector = Guice.createInjector(new ControllerModule(), new AuditLoggerModule(), new CleanupModule());
+    Injector injector = Guice.createInjector(new ControllerModule(), new AuditLoggerModule(), new CleanupModule(), new LdapModule());
 
     // explicitly starting the persist service
     injector.getInstance(AmbariJpaPersistService.class).start();

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RequestDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RequestDAO.java
@@ -443,13 +443,16 @@ public class RequestDAO implements Cleanable {
     final Set<Long> hostTaskIds = new HashSet<>();
     final Set<Long> partialTaskIds = new HashSet<>();
     taskIds.forEach(taskId -> {
-      if (partialTaskIds.size() <= BATCH_SIZE) {
-        partialTaskIds.add(taskId);
-      } else {
+      partialTaskIds.add(taskId);
+      if (partialTaskIds.size() == BATCH_SIZE) {
         hostTaskIds.addAll(topologyLogicalTaskDAO.findHostTaskIdsByPhysicalTaskIds(partialTaskIds));
         partialTaskIds.clear();
       }
     });
+
+    if (!partialTaskIds.isEmpty()) {
+      hostTaskIds.addAll(topologyLogicalTaskDAO.findHostTaskIdsByPhysicalTaskIds(partialTaskIds));
+    }
     return hostTaskIds;
   }
 
@@ -458,13 +461,16 @@ public class RequestDAO implements Cleanable {
     final Set<Long> partialHostTaskIds = new HashSet<>();
 
     hostTaskIds.forEach(taskId -> {
-      if (partialHostTaskIds.size() <= BATCH_SIZE) {
-        partialHostTaskIds.add(taskId);
-      } else {
+      partialHostTaskIds.add(taskId);
+      if (partialHostTaskIds.size() == BATCH_SIZE) {
         hostRequestIds.addAll(topologyHostTaskDAO.findHostRequestIdsByHostTaskIds(partialHostTaskIds));
         partialHostTaskIds.clear();
       }
     });
+
+    if (!partialHostTaskIds.isEmpty()) {
+      hostRequestIds.addAll(topologyHostTaskDAO.findHostRequestIdsByHostTaskIds(partialHostTaskIds));
+    }
     return hostRequestIds;
   }
 
@@ -473,13 +479,16 @@ public class RequestDAO implements Cleanable {
     final Set<Long> partialHostRequestIds = new HashSet<>();
 
     hostRequestIds.forEach(requestId -> {
-      if (partialHostRequestIds.size() <= BATCH_SIZE) {
-        partialHostRequestIds.add(requestId);
-      } else {
+      partialHostRequestIds.add(requestId);
+      if (partialHostRequestIds.size() == BATCH_SIZE) {
         topologyRequestIds.addAll(topologyLogicalRequestDAO.findRequestIdsByIds(partialHostRequestIds));
         partialHostRequestIds.clear();
       }
     });
+
+    if (!partialHostRequestIds.isEmpty()) {
+      topologyRequestIds.addAll(topologyHostTaskDAO.findHostRequestIdsByHostTaskIds(partialHostRequestIds));
+    }
     return topologyRequestIds;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RequestDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RequestDAO.java
@@ -97,9 +97,6 @@ public class RequestDAO implements Cleanable {
   private HostRoleCommandDAO hostRoleCommandDAO;
 
   @Inject
-  private StageDAO stageDAO;
-
-  @Inject
   private TopologyLogicalTaskDAO topologyLogicalTaskDAO;
 
   @Inject
@@ -315,11 +312,11 @@ public class RequestDAO implements Cleanable {
   protected <T> int cleanTableByIds(Set<Long> ids, String paramName, String entityName, Long beforeDateMillis,
                                   String entityQuery, Class<T> type) {
     LOG.info(String.format("Deleting %s entities before date %s", entityName, new Date(beforeDateMillis)));
-    EntityManager entityManager = entityManagerProvider.get();
     int affectedRows = 0;
-    // Batch delete
-    TypedQuery<T> query = entityManager.createNamedQuery(entityQuery, type);
     if (ids != null && !ids.isEmpty()) {
+      EntityManager entityManager = entityManagerProvider.get();
+      // Batch delete
+      TypedQuery<T> query = entityManager.createNamedQuery(entityQuery, type);
       for (int i = 0; i < ids.size(); i += BATCH_SIZE) {
         int endRow = (i + BATCH_SIZE) > ids.size() ? ids.size() : (i + BATCH_SIZE);
         List<Long> idsSubList = new ArrayList<>(ids).subList(i, endRow);
@@ -350,11 +347,11 @@ public class RequestDAO implements Cleanable {
   protected <T> int cleanTableByStageEntityPK(List<StageEntityPK> ids, LinkedList<String> paramNames, String entityName, Long beforeDateMillis,
                                   String entityQuery, Class<T> type) {
     LOG.info(String.format("Deleting %s entities before date %s", entityName, new Date(beforeDateMillis)));
-    EntityManager entityManager = entityManagerProvider.get();
     int affectedRows = 0;
-    // Batch delete
-    TypedQuery<T> query = entityManager.createNamedQuery(entityQuery, type);
     if (ids != null && !ids.isEmpty()) {
+      EntityManager entityManager = entityManagerProvider.get();
+      // Batch delete
+      TypedQuery<T> query = entityManager.createNamedQuery(entityQuery, type);
       for (int i = 0; i < ids.size(); i += BATCH_SIZE) {
         int endRow = (i + BATCH_SIZE) > ids.size() ? ids.size() : (i + BATCH_SIZE);
         List<StageEntityPK> idsSubList = new ArrayList<>(ids).subList(i, endRow);
@@ -374,10 +371,8 @@ public class RequestDAO implements Cleanable {
   @Transactional
   @Override
   public long cleanup(TimeBasedCleanupPolicy policy) {
-    long affectedRows = 0;
-    Long clusterId = null;
     try {
-      clusterId = m_clusters.get().getCluster(policy.getClusterName()).getClusterId();
+      final Long clusterId = m_clusters.get().getCluster(policy.getClusterName()).getClusterId();
       // find request and stage ids that were created before date populated by user.
       List<StageEntityPK> requestStageIds = findRequestAndStageIdsInClusterBeforeDate(clusterId, policy.getToDateInMillis());
 
@@ -392,7 +387,6 @@ public class RequestDAO implements Cleanable {
         }
       }
 
-
       Set<Long> requestIds = new HashSet<>();
       for (StageEntityPK ids : requestStageIds) {
         requestIds.add(ids.getRequestId());
@@ -400,28 +394,19 @@ public class RequestDAO implements Cleanable {
 
       // find task ids using request stage ids
       Set<Long> taskIds = hostRoleCommandDAO.findTaskIdsByRequestStageIds(requestStageIds);
-      LinkedList<String> params = new LinkedList<>();
-      params.add("stageId");
-      params.add("requestId");
 
       // find host task ids, to find related host requests and also to remove needed host tasks
-      Set<Long> hostTaskIds = new HashSet<>();
-      if (taskIds != null && !taskIds.isEmpty()) {
-        hostTaskIds = topologyLogicalTaskDAO.findHostTaskIdsByPhysicalTaskIds(taskIds);
-      }
+      final Set<Long> hostTaskIds = findHostTaskIds(taskIds);
 
       // find host request ids by host task ids to remove later needed host requests
-      Set<Long> hostRequestIds = new HashSet<>();
-      if (!hostTaskIds.isEmpty()) {
-        hostRequestIds = topologyHostTaskDAO.findHostRequestIdsByHostTaskIds(hostTaskIds);
-      }
+      final Set<Long> hostRequestIds = findHostRequestIds(hostTaskIds);
 
-      Set<Long> topologyRequestIds = new HashSet<>();
-      if (!hostRequestIds.isEmpty()) {
-        topologyRequestIds = topologyLogicalRequestDAO.findRequestIdsByIds(hostRequestIds);
-      }
+      final Set<Long> topologyRequestIds = findTopologyRequestIds(hostRequestIds);
 
-
+      final LinkedList<String> params = new LinkedList<>();
+      params.add("stageId");
+      params.add("requestId");
+      long affectedRows = 0;
       //removing all entities one by one according to their relations using stage, task and request ids
       affectedRows += cleanTableByIds(taskIds, "taskIds", "ExecutionCommand", policy.getToDateInMillis(),
               "ExecutionCommandEntity.removeByTaskIds", ExecutionCommandEntity.class);
@@ -447,11 +432,55 @@ public class RequestDAO implements Cleanable {
       affectedRows += cleanTableByIds(requestIds, "requestIds", "Request", policy.getToDateInMillis(),
               "RequestEntity.removeByRequestIds", RequestEntity.class);
 
+      return affectedRows;
     } catch (AmbariException e) {
       LOG.error("Error while looking up cluster with name: {}", policy.getClusterName(), e);
       throw new IllegalStateException(e);
     }
-
-    return affectedRows;
   }
+
+  private Set<Long> findHostTaskIds(Set<Long> taskIds) {
+    final Set<Long> hostTaskIds = new HashSet<>();
+    final Set<Long> partialTaskIds = new HashSet<>();
+    taskIds.forEach(taskId -> {
+      if (partialTaskIds.size() <= BATCH_SIZE) {
+        partialTaskIds.add(taskId);
+      } else {
+        hostTaskIds.addAll(topologyLogicalTaskDAO.findHostTaskIdsByPhysicalTaskIds(partialTaskIds));
+        partialTaskIds.clear();
+      }
+    });
+    return hostTaskIds;
+  }
+
+  private Set<Long> findHostRequestIds(Set<Long> hostTaskIds) {
+    final Set<Long> hostRequestIds = new HashSet<>();
+    final Set<Long> partialHostTaskIds = new HashSet<>();
+
+    hostTaskIds.forEach(taskId -> {
+      if (partialHostTaskIds.size() <= BATCH_SIZE) {
+        partialHostTaskIds.add(taskId);
+      } else {
+        hostRequestIds.addAll(topologyHostTaskDAO.findHostRequestIdsByHostTaskIds(partialHostTaskIds));
+        partialHostTaskIds.clear();
+      }
+    });
+    return hostRequestIds;
+  }
+
+  private Set<Long> findTopologyRequestIds(final Set<Long> hostRequestIds) {
+    final Set<Long> topologyRequestIds = new HashSet<>();
+    final Set<Long> partialHostRequestIds = new HashSet<>();
+
+    hostRequestIds.forEach(requestId -> {
+      if (partialHostRequestIds.size() <= BATCH_SIZE) {
+        partialHostRequestIds.add(requestId);
+      } else {
+        topologyRequestIds.addAll(topologyLogicalRequestDAO.findRequestIdsByIds(partialHostRequestIds));
+        partialHostRequestIds.clear();
+      }
+    });
+    return topologyRequestIds;
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to JDBC driver limitations the cleanup tool failed in case there were too many records in the DB within the selected time range (for instance recent Oracle versions do not allow more than 2k parameters whereas Postgres has a 32k limit). When loading IDs from our tables where there are more records than this limit an error is being thrown:
```
Caused by: org.postgresql.util.PSQLException: An I/O error occurred while sending to the backend.
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:281)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:559)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:417)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:302)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.executeSelect(DatabaseAccessor.java:1009)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.basicExecuteCall(DatabaseAccessor.java:644)
        ... 44 more
Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 33771
        at org.postgresql.core.PGStream.SendInteger2(PGStream.java:196)
        at org.postgresql.core.v3.QueryExecutorImpl.sendParse(QueryExecutorImpl.java:1242)
        at org.postgresql.core.v3.QueryExecutorImpl.sendOneQuery(QueryExecutorImpl.java:1547)
        at org.postgresql.core.v3.QueryExecutorImpl.sendQuery(QueryExecutorImpl.java:1100)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:253)
```
In order to avoid this issue we decided to load these IDs in batches (we use batches of 999 records).

An additional change has been implemented too: we need to load our LDAP module in Guice to let the application run.

## How was this patch tested?

Tested manually:
1. had an Ambari 2.7.0.0-437 in place usinfg embedded Postgres
2. generated sample data in the database
```
[root@c7401 ~]# psql -U ambari
Password for user ambari: 
psql (9.2.23)
Type "help" for help.

ambari=> SELECT count(*) FROM host_role_command;
 count 
-------
 33820
(1 row)
```
3. executed `ambari-server db-purge-history --cluster-name=cluster1 --from-date=2018-05-05`; as expected it's been failed:
```
[root@c7401 ~]# ambari-server db-purge-history --cluster-name=cluster1 --from-date=2018-05-05
Using python  /usr/bin/python
Purge database history...
Ambari Server configured for Embedded Postgres. Confirm you have made a backup of the Ambari Server database [y/n]y
Ambari server is using db type Embedded Postgres. Cleanable database entries older than 2018-05-03 will be purged. Proceed [y/n]y
Purging historical data from the database ...

ERROR: Error encountered while purging the Ambari Server Database. Check the ambari-server.log for details.
Ambari Server 'db-purge-history' completed successfully.

Query: ReportQuery(name="TopologyLogicalTaskEntity.findHostTaskIdsByPhysicalTaskIds" referenceClass=TopologyLogicalTaskEntity sql="SELECT DISTINCT host_task_id FROM topology_logical_task WHERE (physical_task_id IN ?)")
        at org.eclipse.persistence.exceptions.DatabaseException.sqlException(DatabaseException.java:340)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.processExceptionForCommError(DatabaseAccessor.java:1620)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.basicExecuteCall(DatabaseAccessor.java:676)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.executeCall(DatabaseAccessor.java:560)
        at org.eclipse.persistence.internal.sessions.AbstractSession.basicExecuteCall(AbstractSession.java:2055)
        at org.eclipse.persistence.sessions.server.ServerSession.executeCall(ServerSession.java:570)
        at org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism.executeCall(DatasourceCallQueryMechanism.java:242)
        at org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism.executeCall(DatasourceCallQueryMechanism.java:228)
        at org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism.executeSelectCall(DatasourceCallQueryMechanism.java:299)
        at org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism.selectAllRows(DatasourceCallQueryMechanism.java:694)
        at org.eclipse.persistence.internal.queries.ExpressionQueryMechanism.selectAllRowsFromTable(ExpressionQueryMechanism.java:2740)
        at org.eclipse.persistence.internal.queries.ExpressionQueryMechanism.selectAllReportQueryRows(ExpressionQueryMechanism.java:2677)
        at org.eclipse.persistence.queries.ReportQuery.executeDatabaseQuery(ReportQuery.java:852)
        at org.eclipse.persistence.queries.DatabaseQuery.execute(DatabaseQuery.java:904)
        at org.eclipse.persistence.queries.ObjectLevelReadQuery.execute(ObjectLevelReadQuery.java:1134)
        at org.eclipse.persistence.queries.ReadAllQuery.execute(ReadAllQuery.java:460)
        at org.eclipse.persistence.queries.ObjectLevelReadQuery.executeInUnitOfWork(ObjectLevelReadQuery.java:1222)
        at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.internalExecuteQuery(UnitOfWorkImpl.java:2896)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1857)
        at org.eclipse.persistence.internal.sessions.AbstractSession.retryQuery(AbstractSession.java:1927)
        at org.eclipse.persistence.sessions.server.ClientSession.retryQuery(ClientSession.java:694)
        at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.retryQuery(UnitOfWorkImpl.java:5536)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1893)
        at org.eclipse.persistence.internal.sessions.AbstractSession.retryQuery(AbstractSession.java:1927)
        at org.eclipse.persistence.sessions.server.ClientSession.retryQuery(ClientSession.java:694)
        at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.retryQuery(UnitOfWorkImpl.java:5536)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1893)
        at org.eclipse.persistence.internal.sessions.AbstractSession.retryQuery(AbstractSession.java:1927)
        at org.eclipse.persistence.sessions.server.ClientSession.retryQuery(ClientSession.java:694)
        at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.retryQuery(UnitOfWorkImpl.java:5536)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1893)
        at org.eclipse.persistence.internal.sessions.AbstractSession.retryQuery(AbstractSession.java:1927)
        at org.eclipse.persistence.sessions.server.ClientSession.retryQuery(ClientSession.java:694)
        at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.retryQuery(UnitOfWorkImpl.java:5536)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1893)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1839)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1804)
        at org.eclipse.persistence.internal.jpa.QueryImpl.executeReadQuery(QueryImpl.java:258)
        ... 9 more
Caused by: org.postgresql.util.PSQLException: An I/O error occurred while sending to the backend.
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:281)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:559)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:417)
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:302)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.executeSelect(DatabaseAccessor.java:1009)
        at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.basicExecuteCall(DatabaseAccessor.java:644)
        ... 44 more
Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 33771
        at org.postgresql.core.PGStream.SendInteger2(PGStream.java:196)
        at org.postgresql.core.v3.QueryExecutorImpl.sendParse(QueryExecutorImpl.java:1242)
        at org.postgresql.core.v3.QueryExecutorImpl.sendOneQuery(QueryExecutorImpl.java:1547)
        at org.postgresql.core.v3.QueryExecutorImpl.sendQuery(QueryExecutorImpl.java:1100)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:253)
        ... 49 more
```
4, Implemented my changes; replaced the `ambari-server.jar` and re-executed the previous command successfully:
```
[root@c7401 ~]# ambari-server db-purge-history --cluster-name cluster1 -d 2018-05-05
Using python  /usr/bin/python
Purge database history...
Ambari Server configured for Embedded Postgres. Confirm you have made a backup of the Ambari Server database [y/n]y
Ambari server is using db type Embedded Postgres. Cleanable database entries older than 2018-05-05 will be purged. Proceed [y/n]y
Purging historical data from the database ...

Purging historical data completed. Check the ambari-server.log for details.
Ambari Server 'db-purge-history' completed successfully.

04 May 2018 12:32:42,804  INFO [main] CleanupServiceImpl:80 - Running the purge process for DAO: [org.apache.ambari.server.orm.dao.RequestDAO$$EnhancerByGuice$$220cfb40@2d28fb02] with cleanup policy: [org.apache.ambari.server.cleanup.TimeBasedCleanupPolicy@6db328f8]
04 May 2018 12:32:43,150  INFO [main] RequestDAO:314 - Deleting ExecutionCommand entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:43,151  INFO [main] RequestDAO:323 - Deleting ExecutionCommand entity batch with task ids: 352 - 1995
...
04 May 2018 12:32:43,386  INFO [main] RequestDAO:314 - Deleting TopologyLogicalTask entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:43,387  INFO [main] RequestDAO:323 - Deleting TopologyLogicalTask entity batch with task ids: 352 - 1995
...
04 May 2018 12:32:43,577  INFO [main] RequestDAO:314 - Deleting TopologyHostTask entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:43,577  INFO [main] RequestDAO:314 - Deleting TopologyHostRequest entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:43,577  INFO [main] RequestDAO:314 - Deleting HostRoleCommand entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:43,578  INFO [main] RequestDAO:323 - Deleting HostRoleCommand entity batch with task ids: 352 - 1995
...
04 May 2018 12:32:45,953  INFO [main] RequestDAO:349 - Deleting RoleSuccessCriteria entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:45,953  INFO [main] RequestDAO:358 - Deleting RoleSuccessCriteria entity batch with task ids: org.apache.ambari.server.orm.dao.RequestDAO$StageEntityPK@4ab90d01 - org.apache.ambari.server.orm.dao.RequestDAO$StageEntityPK@4ab90d01
04 May 2018 12:32:45,955  INFO [main] RequestDAO:349 - Deleting Stage entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:45,955  INFO [main] RequestDAO:358 - Deleting Stage entity batch with task ids: org.apache.ambari.server.orm.dao.RequestDAO$StageEntityPK@4ab90d01 - org.apache.ambari.server.orm.dao.RequestDAO$StageEntityPK@4ab90d01
04 May 2018 12:32:45,959  INFO [main] RequestDAO:314 - Deleting RequestResourceFilter entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:45,959  INFO [main] RequestDAO:323 - Deleting RequestResourceFilter entity batch with task ids: 43 - 43
04 May 2018 12:32:45,966  INFO [main] RequestDAO:314 - Deleting RequestOperationLevel entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:45,967  INFO [main] RequestDAO:323 - Deleting RequestOperationLevel entity batch with task ids: 43 - 43
04 May 2018 12:32:45,969  INFO [main] RequestDAO:314 - Deleting Request entities before date Sat May 05 00:00:00 UTC 2018
04 May 2018 12:32:45,969  INFO [main] RequestDAO:323 - Deleting Request entity batch with task ids: 43 - 43
04 May 2018 12:32:45,979  INFO [main] CleanupDriver:100 - DB-PURGE - completed. Number of affected records [33778]
```