### PR TITLE
[AMBARI-23866] add retry to Kerberos service check kinit

### DIFF
--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-10/package/scripts/service_check.py
@@ -61,7 +61,10 @@ class KerberosServiceCheck(Script):
       try:
         # kinit
         Execute(kinit_command,
-                user=params.smoke_user
+                user=params.smoke_user,
+                wait_for_finish=True,
+                tries=9,
+                try_sleep=15
                 )
       finally:
         File(ccache_file_path,

--- a/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KERBEROS/1.10.3-30/package/scripts/service_check.py
@@ -61,7 +61,10 @@ class KerberosServiceCheck(Script):
       try:
         # kinit
         Execute(kinit_command,
-                user=params.smoke_user
+                user=params.smoke_user,
+                wait_for_finish=True,
+                tries=9,
+                try_sleep=15
                 )
       finally:
         File(ccache_file_path,


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the Kerberos service check add `retry` and related arguments to the `Execute` of the kinit command. Beside addressing the issue mentioned in the JIRA, this would help with other possible transient issues with Kerberos (not that there are ever any of those...).

Analysis determined that it took 1-2 minutes for a new principal to reach all KDC in our environment. I selected values based on that. 


## How was this patch tested?
`mvn -am -pl ambari-server -DskipSurefireTests test` returns build success. 

This change has been made in our development cluster. The service check runs successful even with temporary failures on single nodes. 

```
Performing kinit using HADOOPDEV1-051118@EXAMPLE.COM
2018-05-11 16:37:09,795 - Execute['/usr/bin/kinit -c /var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0 -kt /etc/security/keytabs/kerberos.service_check.051118.keytab HADOOPDEV1-051118@EXAMPLE.COM'] {'wait_for_finish': True, 'tries': 9, 'user': 'ambari-qa', 'try_sleep': 15}
2018-05-11 16:37:10,086 - Retrying after 15 seconds. Reason: Execution of '/usr/bin/kinit -c /var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0 -kt /etc/security/keytabs/kerberos.service_check.051118.keytab HADOOPDEV1-051118@EXAMPLE.COM' returned 1. kinit: Client 'HADOOPDEV1-051118@EXAMPLE.COM' not found in Kerberos database while getting initial credentials
2018-05-11 16:37:25,451 - Retrying after 15 seconds. Reason: Execution of '/usr/bin/kinit -c /var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0 -kt /etc/security/keytabs/kerberos.service_check.051118.keytab HADOOPDEV1-051118@EXAMPLE.COM' returned 1. kinit: Client 'HADOOPDEV1-051118@EXAMPLE.COM' not found in Kerberos database while getting initial credentials
2018-05-11 16:37:40,759 - Retrying after 15 seconds. Reason: Execution of '/usr/bin/kinit -c /var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0 -kt /etc/security/keytabs/kerberos.service_check.051118.keytab HADOOPDEV1-051118@EXAMPLE.COM' returned 1. kinit: Client 'HADOOPDEV1-051118@EXAMPLE.COM' not found in Kerberos database while getting initial credentials
2018-05-11 16:37:56,113 - Retrying after 15 seconds. Reason: Execution of '/usr/bin/kinit -c /var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0 -kt /etc/security/keytabs/kerberos.service_check.051118.keytab HADOOPDEV1-051118@EXAMPLE.COM' returned 1. kinit: Client 'HADOOPDEV1-051118@EXAMPLE.COM' not found in Kerberos database while getting initial credentials
2018-05-11 16:38:11,652 - File['/var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0'] {'action': ['delete']}
2018-05-11 16:38:11,652 - Deleting File['/var/lib/ambari-agent/tmp/kerberos_service_check_cc_81d80e9daca327fbde59d3ad711ce3a0']

Command completed successfully!
```