### PR TITLE
[AMBARI-23766] Corrupt mapreduce/tez tar.gz may be uploaded to HDFS if parallel execution is enabled

### DIFF
--- a/ambari-agent/src/test/python/resource_management/TestTarArchive.py
+++ b/ambari-agent/src/test/python/resource_management/TestTarArchive.py
@@ -1,0 +1,66 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+from mock.mock import patch, MagicMock
+from unittest import TestCase
+
+from ambari_commons.os_check import OSCheck
+from only_for_platform import os_distro_value
+from resource_management.core.environment import Environment
+from resource_management.libraries.functions import tar_archive
+
+@patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
+class TestTarArchive(TestCase):
+
+  @patch("resource_management.core.providers.system.ExecuteProvider")
+  def test_archive_dir(self, execute_mock):
+    archive = '/home/etc.tar.gz'
+    directory = '/etc'
+
+    with Environment():
+      tar_archive.archive_dir(archive, directory)
+
+    self.assertEqual(execute_mock.call_count, 1)
+    self.assertEqual(execute_mock.call_args[0][0].command, ('tar', '-zcf', archive, '-C', directory, '.'))
+
+
+  @patch("resource_management.core.providers.system.ExecuteProvider")
+  def test_archive_directory_dereference(self, execute_mock):
+    archive = '/home/etc.tar.gz'
+    directory = '/etc'
+
+    with Environment():
+      tar_archive.archive_directory_dereference(archive, directory)
+
+    self.assertEqual(execute_mock.call_count, 1)
+    self.assertEqual(execute_mock.call_args[0][0].command, ('tar', '-zchf', archive, '-C', directory, '.'))
+
+
+  @patch("resource_management.core.providers.system.ExecuteProvider")
+  def test_archive_dir_via_temp_file(self, execute_mock):
+    archive = '/home/etc.tar.gz'
+    directory = '/etc'
+
+    with Environment():
+      tar_archive.archive_dir_via_temp_file(archive, directory)
+
+    self.assertEqual(execute_mock.call_count, 2)
+    self.assertEqual(execute_mock.call_args_list[0][0][0].command[:2], ('tar', '-zchf'))
+    self.assertEqual(execute_mock.call_args_list[0][0][0].command[3:], ('-C', directory, '.'))
+    temp_file = execute_mock.call_args_list[0][0][0].command[2]
+    self.assertEqual(execute_mock.call_args_list[1][0][0].command, ('mv', temp_file, archive))

--- a/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/tar_archive.py
@@ -20,31 +20,44 @@ limitations under the License.
 
 import os
 import tarfile
-import zipfile
+import tempfile
 from contextlib import closing
+
+from ambari_commons import os_utils
 from resource_management.core.resources.system import Execute
 
-def archive_dir(output_filename, input_dir):
-  Execute(('tar', '-zcf', output_filename, '-C', input_dir, '.'),
-    sudo = True,
-    tries = 3,
-    try_sleep = 1,
-  )
-
-def archive_directory_dereference(archive, directory):
+def archive_dir(output_filename, input_dir, follow_links=False):
   """
-  Creates an archive of the specified directory. This will ensure that
-  symlinks are not included, but instead are followed for recursive inclusion.
-  :param archive:   the name of the archive to create, including path
-  :param directory:   the directory to include
+  Creates an archive of the specified directory.
+  :param output_filename: the name of the archive to create, including path
+  :param input_dir: the directory to include
+  :param follow_links: if True, symlinks are followed and the files/directories they point to will be included in the archive
   :return:  None
   """
 
-  Execute(('tar', '-zchf', archive, '-C', directory, '.'),
+  options = '-zchf' if follow_links else '-zcf'
+
+  Execute(('tar', options, output_filename, '-C', input_dir, '.'),
     sudo = True,
     tries = 3,
     try_sleep = 1,
   )
+
+
+def archive_directory_dereference(archive, directory):
+  archive_dir(archive, directory, follow_links=True)
+
+
+def archive_dir_via_temp_file(archive, directory):
+  _, temp_output = tempfile.mkstemp()
+  try:
+    archive_directory_dereference(temp_output, directory)
+  except:
+    os_utils.remove_file(temp_output)
+    raise
+  else:
+    Execute(("mv", temp_output, archive))
+
 
 def untar_archive(archive, directory, silent=True):
   """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #1181, for branch-2.6.

Prepare mapreduce/tez archives at a temporary location, then move them to the final local destination.  Create archives using `tar` instead of Python module.

## How was this patch tested?

Tested cluster creation a few times with `parallel_execution` enabled.

New unit test for the utility functions `tar_archive.archive_dir*`.