### PR TITLE
AMBARI-23738 Need to add pre-upgrade check for Atlas service during stack upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheck.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.checks;
+
+import java.util.Set;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.controller.PrereqCheckRequest;
+import org.apache.ambari.server.state.stack.PrereqCheckStatus;
+import org.apache.ambari.server.state.stack.PrerequisiteCheck;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Singleton;
+
+
+/**
+ * Atlas needs to migrate existing data from TitanDB to JanusGraph.
+ * To migrate existing data to JanusGraph the property atlas.migration.data.filename needs to be present in Atlas applicaton.properties.
+ */
+@Singleton
+@UpgradeCheck(group = UpgradeCheckGroup.INFORMATIONAL_WARNING)
+public class AtlasMigrationPropertyCheck extends AbstractCheckDescriptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AtlasMigrationPropertyCheck.class);
+    private static final String serviceName = "ATLAS";
+
+    /**
+     * Default constructor
+     */
+    public AtlasMigrationPropertyCheck(){  super(CheckDescription.ATLAS_MIGRATION_PROPERTY_CHECK); }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<String> getApplicableServices() { return Sets.newHashSet(serviceName); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void perform(PrerequisiteCheck prerequisiteCheck, PrereqCheckRequest request) throws AmbariException {
+      String atlasMigrationProperty = getProperty(request,"application-properties","atlas.migration.data.filename");
+      if(null == atlasMigrationProperty || StringUtils.isEmpty(atlasMigrationProperty.trim())) {
+        LOG.info("The property atlas.migration.data.filename is not found in application-properties, need to add the property before upgrade.");
+        prerequisiteCheck.getFailedOn().add(serviceName);
+        prerequisiteCheck.setStatus(PrereqCheckStatus.FAIL);
+        prerequisiteCheck.setFailReason(getFailReason(prerequisiteCheck, request));
+      } else if (atlasMigrationProperty.contains("/etc/atlas/conf")) {
+          LOG.info("The property atlas.migration.data.filename is found in application-properties, but it contains with /etc/atlas/conf.");
+          prerequisiteCheck.getFailedOn().add(serviceName);
+          prerequisiteCheck.setStatus(PrereqCheckStatus.WARNING);
+          prerequisiteCheck.setFailReason(getFailReason(prerequisiteCheck, request));
+      } else {
+        LOG.info("The property atlas.migration.data.filename is found, proceeding with upgrade.");
+      }
+    }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheck.java
@@ -58,18 +58,16 @@ public class AtlasMigrationPropertyCheck extends AbstractCheckDescriptor {
     @Override
     public void perform(PrerequisiteCheck prerequisiteCheck, PrereqCheckRequest request) throws AmbariException {
       String atlasMigrationProperty = getProperty(request,"application-properties","atlas.migration.data.filename");
-      if(null == atlasMigrationProperty || StringUtils.isEmpty(atlasMigrationProperty.trim())) {
+      if(null == atlasMigrationProperty || StringUtils.isBlank(atlasMigrationProperty.trim())) {
         LOG.info("The property atlas.migration.data.filename is not found in application-properties, need to add the property before upgrade.");
         prerequisiteCheck.getFailedOn().add(serviceName);
         prerequisiteCheck.setStatus(PrereqCheckStatus.FAIL);
         prerequisiteCheck.setFailReason(getFailReason(prerequisiteCheck, request));
       } else if (atlasMigrationProperty.contains("/etc/atlas/conf")) {
-          LOG.info("The property atlas.migration.data.filename is found in application-properties, but it contains with /etc/atlas/conf.");
+          LOG.info("The property atlas.migration.data.filename is found in application-properties, but it contains atlas conf path ie /etc/atlas/conf. Avoid using conf path for this property.");
           prerequisiteCheck.getFailedOn().add(serviceName);
           prerequisiteCheck.setStatus(PrereqCheckStatus.WARNING);
           prerequisiteCheck.setFailReason(getFailReason(prerequisiteCheck, request));
-      } else {
-        LOG.info("The property atlas.migration.data.filename is found, proceeding with upgrade.");
       }
     }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheck.java
@@ -58,7 +58,7 @@ public class AtlasMigrationPropertyCheck extends AbstractCheckDescriptor {
     @Override
     public void perform(PrerequisiteCheck prerequisiteCheck, PrereqCheckRequest request) throws AmbariException {
       String atlasMigrationProperty = getProperty(request,"application-properties","atlas.migration.data.filename");
-      if(null == atlasMigrationProperty || StringUtils.isBlank(atlasMigrationProperty.trim())) {
+      if(StringUtils.isBlank(atlasMigrationProperty)) {
         LOG.info("The property atlas.migration.data.filename is not found in application-properties, need to add the property before upgrade.");
         prerequisiteCheck.getFailedOn().add(serviceName);
         prerequisiteCheck.setStatus(PrereqCheckStatus.FAIL);

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/CheckDescription.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/CheckDescription.java
@@ -369,7 +369,15 @@ public class CheckDescription {
       new ImmutableMap.Builder<String, String>()
         .put(AbstractCheckDescriptor.DEFAULT,
             "The following services are included in the upgrade but the repository is missing their dependencies:\n%s").build());
-  
+
+
+  public static CheckDescription ATLAS_MIGRATION_PROPERTY_CHECK = new CheckDescription("ATLAS_MIGRATION_PROPERTY_CHECK",
+    PrereqCheckType.SERVICE, "Check for Atlas Migration Property before upgrade.",
+      new ImmutableMap.Builder<String,String>().put(AbstractCheckDescriptor.DEFAULT,
+        "The property atlas.migration.data.filename is missing from application-properties.Do not use /etc/atlas/conf as the value." +
+        "After upgrading Atlas will no longer support TitanDB, Instead it will support JanusGraph." +
+        "Hence need to migrate existing data to newer formats post upgrade. " +
+        "To migrate existing data, Kindly refer and follow Apache Atlas documentation for 1.0 release.").build());
 
   private String m_name;
   private PrereqCheckType m_type;

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/CheckDescription.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/CheckDescription.java
@@ -374,8 +374,8 @@ public class CheckDescription {
   public static CheckDescription ATLAS_MIGRATION_PROPERTY_CHECK = new CheckDescription("ATLAS_MIGRATION_PROPERTY_CHECK",
     PrereqCheckType.SERVICE, "Check for Atlas Migration Property before upgrade.",
       new ImmutableMap.Builder<String,String>().put(AbstractCheckDescriptor.DEFAULT,
-        "The property atlas.migration.data.filename is missing from application-properties.Do not use /etc/atlas/conf as the value." +
-        "After upgrading Atlas will no longer support TitanDB, Instead it will support JanusGraph." +
+        "The property atlas.migration.data.filename is missing from application-properties. Do not use atlas conf path ie /etc/atlas/conf as the value." +
+        "After upgrading Atlas will no longer support TitanDB, instead it will support JanusGraph." +
         "Hence need to migrate existing data to newer formats post upgrade. " +
         "To migrate existing data, Kindly refer and follow Apache Atlas documentation for 1.0 release.").build());
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AtlasMigrationPropertyCheckTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.checks;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.PrereqCheckRequest;
+import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
+
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.DesiredConfig;
+import org.apache.ambari.server.state.RepositoryType;
+import org.apache.ambari.server.state.Service;
+
+import org.apache.ambari.server.state.repository.ClusterVersionSummary;
+import org.apache.ambari.server.state.repository.VersionDefinitionXml;
+import org.apache.ambari.server.state.stack.PrereqCheckStatus;
+import org.apache.ambari.server.state.stack.PrerequisiteCheck;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.Provider;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AtlasMigrationPropertyCheckTest {
+
+    private final Clusters clusters = Mockito.mock(Clusters.class);
+    private final AtlasMigrationPropertyCheck atlasMigrationPropertyCheck = new AtlasMigrationPropertyCheck();
+
+    @Mock
+    private ClusterVersionSummary m_clusterVersionSummary;
+
+    @Mock
+    private VersionDefinitionXml m_vdfXml;
+
+    @Mock
+    private RepositoryVersionEntity m_repositoryVersion;
+
+    final Map<String, Service> m_services = new HashMap<>();
+
+    @Before
+    public void setup() throws Exception {
+        atlasMigrationPropertyCheck.clustersProvider = new Provider<Clusters>() {
+            @Override
+            public Clusters get() { return clusters; }
+        };
+
+        Configuration config = Mockito.mock(Configuration.class);
+        atlasMigrationPropertyCheck.config= config;
+
+        m_services.clear();
+
+        Mockito.when(m_repositoryVersion.getType()).thenReturn(RepositoryType.STANDARD);
+        Mockito.when(m_repositoryVersion.getRepositoryXml()).thenReturn(m_vdfXml);
+        Mockito.when(m_vdfXml.getClusterSummary(Mockito.any(Cluster.class))).thenReturn(m_clusterVersionSummary);
+        Mockito.when(m_clusterVersionSummary.getAvailableServiceNames()).thenReturn(m_services.keySet());
+    }
+
+    public void testIsApplicable() throws AmbariException {
+        final Cluster cluster = Mockito.mock(Cluster.class);
+        final Service service = Mockito.mock(Service.class);
+
+        m_services.put("ATLAS", service);
+
+        Mockito.when(cluster.getServices()).thenReturn(m_services);
+        Mockito.when(cluster.getClusterId()).thenReturn(1L);
+        Mockito.when(clusters.getCluster("cluster")).thenReturn(cluster);
+
+        PrereqCheckRequest request = new PrereqCheckRequest("cluster");
+        request.setTargetRepositoryVersion(m_repositoryVersion);
+
+        Assert.assertTrue(atlasMigrationPropertyCheck.isApplicable(request));
+
+        m_services.remove("ATLAS");
+        Assert.assertFalse(atlasMigrationPropertyCheck.isApplicable(request));
+    }
+
+    @Test
+    public void testPerform() throws Exception {
+        final Cluster cluster = Mockito.mock(Cluster.class);
+        final Map<String, Service> services = new HashMap<>();
+        final Service service = Mockito.mock(Service.class);
+
+        services.put("ATLAS", service);
+
+        Mockito.when(cluster.getServices()).thenReturn(services);
+        Mockito.when(cluster.getClusterId()).thenReturn(1L);
+        Mockito.when(clusters.getCluster("cluster")).thenReturn(cluster);
+
+        final DesiredConfig desiredConfig = Mockito.mock(DesiredConfig.class);
+        Mockito.when(desiredConfig.getTag()).thenReturn("tag");
+        Map<String, DesiredConfig> configMap = new HashMap<>();
+        configMap.put("application-properties", desiredConfig);
+
+        Mockito.when(cluster.getDesiredConfigs()).thenReturn(configMap);
+        final Config config = Mockito.mock(Config.class);
+        Mockito.when(cluster.getConfig(Mockito.anyString(), Mockito.anyString())).thenReturn(config);
+        final Map<String, String> properties = new HashMap<>();
+        Mockito.when(config.getProperties()).thenReturn(properties);
+
+        properties.put("atlas.migration.data.filename", "");
+        PrerequisiteCheck check = new PrerequisiteCheck(null, null);
+        atlasMigrationPropertyCheck.perform(check, new PrereqCheckRequest("cluster"));
+        Assert.assertEquals(PrereqCheckStatus.FAIL, check.getStatus());
+
+        properties.put("atlas.migration.data.filename", "/etc/atlas/conf/upgrade_data.json");
+        check = new PrerequisiteCheck(null, null);
+        atlasMigrationPropertyCheck.perform(check, new PrereqCheckRequest("cluster"));
+        Assert.assertEquals(PrereqCheckStatus.WARNING, check.getStatus());
+
+        properties.put("atlas.migration.data.filename", "/home/atlas/upgrade_data.json");
+        check = new PrerequisiteCheck(null, null);
+        atlasMigrationPropertyCheck.perform(check, new PrereqCheckRequest("cluster"));
+        Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

While upgrading to stack 3.0, Atlas needs to migrate data from existing version to upgraded versions. To migrate the data we need to provide atlas.migration.data.filename property in the application-properties before upgrading the stack.

Hence prior to upgrading from existing stack to 3.0 stack we will need to check if the property atlas.migration.data.filename exists or not.

## How was this patch tested?

Unit Test Report:
[INFO] Running org.apache.ambari.server.checks.AtlasMigrationPropertyCheckTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.611 s - in org.apache.ambari.server.checks.AtlasMigrationPropertyCheckTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0