### PR TITLE
[AMBARI-23852] - Provide a Framework For Adding A Component During Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
@@ -46,6 +46,13 @@ public class ActionExecutionContext {
   private boolean allowRetry = false;
   private RepositoryVersionEntity repositoryVersion;
 
+  /**
+   * If {@code true}, instructs Ambari not to worry about whether or not the
+   * command is valid. This is used in cases where we might have to schedule
+   * commands ahead of time for components which are not yet installed.
+   */
+  private boolean isFutureCommand = false;
+
   private List<ExecutionCommandVisitor> m_visitors = new ArrayList<>();
 
   /**
@@ -268,6 +275,38 @@ public class ActionExecutionContext {
    */
   public interface ExecutionCommandVisitor {
     void visit(ExecutionCommand command);
+  }
+
+  /**
+   * Gets whether Ambari should skip all kinds of command verifications while
+   * scheduling since this command runs in the future and might not be
+   * considered "valid".
+   * <p/>
+   * A use case for this would be during an upgrade where trying to schedule
+   * commands for a component which has yet to be added to the cluster (since
+   * it's added as part of the upgrade).
+   *
+   * @return the skipVerificationOfCommand
+   */
+  public boolean isFutureCommand() {
+    return isFutureCommand;
+  }
+
+  /**
+   * Sets whether Ambari should skip all kinds of command verifications while
+   * scheduling since this command runs in the future and might not be
+   * considered "valid".
+   * <p/>
+   * A use case for this would be during an upgrade where trying to schedule
+   * commands for a component which has yet to be added to the cluster (since
+   * it's added as part of the upgrade).
+   *
+   * @param skipVerificationOfCommand
+   *          {@code true} to have Ambari skip verification of things like
+   *          component hosts while scheduling commands.
+   */
+  public void setIsFutureCommand(boolean isFutureCommand) {
+    this.isFutureCommand = isFutureCommand;
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
@@ -286,7 +286,7 @@ public class ActionExecutionContext {
    * commands for a component which has yet to be added to the cluster (since
    * it's added as part of the upgrade).
    *
-   * @return the skipVerificationOfCommand
+   * @return {@code true} if the command is scheduled to run in the future.
    */
   public boolean isFutureCommand() {
     return isFutureCommand;
@@ -301,7 +301,7 @@ public class ActionExecutionContext {
    * commands for a component which has yet to be added to the cluster (since
    * it's added as part of the upgrade).
    *
-   * @param skipVerificationOfCommand
+   * @param isFutureCommand
    *          {@code true} to have Ambari skip verification of things like
    *          component hosts while scheduling commands.
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -200,6 +200,11 @@ public class AmbariCustomCommandExecutionHelper {
   private Boolean isValidCustomCommand(ActionExecutionContext
       actionExecutionContext, RequestResourceFilter resourceFilter)
       throws AmbariException {
+
+    if (actionExecutionContext.isFutureCommand()) {
+      return true;
+    }
+
     String clusterName = actionExecutionContext.getClusterName();
     String serviceName = resourceFilter.getServiceName();
     String componentName = resourceFilter.getComponentName();
@@ -271,15 +276,19 @@ public class AmbariCustomCommandExecutionHelper {
 
     // Filter hosts that are in MS
     Set<String> ignoredHosts = maintenanceStateHelper.filterHostsInMaintenanceState(
-        candidateHosts, new MaintenanceStateHelper.HostPredicate() {
-          @Override
-          public boolean shouldHostBeRemoved(final String hostname)
-              throws AmbariException {
-            return !maintenanceStateHelper.isOperationAllowed(
-                cluster, actionExecutionContext.getOperationLevel(),
-                resourceFilter, serviceName, componentName, hostname);
+      candidateHosts, new MaintenanceStateHelper.HostPredicate() {
+        @Override
+        public boolean shouldHostBeRemoved(final String hostname)
+            throws AmbariException {
+          if (actionExecutionContext.isFutureCommand()) {
+            return false;
           }
+
+          return !maintenanceStateHelper.isOperationAllowed(
+              cluster, actionExecutionContext.getOperationLevel(),
+              resourceFilter, serviceName, componentName, hostname);
         }
+      }
     );
 
     // Filter unhealthy hosts
@@ -309,7 +318,12 @@ public class AmbariCustomCommandExecutionHelper {
     }
 
     Service service = cluster.getService(serviceName);
+
+    // grab the stack ID from the service first, and use the context's if it's set
     StackId stackId = service.getDesiredStackId();
+    if (null != actionExecutionContext.getRepositoryVersion()) {
+      stackId = actionExecutionContext.getRepositoryVersion().getStackId();
+    }
 
     AmbariMetaInfo ambariMetaInfo = managementController.getAmbariMetaInfo();
     ServiceInfo serviceInfo = ambariMetaInfo.getService(service);
@@ -493,6 +507,11 @@ public class AmbariCustomCommandExecutionHelper {
 
       execCmd.setCommandParams(commandParams);
       execCmd.setRoleParams(roleParams);
+
+      // skip anything else
+      if (actionExecutionContext.isFutureCommand()) {
+        continue;
+      }
 
       // perform any server side command related logic - eg - set desired states on restart
       applyCustomCommandBackendLogic(cluster, serviceName, componentName, commandName, hostName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
@@ -31,6 +31,7 @@ import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.audit.event.AuditEvent;
 import org.apache.ambari.server.utils.StageUtils;
 
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 
 /**
@@ -59,9 +60,15 @@ public abstract class AbstractServerAction implements ServerAction {
   @Inject
   private AuditLogger auditLogger;
 
+  /**
+   * Used to deserialized JSON.
+   */
+  @Inject
+  protected Gson gson;
+
   @Override
   public ExecutionCommand getExecutionCommand() {
-    return this.executionCommand;
+    return executionCommand;
   }
 
   @Override
@@ -71,7 +78,7 @@ public abstract class AbstractServerAction implements ServerAction {
 
   @Override
   public HostRoleCommand getHostRoleCommand() {
-    return this.hostRoleCommand;
+    return hostRoleCommand;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.serveraction.upgrades;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.ServiceComponentNotFoundException;
+import org.apache.ambari.server.actionmanager.HostRoleStatus;
+import org.apache.ambari.server.agent.CommandReport;
+import org.apache.ambari.server.stack.MasterHostResolver;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Host;
+import org.apache.ambari.server.state.Service;
+import org.apache.ambari.server.state.ServiceComponent;
+import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.State;
+import org.apache.ambari.server.state.UpgradeContext;
+import org.apache.ambari.server.state.stack.upgrade.AddComponentTask;
+
+/**
+ * The {@link AddComponentAction} is used to add a component during an upgrade.
+ */
+public class AddComponentAction extends AbstractUpgradeServerAction {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public CommandReport execute(ConcurrentMap<String, Object> requestSharedDataContext)
+      throws AmbariException, InterruptedException {
+
+    Map<String, String> commandParameters = getCommandParameters();
+    if (null == commandParameters || commandParameters.isEmpty()) {
+      return createCommandReport(0, HostRoleStatus.FAILED, "{}", "",
+          "Unable to add a new component to the cluster as there is no information on what to add.");
+    }
+
+    String clusterName = commandParameters.get("clusterName");
+    Cluster cluster = getClusters().getCluster(clusterName);
+    UpgradeContext upgradeContext = getUpgradeContext(cluster);
+
+    // guard against downgrade until there is such a thing as removal of a
+    // component on downgrade
+    if (upgradeContext.isDowngradeAllowed() || upgradeContext.isPatchRevert()) {
+      return createCommandReport(0, HostRoleStatus.SKIPPED_FAILED, "{}", "",
+          "Unable to add a component during an upgrade which can be downgraded.");
+    }
+
+    String serializedJson = commandParameters.get(
+        AddComponentTask.PARAMETER_SERIALIZED_ADD_COMPONENT_TASK);
+
+    AddComponentTask task = gson.fromJson(serializedJson, AddComponentTask.class);
+
+    // build the list of candidate hosts
+    Collection<Host> candidates = MasterHostResolver.getCandidateHosts(cluster, task.hosts,
+        task.hostService, task.hostComponent);
+
+    if (candidates.isEmpty()) {
+      return createCommandReport(0, HostRoleStatus.FAILED, "{}", "", String.format(
+          "Unable to add a new component to the cluster as there are no hosts which contain %s's %s",
+          task.service, task.component));
+    }
+
+    Service service = cluster.getService(task.service);
+    if (null == service) {
+      return createCommandReport(0, HostRoleStatus.FAILED, "{}", "",
+          String.format("Unable to add %s since %s is not installed in this cluster.",
+              task.component, task.service));
+    }
+
+    // create the component if it doesn't exist in the service yet
+    ServiceComponent serviceComponent;
+    try {
+       serviceComponent = service.getServiceComponent(task.component);
+    } catch( ServiceComponentNotFoundException scnfe ) {
+      serviceComponent = service.addServiceComponent(task.component);
+    }
+
+    StringBuilder buffer = new StringBuilder(String.format(
+        "Successfully added %s's %s to the cluster", task.service, task.component)).append(
+            System.lineSeparator());
+
+    Map<String, ServiceComponentHost> existingSCHs = serviceComponent.getServiceComponentHosts();
+
+    for (Host host : candidates) {
+      if (existingSCHs.containsKey(host.getHostName())) {
+        buffer.append("  ")
+        .append(host.getHostName())
+        .append(": ")
+        .append("Already Installed")
+        .append(System.lineSeparator());
+
+        continue;
+      }
+
+      ServiceComponentHost sch = serviceComponent.addServiceComponentHost(host.getHostName());
+      sch.setDesiredState(State.INSTALLED);
+      sch.setState(State.INSTALLED);
+
+      buffer.append("  ")
+        .append(host.getHostName())
+        .append(": ")
+        .append("Installed")
+        .append(System.lineSeparator());
+    }
+
+    Set<String> sortedHosts = candidates.stream().map(host -> host.getHostName()).collect(
+        Collectors.toCollection(() -> new TreeSet<>()));
+
+    Map<String, Object> structureOutMap = new LinkedHashMap<>();
+    structureOutMap.put("service", task.service);
+    structureOutMap.put("component", task.component);
+    structureOutMap.put("hosts", sortedHosts);
+
+    return createCommandReport(0, HostRoleStatus.COMPLETED, gson.toJson(structureOutMap),
+        buffer.toString(), "");
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ComponentVersionCheckAction.java
@@ -68,6 +68,7 @@ public class ComponentVersionCheckAction extends FinalizeUpgradeAction {
   private String getErrors(StringBuilder outSB, StringBuilder errSB, Set<InfoTuple> errors) {
 
     errSB.append("Finalization will not be able to completed because of the following version inconsistencies:");
+    errSB.append(System.lineSeparator());
 
     Set<String> hosts = new TreeSet<>();
     Map<String, JsonArray> hostDetails = new HashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/AddComponentTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/AddComponentTask.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.state.stack.upgrade;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+
+import org.apache.ambari.server.serveraction.upgrades.AddComponentAction;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * The {@link AddComponentTask} is used for adding components during an upgrade.
+ * Components which are added via the task will also be scheduled for a restart
+ * if they appear in the upgrade pack as part of a restart group. This is true
+ * even if they do not exist in the cluster yet.
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "add_component")
+public class AddComponentTask extends ServerSideActionTask {
+
+  /**
+   * The key which represents this task serialized.
+   */
+  public static final String PARAMETER_SERIALIZED_ADD_COMPONENT_TASK = "add-component-task";
+
+  @Expose
+  @XmlTransient
+  private Task.Type type = Type.ADD_COMPONENT;
+
+  /**
+   * The hosts to run the task on. Default to running on
+   * {@link ExecuteHostType#ANY}.
+   */
+  @Expose
+  @XmlAttribute
+  public ExecuteHostType hosts = ExecuteHostType.ANY;
+
+  /**
+   * The service which owns the component to add.
+   */
+  @Expose
+  @XmlAttribute
+  public String service;
+
+  /**
+   * The component to add.
+   */
+  @Expose
+  @XmlAttribute
+  public String component;
+
+  /**
+   * Specifies the hosts which are valid for adding the new component,
+   * restricted by service.
+   */
+  @Expose
+  @XmlAttribute(name = "host-service")
+  public String hostService;
+
+  /**
+   * Specifies the hosts which are valid for adding teh new component,
+   * restricted by component.
+   */
+  @Expose
+  @XmlAttribute(name = "host-component")
+  public String hostComponent;
+
+  /**
+   * Constructor.
+   *
+   */
+  public AddComponentTask() {
+    implClass = AddComponentAction.class.getName();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Task.Type getType() {
+    return type;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public StageWrapper.Type getStageWrapperType() {
+    return StageWrapper.Type.SERVER_SIDE_ACTION;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getActionVerb() {
+    return "Adding";
+  }
+
+  /**
+   * Gets a JSON representation of this task.
+   *
+   * @return a JSON representation of this task.
+   */
+  public String toJson() {
+    return GSON.toJson(this);
+  }
+
+  /**
+   * Gets a string which is comprised of serviceName/componentName
+   *
+   * @return a string which represents this add component task.
+   */
+  public String getServiceAndComponentAsString() {
+    return service + "/" + component;
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ClusterGrouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ClusterGrouping.java
@@ -46,7 +46,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Used to represent cluster-based operations.
@@ -124,7 +124,7 @@ public class ClusterGrouping extends Grouping {
      */
     @Override
     public String toString() {
-      return Objects.toStringHelper(this).add("id", id).add("title",
+      return MoreObjects.toStringHelper(this).add("id", id).add("title",
           title).omitNullValues().toString();
     }
 
@@ -214,6 +214,7 @@ public class ClusterGrouping extends Grouping {
             case MANUAL:
             case SERVER_ACTION:
             case CONFIGURE:
+            case ADD_COMPONENT:
               wrapper = getServerActionStageWrapper(upgradeContext, execution);
               break;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigureTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ConfigureTask.java
@@ -111,8 +111,6 @@ public class ConfigureTask extends ServerSideActionTask {
     implClass = ConfigureAction.class.getName();
   }
 
-  private Task.Type type = Task.Type.CONFIGURE;
-
   @XmlAttribute(name = "id")
   public String id;
 
@@ -130,7 +128,7 @@ public class ConfigureTask extends ServerSideActionTask {
    */
   @Override
   public Type getType() {
-    return type;
+    return Task.Type.CONFIGURE;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -325,8 +325,10 @@ public class Grouping {
     private TaskBucket(Task initial) {
       switch (initial.getType()) {
         case CONFIGURE:
+        case CREATE_AND_CONFIGURE:
         case SERVER_ACTION:
         case MANUAL:
+        case ADD_COMPONENT:
           type = StageWrapper.Type.SERVER_SIDE_ACTION;
           break;
         case EXECUTE:

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapper.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.gson.Gson;
 
 /**
@@ -167,7 +167,7 @@ public class StageWrapper {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", type)
+    return MoreObjects.toStringHelper(this).add("type", type)
         .add("text",text)
         .omitNullValues().toString();
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Task.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Task.java
@@ -17,20 +17,40 @@
  */
 package org.apache.ambari.server.state.stack.upgrade;
 
+import java.util.EnumSet;
+
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
 
 
 /**
  * Base class to identify the items that could possibly occur during an upgrade
  */
-@XmlSeeAlso(value={ExecuteTask.class, CreateAndConfigureTask.class, ConfigureTask.class, ManualTask.class, RestartTask.class, StartTask.class, StopTask.class, ServerActionTask.class, ConfigureFunction.class})
+@XmlSeeAlso(
+    value = { ExecuteTask.class, CreateAndConfigureTask.class, ConfigureTask.class,
+        ManualTask.class, RestartTask.class, StartTask.class, StopTask.class,
+        ServerActionTask.class, ConfigureFunction.class, AddComponentTask.class })
 public abstract class Task {
+
+  /**
+   * A Gson instance to use when doing simple serialization along with
+   * {@link Expose}.
+   */
+  protected final static Gson GSON = new GsonBuilder()
+      .serializeNulls()
+      .setPrettyPrinting()
+      .excludeFieldsWithoutExposeAnnotation()
+      .create();
 
   /**
    * An optional brief description of what this task is doing.
    */
+  @Expose
   @XmlElement(name = "summary")
   public String summary;
 
@@ -38,12 +58,14 @@ public abstract class Task {
    * Whether the task needs to run sequentially, i.e., on its own stage.
    * If false, will be grouped with other tasks.
    */
+  @Expose
   @XmlAttribute(name = "sequential")
   public boolean isSequential = false;
 
   /**
    * The config property to check for timeout.
    */
+  @Expose
   @XmlAttribute(name="timeout-config")
   public String timeoutConfig = null;
 
@@ -72,6 +94,7 @@ public abstract class Task {
   /**
    * The scope for the task
    */
+  @Expose
   @XmlElement(name = "scope")
   public UpgradeScope scope = UpgradeScope.ANY;
 
@@ -133,20 +156,37 @@ public abstract class Task {
     /**
      * Task meant to run against Ambari server.
      */
-    SERVER_ACTION;
+    SERVER_ACTION,
+
+    /**
+     * A task which adds new components to the cluster during the upgrade.
+     */
+    ADD_COMPONENT;
+
+    /**
+     * Commands which run on the server.
+     */
+    public static final EnumSet<Type> SERVER_ACTIONS = EnumSet.of(MANUAL, CONFIGURE, SERVER_ACTION,
+        ADD_COMPONENT);
+
+    /**
+     * Commands which are run on agents.
+     */
+    public static final EnumSet<Type> COMMANDS = EnumSet.of(RESTART, START, CONFIGURE_FUNCTION,
+        STOP, SERVICE_CHECK);
 
     /**
      * @return {@code true} if the task is manual or automated.
      */
     public boolean isServerAction() {
-      return this == MANUAL || this == CONFIGURE || this == SERVER_ACTION;
+      return SERVER_ACTIONS.contains(this);
     }
 
     /**
      * @return {@code true} if the task is a command type (as opposed to an action)
      */
     public boolean isCommand() {
-      return this == RESTART || this == START || this == CONFIGURE_FUNCTION || this == STOP || this == SERVICE_CHECK;
+      return COMMANDS.contains(this);
     }
   }
 }

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -361,6 +361,19 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+
+  <xs:complexType name="add_component">
+    <xs:complexContent>
+      <xs:extension base="abstract-server-task-type">
+        <xs:sequence />
+        <xs:attribute name="service" type="xs:string" use="required"/>
+        <xs:attribute name="component" type="xs:string" use="required"/>
+        <xs:attribute name="host-service" type="xs:string" use="optional"/>
+        <xs:attribute name="host-component" type="xs:string" use="optional"/>
+        <xs:attribute name="hosts" use="required" type="host-target-type" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   
   <xs:complexType name="order-type">
     <xs:sequence>

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/AmbariMetaInfoTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/AmbariMetaInfoTest.java
@@ -120,9 +120,6 @@ public class AmbariMetaInfoTest {
   private static final String SERVICE_NAME_MAPRED2 = "MAPREDUCE2";
   private static final String SERVICE_COMPONENT_NAME = "NAMENODE";
   private static final String OS_TYPE = "centos5";
-  private static final String HDP_REPO_NAME = "HDP";
-  private static final String HDP_REPO_ID = "HDP-2.1.1";
-  private static final String HDP_UTILS_REPO_NAME = "HDP-UTILS";
   private static final String REPO_ID = "HDP-UTILS-1.1.0.15";
   private static final String PROPERTY_NAME = "hbase.regionserver.msginterval";
   private static final String SHARED_PROPERTY_NAME = "content";
@@ -621,8 +618,8 @@ public class AmbariMetaInfoTest {
       "the extended stack.", deletedService);
     Assert.assertNotNull(redefinedService);
     // Components
-    Assert.assertEquals("YARN service is expected to be defined with 3 active" +
-      " components.", 3, redefinedService.getComponents().size());
+    Assert.assertEquals("YARN service is expected to be defined with 4 active" +
+      " components.", 4, redefinedService.getComponents().size());
     Assert.assertEquals("TEZ is expected to be a part of extended stack " +
       "definition", "TEZ", redefinedService.getClientComponent().getName());
     Assert.assertFalse("YARN CLIENT is a deleted component.",

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -231,8 +231,12 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.1.1");
 
-    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.1.1", "ZOOKEEPER");
+    // set the display names of the service and component in the target stack
+    // to make sure that we can correctly render display strings during the
+    // upgrade
+    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.2.0", "ZOOKEEPER");
     si.setDisplayName("Zk");
+
     ComponentInfo ci = si.getComponentByName("ZOOKEEPER_SERVER");
     ci.setDisplayName("ZooKeeper1 Server2");
 
@@ -310,8 +314,12 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.1.1");
 
-    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.1.1", "ZOOKEEPER");
+    // set the display names of the service and component in the target stack
+    // to make sure that we can correctly render display strings during the
+    // upgrade
+    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.2.0", "ZOOKEEPER");
     si.setDisplayName("Zk");
+
     ComponentInfo ci = si.getComponentByName("ZOOKEEPER_SERVER");
     ci.setDisplayName("ZooKeeper1 Server2");
 
@@ -367,8 +375,12 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.1.1");
 
-    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.1.1", "ZOOKEEPER");
+    // set the display names of the service and component in the target stack
+    // to make sure that we can correctly render display strings during the
+    // upgrade
+    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.2.0", "ZOOKEEPER");
     si.setDisplayName("Zk");
+
     ComponentInfo ci = si.getComponentByName("ZOOKEEPER_SERVER");
     ci.setDisplayName("ZooKeeper1 Server2");
 
@@ -1255,8 +1267,12 @@ public class UpgradeHelperTest extends EasyMockSupport {
   public void testUpgradeOrchestrationFullTask() throws Exception {
     Map<String, UpgradePack> upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.1.1");
 
-    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.1.1", "ZOOKEEPER");
+    // set the display names of the service and component in the target stack
+    // to make sure that we can correctly render display strings during the
+    // upgrade
+    ServiceInfo si = ambariMetaInfo.getService("HDP", "2.2.0", "ZOOKEEPER");
     si.setDisplayName("Zk");
+
     ComponentInfo ci = si.getComponentByName("ZOOKEEPER_SERVER");
     ci.setDisplayName("ZooKeeper1 Server2");
 

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/YARN/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.6/services/YARN/metainfo.xml
@@ -71,6 +71,19 @@
             <timeout>600</timeout>
           </commandScript>
         </component>
+
+        <component>
+          <name>YARN_FOO</name>
+          <displayName>Yarn Foo</displayName>
+          <category>SLAVE</category>
+          <cardinality>0+</cardinality>
+          <commandScript>
+            <script>scripts/yarn_foo.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+        </component>
+
         <component>
           <name>YARN_CLIENT</name>
           <displayName>YARN Client</displayName>
@@ -83,6 +96,7 @@
             <timeout>600</timeout>
           </commandScript>
         </component>
+
         <component>
           <name>TEZ</name>
           <category>CLIENT</category>


### PR DESCRIPTION
## What changes were proposed in this pull request?

During an upgrade it might be necessary to add a component automatically. For example, if a component is being replaced between stacks, then Ambari needs to remove the original component and add the new one.

This is a new situation which we've never had before. AMBARI-23553 was created to automatically remove services/components during an upgrade which didn't appear in the new stack. However, to replace a service component is something that involves more thought.

Perhaps we need an action that's similar to this:

```
<group xsi:type="cluster" name="ADD_YARN_TIMELINE_READER" title="Replace ATS with Timeline Reader">
  <execute-stage title="Replace ATS with Timeline Reader">
    <task xsi:type="add_component" service="YARN" component="TIMELINE_READER" host-service="YARN" host-component="APP_TIMELINE_SERVER">
      <summary>Add Timeline Reader to the cluster</summary>
    </task>
  </execute-stage>
</group>
```

## How was this patch tested?
- Performed an Express Upgrade from HDP 2.6 to HDP 3.0 with the following new tasks added to teh upgrade pack:
```
    <group xsi:type="cluster" name="ADD_YARN_TIMELINE_READER" title="Add New YARN Components">
      <direction>UPGRADE</direction>
      <skippable>true</skippable>
      <execute-stage title="Timeline Reader">
        <task xsi:type="add_component" service="YARN" component="TIMELINE_READER" host-service="YARN" host-component="APP_TIMELINE_SERVER" hosts="any">
          <summary>Add Timeline Reader to the cluster</summary>
        </task>
      </execute-stage>
    </group>
```