### PR TITLE
[AMBARI-22953] Some scripts still use subprocess instead of subprocess32

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/main.py
+++ b/ambari-agent/src/main/python/ambari_agent/main.py
@@ -43,39 +43,6 @@ def fix_subprocess_racecondition():
   import gc
 
 
-"""
-# this might cause some unexcepted problems
-def fix_subprocess_popen():
-  '''
-  Workaround for race condition in starting subprocesses concurrently from
-  multiple threads via the subprocess and multiprocessing modules.
-  See http://bugs.python.org/issue19809 for details and repro script.
-  '''
-  import os
-  import sys
-
-  if os.name == 'posix' and sys.version_info[0] < 3:
-    from multiprocessing import forking
-    from ambari_commons import subprocess
-    import threading
-
-    sp_original_init = subprocess.Popen.__init__
-    mp_original_init = forking.Popen.__init__
-    lock = threading.RLock() # guards subprocess creation
-
-    def sp_locked_init(self, *a, **kw):
-      with lock:
-        sp_original_init(self, *a, **kw)
-
-    def mp_locked_init(self, *a, **kw):
-      with lock:
-        mp_original_init(self, *a, **kw)
-
-    subprocess.Popen.__init__ = sp_locked_init
-    forking.Popen.__init__ = mp_locked_init
-"""
-
-#fix_subprocess_popen()
 fix_subprocess_racecondition()
 fix_encoding_reimport_bug()
 

--- a/ambari-agent/src/test/python/ambari_agent/TestController.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestController.py
@@ -41,6 +41,7 @@ from ambari_agent.ExitHelper import ExitHelper
 from ambari_agent.AmbariConfig import AmbariConfig
 from ambari_agent.Facter import FacterLinux
 import ambari_commons
+from ambari_commons import subprocess32
 
 @not_for_platform(PLATFORM_WINDOWS)
 @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
@@ -189,7 +190,7 @@ class TestController(unittest.TestCase):
     self.assertTrue(process_status_commands.called)
 
 
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))
   @patch.object(FacterLinux, "facterInfo", new = MagicMock(return_value={}))
   @patch.object(FacterLinux, "__init__", new = MagicMock(return_value = None))
@@ -231,7 +232,7 @@ class TestController(unittest.TestCase):
     self.assertTrue(aq.start.called)
 
 
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))
   @patch.object(FacterLinux, "facterInfo", new = MagicMock(return_value={}))
   @patch.object(FacterLinux, "__init__", new = MagicMock(return_value = None))

--- a/ambari-agent/src/test/python/ambari_agent/TestHeartbeat.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestHeartbeat.py
@@ -27,6 +27,7 @@ import sys
 import multiprocessing
 from ambari_agent.RecoveryManager import RecoveryManager
 from ambari_agent.StatusCommandsExecutor import SingleProcessStatusCommandsExecutor
+from ambari_commons import subprocess32
 
 
 with patch("platform.linux_distribution", return_value = ('Suse','11','Final')):
@@ -77,7 +78,7 @@ class TestHeartbeat(TestCase):
     self.assertEquals((len(result) is 7) or (len(result) is 8), True)
     self.assertEquals(not heartbeat.reports, True, "Heartbeat should not contain task in progress")
 
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))
   @patch.object(ActionQueue, "result")
   @patch.object(HostInfoLinux, "register")
@@ -203,7 +204,7 @@ class TestHeartbeat(TestCase):
     self.assertEqual.__self__.maxDiff = None
     self.assertEquals(hb, expected)
 
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))
   @patch.object(HostInfoLinux, 'register')
   def test_heartbeat_no_host_check_cmd_in_queue(self, register_mock, Popen_mock):
@@ -232,7 +233,7 @@ class TestHeartbeat(TestCase):
     self.assertFalse(args[2])
     self.assertFalse(args[1])
 
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))
   @patch.object(HostInfoLinux, 'register')
   def test_status_commands_does_not_stack_up(self, register_mock, Popen_mock):
@@ -272,7 +273,7 @@ class TestHeartbeat(TestCase):
     self.assertEquals(len(dummy_controller.statusCommandsExecutor.statusCommandQueue.queue), 2)
 
 
-  @patch("subprocess.Popen")
+  @patch.object(subprocess32, "Popen")
   @patch.object(Hardware, "_chk_writable_mount", new = MagicMock(return_value=True))
   @patch.object(HostInfoLinux, 'register')
   def test_heartbeat_host_check_no_cmd(self, register_mock, Popen_mock):

--- a/ambari-common/src/main/python/resource_management/core/providers/package/apt.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/package/apt.py
@@ -22,7 +22,7 @@ Ambari Agent
 import os
 import tempfile
 import re
-import subprocess
+from ambari_commons import subprocess32
 
 from ambari_commons.constants import AMBARI_SUDO_BINARY
 from ambari_commons.shell import process_executor
@@ -325,7 +325,7 @@ class AptProvider(PackageProvider):
     return dict(configuration)
 
   def get_installed_package_version(self, package_name):
-    code, out, err = self.checked_call("dpkg -s {0} | grep Version | awk '{{print $2}}'".format(package_name), stderr=subprocess.PIPE)
+    code, out, err = self.checked_call("dpkg -s {0} | grep Version | awk '{{print $2}}'".format(package_name), stderr=subprocess32.PIPE)
     return out
 
   def verify_dependencies(self):

--- a/ambari-common/src/main/python/resource_management/libraries/functions/packages_analyzer.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/packages_analyzer.py
@@ -21,7 +21,7 @@ limitations under the License.
 import re
 import sys
 import logging
-import subprocess
+from ambari_commons import subprocess32
 from threading import Thread
 import threading
 from ambari_commons import OSCheck, OSConst
@@ -45,7 +45,7 @@ TIMEOUT_SECONDS = 40
 
 def _launch_subprocess(command):
   isShell = not isinstance(command, (list, tuple))
-  return subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=isShell, close_fds=True)
+  return subprocess32.Popen(command, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE, shell=isShell, close_fds=True)
 
 
 def subprocessWithTimeout(command):

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/kerberos_common.py
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/kerberos_common.py
@@ -21,7 +21,7 @@ import base64
 import getpass
 import os
 import string
-import subprocess
+from ambari_commons import subprocess32
 import sys
 import tempfile
 from tempfile import gettempdir
@@ -349,7 +349,7 @@ class KerberosScript(Script):
 
       # If no keytab data is available and a password was supplied, simply use it.
       elif password is not None:
-        process = subprocess.Popen([kinit_path_local, principal], stdin=subprocess.PIPE)
+        process = subprocess32.Popen([kinit_path_local, principal], stdin=subprocess32.PIPE)
         stdout, stderr = process.communicate(password)
         if process.returncode:
           err_msg = Logger.filter_text("Execution of kinit returned %d. %s" % (process.returncode, stderr))

--- a/ambari-server/src/main/resources/common-services/R4ML/0.8.0/package/scripts/r4ml_client.py
+++ b/ambari-server/src/main/resources/common-services/R4ML/0.8.0/package/scripts/r4ml_client.py
@@ -19,7 +19,7 @@ limitations under the License.
 """
 
 import os
-import subprocess
+from ambari_commons import subprocess32
 from resource_management import *
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions import StackFeature
@@ -71,7 +71,7 @@ class R4MLClient(Script):
     import urllib
     code = 0
     try :
-      code = subprocess.call(["sudo", "which", "R"])
+      code = subprocess32.call(["sudo", "which", "R"])
     except Exception as e :
       Logger.error(str(e))
     if code != 0 :

--- a/ambari-server/src/main/resources/common-services/R4ML/0.8.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/R4ML/0.8.0/package/scripts/service_check.py
@@ -20,7 +20,6 @@ limitations under the License.
 
 from resource_management import *
 from resource_management.libraries.functions.format import format
-import subprocess
 import os
 
 class R4MLServiceCheck(Script):

--- a/ambari-server/src/main/resources/common-services/SYSTEMML/0.10.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/SYSTEMML/0.10.0/package/scripts/service_check.py
@@ -20,7 +20,7 @@ limitations under the License.
 
 from resource_management import *
 from resource_management.libraries.functions.format import format
-import subprocess
+from ambari_commons import subprocess32
 import os
 
 class SystemMLServiceCheck(Script):
@@ -32,7 +32,7 @@ class SystemMLServiceCheck(Script):
             cp = format("{params.stack_root}/current/hadoop-client/*:{params.stack_root}/current/hadoop-mapreduce-client/*:{params.stack_root}/current/hadoop-client/lib/*:{params.systemml_lib_dir}/systemml.jar")
             java = format("{params.java_home}/bin/java")
             command = [java, "-cp", cp, "org.apache.sysml.api.DMLScript", "-s", "print('Apache SystemML');"]
-            process = subprocess.Popen(command, stdout=subprocess.PIPE)
+            process = subprocess32.Popen(command, stdout=subprocess32.PIPE)
             output = process.communicate()[0]
             print output
         

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/package/scripts/namenode.py
@@ -22,7 +22,7 @@ from hdfs_namenode import namenode
 from hdfs import hdfs
 import time
 import json
-import subprocess
+from ambari_commons import subprocess32
 import hdfs_rebalance
 import sys
 import os
@@ -101,9 +101,9 @@ class NameNode(Script):
     _print("Executing command %s\n" % command)
     
     parser = hdfs_rebalance.HdfsParser()
-    proc = subprocess.Popen(
+    proc = subprocess32.Popen(
                             command, 
-                            stdout=subprocess.PIPE, 
+                            stdout=subprocess32.PIPE, 
                             shell=False,
                             close_fds=True,
                             cwd=basedir

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/WEBHCAT/package/files/alert_webhcat_server.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/WEBHCAT/package/files/alert_webhcat_server.py
@@ -19,7 +19,7 @@ limitations under the License.
 """
 
 import json
-import subprocess
+from ambari_commons import subprocess32
 import socket
 import time
 import urllib2
@@ -146,9 +146,9 @@ def execute(configurations={}, parameters={}, host_name=None):
         Execute(kinit_command)
 
       # make a single curl call to get just the http code
-      curl = subprocess.Popen(['curl', '--negotiate', '-u', ':', '-s', '-w', '--location-trusted',
+      curl = subprocess32.Popen(['curl', '--negotiate', '-u', ':', '-s', '-w', '--location-trusted',
         '%{http_code}', '--connect-timeout', curl_connection_timeout,
-        '-o', '/dev/null', query_url], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=kerberos_env)
+        '-o', '/dev/null', query_url], stdout=subprocess32.PIPE, stderr=subprocess32.PIPE, env=kerberos_env)
 
       stdout, stderr = curl.communicate()
 
@@ -170,9 +170,9 @@ def execute(configurations={}, parameters={}, host_name=None):
 
       # now that we have the http status and it was 200, get the content
       start_time = time.time()
-      curl = subprocess.Popen(['curl', '--negotiate', '-u', ':', '-s', '--location-trusted',
+      curl = subprocess32.Popen(['curl', '--negotiate', '-u', ':', '-s', '--location-trusted',
         '--connect-timeout', curl_connection_timeout, query_url, ],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=kerberos_env)
+        stdout=subprocess32.PIPE, stderr=subprocess32.PIPE, env=kerberos_env)
 
       stdout, stderr = curl.communicate()
       total_time = time.time() - start_time

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/YARN/package/files/validateYarnComponentStatus.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/YARN/package/files/validateYarnComponentStatus.py
@@ -19,7 +19,7 @@ limitations under the License.
 '''
 
 import optparse
-import subprocess
+from ambari_commons import subprocess32
 import json
 
 RESOURCEMANAGER = 'rm'
@@ -43,7 +43,7 @@ def getResponse(path, address, ssl_enabled):
       
   command_with_flags = [command,httpGssnegotiate,userpswd,insecure,url]
 
-  proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
   (stdout, stderr) = proc.communicate()
   response = json.loads(stdout)
   if response == None:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/HDFS/package/scripts/hdfs_nfsgateway.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/HDFS/package/scripts/hdfs_nfsgateway.py
@@ -22,7 +22,7 @@ from resource_management.core.logger import Logger
 from resource_management.core.resources import Directory
 from resource_management.core import shell
 from utils import service
-import subprocess,os
+import os
 
 # NFS GATEWAY is always started by root using jsvc due to rpcbind bugs
 # on Linux such as CentOS6.2. https://bugzilla.redhat.com/show_bug.cgi?id=731542

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/HIVE/package/alerts/alert_webhcat_server.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/HIVE/package/alerts/alert_webhcat_server.py
@@ -19,7 +19,7 @@ limitations under the License.
 """
 
 import ambari_simplejson as json # simplejson is much faster comparing to Python 2.6 json module and has the same functions set.
-import subprocess
+from ambari_commons import subprocess32
 import socket
 import time
 import urllib2
@@ -163,7 +163,7 @@ def execute(configurations={}, parameters={}, host_name=None):
       # make a single curl call to get just the http code
       _, stdout, stderr = shell.checked_call(['curl', '--negotiate', '-u', ':', '-sL', '-w',
         '%{http_code}', '--connect-timeout', curl_connection_timeout,
-        '-o', '/dev/null', query_url], stderr=subprocess.PIPE, env=kerberos_env)
+        '-o', '/dev/null', query_url], stderr=subprocess32.PIPE, env=kerberos_env)
 
       if stderr != '':
         raise Exception(stderr)
@@ -185,7 +185,7 @@ def execute(configurations={}, parameters={}, host_name=None):
       start_time = time.time()
       _, stdout, stderr = shell.checked_call(['curl', '--negotiate', '-u', ':', '-sL',
         '--connect-timeout', curl_connection_timeout, query_url, ],
-        stderr=subprocess.PIPE, env=kerberos_env)
+        stderr=subprocess32.PIPE, env=kerberos_env)
 
       total_time = time.time() - start_time
 

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/KERBEROS/package/scripts/kerberos_common.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/KERBEROS/package/scripts/kerberos_common.py
@@ -20,7 +20,7 @@ limitations under the License.
 import base64
 import os
 import string
-import subprocess
+from ambari_commons import subprocess32
 import sys
 import tempfile
 from tempfile import gettempdir
@@ -351,7 +351,7 @@ class KerberosScript(Script):
 
       # If no keytab data is available and a password was supplied, simply use it.
       elif password is not None:
-        process = subprocess.Popen([kinit_path_local, principal], stdin=subprocess.PIPE)
+        process = subprocess32.Popen([kinit_path_local, principal], stdin=subprocess32.PIPE)
         stdout, stderr = process.communicate(password)
         if process.returncode:
           err_msg = Logger.filter_text("Execution of kinit returned %d. %s" % (process.returncode, stderr))

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/SOLR/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/SOLR/package/scripts/service_check.py
@@ -21,7 +21,6 @@ limitations under the License.
 
 from resource_management import *
 from resource_management.libraries.functions.validate import call_and_match_output
-import subprocess
 import time
 
 class SolrServiceCheck(Script):

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/SPARK/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/SPARK/package/scripts/service_check.py
@@ -17,7 +17,7 @@ limitations under the License.
 """
 
 from resource_management import *
-import subprocess
+from ambari_commons import subprocess32
 import time
 
 class SparkServiceCheck(Script):
@@ -47,7 +47,7 @@ class SparkServiceCheck(Script):
 
     is_running = False
     for i in range(1,11):
-      proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
       Logger.info("Try %d, command: %s" % (i, " ".join(command_with_flags)))
       (stdout, stderr) = proc.communicate()
       response = stdout
@@ -65,7 +65,7 @@ class SparkServiceCheck(Script):
 
 
     #command_with_flags = [command, silent, out, head, httpGssnegotiate, userpswd, insecure, url]
-    # proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
     # (stdout, stderr) = proc.communicate()
     # response = stdout
     # if '200' in response:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/YARN/package/files/validateYarnComponentStatus.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/YARN/package/files/validateYarnComponentStatus.py
@@ -19,7 +19,7 @@ limitations under the License.
 '''
 
 import optparse
-import subprocess
+from ambari_commons import subprocess32
 import json
 
 RESOURCEMANAGER = 'rm'
@@ -43,7 +43,7 @@ def getResponse(path, address, ssl_enabled):
 
   command_with_flags = [command,httpGssnegotiate,userpswd,insecure,url]
 
-  proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
   (stdout, stderr) = proc.communicate()
   response = json.loads(stdout)
   if response == None:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/YARN/package/scripts/nodemanager_upgrade.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/YARN/package/scripts/nodemanager_upgrade.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 """
 
-import subprocess
 
 from resource_management.core.logger import Logger
 from resource_management.core.exceptions import Fail

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2.5/services/HDFS/package/scripts/hdfs_nfsgateway.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2.5/services/HDFS/package/scripts/hdfs_nfsgateway.py
@@ -22,7 +22,7 @@ from resource_management.core.logger import Logger
 from resource_management.core.resources import Directory
 from resource_management.core import shell
 from utils import service
-import subprocess,os
+import os
 
 # NFS GATEWAY is always started by root using jsvc due to rpcbind bugs
 # on Linux such as CentOS6.2. https://bugzilla.redhat.com/show_bug.cgi?id=731542

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2.5/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2.5/services/stack_advisor.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 import os, platform
-from subprocess import Popen, PIPE
+from ambari_commons import subprocess32
 
 class BigInsights425StackAdvisor(BigInsights42StackAdvisor):
 
@@ -67,9 +67,9 @@ class BigInsights425StackAdvisor(BigInsights42StackAdvisor):
     distro_version = platform.linux_distribution()[1]
     if distro_version < "7.0" and (py_exec == "/opt/rh/python27/root/usr/bin/python" or py_exec == "/opt/rh/python27/root/usr/bin/python2" or py_exec == "/opt/rh/python27/root/usr/bin/python2.7"):
       # Special handling for RHSCL Python 2.7
-      proc = Popen(['/usr/bin/scl', 'enable', 'python27', '/opt/rh/python27/root/usr/bin/python' ' -V'], stderr=PIPE)
+      proc = subprocess32.Popen(['/usr/bin/scl', 'enable', 'python27', '/opt/rh/python27/root/usr/bin/python' ' -V'], stderr=subprocess32.PIPE)
     else:
-      proc = Popen([py_exec, '-V'], stderr=PIPE)
+      proc = subprocess32.Popen([py_exec, '-V'], stderr=subprocess32.PIPE)
     py_string = proc.communicate()[1]
     py_version = py_string.split()[1]
 

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/HDFS/package/scripts/hdfs_nfsgateway.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/HDFS/package/scripts/hdfs_nfsgateway.py
@@ -22,7 +22,7 @@ from resource_management.core.logger import Logger
 from resource_management.core.resources import Directory
 from resource_management.core import shell
 from utils import service
-import subprocess,os
+import os
 
 # NFS GATEWAY is always started by root using jsvc due to rpcbind bugs
 # on Linux such as CentOS6.2. https://bugzilla.redhat.com/show_bug.cgi?id=731542

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/KAFKA/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/KAFKA/package/scripts/service_check.py
@@ -22,7 +22,7 @@ from resource_management.libraries.functions.validate import call_and_match_outp
 from resource_management.libraries.functions.format import format
 from resource_management.core.logger import Logger
 from resource_management.core import sudo
-import subprocess
+from ambari_commons import subprocess32
 
 class ServiceCheck(Script):
   def service_check(self, env):
@@ -38,7 +38,7 @@ class ServiceCheck(Script):
     create_topic_cmd_exists_output = "Topic \"ambari_kafka_service_check\" already exists."
     source_cmd = format("source {conf_dir}/kafka-env.sh")
     topic_exists_cmd = format("{kafka_home}/bin/kafka-topics.sh --zookeeper {kafka_config[zookeeper.connect]} --topic {topic} --list")
-    topic_exists_cmd_p = subprocess.Popen(topic_exists_cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    topic_exists_cmd_p = subprocess32.Popen(topic_exists_cmd.split(" "), stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
     topic_exists_cmd_out, topic_exists_cmd_err = topic_exists_cmd_p.communicate()
     # run create topic command only if the topic doesn't exists
     if topic not in topic_exists_cmd_out:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/KERBEROS/package/scripts/kerberos_common.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/KERBEROS/package/scripts/kerberos_common.py
@@ -20,7 +20,7 @@ limitations under the License.
 import base64
 import os
 import string
-import subprocess
+from ambari_commons import subprocess32
 import sys
 import tempfile
 from tempfile import gettempdir
@@ -351,7 +351,7 @@ class KerberosScript(Script):
 
       # If no keytab data is available and a password was supplied, simply use it.
       elif password is not None:
-        process = subprocess.Popen([kinit_path_local, principal], stdin=subprocess.PIPE)
+        process = subprocess32.Popen([kinit_path_local, principal], stdin=subprocess32.PIPE)
         stdout, stderr = process.communicate(password)
         if process.returncode:
           err_msg = Logger.filter_text("Execution of kinit returned %d. %s" % (process.returncode, stderr))

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/SOLR/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/SOLR/package/scripts/service_check.py
@@ -21,7 +21,6 @@ limitations under the License.
 
 from resource_management import *
 from resource_management.libraries.functions.validate import call_and_match_output
-import subprocess
 import time
 
 class SolrServiceCheck(Script):

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/SPARK/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/SPARK/package/scripts/service_check.py
@@ -17,7 +17,7 @@ limitations under the License.
 """
 
 from resource_management import *
-import subprocess
+from ambari_commons import subprocess32
 import time
 
 class SparkServiceCheck(Script):
@@ -48,7 +48,7 @@ class SparkServiceCheck(Script):
 
     is_running = False
     for i in range(1,11):
-      proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
       Logger.info("Try %d, command: %s" % (i, " ".join(command_with_flags)))
       (stdout, stderr) = proc.communicate()
       response = stdout
@@ -119,7 +119,7 @@ class SparkServiceCheck(Script):
 
 
     #command_with_flags = [command, silent, out, head, httpGssnegotiate, userpswd, insecure, url]
-    # proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
     # (stdout, stderr) = proc.communicate()
     # response = stdout
     # if '200' in response:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/SYSTEMML/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/SYSTEMML/package/scripts/service_check.py
@@ -20,7 +20,7 @@ limitations under the License.
 
 from resource_management import *
 from resource_management.libraries.functions.format import format
-import subprocess
+from ambari_commons import subprocess32
 import os
 
 class SystemMLServiceCheck(Script):
@@ -32,7 +32,7 @@ class SystemMLServiceCheck(Script):
             cp = format("{params.stack_root}/current/hadoop-client/*:{params.stack_root}/current/hadoop-mapreduce-client/*:{params.stack_root}/current/hadoop-client/lib/*:{params.systemml_lib_dir}/systemml.jar")
             java = format("{params.java_home}/bin/java")
             command = [java, "-cp", cp, "org.apache.sysml.api.DMLScript", "-s", "print('Apache SystemML');"]
-            process = subprocess.Popen(command, stdout=subprocess.PIPE)
+            process = subprocess32.Popen(command, stdout=subprocess32.PIPE)
             output = process.communicate()[0]
             print output
         

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/YARN/package/files/validateYarnComponentStatus.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/YARN/package/files/validateYarnComponentStatus.py
@@ -19,7 +19,7 @@ limitations under the License.
 '''
 
 import optparse
-import subprocess
+from ambari_commons import subprocess32
 import json
 
 RESOURCEMANAGER = 'rm'
@@ -43,7 +43,7 @@ def getResponse(path, address, ssl_enabled):
       
   command_with_flags = [command,httpGssnegotiate,userpswd,insecure,url]
 
-  proc = subprocess.Popen(command_with_flags, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  proc = subprocess32.Popen(command_with_flags, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
   (stdout, stderr) = proc.communicate()
   response = json.loads(stdout)
   if response == None:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/YARN/package/scripts/nodemanager_upgrade.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/YARN/package/scripts/nodemanager_upgrade.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 """
 
-import subprocess
 
 from resource_management.core.logger import Logger
 from resource_management.core.exceptions import Fail

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/YARN/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/YARN/package/scripts/service_check.py
@@ -21,7 +21,6 @@ Ambari Agent
 
 import re
 import sys
-import subprocess
 from resource_management.libraries.functions.version import compare_versions
 from resource_management import *
 import ambari_simplejson as json # simplejson is much faster comparing to Python 2.6 json module and has the same functions set.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove leftover references to `subprocess` in favor of `subprocess32`.

## How was this patch tested?

Ran unit tests:

```
$ mvn -am -pl ambari-agent,ambari-server -DskipSurefireTests -Drat.skip -Dcheckstyle.skip -Del.log=WARN clean test
...
[INFO] BUILD SUCCESS
```

Verified remaining references are not functional:

```
$ grep -r '\<subprocess\>' ambari-{agent,common,server}/src --include='*.py'
ambari-agent/src/main/python/ambari_agent/main.py:  subprocess in Python has race condition with enabling/disabling gc. Which may lead to turning off python garbage collector.
ambari-agent/src/main/python/ambari_agent/main.py:  This function monkey patches subprocess to fix the issue.
ambari-agent/src/main/python/ambari_agent/main.py:  !!! PLEASE NOTE THIS SHOULD BE CALLED BEFORE ANY OTHER INITIALIZATION was done to avoid already created links to subprocess or subprocess.gc or gc
ambari-agent/src/main/python/ambari_agent/main.py:  # monkey patching subprocess
ambari-agent/src/main/python/ambari_agent/main.py:  import subprocess
ambari-agent/src/main/python/ambari_agent/main.py:  subprocess.gc.isenabled = lambda: True
ambari-agent/src/main/python/ambari_agent/main.py:  # re-importing gc to have correct isenabled for non-subprocess contexts
ambari-common/src/main/python/ambari_commons/shell.py:  Watchdog function for subprocess executors
ambari-common/src/main/python/ambari_commons/subprocess32.py:# subprocess - Subprocesses with accessible I/O streams
ambari-common/src/main/python/ambari_commons/subprocess32.py:# can drop subprocess32 in as a replacement for the stdlib subprocess module.
ambari-common/src/main/python/ambari_commons/subprocess32.py:    pass a string to the subprocess's stdin.  If you use this argument
```