### PR TITLE
AMBARI-23894. ZooKeepers Show As Down After EU to HDP 3.0 But They Are Not

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -83,6 +83,7 @@ class ActionQueue(threading.Thread):
     self.tmpdir = self.config.get('agent', 'prefix')
     self.customServiceOrchestrator = initializer_module.customServiceOrchestrator
     self.parallel_execution = self.config.get_parallel_exec_option()
+    self.component_status_executor = initializer_module.component_status_executor
     if self.parallel_execution == 1:
       logger.info("Parallel execution is enabled, will execute agent commands in parallel")
     self.lock = threading.Lock()
@@ -420,6 +421,14 @@ class ActionQueue(threading.Thread):
 
     self.recovery_manager.process_execution_command_result(command, status)
     self.commandStatuses.put_command_status(command, roleResult)
+
+    cluster_id = str(command['clusterId'])
+
+    if cluster_id != '-1' and cluster_id != 'null':
+      service_name = command['serviceName']
+      if service_name != 'null':
+        component_name = command['role']
+        self.component_status_executor.check_component_status(clusterId, service_name, component_name, "STATUS", report=True)
 
   def log_command_output(self, text, taskId):
     """

--- a/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
+++ b/ambari-agent/src/main/python/ambari_agent/HeartbeatThread.py
@@ -78,7 +78,9 @@ class HeartbeatThread(threading.Thread):
     self.responseId = 0
     self.file_cache = initializer_module.file_cache
     self.stale_alerts_monitor = initializer_module.stale_alerts_monitor
-    self.post_registration_actions = [self.file_cache.reset]
+    self.post_registration_actions = [self.file_cache.reset, initializer_module.component_status_executor.clean_not_existing_clusters_info,
+                                      initializer_module.alert_status_reporter.clean_not_existing_clusters_info, initializer_module.host_status_reporter.clean_cache]
+
 
 
   def run(self):

--- a/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
+++ b/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
@@ -38,6 +38,12 @@ from ambari_agent.StaleAlertsMonitor import StaleAlertsMonitor
 from ambari_stomp.adapter.websocket import ConnectionIsAlreadyClosed
 from ambari_agent.listeners.ServerResponsesListener import ServerResponsesListener
 
+from ambari_agent import HeartbeatThread
+from ambari_agent.ComponentStatusExecutor import ComponentStatusExecutor
+from ambari_agent.CommandStatusReporter import CommandStatusReporter
+from ambari_agent.HostStatusReporter import HostStatusReporter
+from ambari_agent.AlertStatusReporter import AlertStatusReporter
+
 logger = logging.getLogger(__name__)
 
 class InitializerModule:
@@ -74,8 +80,21 @@ class InitializerModule:
 
     self.recovery_manager = RecoveryManager(self.config.recovery_cache_dir)
     self.commandStatuses = CommandStatusDict(self)
+
+    self.init_threads()
+
+
+  def init_threads(self):
+    """
+    Initialize thread objects
+    """
+    self.component_status_executor = ComponentStatusExecutor(self)
     self.action_queue = ActionQueue(self)
     self.alert_scheduler_handler = AlertSchedulerHandler(self)
+    self.command_status_reporter = CommandStatusReporter(self)
+    self.host_status_reporter = HostStatusReporter(self)
+    self.alert_status_reporter = AlertStatusReporter(self)
+    self.heartbeat_thread = HeartbeatThread.HeartbeatThread(self)
 
   @property
   def connection(self):

--- a/ambari-common/src/main/python/resource_management/core/providers/accounts.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/accounts.py
@@ -28,8 +28,11 @@ from resource_management.core import shell
 from resource_management.core.providers import Provider
 from resource_management.core.logger import Logger
 from resource_management.core.utils import lazy_property
+from resource_management.core.exceptions import ExecutionFailed
 
 class UserProvider(Provider):
+  USERADD_USER_ALREADY_EXISTS_EXITCODE = 9
+
   options = dict(
     comment=(lambda self: self.user.pw_gecos, "-c"),
     gid=(lambda self: grp.getgrgid(self.user.pw_gid).gr_name, "-g"),
@@ -42,9 +45,11 @@ class UserProvider(Provider):
     
   def action_create(self):
     if not self.user:
+      creating_user = True
       command = ['useradd', "-m"]
       Logger.info("Adding user %s" % self.resource)
     else:
+      creating_user = False
       command = ['usermod']
       
       for option_name, attributes in self.options.iteritems():
@@ -81,7 +86,14 @@ class UserProvider(Provider):
 
     command.append(self.resource.username)
     
-    shell.checked_call(command, sudo=True)
+    try:
+      shell.checked_call(command, sudo=True)
+    except ExecutionFailed as ex:
+      # this "user already exists" can happen due to race condition when multiple processes create user at the same time
+      if creating_user and ex.code == UserProvider.USERADD_USER_ALREADY_EXISTS_EXITCODE and self.user:
+        self.action_create() # run modification of the user
+      else:
+        raise
 
   def action_remove(self):
     if self.user:


### PR DESCRIPTION
STR:

Perform an EU from HDP 2.6 to HDP 3.0
After, 2 of my 3 ZKs are shown as being down. However, they are actually alive on my boxes:

[root@c7402 ~]$ ps aux | grep [z]oo.cfg
zookeep+ 22463  0.2  2.8 3064236 53728 ?       Sl   20:41   0:01 /usr/jdk64/jdk1.8.0_144/bin/java -Dzookeeper.log.dir=/var/log/zookeeper -Dzookeeper.log.file=zookeeper-zookeeper-server-c7402.ambari.apache.org.log -Dzookeeper.root.logger=INFO,ROLLINGFILE -cp /usr/hdp/current/zookeeper-server/bin/../build/classes:/usr/hdp/current/zookeeper-server/bin/../build/lib/*.jar:/usr/hdp/current/zookeeper-server/bin/../lib/xercesMinimal-1.9.6.2.jar:/usr/hdp/current/zookeeper-server/bin/../lib/wagon-provider-api-2.4.jar:/usr/hdp/current/zookeeper-server/bin/../lib/wagon-http-shared4-2.4.jar:/usr/hdp/current/zookeeper-server/bin/../lib/wagon-http-shared-1.0-beta-6.jar:/usr/hdp/current/zookeeper-server/bin/../lib/wagon-http-lightweight-1.0-beta-6.jar:/usr/hdp/current/zookeeper-server/bin/../lib/wagon-http-2.4.jar:/usr/hdp/current/zookeeper-server/bin/../lib/wagon-file-1.0-beta-6.jar:/usr/hdp/current/zookeeper-server/bin/../lib/slf4j-log4j12-1.6.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/slf4j-api-1.6.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/plexus-utils-3.0.8.jar:/usr/hdp/current/zookeeper-server/bin/../lib/plexus-interpolation-1.11.jar:/usr/hdp/current/zookeeper-server/bin/../lib/plexus-container-default-1.0-alpha-9-stable-1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/netty-3.10.5.Final.jar:/usr/hdp/current/zookeeper-server/bin/../lib/nekohtml-1.9.6.2.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-settings-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-repository-metadata-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-project-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-profile-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-plugin-registry-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-model-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-error-diagnostics-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-artifact-manager-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-artifact-2.2.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/maven-ant-tasks-2.1.3.jar:/usr/hdp/current/zookeeper-server/bin/../lib/log4j-1.2.16.jar:/usr/hdp/current/zookeeper-server/bin/../lib/jsoup-1.7.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/jline-0.9.94.jar:/usr/hdp/current/zookeeper-server/bin/../lib/commons-logging-1.1.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/commons-io-2.2.jar:/usr/hdp/current/zookeeper-server/bin/../lib/commons-codec-1.6.jar:/usr/hdp/current/zookeeper-server/bin/../lib/classworlds-1.1-alpha-2.jar:/usr/hdp/current/zookeeper-server/bin/../lib/backport-util-concurrent-3.1.jar:/usr/hdp/current/zookeeper-server/bin/../lib/ant-launcher-1.8.0.jar:/usr/hdp/current/zookeeper-server/bin/../lib/ant-1.8.0.jar:/usr/hdp/current/zookeeper-server/bin/../zookeeper-3.4.6.3.0.0.0-1250.jar:/usr/hdp/current/zookeeper-server/bin/../src/java/lib/*.jar:/usr/hdp/current/zookeeper-server/conf::/usr/share/zookeeper/*:/usr/share/zookeeper/* -Xmx1024m -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false org.apache.zookeeper.server.quorum.QuorumPeerMain /usr/hdp/current/zookeeper-server/conf/zoo.cfg

[root@c7402 ~]$ telnet localhost 2181
Trying ::1...
Connected to localhost.
Escape character is '^]'.
^CConnection closed by foreign host.
But you can see that we clearly think it's down on c7402:

{
  "href" : "http://localhost:8080/api/v1/clusters/c1/hosts/c7402.ambari.apache.org/host_components/ZOOKEEPER_SERVER",
  "HostRoles" : {
    "cluster_name" : "c1",
    "component_name" : "ZOOKEEPER_SERVER",
    "desired_repository_version" : "3.0.0.0-1250",
    "desired_stack_id" : "HDP-3.0",
    "desired_state" : "STARTED",
    "display_name" : "ZooKeeper Server",
    "host_name" : "c7402.ambari.apache.org",
    "maintenance_state" : "OFF",
    "public_host_name" : "c7402.ambari.apache.org",
    "reload_configs" : false,
    "service_name" : "ZOOKEEPER",
    "stale_configs" : false,
    "state" : "INSTALLED",
    "upgrade_state" : "NONE",
    "version" : "3.0.0.0-1250",
    "actual_configs" : { }
  },
  "host" : {
    "href" : "http://localhost:8080/api/v1/clusters/c1/hosts/c7402.ambari.apache.org"
  },
  "component" : [
    {
      "href" : "http://localhost:8080/api/v1/clusters/c1/services/ZOOKEEPER/components/ZOOKEEPER_SERVER",
      "ServiceComponentInfo" : {
        "cluster_name" : "c1",
        "component_name" : "ZOOKEEPER_SERVER",
        "service_name" : "ZOOKEEPER"
      }
    }
  ],
  "processes" : [ ]
}
The PID file looks correct:

[root@c7402 zookeeper]$ cat /var/run/zookeeper/zookeeper_server.pid
22463