### PR TITLE
[AMBARI-23815] NN Federation wizard: Restart Required Services should not restart JN and ZKFC

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step4_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step4_controller.js
@@ -177,7 +177,7 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
       name: 'restart.custom.filter',
       sender: this,
       data: {
-        filter: "HostRoles/component_name!=NAMENODE&HostRoles/component_name!=RANGER_ADMIN&HostRoles/component_name!=RANGER_USERSYNC&HostRoles/cluster_name=" + App.get('clusterName'),
+        filter: "HostRoles/component_name!=NAMENODE&HostRoles/component_name!=JOURNALNODE&HostRoles/component_name!=ZKFC&HostRoles/component_name!=RANGER_ADMIN&HostRoles/component_name!=RANGER_USERSYNC&HostRoles/cluster_name=" + App.get('clusterName'),
         context: "Restart Required Services"
       },
       success: 'startPolling',


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:
Add namespace from UI. In the Restart All Services operation RM fails to start

```
Traceback (most recent call last):
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/decorator.py", line 54, in wrapper
 return function(*args, **kwargs)
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/resourcemanager.py", line 244, in wait_for_dfs_directory_created
 raise Fail("DFS directory '" + dir_path + "' does not exist !")
Fail: DFS directory '/ats/done/' does not exist !
```

The above exception was the cause of the following exception:

```
Traceback (most recent call last):
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/resourcemanager.py", line 261, in <module>
 Resourcemanager().execute()
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
 method(env)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 982, in restart
 self.start(env, upgrade_type=upgrade_type)
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/resourcemanager.py", line 142, in start
 self.wait_for_dfs_directories_created(params.entity_groupfs_store_dir, params.entity_groupfs_active_dir)
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/resourcemanager.py", line 211, in wait_for_dfs_directories_created
 self.wait_for_dfs_directory_created(dir_path, ignored_dfs_dirs)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/decorator.py", line 62, in wrapper
 return function(*args, **kwargs)
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/resourcemanager.py", line 244, in wait_for_dfs_directory_created
 raise Fail("DFS directory '" + dir_path + "' does not exist !")
resource_management.core.exceptions.Fail: DFS directory '/ats/done/' does not exist !
```

But after closing the wizard and starting all the services it started.

Also restarting history server failed on another host

```
Traceback (most recent call last):
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/historyserver.py", line 134, in <module>
 HistoryServer().execute()
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
 method(env)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 982, in restart
 self.start(env, upgrade_type=upgrade_type)
 File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/YARN/package/scripts/historyserver.py", line 95, in start
 skip=params.sysprep_skip_copy_tarballs_hdfs)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/copy_tarball.py", line 502, in copy_to_hdfs
 replace_existing_files=replace_existing_files,
 File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
 self.env.run()
 File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
 self.run_action(resource, action)
 File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
 provider_action()
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 627, in action_create_on_execute
 self.action_delayed("create")
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 624, in action_delayed
 self.get_hdfs_resource_executor().action_delayed(action_name, self)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 333, in action_delayed
 self.action_delayed_for_nameservice(nameservice, action_name, main_resource)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 359, in action_delayed_for_nameservice
 self._create_resource()
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 375, in _create_resource
 self._create_file(self.main_resource.resource.target, source=self.main_resource.resource.source, mode=self.mode)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 490, in _create_file
 self.util.run_command(target, 'CREATE', method='PUT', overwrite=True, assertable_result=False, file_to_put=source, **kwargs)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 178, in run_command
 return self._run_command(*args, **kwargs)
 File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 251, in _run_command
 raise WebHDFSCallException(err_msg, result_dict)
resource_management.libraries.providers.hdfs_resource.WebHDFSCallException: Execution of 'curl -sS -L -w '%\{http_code}' -X PUT --data-binary @/var/lib/ambari-agent/tmp/mapreduce-native-tarball-staging/mapreduce-native.tar.gz -H 'Content-Type: application/octet-stream' --negotiate -u : -k 'https://<Host>:50470/webhdfs/v1/hdp/apps/3.0.0.0-1309/mapreduce/mapreduce.tar.gz?op=CREATE&overwrite=True&permission=444'' returned status_code=403. 
{
 "RemoteException": {
 "exception": "IOException", 
 "javaClassName": "java.io.IOException", 
 "message": "Failed to find datanode, suggest to check cluster health. excludeDatanodes=null"
 }
}
```
 

## How was this patch tested?

UI unit tests:
  21535 passing (25s)
  48 pending
