### PR TITLE
Fixing 2.7.0 as a part of code was missing from 2.6.0 causing Kafka t…

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka.py
@@ -51,12 +51,21 @@ def kafka(upgrade_type=None):
 
        listeners = kafka_server_config['listeners'].replace("localhost", params.hostname)
        Logger.info(format("Kafka listeners: {listeners}"))
-       kafka_server_config['listeners'] = listeners       
 
-       if 'advertised.listeners' in kafka_server_config:
-         advertised_listeners = kafka_server_config['advertised.listeners'].replace("localhost", params.hostname)
-         kafka_server_config['advertised.listeners'] = advertised_listeners
-         Logger.info(format("Kafka advertised listeners: {advertised_listeners}"))
+       if params.kerberos_security_enabled and params.kafka_kerberos_enabled:
+         Logger.info("Kafka kerberos security is enabled.")
+         if "SASL" not in listeners:
+           listeners = listeners.replace("PLAINTEXT", "PLAINTEXTSASL")
+
+         kafka_server_config['listeners'] = listeners
+         kafka_server_config['advertised.listeners'] = listeners
+         Logger.info(format("Kafka advertised listeners: {listeners}"))
+       else:
+         kafka_server_config['listeners'] = listeners
+         if 'advertised.listeners' in kafka_server_config:
+           advertised_listeners = kafka_server_config['advertised.listeners'].replace("localhost", params.hostname)
+           kafka_server_config['advertised.listeners'] = advertised_listeners
+           Logger.info(format("Kafka advertised listeners: {advertised_listeners}"))
     else:
       kafka_server_config['host.name'] = params.hostname
 


### PR DESCRIPTION
…o go down after restart post Ambari Upgrade causing java.lang.IllegalArgumentException

## What changes were proposed in this pull request?

Part of SASL code that exist in 2.6.0 was missing in 2.7.0. Porting that piece of code throwing following error in kafka's server.log
```
[2018-05-05 00:39:50,109] FATAL  (kafka.Kafka$)
java.lang.IllegalArgumentException: requirement failed: security.inter.broker.protocol must be a protocol in the configured set of advertised.listeners. The valid options based on currently configured protocols are Set(PLAINTEXT)
        at scala.Predef$.require(Predef.scala:233)
        at kafka.server.KafkaConfig.validateValues(KafkaConfig.scala:1055)
        at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:1034)
        at kafka.server.KafkaConfig$.fromProps(KafkaConfig.scala:779)
        at kafka.server.KafkaConfig$.fromProps(KafkaConfig.scala:776)
        at kafka.server.KafkaServerStartable$.fromProps(KafkaServerStartable.scala:28)
        at kafka.Kafka$.main(Kafka.scala:58)
        at kafka.Kafka.main(Kafka.scala)
```
 

## How was this patch tested?

Deployed cluster with Ambari-2.6.0 with HDP-2.6.3. Install all service including kafka with kerberos.
Upgrade ambari-server, its database and agent to 2.7.0.
Upgrading ambari-server ask for kafka service restart. After restart, it throws error as above.
Manually changed code at /var/lib/ambari-agent/cache/common-services/KAFKA/0.8.1/package/scripts/kafka.py and try kafka restart. Now its up and running. Its ready for rpm packages to be upgraded.


![screen shot 2018-05-04 at 6 04 57 pm](https://user-images.githubusercontent.com/4481720/39658201-b6b4fb94-4fc5-11e8-836a-ebf779c58b4d.png)
