### PR TITLE
AMBARI-23896. Issues with pagination in Upgrade History page

### DIFF
--- a/ambari-web/app/views/main/admin/stack_upgrade/upgrade_history_view.js
+++ b/ambari-web/app/views/main/admin/stack_upgrade/upgrade_history_view.js
@@ -97,9 +97,7 @@ App.MainAdminStackUpgradeHistoryView = App.TableView.extend(App.TableServerViewM
    */
   selectedCategory: Em.computed.findBy('categories', 'isSelected', true),
 
-  filteredCount: function () {
-    return this.get('filteredContent').map(item => Object.keys(item.get('versions') || {}).length).reduce(Em.sum, 0);
-  }.property('filteredContent'),
+  filteredCount: Em.computed.alias('filteredContent.length'),
 
   /**
    * displaying content filtered by upgrade type and upgrade status.


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
The number of items in a page for this should be the number of upgrade history records, not the number of services under each history record.

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.