### PR TITLE
[AMBARI-23789] Regenerate keytabs on single host should be an experimental feature

### DIFF
--- a/ambari-web/app/config.js
+++ b/ambari-web/app/config.js
@@ -89,7 +89,8 @@ App.supports = {
   enabledWizardForHostOrderedUpgrade: true,
   manageJournalNode: true,
   enableToggleKerberos: true,
-  enableAddDeleteServices: true
+  enableAddDeleteServices: true,
+  regenerateKeytabsOnSingleHost: false
 };
 
 if (App.enableExperimental) {

--- a/ambari-web/app/views/main/host/details.js
+++ b/ambari-web/app/views/main/host/details.js
@@ -80,7 +80,7 @@ App.MainHostDetailsView = Em.View.extend({
         label: this.t('passiveState.turn' + onOff)
       });
     }
-    if (App.get('isKerberosEnabled')){
+    if (App.get('isKerberosEnabled') && App.get('supports.regenerateKeytabsOnSingleHost')){
       var actionMap = App.HostComponentActionMap.getMap(this);
       result.push(actionMap.REGENERATE_KEYTAB_FILE_OPERATIONS);
     }    


### PR DESCRIPTION
## What changes were proposed in this pull request?

Regenerating keytabs on songle host should be available with experimental flag checked only (`regenerateKeytabsOnSingleHost`)

## How was this patch tested?

UI unit tests:
  21522 passing (26s)
  48 pending
