### PR TITLE
[AMBARI-23810] Alerts icon is absent in service page if no alerts present

### DIFF
--- a/ambari-web/app/styles/alerts.less
+++ b/ambari-web/app/styles/alerts.less
@@ -365,7 +365,7 @@
 }
 
 .service-block .summary-box-header {
-  .alerts-crit-count, .alerts-warn-count, .no-alerts-label {
+  .alerts-crit-count, .alerts-warn-count, .no-alerts-label, .alerts-none-count {
     padding: 3px 5px;
     font-size: 10px;
     border-radius: 50%;
@@ -410,6 +410,9 @@
 }
 .label.alerts-warn-count {
   background: @health-status-orange;
+}
+.label.alerts-none-count {
+  background: @top-nav-ops-count-bg-color;
 }
 .label.no-alerts-label {
   background: @health-status-green;

--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -448,6 +448,11 @@ table.diff {
   cursor: pointer;
 }
 
+.alerts-none-count {
+  margin-left: 0;
+  cursor: pointer;
+}
+
 .health-status-HEALTHY, .health-status-LIVE, .health-status-STARTING, .health-status-started, .health-status-starting {
   color: @health-status-green;
 }

--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -57,12 +57,10 @@
           <div class="col-md-4 col-lg-4 service-alerts">
             {{#if view.hasAlertDefinitions}}
               <span {{action "showServiceAlertsPopup" controller.content target="controller"}} class="pull-right">
-                {{#if view.alertsCount}}
-                  <i class="glyphicon glyphicon-bell"></i>
-                  <span {{bindAttr class=":label view.hasCriticalAlerts:alerts-crit-count:alerts-warn-count"}}>
-                    {{view.alertsCount}}
-                  </span>
-                {{/if}}
+                <i class="glyphicon glyphicon-bell"></i>
+                <span {{bindAttr class=":label view.hasCriticalAlerts:alerts-crit-count view.hasNonCriticalAlertsOnly:alerts-warn-count view.hasNoAlerts:alerts-none-count"}}>
+                  {{view.alertsCount}}
+                </span>
               </span>
             {{/if}}
           </div>

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -353,7 +353,11 @@ App.MainServiceInfoSummaryView = Em.View.extend({
 
   alertsCount: Em.computed.alias('controller.content.alertsCount'),
 
+  hasNoAlerts: Em.computed.equal('alertsCount', 0),
+
   hasCriticalAlerts: Em.computed.alias('controller.content.hasCriticalAlerts'),
+
+  hasNonCriticalAlertsOnly: Em.computed.and('!hasNoAlerts', '!hasCriticalAlerts'),
 
   /**
    * Define if service has alert definitions defined

--- a/ambari-web/test/views/main/service/info/summary_test.js
+++ b/ambari-web/test/views/main/service/info/summary_test.js
@@ -44,6 +44,10 @@ describe('App.MainServiceInfoSummaryView', function() {
 
   App.TestAliases.testAsComputedAlias(view, 'hasCriticalAlerts', 'controller.content.hasCriticalAlerts', 'boolean');
 
+  App.TestAliases.testAsComputedEqual(view, 'hasNoAlerts', 'alertsCount', 0);
+
+  App.TestAliases.testAsComputedAnd(view, 'hasNonCriticalAlertsOnly', ['!hasNoAlerts', '!hasCriticalAlerts']);
+
   describe('#servers', function () {
     it('services shouldn\'t have servers except FLUME and ZOOKEEPER', function () {
       expect(view.get('servers')).to.be.empty;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Grayed-out bell should be displayed like in the top nav.

## How was this patch tested?

UI unit tests:
  21530 passing (25s)
  48 pending