### PR TITLE
[AMBARI-22642] LDAPS sync Connection Refused

### DIFF
--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -16,6 +16,8 @@
 
 AMBARI_PASSHPHRASE="DEV"
 export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false"
+# ldap connection pooling
+export AMBARI_JVM_ARGS=$AMBARI_JVM_ARGS" -Dcom.sun.jndi.ldap.connect.pool.protocol='plain ssl' -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 export PATH=$PATH:$ROOT/var/lib/ambari-server
 export PYTHONPATH=$ROOT/usr/lib/ambari-server/lib:$PYTHONPATH
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add `com.sun.jndi.ldap.connect.pool.*` settings to `AMBARI_JVM_ARGS` to enable connection pooling for LDAPS  (secure LDAP, LDAP over SSL) connections. 
We saw errors when attempting to sync a large number of groups (50+) against LDAPS, enabling connection pooling resolved this. 

## How was this patch tested?
The same settings are in place across all our environments. 

Open to feedback on how to test further....
