### PR TITLE
[AMBARI-23782] Log Search: Cluster filter is not working on a few endpoints.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ServiceLogsManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ServiceLogsManager.java
@@ -181,7 +181,7 @@ public class ServiceLogsManager extends ManagerBase<ServiceLogData, ServiceLogRe
 
   public CountDataListResponse getFieldCount(String field, String clusters) {
     SimpleFacetQuery facetQuery = conversionService.convert(field, SimpleFacetQuery.class);
-    if (StringUtils.isEmpty(clusters)) {
+    if (StringUtils.isNotEmpty(clusters)) {
       List<String> clusterFilterList = Splitter.on(",").splitToList(clusters);
       facetQuery.addFilterQuery(new SimpleFilterQuery(new Criteria(CLUSTER).in(clusterFilterList)));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Cluster filter did not work ever on some endpoints. cluster query was never added to the facet request.(and without cluster filter, we could end up with nullpointers as welll)

## How was this patch tested?
tested manually. UTs passed

please review @kasakrisz @swagle @zeroflag @adoroszlai 