### PR TITLE
[AMBARI-23759] - Log graph gets filled with log level icons on clicking inside the graph

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
@@ -173,7 +173,7 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
   protected setChartTimeGap(startDate: Date, endDate: Date): void {
     const gap: ChartTimeGap = this.getTimeGap(startDate, endDate);
     if (gap.value > 0) {
-      this.chartTimeGap = this.getTimeGap(startDate, endDate);
+      this.chartTimeGap = gap;
     }
   }
 

--- a/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
@@ -32,6 +32,13 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
   @Input()
   historyStartEndTimeFormat: string = 'dddd, MMMM DD, YYYY';
 
+  @Input()
+  defaultChartTimeGap: ChartTimeGap = {
+    value: 1,
+    unit: 'h',
+    label: 'filter.timeRange.1hr'
+  };
+
   @Output()
   selectArea: EventEmitter<number[]> = new EventEmitter();
 
@@ -155,7 +162,7 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
    * Simply reset the time gap property to null.
    */
   protected resetChartTimeGap(): void {
-    this.chartTimeGap = null;
+    this.chartTimeGap = this.defaultChartTimeGap;
   }
 
   /**
@@ -164,7 +171,10 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
    * @param {Date} endDate
    */
   protected setChartTimeGap(startDate: Date, endDate: Date): void {
-    this.chartTimeGap = this.getTimeGap(startDate, endDate);
+    const gap: ChartTimeGap = this.getTimeGap(startDate, endDate);
+    if (gap.value > 0) {
+      this.chartTimeGap = this.getTimeGap(startDate, endDate);
+    }
   }
 
   protected getTimeRangeByXRanges(startX: number, endX: number): [number, number] {
@@ -234,10 +244,12 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
         const dragAreaDetails = this.dragArea.node().getBBox();
         const startX = Math.max(0, dragAreaDetails.x);
         const endX = Math.min(this.width, dragAreaDetails.x + dragAreaDetails.width);
-        const dateRange: [number, number] = this.getTimeRangeByXRanges(startX, endX);
-        this.selectArea.emit(dateRange);
-        this.dragArea.remove();
-        this.setChartTimeGap(new Date(dateRange[0]), new Date(dateRange[1]));
+        if (endX !== startX) {
+          const dateRange: [number, number] = this.getTimeRangeByXRanges(startX, endX);
+          this.selectArea.emit(dateRange);
+          this.dragArea.remove();
+          this.setChartTimeGap(new Date(dateRange[0]), new Date(dateRange[1]));
+        }
       })
     );
     d3.selectAll(`svg#${this.svgId} .value, svg#${this.svgId} .axis`).call(d3.drag().on('start', (): void => {

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.spec.ts
@@ -44,6 +44,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('AuditLogsEntriesComponent', () => {
   let component: AuditLogsEntriesComponent;
@@ -94,7 +96,9 @@ describe('AuditLogsEntriesComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.spec.ts
@@ -49,6 +49,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('AuditLogsTableComponent', () => {
   let component: AuditLogsTableComponent;
@@ -104,7 +106,9 @@ describe('AuditLogsTableComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/cluster-filter/cluster-filter.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/cluster-filter/cluster-filter.component.spec.ts
@@ -48,6 +48,8 @@ import {LogsContainerService} from '@app/services/logs-container.service';
 import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('ClusterFilterComponent', () => {
   let component: ClusterFilterComponent;
@@ -103,7 +105,9 @@ describe('ClusterFilterComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ]
     }))
     .compileComponents();

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/context-menu/context-menu.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/context-menu/context-menu.component.spec.ts
@@ -48,6 +48,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('ContextMenuComponent', () => {
   let component: ContextMenuComponent;
@@ -110,7 +112,9 @@ describe('ContextMenuComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.spec.ts
@@ -45,6 +45,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('FiltersPanelComponent', () => {
   let component: FiltersPanelComponent;
@@ -56,7 +58,7 @@ describe('FiltersPanelComponent', () => {
         return {
           subscribe: () => {
           }
-        }
+        };
       }
     };
     TestBed.configureTestingModule({
@@ -102,7 +104,9 @@ describe('FiltersPanelComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/log-context/log-context.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/log-context/log-context.component.spec.ts
@@ -44,6 +44,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
 
 describe('LogContextComponent', () => {
   let component: LogContextComponent;
@@ -94,7 +96,9 @@ describe('LogContextComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.spec.ts
@@ -45,6 +45,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('LogsContainerComponent', () => {
   let component: LogsContainerComponent;
@@ -95,7 +97,9 @@ describe('LogsContainerComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/time-range-picker/time-range-picker.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/time-range-picker/time-range-picker.component.spec.ts
@@ -45,6 +45,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('TimeRangePickerComponent', () => {
   let component: TimeRangePickerComponent;
@@ -92,7 +94,9 @@ describe('TimeRangePickerComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/top-menu/top-menu.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/top-menu/top-menu.component.spec.ts
@@ -47,6 +47,8 @@ import {ClusterSelectionService} from '@app/services/storage/cluster-selection.s
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('TopMenuComponent', () => {
   let component: TopMenuComponent;
@@ -96,7 +98,9 @@ describe('TopMenuComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.spec.ts
@@ -41,6 +41,8 @@ import {LogsContainerService} from '@app/services/logs-container.service';
 import {AuthService} from '@app/services/auth.service';
 
 import {DropdownButtonComponent} from './dropdown-button.component';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
 
 describe('DropdownButtonComponent', () => {
   let component: DropdownButtonComponent;
@@ -52,7 +54,7 @@ describe('DropdownButtonComponent', () => {
         return {
           subscribe: () => {
           }
-        }
+        };
       }
     };
     TestBed.configureTestingModule({
@@ -95,7 +97,9 @@ describe('DropdownButtonComponent', () => {
           useValue: httpClient
         },
         LogsContainerService,
-        AuthService
+        AuthService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.spec.ts
@@ -46,6 +46,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('DropdownListComponent', () => {
   let component: DropdownListComponent;
@@ -104,7 +106,9 @@ describe('DropdownListComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ]
     })
     .compileComponents();

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.spec.ts
@@ -44,6 +44,8 @@ import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
 import {RouterTestingModule} from '@angular/router/testing';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('FilterDropdownComponent', () => {
   let component: FilterDropdownComponent;
@@ -120,7 +122,9 @@ describe('FilterDropdownComponent', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/component-generator.service.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/component-generator.service.spec.ts
@@ -44,6 +44,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
 
 describe('ComponentGeneratorService', () => {
   beforeEach(() => {
@@ -89,7 +91,9 @@ describe('ComponentGeneratorService', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ]
     });
   });

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/history-manager.service.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/history-manager.service.spec.ts
@@ -44,8 +44,10 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
 
-describe('HistoryService', () => {
+describe('HistoryManagerService', () => {
   beforeEach(() => {
 
     TestBed.configureTestingModule({
@@ -89,7 +91,9 @@ describe('HistoryService', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ]
     });
   });

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-container.service.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-container.service.spec.ts
@@ -42,6 +42,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
+import {NotificationService} from '@modules/shared/services/notification.service';
+import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 
 describe('LogsContainerService', () => {
   beforeEach(() => {
@@ -85,7 +87,9 @@ describe('LogsContainerService', () => {
         ClusterSelectionService,
         RoutingUtilsService,
         LogsFilteringUtilsService,
-        LogsStateService
+        LogsStateService,
+        NotificationsService,
+        NotificationService
       ]
     });
   });

--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-container.service.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-container.service.ts
@@ -64,6 +64,7 @@ import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.serv
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {LogLevelComponent} from '@app/components/log-level/log-level.component';
+import {NotificationService, NotificationType} from '@modules/shared/services/notification.service';
 
 @Injectable()
 export class LogsContainerService {
@@ -117,7 +118,7 @@ export class LogsContainerService {
       defaultSelection: [],
       fieldName: 'cluster'
     },
-    timeRange: { // @ToDo remove duplication, this options are in the LogFilteringUtilsService too
+    timeRange: { // @ToDo remove duplication, this options are in the LogsFilteringUtilsService too
       label: 'logs.duration',
       options: [
         [
@@ -619,7 +620,8 @@ export class LogsContainerService {
     private activatedRoute: ActivatedRoute,
     private routingUtils: RoutingUtilsService,
     private logsFilteringUtilsService: LogsFilteringUtilsService,
-    private logsStateService: LogsStateService
+    private logsStateService: LogsStateService,
+    private notificationService: NotificationService
   ) {
     const formItems = Object.keys(this.filters).reduce((currentObject: any, key: string): HomogeneousObject<FormControl> => {
       const formControl = new FormControl();
@@ -1066,14 +1068,25 @@ export class LogsContainerService {
   }
 
   setCustomTimeRange(startTime: number, endTime: number): void {
-    this.filtersForm.controls.timeRange.setValue({
-      label: this.customTimeRangeKey,
-      value: {
-        type: 'CUSTOM',
-        start: moment(startTime),
-        end: moment(endTime)
-      }
-    });
+    const startTimeMoment = moment(startTime);
+    const endTimeMoment = moment(endTime);
+    const diff = endTimeMoment.diff(startTimeMoment);
+    if (diff > 0) {
+      this.filtersForm.controls.timeRange.setValue({
+        label: this.customTimeRangeKey,
+        value: {
+          type: 'CUSTOM',
+          start: moment(startTime),
+          end: moment(endTime)
+        }
+      });
+    } else {
+      this.notificationService.addNotification({
+        title: 'filter.timeRange',
+        message: 'filter.timeRange.error.tooShort',
+        type: NotificationType.ALERT
+      });
+    }
   }
 
   getFiltersData(listType: string): object {

--- a/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
@@ -82,6 +82,8 @@
   "filter.toggleTo.exclude": "Toggle to exclude",
   "filter.toggleTo.include": "Toggle to include",
 
+  "filter.timeRange.error.tooShort": "The selected time range is too short.",
+
   "levels.fatal": "Fatal",
   "levels.error": "Error",
   "levels.warn": "Warn",


### PR DESCRIPTION
## What changes were proposed in this pull request?

By simply clicking on any graph (without drag move) the time range has been set to 0 which caused the problems.
I added several points to check the differences and also I added the default time range when we want to reset the selection.

## How was this patch tested?

It was tested manually and with unit tests (267/267 success)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@aBabiichuk please review it. Thanks.