### PR TITLE
AMBARI-23838 - Amabri server gets NPE due to ambari agent failure whi…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
@@ -1256,14 +1256,14 @@ public class HostImpl implements Host {
       String category = componentInfo.getCategory();
 
       if (MaintenanceState.OFF == maintenanceStateHelper.getEffectiveState(scHost, this)) {
-        if (category.equals("MASTER")) {
+        if ("MASTER".equals(category)) {
           ++masterCount;
-          if (status.equals("STARTED")) {
+          if ("STARTED".equals(status)) {
             ++mastersRunning;
           }
-        } else if (category.equals("SLAVE")) {
+        } else if ("SLAVE".equals(category)) {
           ++slaveCount;
-          if (status.equals("STARTED")) {
+          if ("STARTED".equals(status)) {
             ++slavesRunning;
           }
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
@@ -1254,16 +1254,21 @@ public class HostImpl implements Host {
       String status = scHost.getState().name();
 
       String category = componentInfo.getCategory();
+      if (category == null) {
+        LOG.warn("In stack {}-{} service {} component {} category is null!",
+                stackId.getStackName(), stackId.getStackVersion(), scHost.getServiceName(), scHost.getServiceComponentName());
+        continue;
+      }
 
       if (MaintenanceState.OFF == maintenanceStateHelper.getEffectiveState(scHost, this)) {
-        if ("MASTER".equals(category)) {
+        if (StringUtils.equals("MASTER", category)) {
           ++masterCount;
-          if ("STARTED".equals(status)) {
+          if (StringUtils.equals("STARTED", status)) {
             ++mastersRunning;
           }
-        } else if ("SLAVE".equals(category)) {
+        } else if (StringUtils.equals("SLAVE", category)) {
           ++slaveCount;
-          if ("STARTED".equals(status)) {
+          if (StringUtils.equals("STARTED", status)) {
             ++slavesRunning;
           }
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -1261,14 +1262,14 @@ public class HostImpl implements Host {
       }
 
       if (MaintenanceState.OFF == maintenanceStateHelper.getEffectiveState(scHost, this)) {
-        if (StringUtils.equals("MASTER", category)) {
+        if (Objects.equals("MASTER", category)) {
           ++masterCount;
-          if (StringUtils.equals("STARTED", status)) {
+          if (Objects.equals("STARTED", status)) {
             ++mastersRunning;
           }
-        } else if (StringUtils.equals("SLAVE", category)) {
+        } else if (Objects.equals("SLAVE", category)) {
           ++slaveCount;
-          if (StringUtils.equals("STARTED", status)) {
+          if (Objects.equals("STARTED", status)) {
             ++slavesRunning;
           }
         }


### PR DESCRIPTION
…le registration

## What changes were proposed in this pull request?

If the category of a service component is not present in the stack definition/metainfo.xml a NullPointerException is thrown when the server tries to calculate the host status.
Fix.: Change host status calculation by preparing for null category value.

## How was this patch tested?

Unit tests:
mvn clean install ambari-server

Manually:
Deploy a cluster including a service having a component that lacks category.
Monitor ambari-server.log for NullPointerExceptions when agents register.
Monitor ambari-agents heartbeats. 

Please review 
@swagle @adoroszlai @mpapirkovskyy 