### PR TITLE
AMBARI-23847. User information is missing when upgrade wizard is laun…

### DIFF
--- a/ambari-web/app/app.js
+++ b/ambari-web/app/app.js
@@ -141,7 +141,9 @@ module.exports = Em.Application.create({
     authRoles = $.map(authRoles.split(","), $.trim);
 
     // When Upgrade running(not suspended) only operations related to upgrade should be allowed
-    if ((!this.get('upgradeSuspended') && !authRoles.contains('CLUSTER.UPGRADE_DOWNGRADE_STACK')) &&
+    if ((!this.get('upgradeSuspended') &&
+      !authRoles.contains('CLUSTER.UPGRADE_DOWNGRADE_STACK') &&
+      !authRoles.contains('CLUSTER.MANAGE_USER_PERSISTED_DATA')) &&
       !App.get('supports.opsDuringRollingUpgrade') &&
       !['NOT_REQUIRED', 'COMPLETED'].contains(this.get('upgradeState')) ||
       !App.auth){

--- a/ambari-web/app/controllers/main/admin/stack_and_upgrade_controller.js
+++ b/ambari-web/app/controllers/main/admin/stack_and_upgrade_controller.js
@@ -961,6 +961,7 @@ App.MainAdminStackAndUpgradeController = Em.Controller.extend(App.LocalStorage, 
       localdb: App.db.data
     });
     this.load();
+    App.router.get('wizardWatcherController').setUser(App.router.get('mainAdminStackAndUpgradeController').get('name'));
     this.openUpgradeDialog();
   },
 

--- a/ambari-web/app/routes/stack_upgrade_routes.js
+++ b/ambari-web/app/routes/stack_upgrade_routes.js
@@ -36,7 +36,6 @@ module.exports = App.WizardRoute.extend({
           }
 
           App.router.get('updateController').set('isWorking', false);
-          App.router.get('wizardWatcherController').setUser(router.get('mainAdminStackAndUpgradeController').get('name'));
 
           return App.ModalPopup.show({
             classNames: ['upgrade-wizard-modal'],
@@ -82,6 +81,7 @@ module.exports = App.WizardRoute.extend({
               this.hide();
               if (['NOT_REQUIRED', 'COMPLETED'].contains(App.get('upgradeState'))) {
                 location.reload();
+                App.router.get('wizardWatcherController').resetUser();
               }
             }
           });


### PR DESCRIPTION
…ched by a custom user.

## What changes were proposed in this pull request?
User information is missing when upgrade wizard is launched by a custom user.

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.