### PR TITLE
[AMBARI-23785] Download client configs fails at Oozie client with AttributeError (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
@@ -104,7 +104,7 @@ public class ExecutionCommand extends AgentCommand {
   @JsonIgnore
   private Map<String, Map<String, String>> configurations;
 
-  @SerializedName("configuration_attributes")
+  @SerializedName("configurationAttributes")
   @JsonIgnore
   private Map<String, Map<String, Map<String, String>>> configurationAttributes;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/StatusCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/StatusCommand.java
@@ -52,8 +52,8 @@ public class StatusCommand extends AgentCommand {
   @com.fasterxml.jackson.annotation.JsonProperty("configurations")
   private Map<String, Map<String, String>> configurations;
 
-  @SerializedName("configuration_attributes")
-  @com.fasterxml.jackson.annotation.JsonProperty("configuration_attributes")
+  @SerializedName("configurationAttributes")
+  @com.fasterxml.jackson.annotation.JsonProperty("configurationAttributes")
   private Map<String, Map<String, Map<String, String>>> configurationAttributes;
 
   @SerializedName("commandParams")

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
@@ -413,7 +413,7 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
 
         Map<String, Object> jsonContent = new TreeMap<>();
         jsonContent.put("configurations", configurations);
-        jsonContent.put("configuration_attributes", configurationAttributes);
+        jsonContent.put("configurationAttributes", configurationAttributes);
         jsonContent.put("commandParams", commandParams);
         jsonContent.put("clusterHostInfo", clusterHostInfo);
         jsonContent.put("ambariLevelParams", ambariLevelParams);


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of Perf initiative(AMBARI-22627 and another related jiras), {{configuration_attributes}} were renamed to {{configurationAttributes}}. But due to complex merge, some places still using old name convention

## How was this patch tested?
 UT & Live cluster