### PR TITLE
AMBARI-23769 Insert operation in upgrade pack extension (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
@@ -48,7 +49,9 @@ import org.apache.ambari.server.state.DesiredConfig;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.UpgradeContext;
+import org.apache.ambari.server.state.stack.upgrade.ConfigUpgradeChangeDefinition.ConditionalField;
 import org.apache.ambari.server.state.stack.upgrade.ConfigUpgradeChangeDefinition.ConfigurationKeyValue;
+import org.apache.ambari.server.state.stack.upgrade.ConfigUpgradeChangeDefinition.IfValueMatchType;
 import org.apache.ambari.server.state.stack.upgrade.ConfigUpgradeChangeDefinition.Insert;
 import org.apache.ambari.server.state.stack.upgrade.ConfigUpgradeChangeDefinition.Masked;
 import org.apache.ambari.server.state.stack.upgrade.ConfigUpgradeChangeDefinition.Replace;
@@ -89,6 +92,7 @@ import com.google.inject.Provider;
 public class ConfigureAction extends AbstractUpgradeServerAction {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigureAction.class);
+  private static final String ALL_SYMBOL = "*";
 
   /**
    * Used to update the configuration properties.
@@ -218,8 +222,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     List<Transfer> transfers = Collections.emptyList();
     String transferJson = commandParameters.get(ConfigureTask.PARAMETER_TRANSFERS);
     if (null != transferJson) {
-      transfers = m_gson.fromJson(
-        transferJson, new TypeToken<List<Transfer>>(){}.getType());
+      transfers = m_gson.fromJson(transferJson, new TypeToken<List<Transfer>>(){}.getType());
       transfers = getAllowedTransfers(cluster, configType, transfers);
     }
 
@@ -227,8 +230,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     List<Replace> replacements = Collections.emptyList();
     String replaceJson = commandParameters.get(ConfigureTask.PARAMETER_REPLACEMENTS);
     if (null != replaceJson) {
-      replacements = m_gson.fromJson(
-          replaceJson, new TypeToken<List<Replace>>(){}.getType());
+      replacements = m_gson.fromJson(replaceJson, new TypeToken<List<Replace>>(){}.getType());
       replacements = getAllowedReplacements(cluster, configType, replacements);
     }
 
@@ -236,8 +238,8 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     List<Insert> insertions = Collections.emptyList();
     String insertJson = commandParameters.get(ConfigureTask.PARAMETER_INSERTIONS);
     if (null != insertJson) {
-      insertions = m_gson.fromJson(
-          insertJson, new TypeToken<List<Insert>>(){}.getType());
+      insertions = m_gson.fromJson(insertJson, new TypeToken<List<Insert>>(){}.getType());
+      insertions = getAllowedInsertions(cluster, configType, insertions);
     }
 
     // if there is nothing to do, then skip the task
@@ -366,7 +368,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
 
           break;
         case DELETE:
-          if ("*".equals(transfer.deleteKey)) {
+          if (ALL_SYMBOL.equals(transfer.deleteKey)) {
             newValues.clear();
 
             // append standard output
@@ -666,8 +668,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     List<Replace> allowedReplacements= new ArrayList<>();
 
     for(Replace replacement: replacements){
-      if(isOperationAllowed(cluster, configType, replacement.key,
-          replacement.ifKey, replacement.ifType, replacement.ifValue, replacement.ifKeyState)) {
+      if(isOperationAllowed(cluster, configType, replacement.key, replacement)) {
         allowedReplacements.add(replacement);
       }
     }
@@ -679,8 +680,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     List<ConfigurationKeyValue> allowedSets = new ArrayList<>();
 
     for(ConfigurationKeyValue configurationKeyValue: sets){
-      if(isOperationAllowed(cluster, configType, configurationKeyValue.key,
-          configurationKeyValue.ifKey, configurationKeyValue.ifType, configurationKeyValue.ifValue, configurationKeyValue.ifKeyState)) {
+      if(isOperationAllowed(cluster, configType, configurationKeyValue.key, configurationKeyValue)) {
         allowedSets.add(configurationKeyValue);
       }
     }
@@ -691,21 +691,28 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
   private List<Transfer> getAllowedTransfers(Cluster cluster, String configType, List<Transfer> transfers){
     List<Transfer> allowedTransfers = new ArrayList<>();
     for (Transfer transfer : transfers) {
-      String key = "";
+      String key;
       if(transfer.operation == TransferOperation.DELETE) {
         key = transfer.deleteKey;
       } else {
         key = transfer.fromKey;
       }
 
-      if(isOperationAllowed(cluster, configType, key,
-          transfer.ifKey, transfer.ifType, transfer.ifValue, transfer.ifKeyState)) {
+      if(isOperationAllowed(cluster, configType, key, transfer)) {
         allowedTransfers.add(transfer);
       }
     }
 
     return allowedTransfers;
   }
+
+
+  private List<Insert> getAllowedInsertions(Cluster cluster, String configType, List<Insert> insertions){
+    return insertions.stream()
+      .filter(insertion -> isOperationAllowed(cluster, configType, insertion.key, insertion))
+      .collect(Collectors.toList());
+  }
+
 
   /**
    * Gets whether the {@code set} directive is valid based on the optional
@@ -717,66 +724,63 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
    *          the configuration type for the change (not {@code null}).
    * @param targetPropertyKey
    *          the property to set (not {@code null}).
-   * @param ifKey
-   *          the property name to check in order to satisfy a condition, or
-   *          {@code null} if there is no condition.
-   * @param ifType
-   *          the property type to check in order to satisfy a condition, or
-   *          {@code null} if there is no condition.
-   * @param ifValue
-   *          the property value to compare for equality in order to satisfy a
-   *          condition, or {@code null} if there is no condition.
-   * @param ifKeyState
-   *          the state of the if-property. If the property is
-   *          {@link PropertyKeyState#ABSENT}, then execute the set directory
-   *          only if the if-key is absent.
+   * @param operationItem
+   *           operation field compatible with {@link ConditionalField}
    * @return {@code true} if the set operation should be executed by the
    *         upgrade, {@code false} otherwise.
    */
-  private boolean isOperationAllowed(Cluster cluster, String configType, String targetPropertyKey,
-      String ifKey, String ifType, String ifValue, PropertyKeyState ifKeyState){
+  private boolean isOperationAllowed(Cluster cluster, String configType, String targetPropertyKey, ConditionalField operationItem)
+  {
     boolean isAllowed = true;
 
-    boolean ifKeyIsNotBlank = StringUtils.isNotBlank(ifKey);
-    boolean ifTypeIsNotBlank = StringUtils.isNotBlank(ifType);
-    boolean ifValueIsBlank = StringUtils.isBlank(ifValue);
+    boolean ifKeyIsNotBlank = StringUtils.isNotBlank(operationItem.ifKey);
+    boolean ifTypeIsNotBlank = StringUtils.isNotBlank(operationItem.ifType);
+    boolean ifValueIsBlank = StringUtils.isBlank(operationItem.ifValue);
 
     // if-key/if-type and no value - set only if absent
-    if (ifKeyIsNotBlank && ifTypeIsNotBlank && ifValueIsBlank && ifKeyState == PropertyKeyState.ABSENT) {
-      boolean keyPresent = getDesiredConfigurationKeyPresence(cluster, ifType, ifKey);
+    if (ifKeyIsNotBlank && ifTypeIsNotBlank && ifValueIsBlank && operationItem.ifKeyState == PropertyKeyState.ABSENT) {
+      boolean keyPresent = getDesiredConfigurationKeyPresence(cluster, operationItem.ifType, operationItem.ifKey);
       if (keyPresent) {
         LOG.info("Skipping property operation for {}/{} as the key {} for {} is present",
-          configType, targetPropertyKey, ifKey, ifType);
+          configType, targetPropertyKey, operationItem.ifKey, operationItem.ifType);
         isAllowed = false;
       }
       // if-key/if-type and no value - set only is present
-    } else if (ifKeyIsNotBlank && ifTypeIsNotBlank && ifValueIsBlank && ifKeyState == PropertyKeyState.PRESENT) {
-      boolean keyPresent = getDesiredConfigurationKeyPresence(cluster, ifType, ifKey);
+    } else if (ifKeyIsNotBlank && ifTypeIsNotBlank && ifValueIsBlank
+      && operationItem.ifKeyState == PropertyKeyState.PRESENT) {
+
+      boolean keyPresent = getDesiredConfigurationKeyPresence(cluster, operationItem.ifType, operationItem.ifKey);
       if (!keyPresent) {
         LOG.info("Skipping property operation for {}/{} as the key {} for {} is not present",
-          configType, targetPropertyKey, ifKey, ifType);
+          configType, targetPropertyKey, operationItem.ifKey, operationItem.ifType);
         isAllowed = false;
       }
       // if-key/if-type and a value to check - set only if values match
     } else if (ifKeyIsNotBlank && ifTypeIsNotBlank && !ifValueIsBlank) {
-      String ifConfigType = ifType;
-      String checkValue = getDesiredConfigurationValue(cluster, ifConfigType, ifKey);
+      String checkValue = getDesiredConfigurationValue(cluster, operationItem.ifType, operationItem.ifKey);
 
       // the check value is blank and there is an if-key-state of ABSENT - in
       // this case, it means set the value if it matches or if it's absent
-      if (ifKeyState == PropertyKeyState.ABSENT) {
-        boolean keyPresent = getDesiredConfigurationKeyPresence(cluster, ifType, ifKey);
+      if (operationItem.ifKeyState == PropertyKeyState.ABSENT) {
+        boolean keyPresent = getDesiredConfigurationKeyPresence(cluster, operationItem.ifType, operationItem.ifKey);
         if (!keyPresent) {
           return true;
         }
       }
 
       // the if-key was found, so we need to do a comparison
-      if (!StringUtils.equalsIgnoreCase(ifValue, checkValue)) {
-        // skip adding
-        LOG.info("Skipping property operation for {}/{} as the value {} for {}/{} is not equal to {}",
-                 configType, targetPropertyKey, checkValue, ifConfigType, ifKey, ifValue);
-        isAllowed = false;
+      if (operationItem.ifValueMatchType == IfValueMatchType.PARTIAL) {
+        if (!StringUtils.containsIgnoreCase(checkValue, operationItem.ifValue) ^ operationItem.ifValueNotMatched) {
+          LOG.info("Skipping property operation for {}/{} as the value {} for {}/{} is not found in {}",
+            configType, targetPropertyKey, operationItem.ifValue, operationItem.ifType, operationItem.ifKey, checkValue);
+          isAllowed = false;
+        }
+      } else {
+        if (!StringUtils.equalsIgnoreCase(operationItem.ifValue, checkValue) ^ operationItem.ifValueNotMatched) {
+          LOG.info("Skipping property operation for {}/{} as the value {} for {}/{} is not equal to {}",
+            configType, targetPropertyKey, checkValue, operationItem.ifType, operationItem.ifKey, operationItem.ifValue);
+          isAllowed = false;
+        }
       }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigUpgradeChangeDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigUpgradeChangeDefinition.java
@@ -287,15 +287,8 @@ public class ConfigUpgradeChangeDefinition {
     return inserts;
   }
 
-  /**
-   * Used for configuration updates that should mask their values from being
-   * printed in plain text.
-   */
   @XmlAccessorType(XmlAccessType.FIELD)
-  public static class Masked {
-    @XmlAttribute(name = "mask")
-    public boolean mask = false;
-
+  public static class ConditionalField{
     /**
      * The key to read for the if condition.
      */
@@ -315,10 +308,35 @@ public class ConfigUpgradeChangeDefinition {
     public String ifValue;
 
     /**
+     * Reverse search value result to opposite by allowing
+     * operation to be executed when value not found
+     */
+    @XmlAttribute(name = "if-value-not-matched")
+    public boolean ifValueNotMatched = false;
+
+    /**
+     * the way how to search the value:
+     * {@code IfValueMatchType.EXACT} - full comparison
+     * {@code IfValueMatchType.PARTIAL} - search for substring in string
+     */
+    @XmlAttribute(name = "if-value-match-type")
+    public IfValueMatchType ifValueMatchType = IfValueMatchType.EXACT;
+
+    /**
      * The property key state for the if condition
      */
     @XmlAttribute(name = "if-key-state")
     public PropertyKeyState ifKeyState;
+  }
+
+  /**
+   * Used for configuration updates that should mask their values from being
+   * printed in plain text.
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class Masked extends ConditionalField{
+    @XmlAttribute(name = "mask")
+    public boolean mask = false;
   }
 
 
@@ -532,7 +550,7 @@ public class ConfigUpgradeChangeDefinition {
    */
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlType(name = "insert")
-  public static class Insert {
+  public static class Insert extends Masked{
     /**
      * The key name
      */
@@ -592,6 +610,24 @@ public class ConfigUpgradeChangeDefinition {
      */
     @XmlEnumValue("append")
     APPEND
+  }
+
+  /**
+   * The {@link IfValueMatchType} defines value search behaviour
+   */
+  @XmlEnum
+  public enum IfValueMatchType {
+    /**
+     * Exact value match
+     */
+    @XmlEnumValue("exact")
+    EXACT,
+
+    /**
+     * partial value match
+     */
+    @XmlEnumValue("partial")
+    PARTIAL
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/InMemoryDefaultTestModule.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/InMemoryDefaultTestModule.java
@@ -94,7 +94,7 @@ public class InMemoryDefaultTestModule extends AbstractModule {
     String resourcesDir = "src/test/resources/";
     if (System.getProperty("os.name").contains("Windows")) {
       stacks = ClassLoader.getSystemClassLoader().getResource("stacks").getPath();
-      version = new File(new File(ClassLoader.getSystemClassLoader().getResource("").getPath()).getParent(), "version").getPath();
+      version = new File(new File(ClassLoader.getSystemClassLoader().getResource("").getPath()), "version").getPath();
       sharedResourcesDir = ClassLoader.getSystemClassLoader().getResource("").getPath();
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -1092,9 +1092,9 @@ public class UpgradeHelperTest extends EasyMockSupport {
         configurationJson,
         new TypeToken<List<ConfigUpgradeChangeDefinition.Replace>>() {}.getType());
 
-    assertEquals("1-foo-2\n", replacements.get(0).find);
+    assertEquals("1-foo-2" + System.lineSeparator(), replacements.get(0).find);
     assertEquals("REPLACED", replacements.get(0).replaceWith);
-    assertEquals("3-foo-4\n", replacements.get(1).find);
+    assertEquals("3-foo-4" + System.lineSeparator(), replacements.get(1).find);
     assertEquals("REPLACED", replacements.get(1).replaceWith);
     assertEquals(2, replacements.size());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Insert operation in upgrade packs should be extended in such ways:
 * allow conditional operations

 

Conditions are extended as well, to enrich their functionality:
 * `if-value-match-type`, which allow exact or partial match. Default is exact
 * `if-value-not-matched`, allow operation when no matches found

 

## How was this patch tested?

unit tests