### PR TITLE
[AMBARI-23746] Use serviceGroupName to fetch services and components

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -1433,10 +1433,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
 
     List<Service> services;
-    if (!Strings.isNullOrEmpty(request.getServiceName())) {
-      services = ImmutableList.of(cluster.getService(request.getServiceName()));
-    } else if (!Strings.isNullOrEmpty(request.getServiceGroupName())) {
+    if (!Strings.isNullOrEmpty(request.getServiceGroupName())) {
       services = ImmutableList.copyOf(cluster.getServicesByServiceGroup(request.getServiceGroupName()));
+    } else if (!Strings.isNullOrEmpty(request.getServiceName())) {
+      services = ImmutableList.of(cluster.getService(request.getServiceName()));
     } else {
       services = ImmutableList.copyOf(cluster.getServices().values());
     }
@@ -3119,7 +3119,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
           for (ServiceComponentHost scHost :
               changedScHosts.get(compName).get(newState)) {
 
-            Service service = cluster.getService(scHost.getServiceName());
+            Service service = cluster.getService(scHost.getServiceGroupName(), scHost.getServiceName());
             ServiceComponent serviceComponent = service.getServiceComponent(compName);
             StackId stackId = cluster.getServiceGroup(scHost.getServiceGroupId()).getStackId();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -931,7 +931,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       throws AmbariException {
 
     Clusters clusters = getManagementController().getClusters();
-    return clusters.getCluster(clusterName).getService(serviceName).getServiceComponent(componentName);
+    return clusters.getCluster(clusterName).getService(ServiceGroupName, serviceName).getServiceComponent(componentName);
   }
 
   // Perform direct transitions (without task generation)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -1259,7 +1259,8 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
     Service service = null;
     try {
       cluster = clusters.getCluster(clusterName);
-      service = cluster.getService(serviceName);
+      String serviceGroupName = cluster.getServiceGroup(serviceComponent.getServiceGroupId()).getServiceGroupName();
+      service = cluster.getService(serviceGroupName, serviceName);
     } catch (AmbariException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION

Use serviceGroupName to fetch services and components

(Please fill in changes proposed in this fix)

PUT hostcomponent of same component type on same host.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.