### PR TITLE
AMBARI-23855. Topology cache on agent side is not actual after unsupported services removal during stack upgrade.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertDefinitionsUIUpdateListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertDefinitionsUIUpdateListener.java
@@ -114,10 +114,11 @@ public class AlertDefinitionsUIUpdateListener {
         LOG.warn(msg, e);
       }
     }
-
-    alertDefinitionsHolder.provideAlertDefinitionAgentUpdateEvent(UPDATE, event.getClusterId(), definitions, hostName);
-    Map<Long, AlertCluster> map = Collections.singletonMap(event.getClusterId(), new AlertCluster(definitions, hostName));
-    STOMPUpdatePublisher.publish(new AlertDefinitionsUIUpdateEvent(UPDATE, map));
+    if (!definitions.isEmpty()) {
+      alertDefinitionsHolder.provideAlertDefinitionAgentUpdateEvent(UPDATE, event.getClusterId(), definitions, hostName);
+      Map<Long, AlertCluster> map = Collections.singletonMap(event.getClusterId(), new AlertCluster(definitions, hostName));
+      STOMPUpdatePublisher.publish(new AlertDefinitionsUIUpdateEvent(UPDATE, map));
+    }
   }
 
   @Subscribe
@@ -127,9 +128,11 @@ public class AlertDefinitionsUIUpdateListener {
     if (event.isMasterComponent()) {
       definitions.putAll(helper.get().findByServiceMaster(event.getClusterId(), event.getServiceName()));
     }
-    alertDefinitionsHolder.provideAlertDefinitionAgentUpdateEvent(DELETE, event.getClusterId(), definitions, hostName);
-    Map<Long, AlertCluster> map = Collections.singletonMap(event.getClusterId(), new AlertCluster(definitions, hostName));
-    STOMPUpdatePublisher.publish(new AlertDefinitionsUIUpdateEvent(DELETE, map));
+    if (!definitions.isEmpty()) {
+      alertDefinitionsHolder.provideAlertDefinitionAgentUpdateEvent(DELETE, event.getClusterId(), definitions, hostName);
+      Map<Long, AlertCluster> map = Collections.singletonMap(event.getClusterId(), new AlertCluster(definitions, hostName));
+      STOMPUpdatePublisher.publish(new AlertDefinitionsUIUpdateEvent(DELETE, map));
+    }
   }
 
   private void handleSingleDefinitionChange(AlertDefinitionEventType eventType, AlertDefinition alertDefinition) throws AmbariException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server sends topology delete event to agent after unsupported service removal during stack upgrade.

## How was this patch tested?

Manual testing.