### PR TITLE
[AMBARI-23869] Remove insecure dependencies from Ambari Server

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -104,6 +104,10 @@
             <artifactId>jetty-util</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+        <exclusion>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
         </exclusion>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1721,6 +1721,10 @@
           <artifactId>jetty-util</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
         </exclusion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove insecure dependencies from Ambari Server

**Jetty: Java based HTTP, Servlet, SPDY, WebSocket Server 6.1.26**

- https://nvd.nist.gov/vuln/detail/CVE-2017-9735
- https://nvd.nist.gov/vuln/detail/CVE-2011-4461
- https://nvd.nist.gov/vuln/detail/CVE-2009-1523

```
[INFO] ------------------------------------------------------------------------
[INFO] Building Ambari Server 2.0.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.0.0.0-SNAPSHOT
[INFO] +- org.mortbay.jetty:jsp-api-2.1-glassfish:jar:2.1.v20100127:compile
[INFO] +- org.mortbay.jetty:jsp-2.1-glassfish:jar:2.1.v20100127:compile
[INFO] \- org.apache.hadoop:hadoop-common:jar:2.7.2:compile
[INFO]    \- org.mortbay.jetty:jetty:jar:6.1.26:compile
```
Recommendation is to remove the dependency or upgrade to version 6.1.26.hwx or the latest version, if possible.

## How was this patch tested?

All unit tests passed.

Manually tested cluster.

Before the fix:
```
# find ambari-server/ -name jetty-\*6.1.26.jar
ambari-server/jetty-6.1.26.jar
```

After the fix:
```
# find ambari-server/ -name jetty-\*6.1.26.jar
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.