### PR TITLE
AMBARI-23819. Ambari Agent registration task is failing  (aonishuk)

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/NetUtil.py
+++ b/ambari-agent/src/main/python/ambari_agent/NetUtil.py
@@ -17,7 +17,7 @@
 from urlparse import urlparse
 import logging
 import httplib
-import sys
+import ssl
 from ssl import SSLError
 from ambari_agent.AmbariConfig import AmbariConfig
 from ambari_commons.inet_utils import ensure_ssl_using_protocol
@@ -66,8 +66,8 @@ class NetUtil:
     try:
       parsedurl = urlparse(url)
 
-      if sys.version_info >= (2,7,5) and not ssl_verify_cert:
-          import ssl
+      # hasattr being true means that current python version has default cert verification enabled.
+      if hasattr(ssl, '_create_unverified_context') and not ssl_verify_cert:
           ca_connection = httplib.HTTPSConnection(parsedurl[1], context=ssl._create_unverified_context())
       else:
           ca_connection = httplib.HTTPSConnection(parsedurl[1])


### PR DESCRIPTION
INFO 2018-05-10 10:04:59,174 NetUtil.py:61 - Connecting to https://os-mv-07-test-3.openstacklocal:8440/ca
WARNING 2018-05-10 10:04:59,174 NetUtil.py:92 - Failed to connect to https://os-mv-07-test-3.openstacklocal:8440/ca due to 'module' object has no attribute '_create_unverified_context'  
WARNING 2018-05-10 10:04:59,174 NetUtil.py:115 - Server at https://os-mv-07-test-3.openstacklocal:8440 is not reachable, sleeping for 10 seconds...

Turns out this change was backported from python 2.7.9 to 2.7.5 (verify cert being default), but older python 2.7.5 versions still don't have this (like in this case), this can be easily checked though, not using python ver check (see the patch)