### PR TITLE
[AMBARI-23772] Background Ops modal breaks in some cases

### DIFF
--- a/ambari-web/app/templates/common/host_progress_popup.hbs
+++ b/ambari-web/app/templates/common/host_progress_popup.hbs
@@ -89,18 +89,18 @@
             </td>
           </tr>
           {{/each}}
-        </tbody>
-          {{#if view.isPaginate}}
-            <tfoot>
+        {{/if}}
+      </tbody>
+        {{#if view.isPaginate}}
+          <tfoot>
             <tr>
               <td colspan="5">
                 {{view App.PaginationView}}
               </td>
             </tr>
-            </tfoot>
-          {{/if}}
-        </table>
+          </tfoot>
         {{/if}}
+      </table>
         {{#if view.isShowMore}}
           <div class="show-more" {{action requestMoreOperations}}><a href="#">{{t hostPopup.serviceInfo.showMore}}</a>
           </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
handlebar had wrong alignment for the if else structure which was breaking the modal. Corrected it.

## How was this patch tested?
  21527 passing (24s)
  48 pending