### PR TITLE
[AMBARI-23884] Remove webhcat server as co-hosted component for Hive.

### DIFF
--- a/ambari-web/app/models/stack_service_component.js
+++ b/ambari-web/app/models/stack_service_component.js
@@ -234,6 +234,4 @@ App.StackServiceComponent = DS.Model.extend({
 
 App.StackServiceComponent.FIXTURES = [];
 
-App.StackServiceComponent.coHost = {
-  'WEBHCAT_SERVER': 'HIVE_SERVER'
-};
+App.StackServiceComponent.coHost = {};

--- a/ambari-web/test/models/stack_service_component_test.js
+++ b/ambari-web/test/models/stack_service_component_test.js
@@ -249,8 +249,8 @@ var componentPropertiesValidationTests = [
       isMasterAddableInstallerWizard: false,
       isHAComponentOnly: false,
       isRequiredOnAllHosts: false,
-      coHostedComponents: ['WEBHCAT_SERVER'],
-      isOtherComponentCoHosted: true,
+      coHostedComponents: [],
+      isOtherComponentCoHosted: false,
       isCoHostedComponent: false
     }
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed 'WEBHCAT_SERVER' as coHost  

## How was this patch tested?
Modified the existing test for this and manually tested it  
21534 passing (22s)
  48 pending