### PR TITLE
AMBARI-23794 Fix WebHCat property in kerberize.json in HDP 2.5

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -239,7 +239,9 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
   protected static final String COMPONENT_STATE_SERVICE_COMPONENT_DESIRED_STATE_FK = "hstcomponentstatecomponentname";
   protected static final String HIVE_SERVICE_COMPONENT_WEBHCAT_SERVER = "WEBHCAT_SERVER";
   protected static final String CONFIGURATION_CORE_SITE = "core-site";
+  protected static final String CONFIGURATION_WEBHCAT_SITE = "webhcat-site";
   protected static final String PROPERTY_HADOOP_PROXYUSER_HTTP_HOSTS = "hadoop.proxyuser.HTTP.hosts";
+  protected static final String PROPERTY_TEMPLETON_HIVE_PROPERTIES = "templeton.hive.properties";
   public static final String AMBARI_INFRA_OLD_NAME = "AMBARI_INFRA";
   public static final String AMBARI_INFRA_NEW_NAME = "AMBARI_INFRA_SOLR";
 
@@ -1076,6 +1078,17 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
           if (StringUtils.isNotBlank(currentHadoopProxyuserHttpHosts)) {
             LOG.info("Updating hadoop.proxyuser.HTTP.hosts...");
             coreSiteConfiguration.putProperty(PROPERTY_HADOOP_PROXYUSER_HTTP_HOSTS, currentHadoopProxyuserHttpHosts.replace("webhcat_server_host|", "webhcat_server_hosts|"));
+            updated = true;
+          }
+        }
+        final KerberosConfigurationDescriptor webhcatSiteConfiguration = webhcatServer.getConfiguration(CONFIGURATION_WEBHCAT_SITE);
+        if (webhcatSiteConfiguration != null) {
+          final String currentTempletonHiveProperties = webhcatSiteConfiguration.getProperty(PROPERTY_TEMPLETON_HIVE_PROPERTIES);
+          if (StringUtils.isNotBlank(currentTempletonHiveProperties)) {
+            LOG.info("Updating " + PROPERTY_TEMPLETON_HIVE_PROPERTIES + "...");
+            String newValue = currentTempletonHiveProperties.replace("hive_metastore_host|", "hive_metastore_hosts|");
+            newValue = newValue.replace("\\\\,", "\\,"); // Replacing the concatDelimiter in 'append' variable replacement function
+            webhcatSiteConfiguration.putProperty(PROPERTY_TEMPLETON_HIVE_PROPERTIES, newValue);
             updated = true;
           }
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1058,15 +1058,16 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
       }
     }
 
-    final boolean updatedWebHCatHostsInHadoopProxyuserHttpHostsForHive = updateWebHCatHostsInHadoopProxyuserHttpHostsForHive(kerberosDescriptor);
+    final boolean updateWebHCatHostKerberosDescriptor = updateWebHCatHostKerberosDescriptor(kerberosDescriptor);
 
-    if (ambariInfraService != null || updatedWebHCatHostsInHadoopProxyuserHttpHostsForHive) {
+    if (ambariInfraService != null || updateWebHCatHostKerberosDescriptor) {
       artifactEntity.setArtifactData(kerberosDescriptor.toMap());
       artifactDAO.merge(artifactEntity);
     }
   }
 
-  private boolean updateWebHCatHostsInHadoopProxyuserHttpHostsForHive(KerberosDescriptor kerberosDescriptor) {
+  // some command json elements were modified from ..._host to ..._hosts, kerberos related properties must be adjusted accordingly
+  private boolean updateWebHCatHostKerberosDescriptor(KerberosDescriptor kerberosDescriptor) {
     boolean updated = false;
     final KerberosServiceDescriptor hiveService = kerberosDescriptor.getServices().get(HiveServiceValidator.HIVE_SERVICE);
     if (hiveService != null) {

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
@@ -150,7 +150,7 @@
             {
               "webhcat-site": {
                 "templeton.kerberos.secret": "secret",
-                "templeton.hive.properties": "hive.metastore.local=false,hive.metastore.uris=${clusterHostInfo/hive_metastore_host|each(thrift://%s:9083, \\\\,, \\s*\\,\\s*)},hive.metastore.sasl.enabled=true,hive.metastore.execute.setugi=true,hive.metastore.warehouse.dir=/apps/hive/warehouse,hive.exec.mode.local.auto=false,hive.metastore.kerberos.principal=hive/_HOST@${realm}"
+                "templeton.hive.properties": "hive.metastore.local=false,hive.metastore.uris=${clusterHostInfo/hive_metastore_hosts|each(thrift://%s:9083, \\\\,, \\s*\\,\\s*)},hive.metastore.sasl.enabled=true,hive.metastore.execute.setugi=true,hive.metastore.warehouse.dir=/apps/hive/warehouse,hive.exec.mode.local.auto=false,hive.metastore.kerberos.principal=hive/_HOST@${realm}"
               }
             }
           ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the property name hive_metastore_hosts in kerberos.json for HDP 2.5

## How was this patch tested?

Tested on an openstack cluster.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.