### PR TITLE
[AMBARI-23800] Using the proper concatenation delimiter when using the 'append' variable replacement function in a Kerberized cluster

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1075,7 +1075,9 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
           final String currentHadoopProxyuserHttpHosts = coreSiteConfiguration.getProperty(PROPERTY_HADOOP_PROXYUSER_HTTP_HOSTS);
           if (StringUtils.isNotBlank(currentHadoopProxyuserHttpHosts)) {
             LOG.info("Updating hadoop.proxyuser.HTTP.hosts...");
-            coreSiteConfiguration.putProperty(PROPERTY_HADOOP_PROXYUSER_HTTP_HOSTS, currentHadoopProxyuserHttpHosts.replace("webhcat_server_host|", "webhcat_server_hosts|"));
+            String newValue = currentHadoopProxyuserHttpHosts.replace("webhcat_server_host|", "webhcat_server_hosts|"); // replacing webhcat_server_host to webhcat_server_hosts
+            newValue = newValue.replace("\\\\,", "\\,"); // Replacing the concatDelimiter in 'append' variable replacement function
+            coreSiteConfiguration.putProperty(PROPERTY_HADOOP_PROXYUSER_HTTP_HOSTS, newValue);
             updated = true;
           }
         }

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
@@ -144,7 +144,7 @@
           "configurations": [
             {
               "core-site": {
-                "hadoop.proxyuser.HTTP.hosts": "${clusterHostInfo/webhcat_server_hosts|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\,, true)}"
+                "hadoop.proxyuser.HTTP.hosts": "${clusterHostInfo/webhcat_server_hosts|append(core-site/hadoop.proxyuser.HTTP.hosts, \\,, true)}"
               }
             },
             {

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -1232,8 +1232,10 @@ public class UpgradeCatalog270Test {
 
   @Test
   public void testupdateKerberosDescriptorArtifact() throws Exception {
-    //there is HIVE -> WEBHCAT_SERVER -> configurations -> core-site -> hadoop.proxyuser.HTTP.hosts
     String kerberosDescriptorJson = IOUtils.toString(getClass().getClassLoader().getResourceAsStream("org/apache/ambari/server/upgrade/kerberos_descriptor.json"), "UTF-8");
+
+    //there is HIVE -> WEBHCAT_SERVER -> configurations -> core-site -> hadoop.proxyuser.HTTP.hosts
+    assertTrue(kerberosDescriptorJson.contains("${clusterHostInfo/webhcat_server_host|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\\\\\,, true)}"));
 
     ArtifactEntity artifactEntity = new ArtifactEntity();
     artifactEntity.setArtifactName("kerberos_descriptor");
@@ -1253,7 +1255,7 @@ public class UpgradeCatalog270Test {
     int newCount = substringCount(newKerberosDescriptorJson, AMBARI_INFRA_NEW_NAME);
     assertThat(newCount, is(oldCount));
 
-    assertTrue(newKerberosDescriptorJson.contains("webhcat_server_hosts|"));
+    assertTrue(newKerberosDescriptorJson.contains("${clusterHostInfo/webhcat_server_hosts|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\,, true)}"));
 
     verify(upgradeCatalog270);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We use the `append` [variable replacement function](https://github.com/apache/ambari/blob/trunk/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/VariableReplacementHelper.java#L300) `var/lib/ambari-server/resources/stacks/HDP/2.5/services/HIVE/kerberos.json` for `hadoop.proxyuser.HTTP.hosts`. The problem was that we used the wrong concatenation delimiter - `\,` instead of `,` - and this caused an issue when there are more than one host is listed here.

There are two places where I needed to fix this:
1. overwriting the old value upon upgrade to 2.7
2. fixing this in HIVE's kerberos.json

## How was this patch tested?

Modified the appropriate JUnit test; latest unit tests in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 27:01 min
[INFO] Finished at: 2018-05-10T15:05:05+02:00
[INFO] Final Memory: 161M/758M
[INFO] ------------------------------------------------------------------------
```

In addition to this I executed the following E2E test steps:

1. installed Ambari 2.6.1.5-3
2. installed a cluster (HDFS, Hive, YARN/MR2, ZK, Pig, Slider, Tez, AMS)
3. Kerberized the cluster
4. prepared to upgrade to 2.7.0.0-437
5. just before the `ambari-server upgrade` step I implemented my changes in the code; built the new JAR and replaced it in my test environment; I overwrote the `kerberos.json` in question too
6. upgraded to 2.7.0.0 (w/o any issue) and started the server and agents
7. logged in to Ambari UI and checked HDFS's config; so far so good
8. added mulitple hosts in `hadoop.proxyuser.HTTP.hosts`
9. regenerated the keytabs and checked HDFS's configuration again: the proper value has been shown