### PR TITLE
AMBARI-23778 v3 Ambari assigns /home for NameNode, DataNode and NodeM…

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/Hardware.py
+++ b/ambari-agent/src/main/python/ambari_agent/Hardware.py
@@ -40,7 +40,7 @@ class Hardware:
   CHECK_REMOTE_MOUNTS_KEY = 'agent.check.remote.mounts'
   CHECK_REMOTE_MOUNTS_TIMEOUT_KEY = 'agent.check.mounts.timeout'
   CHECK_REMOTE_MOUNTS_TIMEOUT_DEFAULT = '10'
-  IGNORE_ROOT_MOUNTS = ["proc", "dev", "sys", "boot"]
+  IGNORE_ROOT_MOUNTS = ["proc", "dev", "sys", "boot", "home"]
   IGNORE_DEVICES = ["proc", "tmpfs", "cgroup", "mqueue", "shm"]
   LINUX_PATH_SEP = "/"
 
@@ -174,7 +174,7 @@ class Hardware:
        - mount path or a part of mount path is not in the blacklist
       """
       if mount["device"] not in self.IGNORE_DEVICES and\
-         mount["mountpoint"].split("/")[0] not in self.IGNORE_ROOT_MOUNTS and\
+         mount["mountpoint"].strip()[1:].split("/")[0] not in self.IGNORE_ROOT_MOUNTS and\
          self._chk_writable_mount(mount['mountpoint']) and\
          not path_isfile(mount["mountpoint"]) and\
          not self._is_mount_blacklisted(blacklisted_mount_points, mount["mountpoint"]):


### PR DESCRIPTION
…anager directories

## What changes were proposed in this pull request?

Mount point filtering updated and fixed on the agent side.
These are the changes from @hapylestat 
This PR does not include the revert of the previous attempt. I suggest reverting that separately.

## How was this patch tested?

unit test
test on a cluster
