### PR TITLE
AMBARI-23872. New Alert JSON Is Invalid When Sent To Agents

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/MetricSource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/MetricSource.java
@@ -108,12 +108,14 @@ public class MetricSource extends Source {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
   public static class JmxInfo {
+    @JsonProperty("property_list")
     @SerializedName("property_list")
     private List<String> propertyList;
 
     @SerializedName("value")
     private String value = "{0}";
 
+    @JsonProperty("url_suffix")
     @SerializedName("url_suffix")
     private String urlSuffix = "/jmx";
 


### PR DESCRIPTION
Some alerts are not scheduled on the agent correctly:

ERROR 2018-05-16 20:11:55,186 AlertSchedulerHandler.py:307 - [AlertScheduler] Unable to load an invalid alert definition. It will be skipped.
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/ambari_agent/AlertSchedulerHandler.py", line 287, in __json_to_callable
    alert = MetricAlert(json_definition, source, self.config)
  File "/usr/lib/ambari-agent/lib/ambari_agent/alerts/metric_alert.py", line 52, in __init__
    self.metric_info = JmxMetric(alert_source_meta['jmx'])
  File "/usr/lib/ambari-agent/lib/ambari_agent/alerts/metric_alert.py", line 288, in __init__
    self.property_list = jmx_info['property_list']
KeyError: 'property_list'