### PR TITLE
[AMBARI-23918] [Logsearch UI] 'Component' option missing in the autofill in include filter

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
@@ -29,7 +29,7 @@
 </ng-container>
 <span class="active-parameter-label" *ngIf="isActive && activeItem">{{activeItem.label | translate}}:</span>
 <div [ngClass]="{'search-item-container': true, 'active': isActive, 'value': isValueInput}">
-  <input #parameterInput [(ngModel)]="currentValue" [typeahead]="items" typeaheadOptionField="value"
+  <input #parameterInput [(ngModel)]="currentValue" [typeahead]="items" typeaheadOptionField="label"
          [typeaheadItemTemplate]="listItemTemplate" (typeaheadNoResults)="setParameterNameMatchFlag($event)"
          [typeaheadMinLength]="0"
          (typeaheadOnSelect)="changeParameterName({item: $event.item, isExclude: false})"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The typeahead library should look in the labels not in the values.

## How was this patch tested?

Manually and by unit tests.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

@aBabiichuk please review it. Thanks.