### PR TITLE
AMBARI-23798 - After adding Namespace, Some HDFS Quicklinks do not wo…

### DIFF
--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -488,7 +488,7 @@ App.QuickLinksView = Em.View.extend({
             if (configPropertiesObject && configPropertiesObject.properties) {
               var properties = configPropertiesObject.properties;
               var nnKeyRegex = new RegExp('^dfs\.namenode\.' + protocol + '-address\.');
-              var nnProperties = Object.keys(properties).filter(key => nnKeyRegex.test(key))
+              var nnProperties = Object.keys(properties).filter(key => nnKeyRegex.test(key));
               var nnPropertiesLength = nnProperties.length;
               for (var i = nnPropertiesLength; i--;) {
                 var propertyName = nnProperties[i];

--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -487,8 +487,8 @@ App.QuickLinksView = Em.View.extend({
             var configPropertiesObject = configProperties.findProperty('type', 'hdfs-site');
             if (configPropertiesObject && configPropertiesObject.properties) {
               var properties = configPropertiesObject.properties;
-              var nameServiceId = properties['dfs.nameservices'];
-              var nnProperties = ['dfs.namenode.{0}-address.{1}.nn1', 'dfs.namenode.{0}-address.{1}.nn2'].invoke('format', protocol, nameServiceId);
+              var nnKeyRegex = new RegExp('^dfs\.namenode\.' + protocol + '-address\.');
+              var nnProperties = Object.keys(properties).filter(key => nnKeyRegex.test(key))
               var nnPropertiesLength = nnProperties.length;
               for (var i = nnPropertiesLength; i--;) {
                 var propertyName = nnProperties[i];


### PR DESCRIPTION
…rk intermittently

## What changes were proposed in this pull request?

In a federated cluster when a port of a NameNode is changed the Quicklinks belongs to the name node does not change: a template like dfs.namenode.{0}-address.{1}.nn1 was used when searching for the property name in hdfs-site config which holds the host and port of the NameNode. In this template {1} is replaced with the nameServiceId which is a comma separated list in a federated cluster like "ns1, ns2". There is no such property in the hdfs-site config.
Fix: collect all the namenode-address properties from hdfs-site and while iterating in the result check if the host is the same as the property value contains.

## How was this patch tested?
1. In folder ambari/ambari-web
mvn clean install -DambariVersion=2.7.0.0

2. Manually on a 4 node federated cluster and a hdfs-ha cluster

Please review
@swagle @atkach @aleksandrkovalenko @tobias-istvan 