### PR TITLE
AMBARI-23870. Implement 3.0 Mpack Advisor's Host Component Layout API  Server code for : 'Recommendations' and 'Validations'.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackRecommendationResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackRecommendationResourceDefinition.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.resources;
+
+import org.apache.ambari.server.controller.spi.Resource;
+
+/**
+ * MpackRecommendation resource definition.
+ */
+public class MpackRecommendationResourceDefinition extends BaseResourceDefinition {
+  /**
+   * Constructor.
+   */
+  public MpackRecommendationResourceDefinition() {
+    super(Resource.Type.MpackRecommendation);
+  }
+
+  @Override
+  public String getPluralName() {
+    return "recommendations";
+  }
+
+  @Override
+  public String getSingularName() {
+    return "recommendation";
+  }
+
+  @Override
+  public boolean isCreatable() {
+    return false;
+  }
+}
+

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackValidationResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/MpackValidationResourceDefinition.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.resources;
+
+import org.apache.ambari.server.controller.spi.Resource;
+
+/**
+ * MpackValidation resource definition.
+ */
+public class MpackValidationResourceDefinition extends BaseResourceDefinition {
+  /**
+   * Constructor.
+   */
+  public MpackValidationResourceDefinition() {
+    super(Resource.Type.MpackValidation);
+  }
+
+  @Override
+  public String getPluralName() {
+    return "validations";
+  }
+
+  @Override
+  public String getSingularName() {
+    return "validation";
+  }
+
+  @Override
+  public boolean isCreatable() {
+    return false;
+  }
+}
+

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ResourceInstanceFactoryImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ResourceInstanceFactoryImpl.java
@@ -340,8 +340,16 @@ public class ResourceInstanceFactoryImpl implements ResourceInstanceFactory {
         resourceDefinition = new BlueprintResourceDefinition();
         break;
 
+      case MpackRecommendation:
+        resourceDefinition = new MpackRecommendationResourceDefinition();
+        break;
+
       case Recommendation:
         resourceDefinition = new RecommendationResourceDefinition();
+        break;
+
+      case MpackValidation:
+        resourceDefinition = new MpackValidationResourceDefinition();
         break;
 
       case Validation:

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/MpackRecommendationService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/MpackRecommendationService.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.ambari.annotations.ApiIgnore;
+import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.controller.spi.Resource;
+
+/**
+ * Service responsible for preparing recommendations for host-layout and
+ * configurations.
+ */
+@Path("/mpacks/recommendations")
+public class MpackRecommendationService extends BaseService {
+
+  /**
+   * Returns host-layout recommendations for list of hosts and services.
+   *
+   * @param body http body
+   * @param headers http headers
+   * @param ui uri info
+   * @return recommendations for host-layout
+   */
+  @POST @ApiIgnore // until documented
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response getRecommendation(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
+
+    return handleRequest(headers, body, ui, Request.Type.POST,
+        createRecommendationResource());
+  }
+
+  ResourceInstance createRecommendationResource() {
+    Map<Resource.Type, String> mapIds = new HashMap<>();
+
+    return createResource(Resource.Type.MpackRecommendation, mapIds);
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/MpackValidationService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/MpackValidationService.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.ambari.annotations.ApiIgnore;
+import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.controller.spi.Resource;
+
+/**
+ * Service responsible for validation of host-layout and configurations.
+ */
+@Path("/mpacks/validations")
+public class MpackValidationService extends BaseService {
+
+  /**
+   * Returns validation of host-layout.
+   *
+   * @param body http body
+   * @param headers http headers
+   * @param ui uri info
+   * @return validation items if any
+   */
+  @POST @ApiIgnore // until documented
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response getValidation(String body, @Context HttpHeaders headers, @Context UriInfo ui) {
+
+    return handleRequest(headers, body, ui, Request.Type.POST,
+        createValidationResource());
+  }
+
+  ResourceInstance createValidationResource() {
+    Map<Resource.Type, String> mapIds = new HashMap<>();
+
+    return createResource(Resource.Type.MpackValidation, mapIds);
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor;
+
+@SuppressWarnings("serial")
+public class MpackAdvisorException extends Exception {
+
+  public MpackAdvisorException(String message) {
+    super(message);
+  }
+
+  public MpackAdvisorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorHelper.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackAdvisorCommand;
+import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackComponentLayoutRecommendationCommand;
+import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackComponentLayoutValidationCommand;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse;
+import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+import org.apache.ambari.server.topology.ServiceInstance;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class MpackAdvisorHelper {
+
+  protected static Log LOG = LogFactory.getLog(org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorHelper.class);
+
+  private File mpackRecommendationsDir;
+  private String recommendationsArtifactsLifetime;
+  private int recommendationsArtifactsRolloverMax;
+  public static String pythonMpackAdvisorScript;
+  private final AmbariMetaInfo metaInfo;
+  private final AmbariServerConfigurationHandler ambariServerConfigurationHandler;
+
+  /* Monotonically increasing requestid */
+  private int requestId = 0;
+  private MpackAdvisorRunner maRunner;
+
+  @Inject
+  public MpackAdvisorHelper(Configuration conf, MpackAdvisorRunner maRunner,
+                            AmbariMetaInfo metaInfo, AmbariServerConfigurationHandler ambariServerConfigurationHandler) throws IOException {
+    this.mpackRecommendationsDir = conf.getMpackRecommendationsDir();
+    this.recommendationsArtifactsLifetime = conf.getRecommendationsArtifactsLifetime();
+    this.recommendationsArtifactsRolloverMax = conf.getRecommendationsArtifactsRolloverMax();
+    this.pythonMpackAdvisorScript = conf.getMpackAdvisorScript();
+    this.maRunner = maRunner;
+    this.metaInfo = metaInfo;
+    this.ambariServerConfigurationHandler = ambariServerConfigurationHandler;
+  }
+
+  /**
+   * Returns validation (component-layout or configurations) result for the
+   * request.
+   *
+   * @param request the validation request
+   * @return {@link MpackValidationResponse} instance
+   * @throws MpackAdvisorException in case of mpack advisor script errors
+   */
+  public synchronized MpackValidationResponse validate(MpackAdvisorRequest request)
+      throws MpackAdvisorException {
+    requestId = generateRequestId();
+
+    MpackAdvisorCommand<MpackValidationResponse> command = createValidationCommand(request);
+
+    return command.invoke(request);
+  }
+
+  MpackAdvisorCommand<MpackValidationResponse> createValidationCommand(MpackAdvisorRequest request) throws MpackAdvisorException {
+    MpackAdvisorCommand<MpackValidationResponse> command = null;
+
+    MpackAdvisorRequest.MpackAdvisorRequestType requestType = request.getRequestType();
+    ServiceInfo.ServiceAdvisorType serviceAdvisorType = getServiceAdvisorTypeFromRequest(request);
+
+    if (requestType == MpackAdvisorRequest.MpackAdvisorRequestType.HOST_GROUPS) {
+          command = new MpackComponentLayoutValidationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
+              requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+    } else {
+      // TODO : for other MpackAdvisorRequestType's.
+      throw new MpackAdvisorRequestException(String.format("Unsupported request type, type=%s",
+          requestType));
+    }
+
+    return command;
+  }
+
+  public synchronized MpackRecommendationResponse recommend(MpackAdvisorRequest request)
+      throws MpackAdvisorException {
+    requestId = generateRequestId();
+
+    MpackRecommendationResponse response = null;
+    ServiceInfo.ServiceAdvisorType serviceAdvisorType = getServiceAdvisorTypeFromRequest(request);
+    MpackAdvisorCommand<MpackRecommendationResponse> command = createRecommendationCommand(serviceAdvisorType, request);
+    response = command.invoke(request);
+
+    return response;
+  }
+
+
+  MpackAdvisorCommand<MpackRecommendationResponse> createRecommendationCommand(ServiceInfo.ServiceAdvisorType serviceAdvisorType, MpackAdvisorRequest request) throws MpackAdvisorException {
+      MpackAdvisorRequest.MpackAdvisorRequestType requestType = request.getRequestType();
+
+    MpackAdvisorCommand<MpackRecommendationResponse> command;
+    if (requestType == MpackAdvisorRequest.MpackAdvisorRequestType.HOST_GROUPS) {
+      command = new MpackComponentLayoutRecommendationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
+          requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+    } else {
+      // TODO : for other MpackAdvisorRequestType's.
+      throw new MpackAdvisorRequestException(String.format("Unsupported request type, type=%s",
+          requestType));
+    }
+
+    return command;
+  }
+
+  /**
+   * Iterates over the request->mpackInstances and its serviceInstances to determine the ServiceAdvisorType.
+   * Queries for the Service Advisor Type as soon as it gets a serviceInstance in MpackInstance which is of
+   * Server Type. ("*_CLIENTS" will not have a Service Advisor, hence can't be queried for).
+   *
+   * Assumes that for a given request that all the ServiceInstances (across all Mpack Instances) will be
+   * of same Advisor Type (ServiceInfo.ServiceAdvisorType).
+   *
+   * @param  request Passed-in request.
+   * @return Service Advisor type for that Stack, Version, and Service
+   */
+  private ServiceInfo.ServiceAdvisorType getServiceAdvisorTypeFromRequest(MpackAdvisorRequest request)
+      throws MpackAdvisorRequestException {
+    Collection<MpackInstance> mpackInstances = request.getMpackInstances();
+    ServiceInfo.ServiceAdvisorType serviceAdvisorType = null;
+    if (mpackInstances != null && !mpackInstances.isEmpty()) {
+      Iterator<MpackInstance> mpackInstancesItr = mpackInstances.iterator();
+      while (mpackInstancesItr.hasNext()) {
+        MpackInstance mpackInstance = mpackInstancesItr.next();
+        Collection<ServiceInstance> serviceInstances = mpackInstance.getServiceInstances();
+        if (serviceInstances != null && !serviceInstances.isEmpty()) {
+          Iterator<ServiceInstance> svcInstancesItr = serviceInstances.iterator();
+          while (svcInstancesItr.hasNext()) {
+            ServiceInstance serviceInstance = svcInstancesItr.next();
+            String serviceType = serviceInstance.getType();
+            if (serviceType.endsWith("_CLIENTS")) {
+              continue; // Ignore if a client is fetched.
+            } else {
+              return getServiceAdvisorType(mpackInstance.getMpackType(), mpackInstance.getMpackVersion(), serviceType);
+            }
+          }
+        }
+      }
+    } else {
+      throw new MpackAdvisorRequestException(String.format("Read MpackInstances is null or empty. Request type =%s",
+          request.getRequestType()));
+    }
+    return serviceAdvisorType;
+  }
+
+  /**
+   * Get the Service Advisor type that the service defines for the specified mpack's stack and version.
+   * If an error, return null.
+   *
+   * @param stackName Stack Name
+   * @param stackVersion Stack Version
+   * @param serviceName Service Name
+   * @return Service Advisor type for that Stack, Version, and Service
+   */
+  private ServiceInfo.ServiceAdvisorType getServiceAdvisorType(String stackName, String stackVersion, String serviceName) {
+    try {
+      ServiceInfo service = metaInfo.getService(stackName, stackVersion, serviceName);
+      ServiceInfo.ServiceAdvisorType serviceAdvisorType = service.getServiceAdvisorType();
+
+      return serviceAdvisorType;
+    } catch (AmbariException e) {
+      ;
+    }
+    return null;
+  }
+
+  /**
+   * Returns an incremented requestId. Rollsover back to 0 in case the requestId >= recommendationsArtifactsrollovermax
+   * @return {int requestId}
+   */
+  private int generateRequestId(){
+    requestId += 1;
+    return requestId % recommendationsArtifactsRolloverMax;
+
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorRequest.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse.HostGroup;
+import org.apache.ambari.server.state.ChangedConfigInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+import org.apache.ambari.server.topology.ServiceInstance;
+
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Mpack Advisor request.
+ */
+public class MpackAdvisorRequest {
+
+  private MpackAdvisorRequestType requestType;
+  private List<String> hosts = new ArrayList<>();
+  //      Mpack Instance Name -> Component Name -> host(s)
+  private Map<String, Map<String, Set<String>>> componentHostsMap = new HashMap<>();
+  private Map<String, Map<String, Map<String, String>>> configurations = new HashMap<>();
+  private List<ChangedConfigInfo> changedConfigurations = new LinkedList<>();
+  private Map<String, String> userContext = new HashMap<>();
+  private Boolean gplLicenseAccepted;
+
+  @JsonProperty
+  private Recommendation recommendation = new Recommendation();
+
+  public static class Recommendation {
+    @JsonProperty
+    private Blueprint blueprint =  new Blueprint();
+
+    private Map<String, Set<String>> blueprint_cluster_binding =  new HashMap<>();
+
+    public Blueprint getBlueprint() {
+      return blueprint;
+    }
+
+    public void setBlueprint(Blueprint blueprint) {
+      this.blueprint = blueprint;
+    }
+
+    public Map<String, Set<String>> getBlueprintClusterBinding() {
+      return blueprint_cluster_binding;
+    }
+
+    public void setBlueprintClusterBinding(Map<String, Set<String>> blueprint_cluster_binding) {
+      this.blueprint_cluster_binding = blueprint_cluster_binding;
+    }
+  }
+
+  public static class Blueprint {
+    @JsonProperty("host_groups")
+    private Collection<HostGroup> hostGroups;
+    @JsonProperty("mpack_instances")
+    private Collection<MpackInstance> mpacks;
+
+    public void setHostGroups(Collection<HostGroup> hostGroups) {
+      this.hostGroups = hostGroups;
+    }
+
+    public Collection<HostGroup> getHostGroups() {
+      return this.hostGroups;
+    }
+
+    public void setMpackInstances(Collection<MpackInstance> mpacks) {
+      this.mpacks = mpacks;
+    }
+
+    public Collection<MpackInstance> getMpackInstances() {
+      return this.mpacks;
+    }
+  }
+
+  public Recommendation getRecommendation() {
+    return recommendation;
+  }
+
+  public void setRecommendations(Recommendation recommendation) {
+    this.recommendation = recommendation;
+  }
+
+  public MpackAdvisorRequestType getRequestType() {
+    return requestType;
+  }
+
+  public Map<String, Map<String, Map<String, String>>> getConfigurations() {
+    return configurations;
+  }
+
+  public List<ChangedConfigInfo> getChangedConfigurations() {
+    return changedConfigurations;
+  }
+
+  public void setChangedConfigurations(List<ChangedConfigInfo> changedConfigurations) {
+    this.changedConfigurations = changedConfigurations;
+  }
+
+  public Map<String, String> getUserContext() {
+    return this.userContext;
+  }
+
+  public void setUserContext(Map<String, String> userContext) {
+    this.userContext = userContext;
+  }
+
+  /**
+   * @return true if GPL license is accepted, false otherwise
+   */
+  public Boolean getGplLicenseAccepted() {
+    return gplLicenseAccepted;
+  }
+
+  public List<String> getHosts() {
+    return hosts;
+  }
+
+  public static class MpackAdvisorRequestBuilder {
+    MpackAdvisorRequest instance;
+
+    private MpackAdvisorRequestBuilder() {
+      this.instance = new MpackAdvisorRequest();
+    }
+
+    public static MpackAdvisorRequestBuilder forStack() {
+      return new MpackAdvisorRequestBuilder();
+    }
+
+    public MpackAdvisorRequestBuilder ofType(MpackAdvisorRequestType requestType) {
+      this.instance.requestType = requestType;
+      return this;
+    }
+
+    public MpackAdvisorRequestBuilder forHosts(List<String> hosts) {
+      this.instance.hosts = hosts;
+      return this;
+    }
+
+    public MpackAdvisorRequestBuilder forMpackInstances(Collection<MpackInstance> mpackInstances) {
+      this.instance.recommendation.blueprint.mpacks = mpackInstances;
+      return this;
+    }
+
+    public MpackAdvisorRequestBuilder forComponentHostsMap(Collection<HostGroup> hgCompMap) {
+      this.instance.recommendation.blueprint.hostGroups = hgCompMap;
+      return this;
+    }
+
+    public MpackAdvisorRequestBuilder forHostsGroupBindings(
+        Map<String, Set<String>> blueprint_cluster_binding) {
+      this.instance.recommendation.blueprint_cluster_binding = blueprint_cluster_binding;
+      return this;
+    }
+
+    public MpackAdvisorRequest.MpackAdvisorRequestBuilder withMpacksToComponentsHostsMap(
+        Map<String, Map<String, Set<String>>> componentHostsMap) {
+      this.instance.componentHostsMap = componentHostsMap;
+      return this;
+    }
+
+    public MpackAdvisorRequest.MpackAdvisorRequestBuilder withConfigurations(
+        Map<String, Map<String, Map<String, String>>> configurations) {
+      this.instance.configurations = configurations;
+      return this;
+    }
+
+    public MpackAdvisorRequest.MpackAdvisorRequestBuilder withChangedConfigurations(
+        List<ChangedConfigInfo> changedConfigurations) {
+      this.instance.changedConfigurations = changedConfigurations;
+      return this;
+    }
+
+    public MpackAdvisorRequest.MpackAdvisorRequestBuilder withUserContext(
+        Map<String, String> userContext) {
+      this.instance.userContext = userContext;
+      return this;
+    }
+
+    /**
+     * Set GPL license acceptance parameter to request.
+     * @param gplLicenseAccepted is GPL license accepted.
+     * @return mpack advisor request builder.
+     */
+    public MpackAdvisorRequest.MpackAdvisorRequestBuilder withGPLLicenseAccepted(
+        Boolean gplLicenseAccepted) {
+      this.instance.gplLicenseAccepted = gplLicenseAccepted;
+      return this;
+    }
+
+    public MpackAdvisorRequest build() {
+      return this.instance;
+    }
+  }
+
+  public enum MpackAdvisorRequestType {
+    HOST_GROUPS("host_groups"),
+    CONFIGURATIONS("configurations"),
+    SSO_CONFIGURATIONS("sso-configurations"),
+    CONFIGURATION_DEPENDENCIES("configuration-dependencies");
+
+    private String type;
+
+    MpackAdvisorRequestType(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public String toString() {
+      return type;
+    }
+
+    public static MpackAdvisorRequestType fromString(String text) throws MpackAdvisorException {
+      if (text != null) {
+        for (MpackAdvisorRequestType next : MpackAdvisorRequestType.values()) {
+          if (text.equalsIgnoreCase(next.type)) {
+            return next;
+          }
+        }
+      }
+      throw new MpackAdvisorException(String.format(
+          "Unknown request type: %s, possible values: %s", text, Arrays.toString(MpackAdvisorRequestType.values())));
+    }
+  }
+
+  public String getMpackServiceInstanceTypeCommaSeparated(MpackInstance mpackInstance) {
+    Collection<String> serviceInstancesTypeList = new ArrayList<>();
+    for (ServiceInstance serviceInstance : mpackInstance.getServiceInstances()) {
+      serviceInstancesTypeList.add(serviceInstance.getType());
+    }
+    return StringUtils.join(serviceInstancesTypeList, ",");
+  }
+
+  public Map<String, Map<String, Set<String>>> getComponentHostsMap() {
+    return componentHostsMap;
+  }
+
+  public String getHostsCommaSeparated() {
+    return StringUtils.join(hosts, ",");
+  }
+
+  /******
+   * Helper Functions
+   *******/
+
+  public Collection<MpackInstance> getMpackInstances() {
+    return this.getRecommendation().getBlueprint().getMpackInstances();
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorRequestException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorRequestException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor;
+
+@SuppressWarnings("serial")
+public class MpackAdvisorRequestException extends MpackAdvisorException {
+
+  public MpackAdvisorRequestException(String message) {
+    super(message);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Abstract stack advisor response POJO.
+ */
+
+public abstract class MpackAdvisorResponse {
+
+  private int id;
+
+  @JsonProperty("Versions")
+  private Version version;
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public Version getVersion() {
+    return version;
+  }
+
+  public void setVersion(Version version) {
+    this.version = version;
+  }
+
+  public static class Version {
+    @JsonProperty("stack_name")
+    private String stackName;
+
+    @JsonProperty("stack_version")
+    private String stackVersion;
+
+    public String getStackName() {
+      return stackName;
+    }
+
+    public void setStackName(String stackName) {
+      this.stackName = stackName;
+    }
+
+    public String getStackVersion() {
+      return stackVersion;
+    }
+
+    public void setStackVersion(String stackVersion) {
+      this.stackVersion = stackVersion;
+    }
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorRunner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorRunner.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackAdvisorCommandType;
+import org.apache.ambari.server.api.services.stackadvisor.commands.StackAdvisorCommandType;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class MpackAdvisorRunner {
+
+  private final static Logger LOG = LoggerFactory.getLogger(MpackAdvisorRunner.class);
+
+  @Inject
+  private Configuration configs;
+
+  /**
+   * Runs mpack_advisor_wrapper.py script in the specified {@code actionDirectory}.
+   *
+   * @param serviceAdvisorType PYTHON or JAVA
+   * @param maCommandType {@link StackAdvisorCommandType} to run.
+   * @param actionDirectory directory for the action
+   */
+  public void runScript(ServiceInfo.ServiceAdvisorType serviceAdvisorType, MpackAdvisorCommandType maCommandType, File actionDirectory)
+      throws MpackAdvisorException {
+    LOG.info(String.format("MpackAdvisorRunner. serviceAdvisorType=%s, actionDirectory=%s, command=%s", serviceAdvisorType, actionDirectory,
+        maCommandType));
+
+    String outputFile = actionDirectory + File.separator + "mpackadvisor.out";
+    String errorFile = actionDirectory + File.separator + "mpackadvisor.err";
+
+    String hostsFile = actionDirectory + File.separator + "hosts.json";
+    String servicesFile = actionDirectory + File.separator + "services.json";
+
+    LOG.info("MpackAdvisorRunner. Expected files: hosts.json={}, services.json={}, output={}, error={}", hostsFile, servicesFile, outputFile, errorFile);
+
+    int stackAdvisorReturnCode = -1;
+
+    switch (serviceAdvisorType) {
+      case JAVA:
+        // TODO : Future Reference point to start : StackAdvisorRunner.java
+        break;
+      case PYTHON:
+        LOG.info("MpackAdvisorRunner.runScript(): Calling Python Mpack Advisor.");
+        ProcessBuilder builder = prepareShellCommand(ServiceInfo.ServiceAdvisorType.PYTHON, MpackAdvisorHelper.pythonMpackAdvisorScript, maCommandType,
+            actionDirectory, outputFile, errorFile);
+        builder.environment().put("METADATA_DIR_PATH", configs.getProperty(Configuration.METADATA_DIR_PATH));
+        builder.environment().put("BASE_SERVICE_ADVISOR", Paths.get(configs.getProperty(Configuration.METADATA_DIR_PATH), "service_advisor.py").toString());
+        builder.environment().put("BASE_STACK_ADVISOR", Paths.get(configs.getProperty(Configuration.METADATA_DIR_PATH), "stack_advisor.py").toString());
+        stackAdvisorReturnCode = launchProcess(builder);
+        break;
+    }
+
+    // For both Python and Java, need to process log files for now.
+    processLogs(stackAdvisorReturnCode, outputFile, errorFile);
+  }
+
+  /**
+   * Launch a process, wait for it to finish, and return its exit code.
+   * @param builder Process Builder
+   * @return
+   * @throws MpackAdvisorException
+   */
+  private int launchProcess(ProcessBuilder builder) throws MpackAdvisorException {
+    int exitCode = -1;
+    Process process = null;
+    try {
+      process = builder.start();
+      exitCode = process.waitFor();
+    } catch (Exception ioe) {
+      String message = "Error executing Mpack Advisor: ";
+      LOG.error(message, ioe);
+      throw new MpackAdvisorException(message + ioe.getMessage());
+    } finally {
+      if (process != null) {
+        process.destroy();
+      }
+    }
+    return exitCode;
+  }
+
+  /**
+   * Process the exit code and logs. If non-zero then parse the log files and raise the appropriate exception.
+   * @param exitCode Process exit code
+   * @param outputFile Path to output file
+   * @param errorFile Path to error file
+   * @throws MpackAdvisorException
+   */
+  private void processLogs(int exitCode, String outputFile, String errorFile) throws MpackAdvisorException {
+    String outMessage = printMessage("stdout", outputFile);
+    String errMessage = printMessage("stderr", errorFile);
+
+    try {
+      if (exitCode != 0) {
+        String errorMessage;
+        if (errMessage != null) {
+          // We want to get the last line.
+          int index = errMessage.lastIndexOf("\n");
+          if (index > 0 && index == (errMessage.length() - 1)) {
+            index = errMessage.lastIndexOf("\n", index - 1); // sentence ended with newline
+          }
+          if (index > -1) {
+            errMessage = errMessage.substring(index + 1).trim();
+          }
+          errorMessage = String.format("Mpack Advisor reported an error. Exit Code: %s. Error: %s ", exitCode, errMessage);
+        } else {
+          errorMessage = String.format("Error occurred during Mpack Advisor execution. Exit Code: %s", exitCode);
+        }
+        errorMessage += "\nStdOut file: " + outputFile + "\n";
+        errorMessage += "\nStdErr file: " + errorFile;
+        switch (exitCode) {
+          case 1:
+            throw new MpackAdvisorRequestException(errorMessage);
+          case 2:
+            throw new MpackAdvisorException(errorMessage);
+        }
+      }
+    } catch (MpackAdvisorException ex) {
+      throw ex;
+    }
+  }
+
+  /**
+   * Logs messages from the output/error file.
+   * @param type Severity type, stdout or stderr
+   * @param file File path
+   * @return File to a String
+   */
+  private String printMessage(String type, String file) {
+    String message = null;
+    try {
+      message = FileUtils.readFileToString(new File(file)).trim();
+      LOG.info("    Advisor script {}: {}", type, message);
+    } catch (IOException io) {
+      LOG.error("Error in reading script log files", io);
+    }
+    return message;
+  }
+
+  /**
+   * Gets an instance of a {@link ProcessBuilder} that's ready to execute the
+   * shell command to run the stack advisor script. This will take the
+   * environment variables from the current process.
+   *
+   * @param serviceAdvisorType Python or Java
+   * @param script Python script or jar path
+   * @param maCommandType command type such as validate, configure
+   * @param actionDirectory Directory that contains hosts.json, services.json, and output files
+   * @param outputFile Output file path
+   * @param errorFile Error file path
+   * @return Process that can launch
+   */
+  ProcessBuilder prepareShellCommand(ServiceInfo.ServiceAdvisorType serviceAdvisorType, String script,
+                                     MpackAdvisorCommandType maCommandType,
+                                     File actionDirectory, String outputFile, String errorFile) {
+    String hostsFile = actionDirectory + File.separator + "hosts.json";
+    String servicesFile = actionDirectory + File.separator + "services.json";
+
+    // includes the original command plus the arguments for it
+    List<String> builderParameters = new ArrayList<>();
+
+    switch (serviceAdvisorType) {
+      case PYTHON:
+      case JAVA:
+        if (System.getProperty("os.name").contains("Windows")) {
+          builderParameters.add("cmd");
+          builderParameters.add("/c");
+        } else {
+          builderParameters.add("sh");
+          builderParameters.add("-c");
+        }
+        break;
+      default:
+        break;
+    }
+
+    // for the 3rd argument, build a single parameter since we use -c
+    // ProcessBuilder doesn't support output redirection until JDK 1.7
+    String commandStringParameters[] = new String[] {script, maCommandType.toString(), hostsFile, servicesFile, "1>", outputFile, "2>", errorFile};
+
+    StringBuilder commandString = new StringBuilder();
+    for (String command : commandStringParameters) {
+      commandString.append(command).append(" ");
+    }
+
+    builderParameters.add(commandString.toString());
+
+    LOG.debug("MpackAdvisorRunner. Mpack advisor command is {}", StringUtils.join(" ", builderParameters));
+
+    return new ProcessBuilder(builderParameters);
+  }
+
+  public void setConfigs(Configuration configs) {
+    this.configs = configs;
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackAdvisorCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackAdvisorCommand.java
@@ -1,0 +1,504 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor.commands;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.ambari.server.api.resources.ResourceInstance;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.BaseService;
+import org.apache.ambari.server.api.services.LocalUriInfo;
+import org.apache.ambari.server.api.services.Request;
+import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorResponse;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRunner;
+import org.apache.ambari.server.controller.RootComponent;
+import org.apache.ambari.server.controller.RootService;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.controller.spi.NoSuchResourceException;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+import org.apache.ambari.server.utils.DateUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parent for all commands.
+ */
+public abstract class MpackAdvisorCommand<T extends MpackAdvisorResponse> extends BaseService {
+
+  /**
+   * Type of response object provided by extending classes when
+   *  is called.
+   */
+  private Class<T> type;
+
+  private static final Logger LOG = LoggerFactory.getLogger(MpackAdvisorCommand.class);
+
+  private static final String GET_HOSTS_INFO_URI = "/api/v1/hosts"
+      + "?fields=Hosts/*&Hosts/host_name.in(%s)";
+
+  private static final String GET_SERVICES_INFO_URI = "/api/v1/stacks/%s/versions/%s/"
+      + "?fields=services/StackServices/service_name,services/StackServices/service_version"
+      + ",services/components/StackServiceComponents,services/components/dependencies/Dependencies/scope"
+      + ",services/components/dependencies/Dependencies/conditions,services/components/auto_deploy"
+      + ",services/configurations/StackConfigurations/property_depends_on"
+      + ",services/configurations/dependencies/StackConfigurationDependency/dependency_name"
+      + ",services/configurations/dependencies/StackConfigurationDependency/dependency_type,services/configurations/StackConfigurations/type"
+      + "&services/StackServices/service_name.in(%s)";
+
+  private static final String SERVICES_PROPERTY = "services";
+  private static final String SERVICES_COMPONENTS_PROPERTY = "components";
+  private static final String STACK_SERVICES_PROPERTY = "StackServices";
+  private static final String COMPONENT_INFO_PROPERTY = "StackServiceComponents";
+  private static final String COMPONENT_MPACK_NAME_PROPERTY = "stack_name";
+  private static final String COMPONENT_NAME_PROPERTY = "component_name";
+  private static final String COMPONENT_HOSTNAMES_PROPERTY = "hostnames";
+  private static final String CONFIGURATIONS_PROPERTY = "configurations";
+  private static final String CHANGED_CONFIGURATIONS_PROPERTY = "changed-configurations";
+  private static final String USER_CONTEXT_PROPERTY = "user-context";
+  private static final String GPL_LICENSE_ACCEPTED = "gpl-license-accepted";
+  private static final String AMBARI_SERVER_PROPERTIES_PROPERTY = "ambari-server-properties";
+  private static final String AMBARI_SERVER_CONFIGURATIONS_PROPERTY = "ambari-server-configuration";
+
+  private File mpackRecommendationsDir;
+  private String recommendationsArtifactsLifetime;
+  private ServiceInfo.ServiceAdvisorType serviceAdvisorType;
+
+  private int requestId;
+  private File mpackRequestDirectory;
+  private MpackAdvisorRunner maRunner;
+
+  protected ObjectMapper mapper;
+
+  private final AmbariMetaInfo metaInfo;
+
+  private final AmbariServerConfigurationHandler ambariServerConfigurationHandler;
+
+  @SuppressWarnings("unchecked")
+  public MpackAdvisorCommand(File mpackmpackRecommendationsDir, String recommendationsArtifactsLifetime, ServiceInfo.ServiceAdvisorType serviceAdvisorType, int requestId,
+                             MpackAdvisorRunner maRunner, AmbariMetaInfo metaInfo, AmbariServerConfigurationHandler ambariServerConfigurationHandler) {
+    this.type = (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass())
+        .getActualTypeArguments()[0];
+
+    this.mapper = new ObjectMapper();
+    this.mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
+
+    this.mpackRecommendationsDir = mpackmpackRecommendationsDir;
+    this.recommendationsArtifactsLifetime = recommendationsArtifactsLifetime;
+    this.serviceAdvisorType = serviceAdvisorType;
+    this.requestId = requestId;
+    this.maRunner = maRunner;
+    this.metaInfo = metaInfo;
+    this.ambariServerConfigurationHandler = ambariServerConfigurationHandler;
+  }
+
+  public ServiceInfo.ServiceAdvisorType getServiceAdvisorType() {
+    return this.serviceAdvisorType;
+  }
+
+  protected abstract MpackAdvisorCommandType getCommandType();
+
+  /**
+   * Simple holder for 'hosts.json' and 'services.json' data.
+   */
+  public static class MpackAdvisorData {
+    protected String hostsJSON;
+    protected String servicesJSON;
+
+    public MpackAdvisorData(String hostsJSON, String servicesJSON) {
+      this.hostsJSON = hostsJSON;
+      this.servicesJSON = servicesJSON;
+    }
+  }
+
+  /**
+   * Name with the result JSON, e.g. "component-layout.json" or "validations.json" .
+   *
+   * @return the file name
+   */
+  protected abstract String getResultFileName();
+
+  protected abstract void validate(MpackAdvisorRequest request) throws MpackAdvisorException;
+
+  protected ObjectNode adjust(String servicesJSON, MpackAdvisorRequest request) {
+    try {
+      ObjectNode root = (ObjectNode) this.mapper.readTree(servicesJSON);
+
+      populateComponentHostsMap(root, request.getComponentHostsMap());
+      populateServiceAdvisors(root);
+      populateConfigurations(root, request);
+      populateAmbariServerInfo(root);
+      populateAmbariConfiguration(root);
+      // Get previous data, if any from data.servicesJSON and append to it.
+      return root;
+    } catch (Exception e) {
+      // should not happen
+      String message = "Error parsing services.json file content: " + e.getMessage();
+      LOG.warn(message, e);
+      throw new WebApplicationException(Response.status(Status.BAD_REQUEST).entity(message).build());
+    }
+  }
+
+  /**
+   * Retrieves the Ambari configuration if exists and adds it to services.json
+   *
+   * @param root The JSON document that will become service.json when passed to the stack advisor engine
+   */
+  void populateAmbariConfiguration(ObjectNode root) throws NoSuchResourceException {
+    Map<String, RootServiceComponentConfiguration> config = ambariServerConfigurationHandler.getConfigurations(null);
+    Map<String, Map<String,String>> result = new HashMap<>();
+    for (String category : config.keySet()) {
+      result.put(category, config.get(category).getProperties());
+    }
+    root.put(AMBARI_SERVER_CONFIGURATIONS_PROPERTY, mapper.valueToTree(result));
+  }
+
+  private void populateConfigurations(ObjectNode root,
+                                      MpackAdvisorRequest request) {
+    Map<String, Map<String, Map<String, String>>> configurations = request.getConfigurations();
+    ObjectNode configurationsNode = root.putObject(CONFIGURATIONS_PROPERTY);
+    for (String siteName : configurations.keySet()) {
+      ObjectNode siteNode = configurationsNode.putObject(siteName);
+
+      Map<String, Map<String, String>> siteMap = configurations.get(siteName);
+      for (String properties : siteMap.keySet()) {
+        ObjectNode propertiesNode = siteNode.putObject(properties);
+
+        Map<String, String> propertiesMap = siteMap.get(properties);
+        for (String propertyName : propertiesMap.keySet()) {
+          String propertyValue = propertiesMap.get(propertyName);
+          propertiesNode.put(propertyName, propertyValue);
+        }
+      }
+    }
+    JsonNode changedConfigs = mapper.valueToTree(request.getChangedConfigurations());
+    root.put(CHANGED_CONFIGURATIONS_PROPERTY, changedConfigs);
+
+    JsonNode userContext = mapper.valueToTree(request.getUserContext());
+    root.put(USER_CONTEXT_PROPERTY, userContext);
+    root.put(GPL_LICENSE_ACCEPTED, request.getGplLicenseAccepted());
+  }
+
+  protected void populateAmbariServerInfo(ObjectNode root) {
+    Map<String, String> serverProperties = metaInfo.getAmbariServerProperties();
+
+    if (serverProperties != null && !serverProperties.isEmpty()) {
+      JsonNode serverPropertiesNode = mapper.convertValue(serverProperties, JsonNode.class);
+      root.put(AMBARI_SERVER_PROPERTIES_PROPERTY, serverPropertiesNode);
+    }
+  }
+
+  private void populateComponentHostsMap(ObjectNode root, Map<String, Map<String, Set<String>>> mpacksToComponentsHostsMap) {
+    ArrayNode services = (ArrayNode) root.get(SERVICES_PROPERTY);
+    Iterator<JsonNode> servicesIter = services.getElements();
+
+    while (servicesIter.hasNext()) {
+      JsonNode service = servicesIter.next();
+      ArrayNode components = (ArrayNode) service.get(SERVICES_COMPONENTS_PROPERTY);
+      Iterator<JsonNode> componentsIter = components.getElements();
+
+      while (componentsIter.hasNext()) {
+        JsonNode component = componentsIter.next();
+        ObjectNode componentInfo = (ObjectNode) component.get(COMPONENT_INFO_PROPERTY);
+        String componentMpackName = componentInfo.get(COMPONENT_MPACK_NAME_PROPERTY).getTextValue();
+        String componentName = componentInfo.get(COMPONENT_NAME_PROPERTY).getTextValue();
+
+        Map<String, Set<String>> mpackComponentsHostMap = mpacksToComponentsHostsMap.get(componentMpackName);
+        ArrayNode hostnames = componentInfo.putArray(COMPONENT_HOSTNAMES_PROPERTY);
+        if (mpackComponentsHostMap != null) {
+          Set<String> componentHosts = mpackComponentsHostMap.get(componentName);
+          if (null != componentHosts) {
+            for (String hostName : componentHosts) {
+              hostnames.add(hostName);
+            }
+          }
+        } else {
+          LOG.info("Mpack Instance : "+componentMpackName+"'s componentsHost Map is empty.");
+        }
+      }
+    }
+  }
+
+  private void populateServiceAdvisors(ObjectNode root) {
+    ArrayNode services = (ArrayNode) root.get(SERVICES_PROPERTY);
+    Iterator<JsonNode> servicesIter = services.getElements();
+
+    ObjectNode version = (ObjectNode) root.get("Versions");
+    String stackName = version.get("stack_name").asText();
+    String stackVersion = version.get("stack_version").asText();
+
+    while (servicesIter.hasNext()) {
+      JsonNode service = servicesIter.next();
+      ObjectNode serviceVersion = (ObjectNode) service.get(STACK_SERVICES_PROPERTY);
+      String serviceName = serviceVersion.get("service_name").getTextValue();
+      try {
+        ServiceInfo serviceInfo = metaInfo.getService(stackName, stackVersion, serviceName);
+        if (serviceInfo.getAdvisorFile() != null) {
+          serviceVersion.put("advisor_name", serviceInfo.getAdvisorName());
+          serviceVersion.put("advisor_path", serviceInfo.getAdvisorFile().getAbsolutePath());
+        }
+      }
+      catch (Exception e) {
+        LOG.error("Error adding service advisor information to services.json", e);
+      }
+    }
+  }
+
+  public synchronized T invoke(MpackAdvisorRequest request) throws MpackAdvisorException {
+    validate(request);
+    String hostsJSON = getHostsInformation(request);
+    MpackAdvisorData updatedMpackServicesData = getServicesInformation(request, hostsJSON);
+
+    try {
+      createRequestDirectory();
+
+      FileUtils.writeStringToFile(new File(mpackRequestDirectory, "hosts.json"), updatedMpackServicesData.hostsJSON);
+      FileUtils.writeStringToFile(new File(mpackRequestDirectory, "services.json"), updatedMpackServicesData.servicesJSON);
+
+      maRunner.runScript(serviceAdvisorType, getCommandType(), mpackRequestDirectory);
+      String result = FileUtils.readFileToString(new File(mpackRequestDirectory, getResultFileName()));
+
+      T response = this.mapper.readValue(result, this.type);
+      return updateResponse(request, setRequestId(response));
+    } catch (MpackAdvisorException ex) {
+      throw ex;
+    } catch (Exception e) {
+      String message = "Error occured during mpack advisor command invocation: ";
+      LOG.warn(message, e);
+      throw new MpackAdvisorException(message + e.getMessage());
+    }
+  }
+
+  protected abstract T updateResponse(MpackAdvisorRequest request, T response);
+
+  private T setRequestId(T response) {
+    response.setId(requestId);
+    return response;
+  }
+
+  /**
+   * Create request id directory for each call
+   */
+  private void createRequestDirectory() throws IOException {
+    if (!mpackRecommendationsDir.exists()) {
+      if (!mpackRecommendationsDir.mkdirs()) {
+        throw new IOException("Cannot create " + mpackRecommendationsDir);
+      }
+    }
+
+    cleanupRequestDirectory();
+
+    mpackRequestDirectory = new File(mpackRecommendationsDir, Integer.toString(requestId));
+
+    if (mpackRequestDirectory.exists()) {
+      FileUtils.deleteDirectory(mpackRequestDirectory);
+    }
+    if (!mpackRequestDirectory.mkdirs()) {
+      throw new IOException("Cannot create " + mpackRequestDirectory);
+    }
+  }
+
+  /**
+   * Deletes folders older than (now - recommendationsArtifactsLifetime)
+   */
+  private void cleanupRequestDirectory() throws IOException {
+    final Date cutoffDate = DateUtils.getDateSpecifiedTimeAgo(recommendationsArtifactsLifetime); // subdirectories older than this date will be deleted
+
+    String[] oldDirectories = mpackRecommendationsDir.list(new FilenameFilter() {
+      @Override
+      public boolean accept(File current, String name) {
+        File file = new File(current, name);
+        return file.isDirectory() && !FileUtils.isFileNewer(file, cutoffDate);
+      }
+    });
+
+    if(oldDirectories.length > 0) {
+      LOG.info(String.format("Deleting old directories %s from %s", StringUtils.join(oldDirectories, ", "), mpackRecommendationsDir));
+    }
+
+    for(String oldDirectory:oldDirectories) {
+      FileUtils.deleteQuietly(new File(mpackRecommendationsDir, oldDirectory));
+    }
+  }
+
+  String getHostsInformation(MpackAdvisorRequest request) throws MpackAdvisorException {
+    String hostsURI = String.format(GET_HOSTS_INFO_URI, request.getHostsCommaSeparated());
+
+    Response response = handleRequest(null, null, new LocalUriInfo(hostsURI), Request.Type.GET,
+        createHostResource());
+
+    if (response.getStatus() != Status.OK.getStatusCode()) {
+      String message = String.format(
+          "Error occured during hosts information retrieving, status=%s, response=%s",
+          response.getStatus(), (String) response.getEntity());
+      LOG.warn(message);
+      throw new MpackAdvisorException(message);
+    }
+
+    String hostsJSON = (String) response.getEntity();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Hosts information: {}", hostsJSON);
+    }
+
+    Collection<String> unregistered = getUnregisteredHosts(hostsJSON, request.getHosts());
+    if (unregistered.size() > 0) {
+      String message = String.format("There are unregistered hosts in the request, %s",
+          Arrays.toString(unregistered.toArray()));
+      LOG.warn(message);
+      throw new MpackAdvisorException(message);
+    }
+
+    return hostsJSON;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Collection<String> getUnregisteredHosts(String hostsJSON, List<String> hosts)
+      throws MpackAdvisorException {
+    ObjectMapper mapper = new ObjectMapper();
+    List<String> registeredHosts = new ArrayList<>();
+
+    try {
+      JsonNode root = mapper.readTree(hostsJSON);
+      Iterator<JsonNode> iterator = root.get("items").getElements();
+      while (iterator.hasNext()) {
+        JsonNode next = iterator.next();
+        String hostName = next.get("Hosts").get("host_name").getTextValue();
+        registeredHosts.add(hostName);
+      }
+
+      return CollectionUtils.subtract(hosts, registeredHosts);
+    } catch (Exception e) {
+      throw new MpackAdvisorException("Error occured during calculating unregistered hosts", e);
+    }
+  }
+
+  /*
+   Gets the updated Services information across Mpacks passed-in.
+   It does the following:
+    - Iterates through all the passed-in Mpacks instances (eg: HDPCORE-MKG), fetches their Stack Information.
+    - For each Mpack instance Type (eg: HDPCORE), makes call to its Stack API, and gathers the stack's static information (dependencies etc.)
+    - Calls adjust() function, which updates the services related information.
+    - Maintains a global ArrayNode across Mpack Instances 'updatedServicesAcrossMpacks' to keep the updated Service Array Nodes across Mpacks.
+      (Reason : We want to write services.json with 'services' element, having array of service instances across Mpacks together, to maintain
+      Python Stack Advisor compatibility.)
+   */
+  MpackAdvisorData getServicesInformation(MpackAdvisorRequest request, String hostsJSON) throws MpackAdvisorException {
+
+    Collection<MpackInstance> mpackInstances = request.getMpackInstances();
+    String servicesInfoFromMpack = null;
+    MpackAdvisorData updatedMpackAdvisorData = new MpackAdvisorData(hostsJSON, null);
+
+    // Maintains the updated Services Across mpacks as we iterate.
+    ArrayNode updatedServicesAcrossMpacks = mapper.createArrayNode();
+
+    // Maintains the updated Services in a given mpack, as we iterate which we add to 'updatedServicesAcrossMpacks'.
+    ObjectNode updatedServicesInfoForMpack = mapper.createObjectNode();
+
+    for (MpackInstance mpackInstance : mpackInstances) {
+      String stackType = mpackInstance.getMpackType();
+      String stackVersion = mpackInstance.getMpackVersion();
+      String servicesURI = String.format(GET_SERVICES_INFO_URI, stackType, stackVersion,
+          request.getMpackServiceInstanceTypeCommaSeparated(mpackInstance));
+
+      Response response = handleRequest(null, null, new LocalUriInfo(servicesURI),
+          Request.Type.GET, createStackVersionResource(stackType, stackVersion));
+
+      servicesInfoFromMpack = (String) response.getEntity();
+      if (response.getStatus() != Status.OK.getStatusCode()) {
+        String message = String.format(
+            "Error occured during services information retrieving, status=%s, response=%s",
+            response.getStatus(), (String) response.getEntity());
+        LOG.warn(message);
+        throw new MpackAdvisorException(message);
+      }
+
+      updatedServicesInfoForMpack = adjust(servicesInfoFromMpack, request);
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Services information: {}", servicesInfoFromMpack);
+      }
+
+      for (Iterator<JsonNode> svcInstanceItr = updatedServicesInfoForMpack.get("services").getElements(); svcInstanceItr.hasNext(); ) {
+        updatedServicesAcrossMpacks.add(svcInstanceItr.next());
+      }
+    }
+
+    // Preparing the return object as follows:
+    updatedServicesInfoForMpack.put("services", updatedServicesAcrossMpacks);
+    updatedServicesInfoForMpack.remove("Versions");
+    updatedServicesInfoForMpack.remove("href");
+
+    try {
+      updatedMpackAdvisorData.servicesJSON = mapper.writeValueAsString(updatedServicesInfoForMpack);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return updatedMpackAdvisorData;
+  }
+
+  private ResourceInstance createHostResource() {
+    Map<Resource.Type, String> mapIds = new HashMap<>();
+    return createResource(Resource.Type.Host, mapIds);
+  }
+
+  private ResourceInstance createConfigResource() {
+    Map<Resource.Type, String> mapIds = new HashMap<>();
+    mapIds.put(Resource.Type.RootService, RootService.AMBARI.name());
+    mapIds.put(Resource.Type.RootServiceComponent, RootComponent.AMBARI_SERVER.name());
+
+    return createResource(Resource.Type.RootServiceComponentConfiguration, mapIds);
+  }
+
+  private ResourceInstance createStackVersionResource(String stackName, String stackVersion) {
+    Map<Resource.Type, String> mapIds = new HashMap<>();
+    mapIds.put(Resource.Type.Stack, stackName);
+    mapIds.put(Resource.Type.StackVersion, stackVersion);
+
+    return createResource(Resource.Type.StackVersion, mapIds);
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackAdvisorCommandType.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackAdvisorCommandType.java
@@ -1,0 +1,49 @@
+package org.apache.ambari.server.api.services.mpackadvisor.commands;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * MpackAdvisorCommand types enumeration.
+ */
+public enum MpackAdvisorCommandType {
+
+  RECOMMEND_COMPONENT_LAYOUT("recommend-component-layout"),
+
+  VALIDATE_COMPONENT_LAYOUT("validate-component-layout"),
+
+  RECOMMEND_CONFIGURATIONS("recommend-configurations"),
+
+  RECOMMEND_CONFIGURATIONS_FOR_SSO("recommend-configurations-for-sso"),
+
+  RECOMMEND_CONFIGURATION_DEPENDENCIES("recommend-configuration-dependencies"),
+
+  VALIDATE_CONFIGURATIONS("validate-configurations");
+
+  private final String name;
+
+  MpackAdvisorCommandType(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}
+

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackComponentLayoutRecommendationCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackComponentLayoutRecommendationCommand.java
@@ -1,0 +1,82 @@
+package org.apache.ambari.server.api.services.mpackadvisor.commands;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRunner;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+
+/**
+ * {@link org.apache.ambari.server.api.services.mpackadvisor.commands.MpackAdvisorCommand} implementation for component-layout
+ * recommendation.
+ */
+public class MpackComponentLayoutRecommendationCommand extends
+    MpackAdvisorCommand<MpackRecommendationResponse> {
+
+  public MpackComponentLayoutRecommendationCommand(File recommendationsDir,
+                                              String recommendationsArtifactsLifetime,
+                                              ServiceInfo.ServiceAdvisorType serviceAdvisorType,
+                                              int requestId,
+                                              MpackAdvisorRunner maRunner,
+                                              AmbariMetaInfo metaInfo,
+                                              AmbariServerConfigurationHandler ambariServerConfigurationHandler) {
+    super(recommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType, requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+  }
+
+  @Override
+  protected MpackAdvisorCommandType getCommandType() {
+    return MpackAdvisorCommandType.RECOMMEND_COMPONENT_LAYOUT;
+  }
+
+  @Override
+  protected void validate(MpackAdvisorRequest request) throws MpackAdvisorException {
+    if (request.getHosts() == null || request.getHosts().isEmpty()) {
+      throw new MpackAdvisorException("Hosts must not be empty");
+    }
+
+    if (request.getMpackInstances() != null || !request.getMpackInstances().isEmpty()) {
+      for (MpackInstance mpackInstance : request.getMpackInstances()) {
+        if (mpackInstance.getServiceInstances() == null || mpackInstance.getServiceInstances().isEmpty()) {
+          throw new MpackAdvisorException("Service instances for Mpack Instance " + mpackInstance.getMpackName()
+              + " is empty.");
+        }
+      }
+    } else {
+      throw new MpackAdvisorException("Request's Mpack instances is null or empty.");
+    }
+  }
+
+  @Override
+  protected MpackRecommendationResponse updateResponse(MpackAdvisorRequest request, MpackRecommendationResponse response) {
+    return response;
+  }
+
+  @Override
+  protected String getResultFileName() {
+    return "component-layout.json";
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackComponentLayoutValidationCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackComponentLayoutValidationCommand.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor.commands;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRunner;
+import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+
+/**
+ * {@link MpackAdvisorCommand} implementation for component-layout validation.
+ */
+public class MpackComponentLayoutValidationCommand extends MpackAdvisorCommand<MpackValidationResponse> {
+
+  public MpackComponentLayoutValidationCommand(File recommendationsDir,
+                                          String recommendationsArtifactsLifetime,
+                                          ServiceInfo.ServiceAdvisorType serviceAdvisorType,
+                                          int requestId,
+                                          MpackAdvisorRunner maRunner,
+                                          AmbariMetaInfo metaInfo,
+                                          AmbariServerConfigurationHandler ambariServerConfigurationHandler) {
+    super(recommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType, requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+  }
+
+  @Override
+  protected MpackAdvisorCommandType getCommandType() {
+    return MpackAdvisorCommandType.VALIDATE_COMPONENT_LAYOUT;
+  }
+
+  @Override
+  protected void validate(MpackAdvisorRequest request) throws MpackAdvisorException {
+    if (request.getHosts() == null || request.getHosts().isEmpty() ) {
+      throw new MpackAdvisorException("Hosts must not be empty");
+    }
+
+    // Check Mpacks and its service Instances
+    Collection<MpackInstance> mpackInstances = request.getMpackInstances();
+    if (mpackInstances == null || mpackInstances.isEmpty()) {
+      throw new MpackAdvisorException("MpackInstances must not be empty");
+    }
+
+    for (MpackInstance mpackInstance : mpackInstances) {
+      if (mpackInstance.getServiceInstances() == null || mpackInstance.getServiceInstances().isEmpty()) {
+        throw new MpackAdvisorException("MpackInstance " + mpackInstance.getMpackName() + " service Instances must not be empty");
+      }
+    }
+  }
+
+  @Override
+  protected MpackValidationResponse updateResponse(MpackAdvisorRequest request, MpackValidationResponse response) {
+    return response;
+  }
+
+  @Override
+  protected String getResultFileName() {
+    return "component-layout-validation.json";
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/recommendations/MpackRecommendationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/recommendations/MpackRecommendationResponse.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor.recommendations;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorResponse;
+import org.apache.ambari.server.state.ValueAttributesInfo;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+/**
+ * Recommendation response POJO.
+ */
+public class MpackRecommendationResponse extends MpackAdvisorResponse {
+
+  @JsonProperty
+  private Set<String> hosts;
+
+  @JsonProperty
+  private Set<String> services;
+
+  @JsonProperty
+  private Recommendation recommendations;
+
+  public Set<String> getHosts() {
+    return hosts;
+  }
+
+  public void setHosts(Set<String> hosts) {
+    this.hosts = hosts;
+  }
+
+  public Set<String> getServices() {
+    return services;
+  }
+
+  public void setServices(Set<String> services) {
+    this.services = services;
+  }
+
+  public Recommendation getRecommendations() {
+    return recommendations;
+  }
+
+  public void setRecommendations(Recommendation recommendations) {
+    this.recommendations = recommendations;
+  }
+
+  public static class Recommendation {
+    @JsonProperty
+    private Blueprint blueprint;
+
+    @JsonProperty("blueprint_cluster_binding")
+    private BlueprintClusterBinding blueprintClusterBinding;
+
+    @JsonProperty("config-groups")
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    private Set<ConfigGroup> configGroups;
+
+    public Blueprint getBlueprint() {
+      return blueprint;
+    }
+
+    public void setBlueprint(Blueprint blueprint) {
+      this.blueprint = blueprint;
+    }
+
+    public BlueprintClusterBinding getBlueprintClusterBinding() {
+      return blueprintClusterBinding;
+    }
+
+    public void setBlueprintClusterBinding(BlueprintClusterBinding blueprintClusterBinding) {
+      this.blueprintClusterBinding = blueprintClusterBinding;
+    }
+
+    public Set<ConfigGroup> getConfigGroups() {
+      return configGroups;
+    }
+
+    public void setConfigGroups(Set<ConfigGroup> configGroups) {
+      this.configGroups = configGroups;
+    }
+  }
+
+  public static class Blueprint {
+    @JsonProperty
+    private Map<String, BlueprintConfigurations> configurations;
+
+    @JsonProperty("host_groups")
+    private Set<HostGroup> hostGroups;
+
+    public Map<String, BlueprintConfigurations> getConfigurations() {
+      return configurations;
+    }
+
+    public void setConfigurations(Map<String, BlueprintConfigurations> configurations) {
+      this.configurations = configurations;
+    }
+
+    public Set<HostGroup> getHostGroups() {
+      return hostGroups;
+    }
+
+    public void setHostGroups(Set<HostGroup> hostGroups) {
+      this.hostGroups = hostGroups;
+    }
+  }
+
+  public static class BlueprintConfigurations {
+    @JsonProperty
+    private final Map<String, String> properties = new HashMap<>();
+
+    @JsonProperty("property_attributes")
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    private Map<String, ValueAttributesInfo> propertyAttributes = null;
+
+    public BlueprintConfigurations() {
+
+    }
+
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+
+    /**
+     * Returns a map of properties for this configuration.
+     * <p/>
+     * It is expected that a non-null value is always returned.
+     *
+     * @param properties a map of properties, always non-null
+     */
+    public void setProperties(Map<String, String> properties) {
+      this.properties.clear();
+      if(properties != null) {
+        this.properties.putAll(properties);
+      }
+    }
+
+    public Map<String, ValueAttributesInfo> getPropertyAttributes() {
+      return propertyAttributes;
+    }
+
+    public void setPropertyAttributes(Map<String, ValueAttributesInfo> propertyAttributes) {
+      this.propertyAttributes = propertyAttributes;
+    }
+  }
+
+  public static class HostGroup {
+    @JsonProperty //("name")
+    private String name;
+
+    @JsonProperty
+    private Set<Map<String, String>> components;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public Set<Map<String, String>> getComponents() {
+      return components;
+    }
+
+    public void setComponents(Set<Map<String, String>> components) {
+      this.components = components;
+    }
+  }
+
+  public static class BlueprintClusterBinding {
+    @JsonProperty("host_groups")
+    private Set<BindingHostGroup> hostGroups;
+
+    public Set<BindingHostGroup> getHostGroups() {
+      return hostGroups;
+    }
+
+    public void setHostGroups(Set<BindingHostGroup> hostGroups) {
+      this.hostGroups = hostGroups;
+    }
+  }
+
+  public static class BindingHostGroup {
+    @JsonProperty
+    private String name;
+
+    @JsonProperty
+    private Set<Map<String, String>> hosts;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public Set<Map<String, String>> getHosts() {
+      return hosts;
+    }
+
+    public void setHosts(Set<Map<String, String>> hosts) {
+      this.hosts = hosts;
+    }
+  }
+
+  public static class ConfigGroup {
+
+    @JsonProperty
+    private List<String> hosts;
+
+    @JsonProperty
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    private Map<String, BlueprintConfigurations> configurations =
+        new HashMap<>();
+
+    @JsonProperty("dependent_configurations")
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    private Map<String, BlueprintConfigurations> dependentConfigurations =
+        new HashMap<>();
+
+    public ConfigGroup() {
+
+    }
+
+    public List<String> getHosts() {
+      return hosts;
+    }
+
+    public void setHosts(List<String> hosts) {
+      this.hosts = hosts;
+    }
+
+    public Map<String, BlueprintConfigurations> getConfigurations() {
+      return configurations;
+    }
+
+    public void setConfigurations(Map<String, BlueprintConfigurations> configurations) {
+      this.configurations = configurations;
+    }
+
+    public Map<String, BlueprintConfigurations> getDependentConfigurations() {
+      return dependentConfigurations;
+    }
+
+    public void setDependentConfigurations(Map<String, BlueprintConfigurations> dependentConfigurations) {
+      this.dependentConfigurations = dependentConfigurations;
+    }
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/validations/MpackValidationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/validations/MpackValidationResponse.java
@@ -1,0 +1,143 @@
+package org.apache.ambari.server.api.services.mpackadvisor.validations;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Set;
+
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorResponse;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Validation response POJO.
+ */
+public class MpackValidationResponse extends MpackAdvisorResponse {
+
+  @JsonProperty
+  private Set<org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem> items;
+
+  public Set<org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem> getItems() {
+    return items;
+  }
+
+  public void setItems(Set<org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem> items) {
+    this.items = items;
+  }
+
+  public static class ValidationItem {
+    @JsonProperty
+    private String type;
+
+    @JsonProperty
+    private String level;
+
+    @JsonProperty
+    private String message;
+
+    @JsonProperty("mpack-name")
+    private String mpackName;
+
+    @JsonProperty("mpack-version")
+    private String mpackVersion;
+
+    @JsonProperty("component-name")
+    private String componentName;
+
+    @JsonProperty
+    private String host;
+
+    @JsonProperty("config-type")
+    private String configType;
+
+    @JsonProperty("config-name")
+    private String configName;
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getLevel() {
+      return level;
+    }
+
+    public void setLevel(String level) {
+      this.level = level;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
+    }
+
+    public String getMpackName() {
+      return mpackName;
+    }
+
+    public void setMpackName(String mpackName) {
+      this.mpackName = mpackName;
+    }
+
+    public String getMpackVersion() {
+      return mpackVersion;
+    }
+
+    public void setMpackVersion(String mpackVersion) {
+      this.mpackVersion = mpackVersion;
+    }
+
+    public String getComponentName() {
+      return componentName;
+    }
+
+    public void setComponentName(String componentName) {
+      this.componentName = componentName;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public void setHost(String host) {
+      this.host = host;
+    }
+
+    public String getConfigType() {
+      return configType;
+    }
+
+    public void setConfigType(String configType) {
+      this.configType = configType;
+    }
+
+    public String getConfigName() {
+      return configName;
+    }
+
+    public void setConfigName(String configName) {
+      this.configName = configName;
+    }
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -427,6 +427,14 @@ public class Configuration {
       "recommendations.dir", AmbariPath.getPath("/var/run/ambari-server/stack-recommendations"));
 
   /**
+   * The directory on the Ambari Server file system used for storing
+   * Mpack Recommendation API artifacts.
+   */
+  @Markdown(description = "The directory on the Ambari Server file system used for storing Mpack Recommendation API artifacts.")
+  public static final ConfigurationProperty<String> MPACK_RECOMMENDATIONS_DIR = new ConfigurationProperty<>(
+      "mpackrecommendations.dir", AmbariPath.getPath("/var/run/ambari-server/mpack-recommendations"));
+
+  /**
    * The location and name of the Python stack advisor script executed when
    * configuring services.
    */
@@ -434,6 +442,15 @@ public class Configuration {
   public static final ConfigurationProperty<String> STACK_ADVISOR_SCRIPT = new ConfigurationProperty<>(
       "stackadvisor.script",
       AmbariPath.getPath("/var/lib/ambari-server/resources/scripts/stack_advisor.py"));
+
+  /**
+   * The location and name of the Python mpack advisor script executed when
+   * configuring services.
+   */
+  @Markdown(description = "The location and name of the Python stack advisor script executed when configuring services.")
+  public static final ConfigurationProperty<String> MPACK_ADVISOR_SCRIPT = new ConfigurationProperty<>(
+      "mpackadvisor.script",
+      AmbariPath.getPath("/var/lib/ambari-server/resources/scripts/mpack_advisor_wrapper.py"));
 
   /**
    * The name of the shell script used to wrap all invocations of Python by Ambari.
@@ -3314,6 +3331,11 @@ public class Configuration {
     return new File(fileName);
   }
 
+  public File getMpackRecommendationsDir() {
+    String fileName = getProperty(MPACK_RECOMMENDATIONS_DIR);
+    return new File(fileName);
+  }
+
   public String getRecommendationsArtifactsLifetime() {
     return getProperty(RECOMMENDATIONS_ARTIFACTS_LIFETIME);
   }
@@ -3342,6 +3364,10 @@ public class Configuration {
 
   public String getStackAdvisorScript() {
     return getProperty(STACK_ADVISOR_SCRIPT);
+  }
+
+  public String getMpackAdvisorScript() {
+    return getProperty(MPACK_ADVISOR_SCRIPT);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -53,6 +53,7 @@ import org.apache.ambari.server.api.services.BaseService;
 import org.apache.ambari.server.api.services.KeyService;
 import org.apache.ambari.server.api.services.PersistKeyValueImpl;
 import org.apache.ambari.server.api.services.PersistKeyValueService;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorHelper;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorBlueprintProcessor;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
 import org.apache.ambari.server.audit.AuditLoggerModule;
@@ -71,6 +72,7 @@ import org.apache.ambari.server.controller.internal.BaseClusterRequest;
 import org.apache.ambari.server.controller.internal.ClusterPrivilegeResourceProvider;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.HostResourceProvider;
+import org.apache.ambari.server.controller.internal.MpackAdvisorResourceProvider;
 import org.apache.ambari.server.controller.internal.PermissionResourceProvider;
 import org.apache.ambari.server.controller.internal.PrivilegeResourceProvider;
 import org.apache.ambari.server.controller.internal.RegistryAdvisorResourceProvider;
@@ -911,6 +913,8 @@ public class AmbariServer {
     BootStrapResource.init(injector.getInstance(BootStrapImpl.class));
     StackAdvisorResourceProvider.init(injector.getInstance(StackAdvisorHelper.class),
             injector.getInstance(Configuration.class));
+    MpackAdvisorResourceProvider.init(injector.getInstance(MpackAdvisorHelper.class),
+        injector.getInstance(Configuration.class));
     RegistryAdvisorResourceProvider.init(injector.getInstance(RegistryAdvisor.class));
 
     StageUtils.setGson(injector.getInstance(Gson.class));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractControllerResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AbstractControllerResourceProvider.java
@@ -225,8 +225,12 @@ public abstract class AbstractControllerResourceProvider extends AbstractAuthori
         return resourceProviderFactory.getBlueprintResourceProvider(managementController);
       case KerberosDescriptor:
         return resourceProviderFactory.getKerberosDescriptorResourceProvider(managementController);
+      case MpackRecommendation:
+        return new MpackRecommendationResourceProvider(managementController);
       case Recommendation:
         return new RecommendationResourceProvider(managementController);
+      case MpackValidation:
+        return new MpackValidationResourceProvider(managementController);
       case Validation:
         return new ValidationResourceProvider(managementController);
       case ClientConfig:

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackAdvisorResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackAdvisorResourceProvider.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorHelper;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest.MpackAdvisorRequestBuilder;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest.MpackAdvisorRequestType;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse.HostGroup;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.spi.Request;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.controller.spi.Resource.Type;
+import org.apache.ambari.server.state.ChangedConfigInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+import org.apache.ambari.server.topology.ServiceInstance;
+import org.apache.commons.collections.bag.HashBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+
+/**
+ * Abstract superclass for recommendations and validations.
+ */
+public abstract class MpackAdvisorResourceProvider extends ReadOnlyResourceProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StackAdvisorResourceProvider.class);
+
+  private static final String HOST_PROPERTY = "hosts";
+  private static final String RECOMMENDATIONS_PROPERTY = "recommendations";
+  private static final String BLUEPRINT_PROPERTY = "blueprint";
+
+  private static final String BLUEPRINT_MPACK_INSTANCES_PROPERTY = RECOMMENDATIONS_PROPERTY + "/" + BLUEPRINT_PROPERTY + "/mpack_instances";
+  private static final String BLUEPRINT_MPACK_INSTANCES_NAME_PROPERTY = "name";
+  private static final String BLUEPRINT_MPACK_INSTANCES_TYPE_PROPERTY = "type";
+  private static final String BLUEPRINT_MPACK_INSTANCES_VERSION_PROPERTY = "version";
+
+  // Service Instances related
+  private static final String MPACK_SERVICE_INSTANCES_PROPERTY = "service_instances";
+  private static final String MPACK_SERVICE_INSTANCE_NAME_PROPERTY = "name";
+  private static final String MPACK_SERVICE_INSTANCE_TYPE_PROPERTY = "type";
+
+  // Blueprint -> host-group related
+  private static final String BLUEPRINT_HOST_GROUPS_PROPERTY = RECOMMENDATIONS_PROPERTY + "/" + BLUEPRINT_PROPERTY + "/host_groups";
+
+  private static final String BLUEPRINT_HOST_GROUPS_NAME_PROPERTY = "name";
+  private static final String BLUEPRINT_HOST_GROUPS_COMPONENTS_PROPERTY = "components";
+  private static final String BLUEPRINT_HOST_GROUPS_COMPONENTS_NAME_PROPERTY = "name";
+  private static final String BLUEPRINT_HOST_GROUPS_COMPONENTS_MPACK_INSTANCE_PROPERTY = "mpack_instance";
+  private static final String BLUEPRINT_HOST_GROUPS_COMPONENTS_SERVICE_INSTANCE_PROPERTY = "service_instance";
+
+  private static final String CHANGED_CONFIGURATIONS_PROPERTY = "changed_configurations";
+  private static final String OPERATION_PROPERTY = "operation";
+  private static final String OPERATION_DETAILS_PROPERTY = "operation_details";
+
+  // Blueprint -> blueprint_cluster_binding related
+  private static final String BLUEPRINT_CLUSTER_BINDING_PROPERTY = "blueprint_cluster_binding";
+  private static final String BINDING_HOST_GROUPS_PROPERTY = RECOMMENDATIONS_PROPERTY + "/" + BLUEPRINT_CLUSTER_BINDING_PROPERTY + "/host_groups";
+  private static final String BINDING_HOST_GROUPS_NAME_PROPERTY = "name";
+  private static final String BINDING_HOST_GROUPS_HOSTS_PROPERTY = "hosts";
+  private static final String BINDING_HOST_GROUPS_HOSTS_NAME_PROPERTY = "fqdn";
+
+  protected static final String USER_CONTEXT_OPERATION_PROPERTY = "user_context/operation";
+  protected static final String USER_CONTEXT_OPERATION_DETAILS_PROPERTY = "user_context/operation_details";
+
+  protected static Configuration configuration;
+  protected static MpackAdvisorHelper maHelper;
+
+  @Inject
+  public static void init(MpackAdvisorHelper instance, Configuration serverConfig) {
+    maHelper = instance;
+    configuration = serverConfig;
+  }
+
+  protected MpackAdvisorResourceProvider(Resource.Type type, Set<String> propertyIds, Map<Type, String> keyPropertyIds,
+                                         AmbariManagementController managementController) {
+    super(type, propertyIds, keyPropertyIds, managementController);
+  }
+
+  protected abstract String getRequestTypePropertyId();
+
+  @SuppressWarnings("unchecked")
+  protected MpackAdvisorRequest prepareMpackAdvisorRequest(Request request) {
+    try {
+      MpackAdvisorRequestType requestType = MpackAdvisorRequestType
+          .fromString((String) getRequestProperty(request, getRequestTypePropertyId()));
+
+      /*
+       * ClassCastException will occur if hosts or services are empty in the
+       * request.
+       *
+       * @see JsonRequestBodyParser for arrays parsing
+       */
+
+      // Hosts Related parsing
+      Object hostsObject = getRequestProperty(request, HOST_PROPERTY);
+      if (hostsObject instanceof LinkedHashSet) {
+        if (((LinkedHashSet)hostsObject).isEmpty()) {
+          throw new Exception("Empty host list passed to recommendation service");
+        }
+      }
+      List<String> hosts = (List<String>) hostsObject;
+
+      Collection<MpackInstance> mpackInstances = parseMpackInstances(request);
+      Collection<HostGroup> hgCompMap = prepareHostGroupComponentsMap(request);
+      Map<String, Set<String>> hgHostsMap = calculateHostGroupHostsMap(request);
+      Map<String, Map<String, Set<String>>> mpacksToComponentsHostsMap = populateComponentHostsMap(hgCompMap, hgHostsMap);
+      Map<String, Map<String, Map<String, String>>> configurations = calculateConfigurations(request);
+      Map<String, String> userContext = readUserContext(request);
+      Boolean gplLicenseAccepted = configuration.getGplLicenseAccepted();
+
+      List<ChangedConfigInfo> changedConfigurations =
+          requestType == MpackAdvisorRequest.MpackAdvisorRequestType.CONFIGURATION_DEPENDENCIES ?
+              calculateChangedConfigurations(request) : Collections.emptyList();
+
+      return MpackAdvisorRequestBuilder.
+          forStack().
+          ofType(requestType).
+          forHosts(hosts).
+          forMpackInstances(mpackInstances).
+          forComponentHostsMap(hgCompMap).
+          forHostsGroupBindings(hgHostsMap).
+          withMpacksToComponentsHostsMap(mpacksToComponentsHostsMap).
+          withConfigurations(configurations).
+          withChangedConfigurations(changedConfigurations).
+          withUserContext(userContext).
+          withGPLLicenseAccepted(gplLicenseAccepted).
+          build();
+    } catch (Exception e) {
+      LOG.warn("Error occurred during preparation of stack advisor request", e);
+      Response response = Response.status(Status.BAD_REQUEST)
+          .entity(String.format("Request body is not correct, error: %s", e.getMessage())).build();
+      throw new WebApplicationException(response);
+    }
+  }
+
+  private Collection<MpackInstance> parseMpackInstances(Request request) {
+    Collection<MpackInstance> mpackInstancesBag = new HashBag();
+    Set<Map<String, Object>> reqMpackInstances = (Set<Map<String, Object>>) getRequestProperty(
+        request, BLUEPRINT_MPACK_INSTANCES_PROPERTY);
+    if (reqMpackInstances != null) {
+      for (Map<String, Object> reqMpackInstance : reqMpackInstances) {
+        String mpackName = (String) reqMpackInstance.get(BLUEPRINT_MPACK_INSTANCES_NAME_PROPERTY);
+        String mpackType = (String) reqMpackInstance.get(BLUEPRINT_MPACK_INSTANCES_TYPE_PROPERTY);
+        String mpackVersion = (String) reqMpackInstance.get(BLUEPRINT_MPACK_INSTANCES_VERSION_PROPERTY);
+
+        Collection<ServiceInstance> serviceInstances = new HashBag();
+        Set<Map<String, Object>> reqServiceInstances =
+            (Set<Map<String, Object>>) reqMpackInstance.get(MPACK_SERVICE_INSTANCES_PROPERTY);
+        for (Map<String, Object> instance : reqServiceInstances) {
+          ServiceInstance serviceInstance = new ServiceInstance();
+          serviceInstance.setName((String) instance.get(MPACK_SERVICE_INSTANCE_NAME_PROPERTY));
+          serviceInstance.setType((String) instance.get(MPACK_SERVICE_INSTANCE_TYPE_PROPERTY));
+          // If type is not provided, set it to Name.
+          if (serviceInstance.getType() == null) {
+            serviceInstance.setType(serviceInstance.getName());
+          }
+          serviceInstances.add(serviceInstance);
+        }
+        // Update mpackInstancesBag
+        mpackInstancesBag.add(new MpackInstance(mpackName, mpackType, mpackVersion ,serviceInstances));
+      }
+    }
+    return mpackInstancesBag;
+  }
+
+  /**
+   * Will prepare host-group names to components names map from the
+   * recommendation blueprint host groups.
+   *
+   * @param request mpack advisor request
+   * @return host-group to components map
+   */
+  @SuppressWarnings("unchecked")
+  private Collection<HostGroup> prepareHostGroupComponentsMap(Request request) {
+    Set<Map<String, Object>> hostGroups = (Set<Map<String, Object>>) getRequestProperty(request,
+        BLUEPRINT_HOST_GROUPS_PROPERTY);
+
+    Collection<HostGroup> hgCompMap = new HashBag();
+    if (hostGroups != null) {
+      for (Map<String, Object> hostGroup : hostGroups) {
+        String hostGroupName = (String) hostGroup.get(BLUEPRINT_HOST_GROUPS_NAME_PROPERTY);
+
+        Set<Map<String, String>> rcvdComponentsSet = (Set<Map<String, String>>) hostGroup
+            .get(BLUEPRINT_HOST_GROUPS_COMPONENTS_PROPERTY);
+
+
+        Set<Map<String, String>> componentSet = new HashSet();
+        for (Map<String, String> component : rcvdComponentsSet) {
+          Map<String, String> components = new HashMap<>();
+          components.put(BLUEPRINT_HOST_GROUPS_COMPONENTS_NAME_PROPERTY,
+              component.get(BLUEPRINT_HOST_GROUPS_COMPONENTS_NAME_PROPERTY));
+          components.put(BLUEPRINT_HOST_GROUPS_COMPONENTS_MPACK_INSTANCE_PROPERTY,
+              component.get(BLUEPRINT_HOST_GROUPS_COMPONENTS_MPACK_INSTANCE_PROPERTY));
+          components.put(BLUEPRINT_HOST_GROUPS_COMPONENTS_SERVICE_INSTANCE_PROPERTY,
+              component.get(BLUEPRINT_HOST_GROUPS_COMPONENTS_SERVICE_INSTANCE_PROPERTY));
+
+          componentSet.add(components);
+        }
+
+        HostGroup hg = new HostGroup();
+        hg.setComponents(componentSet);
+        hg.setName(hostGroupName);
+        hgCompMap.add(hg);
+      }
+    }
+    return hgCompMap;
+  }
+
+  /**
+   * Will prepare host-group names to hosts names map from the recommendation
+   * binding host groups.
+   *
+   * @param request stack advisor request
+   * @return host-group to hosts map
+   */
+  @SuppressWarnings("unchecked")
+  private Map<String, Set<String>> calculateHostGroupHostsMap(Request request) {
+    Set<Map<String, Object>> bindingHostGroups = (Set<Map<String, Object>>) getRequestProperty(
+        request, BINDING_HOST_GROUPS_PROPERTY);
+    Map<String, Set<String>> map = new HashMap<>();
+    if (bindingHostGroups != null) {
+      for (Map<String, Object> hostGroup : bindingHostGroups) {
+        String hostGroupName = (String) hostGroup.get(BINDING_HOST_GROUPS_NAME_PROPERTY);
+
+        Set<Map<String, Object>> hostsSet = (Set<Map<String, Object>>) hostGroup
+            .get(BINDING_HOST_GROUPS_HOSTS_PROPERTY);
+
+        Set<String> hosts = new HashSet<>();
+        for (Map<String, Object> host : hostsSet) {
+          hosts.add((String) host.get(BINDING_HOST_GROUPS_HOSTS_NAME_PROPERTY));
+        }
+
+        map.put(hostGroupName, hosts);
+      }
+    }
+
+    return map;
+  }
+
+  protected static final String CONFIGURATIONS_PROPERTY_ID = "recommendations/blueprint/configurations/";
+  protected Map<String, Map<String, Map<String, String>>> calculateConfigurations(Request request) {
+    Map<String, Map<String, Map<String, String>>> configurations = new HashMap<>();
+    Map<String, Object> properties = request.getProperties().iterator().next();
+    for (String property : properties.keySet()) {
+      if (property.startsWith(CONFIGURATIONS_PROPERTY_ID)) {
+        try {
+          String propertyEnd = property.substring(CONFIGURATIONS_PROPERTY_ID.length()); // mapred-site/properties/yarn.app.mapreduce.am.resource.mb
+          String[] propertyPath = propertyEnd.split("/"); // length == 3
+          String siteName = propertyPath[0];
+          String propertiesProperty = propertyPath[1];
+          String propertyName = propertyPath[2];
+
+          Map<String, Map<String, String>> siteMap = configurations.get(siteName);
+          if (siteMap == null) {
+            siteMap = new HashMap<>();
+            configurations.put(siteName, siteMap);
+          }
+
+          Map<String, String> propertiesMap = siteMap.get(propertiesProperty);
+          if (propertiesMap == null) {
+            propertiesMap = new HashMap<>();
+            siteMap.put(propertiesProperty, propertiesMap);
+          }
+
+          Object propVal = properties.get(property);
+          if (propVal != null)
+            propertiesMap.put(propertyName, propVal.toString());
+          else
+            LOG.info(String.format("No value specified for configuration property, name = %s ", property));
+
+        } catch (Exception e) {
+          LOG.debug(String.format("Error handling configuration property, name = %s", property), e);
+          // do nothing
+        }
+      }
+    }
+    return configurations;
+  }
+
+  protected List<ChangedConfigInfo> calculateChangedConfigurations(Request request) {
+    List<ChangedConfigInfo> configs =
+        new LinkedList<>();
+    HashSet<HashMap<String, String>> changedConfigs =
+        (HashSet<HashMap<String, String>>) getRequestProperty(request, CHANGED_CONFIGURATIONS_PROPERTY);
+    for (HashMap<String, String> props: changedConfigs) {
+      configs.add(new ChangedConfigInfo(props.get("type"), props.get("name"), props.get("old_value")));
+    }
+
+    return configs;
+  }
+
+  /**
+   * Parse the user contex for the call. Typical structure
+   * { "operation" : "createCluster" }
+   * { "operation" : "addService", "services" : "Atlas,Slider" }
+   * @param request
+   * @return
+   */
+  protected Map<String, String> readUserContext(Request request) {
+    HashMap<String, String> userContext = new HashMap<>();
+    if (null != getRequestProperty(request, USER_CONTEXT_OPERATION_PROPERTY)) {
+      userContext.put(OPERATION_PROPERTY,
+          (String) getRequestProperty(request, USER_CONTEXT_OPERATION_PROPERTY));
+    }
+    if (null != getRequestProperty(request, USER_CONTEXT_OPERATION_DETAILS_PROPERTY)) {
+      userContext.put(OPERATION_DETAILS_PROPERTY,
+          (String) getRequestProperty(request, USER_CONTEXT_OPERATION_DETAILS_PROPERTY));
+    }
+    return userContext;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Map<String, Set<String>>> populateComponentHostsMap(Collection<HostGroup> hostGroups,
+                                                              Map<String, Set<String>> bindingHostGroups) {
+    /*
+     * ClassCastException may occur in case of body inconsistency: property
+     * missed, etc.
+     */
+
+    Map<String, Map<String, Set<String>>> mpacksToComponentsHostsMap = new HashMap<>();
+    if (null != bindingHostGroups && null != hostGroups) {
+      Iterator hgItr = hostGroups.iterator();
+      while (hgItr.hasNext()) {
+        HostGroup hostGrp = (HostGroup) hgItr.next();
+        String hgName = hostGrp.getName();
+        Set<Map<String, String>> components = hostGrp.getComponents();
+
+        Set<String> hosts = bindingHostGroups.get(hgName);
+        Iterator compItr = components.iterator();
+        while (compItr.hasNext()) {
+          Map<String, String> compValueMap = (Map<String, String>) compItr.next();
+          String compName = compValueMap.get("name");
+          String compMpackname = compValueMap.get("mpack_instance");
+          Map<String, Set<String>> mpackToComponentsHostsMap = mpacksToComponentsHostsMap.get(compMpackname);
+          if (mpackToComponentsHostsMap == null) {
+            mpackToComponentsHostsMap = new HashMap<>();
+            mpacksToComponentsHostsMap.put(compMpackname, mpackToComponentsHostsMap);
+          }
+          // Check if 'compName' exists. If exists, fetch and update to its existing hosts.
+          // else, add the 'compName' along with its hosts.
+          Set<String> updatedHosts = mpackToComponentsHostsMap.get(compName);
+          if (updatedHosts == null || updatedHosts.isEmpty()) {
+            mpackToComponentsHostsMap.put(compName, hosts);
+          } else {
+            // Fetch and update the existing host(s) Set.
+            updatedHosts.addAll(hosts);
+            mpackToComponentsHostsMap.put(compName, updatedHosts);
+          }
+        }
+      }
+    }
+
+    return mpacksToComponentsHostsMap;
+  }
+
+  protected Object getRequestProperty(Request request, String propertyName) {
+    for (Map<String, Object> propertyMap : request.getProperties()) {
+      if (propertyMap.containsKey(propertyName)) {
+        return propertyMap.get(propertyName);
+      }
+    }
+    return null;
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackRecommendationResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackRecommendationResourceProvider.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequestException;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse.BindingHostGroup;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse.HostGroup;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
+import org.apache.ambari.server.controller.spi.Request;
+import org.apache.ambari.server.controller.spi.RequestStatus;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.controller.spi.Resource.Type;
+import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
+import org.apache.ambari.server.controller.spi.SystemException;
+import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+
+public class MpackRecommendationResourceProvider extends MpackAdvisorResourceProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MpackRecommendationResourceProvider.class);
+
+  protected static final String RECOMMENDATION_ID_PROPERTY_ID = PropertyHelper.getPropertyId(
+      "MpackRecommendation", "id");
+
+  protected static final String HOSTS_PROPERTY_ID = "hosts";
+  protected static final String SERVICES_PROPERTY_ID = "services";
+  protected static final String RECOMMEND_PROPERTY_ID = "recommend";
+  protected static final String RECOMMENDATIONS_PROPERTY_ID = "recommendations";
+
+  protected static final String BLUEPRINT_PROPERTY_ID = PropertyHelper
+      .getPropertyId("recommendations", "blueprint");
+  protected static final String BLUEPRINT_CONFIGURATIONS_PROPERTY_ID = PropertyHelper
+      .getPropertyId("recommendations/blueprint", "configurations");
+
+  protected static final String BLUEPRINT_HOST_GROUPS_PROPERTY_ID = PropertyHelper.getPropertyId(
+      "recommendations/blueprint", "host_groups");
+  protected static final String BLUEPRINT_HOST_GROUPS_NAME_PROPERTY_ID = "name";
+  protected static final String BLUEPRINT_HOST_GROUPS_COMPONENTS_PROPERTY_ID = "components";
+
+  protected static final String BINDING_HOST_GROUPS_PROPERTY_ID = PropertyHelper.getPropertyId(
+      "recommendations/blueprint_cluster_binding", "host_groups");
+  protected static final String BINDING_HOST_GROUPS_NAME_PROPERTY_ID = "name";
+  protected static final String BINDING_HOST_GROUPS_HOSTS_PROPERTY_ID = "hosts";
+  protected static final String BINDING_PROPERTY_ID = PropertyHelper
+      .getPropertyId("recommendations", "blueprint_cluster_binding");
+
+
+  /**
+   * The key property ids for a Recommendation resource.
+   */
+  private static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
+      .put(Type.MpackRecommendation, RECOMMENDATION_ID_PROPERTY_ID)
+      .build();
+
+  /**
+   * The property ids for a Recommendation resource.
+   */
+  private static Set<String> propertyIds = Sets.newHashSet(
+      RECOMMENDATION_ID_PROPERTY_ID,
+      RECOMMEND_PROPERTY_ID,
+      HOSTS_PROPERTY_ID,
+      RECOMMENDATIONS_PROPERTY_ID,
+      BLUEPRINT_PROPERTY_ID,
+      BLUEPRINT_CONFIGURATIONS_PROPERTY_ID,
+      BLUEPRINT_HOST_GROUPS_PROPERTY_ID,
+      PropertyHelper.getPropertyId(BLUEPRINT_HOST_GROUPS_PROPERTY_ID, BLUEPRINT_HOST_GROUPS_NAME_PROPERTY_ID),
+      PropertyHelper.getPropertyId(BLUEPRINT_HOST_GROUPS_PROPERTY_ID, BLUEPRINT_HOST_GROUPS_COMPONENTS_PROPERTY_ID),
+      BINDING_PROPERTY_ID,
+      BINDING_HOST_GROUPS_PROPERTY_ID,
+      PropertyHelper.getPropertyId(BINDING_HOST_GROUPS_PROPERTY_ID, BINDING_HOST_GROUPS_NAME_PROPERTY_ID),
+      PropertyHelper.getPropertyId(BINDING_HOST_GROUPS_PROPERTY_ID, BINDING_HOST_GROUPS_HOSTS_PROPERTY_ID),
+      BINDING_HOST_GROUPS_NAME_PROPERTY_ID,
+      BINDING_HOST_GROUPS_HOSTS_PROPERTY_ID);
+
+
+  protected MpackRecommendationResourceProvider(AmbariManagementController managementController) {
+    super(Type.MpackRecommendation, propertyIds, keyPropertyIds, managementController);
+  }
+
+  @Override
+  protected String getRequestTypePropertyId() {
+    return RECOMMEND_PROPERTY_ID;
+  }
+
+  @Override
+  public RequestStatus createResources(final Request request) throws SystemException,
+      UnsupportedPropertyException, ResourceAlreadyExistsException, NoSuchParentResourceException {
+    MpackAdvisorRequest recommendationRequest = prepareMpackAdvisorRequest(request);
+
+    final MpackRecommendationResponse response;
+    try {
+      response = maHelper.recommend(recommendationRequest);
+    } catch (MpackAdvisorRequestException e) {
+      LOG.warn("Error occured during recommendation", e);
+      throw new IllegalArgumentException(e.getMessage(), e);
+    } catch (MpackAdvisorException e) {
+      LOG.warn("Error occured during recommendation", e);
+      throw new SystemException(e.getMessage(), e);
+    }
+
+    Resource recommendation = createResources(new Command<Resource>() {
+      @Override
+      public Resource invoke() throws AmbariException {
+
+        Resource resource = new ResourceImpl(Resource.Type.MpackRecommendation);
+        setResourceProperty(resource, RECOMMENDATION_ID_PROPERTY_ID, response.getId(), getPropertyIds());
+        setResourceProperty(resource, HOSTS_PROPERTY_ID, response.getHosts(), getPropertyIds());
+        setResourceProperty(resource, SERVICES_PROPERTY_ID, response.getServices(),
+            getPropertyIds());
+        setResourceProperty(resource, BLUEPRINT_CONFIGURATIONS_PROPERTY_ID, response
+            .getRecommendations().getBlueprint().getConfigurations(), getPropertyIds());
+
+        Set<HostGroup> hostGroups = response.getRecommendations().getBlueprint().getHostGroups();
+        List<Map<String, Object>> listGroupProps = new ArrayList<>();
+        for (HostGroup hostGroup : hostGroups) {
+          Map<String, Object> mapGroupProps = new HashMap<>();
+          mapGroupProps.put(BLUEPRINT_HOST_GROUPS_NAME_PROPERTY_ID, hostGroup.getName());
+          mapGroupProps
+              .put(BLUEPRINT_HOST_GROUPS_COMPONENTS_PROPERTY_ID, hostGroup.getComponents());
+          listGroupProps.add(mapGroupProps);
+        }
+        setResourceProperty(resource, BLUEPRINT_HOST_GROUPS_PROPERTY_ID, listGroupProps,
+            getPropertyIds());
+
+        Set<BindingHostGroup> bindingHostGroups = response.getRecommendations()
+            .getBlueprintClusterBinding().getHostGroups();
+        List<Map<String, Object>> listBindingGroupProps = new ArrayList<>();
+        for (BindingHostGroup hostGroup : bindingHostGroups) {
+          Map<String, Object> mapGroupProps = new HashMap<>();
+          mapGroupProps.put(BINDING_HOST_GROUPS_NAME_PROPERTY_ID, hostGroup.getName());
+          mapGroupProps.put(BINDING_HOST_GROUPS_HOSTS_PROPERTY_ID, hostGroup.getHosts());
+          listBindingGroupProps.add(mapGroupProps);
+        }
+        setResourceProperty(resource, BINDING_HOST_GROUPS_PROPERTY_ID, listBindingGroupProps,
+            getPropertyIds());
+
+        return resource;
+      }
+    });
+
+    notifyCreate(Resource.Type.MpackRecommendation, request);
+
+    Set<Resource> resources = new HashSet<>(Arrays.asList(recommendation));
+    return new RequestStatusImpl(null, resources);
+  }
+
+  @Override
+  protected Set<String> getPKPropertyIds() {
+    return new HashSet<>(keyPropertyIds.values());
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackValidationResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackValidationResourceProvider.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.controller.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequestException;
+import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse;
+import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
+import org.apache.ambari.server.controller.spi.Request;
+import org.apache.ambari.server.controller.spi.RequestStatus;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.controller.spi.Resource.Type;
+import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
+import org.apache.ambari.server.controller.spi.SystemException;
+import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+
+public class MpackValidationResourceProvider extends MpackAdvisorResourceProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ValidationResourceProvider.class);
+
+  protected static final String VALIDATION_ID_PROPERTY_ID = PropertyHelper.getPropertyId(
+      "MpackValidation", "id");
+  protected static final String VALIDATE_PROPERTY_ID = "validate";
+
+  protected static final String ITEMS_PROPERTY_ID = "items";
+  protected static final String TYPE_PROPERTY_ID = "type";
+  protected static final String LEVE_PROPERTY_ID = "level";
+  protected static final String MESSAGE_PROPERTY_ID = "message";
+  protected static final String COMPONENT_NAME_PROPERTY_ID = "component-name";
+  protected static final String HOST_PROPERTY_ID = "host";
+  protected static final String CONFIG_TYPE_PROPERTY_ID = "config-type";
+  protected static final String CONFIG_NAME_PROPERTY_ID = "config-name";
+  protected static final String HOST_GROUP_PROPERTY_ID = "host-group";
+  protected static final String HOSTS_PROPERTY_ID = "hosts";
+  protected static final String SERVICES_PROPERTY_ID = "services";
+  protected static final String RECOMMENDATIONS_PROPERTY_ID = "recommendations";
+
+  protected static final String ITEMS_TYPE_PROPERTY_ID = PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, TYPE_PROPERTY_ID);
+  protected static final String ITEMS_LEVE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, LEVE_PROPERTY_ID);
+  protected static final String ITEMS_MESSAGE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, MESSAGE_PROPERTY_ID);
+  protected static final String ITEMS_COMPONENT_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, COMPONENT_NAME_PROPERTY_ID);
+  protected static final String ITEMS_HOST_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, HOST_PROPERTY_ID);
+  protected static final String ITEMS_CONFIG_TYPE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, CONFIG_TYPE_PROPERTY_ID);
+  protected static final String ITEMS_CONFIG_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, CONFIG_NAME_PROPERTY_ID);
+  protected static final String ITEMS_HOST_GROUP_PROPERTY_ID = PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, HOST_GROUP_PROPERTY_ID);
+
+  /**
+   * The key property ids for a Validation resource.
+   */
+  private static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
+      .put(Type.MpackValidation, VALIDATION_ID_PROPERTY_ID)
+      .build();
+
+  /**
+   * The property ids for a Validation resource.
+   */
+  private static Set<String> propertyIds = Sets.newHashSet(
+      VALIDATION_ID_PROPERTY_ID,
+      VALIDATE_PROPERTY_ID,
+      ITEMS_PROPERTY_ID,
+      ITEMS_TYPE_PROPERTY_ID,
+      ITEMS_LEVE_PROPERTY_ID,
+      ITEMS_MESSAGE_PROPERTY_ID,
+      ITEMS_COMPONENT_NAME_PROPERTY_ID,
+      ITEMS_HOST_PROPERTY_ID,
+      ITEMS_CONFIG_TYPE_PROPERTY_ID,
+      ITEMS_CONFIG_NAME_PROPERTY_ID,
+      ITEMS_HOST_GROUP_PROPERTY_ID,
+      HOSTS_PROPERTY_ID,
+      SERVICES_PROPERTY_ID,
+      RECOMMENDATIONS_PROPERTY_ID);
+
+  protected MpackValidationResourceProvider(AmbariManagementController managementController) {
+    super(Type.MpackValidation, propertyIds, keyPropertyIds, managementController);
+  }
+
+  @Override
+  protected String getRequestTypePropertyId() {
+    return VALIDATE_PROPERTY_ID;
+  }
+
+  @Override
+  public RequestStatus createResources(final Request request) throws SystemException,
+      UnsupportedPropertyException, ResourceAlreadyExistsException, NoSuchParentResourceException {
+    MpackAdvisorRequest validationRequest = prepareMpackAdvisorRequest(request);
+
+    final MpackValidationResponse response;
+    try {
+      response = maHelper.validate(validationRequest);
+    } catch (MpackAdvisorRequestException e) {
+      LOG.warn("Error occurred during validation", e);
+      throw new IllegalArgumentException(e.getMessage(), e);
+    } catch (MpackAdvisorException e) {
+      LOG.warn("Error occurred during validation", e);
+      throw new SystemException(e.getMessage(), e);
+    }
+
+    Resource validation = createResources(new Command<Resource>() {
+      @Override
+      public Resource invoke() throws AmbariException {
+
+        Resource resource = new ResourceImpl(Type.MpackValidation);
+        setResourceProperty(resource, VALIDATION_ID_PROPERTY_ID, response.getId(), getPropertyIds());
+
+        List<Map<String, Object>> listItemProps = new ArrayList<>();
+
+        Set<ValidationItem> items = response.getItems();
+        for (ValidationItem item : items) {
+          Map<String, Object> mapItemProps = new HashMap<>();
+          mapItemProps.put(TYPE_PROPERTY_ID, item.getType());
+          mapItemProps.put(LEVE_PROPERTY_ID, item.getLevel());
+          mapItemProps.put(MESSAGE_PROPERTY_ID, item.getMessage());
+
+          if (item.getComponentName() != null) {
+            mapItemProps.put(COMPONENT_NAME_PROPERTY_ID, item.getComponentName());
+          }
+          if (item.getHost() != null) {
+            mapItemProps.put(HOST_PROPERTY_ID, item.getHost());
+          }
+          if (item.getConfigType() != null) {
+            mapItemProps.put(CONFIG_TYPE_PROPERTY_ID, item.getConfigType());
+            mapItemProps.put(CONFIG_NAME_PROPERTY_ID, item.getConfigName());
+          }
+          listItemProps.add(mapItemProps);
+        }
+        setResourceProperty(resource, ITEMS_PROPERTY_ID, listItemProps, getPropertyIds());
+
+        return resource;
+      }
+    });
+    notifyCreate(Resource.Type.MpackValidation, request);
+
+    Set<Resource> resources = new HashSet<>(Arrays.asList(validation));
+    return new RequestStatusImpl(null, resources);
+  }
+
+  @Override
+  protected Set<String> getPKPropertyIds() {
+    return new HashSet<>(keyPropertyIds.values());
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/spi/Resource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/spi/Resource.java
@@ -130,7 +130,9 @@ public interface Resource {
     ViewVersion,
     ViewInstance,
     Blueprint,
+    MpackRecommendation,
     Recommendation,
+    MpackValidation,
     Validation,
     HostComponentProcess,
     Permission,
@@ -263,7 +265,9 @@ public interface Resource {
     public static final Type ViewVersion = InternalType.ViewVersion.getType();
     public static final Type ViewInstance = InternalType.ViewInstance.getType();
     public static final Type Blueprint = InternalType.Blueprint.getType();
+    public static final Type MpackRecommendation = InternalType.MpackRecommendation.getType();
     public static final Type Recommendation = InternalType.Recommendation.getType();
+    public static final Type MpackValidation = InternalType.MpackValidation.getType();
     public static final Type Validation = InternalType.Validation.getType();
     public static final Type HostComponentProcess = InternalType.HostComponentProcess.getType();
     public static final Type Permission = InternalType.Permission.getType();

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackServiceDirectory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackServiceDirectory.java
@@ -19,8 +19,10 @@
 package org.apache.ambari.server.stack;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -101,8 +103,17 @@ public class StackServiceDirectory extends ServiceDirectory {
     String stackName = stackDir.getName();
     String versionString = stackVersionDir.getName().replaceAll("\\.", "");
 
+    List<String> legacyStackNames = new ArrayList<>(Arrays.asList("HDP", "HDF")); // Old stacks.
+    String advisorClassName = "";
+    if (legacyStackNames.contains(stackName)) {
+      advisorClassName = stackName + versionString + serviceName + "ServiceAdvisor";
+    } else {
+      // Mpack world and its corresponding Stacks, where we shouldn't have
+      // stackName + versionString prefixed.
+      advisorClassName = serviceName + "ServiceAdvisor";
+    }
+
     // Remove illegal python characters from the advisor name
-    String advisorClassName = stackName + versionString + serviceName + "ServiceAdvisor";
     advisorClassName = advisorClassName.replaceAll("[^a-zA-Z0-9]+", "");
 
     return advisorClassName;

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Component.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Component.java
@@ -31,6 +31,9 @@ public class Component {
   private final String name;
 
   @Nullable
+  private final String mpackInstance;
+
+  @Nullable
   private final StackId stackId;
 
   @Nullable
@@ -42,9 +45,18 @@ public class Component {
     this(name, null, null, null);
   }
 
+  public Component(String name, @Nullable String mpackInstance, @Nullable String serviceInstance) {
+    this.name = name;
+    this.stackId = null;
+    this.mpackInstance = mpackInstance;
+    this.serviceInstance = serviceInstance;
+    this.provisionAction = null;
+  }
+
   public Component(String name, @Nullable StackId stackId, @Nullable String serviceInstance, ProvisionAction provisionAction) {
     this.name = name;
     this.stackId = stackId;
+    this.mpackInstance = null;
     this.serviceInstance = serviceInstance;
     this.provisionAction = provisionAction;
   }
@@ -73,6 +85,9 @@ public class Component {
   }
 
 
+  public String getMpackInstance() {
+    return this.mpackInstance;
+  }
   /**
    * @return the service instance this component belongs to. Can be {@code null} if component does not belong to a service
    * instance (there is a single service of the component's service type)
@@ -84,7 +99,7 @@ public class Component {
   /**
    * Gets the provision action associated with this component.
    *
-   * @return the provision action for this component, which
+   * @return the provision action for this component, whichRequest's Mpack instances isRequest's Mpack instances is
    *         may be null if the default action is to be used
    */
   public ProvisionAction getProvisionAction() {
@@ -96,6 +111,7 @@ public class Component {
     return com.google.common.base.Objects.toStringHelper(this)
       .add("name", name)
       .add("stackId", stackId)
+      .add("mpackInstance", mpackInstance)
       .add("serviceInstance", serviceInstance)
       .add("provisionAction", provisionAction)
       .toString();
@@ -109,12 +125,13 @@ public class Component {
     Component component = (Component) o;
     return Objects.equals(name, component.name) &&
       Objects.equals(stackId, component.stackId) &&
+      Objects.equals(mpackInstance, component.mpackInstance) &&
       Objects.equals(serviceInstance, component.serviceInstance) &&
       provisionAction == component.provisionAction;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, stackId, serviceInstance, provisionAction);
+    return Objects.hash(name, stackId, mpackInstance, serviceInstance, provisionAction);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/MpackInstance.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/MpackInstance.java
@@ -43,6 +43,8 @@ public class MpackInstance implements Configurable {
   @JsonProperty("url")
   private String url;
 
+  private String mpackType;
+
   private Stack stack;
   private Configuration configuration = new Configuration();
 
@@ -57,6 +59,13 @@ public class MpackInstance implements Configurable {
     this.configuration = configuration;
   }
 
+  public MpackInstance(String mpackName, String mpackType, String mpackVersion, Collection<ServiceInstance> serviceInstances) {
+    this.mpackName = mpackName;
+    this.mpackType = mpackType;
+    this.mpackVersion = mpackVersion;
+    this.serviceInstances = serviceInstances;
+  }
+
   public MpackInstance() { }
 
   public String getMpackName() {
@@ -66,6 +75,15 @@ public class MpackInstance implements Configurable {
   public void setMpackName(String mpackName) {
     this.mpackName = mpackName;
   }
+
+  public String getMpackType() {
+    return mpackType;
+  }
+
+  public void setMpackType(String mpackType) {
+    this.mpackType = mpackType;
+  }
+
 
   public String getMpackVersion() {
     return mpackVersion;


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Mpack Host Component Layout - Recommendation & Validation**

**Brief :** Being in 3.0 world, where there will be more than one Mpack supported, implies that the 
pre 3.0 Stack/Service Advisor (which has been single stack only) will not be able to handle the 
multi-Mpack world (internally providing with more than 1 stack), for **Recommendation** and 
**Validations** for following :
	

-  **Host Component Layout**, and
- 	 **Configurations**.

**This PULL request covers the implementation of Recommendation and Validation for "Host Component Layout", and encompasses the following:**

    
- New Mpack Recommendation and Validation Endpoints:
    - http://[AmbariServer]:8080/api/v1/mpacks/recommendations
    - http://[AmbariServer]:8080/api/v1/mpacks/validations
      _**They end up calling the below code:**_
    - New 'ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor' (similar to 'stackadvisor') module which implements :
     - Mapping Host Component Layout 'Request Body' mapping in : MpackAdvisorRequest.java         Calling NEW Mpack Advisor Python module from the Pull Request :               https://github.com/apache/ambari/commit/ca2d0ef
     - Maps the result from python code back into : MpackRecommendationResponse.java and              MpackRecommendationValidation.java.
     - Send the response body back for the API.

 

## How was this patch tested?

Tested on live cluster by deploying the JAVA code (current PULL request) and under review accompanying Mpack Advisor Python code from :  https://github.com/apache/ambari/commit/ca2d0ef

Used 2 reference Mpacks : **(1).** HDPCORE and **(2).** ODS.

## Host Component Layout RECOMMENDATION:

**_API : POST http://AmbariServer:8080/api/v1/mpacks/recommendations_**

**Request Body :**

```
{  
   "hosts":[  
      "host1.example.com",
      "host2.example.com"
   ],
   "recommend":"host_groups",
   "recommendations":{  
      "blueprint":{  
         "mpack_instances":[  
            {  
               "name":"HDPCORE",
               "type":"HDPCORE",
               "version":"1.0.0-b290",
               "service_instances":[  
                  {  
                     "name":"HDFS"
                  },
                  {  
                     "name":"ZK1",
                     "type":"ZOOKEEPER"
                  },
                  {  
                     "name":"ZK2",
                     "type":"ZOOKEEPER"
                  },
                  {  
                     "name":"HADOOP_CLIENTS"
                  },
                  {  
                     "name":"ZOOKEEPER_CLIENTS"
                  }
               ]
            },
            {  
               "name":"ODS-DEFAULT",
               "type":"ODS",
               "version":"1.0.0-b153",
               "service_instances":[  
                  {  
                     "name":"HBASE"
                  },
                  {  
                     "name":"HADOOP_CLIENTS"
                  },
                  {  
                     "name":"HBASE_CLIENTS"
                  }
               ]
            }
         ]
      }
   }
}            
```
 
### Created **hosts.json** and **services.json** by JAVA Server Mpack Advisor code :

[hosts.json.log](https://github.com/apache/ambari/files/2011704/hosts.json.log)
[services.json.log](https://github.com/apache/ambari/files/2011705/services.json.log)

          

**Response:**

```
{
  "resources" : [
    {
      "href" : "http://<AmbariServer>:8080/api/v1/mpacks/recommendations/8",
      "hosts" : [
        "host2.example.com",
        "host1.example.com"
      ],
      "MpackRecommendation" : {
        "id" : 8
      },
      "recommendations" : {
        "blueprint" : {
          "configurations" : null,
          "host_groups" : [
            {
              "components" : [
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "JOURNALNODE",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "ZKFC",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "DATANODE",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "SECONDARY_NAMENODE",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "ZOOKEEPER_SERVER",
                  "service_instance" : "ZOOKEEPER"
                },
                {
                  "mpack_instance" : "ODS",
                  "name" : "HBASE_REGIONSERVER",
                  "service_instance" : "HBASE"
                }
              ],
              "name" : "host-group-2"
            },
            {
              "components" : [
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "NAMENODE",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "ODS",
                  "name" : "HBASE_MASTER",
                  "service_instance" : "HBASE"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "HADOOP_CLIENT",
                  "service_instance" : "HADOOP_CLIENTS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "JOURNALNODE",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "ODS",
                  "name" : "HADOOP_CLIENT",
                  "service_instance" : "HADOOP_CLIENTS"
                },
                {
                  "mpack_instance" : "ODS",
                  "name" : "HBASE_CLIENT",
                  "service_instance" : "HBASE"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "ZKFC",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "DATANODE",
                  "service_instance" : "HDFS"
                },
                {
                  "mpack_instance" : "ODS",
                  "name" : "HBASE_CLIENT",
                  "service_instance" : "HBASE_CLIENTS"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "ZOOKEEPER_SERVER",
                  "service_instance" : "ZOOKEEPER"
                },
                {
                  "mpack_instance" : "ODS",
                  "name" : "HBASE_REGIONSERVER",
                  "service_instance" : "HBASE"
                },
                {
                  "mpack_instance" : "HDPCORE",
                  "name" : "ZOOKEEPER_CLIENT",
                  "service_instance" : "ZOOKEEPER_CLIENTS"
                }
              ],
              "name" : "host-group-1"
            }
          ]
        },
        "blueprint_cluster_binding" : {
          "host_groups" : [
            {
              "hosts" : [
                {
                  "fqdn" : "host2.example.com"
                }
              ],
              "name" : "host-group-2"
            },
            {
              "hosts" : [
                {
                  "fqdn" : "host1.example.com"
                }
              ],
              "name" : "host-group-1"
            }
          ]
        }
      }
    }
  ]
}


```

## Host Component Layout VALIDATION:

**_API : POST http://AmbariServer:8080/api/v1/mpacks/validations_**

**Request Body :**


```
{
  "hosts": [
    "host2.example.com",
    "host1.example.com"
  ],
  "validate": "host_groups",
  "recommendations": {
    "blueprint": {
      "configurations": null,
      "mpack_instances": [
        {
          "name": "HDPCORE",
          "type": "HDPCORE",
          "version": "1.0.0-b290",
          "service_instances": [
            {
              "name": "HDFS"
            },
            {
              "name": "ZK1",
              "type": "ZOOKEEPER"
            },
            {
              "name": "ZK2",
              "type": "ZOOKEEPER"
            },
            {
              "name": "HADOOP_CLIENTS"
            },
            {
              "name": "ZOOKEEPER_CLIENTS"
            }
          ]
        },
        {
          "name": "ODS-DEFAULT",
          "type": "ODS",
          "version": "1.0.0-b153",
          "service_instances": [
            {
              "name": "HBASE"
            },
            {
              "name": "HADOOP_CLIENTS"
            },
            {
              "name": "HBASE_CLIENTS"
            }
          ]
        }
      ],
      "host_groups": [
        {
          "components": [
            {
              "mpack_instance": "HDPCORE",
              "name": "NAMENODE",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "ODS",
              "name": "HBASE_MASTER",
              "service_instance": "HBASE"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "HADOOP_CLIENT",
              "service_instance": "HADOOP_CLIENTS"
            },
            {
              "mpack_instance": "ODS",
              "name": "HADOOP_CLIENT",
              "service_instance": "HADOOP_CLIENTS"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "ZKFC",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "ODS",
              "name": "HBASE_CLIENT",
              "service_instance": "HBASE_CLIENTS"
            },
            {
              "mpack_instance": "ODS",
              "name": "HBASE_REGIONSERVER",
              "service_instance": "HBASE"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "ZOOKEEPER_CLIENT",
              "service_instance": "ZOOKEEPER_CLIENTS"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "JOURNALNODE",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "ODS",
              "name": "HBASE_CLIENT",
              "service_instance": "HBASE"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "DATANODE",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "SECONDARY_NAMENODE",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "ZOOKEEPER_SERVER",
              "service_instance": "ZOOKEEPER"
            }
          ],
          "name": "host-group-1"
        },
        {
          "components": [
            {
              "mpack_instance": "HDPCORE",
              "name": "JOURNALNODE",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "ZKFC",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "HDPCORE",
              "name": "DATANODE",
              "service_instance": "HDFS"
            },
            {
              "mpack_instance": "ODS",
              "name": "HBASE_REGIONSERVER",
              "service_instance": "HBASE"
            }
          ],
          "name": "host-group-2"
        }
      ]
    },
    "blueprint_cluster_binding": {
      "host_groups": [
        {
          "hosts": [
            {
              "fqdn": "host1.example.com"
            }
          ],
          "name": "host-group-1"
        },
        {
          "hosts": [
            {
              "fqdn": "host2.example.com"
            }
          ],
          "name": "host-group-2"
        }
      ]
    }
  }
}

```

### Created **hosts.json** and **services.json** by JAVA Server Mpack Advisor code :

[hosts.json.log](https://github.com/apache/ambari/files/2011709/hosts.json.log)
[services.json.log](https://github.com/apache/ambari/files/2011710/services.json.log)


**Response:**


```
{
  "resources" : [
    {
      "href" : "http://<AmbariServer>:8080/api/v1/mpacks/validations/10",
      "items" : [
        {
          "component-name" : "HBASE_MASTER",
          "level" : "ERROR",
          "type" : "host-component",
          "message" : "HBase Master requires ZOOKEEPER_SERVER to be present in the cluster."
        },
        {
          "component-name" : "HBASE_MASTER",
          "level" : "ERROR",
          "type" : "host-component",
          "message" : "HBase Master requires HDFS_CLIENT to be co-hosted on following host(s): host2.example.com, host1.example.com."
        }
      ],
      "MpackValidation" : {
        "id" : 10
      }
    }
  ]
}
```