### PR TITLE
AMBARI-23794 Using the proper concatenation delimiter when using the …

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/kerberos.json
@@ -150,7 +150,7 @@
             {
               "webhcat-site": {
                 "templeton.kerberos.secret": "secret",
-                "templeton.hive.properties": "hive.metastore.local=false,hive.metastore.uris=${clusterHostInfo/hive_metastore_hosts|each(thrift://%s:9083, \\\\,, \\s*\\,\\s*)},hive.metastore.sasl.enabled=true,hive.metastore.execute.setugi=true,hive.metastore.warehouse.dir=/apps/hive/warehouse,hive.exec.mode.local.auto=false,hive.metastore.kerberos.principal=hive/_HOST@${realm}"
+                "templeton.hive.properties": "hive.metastore.local=false,hive.metastore.uris=${clusterHostInfo/hive_metastore_hosts|each(thrift://%s:9083, \\,, \\s*\\,\\s*)},hive.metastore.sasl.enabled=true,hive.metastore.execute.setugi=true,hive.metastore.warehouse.dir=/apps/hive/warehouse,hive.exec.mode.local.auto=false,hive.metastore.kerberos.principal=hive/_HOST@${realm}"
               }
             }
           ]


### PR DESCRIPTION
…'each' variable replacement function in a Kerberized cluster

## What changes were proposed in this pull request?

fix erroneous delimiter

## How was this patch tested?

Tested on local cluster.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.