### PR TITLE
[AMBARI-23835] Port is not cleared for Superset Database type if Mysql is selected than SQLLite is selected in Installer Wizard (dsen)

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/stack_advisor.py
@@ -243,6 +243,8 @@ class HDP26StackAdvisor(HDP25StackAdvisor):
             putSupersetProperty("SUPERSET_DATABASE_PORT", "3306")
         elif superset_database_type == "postgresql":
             putSupersetProperty("SUPERSET_DATABASE_PORT", "5432")
+        elif superset_database_type == "sqlite":
+            putSupersetProperty("SUPERSET_DATABASE_PORT", "")
 
   def recommendYARNConfigurations(self, configurations, clusterData, services, hosts):
     super(HDP26StackAdvisor, self).recommendYARNConfigurations(configurations, clusterData, services, hosts)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added sqlite condition
## How was this patch tested?
Manually