### PR TITLE
[AMBARI-23380] Fix intermittent "No such file or directory" error in TestHostCleanup

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
@@ -425,7 +425,7 @@ class HostCleanup:
     for folder in folders:
       for filename in os.listdir(folder):
         fileToCheck = os.path.join(folder, filename)
-        stat = os.stat(fileToCheck)
+        stat = os.lstat(fileToCheck)
         if stat.st_uid in userIds:
           self.do_erase_dir_silent([fileToCheck])
           logger.info("Deleting file/folder: " + fileToCheck)

--- a/ambari-agent/src/test/python/ambari_agent/TestHostCleanup.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestHostCleanup.py
@@ -331,7 +331,7 @@ class TestHostCleanup(TestCase):
     sys.stdout = sys.__stdout__
 
   @patch.object(HostCleanup.HostCleanup, 'do_erase_dir_silent')
-  @patch("os.stat")
+  @patch("os.lstat")
   @patch("os.path.join")
   @patch("os.listdir")
   def test_do_delete_by_owner(self, listdir_mock, join_mock, stat_mock, do_erase_dir_silent_method):


### PR DESCRIPTION
## What changes were proposed in this pull request?

The cause of the unit test error is a dangling symlink.  On certain Jenkins nodes this is consistently reproducible, the same file is "missing":

https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/2151/consoleText
```
Building remotely on H34 (ubuntu xenial) in workspace /home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder
OSError: [Errno 2] No such file or directory: '/tmp/symlink156487370720650064test_link'
2673431 [INFO] Finished at: 2018-05-07T06:15:31Z
```

https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/2165/consoleText
```
Building remotely on H34 (ubuntu xenial) in workspace /home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder
OSError: [Errno 2] No such file or directory: '/tmp/symlink156487370720650064test_link'
2811865 [INFO] Finished at: 2018-05-07T19:49:26Z
```

https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/2168/consoleText
```
Building remotely on H34 (ubuntu xenial) in workspace /home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder
OSError: [Errno 2] No such file or directory: '/tmp/symlink156487370720650064test_link'
2732578 [INFO] Finished at: 2018-05-07T21:56:54Z
```

Steps to reproduce:

```
$ ln -s no_such_file /tmp/symlink156487370720650064test_link
$ file /tmp/symlink156487370720650064test_link
/tmp/symlink156487370720650064test_link: broken symbolic link to no_such_file
$ python <<EOF
import os
os.stat('/tmp/symlink156487370720650064test_link')
EOF

Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
OSError: [Errno 2] No such file or directory: '/tmp/symlink156487370720650064test_link'
```

## How was this patch tested?

```
$ ln -s no_such_file /tmp/symlink156487370720650064test_link
$ mvn -am -pl ambari-agent -Drat.skip -Dcheckstyle.skip -DskipSurefireTests clean test
...
Ran 458 tests in 28.135s

OK
```