### PR TITLE
[AMBARI-23809] Identical sets of capacity scheduler properties are displayed as unequal ones in configs comparison view

### DIFF
--- a/ambari-web/app/mappers/configs/stack_config_properties_mapper.js
+++ b/ambari-web/app/mappers/configs/stack_config_properties_mapper.js
@@ -147,6 +147,9 @@ App.stackConfigPropertiesMapper = App.QuickDataMapper.create({
           staticConfigInfo.description = App.config.getDescription(staticConfigInfo.description, staticConfigInfo.displayType);
           staticConfigInfo.name = JSON.parse('"' + staticConfigInfo.name + '"');
           staticConfigInfo.isUserProperty = false;
+          if (Em.isNone(staticConfigInfo.index)) {
+            staticConfigInfo.index = Infinity;
+          }
           App.configsCollection.add(staticConfigInfo);
 
         }, this);


### PR DESCRIPTION
## What changes were proposed in this pull request?

While comparing different YARN config versions, capacity scheduler values are shown as different ones. The only displayed difference is the order of properties in those sets, though even the order is the same for both versions.

## How was this patch tested?

UI unit tests:
  21522 passing (25s)
  48 pending
