### PR TITLE
[AMBARI-23746] Use stackSettings instead of clusterLevelParams. Fetch…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/execution_command.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/execution_command.py
@@ -258,7 +258,7 @@ class ExecutionCommand(object):
     Retrieve mpack name from command.json, i.e "stack_name": "HDPCORE"
     :return: mpack name string
     """
-    return self.__get_value("clusterLevelParams/stack_name")
+    return self.__get_value("stackSettings/stack_name")
 
   def get_mpack_version(self):
     """

--- a/ambari-common/src/main/python/resource_management/libraries/functions/conf_select.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/conf_select.py
@@ -54,7 +54,7 @@ def get_package_dirs():
   Get package dir mappings
   :return:
   """
-  stack_name = default("/clusterLevelParams/stack_name", None)
+  stack_name = default("/stackSettings/stack_name", None)
   if stack_name is None:
     raise Fail("The stack name is not present in the command. Packages for conf-select tool cannot be loaded.")
 
@@ -329,7 +329,7 @@ def get_restricted_packages():
     Logger.info("No services found, there are no restrictions for conf-select")
     return package_names
 
-  stack_name = default("/clusterLevelParams/stack_name", None)
+  stack_name = default("/stackSettings/stack_name", None)
   if stack_name is None:
     Logger.info("The stack name is not present in the command. Restricted names skipped.")
     return package_names

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
@@ -45,7 +45,7 @@ def check_stack_feature(stack_feature, stack_version):
   from resource_management.libraries.functions.default import default
   from resource_management.libraries.functions.version import compare_versions
 
-  stack_name = default("/clusterLevelParams/stack_name", None)
+  stack_name = default("/stackSettings/stack_name", None)
   if stack_name is None:
     Logger.warning("Cannot find the stack name in the command. Stack features cannot be loaded")
     return False

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_select.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_select.py
@@ -184,7 +184,7 @@ def get_packages(scope, service_name = None, component_name = None):
     component_name = config['role']
 
 
-  stack_name = default("/clusterLevelParams/stack_name", None)
+  stack_name = default("/stackSettings/stack_name", None)
   if stack_name is None:
     raise Fail("The stack name is not present in the command. Packages for stack-select tool cannot be loaded.")
 
@@ -438,7 +438,7 @@ def _get_upgrade_stack():
   """
   from resource_management.libraries.functions.default import default
   direction = default("/commandParams/upgrade_direction", None)
-  stack_name = default("/clusterLevelParams/stack_name", None)
+  stack_name = default("/stackSettings/stack_name", None)
   stack_version = default("/commandParams/version", None)
 
   if direction and stack_name and stack_version:

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_tools.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_tools.py
@@ -41,7 +41,7 @@ def get_stack_tool(name):
   """
   from resource_management.libraries.functions.default import default
 
-  stack_name = default("/clusterLevelParams/stack_name", None)
+  stack_name = default("/stackSettings/stack_name", None)
   if stack_name is None:
     Logger.warning("Cannot find the stack name in the command. Stack tools cannot be loaded")
     return None, None, None

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -652,11 +652,11 @@ class Script(object):
   @staticmethod
   def get_stack_name():
     """
-    Gets the name of the stack from clusterLevelParams/stack_name.
+    Gets the name of the stack from stackSettings/stack_name.
     :return: a stack name or None
     """
     from resource_management.libraries.functions.default import default
-    stack_name = default("/clusterLevelParams/stack_name", None)
+    stack_name = default("/stackSettings/stack_name", None)
     if stack_name is None:
       stack_name = default("/configurations/cluster-env/stack_name", "HDP")
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -1418,11 +1418,12 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       }
     }
 
-    Set<Service> services = new HashSet<>();
+    request.setServiceGroupName(cluster.getServiceByComponentId(request.getComponentId()).getServiceGroupName());
+    List<Service> services = new ArrayList<>();
     if (request.getServiceName() != null && !request.getServiceName().isEmpty()) {
       services.add(cluster.getService(request.getServiceName()));
     } else {
-      services.addAll(cluster.getServices().values());
+      services.addAll(cluster.getServicesByServiceGroup(request.getServiceGroupName()));
     }
 
     Set<ServiceComponentHostResponse> response =

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -561,7 +561,13 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
       checkDesiredState = true;
     }
 
-    for (Service s : cluster.getServicesByServiceGroup(serviceGroupName)) {
+    Collection<Service> clusterServices;
+    if(request.getServiceGroupName() != null){
+     clusterServices = cluster.getServicesByServiceGroup(serviceGroupName);
+    }else{
+      clusterServices = cluster.getServicesById().values();
+    }
+    for (Service s : clusterServices) {
       if (checkDesiredState
           && (desiredStateToCheck != s.getDesiredState())) {
         // skip non matching state


### PR DESCRIPTION
… services by serviceGroupName where applicable

1. stack_select and stack_tools.py fetches stack_name from clusterLevelParams. But we will get rid of those two properties under cluster meta data because cluster will not be tied to a stack. Instead it should get this value from stackSettings which is specific to an mpack.

2. During update services, the services need to be fetched by particular service group name

3. UI still needs a way to fetch all services across serviceGroups hence the if-else block to satisfy conditions for
GET /servicegroups/<servicegroupname>/services and
GET /cluster/<clustername>/services

(Please fill in changes proposed in this fix)
GET /servicegroups/<servicegroupname>/services and
GET /cluster/<clustername>/services
PUT http://{{ambari_server}}:8080/api/v1/clusters/cl1/hosts/hdpcore-ods-2.openstacklocal/host_components/9


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.