### PR TITLE
[AMBARI-23864]  : Need to add new property for Ranger-Tagsync when enabl…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -565,9 +565,7 @@ public class BlueprintConfigurationProcessor {
     String clusterName = getClusterName();
 
     // Getting configuration and properties for adding configurations to ranger-tagsync-site
-    Map<String, String> rangerHDFSPluginProperties = null;
     boolean isRangerHDFSPluginEnabled =  false;
-    Map<String, String> rangerHDFSSecurityConfig = null;
     String rangerHDFSPluginServiceName = "";
 
     String atlasServerComponentName = "ATLAS_SERVER";
@@ -577,10 +575,10 @@ public class BlueprintConfigurationProcessor {
     boolean isRangerTagsyncToBeInstalled = (clusterTopology.getHostGroupsForComponent(rangerTagsyncComponentName).size() >= 1);
     boolean isAtlasServerToBeInstalled = (clusterTopology.getHostGroupsForComponent(atlasServerComponentName).size() >= 1);
     if (isRangerAdminToBeInstalled) {
-      rangerHDFSPluginProperties = clusterProps.get("ranger-hdfs-plugin-properties");
+      Map<String, String> rangerHDFSPluginProperties = clusterProps.get("ranger-hdfs-plugin-properties");
       String rangerHDFSPluginEnabledValue = rangerHDFSPluginProperties.getOrDefault("ranger-hdfs-plugin-enabled","No");
       isRangerHDFSPluginEnabled = ("yes".equalsIgnoreCase(rangerHDFSPluginEnabledValue));
-      rangerHDFSSecurityConfig = clusterProps.get("ranger-hdfs-security");
+      Map<String, String> rangerHDFSSecurityConfig = clusterProps.get("ranger-hdfs-security");
       rangerHDFSPluginServiceName = rangerHDFSSecurityConfig.get("ranger.plugin.hdfs.service.name");
     }
 


### PR DESCRIPTION
…ing federation for Namenode-HA via Blueprints

## What changes were proposed in this pull request?
Need to dynamically add properties in config-type ranger-tagsync-site when cluster is being setup via blueprint . This should be done when Atlas and Ranger-Tagsync service is installed.
PS: The patch provided is still in preliminary stages and work in progress.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested a fresh cluster setup via blueprint with requried services.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.