### PR TITLE
[AMBARI-23851] No relationship between generic parameter and method argument

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
@@ -103,7 +103,7 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
   /**
    * Remove data for the given host.
    */
-  public final void onHostRemoved(String hostId) {
+  public final void onHostRemoved(Long hostId) {
     data.remove(hostId);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AlertDefinitionsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AlertDefinitionsHolder.java
@@ -153,8 +153,8 @@ public class AlertDefinitionsHolder extends AgentHostDataHolder<AlertDefinitions
 
   @Subscribe
   public void onHostsRemoved(HostsRemovedEvent event) {
-    for (String hostName : event.getHostNames()) {
-      onHostRemoved(hostName);
+    for (Long hostId : event.getHostIds()) {
+      onHostRemoved(hostId);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -998,6 +998,7 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
   private void processDeleteHostRequests(List<HostRequest> requests,  Clusters clusters, DeleteStatusMetaData deleteStatusMetaData) throws AmbariException {
     Set<String> hostsClusters = new HashSet<>();
     Set<String> hostNames = new HashSet<>();
+    Set<Long> hostIds = new HashSet<>();
     Set<Cluster> allClustersWithHosts = new HashSet<>();
     TreeMap<String, TopologyCluster> topologyUpdates = new TreeMap<>();
     for (HostRequest hostRequest : requests) {
@@ -1005,6 +1006,7 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
       String hostname = hostRequest.getHostname();
       Long hostId = clusters.getHost(hostname).getHostId();
       hostNames.add(hostname);
+      hostIds.add(hostId);
 
       if (hostRequest.getClusterName() != null) {
         hostsClusters.add(hostRequest.getClusterName());
@@ -1065,7 +1067,7 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
         logicalRequest.removeHostRequestByHostName(hostname);
       }
     }
-    clusters.publishHostsDeletion(allClustersWithHosts, hostNames);
+    clusters.publishHostsDeletion(hostIds, hostNames);
     TopologyUpdateEvent topologyUpdateEvent = new TopologyUpdateEvent(topologyUpdates,
         TopologyUpdateEvent.EventType.DELETE);
     topologyHolder.updateData(topologyUpdateEvent);

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/HostsRemovedEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/HostsRemovedEvent.java
@@ -20,69 +20,37 @@ package org.apache.ambari.server.events;
 import java.util.Collections;
 import java.util.Set;
 
-import org.apache.ambari.server.state.Cluster;
-
 /**
  * The {@link HostsRemovedEvent} class is fired when the hosts are removed from the
  * cluster.
  */
 public class HostsRemovedEvent extends AmbariEvent {
 
-  /**
-   * The clusters that the removed hosts belonged to.
-   */
-  private final Set<Cluster> m_clusters;
+  private final Set<Long> hostIds;
+  private final Set<String> hosts;
 
-  /**
-   * Removed hosts.
-   */
-  private final Set<String> m_hosts;
-
-  /**
-   * Constructor.
-   * @param hosts
-   * @param clusters
-   */
-  public HostsRemovedEvent(Set<String> hosts, Set<Cluster> clusters) {
+  public HostsRemovedEvent(Set<String> hosts, Set<Long> hostIds) {
     super(AmbariEventType.HOST_REMOVED);
-    m_clusters = clusters;
-    m_hosts = hosts;
+    this.hostIds = hostIds != null ? hostIds : Collections.emptySet();
+    this.hosts = hosts != null ? hosts : Collections.emptySet();
   }
 
   /**
-   * The clusters that the hosts belonged to.
-   *
-   * @return the clusters, or an empty set.
-   */
-  public Set<Cluster> getClusters() {
-    if (null == m_clusters) {
-      return Collections.emptySet();
-    }
-
-    return m_clusters;
-  }
-
-  /**
-   * Removed hosts.
-   * @return
+   * @return names of removed hosts
    */
   public Set<String> getHostNames() {
-    if (null == m_hosts) {
-      return Collections.emptySet();
-    }
-
-    return m_hosts;
+    return hosts;
   }
 
   /**
-   * {@inheritDoc}
+   * @return ids of removed hosts
    */
+  public Set<Long> getHostIds() {
+    return hostIds;
+  }
+
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder("HostsRemovedEvent{");
-    sb.append("m_clusters=").append(m_clusters);
-    sb.append(", m_hosts=").append(m_hosts);
-    sb.append('}');
-    return sb.toString();
+    return "HostsRemovedEvent{" + hosts + "}";
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostConfigMappingDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostConfigMappingDAO.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
@@ -59,7 +57,6 @@ public class HostConfigMappingDAO {
   @Inject
   private HostDAO hostDAO;
 
-  private final ReadWriteLock gl = new ReentrantReadWriteLock();
   private ConcurrentHashMap<Long, Set<HostConfigMapping>> hostConfigMappingByHost;
   
   private volatile boolean cacheLoaded;
@@ -282,9 +279,6 @@ public class HostConfigMappingDAO {
     return daoUtils.selectAll(entityManagerProvider.get(), HostConfigMappingEntity.class);
   }
 
-  /**
-   * @param hostId
-   */
   @Transactional
   public void removeByHostId(Long hostId) {
     populateCache();
@@ -308,17 +302,13 @@ public class HostConfigMappingDAO {
     }
   }
 
-  /**
-   * @param clusterId
-   * @param hostName
-   */
   @Transactional
   public void removeByClusterAndHostName(final long clusterId, String hostName) {
     populateCache();
 
     HostEntity hostEntity = hostDAO.findByName(hostName);
     if (hostEntity != null) {
-      if (hostConfigMappingByHost.containsKey(hostName)) {
+      if (hostConfigMappingByHost.containsKey(hostEntity.getHostId())) {
         // Delete from db
         TypedQuery<HostConfigMappingEntity> query = entityManagerProvider.get().createQuery(
             "SELECT entity FROM HostConfigMappingEntity entity " +

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
@@ -233,11 +233,8 @@ public interface Clusters {
 
   /**
    * Publish event set of hosts were removed
-   * @param clusters
-   * @param hostNames
-   * @throws AmbariException
    */
-  void publishHostsDeletion(Set<Cluster> clusters, Set<String> hostNames)
+  void publishHostsDeletion(Set<Long> hostIds, Set<String> hostNames)
       throws AmbariException;
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -830,10 +830,10 @@ public class ClustersImpl implements Clusters {
   }
 
   @Override
-  public void publishHostsDeletion(Set<Cluster> clusters, Set<String> hostNames) throws AmbariException {
+  public void publishHostsDeletion(Set<Long> hostIds, Set<String> hostNames) throws AmbariException {
     // Publish the event, using the original list of clusters that the host
     // belonged to
-    HostsRemovedEvent event = new HostsRemovedEvent(hostNames, clusters);
+    HostsRemovedEvent event = new HostsRemovedEvent(hostNames, hostIds);
     eventPublisher.publish(event);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
@@ -1084,8 +1084,9 @@ public class HostResourceProviderTest extends EasyMockSupport {
     expect(cluster.getClusterId()).andReturn(100L).anyTimes();
     expect(cluster.getDesiredConfigs()).andReturn(new HashMap<>()).anyTimes();
     clusters.deleteHost("Host100");
-    clusters.publishHostsDeletion(Collections.EMPTY_SET, Collections.singleton("Host100"));
+    clusters.publishHostsDeletion(Collections.singleton(1L), Collections.singleton("Host100"));
     expect(host1.getHostName()).andReturn("Host100").anyTimes();
+    expect(host1.getHostId()).andReturn(1L).anyTimes();
     expect(healthStatus.getHealthStatus()).andReturn(HostHealthStatus.HealthStatus.HEALTHY).anyTimes();
     expect(healthStatus.getHealthReport()).andReturn("HEALTHY").anyTimes();
     expect(topologyManager.getRequests(Collections.emptyList())).andReturn(Collections.emptyList()).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListenerTest.java
@@ -398,7 +398,9 @@ public class HostVersionOutOfSyncListenerTest {
     // add the 2nd host
     addHost("h2");
     clusters.mapHostToCluster("h2", "c1");
-    clusters.getHost("h2").setState(HostState.HEALTHY);
+    Host host = clusters.getHost("h2");
+    Long hostId = host.getHostId();
+    host.setState(HostState.HEALTHY);
 
     StackId stackId = new StackId(this.stackId);
     RepositoryVersionEntity repositoryVersionEntity = helper.getOrCreateRepositoryVersion(stackId,
@@ -432,7 +434,7 @@ public class HostVersionOutOfSyncListenerTest {
     // event handle it
     injector.getInstance(UnitOfWork.class).begin();
     clusters.deleteHost("h2");
-    clusters.publishHostsDeletion(Collections.singleton(c1), Collections.singleton("h2"));
+    clusters.publishHostsDeletion(Collections.singleton(hostId), Collections.singleton("h2"));
     injector.getInstance(UnitOfWork.class).end();
     assertRepoVersionState("2.2.0", RepositoryVersionState.CURRENT);
     assertRepoVersionState("2.2.9-9999", RepositoryVersionState.INSTALLED);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix wrong type of argument used for collection lookup/removal as pointed out by FindBugs.  These calls cannot succeed, causing eg. memory leak (in case of removal).

https://issues.apache.org/jira/browse/AMBARI-23851

## How was this patch tested?

Ran relevant unit tests.