### PR TITLE
[AMBARI-23844] Infra Solr: support for manage security.json manually.

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
@@ -314,12 +314,15 @@ def add_solr_roles(config, roles = [], new_service_principals = [], tries = 30, 
   solr_port = default_config(config, 'configurations/infra-solr-env/infra_solr_port', '8886')
   kinit_path_local = get_kinit_path(default_config(config, '/configurations/kerberos-env/executable_search_paths', None))
   infra_solr_custom_security_json_content = None
-
+  infra_solr_security_manually_managed = False
   if 'infra-solr-security-json' in config['configurations']:
     infra_solr_custom_security_json_content = config['configurations']['infra-solr-security-json']['content']
+    infra_solr_security_manually_managed = config['configurations']['infra-solr-security-json']['infra_solr_security_manually_managed']
 
   Logger.info(format("Adding {roles} roles to {new_service_principals} if infra-solr is installed."))
-  if infra_solr_custom_security_json_content and str(infra_solr_custom_security_json_content).strip():
+  if infra_solr_security_manually_managed:
+    Logger.info("security.json file is manually managed, skip adding roles...")
+  elif infra_solr_custom_security_json_content and str(infra_solr_custom_security_json_content).strip():
     Logger.info("Custom security.json is not empty for infra-solr, skip adding roles...")
   elif security_enabled \
     and "infra-solr-env" in config['configurations'] \

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-security-json.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-security-json.xml
@@ -125,6 +125,16 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>infra_solr_security_manually_managed</name>
+    <value>false</value>
+    <display-name>Manually Managed</display-name>
+    <description>Manage /security.json manually (Service start wont override /security.json)</description>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>content</name>
     <display-name>Custom security.json template</display-name>
     <description>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -125,6 +125,9 @@ if "infra-solr-env" in config['configurations']:
 
   zk_quorum = format(default('configurations/infra-solr-env/infra_solr_zookeeper_quorum', zookeeper_quorum))
 
+if 'infra-solr-security-json' in config['configurations']:
+  infra_solr_security_manually_managed = default("/configurations/infra-solr-security-json/infra_solr_security_manually_managed", False)
+
 default_ranger_audit_users = 'nn,hbase,hive,knox,kafka,kms,storm,yarn,nifi'
 
 if security_enabled:

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
@@ -131,16 +131,16 @@ def setup_solr_znode_env():
     jaas_file=jaas_file,
     java_opts=java_opts
   )
-
-  solr_cloud_util.setup_kerberos_plugin(
-    zookeeper_quorum=params.zk_quorum,
-    solr_znode=params.infra_solr_znode,
-    jaas_file=jaas_file,
-    java64_home=params.java64_home,
-    secure=params.security_enabled,
-    security_json_location=security_json_file_location,
-    java_opts=java_opts
-  )
+  if not params.infra_solr_security_manually_managed:
+    solr_cloud_util.setup_kerberos_plugin(
+      zookeeper_quorum=params.zk_quorum,
+      solr_znode=params.infra_solr_znode,
+      jaas_file=jaas_file,
+      java64_home=params.java64_home,
+      secure=params.security_enabled,
+      security_json_location=security_json_file_location,
+      java_opts=java_opts
+    )
 
   if params.security_enabled:
     solr_cloud_util.secure_solr_znode(


### PR DESCRIPTION
## What changes were proposed in this pull request?
security.json file (generated by Ambari) is uploaded (overriden) during Infra Solr startup, add a new option in order to turn this feature off and manage security.json manually: `infra-solr-security-json/infra_solr_security_manually_managed`

## How was this patch tested?
```bash
Total run:3
Total errors:0
Total failures:0
OK
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 49.530 s
[INFO] Finished at: 2018-05-15T13:49:20+02:00
[INFO] Final Memory: 108M/1732M
[INFO] ------------------------------------------------------------------------
```
please review @zeroflag @kasakrisz @g-boros 