### PR TITLE
[AMBARI-23856] YARN TimelineReader and Registry DNS Are Not Able to be Added via the UI

### DIFF
--- a/ambari-web/app/models/stack_service_component.js
+++ b/ambari-web/app/models/stack_service_component.js
@@ -85,7 +85,7 @@ App.StackServiceComponent = DS.Model.extend({
     opt.scope = opt.scope || '*';
     var dependencies = this.get('dependencies');
     dependencies = opt.scope === '*' ? dependencies : dependencies.filterProperty('scope', opt.scope);
-    if (dependencies.length == 0) return [];
+    if (dependencies.length === 0) return [];
     installedComponents = installedComponents.map(function(each) { return App.StackServiceComponent.find(each); });
     return dependencies.filter(function (dependency) {
       return !installedComponents.some(function(each) {
@@ -133,13 +133,13 @@ App.StackServiceComponent = DS.Model.extend({
   isAddableToHost: function() {
     return this.get('isMasterAddableInstallerWizard')
       || ((this.get('isNotAddableOnlyInInstall') || this.get('isSlave') || this.get('isClient'))
-        && (!this.get('isHAComponentOnly') || (App.get('isHaEnabled') && this.get('componentName') == 'JOURNALNODE')));
+        && (!this.get('isHAComponentOnly') || (App.get('isHaEnabled') && this.get('componentName') === 'JOURNALNODE')));
   }.property('componentName'),
 
   /** @property {Boolean} isDeletable - component supports delete action **/
   isDeletable: function() {
     var ignored = [];
-    return (this.get('isAddableToHost') && !ignored.contains(this.get('componentName'))) || (this.get('componentName') == 'MYSQL_SERVER');
+    return (this.get('isAddableToHost') && !ignored.contains(this.get('componentName'))) || (this.get('componentName') === 'MYSQL_SERVER');
   }.property('componentName'),
 
   /** @property {Boolean} isShownOnInstallerAssignMasterPage - component visible on "Assign Masters" step of Install Wizard **/
@@ -198,7 +198,7 @@ App.StackServiceComponent = DS.Model.extend({
   /** @property {Number} defaultNoOfMasterHosts - default number of master hosts on Assign Master page: **/
   defaultNoOfMasterHosts: function() {
      if (this.get('isMasterAddableInstallerWizard')) {
-       return this.get('componentName') == 'ZOOKEEPER_SERVER' ? 3 : this.get('minToInstall');
+       return this.get('componentName') === 'ZOOKEEPER_SERVER' ? 3 : this.get('minToInstall');
      }
   }.property('componentName'),
 
@@ -224,7 +224,8 @@ App.StackServiceComponent = DS.Model.extend({
   }.property('componentName'),
 
   /** @property {Boolean} isNotAddableOnlyInInstall - is this component addable, except Install and Add Service Wizards  **/
-  isNotAddableOnlyInInstall: Em.computed.existsIn('componentName', ['HIVE_METASTORE', 'HIVE_SERVER', 'RANGER_KMS_SERVER', 'OOZIE_SERVER']),
+  isNotAddableOnlyInInstall: Em.computed.existsIn('componentName', ['HIVE_METASTORE', 'HIVE_SERVER', 'RANGER_KMS_SERVER',
+    'OOZIE_SERVER', 'TIMELINE_READER', 'YARN_REGISTRY_DNS']),
 
   /** @property {Boolean} isNotAllowedOnSingleNodeCluster - is this component allowed on single node  **/
   isNotAllowedOnSingleNodeCluster: Em.computed.existsIn('componentName', ['HAWQSTANDBY'])

--- a/ambari-web/app/views/main/host/summary.js
+++ b/ambari-web/app/views/main/host/summary.js
@@ -255,7 +255,7 @@ App.MainHostSummaryView = Em.View.extend(App.TimeRangeMixin, {
    * @returns {boolean}
    */
   hasCardinalityConflict: function(componentName) {
-    var totalCount = App.SlaveComponent.find(componentName).get('totalCount');
+    var totalCount = App.HostComponent.getCount(componentName, 'totalCount');
     var maxToInstall = App.StackServiceComponent.find(componentName).get('maxToInstall');
     return !(totalCount < maxToInstall);
   },

--- a/ambari-web/test/views/main/host/summary_test.js
+++ b/ambari-web/test/views/main/host/summary_test.js
@@ -308,19 +308,17 @@ describe('App.MainHostSummaryView', function() {
   describe("#hasCardinalityConflict()", function () {
 
     beforeEach(function() {
-      this.mockSlave = sinon.stub(App.SlaveComponent, 'find');
+      this.mockComponent = sinon.stub(App.HostComponent, 'getCount');
       this.mockStack = sinon.stub(App.StackServiceComponent, 'find');
     });
 
     afterEach(function() {
-      this.mockSlave.restore();
+      this.mockComponent.restore();
       this.mockStack.restore();
     });
 
     it("totalCount equal to maxToInstall", function() {
-      this.mockSlave.returns(Em.Object.create({
-        totalCount: 1
-      }));
+      this.mockComponent.returns(1);
       this.mockStack.returns(Em.Object.create({
         maxToInstall: 1
       }));
@@ -328,9 +326,7 @@ describe('App.MainHostSummaryView', function() {
     });
 
     it("totalCount more than maxToInstall", function() {
-      this.mockSlave.returns(Em.Object.create({
-        totalCount: 2
-      }));
+      this.mockComponent.returns(2);
       this.mockStack.returns(Em.Object.create({
         maxToInstall: 1
       }));
@@ -338,9 +334,7 @@ describe('App.MainHostSummaryView', function() {
     });
 
     it("totalCount less than maxToInstall", function() {
-      this.mockSlave.returns(Em.Object.create({
-        totalCount: 0
-      }));
+      this.mockComponent.returns(0);
       this.mockStack.returns(Em.Object.create({
         maxToInstall: 1
       }));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Yarn Registry DNS and Timeline Reader component are made addable from host summary page.
No configs are required to be changed as part of adding these components.

## How was this patch tested?
Made related changes to unit tests and verified them to be working
Verified manually that these yarn components can be added to a cluster from host summary page.