### PR TITLE
AMBARI-23842. Timeline service is shown as stopped, while it is started

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
+++ b/ambari-agent/src/main/python/ambari_agent/ConfigurationBuilder.py
@@ -42,7 +42,8 @@ class ConfigurationBuilder:
         'hostLevelParams': host_level_params_cache,
         'clusterHostInfo': self.topology_cache.get_cluster_host_info(cluster_id),
         'localComponents': self.topology_cache.get_cluster_local_components(cluster_id),
-        'agentLevelParams': {'hostname': self.topology_cache.get_current_host_info(cluster_id)['hostName']}
+        'agentLevelParams': {'hostname': self.topology_cache.get_current_host_info(cluster_id)['hostName']},
+        'clusterName': metadata_cache.clusterLevelParams.cluster_name
       }
 
       if service_name is not None and service_name != 'null':


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/timelinereader.py", line 108, in <module>
    ApplicationTimelineReader().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/timelinereader.py", line 87, in status
    for pid_file in self.get_pid_files():
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/timelinereader.py", line 99, in get_pid_files
    import params
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/params.py", line 29, in <module>
    from params_linux import *
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/params_linux.py", line 473, in <module>
    repo_name = str(config['clusterName']) + '_yarn'
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/config_dictionary.py", line 73, in __getattr__
    raise Fail("Configuration parameter '" + self.name + "' was not found in configurations dictionary!")
resource_management.core.exceptions.Fail: Configuration parameter 'clusterName' was not found in configurations dictionary!