### PR TITLE
AMBARI-23867 : Remove dependency on org.gridgain:ignite-shmem 1.0.0 in Ambari Metrics Collector

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -812,6 +812,12 @@
       <groupId>org.apache.ignite</groupId>
       <artifactId>ignite-core</artifactId>
       <version>2.1.0</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>ignite-shmem</artifactId>
+          <groupId>org.gridgain</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ignite</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove dependency that cause CVE.

## How was this patch tested?

mvn clean install. Manually tested by removing the JAR on a deployed AMS instance and restart Metrics collector.