### PR TITLE
ambari-logsearch: Add jdeb support

### DIFF
--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -49,6 +49,29 @@
   </properties>
   <build>
     <plugins>
+
+     <plugin>
+         <groupId>org.vafer</groupId>
+         <artifactId>jdeb</artifactId>
+         <version>1.0.1</version>
+         <executions>
+           <execution>
+             <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+             <id>stub-execution</id>
+             <phase>none</phase>
+             <goals>
+               <goal>jdeb</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <skip>true</skip>
+           <attach>false</attach>
+           <submodules>false</submodules>
+           <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+         </configuration>
+       </plugin>
+
       <plugin>
         <inherited>false</inherited>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
This patch add debian package creation support for ambari-logsearch
package.

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>

## What changes were proposed in this pull request?

Add jdeb support for ambari-logsearch

## How was this patch tested?

The build (release-2.5.2) and test is done on AArch64 machine with Debian-9

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.