### PR TITLE
[AMBARI-23746] Fix typo in map lookup

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1193,9 +1193,8 @@ public class ClusterImpl implements Cluster {
   @Override
   public List<Service> getServicesByServiceGroup(String serviceGroupName) {
     List<Service> servicesByServiceGroup = new ArrayList<>();
-    for(Entry<Long, Service> serviceEntry: servicesById.entrySet()){
-      Service s = servicesById.get(serviceEntry.getValue());
-      if (s.getServiceGroupName().equals(serviceGroupName)){
+    for (Service s : servicesById.values()) {
+      if (s.getServiceGroupName().equals(serviceGroupName)) {
         servicesByServiceGroup.add(s);
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a typo introduced in #1200, where map is searched by value instead of using value directly:

https://github.com/apache/ambari/blob/c715e17315e18cde47c2c743518df4752dbf9216/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java#L1195-L1197

causes:

```
08 May 2018 13:06:58,215 ERROR [ambari-client-thread-106] ReadHandler:102 - Caught a runtime exception executing a query
java.lang.ClassCastException: org.apache.ambari.server.state.ServiceImpl$$EnhancerByGuice$$1906112c cannot be cast to java.lang.Comparable
        at java.util.concurrent.ConcurrentSkipListMap.cpr(ConcurrentSkipListMap.java:655)
        at java.util.concurrent.ConcurrentSkipListMap.findPredecessor(ConcurrentSkipListMap.java:682)
        at java.util.concurrent.ConcurrentSkipListMap.doGet(ConcurrentSkipListMap.java:781)
        at java.util.concurrent.ConcurrentSkipListMap.get(ConcurrentSkipListMap.java:1546)
        at org.apache.ambari.server.state.cluster.ClusterImpl.getServicesByServiceGroup(ClusterImpl.java:1197)
```

when trying to view cluster via web UI.

## How was this patch tested?

Replaced ambari-server.jar, checked web UI.

<!-- [skip ci] -->