### PR TITLE
[AMBARI-23768] Icon for "start demo ldap" is missing

### DIFF
--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -426,7 +426,7 @@ App.HostComponentActionMap = {
         customCommand: 'STARTDEMOLDAP',
         context: Em.I18n.t('services.service.actions.run.startLdapKnox.context'),
         label: Em.I18n.t('services.service.actions.run.startLdapKnox.context'),
-        cssClass: 'glyphicon glyphicon-play-sign',
+        cssClass: 'icon icon-play-sign',
         disabled: false
       },
       STOPDEMOLDAP: {

--- a/ambari-web/test/views/main/service/item_test.js
+++ b/ambari-web/test/views/main/service/item_test.js
@@ -425,7 +425,7 @@ describe('App.MainServiceItemView', function () {
             {"action": "restartAllHostComponents", "context": "KNOX", "label": "Restart All", "cssClass": "glyphicon glyphicon-time", "disabled": false},
             {"action": "runSmokeTest", "label": "Run Service Check", "cssClass": "glyphicon glyphicon-thumbs-up", "disabled": false},
             {"action": "turnOnOffPassive", "context": "Turn On Maintenance Mode for Knox", "label": "Turn On Maintenance Mode", "cssClass": "icon-medkit", "disabled": false},
-            {"action": "startLdapKnox", "customCommand": "STARTDEMOLDAP", "context": "Start Demo LDAP", "label": "Start Demo LDAP", "cssClass": "glyphicon glyphicon-play-sign", "disabled": false},
+            {"action": "startLdapKnox", "customCommand": "STARTDEMOLDAP", "context": "Start Demo LDAP", "label": "Start Demo LDAP", "cssClass": "icon icon-play-sign", "disabled": false},
             {"action": "stopLdapKnox", "customCommand": "STOPDEMOLDAP", "context": "Stop Demo LDAP", "label": "Stop Demo LDAP", "cssClass": "glyphicon glyphicon-stop", "disabled": false},
             {"action": "downloadClientConfigs", "label": "Download Client Configs", "cssClass": "glyphicon glyphicon-download-alt", "isHidden": true, "disabled": false, "hasSubmenu": false, "submenuOptions": []}
           ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Icon for "Start Demo Ldap" is missing from knox action list in ambari.

## How was this patch tested?

UI unit tests:
  21527 passing (25s)
  48 pending
