### PR TITLE
[AMBARI-23857] Idempotent mpack registration UI change

### DIFF
--- a/ambari-web/app/controllers/wizard/downloadMpacks_controller.js
+++ b/ambari-web/app/controllers/wizard/downloadMpacks_controller.js
@@ -94,13 +94,18 @@ App.WizardDownloadMpacksController = App.WizardStepController.extend({
   },
 
   loadMpackInfo: function (data) {
-    App.ajax.send({
-      name: 'mpack.get_registered_mpack',
-      sender: this,
-      data: {
-        id: data.resources[0].MpackInfo.id
-      }
-    }).then(mpackInfo => this.get('content.registeredMpacks').push(mpackInfo));
+    const id = data.resources[0].MpackInfo.id;
+    const registeredMpacks = this.get('content.registeredMpacks');
+    
+    if (!registeredMpacks.find(mpack => mpack.MpackInfo.id === id)) {
+      App.ajax.send({
+        name: 'mpack.get_registered_mpack',
+        sender: this,
+        data: {
+          id: id
+        }
+      }).then(mpackInfo => registeredMpacks.push(mpackInfo));
+    }  
   },
 
   retryDownload: function (event) {

--- a/ambari-web/test/controllers/wizard/downloadMpacks_test.js
+++ b/ambari-web/test/controllers/wizard/downloadMpacks_test.js
@@ -127,7 +127,7 @@ describe('App.WizardConfigureDownloadController', function () {
     });
   });
 
-  describe.only('#loadMpackInfo', function () {
+  describe('#loadMpackInfo', function () {
     it('Adds mpackInfo to registered mpacks list only once.', function () {
       controller.set('content.registeredMpacks', []);
       var mpackInfo = { MpackInfo: { id: 1 } };

--- a/ambari-web/test/controllers/wizard/downloadMpacks_test.js
+++ b/ambari-web/test/controllers/wizard/downloadMpacks_test.js
@@ -37,6 +37,7 @@ describe('App.WizardConfigureDownloadController', function () {
     ];
 
     controller.set('mpacks', mpacks);
+    controller.set('content', {});
   })
 
   describe('#downloadMpackSuccess', function () {
@@ -107,7 +108,7 @@ describe('App.WizardConfigureDownloadController', function () {
       expect(controller.downloadMpack).to.be.called;
 
       controller.downloadMpack.restore();
-    })
+    });
   });
 
   describe('#showError', function () {
@@ -123,6 +124,27 @@ describe('App.WizardConfigureDownloadController', function () {
       expect(App.ModalPopup.show).to.be.called;
 
       App.ModalPopup.show.restore();
-    })
+    });
+  });
+
+  describe.only('#loadMpackInfo', function () {
+    it('Adds mpackInfo to registered mpacks list only once.', function () {
+      controller.set('content.registeredMpacks', []);
+      var mpackInfo = { MpackInfo: { id: 1 } };
+      var expected = [mpackInfo];
+      
+      App.ajax.send.restore();
+      sinon.stub(App.ajax, 'send').returns({
+        then: function () {
+          controller.get('content.registeredMpacks').push(mpackInfo);
+        }
+      });
+
+      controller.loadMpackInfo({ resources: [mpackInfo] });
+      expect(controller.get('content.registeredMpacks')).to.deep.equal(expected);
+
+      controller.loadMpackInfo({ resources: [mpackInfo] });
+      expect(controller.get('content.registeredMpacks').length).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated front end to account to avoid treating repeated registrations as duplicate mpacks.

## How was this patch tested?

Created new unit test.
All unit test passing.