### PR TITLE
AMBARI-23788. Make server/agent connection with no cert verification possibly for python 2.7.5

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/NetUtil.py
+++ b/ambari-agent/src/main/python/ambari_agent/NetUtil.py
@@ -66,7 +66,7 @@ class NetUtil:
     try:
       parsedurl = urlparse(url)
 
-      if sys.version_info >= (2,7,9) and not ssl_verify_cert:
+      if sys.version_info >= (2,7,5) and not ssl_verify_cert:
           import ssl
           ca_connection = httplib.HTTPSConnection(parsedurl[1], context=ssl._create_unverified_context())
       else:


### PR DESCRIPTION
From python changelog:
2017-01-23 - Charalampos Stratakis <cstratak@redhat.com> - 2.7.5-51
- Enable certificate verification by default
Resolves: rhbz#1219110