### PR TITLE
[AMBARI-21701] Check for import from org.apache.ambari.metrics.sink.relocated

### DIFF
--- a/ambari-server/checkstyle.xml
+++ b/ambari-server/checkstyle.xml
@@ -24,7 +24,7 @@
     <!-- imports -->
     <module name="AvoidStarImport"/>
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="sun, org.apache.hadoop.metrics2.sink.relocated"/>
+      <property name="illegalPkgs" value="sun, org.apache.ambari.metrics.sink.relocated, org.apache.hadoop.metrics2.sink.relocated"/>
     </module>
     <module name="ImportOrder">
       <property name="groups" value="java,javax,org,com,*"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `org.apache.ambari.metrics.sink.relocated` to the list of illegal packages to be used in `ambari-server`.  This package is available only if compiled with `ambari-metrics` (eg. Jenkins), but is not included in `ambari-server` dependencies.

## How was this patch tested?

Temporarily added [unwanted import](https://github.com/apache/ambari/blob/021462339cc4eb4b6c49e7dfbdba29ce77f94a6d/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java#L33), then ran check:

```
$ mvn -pl ambari-server checkstyle:check
[INFO] --- maven-checkstyle-plugin:2.17:check (default-cli) @ ambari-server ---
[INFO] Starting audit...
[ERROR] ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java:33:1: Import from illegal package - org.apache.ambari.metrics.sink.relocated.curator.shaded.com.google.common.collect.Lists. [IllegalImport]
Audit done.
```

Check on current `trunk`:

```
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
Audit done.
```