### PR TITLE
ambari-funtest: Add jdeb support

### DIFF
--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -24,6 +24,29 @@
   <description>Ambari Functional Tests</description>
   <build>
     <plugins>
+
+     <plugin>
+         <groupId>org.vafer</groupId>
+         <artifactId>jdeb</artifactId>
+         <version>1.0.1</version>
+         <executions>
+           <execution>
+             <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+             <id>stub-execution</id>
+             <phase>none</phase>
+             <goals>
+               <goal>jdeb</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <skip>true</skip>
+           <attach>false</attach>
+           <submodules>false</submodules>
+           <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+         </configuration>
+       </plugin>
+
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
This patch add debian package creation support for ambari-funtest
package.

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>

## What changes were proposed in this pull request?

Add jdeb support for ambari-funtest.

## How was this patch tested?

I did a build (release-2.5.2) and test the package on AArch64 machine installed with Debian-9

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.