### PR TITLE
AMBARI-23805 - HBase deployment failed in Namenode Federated Environment

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
@@ -19,29 +19,25 @@ limitations under the License.
 Ambari Agent
 
 """
-import re
-import os
+import \
+  ambari_simplejson as json  # simplejson is much faster comparing to Python 2.6 json module and has the same functions set.
 import grp
+import os
 import pwd
+import re
 import time
-from resource_management.core.environment import Environment
-from resource_management.core.base import Fail
-from resource_management.core.resources.system import Execute
-from resource_management.core.resources.system import File
-from resource_management.core.providers import Provider
-from resource_management.core.logger import Logger
 from resource_management.core import shell
 from resource_management.core import sudo
-from resource_management.libraries.script import Script
+from resource_management.core.base import Fail
+from resource_management.core.environment import Environment
+from resource_management.core.logger import Logger
+from resource_management.core.providers import Provider
+from resource_management.core.resources.system import Execute
+from resource_management.core.resources.system import File
 from resource_management.libraries.functions import format
-from resource_management.libraries.functions.get_user_call_output import get_user_call_output
-from resource_management.libraries.functions import is_empty
 from resource_management.libraries.functions import namenode_ha_utils
+from resource_management.libraries.functions.get_user_call_output import get_user_call_output
 from resource_management.libraries.functions.hdfs_utils import is_https_enabled_in_hdfs
-
-
-import ambari_simplejson as json # simplejson is much faster comparing to Python 2.6 json module and has the same functions set.
-from ambari_commons import subprocess32
 
 JSON_PATH = '/var/lib/ambari-agent/tmp/hdfs_resources_{timestamp}.json'
 JAR_PATH = '/var/lib/ambari-agent/lib/fast-hdfs-resource.jar'
@@ -151,15 +147,12 @@ class WebHDFSCallException(Fail):
 
 class WebHDFSUtil:
   def __init__(self, hdfs_site, nameservice, run_user, security_enabled, logoutput=None):
-    https_nn_address = namenode_ha_utils.get_property_for_active_namenode(hdfs_site, nameservice, 'dfs.namenode.https-address',
-                                                                          security_enabled, run_user)
-    http_nn_address = namenode_ha_utils.get_property_for_active_namenode(hdfs_site, nameservice, 'dfs.namenode.http-address',
-                                                                         security_enabled, run_user)
     self.is_https_enabled = is_https_enabled_in_hdfs(hdfs_site['dfs.http.policy'], hdfs_site['dfs.https.enable'])
-
-    address = https_nn_address if self.is_https_enabled else http_nn_address
+    address_property = 'dfs.namenode.https-address' if self.is_https_enabled else 'dfs.namenode.http-address'
+    address = namenode_ha_utils.get_property_for_active_namenode(hdfs_site, nameservice, address_property,
+                                                                 security_enabled, run_user)
     protocol = "https" if self.is_https_enabled else "http"
-    
+
     self.address = format("{protocol}://{address}")
     self.run_user = run_user
     self.security_enabled = security_enabled


### PR DESCRIPTION
## What changes were proposed in this pull request?

If hdfs-site configuration does not contains dfs.namenode.https-address.* properties starting NameNodes fails in a federated cluster even if https is turned of. This is also affects HBase start.
Cause: both dfs.namenode.https-address.* and dfs.namenode.http-address.* properties are queried and after then only one of them were used based on https is turned on or off.
Fix: Check https is turned on first and pull the necessary properties only

## How was this patch tested?

Manually: on 4 node federated cluster remove dfs.namenode.https-address.* properties and restart services.

Please review:
@swagle @adoroszlai @aonishuk