### PR TITLE
[AMBARI-23757] - [Logsearch UI] Component filter 'All' not refreshing results

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/filter-button/filter-button.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/filter-button/filter-button.component.ts
@@ -55,28 +55,43 @@ export class FilterButtonComponent extends MenuButtonComponent implements Contro
     }
   }
 
-  updateSelection(item: ListItem): void {
-    if (this.isMultipleChoice) {
-      const itemIndex = this.subItems.findIndex((option: ListItem): boolean => {
-        return this.utils.isEqual(option.value, item.value);
-      });
-      if (itemIndex > -1) {
-        this.subItems[itemIndex].isChecked = item.isChecked;
-        this.selection = this.subItems.filter((option: ListItem): boolean => option.isChecked);
+  updateSelection(updatedItem: ListItem | ListItem[]): void {
+    if (updatedItem) {
+      const items: ListItem[] = Array.isArray(updatedItem) ? updatedItem : [updatedItem];
+      if (this.isMultipleChoice) {
+        items.forEach((item: ListItem) => {
+          if (this.subItems && this.subItems.length) {
+            const itemToUpdate: ListItem = this.subItems.find((option: ListItem) => this.utils.isEqual(option.value, item.value));
+            if (itemToUpdate) {
+              itemToUpdate.isChecked = item.isChecked;
+            }
+          }
+        });
+      } else {
+        const selectedItem: ListItem = items.find((item: ListItem) => item.isChecked);
+        this.subItems.forEach((item: ListItem) => {
+          item.isChecked = !!selectedItem && this.utils.isEqual(item.value, selectedItem.value);
+        });
       }
-    } else if (!this.utils.isEqual(this.selection[0], item)) {
-      this.selection = [item];
+    } else {
+      this.subItems.forEach((item: ListItem) => item.isChecked = false);
+      this.selection = [];
     }
+    const checkedItems = this.subItems.filter((option: ListItem): boolean => option.isChecked);
+    this.selection = checkedItems;
+    this.selectItem.emit(checkedItems.map((option: ListItem): any => option.value));
+    this.dropdownList.doItemsCheck();
   }
 
   writeValue(items: ListItem[]) {
     if (items && items.length) {
-      items.forEach((item) => {
-        this.updateSelection({
+      const listItems: ListItem[] = items.map((item: ListItem) => {
+        return {
           ...item,
-          isChecked: true
-        });
+            isChecked: true
+        };
       });
+      this.updateSelection(listItems);
     }
   }
 

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/menu-button/menu-button.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/menu-button/menu-button.component.html
@@ -27,6 +27,6 @@
       (selectedItemChange)="onDropdownItemChange($event)" [isMultipleChoice]="isMultipleChoice"
       [additionalLabelComponentSetter]="additionalLabelComponentSetter"
       [ngClass]="'dropdown-menu' + (isRightAlign ? ' dropdown-menu-right' : '') + (listClass ? ' ' + listClass : '')"
-      [useLocalFilter]="useDropDownLocalFilter"
+      [useLocalFilter]="useDropDownLocalFilter" #dropdownList
   ></ul>
 </div>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/menu-button/menu-button.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/menu-button/menu-button.component.ts
@@ -18,6 +18,7 @@
 
 import {Component, Input, Output, ViewChild, ElementRef, EventEmitter} from '@angular/core';
 import {ListItem} from '@app/classes/list-item';
+import {DropdownListComponent} from '@modules/shared/components/dropdown-list/dropdown-list.component';
 
 @Component({
   selector: 'menu-button',
@@ -28,6 +29,9 @@ export class MenuButtonComponent {
 
   @ViewChild('dropdown')
   dropdown: ElementRef;
+
+  @ViewChild('dropdownList')
+  dropdownList: DropdownListComponent;
 
   @Input()
   label?: string;
@@ -88,7 +92,7 @@ export class MenuButtonComponent {
   buttonClick: EventEmitter<void> = new EventEmitter();
 
   @Output()
-  selectItem: EventEmitter<ListItem> = new EventEmitter();
+  selectItem: EventEmitter<ListItem | ListItem[]> = new EventEmitter();
 
   /**
    * This is a private property to indicate the mousedown timestamp, so that we can check it when teh click event
@@ -211,17 +215,20 @@ export class MenuButtonComponent {
   /**
    * The main goal if this function is tho handle the item change event on the child dropdown list.
    * Should update the value and close the dropdown if it is not multiple choice type.
-   * @param {ListItem} options The selected item(s) from the dropdown list.
+   * @param {ListItem} item The selected item(s) from the dropdown list.
    */
-  onDropdownItemChange(options: ListItem) {
-    this.updateSelection(options);
+  onDropdownItemChange(item: ListItem | ListItem[]) {
+    this.updateSelection(item);
     if (!this.isMultipleChoice) {
       this.closeDropdown();
     }
   }
 
-  updateSelection(options: ListItem) {
-    this.selectItem.emit(options);
+  updateSelection(item: ListItem | ListItem[]) {
+    this.selectItem.emit(item);
+    if (this.dropdownList) {
+      this.dropdownList.doItemsCheck();
+    }
   }
 
 }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.ts
@@ -85,26 +85,31 @@ export class DropdownButtonComponent {
 
   constructor(protected utils: UtilsService) {}
 
-  updateSelection(item: ListItem): void {
-    if (this.isMultipleChoice) {
-      this.options.find((option: ListItem): boolean => {
-        return this.utils.isEqual(option.value, item.value);
-      }).isChecked = item.isChecked;
-      const checkedItems = this.options.filter((option: ListItem): boolean => option.isChecked);
-      this.selection = checkedItems;
-      this.selectItem.emit(checkedItems.map((option: ListItem): any => option.value));
+  updateSelection(updatedItem: ListItem | ListItem[]): void {
+    if (updatedItem) {
+      const items: ListItem[] = Array.isArray(updatedItem) ? updatedItem : [updatedItem];
+      if (this.isMultipleChoice) {
+        items.forEach((item: ListItem) => {
+          if (this.options && this.options.length) {
+            const itemToUpdate: ListItem = this.options.find((option: ListItem) => this.utils.isEqual(option.value, item.value));
+            if (itemToUpdate) {
+              itemToUpdate.isChecked = item.isChecked;
+            }
+          }
+        });
+      } else {
+        const selectedItem: ListItem = items.find((item: ListItem) => item.isChecked);
+        this.options.forEach((item: ListItem) => {
+          item.isChecked = !!selectedItem && this.utils.isEqual(item.value, selectedItem.value);
+        });
+      }
     } else {
-      if (item) {
-        item.isChecked = true;
-      }
-      if (!this.utils.isEqual(this.selection[0], item)) {
-        if (this.selection && this.selection.length) {
-          this.selection[0].isChecked = false;
-        }
-        this.selection = item ? [item] : [];
-        this.selectItem.emit(item ? item.value : undefined);
-      }
+      this.options.forEach((item: ListItem) => item.isChecked = false);
+      this.selection = [];
     }
+    const checkedItems = this.options.filter((option: ListItem): boolean => option.isChecked);
+    this.selection = checkedItems;
+    this.selectItem.emit(checkedItems.map((option: ListItem): any => option.value));
   }
 
 }


### PR DESCRIPTION
Component filter 'All' not refreshing logs after selecting an individual component

## What changes were proposed in this pull request?

In multiselect filter dropdowns both "select all" and the "clear" buttons should trigger to load the new log list.

## How was this patch tested?

Manually and with unit tests (267/267 success)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@aBabiichuk please review it. Thanks.