### PR TITLE
[AMBARI-23822] Infra Solr: Migration script does not backup/restore all of the cores.

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
+++ b/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
@@ -148,6 +148,10 @@ def fill_parameters(options):
     params['solr_skip_cores'] = options.skip_cores
   if options.solr_shards:
     params['solr_shards'] = options.solr_shards
+  if options.solr_hdfs_path:
+    params['solr_hdfs_path'] = options.solr_hdfs_path
+  if options.solr_keep_backup:
+    params['solr_keep_backup'] = True
   return params
 
 def validte_common_options(options, parser):
@@ -235,6 +239,9 @@ if __name__=="__main__":
   parser.add_option("--core-filter", dest="core_filter", default=None, type="string", help="core filter for replica folders")
   parser.add_option("--skip-cores", dest="skip_cores", default=None, type="string", help="specific cores to skip (comma separated)")
   parser.add_option("--shards", dest="solr_shards", type="int", default=0, help="number of shards (required to set properly for restore)")
+  parser.add_option("--solr-hdfs-path", dest="solr_hdfs_path", type="string", default=None, help="Base path of Solr (where collections are located) if HDFS is used (like /user/infra-solr)")
+  parser.add_option("--solr-keep-backup", dest="solr_keep_backup", default=False, action="store_true", help="If it is turned on, Snapshot Solr data will not be deleted from the filesystem during restore.")
+
   (options, args) = parser.parse_args()
 
   protocol = 'https' if options.ssl else 'http'

--- a/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
+++ b/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
@@ -144,7 +144,10 @@ def fill_parameters(options):
     params['solr_check_hosts'] = False
   if options.core_filter:
     params['solr_core_filter'] = options.core_filter
-
+  if options.core_filter:
+    params['solr_skip_cores'] = options.skip_cores
+  if options.solr_shards:
+    params['solr_shards'] = options.solr_shards
   return params
 
 def validte_common_options(options, parser):
@@ -230,7 +233,8 @@ if __name__=="__main__":
   parser.add_option("--solr-hosts", dest="solr_hosts", type="string", help="comma separated list of solr hosts")
   parser.add_option("--disable-solr-host-check", dest="disable_solr_host_check", action="store_true", default=False, help="Disable to check solr hosts are good for the collection backups")
   parser.add_option("--core-filter", dest="core_filter", default=None, type="string", help="core filter for replica folders")
-
+  parser.add_option("--skip-cores", dest="skip_cores", default=None, type="string", help="specific cores to skip (comma separated)")
+  parser.add_option("--shards", dest="solr_shards", type="int", default=0, help="number of shards (required to set properly for restore)")
   (options, args) = parser.parse_args()
 
   protocol = 'https' if options.ssl else 'http'

--- a/ambari-logsearch/docker/knox/logsearch/1.0.0/service.xml
+++ b/ambari-logsearch/docker/knox/logsearch/1.0.0/service.xml
@@ -16,13 +16,6 @@
   limitations under the License.
 -->
 <service role="LOGSEARCH" name="logsearch" version="1.0.0">
-
-  <policies>
-    <policy role="webappsec"/>
-    <policy role="authentication" name="Anonymous"/>
-    <policy role="rewrite"/>
-    <policy role="authorization"/>
-  </policies>
   <routes>
 
     <route path="/logsearch">

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
@@ -58,7 +58,8 @@
               <commandScript>
                 <script>scripts/infra_solr.py</script>
                 <scriptType>PYTHON</scriptType>
-                <timeout>1200</timeout>
+                <background>true</background>
+                <timeout>36000</timeout>
               </commandScript>
             </customCommand>
             <customCommand>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/collection.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/collection.py
@@ -20,28 +20,49 @@ import time
 from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Directory, Execute, File
 from resource_management.libraries.functions.format import format
+from resource_management.libraries.resources.properties_file import PropertiesFile
+
 
 def backup_collection(env):
-    """
-    Backup collections using replication API (as Solr Cloud Backup API is not available in Solr 5)
-    """
-    import params, command_commons
-    env.set_params(command_commons)
+  """
+  Backup collections using replication API (as Solr Cloud Backup API is not available in Solr 5)
+  If the cluster is not kerberized, it will be needed to resolve ip addresses to hostnames (as SOLR_HOST=`hostname -f` is not used by default in infra-solr-env)
+  """
+  import params, command_commons
+  env.set_params(command_commons)
 
-    Directory(command_commons.index_location,
-              mode=0755,
-              cd_access='a',
-              owner=params.infra_solr_user,
-              group=params.user_group
-              )
-    collection_available = command_commons.is_collection_available_on_host()
-    if not collection_available:
-      Logger.info(format("No any '{collection}' replica is used on {params.hostname} host"))
-      return
+  Directory(command_commons.index_location,
+            mode=0755,
+            cd_access='a',
+            owner=params.infra_solr_user,
+            group=params.user_group
+            )
+  host_cores_data_map = command_commons.get_host_cores_for_collection()
 
-    Logger.info(format("Backup Solr Collection {collection} to {index_location}"))
+  Logger.info(format("Backup Solr Collection {collection} to {index_location}"))
 
-    solr_request_path = format("{collection}/replication?command=BACKUP&location={index_location}&name={backup_name}&wt=json")
+  host_core_map = host_cores_data_map[command_commons.HOST_CORES]
+
+  host_or_ip = params.hostname
+  # IP resolve - for unsecure cluster
+  host_ip_pairs = {}
+  if not params.security_enabled:
+    keys = host_core_map.keys()
+    for key in keys:
+      if command_commons.is_ip(key):
+        resolved_hostname = command_commons.resolve_ip_to_hostname(key)
+        host_ip_pairs[resolved_hostname] = key
+
+  if params.hostname in host_ip_pairs:
+    host_or_ip = host_ip_pairs[params.hostname]
+
+  cores = host_core_map[host_or_ip] if host_or_ip in host_core_map else []
+
+  for core in cores:
+    if core in command_commons.skip_cores:
+      Logger.info(format("Core '{core}' is filtered out."))
+      continue
+    solr_request_path = format("{core}/replication?command=BACKUP&location={index_location}&name={core}&wt=json")
     backup_api_cmd = command_commons.create_solr_api_request_command(solr_request_path)
 
     Execute(backup_api_cmd, user=params.infra_solr_user, logoutput=True)
@@ -50,41 +71,127 @@ def backup_collection(env):
       Logger.info("Sleep 5 seconds to wait until the backup request is executed.")
       time.sleep(5)
       Logger.info("Check backup status ...")
-      solr_status_request_path = format("{collection}/replication?command=details&wt=json")
+      solr_status_request_path = format("{core}/replication?command=details&wt=json")
       status_check_json_output = format("{index_location}/backup_status.json")
-      status_check_cmd = command_commons.create_solr_api_request_command(solr_status_request_path, status_check_json_output)
-      command_commons.snapshot_status_check(status_check_cmd, status_check_json_output, command_commons.backup_name, True,
-        log_output=command_commons.log_output, tries=command_commons.request_tries, time_interval=command_commons.request_time_interval)
+      status_check_cmd = command_commons.create_solr_api_request_command(solr_status_request_path,
+                                                                         status_check_json_output)
+      command_commons.snapshot_status_check(status_check_cmd, status_check_json_output, core, True,
+                                            log_output=command_commons.log_output, tries=command_commons.request_tries,
+                                            time_interval=command_commons.request_time_interval)
+
 
 def restore_collection(env):
-    """
-    Restore collections using replication API (as Solr Cloud Backup API is not available in Solr 5)
-    """
-    import params, command_commons
-    env.set_params(command_commons)
+  """
+  Restore collections - by copying snapshots with backup_* prefix, then remove old one and remove backup_* prefixes from the folder names.
+  """
+  import params, command_commons
+  env.set_params(command_commons)
 
-    collection_available = command_commons.is_collection_available_on_host()
-    if command_commons.check_hosts and not collection_available:
-      Logger.info(format("No any '{collection}' replica is used on {params.hostname} host"))
-      return
+  host_cores_backup_map = command_commons.read_backup_json()
+  host_cores_map = command_commons.get_host_cores_for_collection(backup=False)
 
-    Logger.info(format("Remove write.lock files from folder '{index_location}'"))
-    for write_lock_file in command_commons.get_files_by_pattern(format("{index_location}"), 'write.lock'):
-      File(write_lock_file, action="delete")
+  original_core_host_pairs = command_commons.sort_core_host_pairs(host_cores_backup_map[command_commons.CORE_HOST])
+  new_core_host_pairs = command_commons.sort_core_host_pairs(host_cores_map[command_commons.CORE_HOST])
 
-    Logger.info(format("Restore Solr Collection {collection} from {index_location}"))
+  core_pairs = command_commons.create_core_pairs(original_core_host_pairs, new_core_host_pairs)
+  Logger.info("Generated core pairs: " + str(core_pairs))
 
-    solr_request_path = format("{collection}/replication?command=RESTORE&location={index_location}&name={backup_name}&wt=json")
-    restore_api_cmd = command_commons.create_solr_api_request_command(solr_request_path)
+  Logger.info(format("Remove write.lock files from folder '{index_location}'"))
+  for write_lock_file in command_commons.get_files_by_pattern(format("{index_location}"), 'write.lock'):
+    File(write_lock_file, action="delete")
 
-    Execute(restore_api_cmd, user=params.infra_solr_user, logoutput=True)
+  Logger.info(format("Restore Solr Collection {collection} from {index_location} ..."))
 
-    if command_commons.request_async is False:
-      Logger.info("Sleep 5 seconds to wait until the restore request is executed.")
-      time.sleep(5)
-      Logger.info("Check restore status ...")
-      solr_status_request_path = format("{collection}/replication?command=restorestatus&wt=json")
-      status_check_json_output = format("{index_location}/restore_status.json")
-      status_check_cmd = command_commons.create_solr_api_request_command(solr_status_request_path, status_check_json_output)
-      command_commons.snapshot_status_check(status_check_cmd, status_check_json_output, command_commons.backup_name, False,
-        log_output=command_commons.log_output, tries=command_commons.request_tries, time_interval=command_commons.request_time_interval)
+  if command_commons.collection in ["ranger_audits", "history", "hadoop_logs", "audit_logs",
+                                    "vertex_index", "edge_index",
+                                    "fulltext_index"]:  # Make sure ambari wont delete an important collection
+    raise Exeption(format(
+      "Selected collection for restore is: {collection}. It is not recommended to restore on default collections."))
+
+  for core_data in core_pairs:
+    src_core = core_data['src_core']
+    target_core = core_data['target_core']
+
+    if src_core in command_commons.skip_cores:
+      Logger.info(format("Core '{src_core}' (src) is filtered out."))
+      continue
+    elif target_core in command_commons.skip_cores:
+      Logger.info(format("Core '{target_core}' (target) is filtered out."))
+      continue
+
+    core_data = host_cores_map[command_commons.CORE_DATA]
+    only_if_cmd = format("test -d {index_location}/snapshot.{src_core}")
+    core_root_dir = format("{solr_datadir}/backup_{target_core}")
+    core_root_without_backup_dir = format("{solr_datadir}/{target_core}")
+
+    Directory([format("{core_root_dir}/data/index"),
+               format("{core_root_dir}/data/tlog"),
+               format("{core_root_dir}/data/snapshot_metadata")],
+              mode=0755,
+              cd_access='a',
+              create_parents=True,
+              owner=params.infra_solr_user,
+              group=params.user_group,
+              only_if=only_if_cmd
+              )
+
+    core_details = core_data[target_core]
+    core_properties = {}
+    core_properties['numShards'] = command_commons.solr_num_shards
+    core_properties['collection.configName'] = "ranger_audits"
+    core_properties['name'] = target_core
+    core_properties['replicaType'] = core_details['type']
+    core_properties['collection'] = command_commons.collection
+    core_properties['coreNodeName'] = core_details['node']
+    core_properties['shard'] = core_details['shard']
+
+    copy_cmd = format(
+      "mv {index_location}/snapshot.{src_core}/* {core_root_dir}/data/index/") if command_commons.solr_keep_backup \
+      else format("cp -r {index_location}/snapshot.{src_core}/* {core_root_dir}/data/index/")
+    Execute(
+      copy_cmd, only_if=only_if_cmd,
+      user=params.infra_solr_user,
+      logoutput=True
+    )
+    PropertiesFile(
+      core_root_dir + '/core.properties',
+      properties=core_properties,
+      owner=params.infra_solr_user,
+      group=params.user_group,
+      mode=0644,
+      only_if=only_if_cmd
+    )
+
+  Execute(format("rm -rf {solr_datadir}/{collection}*"),
+          user=params.infra_solr_user,
+          logoutput=True)
+
+  for core_data in core_pairs:
+    src_core = core_data['src_core']
+    target_core = core_data['target_core']
+
+    if src_core in command_commons.skip_cores:
+      Logger.info(format("Core '{src_core}' (src) is filtered out."))
+      continue
+    elif target_core in command_commons.skip_cores:
+      Logger.info(format("Core '{target_core}' (target) is filtered out."))
+      continue
+
+    core_root_dir = format("{solr_datadir}/backup_{target_core}")
+    core_root_without_backup_dir = format("{solr_datadir}/{target_core}")
+    Execute(
+      format("mv {core_root_dir} {core_root_without_backup_dir}"),
+      user=params.infra_solr_user,
+      logoutput=True,
+      only_if=format("test -d {core_root_dir}")
+    )
+
+    Directory([format("{core_root_without_backup_dir}")],
+              mode=0755,
+              cd_access='a',
+              create_parents=True,
+              owner=params.infra_solr_user,
+              group=params.user_group,
+              recursive_ownership=True,
+              only_if=format("test -d {core_root_without_backup_dir}")
+              )

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/migrate.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/migrate.py
@@ -28,11 +28,6 @@ def migrate_index(env):
   import params, command_commons
   env.set_params(command_commons)
 
-  collection_available = command_commons.is_collection_available_on_host()
-  if not collection_available:
-    Logger.info(format("No any '{collection}' replica is used on {params.hostname} host"))
-    return
-
   index_migrate_cmd = format("{index_helper_script} upgrade-index -d {index_location} -v {index_version}")
 
   if command_commons.force is True:

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/templates/infra-solr-security.json.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/templates/infra-solr-security.json.j2
@@ -67,6 +67,12 @@
        "role": ["admin", "{{infra_solr_role_ranger_admin}}", "{{infra_solr_role_ranger_audit}}"],
        "name": "ranger-manager",
        "path": "/*"
+    },
+    {
+       "collection": "old_ranger_audits",
+       "role": ["admin", "{{infra_solr_role_ranger_admin}}", "{{infra_solr_role_ranger_audit}}"],
+       "name": "backup-ranger-manager",
+       "path": "/*"
     }]
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- backup all of the cores in different calls
- make sure we can use those calls on specific hosts
- resolve ip addresses in the cluster is not secure
- restore often not works as expected, or after a successful restore solr can revert the changes, so the restore will be just a copy command
- add skip cores support (in order if the command failed between 2 backup/restore tasks)
- add old_ranger_audits collection to permissions list

because of restore changes copy won't work on hdfs, i will need to use hdfs commands for copying/moving files. that work is in progress...

## How was this patch tested?
manually.

please review @kasakrisz @swagle @g-boros 