### PR TITLE
[AMBARI-23746] Distinguish componentId and hostComponentId

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -1398,13 +1398,15 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       }
     }
 
-    if (request.getComponentId() != null) {
-      Service service = cluster.getServiceByComponentId(request.getComponentId());
-      if (Strings.isNullOrEmpty(request.getServiceGroupName())) {
-        request.setServiceGroupName(service.getServiceGroupName());
-      }
-      if (Strings.isNullOrEmpty(request.getServiceName())) {
-        request.setServiceName(service.getName());
+    if (request.getHostComponentId() != null) {
+      ServiceComponentHost sch = cluster.getHostComponentById(request.getHostComponentId());
+      if (sch != null) {
+        if (Strings.isNullOrEmpty(request.getServiceGroupName())) {
+          request.setServiceGroupName(sch.getServiceGroupName());
+        }
+        if (Strings.isNullOrEmpty(request.getServiceName())) {
+          request.setServiceName(sch.getServiceName());
+        }
       }
     }
 
@@ -1482,18 +1484,18 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
      */
     ServiceComponentDesiredStateEntity serviceComponentDesiredStateEntity = null;
     HostComponentStateEntity hostComponentStateEntity = null;
-    if (request.getComponentId() != null) {
-      hostComponentStateEntity = hostComponentStateDAO.findById(request.getComponentId());
+    if (request.getHostComponentId() != null) {
+      hostComponentStateEntity = hostComponentStateDAO.findById(request.getHostComponentId());
       if (hostComponentStateEntity == null) {
         throw new AmbariException("Could not find Host Component resource for"
-                + " componentId = "+ request.getComponentId());
+                + " componentId = "+ request.getHostComponentId());
       }
       serviceComponentDesiredStateEntity = serviceComponentDesiredStateDAO.findByName(hostComponentStateEntity.getClusterId(),
               hostComponentStateEntity.getServiceGroupId(), hostComponentStateEntity.getServiceId(),
               hostComponentStateEntity.getComponentName(), hostComponentStateEntity.getComponentType());
       if (serviceComponentDesiredStateEntity == null) {
         throw new AmbariException("Could not find Service Component resource for"
-                + " componentId = " + request.getComponentId() + ", serviceGroupId = " + hostComponentStateEntity.getServiceGroupId()
+                + " componentId = " + request.getHostComponentId() + ", serviceGroupId = " + hostComponentStateEntity.getServiceGroupId()
                 + ", serviceId = " + hostComponentStateEntity.getServiceId() + ", componentName = " + hostComponentStateEntity.getComponentName()
                 + ", componntType = " + hostComponentStateEntity.getComponentType());
         }
@@ -1574,7 +1576,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
             response.add(r);
           } catch (ServiceComponentHostNotFoundException e) {
-            if (request.getServiceName() == null || request.getComponentId() == null) {
+            if (request.getServiceName() == null || request.getHostComponentId() == null) {
               // Ignore the exception if either the service name or component name are not specified.
               // This is an artifact of how we get host_components and can happen in the case where
               // we get all host_components for a host, for example.
@@ -1586,7 +1588,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
               // condition.
               LOG.debug("ServiceComponentHost not found ", e);
               throw new ServiceComponentHostNotFoundException(cluster.getClusterName(),
-                  request.getServiceName(), request.getComponentId(), request.getHostname());
+                  request.getServiceName(), request.getHostComponentId(), request.getHostname());
             }
           }
         } else {
@@ -3797,7 +3799,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     // if any request are for the whole host, they need to be expanded
     for (ServiceComponentHostRequest request : requests) {
-      if (null == request.getComponentId()) {
+      if (null == request.getHostComponentId()) {
         if (null == request.getClusterName() || request.getClusterName().isEmpty() ||
             null == request.getHostname() || request.getHostname().isEmpty()) {
           throw new IllegalArgumentException("Cluster name and hostname must be specified.");
@@ -3832,10 +3834,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       Service s = null;
 
       if (StringUtils.isEmpty(request.getServiceName())) {
-        hostComponentStateEntity = hostComponentStateDAO.findById(request.getComponentId());
+        hostComponentStateEntity = hostComponentStateDAO.findById(request.getHostComponentId());
         if (hostComponentStateEntity == null) {
           throw new AmbariException("Could not find Host Component resource for"
-                  + " componentId = "+ request.getComponentId());
+                  + " componentId = "+ request.getHostComponentId());
         }
         s = cluster.getService(hostComponentStateEntity.getServiceId());
         request.setServiceGroupName(s.getServiceGroupName());
@@ -3848,7 +3850,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         + ", clusterName=" + request.getClusterName()
         + ", serviceGroupName=" + request.getServiceGroupName()
         + ", serviceName=" + request.getServiceName()
-        + ", componentId=" + request.getComponentId()
+        + ", componentId=" + request.getHostComponentId()
         + ", componentName=" + request.getComponentName()
         + ", componentType=" + request.getComponentType()
         + ", hostname=" + request.getHostname()

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceComponentHostRequest.java
@@ -26,7 +26,7 @@ public class ServiceComponentHostRequest {
   private String clusterName; // REF
   private String serviceGroupName;
   private String serviceName;
-  private Long componentId;
+  private Long hostComponentId;
   private String componentName;
   private String componentType;
   private String hostname;
@@ -41,7 +41,7 @@ public class ServiceComponentHostRequest {
   public ServiceComponentHostRequest(String clusterName,
                                      String serviceGroupName,
                                      String serviceName,
-                                     Long componentId,
+                                     Long hostComponentId,
                                      String componentName,
                                      String componentType,
                                      String hostname,
@@ -49,7 +49,7 @@ public class ServiceComponentHostRequest {
     this.clusterName = clusterName;
     this.serviceGroupName = serviceGroupName;
     this.serviceName = serviceName;
-    this.componentId = componentId;
+    this.hostComponentId = hostComponentId;
     this.componentName = componentName;
     this.componentType = componentType;
     this.hostname = hostname;
@@ -91,10 +91,10 @@ public class ServiceComponentHostRequest {
   }
 
   /**
-   * @return the componentd
+   * @return the ID of the host component
    */
-  public Long getComponentId() {
-    return componentId;
+  public Long getHostComponentId() {
+    return hostComponentId;
   }
 
   /**
@@ -112,10 +112,10 @@ public class ServiceComponentHostRequest {
   }
 
   /**
-   * @param componentId the componentId to set
+   * @param hostComponentId ID of the host component the request applies to
    */
-  public void setComponentId(Long componentId) {
-    this.componentId = componentId;
+  public void setHostComponentId(Long hostComponentId) {
+    this.hostComponentId = hostComponentId;
   }
 
   /**
@@ -201,7 +201,7 @@ public class ServiceComponentHostRequest {
     sb.append("{" + " clusterName=").append(clusterName)
       .append(", serviceGroupName=").append(serviceGroupName)
       .append(", serviceName=").append(serviceName)
-      .append(", componentId=").append(componentId)
+      .append(", componentId=").append(hostComponentId)
       .append(", componentName=").append(componentName)
       .append(", componentType=").append(componentType)
       .append(", hostname=").append(hostname)
@@ -244,7 +244,7 @@ public class ServiceComponentHostRequest {
     return Objects.equals(clusterName, other.clusterName) &&
       Objects.equals(serviceGroupName, other.serviceGroupName) &&
       Objects.equals(serviceName, other.serviceName) &&
-      Objects.equals(componentId, other.componentId) &&
+      Objects.equals(hostComponentId, other.hostComponentId) &&
       Objects.equals(componentName, other.componentName) &&
       Objects.equals(componentType, other.componentType) &&
       Objects.equals(hostname, other.hostname) &&
@@ -259,7 +259,7 @@ public class ServiceComponentHostRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(clusterName, serviceGroupName, serviceName, componentId, componentName, componentType, hostname,
+    return Objects.hash(clusterName, serviceGroupName, serviceName, hostComponentId, componentName, componentType, hostname,
       publicHostname, desiredState, state, desiredStackId, staleConfig, adminState, maintenanceState);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -344,7 +344,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
     notifyDelete(Resource.Type.HostComponent, predicate);
     for(ServiceComponentHostRequest svcCmpntHostReq : requests) {
-      deleteStatusMetaData.addDeletedKey("component_id: "+svcCmpntHostReq.getComponentId());
+      deleteStatusMetaData.addDeletedKey("component_id: "+svcCmpntHostReq.getHostComponentId());
     }
     return getRequestStatus(null, null, deleteStatusMetaData);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -178,6 +178,8 @@ public interface Cluster {
 
   String getComponentType(Long componentId) throws AmbariException;
 
+  ServiceComponentHost getHostComponentById(Long hostComponentId);
+
   /**
    * Get all services
    *

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
@@ -26,6 +26,8 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -251,6 +253,9 @@ public class ClusterImplTest {
     ServiceComponentHost tezClientHost1 =  tezClient.addServiceComponentHost(hostName1);
     ServiceComponentHost tezClientHost2 = tezClient.addServiceComponentHost(hostName2);
 
+    assertSame(tezClientHost1, cluster.getHostComponentById(tezClientHost1.getHostComponentId()));
+    assertSame(tezClientHost2, cluster.getHostComponentById(tezClientHost2.getHostComponentId()));
+
     // When
     cluster.deleteService(serviceToDelete, new DeleteHostComponentStatusMetaData());
 
@@ -264,6 +269,8 @@ public class ClusterImplTest {
 
     assertTrue("All components of the deleted service should be removed from all hosts", checkHost1 && checkHost2);
 
+    assertNull(cluster.getHostComponentById(tezClientHost1.getHostComponentId()));
+    assertNull(cluster.getHostComponentById(tezClientHost2.getHostComponentId()));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Component ID (internal) and host component ID (exposed in API requests) is not the same.  #1254 and #1265 added code that used host component ID as if it were component ID.  This caused some API requests by ID fail with "404 HostComponent not found" in case the component and host component identified by the same ID belong to different services or service groups.

```
ambari=> SELECT id, sc.service_id, sch.service_id FROM hostcomponentdesiredstate sch JOIN servicecomponentdesiredstate sc USING (id) WHERE sch.service_id != sc.service_id ORDER BY id;
 id | service_id | service_id
----+------------+------------
  4 |          5 |          3
  6 |          3 |          5
(2 rows)
```

This change:

* clarifies the difference by renaming `componentId` in `ServiceComponentHostRequest` to `hostComponentId`
* adds new method to look up `ServiceComponentHost` by ID via `Cluster`
* use the new lookup for the host component request broken by previous PRs

## How was this patch tested?

Deployed HDFS + Zookeeper cluster via blueprint.  Tested GET request for each host component, including those that were previously returning 404.  Also tested DELETE host component.

Minor tweak in existing unit test to exercise the new map.