### PR TITLE
[AMBARI-23868] Log Search web alert gets 401 http status code if KNOX SSO is enabled.

### DIFF
--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/alerts.json
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/alerts.json
@@ -10,8 +10,8 @@
         "source": {
           "type": "WEB",
           "uri": {
-            "http": "{{logsearch-properties/logsearch.http.port}}",
-            "https": "{{logsearch-properties/logsearch.https.port}}",
+            "http": "{{logsearch-properties/logsearch.protocol}}://0.0.0.0:{{logsearch-properties/logsearch.http.port}}/api/v1/info",
+            "https": "{{logsearch-properties/logsearch.protocol}}://0.0.0.0:{{logsearch-properties/logsearch.https.port}}/api/v1/info",
             "https_property": "{{logsearch-properties/logsearch.protocol}}",
             "https_property_value": "https",
             "default_port": 61888,

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
@@ -415,4 +415,4 @@ logsearch_server_host = ""
 logsearch_ui_port =  logsearch_https_port if logsearch_protocol == 'https' else logsearch_http_port
 if logsearch_server_hosts is not None and len(logsearch_server_hosts) > 0:
   logsearch_server_host = logsearch_server_hosts[0]
-smoke_logsearch_cmd = format('curl -k -s -o /dev/null -w "%{{http_code}}" {logsearch_protocol}://{logsearch_server_host}:{logsearch_ui_port}/ | grep 200')
+smoke_logsearch_cmd = format('curl -k -s -o /dev/null -w "%{{http_code}}" {logsearch_protocol}://{logsearch_server_host}:{logsearch_ui_port}/api/v1/info | grep 200')


### PR DESCRIPTION
## What changes were proposed in this pull request?

Root is protected when KNOX SSO is enabled, therefore the basic web alert.
So i can use logsearch address for http and https property instead of the port. (i can use 0.0.0.0 address as that is replaced with the hostname by web_alert.py)

I did not include any upgrade changes, the issue is not that critical and its easy to fix (as logsearch is tech preview there wont be that use case anyway)

## How was this patch tested?
manually. if logsearch was stopped, it showed connection was refused during access the /api/v1/info api

please review @zeroflag @g-boros @swagle @kasakrisz 