### PR TITLE
[AMBARI-23793]. MySQL Connector JAR distribution is broken (amagyar)

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -247,6 +247,12 @@
         <version>1.3</version>
       </dependency>
       <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>3.1.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
         <version>${powermock.version}</version>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1271,6 +1271,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.agent.stomp.dto.MetadataCluster;
 import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
+import org.apache.ambari.server.events.AmbariPropertiesChangedEvent;
 import org.apache.ambari.server.events.ClusterComponentsRepoChangedEvent;
 import org.apache.ambari.server.events.ClusterConfigChangedEvent;
 import org.apache.ambari.server.events.MetadataUpdateEvent;
@@ -106,5 +107,10 @@ public class MetadataHolder extends AgentClusterDataHolder<MetadataUpdateEvent> 
   public void onServiceCredentialStoreUpdate(ServiceCredentialStoreUpdateEvent serviceCredentialStoreUpdateEvent) throws AmbariException {
     Cluster cluster = m_clusters.get().getCluster(serviceCredentialStoreUpdateEvent.getClusterId());
     updateData(ambariManagementController.getClusterMetadataOnServiceCredentialStoreUpdate(cluster, serviceCredentialStoreUpdateEvent.getServiceName()));
+  }
+
+  @Subscribe
+  public void onAmbariPropertiesChange(AmbariPropertiesChangedEvent event) throws AmbariException {
+    updateData(ambariManagementController.getClustersMetadata());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -2931,7 +2931,7 @@ public class Configuration {
   private void writeConfigFile(Properties propertiesToStore, boolean append) throws AmbariException {
     File configFile = null;
     try {
-      configFile = new File(Configuration.class.getClassLoader().getResource(Configuration.CONFIG_FILE).getPath());
+      configFile = getConfigFile();
       propertiesToStore.store(new OutputStreamWriter(new FileOutputStream(configFile, append), Charsets.UTF_8), null);
     } catch (Exception e) {
       LOG.error("Cannot write properties [" + propertiesToStore + "] into configuration file [" + configFile + ", " + append + "] ");
@@ -3091,7 +3091,7 @@ public class Configuration {
   }
 
   public Map<String, String> getDatabaseConnectorNames() {
-    File file = new File(Configuration.class.getClassLoader().getResource(CONFIG_FILE).getPath());
+    File file = getConfigFile();
     Long currentConfigLastModifiedDate = file.lastModified();
     Properties properties = null;
     if (currentConfigLastModifiedDate.longValue() != configLastModifiedDateForCustomJDBC.longValue()) {
@@ -3115,8 +3115,12 @@ public class Configuration {
     return databaseConnectorNames;
   }
 
+  public File getConfigFile() {
+    return new File(Configuration.class.getClassLoader().getResource(CONFIG_FILE).getPath());
+  }
+
   public Map<String, String> getPreviousDatabaseConnectorNames() {
-    File file = new File(Configuration.class.getClassLoader().getResource(CONFIG_FILE).getPath());
+    File file = getConfigFile();
     Long currentConfigLastModifiedDate = file.lastModified();
     Properties properties = null;
     if (currentConfigLastModifiedDate.longValue() != configLastModifiedDateForCustomJDBCToRemove.longValue()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/SingleFileWatch.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/SingleFileWatch.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.ambari.server.configuration;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Watchdog that notifies a listener on a file content change.
+ */
+public class SingleFileWatch implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(SingleFileWatch.class);
+  private final File file;
+  private final Consumer<File> changeListener;
+  private final Thread thread;
+  private volatile boolean started = false;
+
+  /**
+   * @param file to be watched
+   * @param changeListener to be notified if the file content changes
+   */
+  public SingleFileWatch(File file, Consumer<File> changeListener) {
+    this.file = file;
+    this.changeListener = changeListener;
+    this.thread = new Thread(this, toString());
+  }
+
+  /**
+   * Start the watch service in the background
+   */
+  public void start() {
+    LOG.info("Starting " + this);
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  /**
+   * Stop the watch service
+   */
+  public void stop() {
+    LOG.info("Stopping " + this);
+    started = false;
+    thread.interrupt();
+  }
+
+  /**
+   * @return true if the WatchService is started in the background and registered on the given directory
+   */
+  public boolean isStarted() {
+    return started;
+  }
+
+  public void run() {
+    try {
+      checkForFileModifications();
+    } catch (IOException e) {
+      LOG.error(this + " error", e);
+      started = false;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.info(this + " interrupted");
+      started = false;
+    }
+  }
+
+  /**
+   * WatchService can only watch directories not individual files, we're watching the parent directory and filter events by filename
+   */
+  private void checkForFileModifications() throws IOException, InterruptedException {
+    try (WatchService watch = FileSystems.getDefault().newWatchService()) {
+      register(watch);
+      while (started) {
+        WatchKey key = watch.take();
+        key.pollEvents().stream()
+          .map(event -> (Path) event.context())
+          .filter(path -> file.toPath().getFileName().equals(path.getFileName()))
+          .findAny()
+          .ifPresent(this::notifyListener);
+        key.reset();
+      }
+    }
+  }
+
+  private void register(WatchService watch) throws IOException {
+    Path parent = parentDirectory();
+    LOG.info("Registering on {}", parent);
+    parent.register(watch, ENTRY_MODIFY);
+    started = true;
+  }
+
+  private void notifyListener(Path path) {
+    LOG.info(path + " changed. Sending notification.");
+    try {
+      changeListener.accept(file);
+    } catch (Exception e) {
+      LOG.warn("Error while notifying " + this + " listener", e);
+    }
+  }
+
+  private Path parentDirectory() {
+    return file.getParentFile().toPath();
+  }
+
+  public String toString() {
+    return "SingleFileWatcher:" + file.getName();
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/SingleFileWatch.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/SingleFileWatch.java
@@ -117,7 +117,7 @@ public class SingleFileWatch implements Runnable {
   }
 
   private void notifyListener(Path path) {
-    LOG.info(path + " changed. Sending notification.");
+    LOG.info("{} changed. Sending notification.", path);
     try {
       changeListener.accept(file);
     } catch (Exception e) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -59,6 +59,7 @@ import org.apache.ambari.server.checks.DatabaseConsistencyCheckHelper;
 import org.apache.ambari.server.checks.DatabaseConsistencyCheckResult;
 import org.apache.ambari.server.configuration.ComponentSSLConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.configuration.SingleFileWatch;
 import org.apache.ambari.server.configuration.spring.AgentStompConfig;
 import org.apache.ambari.server.configuration.spring.ApiSecurityConfig;
 import org.apache.ambari.server.configuration.spring.ApiStompConfig;
@@ -79,6 +80,8 @@ import org.apache.ambari.server.controller.internal.ViewPermissionResourceProvid
 import org.apache.ambari.server.controller.metrics.ThreadPoolEnabledPropertyProvider;
 import org.apache.ambari.server.controller.utilities.KerberosChecker;
 import org.apache.ambari.server.controller.utilities.KerberosIdentityCleaner;
+import org.apache.ambari.server.events.AmbariPropertiesChangedEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.ldap.LdapModule;
 import org.apache.ambari.server.metrics.system.MetricsService;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
@@ -945,6 +948,15 @@ public class AmbariServer {
 
     KerberosIdentityCleaner identityCleaner = injector.getInstance(KerberosIdentityCleaner.class);
     identityCleaner.register();
+
+    configureFileWatcher();
+  }
+
+  private void configureFileWatcher() {
+    AmbariEventPublisher ambariEventPublisher = injector.getInstance(AmbariEventPublisher.class);
+    Configuration config = injector.getInstance(Configuration.class);
+    SingleFileWatch watch = new SingleFileWatch(config.getConfigFile(), file -> ambariEventPublisher.publish(new AmbariPropertiesChangedEvent()));
+    watch.start();
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariEvent.java
@@ -168,6 +168,11 @@ public abstract class AmbariEvent {
     AMBARI_CONFIGURATION_CHANGED,
 
     /**
+     * Ambari properties changed event;
+     */
+    AMBARI_PROPERTIES_CHANGED,
+
+    /**
      * JPA initialized
      */
     JPA_INITIALIZED,

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariPropertiesChangedEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariPropertiesChangedEvent.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.ambari.server.events;
+
+public class AmbariPropertiesChangedEvent extends AmbariEvent {
+
+  public AmbariPropertiesChangedEvent() {
+    super(AmbariEventType.AMBARI_CONFIGURATION_CHANGED);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariPropertiesChangedEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AmbariPropertiesChangedEvent.java
@@ -20,6 +20,9 @@
 
 package org.apache.ambari.server.events;
 
+/**
+ * This event is fired when ambari.properties file changes
+ */
 public class AmbariPropertiesChangedEvent extends AmbariEvent {
 
   public AmbariPropertiesChangedEvent() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/SingleFileWatchTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/SingleFileWatchTest.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.ambari.server.configuration;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.commons.io.FileUtils.writeStringToFile;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SingleFileWatchTest {
+  @Rule
+  public TemporaryFolder tmp = new TemporaryFolder();
+  private SingleFileWatch watchDog;
+  private File fileToWatch;
+  private volatile int numberOfEventsReceived = 0;
+
+  @Before
+  public void setUp() throws Exception {
+    fileToWatch = tmp.newFile();
+    watchDog = new SingleFileWatch(fileToWatch, file -> numberOfEventsReceived++);
+    watchDog.start();
+    await().atMost(3, SECONDS).until(watchDog::isStarted);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    watchDog.stop();
+  }
+
+  @Test
+  public void testTriggersEventsOnMultipleFileChange() throws Exception {
+    assumeTrue(SystemUtils.IS_OS_LINUX); // the OSX implementation of WatchService is really slow
+    changeFile("change1");
+    await().atMost(15, SECONDS).until(() -> numberOfEventsReceived == 1);
+    changeFile("change2");
+    await().atMost(15, SECONDS).until(() -> numberOfEventsReceived == 2);
+  }
+
+  private void changeFile(String content) throws IOException {
+    writeStringToFile(fileToWatch, content, "UTF-8");
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/SingleFileWatchTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/SingleFileWatchTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assume.assumeTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/SingleFileWatchTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/SingleFileWatchTest.java
@@ -44,6 +44,7 @@ public class SingleFileWatchTest {
 
   @Before
   public void setUp() throws Exception {
+    tmp.create();
     fileToWatch = tmp.newFile();
     watchDog = new SingleFileWatch(fileToWatch, file -> numberOfEventsReceived++);
     watchDog.start();


### PR DESCRIPTION
## What changes were proposed in this pull request?

After running _ambari-server setup --jdbc-db=mysql_ ambari.properties file changes, but these changes are not visible in ambariLevelParams of command jsons. Amabari agent still sees a cached version of these parameters. 

This fix triggers an event which invalidates the cache when ambari.properties file changes.

## How was this patch tested?

I ran the following command

```bash
$ ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar
```

and inspected ambariLevel params of /var/lib/ambari-agent/data/command-XXX.json