### PR TITLE
[AMBARI-23801] Unable to add Hive Metastore from Host detail Page

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1159,20 +1159,16 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
    * @method loadWebHCatConfigs
    */
   loadWebHCatConfigs: function (data, opt, params) {
-    var request = App.ajax.send({
-      name: 'admin.get.all_configurations',
-      sender: this,
-      data: {
-        webHCat: true,
-        urlParams: [
-          '(type=hive-site&tag=' + data.Clusters.desired_configs['hive-site'].tag + ')',
-          '(type=webhcat-site&tag=' + data.Clusters.desired_configs['webhcat-site'].tag + ')',
-          '(type=hive-env&tag=' + data.Clusters.desired_configs['hive-env'].tag + ')',
-          '(type=core-site&tag=' + data.Clusters.desired_configs['core-site'].tag + ')'
-        ].join('|')
-      },
-      success: params.callback
-    });
+    const urlParams = this.getUrlParamsForConfigsRequest(data, ['hive-site', 'webhcat-site', 'hive-env', 'core-site']),
+      request = App.ajax.send({
+        name: 'admin.get.all_configurations',
+        sender: this,
+        data: {
+          webHCat: true,
+          urlParams
+        },
+        success: params.callback
+      });
     this.trackRequest(request);
     return request;
   },
@@ -1185,19 +1181,15 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
    * @method loadHiveConfigs
    */
   loadHiveConfigs: function (data, opt, params) {
-    var request = App.ajax.send({
-      name: 'admin.get.all_configurations',
-      sender: this,
-      data: {
-        urlParams: [
-          '(type=hive-site&tag=' + data.Clusters.desired_configs['hive-site'].tag + ')',
-          '(type=webhcat-site&tag=' + data.Clusters.desired_configs['webhcat-site'].tag + ')',
-          '(type=hive-env&tag=' + data.Clusters.desired_configs['hive-env'].tag + ')',
-          '(type=core-site&tag=' + data.Clusters.desired_configs['core-site'].tag + ')'
-        ].join('|')
-      },
-      success: params.callback
-    });
+    const urlParams = this.getUrlParamsForConfigsRequest(data, ['hive-site', 'webhcat-site', 'hive-env', 'core-site']),
+      request = App.ajax.send({
+        name: 'admin.get.all_configurations',
+        sender: this,
+        data: {
+          urlParams
+        },
+        success: params.callback
+      });
     this.trackRequest(request);
     return request;
   },
@@ -1406,17 +1398,15 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
    * @method loadRangerConfigs
    */
   loadRangerConfigs: function (data, opt, params) {
-    var request = App.ajax.send({
-      name: 'admin.get.all_configurations',
-      sender: this,
-      data: {
-        urlParams: '(type=core-site&tag=' + data.Clusters.desired_configs['core-site'].tag + ')|' +
-        '(type=hdfs-site&tag=' + data.Clusters.desired_configs['hdfs-site'].tag + ')|' +
-        '(type=kms-env&tag=' + data.Clusters.desired_configs['kms-env'].tag + ')|' +
-        '(type=kms-site&tag=' + data.Clusters.desired_configs['kms-site'].tag + ')'
-      },
-      success: params.callback
-    });
+    const urlParams = this.getUrlParamsForConfigsRequest(data, ['core-site', 'hdfs-site', 'kms-env', 'kms-site']),
+      request = App.ajax.send({
+        name: 'admin.get.all_configurations',
+        sender: this,
+        data: {
+          urlParams
+        },
+        success: params.callback
+      });
     this.trackRequest(request);
   },
 
@@ -3231,5 +3221,18 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
   regenerateKeytabFileOperationsRequestError: function () {
     App.showAlertPopup(Em.I18n.t('common.error'), Em.I18n.t('alerts.notifications.regenerateKeytab.host.error').format(this.content.get('hostName')));
   },
+
+  /**
+   * Returns URL parameters for configs request by certain tags
+   * @param {object} data - object with desired configs tags received from API
+   * @param {string[]} configTypes - list of config types
+   * @returns {string}
+   */
+  getUrlParamsForConfigsRequest: function (data, configTypes) {
+    return configTypes.map(type => {
+      const tag = Em.get(data, `Clusters.desired_configs.${type}.tag`);
+      return tag ? `(type=${type}&tag=${tag})` : null;
+    }).compact().join('|');
+  }
 
 });

--- a/ambari-web/test/controllers/main/host/details_test.js
+++ b/ambari-web/test/controllers/main/host/details_test.js
@@ -4362,4 +4362,80 @@ describe('App.MainHostDetailsController', function () {
       expect(controller.get('hdfsUser')).to.be.equal('val')
     });
   });
+
+  describe('#getUrlParamsForConfigsRequest', function () {
+    var cases = [
+      {
+        data: {
+          Clusters: {
+            desired_configs: {
+              't0-site': {
+                tag: 'v0'
+              },
+              't0-env': {
+                tag: 'v1'
+              },
+              't0-log4j': {
+                tag: 'v2'
+              },
+              't2-site': {
+                tag: 'v3'
+              }
+            }
+          }
+        },
+        types: ['t0-site', 't0-env', 't0-log4j', 't1-site'],
+        result: '(type=t0-site&tag=v0)|(type=t0-env&tag=v1)|(type=t0-log4j&tag=v2)',
+        title: 'several types available'
+      },
+      {
+        data: {
+          Clusters: {
+            desired_configs: {
+              't1-site': {
+                tag: 'v4'
+              },
+              't2-env': {
+                tag: 'v5'
+              },
+              't2-log4j': {
+                tag: 'v6'
+              }
+            }
+          }
+        },
+        types: ['t1-site', 't1-env', 't1-log4j'],
+        result: '(type=t1-site&tag=v4)',
+        title: 'single type available'
+      },
+      {
+        data: {
+          Clusters: {
+            desired_configs: {
+              't3-site': {
+                tag: 'v7'
+              },
+              't3-env': {
+                tag: 'v8'
+              },
+              't3-log4j': {
+                tag: 'v9'
+              }
+            }
+          }
+        },
+        types: ['t2-site', 't2-env', 't2-log4j'],
+        result: '',
+        title: 'no types available'
+      }
+    ];
+
+    cases.forEach(function (test) {
+      describe(test.title, function () {
+        it('should return ' + test.result, function () {
+          expect(controller.getUrlParamsForConfigsRequest(test.data, test.types)).to.equal(test.result);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding Hive Metastore from Host detail page leads to the modal window being stuck and javascript errors:

```
Uncaught TypeError: Cannot read property 'tag' of undefined
    at Class.loadHiveConfigs (app.js:24588)
    at Class.opt.success (app.js:181624)
    at fire (vendor.js:1141)
    at Object.fireWith [as resolveWith] (vendor.js:1252)
    at done (vendor.js:8178)
    at XMLHttpRequest.callback (vendor.js:8702)
```

## How was this patch tested?

UI unit tests:
  21533 passing (44s)
  48 pending
