### PR TITLE
[AMBARI-23907] HDFS Prepare should not be called if there is no path to Downgrade

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/upgrade_summary.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/upgrade_summary.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.constants import Direction
 
-UpgradeSummary = namedtuple("UpgradeSummary", "type direction orchestration is_revert services")
+UpgradeSummary = namedtuple("UpgradeSummary", "type direction orchestration is_revert services is_downgrade_allowed")
 UpgradeServiceSummary = namedtuple("UpgradeServiceSummary", "service_name source_stack source_version target_stack target_version")
 
 
@@ -100,7 +100,8 @@ def get_upgrade_summary():
 
   return UpgradeSummary(type=upgrade_summary["type"], direction=upgrade_summary["direction"],
     orchestration=upgrade_summary["orchestration"], is_revert = upgrade_summary["isRevert"],
-    services = service_summary_dict)
+    services = service_summary_dict,
+    is_downgrade_allowed=upgrade_summary["isDowngradeAllowed"])
 
 
 def get_downgrade_from_version(service_name = None):

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -507,10 +507,20 @@ public class UpgradeContext {
     m_cluster = cluster;
     m_type = upgradeEntity.getUpgradeType();
     m_direction = upgradeEntity.getDirection();
+    // !!! this is the overall target stack repo version, not the source repo
     m_repositoryVersion = upgradeEntity.getRepositoryVersion();
 
     m_autoSkipComponentFailures = upgradeEntity.isComponentFailureAutoSkipped();
     m_autoSkipServiceCheckFailures = upgradeEntity.isServiceCheckFailureAutoSkipped();
+
+    /*
+     * This feels wrong.  We need the upgrade pack used when creating the upgrade, as that
+     * is really the source, not the target.  Can NOT use upgradeEntity.getRepositoryVersion() here
+     * for the stack id. Consulting the service map should work out since full upgrades are all same source stack,
+     * and patches by definition are the same source stack (just different repos of that stack).
+     */
+    @Experimental(feature = ExperimentalFeature.PATCH_UPGRADES)
+    StackId stackId = null;
 
     List<UpgradeHistoryEntity> allHistory = upgradeEntity.getHistory();
     for (UpgradeHistoryEntity history : allHistory) {
@@ -520,11 +530,14 @@ public class UpgradeContext {
       m_sourceRepositoryMap.put(serviceName, sourceRepositoryVersion);
       m_targetRepositoryMap.put(serviceName, targetRepositoryVersion);
       m_services.add(serviceName);
+
+      if (null == stackId) {
+        stackId = sourceRepositoryVersion.getStackId();
+      }
     }
 
-    @Experimental(feature = ExperimentalFeature.PATCH_UPGRADES, comment = "This is wrong")
     String upgradePackage = upgradeEntity.getUpgradePackage();
-    StackId stackId = m_repositoryVersion.getStackId();
+    stackId = (null != stackId) ? stackId : m_repositoryVersion.getStackId(); // fallback to old value
     Map<String, UpgradePack> packs = m_metaInfo.getUpgradePacks(stackId.getStackName(), stackId.getStackVersion());
     m_upgradePack = packs.get(upgradePackage);
 
@@ -955,6 +968,8 @@ public class UpgradeContext {
     summary.type = m_type;
     summary.orchestration = m_orchestration;
     summary.isRevert = m_isRevert;
+
+    summary.isDowngradeAllowed = isDowngradeAllowed();
 
     summary.services = new HashMap<>();
 
@@ -1387,6 +1402,9 @@ public class UpgradeContext {
 
     @SerializedName("isRevert")
     public boolean isRevert = false;
+
+    @SerializedName("downgradeAllowed")
+    public boolean isDowngradeAllowed = true;
 
     @SerializedName("services")
     public Map<String, UpgradeServiceSummary> services;

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -31,6 +31,7 @@ from resource_management.libraries.script.script import Script
 from resource_management.core.resources.system import Execute, File
 from resource_management.core import shell
 from resource_management.libraries.functions import stack_select
+from resource_management.libraries.functions import upgrade_summary
 from resource_management.libraries.functions.constants import Direction
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.security_commons import build_expectations, \
@@ -214,8 +215,13 @@ class NameNodeDefault(NameNode):
       namenode_upgrade.prepare_upgrade_backup_namenode_dir()
     namenode_upgrade.prepare_upgrade_finalize_previous_upgrades(hdfs_binary)
 
-    # Call -rollingUpgrade prepare
-    namenode_upgrade.prepare_rolling_upgrade(hdfs_binary)
+    summary = upgrade_summary.get_upgrade_summary()
+
+    if summary is not None and summary.is_downgrade_allowed:
+      # Call -rollingUpgrade prepare
+      namenode_upgrade.prepare_rolling_upgrade(hdfs_binary)
+    else:
+      Logger.info("Downgrade will not be possible. Skipping '-rollingUpgrade prepare'")
 
   def prepare_rolling_upgrade(self, env):
     hfds_binary = self.get_hdfs_binary()

--- a/ambari-server/src/test/python/TestStackFeature.py
+++ b/ambari-server/src/test/python/TestStackFeature.py
@@ -195,7 +195,8 @@ class TestStackFeature(TestCase):
         "direction":"UPGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }
 
@@ -232,7 +233,8 @@ class TestStackFeature(TestCase):
         "direction":"DOWNGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }
 
@@ -270,7 +272,8 @@ class TestStackFeature(TestCase):
         "direction":"DOWNGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }
 

--- a/ambari-server/src/test/python/TestStackSelect.py
+++ b/ambari-server/src/test/python/TestStackSelect.py
@@ -160,7 +160,8 @@ class TestStackSelect(TestCase):
         "direction":"UPGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }
 
@@ -198,7 +199,8 @@ class TestStackSelect(TestCase):
         "direction":"UPGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }
 

--- a/ambari-server/src/test/python/TestUpgradeSummary.py
+++ b/ambari-server/src/test/python/TestUpgradeSummary.py
@@ -96,7 +96,8 @@ class TestUpgradeSummary(TestCase):
         "direction":"UPGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }
 
@@ -132,6 +133,7 @@ class TestUpgradeSummary(TestCase):
         "direction":"DOWNGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "isDowngradeAllowed": True
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there is no path to downgrade for EU, there is no need to call `-rollingUpgrade prepare`

## How was this patch tested?

Manual testing and updated some python unit tests.