### PR TITLE
[AMBARI-23773] Suppress FindBugs warnings for EclipseLink-generated code

### DIFF
--- a/ambari-server/findbugs.exclude.xml
+++ b/ambari-server/findbugs.exclude.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <Class name="~.*Entity" />
+    <Method name="~_persistence_[gs]et" />
+    <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ" />
+  </Match>
+</FindBugsFilter>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -662,6 +662,7 @@
           <failOnError>false</failOnError>
           <threshold>Low</threshold>
           <findbugsXmlOutputDirectory>${project.basedir}/target/findbugs</findbugsXmlOutputDirectory>
+          <excludeFilterFile>${project.basedir}/findbugs.exclude.xml</excludeFilterFile>
         </configuration>
         <executions>
           <execution>
@@ -691,6 +692,9 @@
               <includes>
                 <include>*.xml</include>
               </includes>
+              <excludes>
+                <exclude>findbugs.exclude.xml</exclude>
+              </excludes>
               <outputDir>${project.basedir}/target/findbugs</outputDir>
               <stylesheet>fancy-hist.xsl</stylesheet>
               <fileMappers>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suppress FindBugs warnings related to code generated by EclipseLink that we have no control over.

Example:

```
[INFO] Comparison of String parameter using == or != in org.apache.ambari.server.orm.entities.AlertCurrentEntity._persistence_get(String)  [org.apache.ambari.server.orm.entities.AlertCurrentEntity] In AlertCurrentEntity.java ES_COMPARING_PARAMETER_STRING_WITH_EQ
[INFO] Comparison of String parameter using == or != in org.apache.ambari.server.orm.entities.AlertCurrentEntity._persistence_set(String, Object)  [org.apache.ambari.server.orm.entities.AlertCurrentEntity] In AlertCurrentEntity.java ES_COMPARING_PARAMETER_STRING_WITH_EQ
```

Almost half of all issues reported by FindBugs:

```
$ grep 'Total bugs' 9187.log
[INFO] Total bugs: 3126
$ grep 'Entity.*ES_COMPARING_PARAMETER_STRING_WITH_EQ' 9187.log | wc
    1428   23562  398424
```

https://builds.apache.org/job/Ambari-trunk-Commit/9187/consoleText
https://issues.apache.org/jira/browse/AMBARI-23773

## How was this patch tested?

```
$ mvn -am -pl ambari-server -DskipTests clean verify
...
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 5783 licenses.
...
[INFO] Total bugs: 1698
...
[INFO] BUILD SUCCESS
```