### PR TITLE
AMBARI-23791. Agent is not notified about cluster delete in runtime.

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ClusterMetadataCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/ClusterMetadataCache.py
@@ -38,5 +38,23 @@ class ClusterMetadataCache(ClusterCache):
     """
     super(ClusterMetadataCache, self).__init__(cluster_cache_dir)
 
+  def cache_delete(self, cache_update, cache_hash):
+    """
+    Only deleting cluster is supported here
+    """
+    mutable_dict = self._get_mutable_copy()
+    clusters_ids_to_delete = []
+
+    for cluster_id, cluster_updates_dict in cache_update.iteritems():
+      if cluster_updates_dict != {}:
+        raise Exception("Deleting cluster subvalues is not supported")
+
+      clusters_ids_to_delete.append(cluster_id)
+
+    for cluster_id in clusters_ids_to_delete:
+      del mutable_dict[cluster_id]
+
+    self.rewrite_cache(mutable_dict, cache_hash)
+
   def get_cache_name(self):
     return 'metadata'

--- a/ambari-agent/src/main/python/ambari_agent/listeners/MetadataEventListener.py
+++ b/ambari-agent/src/main/python/ambari_agent/listeners/MetadataEventListener.py
@@ -47,7 +47,16 @@ class MetadataEventListener(EventListener):
     if message == {}:
       return
 
-    self.metadata_cache.cache_update(message['clusters'], message['hash'])
+    event_type = message['eventType']
+
+    if event_type == 'CREATE':
+      self.metadata_cache.rewrite_cache(message['clusters'], message['hash'])
+    elif event_type == 'UPDATE':
+      self.metadata_cache.cache_update(message['clusters'], message['hash'])
+    elif event_type == 'DELETE':
+      self.metadata_cache.cache_delete(message['clusters'], message['hash'])
+    else:
+      logger.error("Unknown event type '{0}' for metadata event")
 
     try:
       self.config.update_configuration_from_metadata(message['clusters']['-1']['agentConfigs'])

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
@@ -54,6 +54,10 @@ public class AgentConfigsHolder extends AgentHostDataHolder<AgentConfigsUpdateEv
     return configHelper.getHostActualConfigs(hostId);
   }
 
+  public AgentConfigsUpdateEvent getCurrentDataExcludeCluster(Long hostId, Long clusterId) throws AmbariException {
+    return configHelper.getHostActualConfigsExcludeCluster(hostId, clusterId);
+  }
+
   protected boolean handleUpdate(AgentConfigsUpdateEvent update) throws AmbariException {
     setData(update, update.getHostId());
     return true;

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolder.java
@@ -55,9 +55,16 @@ public class HostLevelParamsHolder extends AgentHostDataHolder<HostLevelParamsUp
 
   @Override
   public HostLevelParamsUpdateEvent getCurrentData(Long hostId) throws AmbariException {
+    return getCurrentDataExcludeCluster(hostId, null);
+  }
+
+  public HostLevelParamsUpdateEvent getCurrentDataExcludeCluster(Long hostId, Long clusterId) throws AmbariException {
     TreeMap<String, HostLevelParamsCluster> hostLevelParamsClusters = new TreeMap<>();
     Host host = clusters.getHostById(hostId);
     for (Cluster cl : clusters.getClustersForHost(host.getHostName())) {
+      if (clusterId != null && cl.getClusterId() == clusterId) {
+        continue;
+      }
       HostLevelParamsCluster hostLevelParamsCluster = new HostLevelParamsCluster(
           m_ambariManagementController.get().retrieveHostRepositories(cl, host),
           recoveryConfigHelper.getRecoveryConfig(cl.getClusterName(), host.getHostName()));

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
@@ -18,8 +18,10 @@
 package org.apache.ambari.server.agent.stomp;
 
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.ClusterNotFoundException;
 import org.apache.ambari.server.agent.stomp.dto.MetadataCluster;
 import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
 import org.apache.ambari.server.events.AmbariPropertiesChangedEvent;
@@ -28,6 +30,7 @@ import org.apache.ambari.server.events.ClusterConfigChangedEvent;
 import org.apache.ambari.server.events.MetadataUpdateEvent;
 import org.apache.ambari.server.events.ServiceCredentialStoreUpdateEvent;
 import org.apache.ambari.server.events.ServiceInstalledEvent;
+import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
@@ -57,23 +60,52 @@ public class MetadataHolder extends AgentClusterDataHolder<MetadataUpdateEvent> 
     return ambariManagementController.getClustersMetadata();
   }
 
+  public MetadataUpdateEvent getDeleteMetadata(Long clusterId) throws AmbariException {
+    TreeMap<String, MetadataCluster> clusterToRemove = new TreeMap<>();
+    if (clusterId != null) {
+      clusterToRemove.put(Long.toString(clusterId), MetadataCluster.emptyMetadataCluster());
+    }
+    MetadataUpdateEvent deleteEvent = new MetadataUpdateEvent(clusterToRemove, null ,
+        UpdateEventType.DELETE);
+    return deleteEvent;
+  }
+
   @Override
   protected boolean handleUpdate(MetadataUpdateEvent update) throws AmbariException {
     boolean changed = false;
+    UpdateEventType eventType = update.getEventType();
     if (MapUtils.isNotEmpty(update.getMetadataClusters())) {
       for (Map.Entry<String, MetadataCluster> metadataClusterEntry : update.getMetadataClusters().entrySet()) {
         MetadataCluster updatedCluster = metadataClusterEntry.getValue();
         String clusterId = metadataClusterEntry.getKey();
         Map<String, MetadataCluster> clusters = getData().getMetadataClusters();
         if (clusters.containsKey(clusterId)) {
-          MetadataCluster cluster = clusters.get(clusterId);
-          cluster.getClusterLevelParams().putAll(updatedCluster.getClusterLevelParams());
-          cluster.getServiceLevelParams().putAll(updatedCluster.getServiceLevelParams());
-          cluster.getStatusCommandsToRun().addAll(updatedCluster.getStatusCommandsToRun());
+          if (eventType.equals(UpdateEventType.DELETE)) {
+            getData().getMetadataClusters().remove(clusterId);
+            changed = true;
+          } else {
+            MetadataCluster cluster = clusters.get(clusterId);
+            if (!cluster.getClusterLevelParams().equals(updatedCluster.getClusterLevelParams())) {
+              cluster.getClusterLevelParams().putAll(updatedCluster.getClusterLevelParams());
+              changed = true;
+            }
+            if (!cluster.getServiceLevelParams().equals(updatedCluster.getServiceLevelParams())) {
+              cluster.getServiceLevelParams().putAll(updatedCluster.getServiceLevelParams());
+              changed = true;
+            }
+            if (!cluster.getStatusCommandsToRun().equals(updatedCluster.getStatusCommandsToRun())) {
+              cluster.getStatusCommandsToRun().addAll(updatedCluster.getStatusCommandsToRun());
+              changed = true;
+            }
+          }
         } else {
-          clusters.put(clusterId, updatedCluster);
+          if (eventType.equals(UpdateEventType.UPDATE)) {
+            clusters.put(clusterId, updatedCluster);
+            changed = true;
+          } else {
+            throw new ClusterNotFoundException(Long.parseLong(clusterId));
+          }
         }
-        changed = true;
       }
     }
     return changed;

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
@@ -65,7 +65,7 @@ public class MetadataHolder extends AgentClusterDataHolder<MetadataUpdateEvent> 
     if (clusterId != null) {
       clusterToRemove.put(Long.toString(clusterId), MetadataCluster.emptyMetadataCluster());
     }
-    MetadataUpdateEvent deleteEvent = new MetadataUpdateEvent(clusterToRemove, null ,
+    MetadataUpdateEvent deleteEvent = new MetadataUpdateEvent(clusterToRemove, null , null,
         UpdateEventType.DELETE);
     return deleteEvent;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/AlertCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/AlertCluster.java
@@ -59,6 +59,11 @@ public class AlertCluster {
     this.staleIntervalMultiplier = null;
   }
 
+  private AlertCluster() {
+    alertDefinitions = null;
+    hostName = null;
+  }
+
   @JsonProperty("staleIntervalMultiplier")
   public Integer getStaleIntervalMultiplier() {
     return staleIntervalMultiplier;
@@ -66,7 +71,7 @@ public class AlertCluster {
 
   @JsonProperty("alertDefinitions")
   public Collection<AlertDefinition> getAlertDefinitions() {
-    return alertDefinitions.values();
+    return alertDefinitions == null ? Collections.emptyList() : alertDefinitions.values();
   }
 
   @JsonProperty("hostName")
@@ -109,5 +114,9 @@ public class AlertCluster {
     }
 
     return changed;
+  }
+
+  public static AlertCluster emptyAlertCluster() {
+    return new AlertCluster();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
@@ -51,7 +51,7 @@ public class MetadataCluster {
   }
 
   public static MetadataCluster emptyMetadataCluster() {
-    return new MetadataCluster(null, null, null);
+    return new MetadataCluster(null, null, null, null);
   }
 
   public Set<String> getStatusCommandsToRun() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
@@ -50,6 +50,10 @@ public class MetadataCluster {
     this.agentConfigs = agentConfigs;
   }
 
+  public static MetadataCluster emptyMetadataCluster() {
+    return new MetadataCluster(null, null, null);
+  }
+
   public Set<String> getStatusCommandsToRun() {
     return statusCommandsToRun;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/TopologyCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/TopologyCluster.java
@@ -21,7 +21,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.apache.ambari.server.events.TopologyUpdateEvent;
+import org.apache.ambari.server.events.UpdateEventType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.SetUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -44,14 +45,14 @@ public class TopologyCluster {
   }
 
   public boolean update(Set<TopologyComponent> componentsToUpdate, Set<TopologyHost> hostsToUpdate,
-                     TopologyUpdateEvent.EventType eventType) {
+                     UpdateEventType eventType) {
     boolean changed = false;
     for (TopologyComponent componentToUpdate : componentsToUpdate) {
       boolean isPresent = false;
       for (Iterator<TopologyComponent> iter = getTopologyComponents().iterator(); iter.hasNext() && !isPresent; ) {
         TopologyComponent existsComponent = iter.next();
         if (existsComponent.equals(componentToUpdate)) {
-          if (eventType.equals(TopologyUpdateEvent.EventType.DELETE)) {
+          if (eventType.equals(UpdateEventType.DELETE)) {
             if (SetUtils.isEqualSet(existsComponent.getHostIds(), componentToUpdate.getHostIds())) {
               iter.remove();
               changed = true;
@@ -64,7 +65,7 @@ public class TopologyCluster {
           isPresent = true;
         }
       }
-      if (!isPresent && eventType.equals(TopologyUpdateEvent.EventType.UPDATE)) {
+      if (!isPresent && eventType.equals(UpdateEventType.UPDATE)) {
         getTopologyComponents().add(componentToUpdate);
         changed = true;
       }
@@ -74,7 +75,7 @@ public class TopologyCluster {
       for (Iterator<TopologyHost> iter = getTopologyHosts().iterator(); iter.hasNext() && !isPresent; ) {
         TopologyHost existsHost = iter.next();
         if (existsHost.equals(hostToUpdate)) {
-          if (eventType.equals(TopologyUpdateEvent.EventType.DELETE)) {
+          if (eventType.equals(UpdateEventType.DELETE)) {
             iter.remove();
             changed = true;
           } else {
@@ -83,7 +84,7 @@ public class TopologyCluster {
           isPresent = true;
         }
       }
-      if (!isPresent && eventType.equals(TopologyUpdateEvent.EventType.UPDATE)) {
+      if (!isPresent && eventType.equals(UpdateEventType.UPDATE)) {
         getTopologyHosts().add(hostToUpdate);
         changed = true;
       }
@@ -108,13 +109,19 @@ public class TopologyCluster {
   }
 
   public TopologyCluster deepCopyCluster() {
-    Set<TopologyComponent> copiedComponents = new HashSet<>();
-    for (TopologyComponent topologyComponent : topologyComponents) {
-      copiedComponents.add(topologyComponent.deepCopy());
+    Set<TopologyComponent> copiedComponents = null;
+    if (CollectionUtils.isNotEmpty(topologyComponents)) {
+      copiedComponents = new HashSet<>();
+      for (TopologyComponent topologyComponent : topologyComponents) {
+        copiedComponents.add(topologyComponent.deepCopy());
+      }
     }
-    Set<TopologyHost> copiedHosts = new HashSet<>();
-    for (TopologyHost topologyHost : topologyHosts) {
-      copiedHosts.add(topologyHost.deepCopy());
+    Set<TopologyHost> copiedHosts = null;
+    if (CollectionUtils.isNotEmpty(topologyHosts)) {
+      copiedHosts = new HashSet<>();
+      for (TopologyHost topologyHost : topologyHosts) {
+        copiedHosts.add(topologyHost.deepCopy());
+      }
     }
     return new TopologyCluster(copiedComponents, copiedHosts);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -137,6 +137,7 @@ import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.customactions.ActionDefinition;
 import org.apache.ambari.server.events.MetadataUpdateEvent;
 import org.apache.ambari.server.events.TopologyUpdateEvent;
+import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.metadata.ActionMetadata;
 import org.apache.ambari.server.metadata.RoleCommandOrder;
@@ -800,7 +801,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         Set<TopologyComponent> newComponents = new HashSet<>();
         newComponents.add(newComponent);
         topologyUpdates.get(clusterId).update(newComponents, Collections.emptySet(),
-            TopologyUpdateEvent.EventType.UPDATE);
+            UpdateEventType.UPDATE);
       } else {
         topologyUpdates.get(clusterId).addTopologyComponent(newComponent);
       }
@@ -809,7 +810,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       Host host = clusters.getHost(hostName);
       m_hostLevelParamsHolder.get().updateData(m_hostLevelParamsHolder.get().getCurrentData(host.getHostId()));
     }
-    return new TopologyUpdateEvent(topologyUpdates, TopologyUpdateEvent.EventType.UPDATE);
+    return new TopologyUpdateEvent(topologyUpdates, UpdateEventType.UPDATE);
   }
 
   private void setMonitoringServicesRestartRequired(
@@ -5575,7 +5576,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   }
 
   /**
-   * Collects metadata info about clusters for agent.
+   * Collects full metadata info about clusters for agent.
    * @return metadata info about clusters
    * @throws AmbariException
    */
@@ -5595,7 +5596,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
 
     MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        getMetadataAmbariLevelParams(), getMetadataAgentConfigs());
+        getMetadataAmbariLevelParams(), getMetadataAgentConfigs(), UpdateEventType.CREATE);
     return metadataUpdateEvent;
   }
 
@@ -5612,7 +5613,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
 
     MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs());
+        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
     return metadataUpdateEvent;
   }
 
@@ -5628,7 +5629,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
 
     MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs());
+        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
     return metadataUpdateEvent;
   }
 
@@ -5642,22 +5643,12 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
 
     MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs());
+        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
     return metadataUpdateEvent;
   }
 
   public MetadataUpdateEvent getClusterMetadataOnServiceInstall(Cluster cl, String serviceName) throws AmbariException {
-    TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
-
-    MetadataCluster metadataCluster = new MetadataCluster(null,
-        getMetadataServiceLevelParams(cl.getService(serviceName)),
-        new TreeMap<>(),
-        null);
-    metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
-
-    MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs());
-    return metadataUpdateEvent;
+    return getClusterMetadataOnServiceCredentialStoreUpdate(cl, serviceName);
   }
 
   public MetadataUpdateEvent getClusterMetadataOnServiceCredentialStoreUpdate(Cluster cl, String serviceName) throws AmbariException {
@@ -5670,7 +5661,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
 
     MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs());
+        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
     return metadataUpdateEvent;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -230,7 +230,7 @@ import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpSucceede
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStartEvent;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStopEvent;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostUpgradeEvent;
-import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.apache.ambari.server.topology.Setting;
 import org.apache.ambari.server.utils.SecretReference;
 import org.apache.ambari.server.utils.StageUtils;
@@ -359,7 +359,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   protected OsFamily osFamily;
 
   @Inject
-  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
+  private STOMPComponentsDeleteHandler STOMPComponentsDeleteHandler;
 
   @Inject
   private Provider<TopologyHolder> m_topologyHolder;
@@ -3666,7 +3666,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     //Response for these requests will have empty body with appropriate error code.
     if (deleteMetaData.getDeletedKeys().size() + deleteMetaData.getExceptionForKeys().size() == 1) {
       if (deleteMetaData.getDeletedKeys().size() == 1) {
-        STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
+        STOMPComponentsDeleteHandler.processDeleteByMetaData(deleteMetaData);
         return null;
       }
       Exception ex = deleteMetaData.getExceptionForKeys().values().iterator().next();
@@ -3681,7 +3681,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     if (!safeToRemoveSCHs.isEmpty()) {
       setMonitoringServicesRestartRequired(requests);
     }
-    STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
+    STOMPComponentsDeleteHandler.processDeleteByMetaData(deleteMetaData);
     return deleteMetaData;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -230,8 +230,8 @@ import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpSucceede
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStartEvent;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStopEvent;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostUpgradeEvent;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
 import org.apache.ambari.server.topology.Setting;
-import org.apache.ambari.server.topology.TopologyDeleteFormer;
 import org.apache.ambari.server.utils.SecretReference;
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -359,7 +359,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   protected OsFamily osFamily;
 
   @Inject
-  private TopologyDeleteFormer topologyDeleteFormer;
+  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
 
   @Inject
   private Provider<TopologyHolder> m_topologyHolder;
@@ -3666,7 +3666,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     //Response for these requests will have empty body with appropriate error code.
     if (deleteMetaData.getDeletedKeys().size() + deleteMetaData.getExceptionForKeys().size() == 1) {
       if (deleteMetaData.getDeletedKeys().size() == 1) {
-        topologyDeleteFormer.processDeleteMetaData(deleteMetaData);
+        STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
         return null;
       }
       Exception ex = deleteMetaData.getExceptionForKeys().values().iterator().next();
@@ -3681,7 +3681,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     if (!safeToRemoveSCHs.isEmpty()) {
       setMonitoringServicesRestartRequired(requests);
     }
-    topologyDeleteFormer.processDeleteMetaData(deleteMetaData);
+    STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
     return deleteMetaData;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -61,7 +61,7 @@ import org.apache.ambari.server.state.ServiceComponentFactory;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
@@ -171,7 +171,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
   private MaintenanceStateHelper maintenanceStateHelper;
 
   @Inject
-  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
+  private STOMPComponentsDeleteHandler STOMPComponentsDeleteHandler;
 
   // ----- Constructors ----------------------------------------------------
 
@@ -797,13 +797,13 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
       if (sc != null) {
         deleteHostComponentsForServiceComponent(sc, request, deleteMetaData);
-        STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
+        STOMPComponentsDeleteHandler.processDeleteByMetaDataException(deleteMetaData);
         sc.setDesiredState(State.DISABLED);
         s.deleteServiceComponent(request.getComponentName(), deleteMetaData);
-        STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
+        STOMPComponentsDeleteHandler.processDeleteByMetaDataException(deleteMetaData);
       }
     }
-    STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
+    STOMPComponentsDeleteHandler.processDeleteByMetaData(deleteMetaData);
     return null;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -61,7 +61,7 @@ import org.apache.ambari.server.state.ServiceComponentFactory;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.TopologyDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
@@ -171,7 +171,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
   private MaintenanceStateHelper maintenanceStateHelper;
 
   @Inject
-  private TopologyDeleteFormer topologyDeleteFormer;
+  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
 
   // ----- Constructors ----------------------------------------------------
 
@@ -797,13 +797,13 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
       if (sc != null) {
         deleteHostComponentsForServiceComponent(sc, request, deleteMetaData);
-        topologyDeleteFormer.processDeleteMetaDataException(deleteMetaData);
+        STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
         sc.setDesiredState(State.DISABLED);
         s.deleteServiceComponent(request.getComponentName(), deleteMetaData);
-        topologyDeleteFormer.processDeleteMetaDataException(deleteMetaData);
+        STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
       }
     }
-    topologyDeleteFormer.processDeleteMetaData(deleteMetaData);
+    STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
     return null;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -62,6 +62,7 @@ import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.events.HostLevelParamsUpdateEvent;
 import org.apache.ambari.server.events.TopologyUpdateEvent;
+import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.security.authorization.AuthorizationHelper;
 import org.apache.ambari.server.security.authorization.ResourceType;
@@ -582,7 +583,7 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
       hostLevelParamsHolder.updateData(hostLevelParamsUpdateEvent);
     }
     TopologyUpdateEvent topologyUpdateEvent =
-        new TopologyUpdateEvent(addedTopologies, TopologyUpdateEvent.EventType.UPDATE);
+        new TopologyUpdateEvent(addedTopologies, UpdateEventType.UPDATE);
     topologyHolder.updateData(topologyUpdateEvent);
   }
 
@@ -934,7 +935,7 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
       }
       topologyUpdates.get(clusterId.toString()).addTopologyHost(topologyHost);
       TopologyUpdateEvent topologyUpdateEvent = new TopologyUpdateEvent(topologyUpdates,
-          TopologyUpdateEvent.EventType.UPDATE);
+          UpdateEventType.UPDATE);
       topologyHolder.updateData(topologyUpdateEvent);
       //todo: if attempt was made to update a property other than those
       //todo: that are allowed above, should throw exception
@@ -1067,7 +1068,7 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
     }
     clusters.publishHostsDeletion(allClustersWithHosts, hostNames);
     TopologyUpdateEvent topologyUpdateEvent = new TopologyUpdateEvent(topologyUpdates,
-        TopologyUpdateEvent.EventType.DELETE);
+        UpdateEventType.DELETE);
     topologyHolder.updateData(topologyUpdateEvent);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -75,7 +75,7 @@ import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.TopologyDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
@@ -186,7 +186,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   private KerberosHelper kerberosHelper;
 
   @Inject
-  private TopologyDeleteFormer topologyDeleteFormer;
+  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
 
   /**
    * Used to lookup the repository when creating services.
@@ -967,9 +967,9 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     DeleteHostComponentStatusMetaData deleteMetaData = new DeleteHostComponentStatusMetaData();
     for (Service service : removable) {
       service.getCluster().deleteService(service.getName(), deleteMetaData);
-      topologyDeleteFormer.processDeleteMetaDataException(deleteMetaData);
+      STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
     }
-    topologyDeleteFormer.processDeleteMetaData(deleteMetaData);
+    STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
 
     return null;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -75,7 +75,7 @@ import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
@@ -186,7 +186,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   private KerberosHelper kerberosHelper;
 
   @Inject
-  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
+  private STOMPComponentsDeleteHandler STOMPComponentsDeleteHandler;
 
   /**
    * Used to lookup the repository when creating services.
@@ -967,9 +967,9 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     DeleteHostComponentStatusMetaData deleteMetaData = new DeleteHostComponentStatusMetaData();
     for (Service service : removable) {
       service.getCluster().deleteService(service.getName(), deleteMetaData);
-      STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
+      STOMPComponentsDeleteHandler.processDeleteByMetaDataException(deleteMetaData);
     }
-    STOMPComponentsDeleteFormer.processDeleteByMetaData(deleteMetaData);
+    STOMPComponentsDeleteHandler.processDeleteByMetaData(deleteMetaData);
 
     return null;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/MetadataUpdateEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/MetadataUpdateEvent.java
@@ -43,6 +43,8 @@ public class MetadataUpdateEvent extends STOMPEvent implements Hashable {
    */
   private String hash;
 
+  private final UpdateEventType eventType;
+
   /**
    * Map of metadatas for each cluster by cluster ids.
    */
@@ -52,14 +54,19 @@ public class MetadataUpdateEvent extends STOMPEvent implements Hashable {
   private MetadataUpdateEvent() {
     super(Type.METADATA);
     metadataClusters = null;
+    eventType = null;
   }
 
-  public MetadataUpdateEvent(SortedMap<String, MetadataCluster> metadataClusters, SortedMap<String, String> ambariLevelParams, SortedMap<String, SortedMap<String, String>> metadataAgentConfigs) {
+  public MetadataUpdateEvent(SortedMap<String, MetadataCluster> metadataClusters,
+                             SortedMap<String, String> ambariLevelParams,
+                             SortedMap<String, SortedMap<String, String>> metadataAgentConfigs,
+                             UpdateEventType eventType) {
     super(Type.METADATA);
     this.metadataClusters = metadataClusters;
     if (ambariLevelParams != null) {
       this.metadataClusters.put(AMBARI_LEVEL_CLUSTER_ID, new MetadataCluster(null, new TreeMap<>(), ambariLevelParams, metadataAgentConfigs));
     }
+    this.eventType = eventType;
   }
 
   public Map<String, MetadataCluster> getMetadataClusters() {
@@ -74,6 +81,10 @@ public class MetadataUpdateEvent extends STOMPEvent implements Hashable {
   @Override
   public void setHash(String hash) {
     this.hash = hash;
+  }
+
+  public UpdateEventType getEventType() {
+    return eventType;
   }
 
   public static MetadataUpdateEvent emptyUpdate() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/TopologyAgentUpdateEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/TopologyAgentUpdateEvent.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class TopologyAgentUpdateEvent extends TopologyUpdateEvent {
-  public TopologyAgentUpdateEvent(SortedMap<String, TopologyCluster> clusters, String hash, EventType eventType) {
+  public TopologyAgentUpdateEvent(SortedMap<String, TopologyCluster> clusters, String hash, UpdateEventType eventType) {
     super(Type.AGENT_TOPOLOGY, clusters, hash, eventType);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/TopologyUpdateEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/TopologyUpdateEvent.java
@@ -50,13 +50,13 @@ public class TopologyUpdateEvent extends STOMPEvent implements Hashable {
    * Type of update, is used to differ full current topology (CREATE), adding new or update existing topology
    * elements (UPDATE) and removing existing topology elements (DELETE).
    */
-  private final EventType eventType;
+  private final UpdateEventType eventType;
 
-  public TopologyUpdateEvent(SortedMap<String, TopologyCluster> clusters, EventType eventType) {
+  public TopologyUpdateEvent(SortedMap<String, TopologyCluster> clusters, UpdateEventType eventType) {
     this(Type.UI_TOPOLOGY, clusters, null, eventType);
   }
 
-  public TopologyUpdateEvent(Type type, SortedMap<String, TopologyCluster> clusters, String hash, EventType eventType) {
+  public TopologyUpdateEvent(Type type, SortedMap<String, TopologyCluster> clusters, String hash, UpdateEventType eventType) {
     super(type);
     this.clusters = clusters;
     this.hash = hash;
@@ -77,7 +77,7 @@ public class TopologyUpdateEvent extends STOMPEvent implements Hashable {
     return copiedEvent;
   }
 
-  public EventType getEventType() {
+  public UpdateEventType getEventType() {
     return eventType;
   }
 
@@ -91,12 +91,6 @@ public class TopologyUpdateEvent extends STOMPEvent implements Hashable {
 
   public static TopologyUpdateEvent emptyUpdate() {
     return new TopologyUpdateEvent(null, null);
-  }
-
-  public enum EventType {
-    CREATE,
-    DELETE,
-    UPDATE
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/UpdateEventType.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/UpdateEventType.java
@@ -21,7 +21,6 @@ package org.apache.ambari.server.events;
 /**
  * Is used to inform the agent about update assignment.
  */
-//TODO refactor other update events to use this class instead own update types.
 public enum UpdateEventType {
   CREATE,
   UPDATE,

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -2025,10 +2025,17 @@ public class ConfigHelper {
    * @throws AmbariException
    */
   public AgentConfigsUpdateEvent getHostActualConfigs(Long hostId) throws AmbariException {
+    return getHostActualConfigsExcludeCluster(hostId, null);
+  }
+
+  public AgentConfigsUpdateEvent getHostActualConfigsExcludeCluster(Long hostId, Long clusterId) throws AmbariException {
     TreeMap<String, ClusterConfigs> clustersConfigs = new TreeMap<>();
 
     Host host = clusters.getHostById(hostId);
     for (Cluster cl : clusters.getClusters().values()) {
+      if (clusterId != null && cl.getClusterId() == clusterId) {
+        continue;
+      }
       Map<String, Map<String, String>> configurations = new HashMap<>();
       Map<String, Map<String, Map<String, String>>> configurationAttributes = new HashMap<>();
       if (LOG.isInfoEnabled()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -144,7 +144,7 @@ import org.apache.ambari.server.state.repository.ClusterVersionSummary;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.scheduler.RequestExecution;
 import org.apache.ambari.server.state.scheduler.RequestExecutionFactory;
-import org.apache.ambari.server.topology.TopologyDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
 import org.apache.ambari.server.topology.TopologyRequest;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -278,7 +278,7 @@ public class ClusterImpl implements Cluster {
   private TopologyRequestDAO topologyRequestDAO;
 
   @Inject
-  private TopologyDeleteFormer topologyDeleteFormer;
+  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
 
   /**
    * Data access object used for looking up stacks from the database.
@@ -1280,9 +1280,9 @@ public class ClusterImpl implements Cluster {
       DeleteHostComponentStatusMetaData deleteMetaData = new DeleteHostComponentStatusMetaData();
       for (Service service : services.values()) {
         deleteService(service, deleteMetaData);
-        topologyDeleteFormer.processDeleteMetaDataException(deleteMetaData);
+        STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
       }
-      topologyDeleteFormer.processDeleteCluster(getClusterId());
+      STOMPComponentsDeleteFormer.processDeleteCluster(getClusterId());
       services.clear();
     } finally {
       clusterGlobalLock.writeLock().unlock();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -144,7 +144,7 @@ import org.apache.ambari.server.state.repository.ClusterVersionSummary;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.scheduler.RequestExecution;
 import org.apache.ambari.server.state.scheduler.RequestExecutionFactory;
-import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.apache.ambari.server.topology.TopologyRequest;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -278,7 +278,7 @@ public class ClusterImpl implements Cluster {
   private TopologyRequestDAO topologyRequestDAO;
 
   @Inject
-  private STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer;
+  private STOMPComponentsDeleteHandler STOMPComponentsDeleteHandler;
 
   /**
    * Data access object used for looking up stacks from the database.
@@ -1280,9 +1280,9 @@ public class ClusterImpl implements Cluster {
       DeleteHostComponentStatusMetaData deleteMetaData = new DeleteHostComponentStatusMetaData();
       for (Service service : services.values()) {
         deleteService(service, deleteMetaData);
-        STOMPComponentsDeleteFormer.processDeleteByMetaDataException(deleteMetaData);
+        STOMPComponentsDeleteHandler.processDeleteByMetaDataException(deleteMetaData);
       }
-      STOMPComponentsDeleteFormer.processDeleteCluster(getClusterId());
+      STOMPComponentsDeleteHandler.processDeleteCluster(getClusterId());
       services.clear();
     } finally {
       clusterGlobalLock.writeLock().unlock();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1282,7 +1282,7 @@ public class ClusterImpl implements Cluster {
         deleteService(service, deleteMetaData);
         topologyDeleteFormer.processDeleteMetaDataException(deleteMetaData);
       }
-      topologyDeleteFormer.processDeleteCluster(Long.toString(getClusterId()));
+      topologyDeleteFormer.processDeleteCluster(getClusterId());
       services.clear();
     } finally {
       clusterGlobalLock.writeLock().unlock();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.events.HostRegisteredEvent;
 import org.apache.ambari.server.events.HostsAddedEvent;
 import org.apache.ambari.server.events.HostsRemovedEvent;
 import org.apache.ambari.server.events.TopologyUpdateEvent;
+import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.ClusterDAO;
 import org.apache.ambari.server.orm.dao.HostConfigMappingDAO;
@@ -380,7 +381,7 @@ public class ClustersImpl implements Clusters {
     TopologyCluster addedCluster = new TopologyCluster();
     addedClusters.put(Long.toString(cluster.getClusterId()), addedCluster);
     TopologyUpdateEvent topologyUpdateEvent = new TopologyUpdateEvent(addedClusters,
-        TopologyUpdateEvent.EventType.UPDATE);
+        UpdateEventType.UPDATE);
     m_topologyHolder.get().updateData(topologyUpdateEvent);
     m_metadataHolder.get().updateData(m_ambariManagementController.get().getClusterMetadata(cluster));
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.events.ServiceComponentInstalledEvent;
 import org.apache.ambari.server.events.ServiceComponentUninstalledEvent;
 import org.apache.ambari.server.events.StaleConfigsUpdateEvent;
 import org.apache.ambari.server.events.TopologyUpdateEvent;
+import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.events.publishers.STOMPUpdatePublisher;
 import org.apache.ambari.server.orm.dao.HostComponentDesiredStateDAO;
@@ -976,7 +977,7 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
           .setHostNames(new HashSet<>(Collections.singletonList(hostName)))
           .build());
       TopologyUpdateEvent hostComponentVersionUpdate = new TopologyUpdateEvent(topologyUpdates,
-          TopologyUpdateEvent.EventType.UPDATE);
+          UpdateEventType.UPDATE);
       m_topologyHolder.get().updateData(hostComponentVersionUpdate);
     } else {
       LOG.warn("Setting a member on an entity object that may have been "

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/STOMPComponentsDeleteFormer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/STOMPComponentsDeleteFormer.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
+import org.apache.ambari.server.agent.stomp.AlertDefinitionsHolder;
 import org.apache.ambari.server.agent.stomp.HostLevelParamsHolder;
 import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.agent.stomp.TopologyHolder;
@@ -53,6 +54,9 @@ public class STOMPComponentsDeleteFormer {
 
   @Inject
   private Provider<HostLevelParamsHolder> hostLevelParamsHolder;
+
+  @Inject
+  private Provider<AlertDefinitionsHolder> alertDefinitionsHolder;
 
   @Inject
   private Clusters clusters;
@@ -94,6 +98,9 @@ public class STOMPComponentsDeleteFormer {
     for (Long hostId : changedHosts) {
       agentConfigsHolder.get().updateData(agentConfigsHolder.get().getCurrentDataExcludeCluster(hostId, clusterId));
       hostLevelParamsHolder.get().updateData(hostLevelParamsHolder.get().getCurrentDataExcludeCluster(hostId, clusterId));
+      if (clusterId != null) {
+        alertDefinitionsHolder.get().updateData(alertDefinitionsHolder.get().getDeleteCluster(clusterId, hostId));
+      }
     }
     metadataHolder.get().updateData(metadataHolder.get().getDeleteMetadata(clusterId));
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/STOMPComponentsDeleteHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/STOMPComponentsDeleteHandler.java
@@ -41,7 +41,7 @@ import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
 @Singleton
-public class STOMPComponentsDeleteFormer {
+public class STOMPComponentsDeleteHandler {
 
   @Inject
   private Provider<TopologyHolder> m_topologyHolder;

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/STOMPComponentsDeleteHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/STOMPComponentsDeleteHandler.java
@@ -96,13 +96,20 @@ public class STOMPComponentsDeleteHandler {
   private void updateNonTopologyAgentInfo(Set<Long> changedHosts, Long clusterId) throws AmbariException {
 
     for (Long hostId : changedHosts) {
-      agentConfigsHolder.get().updateData(agentConfigsHolder.get().getCurrentDataExcludeCluster(hostId, clusterId));
-      hostLevelParamsHolder.get().updateData(hostLevelParamsHolder.get().getCurrentDataExcludeCluster(hostId, clusterId));
       if (clusterId != null) {
         alertDefinitionsHolder.get().updateData(alertDefinitionsHolder.get().getDeleteCluster(clusterId, hostId));
+        agentConfigsHolder.get().updateData(agentConfigsHolder.get().getCurrentDataExcludeCluster(hostId, clusterId));
+        hostLevelParamsHolder.get().updateData(hostLevelParamsHolder.get().getCurrentDataExcludeCluster(hostId, clusterId));
+      } else {
+        agentConfigsHolder.get().updateData(agentConfigsHolder.get().getCurrentData(hostId));
+        hostLevelParamsHolder.get().updateData(hostLevelParamsHolder.get().getCurrentData(hostId));
       }
     }
-    metadataHolder.get().updateData(metadataHolder.get().getDeleteMetadata(clusterId));
+    if (clusterId != null) {
+      metadataHolder.get().updateData(metadataHolder.get().getDeleteMetadata(clusterId));
+    } else {
+      metadataHolder.get().updateData(metadataHolder.get().getCurrentData());
+    }
   }
 
   public TreeMap<String, TopologyCluster> createUpdateFromDeleteByMetaData(DeleteHostComponentStatusMetaData metaData) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.ObjectNotFoundException;
 import org.apache.ambari.server.ServiceComponentNotFoundException;
+import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.agent.stomp.TopologyHolder;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.AmbariManagementController;
@@ -79,7 +80,7 @@ import org.apache.ambari.server.state.ServiceComponentFactory;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.TopologyDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -587,21 +588,30 @@ public class ComponentResourceProviderTest {
     ComponentResourceProvider provider = new ComponentResourceProvider(managementController,
         maintenanceStateHelper);
 
-    Field topologyDeleteFormerField = ComponentResourceProvider.class.getDeclaredField("topologyDeleteFormer");
-    topologyDeleteFormerField.setAccessible(true);
-    TopologyDeleteFormer topologyDeleteFormer = new TopologyDeleteFormer();
-    topologyDeleteFormerField.set(provider, topologyDeleteFormer);
+    Field STOMPComponentsDeleteFormerField = ComponentResourceProvider.class.getDeclaredField("STOMPComponentsDeleteFormer");
+    STOMPComponentsDeleteFormerField.setAccessible(true);
+    STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer = new STOMPComponentsDeleteFormer();
+    STOMPComponentsDeleteFormerField.set(provider, STOMPComponentsDeleteFormer);
 
-    Field topologyHolderProviderField = TopologyDeleteFormer.class.getDeclaredField("m_topologyHolder");
+    Field topologyHolderProviderField = STOMPComponentsDeleteFormer.class.getDeclaredField("m_topologyHolder");
     topologyHolderProviderField.setAccessible(true);
     Provider<TopologyHolder> m_topologyHolder = createMock(Provider.class);
-    topologyHolderProviderField.set(topologyDeleteFormer, m_topologyHolder);
+    topologyHolderProviderField.set(STOMPComponentsDeleteFormer, m_topologyHolder);
 
     TopologyHolder topologyHolder = createNiceMock(TopologyHolder.class);
 
     expect(m_topologyHolder.get()).andReturn(topologyHolder).anyTimes();
 
-    replay(m_topologyHolder, topologyHolder);
+    Field metadataHolderProviderField = STOMPComponentsDeleteFormer.class.getDeclaredField("metadataHolder");
+    metadataHolderProviderField.setAccessible(true);
+    Provider<MetadataHolder> m_metadataHolder = createMock(Provider.class);
+    metadataHolderProviderField.set(STOMPComponentsDeleteFormer, m_metadataHolder);
+
+    MetadataHolder metadataHolder = createNiceMock(MetadataHolder.class);
+
+    expect(m_metadataHolder.get()).andReturn(metadataHolder).anyTimes();
+
+    replay(m_metadataHolder, metadataHolder, m_topologyHolder, topologyHolder);
     return provider;
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -80,7 +80,7 @@ import org.apache.ambari.server.state.ServiceComponentFactory;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -588,24 +588,24 @@ public class ComponentResourceProviderTest {
     ComponentResourceProvider provider = new ComponentResourceProvider(managementController,
         maintenanceStateHelper);
 
-    Field STOMPComponentsDeleteFormerField = ComponentResourceProvider.class.getDeclaredField("STOMPComponentsDeleteFormer");
-    STOMPComponentsDeleteFormerField.setAccessible(true);
-    STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer = new STOMPComponentsDeleteFormer();
-    STOMPComponentsDeleteFormerField.set(provider, STOMPComponentsDeleteFormer);
+    Field STOMPComponentsDeleteHandlerField = ComponentResourceProvider.class.getDeclaredField("STOMPComponentsDeleteHandler");
+    STOMPComponentsDeleteHandlerField.setAccessible(true);
+    STOMPComponentsDeleteHandler STOMPComponentsDeleteHandler = new STOMPComponentsDeleteHandler();
+    STOMPComponentsDeleteHandlerField.set(provider, STOMPComponentsDeleteHandler);
 
-    Field topologyHolderProviderField = STOMPComponentsDeleteFormer.class.getDeclaredField("m_topologyHolder");
+    Field topologyHolderProviderField = STOMPComponentsDeleteHandler.class.getDeclaredField("m_topologyHolder");
     topologyHolderProviderField.setAccessible(true);
     Provider<TopologyHolder> m_topologyHolder = createMock(Provider.class);
-    topologyHolderProviderField.set(STOMPComponentsDeleteFormer, m_topologyHolder);
+    topologyHolderProviderField.set(STOMPComponentsDeleteHandler, m_topologyHolder);
 
     TopologyHolder topologyHolder = createNiceMock(TopologyHolder.class);
 
     expect(m_topologyHolder.get()).andReturn(topologyHolder).anyTimes();
 
-    Field metadataHolderProviderField = STOMPComponentsDeleteFormer.class.getDeclaredField("metadataHolder");
+    Field metadataHolderProviderField = STOMPComponentsDeleteHandler.class.getDeclaredField("metadataHolder");
     metadataHolderProviderField.setAccessible(true);
     Provider<MetadataHolder> m_metadataHolder = createMock(Provider.class);
-    metadataHolderProviderField.set(STOMPComponentsDeleteFormer, m_metadataHolder);
+    metadataHolderProviderField.set(STOMPComponentsDeleteHandler, m_metadataHolder);
 
     MetadataHolder metadataHolder = createNiceMock(MetadataHolder.class);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
@@ -77,7 +77,7 @@ import org.apache.ambari.server.state.ServiceFactory;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.TopologyDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -1421,11 +1421,11 @@ public class ServiceResourceProviderTest {
     ServiceResourceProvider serviceResourceProvider =
         new ServiceResourceProvider(managementController, maintenanceStateHelper, repositoryVersionDAO);
 
-    Field topologyDeleteFormerField = ServiceResourceProvider.class.getDeclaredField("topologyDeleteFormer");
-    topologyDeleteFormerField.setAccessible(true);
-    TopologyDeleteFormer topologyDeleteFormer = createNiceMock(TopologyDeleteFormer.class);
-    topologyDeleteFormerField.set(serviceResourceProvider, topologyDeleteFormer);
-    replay(topologyDeleteFormer);
+    Field STOMPComponentsDeleteFormerField = ServiceResourceProvider.class.getDeclaredField("STOMPComponentsDeleteFormer");
+    STOMPComponentsDeleteFormerField.setAccessible(true);
+    STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer = createNiceMock(STOMPComponentsDeleteFormer.class);
+    STOMPComponentsDeleteFormerField.set(serviceResourceProvider, STOMPComponentsDeleteFormer);
+    replay(STOMPComponentsDeleteFormer);
     return serviceResourceProvider;
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
@@ -77,7 +77,7 @@ import org.apache.ambari.server.state.ServiceFactory;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
-import org.apache.ambari.server.topology.STOMPComponentsDeleteFormer;
+import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -1421,11 +1421,11 @@ public class ServiceResourceProviderTest {
     ServiceResourceProvider serviceResourceProvider =
         new ServiceResourceProvider(managementController, maintenanceStateHelper, repositoryVersionDAO);
 
-    Field STOMPComponentsDeleteFormerField = ServiceResourceProvider.class.getDeclaredField("STOMPComponentsDeleteFormer");
-    STOMPComponentsDeleteFormerField.setAccessible(true);
-    STOMPComponentsDeleteFormer STOMPComponentsDeleteFormer = createNiceMock(STOMPComponentsDeleteFormer.class);
-    STOMPComponentsDeleteFormerField.set(serviceResourceProvider, STOMPComponentsDeleteFormer);
-    replay(STOMPComponentsDeleteFormer);
+    Field STOMPComponentsDeleteHandlerField = ServiceResourceProvider.class.getDeclaredField("STOMPComponentsDeleteHandler");
+    STOMPComponentsDeleteHandlerField.setAccessible(true);
+    STOMPComponentsDeleteHandler STOMPComponentsDeleteHandler = createNiceMock(STOMPComponentsDeleteHandler.class);
+    STOMPComponentsDeleteHandlerField.set(serviceResourceProvider, STOMPComponentsDeleteHandler);
+    replay(STOMPComponentsDeleteHandler);
     return serviceResourceProvider;
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/EventsTest.java
@@ -126,6 +126,7 @@ public class EventsTest {
     m_repositoryVersion = m_helper.getOrCreateRepositoryVersion(stackId, REPO_VERSION);
 
     m_clusters.mapHostToCluster(HOSTNAME, m_clusterName);
+    m_clusters.updateHostMappings(host);
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
@@ -413,16 +413,20 @@ public class ClustersTest {
     clusters.addHost(h1);
     clusters.addHost(h2);
 
-    Host host1 = clusters.getHost(h1);
 
-    setOsFamily(clusters.getHost(h1), "centos", "5.9");
-    setOsFamily(clusters.getHost(h2), "centos", "5.9");
+    Host host1 = clusters.getHost(h1);
+    Host host2 = clusters.getHost(h2);
+
+    setOsFamily(host1, "centos", "5.9");
+    setOsFamily(host2, "centos", "5.9");
 
     clusters.mapAndPublishHostsToCluster(new HashSet<String>() {
       {
         addAll(Arrays.asList(h1, h2));
       }
     }, c1);
+    clusters.updateHostMappings(host1);
+    clusters.updateHostMappings(host2);
 
     // host config override
     host1.addDesiredConfig(cluster.getClusterId(), true, "_test", config2);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server notify agents about updates in agent cached info (topology, host configs, metadata, host-level params, alert definitions) after cluster removal.

## How was this patch tested?

Manual testing.