### PR TITLE
[AMBARI-23906] - Topology Event Should Be Sent When Adding Host Components During Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementController.java
@@ -38,6 +38,7 @@ import org.apache.ambari.server.controller.metrics.MetricsCollectorHAManager;
 import org.apache.ambari.server.controller.metrics.timeline.cache.TimelineMetricCacheProvider;
 import org.apache.ambari.server.events.AmbariEvent;
 import org.apache.ambari.server.events.MetadataUpdateEvent;
+import org.apache.ambari.server.events.TopologyUpdateEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.metadata.RoleCommandOrder;
 import org.apache.ambari.server.orm.entities.ExtensionLinkEntity;
@@ -913,5 +914,8 @@ public interface AmbariManagementController {
   HostRepositories retrieveHostRepositories(Cluster cluster, Host host) throws AmbariException;
 
   MetadataUpdateEvent getClusterMetadataOnConfigsUpdate(Cluster cluster) throws AmbariException;
+
+  TopologyUpdateEvent getAddedComponentsTopologyEvent(Set<ServiceComponentHostRequest> requests)
+      throws AmbariException;
 }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -779,8 +779,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       hostNames.add(hostName);
       ServiceComponentHost sch = sc.getServiceComponentHost(request.getHostname());
 
-      StackId stackId = cluster.getDesiredStackVersion();
-
       TopologyComponent newComponent = TopologyComponent.newBuilder()
           .setComponentName(sch.getServiceComponentName())
           .setServiceName(sch.getServiceName())
@@ -5896,7 +5894,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     Map<String, Map<String,String>> agentConfigsMap = configs.getAgentConfigsMap();
 
     for (String key : agentConfigsMap.keySet()) {
-      agentConfigs.put(key, new TreeMap<String, String>(agentConfigsMap.get(key)));
+      agentConfigs.put(key, new TreeMap<>(agentConfigsMap.get(key)));
     }
 
     return agentConfigs;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -107,9 +107,7 @@ import org.apache.ambari.server.actionmanager.Stage;
 import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.agent.CommandRepository;
 import org.apache.ambari.server.agent.ExecutionCommand;
-import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.agent.stomp.HostLevelParamsHolder;
-import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.agent.stomp.TopologyHolder;
 import org.apache.ambari.server.agent.stomp.dto.HostRepositories;
 import org.apache.ambari.server.agent.stomp.dto.MetadataCluster;
@@ -364,10 +362,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   @Inject
   private Provider<TopologyHolder> m_topologyHolder;
 
-  private Provider<MetadataHolder> m_metadataHolder;
-
-  private Provider<AgentConfigsHolder> m_agentConfigsHolder;
-
   @Inject
   private Provider<HostLevelParamsHolder> m_hostLevelParamsHolder;
 
@@ -426,8 +420,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     masterHostname =  InetAddress.getLocalHost().getCanonicalHostName();
     maintenanceStateHelper = injector.getInstance(MaintenanceStateHelper.class);
     kerberosHelper = injector.getInstance(KerberosHelper.class);
-    m_metadataHolder = injector.getProvider(MetadataHolder.class);
-    m_agentConfigsHolder = injector.getProvider(AgentConfigsHolder.class);
     if(configs != null)
     {
       if (configs.getApiSSLAuthentication()) {
@@ -756,7 +748,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
   }
 
-  private TopologyUpdateEvent getAddedComponentsTopologyEvent(Set<ServiceComponentHostRequest> requests)
+  /**
+   * {@inheritDoc}
+   */
+  public TopologyUpdateEvent getAddedComponentsTopologyEvent(Set<ServiceComponentHostRequest> requests)
     throws AmbariException {
     TreeMap<String, TopologyCluster> topologyUpdates = new TreeMap<>();
     Set<String> hostsToUpdate = new HashSet<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
@@ -29,6 +29,7 @@ import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.ServiceComponentNotFoundException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
+import org.apache.ambari.server.events.listeners.upgrade.StackVersionListener;
 import org.apache.ambari.server.stack.MasterHostResolver;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Host;
@@ -118,6 +119,7 @@ public class AddComponentAction extends AbstractUpgradeServerAction {
       ServiceComponentHost sch = serviceComponent.addServiceComponentHost(host.getHostName());
       sch.setDesiredState(State.INSTALLED);
       sch.setState(State.INSTALLED);
+      sch.setVersion(StackVersionListener.UNKNOWN_VERSION);
 
       buffer.append("  ")
         .append(host.getHostName())

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
@@ -119,6 +119,10 @@ public class AddComponentAction extends AbstractUpgradeServerAction {
       ServiceComponentHost sch = serviceComponent.addServiceComponentHost(host.getHostName());
       sch.setDesiredState(State.INSTALLED);
       sch.setState(State.INSTALLED);
+
+      // for now, this is the easiest way to fire a topology event which
+      // refreshes the information about the cluster (needed for restart
+      // commands)
       sch.setVersion(StackVersionListener.UNKNOWN_VERSION);
 
       buffer.append("  ")

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -529,6 +529,7 @@ public class ClustersImpl implements Clusters {
     // the hosts by ID map is updated separately since the host has not yet
     // been persisted yet - the below event is what causes the persist
     getHostsByName().put(hostname, host);
+    getHostsById().put(host.getHostId(), host);
 
     getHostClustersMap().put(hostname,
         Collections.newSetFromMap(new ConcurrentHashMap<>()));

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -20,10 +20,8 @@ package org.apache.ambari.server.state.svccomphost;
 
 import java.text.MessageFormat;
 import java.util.Collections;
-import java.util.HashSet;
- import java.util.List;
+import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,9 +32,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.agent.AlertDefinitionCommand;
 import org.apache.ambari.server.agent.stomp.TopologyHolder;
-import org.apache.ambari.server.agent.stomp.dto.TopologyCluster;
-import org.apache.ambari.server.agent.stomp.dto.TopologyComponent;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.ServiceComponentHostRequest;
 import org.apache.ambari.server.controller.ServiceComponentHostResponse;
 import org.apache.ambari.server.controller.internal.DeleteHostComponentStatusMetaData;
 import org.apache.ambari.server.events.AlertHashInvalidationEvent;
@@ -47,7 +45,6 @@ import org.apache.ambari.server.events.ServiceComponentInstalledEvent;
 import org.apache.ambari.server.events.ServiceComponentUninstalledEvent;
 import org.apache.ambari.server.events.StaleConfigsUpdateEvent;
 import org.apache.ambari.server.events.TopologyUpdateEvent;
-import org.apache.ambari.server.events.UpdateEventType;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.events.publishers.STOMPUpdatePublisher;
 import org.apache.ambari.server.orm.dao.HostComponentDesiredStateDAO;
@@ -149,6 +146,12 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
    */
   @Inject
   private AlertDefinitionHash alertDefinitionHash;
+
+  /**
+   * Used for topology event creation updates
+   */
+  @Inject
+  private Provider<AmbariManagementController> controller;
 
   /**
    * Used to publish events relating to service CRUD operations.
@@ -966,19 +969,15 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
     if (stateEntity != null) {
       stateEntity.setVersion(version);
       stateEntity = hostComponentStateDAO.merge(stateEntity);
-      TreeMap<String, TopologyCluster> topologyUpdates = new TreeMap<>();
-      topologyUpdates.put(Long.toString(getClusterId()), new TopologyCluster());
-      Long hostId = getHost().getHostId();
-      topologyUpdates.get(Long.toString(getClusterId())).addTopologyComponent(TopologyComponent.newBuilder()
-          .setComponentName(getServiceComponentName())
-          .setServiceName(getServiceName())
-          .setVersion(stateEntity.getVersion())
-          .setHostIds(new HashSet<>(Collections.singletonList(hostId)))
-          .setHostNames(new HashSet<>(Collections.singletonList(hostName)))
-          .build());
-      TopologyUpdateEvent hostComponentVersionUpdate = new TopologyUpdateEvent(topologyUpdates,
-          UpdateEventType.UPDATE);
-      m_topologyHolder.get().updateData(hostComponentVersionUpdate);
+
+      ServiceComponentHostRequest serviceComponentHostRequest = new ServiceComponentHostRequest(
+          serviceComponent.getClusterName(), serviceComponent.getServiceName(),
+          serviceComponent.getName(), hostName, getDesiredState().name());
+
+      TopologyUpdateEvent updateEvent = controller.get().getAddedComponentsTopologyEvent(
+          Collections.singleton(serviceComponentHostRequest));
+
+      m_topologyHolder.get().updateData(updateEvent);
     } else {
       LOG.warn("Setting a member on an entity object that may have been "
           + "previously deleted, serviceName = " + getServiceName() + ", " + "componentName = "

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -2265,7 +2265,7 @@ public class AmbariManagementControllerImplTest {
 
     public NestedTestClass(ActionManager actionManager, Clusters clusters, Injector injector, OsFamily osFamilyMock) throws Exception {
       super(actionManager, clusters, injector);
-      this.osFamily = osFamilyMock;
+      osFamily = osFamilyMock;
     }
 
 //    public ServiceOsSpecific testPopulateServicePackagesInfo(ServiceInfo serviceInfo, Map<String, String> hostParams,
@@ -2432,8 +2432,6 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(Gson.class)).andReturn(gson);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(maintenanceStateHelper);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(kerberosHelper);
-    expect(injector.getProvider(MetadataHolder.class)).andReturn(m_metadataHolder);
-    expect(injector.getProvider(AgentConfigsHolder.class)).andReturn(m_agentConfigsHolder);
   }
 
   public static void constructorInit(Injector injector, Capture<AmbariManagementController> controllerCapture,
@@ -2442,7 +2440,5 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(null);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(kerberosHelper);
-    expect(injector.getProvider(MetadataHolder.class)).andReturn(null);
-    expect(injector.getProvider(AgentConfigsHolder.class)).andReturn(null);
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeSummaryResourceProviderTest.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,6 +60,7 @@ import org.apache.ambari.server.orm.dao.StageDAO;
 import org.apache.ambari.server.orm.dao.UpgradeDAO;
 import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.HostRoleCommandEntity;
+import org.apache.ambari.server.orm.entities.RepoOsEntity;
 import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
 import org.apache.ambari.server.orm.entities.RequestEntity;
 import org.apache.ambari.server.orm.entities.StackEntity;
@@ -147,9 +149,15 @@ public class UpgradeSummaryResourceProviderTest {
   public void createCluster() throws Exception {
     StackEntity stackEntity = stackDAO.find("HDP", "2.2.0");
 
+    List<RepoOsEntity> osRedhat6 = new ArrayList<>();
+    RepoOsEntity repoOsEntity = new RepoOsEntity();
+    repoOsEntity.setFamily("redhat6");
+    repoOsEntity.setAmbariManaged(true);
+    osRedhat6.add(repoOsEntity);
+
     RepositoryVersionEntity repoVersionEntity = new RepositoryVersionEntity();
     repoVersionEntity.setDisplayName("For Stack Version 2.2.0");
-    repoVersionEntity.addRepoOsEntities(new ArrayList<>());
+    repoVersionEntity.addRepoOsEntities(osRedhat6);
     repoVersionEntity.setStack(stackEntity);
     repoVersionEntity.setVersion("2.2.0.0");
     repoVersionDAO.create(repoVersionEntity);

--- a/ambari-server/src/test/resources/stacks/HDP/2.0.8/services/HBASE/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.0.8/services/HBASE/metainfo.xml
@@ -61,6 +61,10 @@
         <component>
           <name>HBASE_CLIENT</name>
           <category>CLIENT</category>
+          <commandScript>
+            <script>scripts/hbase_client.py</script>
+            <scriptType>PYTHON</scriptType>
+          </commandScript>          
         </component>
       </components>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

With AMBARI-23852, it's possible that new components can be added during upgrade. However, Ambari currently has a problem where topology update events are separate from `Cluster.addServiceComponentHost()` method calls.

This dis-association is being addressed as a whole in another Jira. However, for now, we can easily fix this by called `ServiceComponentHost.setVersion()` after creating it since this method actually sends the update we want.

## How was this patch tested?
Performed an EU from HDP 2.6 to HDP 3.0 and verified that the TimelineReader topology event was sent.