### PR TITLE
[AMBARI-21816] test_kms_server timing issue

### DIFF
--- a/ambari-server/src/test/python/stacks/2.5/RANGER_KMS/test_kms_server.py
+++ b/ambari-server/src/test/python/stacks/2.5/RANGER_KMS/test_kms_server.py
@@ -500,6 +500,7 @@ class TestRangerKMS(RMFTestCase):
   @patch("resource_management.libraries.functions.ranger_functions_v2.RangeradminV2.get_repository_by_name_curl", new=MagicMock(return_value=({'name': 'c1_kms'})))
   @patch("resource_management.libraries.functions.ranger_functions_v2.RangeradminV2.create_repository_curl", new=MagicMock(return_value=({'name': 'c1_kms'})))
   @patch("os.path.isfile")
+  @patch("kms.datetime", new=DTMOCK())
   def test_start_secured(self, isfile_mock):
 
     self.executeScript(self.COMMON_SERVICES_PACKAGE_DIR + "/scripts/kms_server.py",
@@ -513,7 +514,7 @@ class TestRangerKMS(RMFTestCase):
 
     # TODO repo call in secure
 
-    current_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    current_datetime = self.current_date.strftime("%Y-%m-%d %H:%M:%S")
 
     self.assertResourceCalled('File', '/usr/hdp/current/ranger-kms/conf/ranger-security.xml',
       owner = 'kms',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix [intermittent unit test](https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/2216/consoleText) failure due to using actual time in Ranger test script.

```
FAIL: test_start_secured (test_kms_server.TestRangerKMS)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-common/src/test/python/mock/mock.py", line 1199, in patched
    return func(*args, **keywargs)
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-server/src/test/python/stacks/2.5/RANGER_KMS/test_kms_server.py", line 522, in test_start_secured
    mode = 0644
  File "/home/jenkins/jenkins-slave/workspace/Ambari-Github-PullRequest-Builder/ambari-server/src/test/python/stacks/utils/RMFTestCase.py", line 345, in assertResourceCalled
    self.assertEquals(kwargs, resource.arguments)
AssertionError: {'owner': 'kms', 'content': '<ranger>\n<enabled>2018-05-10 11:19:42</enabled>\n< [truncated]... != {'content': '<ranger>\n<enabled>2018-05-10 11:19:41</enabled>\n</ranger>', 'owne [truncated]...
- {'content': '<ranger>\n<enabled>2018-05-10 11:19:42</enabled>\n</ranger>',
?                                                   ^

+ {'content': '<ranger>\n<enabled>2018-05-10 11:19:41</enabled>\n</ranger>',
?                                                   ^
```

https://issues.apache.org/jira/browse/AMBARI-21816

## How was this patch tested?

Added `time.sleep(5)` in [kms.py](https://github.com/apache/ambari/blob/cd82331950dee0a3a8eba8cbdae5abcdfaca2f82/ambari-server/src/main/resources/common-services/RANGER_KMS/0.5.0.2.3/package/scripts/kms.py#L428), verified that test fails without the fix and passes with the fix.