### PR TITLE
[AMBARI-23904] ZKFC fails to start while moving Namenode on a cluster with multiple namespaces

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step3_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step3_controller.js
@@ -482,7 +482,7 @@ App.ReassignMasterWizardStep3Controller = Em.Controller.extend({
       if (additionalConfigs.hasOwnProperty(site)) {
         for (var property in additionalConfigs[site]) {
           if (additionalConfigs[site].hasOwnProperty(property)) {
-            if (App.get('isHaEnabled') && componentName === 'NAMENODE' && (property === 'fs.defaultFS' || property === 'dfs.namenode.rpc-address')) continue;
+            if (App.get('isHaEnabled') && componentName === 'NAMENODE' && (['fs.defaultFS', 'dfs.namenode.rpc-address', 'dfs.namenode.http-address', 'dfs.namenode.https-address'].contains(property))) continue;
 
             configs[site][property] = additionalConfigs[site][property].replace('<replace-value>', replaceValue);
             if (!this.get('propertiesToChange').hasOwnProperty(site)) {
@@ -553,9 +553,9 @@ App.ReassignMasterWizardStep3Controller = Em.Controller.extend({
           httpAddressPropertiesNames = propertyNames.filter(propertyName => propertyName.startsWith(propertyNameStart)),
           matchingPropertyName = httpAddressPropertiesNames.find(propertyName => configsObject[propertyName].startsWith(this.get('content.reassignHosts.source')));
         if (matchingPropertyName) {
-          const nameSpaceMatch = matchingPropertyName.match(new RegExp(`${propertyNameStart}(\\w+)`));
+          const nameNodeSuffixMatch = matchingPropertyName.match(new RegExp(`${propertyNameStart}(\\w+)`));
           ret.namespaceId = nameSpace;
-          ret.suffix = nameSpaceMatch && nameSpaceMatch[1];
+          ret.suffix = nameNodeSuffixMatch && nameNodeSuffixMatch[1];
           break;
         }
       }

--- a/ambari-web/app/utils/configs/move_namenode_config_initializer.js
+++ b/ambari-web/app/utils/configs/move_namenode_config_initializer.js
@@ -30,7 +30,8 @@ App.MoveNameNodeConfigInitializer = App.MoveComponentConfigInitializerClass.crea
   initializers: {
     'dfs.namenode.http-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(50070),
     'dfs.namenode.https-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(50470),
-    'dfs.namenode.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8020)
+    'dfs.namenode.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8020),
+    'dfs.namenode.servicerpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8021),
   },
 
   uniqueInitializers: {


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR: 
- Deploy a cluster with 2 namespaces using blueprint.
- Use the UI wizard to move Active Namenode for namespace NS2
- Perform manual operations when prompted in the wizard (FormatZkfc on other 3 hosts, perform bootstrapStandby on the new NN)
- In the final step, start all services, ZKFC fails to start on the host where we moved the NN 

```
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/zkfc_slave.py", line 192, in <module>
    ZkfcSlave().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/zkfc_slave.py", line 71, in start
    ZkfcSlaveDefault.start_static(env, upgrade_type)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/zkfc_slave.py", line 96, in start_static
    create_log_dir=True
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/utils.py", line 258, in service
    Execute(daemon_cmd, not_if=process_id_exists_command, environment=hadoop_env_exports)
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/system.py", line 263, in action_run
    returns=self.resource.returns)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 72, in inner
    result = function(command, **kwargs)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 102, in checked_call
    tries=tries, try_sleep=try_sleep, timeout_kill_strategy=timeout_kill_strategy, returns=returns)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 150, in _call_wrapper
    result = _call(command, **kwargs_copy)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 308, in _call
    raise ExecutionFailed(err_msg, code, out, err)
resource_management.core.exceptions.ExecutionFailed: Execution of 'ambari-sudo.sh su cstm-hdfs -l -s /bin/bash -c 'ulimit -c unlimited ;  /usr/hdp/3.0.0.0-1316/hadoop/bin/hdfs --config /usr/hdp/3.0.0.0-1316/hadoop/conf --daemon start zkfc'' returned 1. ######## Hortonworks #############
This is MOTD message, added for testing in qe infra
WARNING: HADOOP_ZKFC_OPTS has been replaced by HDFS_ZKFC_OPTS. Using value of HADOOP_ZKFC_OPTS.
```

## How was this patch tested?

UI unit tests:
  21534 passing (25s)
  48 pending