### PR TITLE
AMBARI-23923. Implement 3.0 Mpack Advisor's Configuration Recommendation API Server code for 'Cluster Create'

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorHelper.java
@@ -28,6 +28,7 @@ import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackAdvisorCommand;
 import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackComponentLayoutRecommendationCommand;
 import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackComponentLayoutValidationCommand;
+import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackConfigurationRecommendationCommand;
 import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse;
 import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse;
 import org.apache.ambari.server.configuration.Configuration;
@@ -123,6 +124,9 @@ public class MpackAdvisorHelper {
     MpackAdvisorCommand<MpackRecommendationResponse> command;
     if (requestType == MpackAdvisorRequest.MpackAdvisorRequestType.HOST_GROUPS) {
       command = new MpackComponentLayoutRecommendationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
+          requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+    }  else if (requestType == MpackAdvisorRequest.MpackAdvisorRequestType.CONFIGURATIONS) {
+      command = new MpackConfigurationRecommendationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
           requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
     } else {
       // TODO : for other MpackAdvisorRequestType's.

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorResponse.java
@@ -28,7 +28,7 @@ public abstract class MpackAdvisorResponse {
 
   private int id;
 
-  @JsonProperty("Versions")
+  @JsonProperty("versions")
   private Version version;
 
   public int getId() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackConfigurationRecommendationCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackConfigurationRecommendationCommand.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor.commands;
+
+
+import java.io.File;
+
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRunner;
+import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.topology.MpackInstance;
+
+/**
+ * {@link org.apache.ambari.server.api.services.mpackadvisor.commands.MpackAdvisorCommand} implementation for
+ * configuration recommendation.
+ */
+public class MpackConfigurationRecommendationCommand extends
+    MpackAdvisorCommand<MpackRecommendationResponse> {
+
+  public MpackConfigurationRecommendationCommand(File recommendationsDir,
+                                                 String recommendationsArtifactsLifetime,
+                                                 ServiceInfo.ServiceAdvisorType serviceAdvisorType,
+                                                 int requestId,
+                                                 MpackAdvisorRunner maRunner,
+                                                 AmbariMetaInfo metaInfo,
+                                                 AmbariServerConfigurationHandler ambariServerConfigurationHandler) {
+    super(recommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType, requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+  }
+  @Override
+  protected MpackAdvisorCommandType getCommandType() {
+    return MpackAdvisorCommandType.RECOMMEND_CONFIGURATIONS;
+  }
+
+  @Override
+  protected void validate(MpackAdvisorRequest request) throws MpackAdvisorException {
+    if (request.getHosts() == null || request.getHosts().isEmpty()) {
+      throw new MpackAdvisorException("Hosts must not be empty");
+    }
+
+    if (request.getMpackInstances() != null || !request.getMpackInstances().isEmpty()) {
+      for (MpackInstance mpackInstance : request.getMpackInstances()) {
+        if (mpackInstance.getServiceInstances() == null || mpackInstance.getServiceInstances().isEmpty()) {
+          throw new MpackAdvisorException("Service instances for Mpack Instance " + mpackInstance.getMpackName()
+              + " is empty.");
+        }
+      }
+    } else {
+      throw new MpackAdvisorException("Request's Mpack instances is null or empty.");
+    }
+  }
+
+  @Override
+  protected MpackRecommendationResponse updateResponse(MpackAdvisorRequest request, MpackRecommendationResponse response) {
+
+    // TODO Update HostGroups and BpClusterbindings
+    return response;
+  }
+
+  @Override
+  protected String getResultFileName() {
+    return "configurations.json";
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/recommendations/MpackRecommendationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/recommendations/MpackRecommendationResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.api.services.mpackadvisor.recommendations;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,12 +104,115 @@ public class MpackRecommendationResponse extends MpackAdvisorResponse {
     }
   }
 
+  /* TODO : Even though MpackInstance class exists at :
+   * ambari-server/src/main/java/org/apache/ambari/server/topology/MpackInstance.java,
+   * we need the MpackInstance -> ServiceInstance to have BlueprintConfigurations
+   * class to handle the read Configurations with ease.
+   * Need to look into using the existing classes.
+   */
+
+  public static class MpackInstance {
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("version")
+    private String version;
+
+    private String mpackType;
+
+    @JsonProperty("service_instances")
+    private Collection<ServiceInstance> serviceInstances = new ArrayList<>();
+
+    public String getName() {
+      return name;
+    }
+    public void setName(String mpackName) {
+      this.name = mpackName;
+    }
+    public String getVersion() {
+      return version;
+    }
+    public void setVersion(String mpackVersion) {
+      this.version = mpackVersion;
+    }
+    public Collection<ServiceInstance> getServiceInstances() {
+      return serviceInstances;
+    }
+
+    public void setServiceInstances(Collection<ServiceInstance> serviceInstances) {
+      this.serviceInstances = serviceInstances;
+      serviceInstances.forEach(si -> si.setMpackInstance(this));
+    }
+    public void addServiceInstance(ServiceInstance serviceInstance) {
+      serviceInstances.add(serviceInstance);
+      serviceInstance.setMpackInstance(this);
+    }
+  }
+
+  public static class ServiceInstance {
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("version")
+    private String version;
+    @JsonProperty
+    private Map<String, BlueprintConfigurations> configurations;
+
+    @JsonProperty("mpackInstance")
+    private MpackInstance mpackInstance;
+
+    public ServiceInstance() { }
+
+    public Map<String, BlueprintConfigurations> getConfigurations() {
+      return configurations;
+    }
+
+    public void setConfigurations(Map<String, BlueprintConfigurations> configurations) {
+      this.configurations = configurations;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public MpackInstance getMpackInstance() {
+      return mpackInstance;
+    }
+
+    void setMpackInstance(MpackInstance mpackInstance) {
+      this.mpackInstance = mpackInstance;
+    }
+  }
+
   public static class Blueprint {
     @JsonProperty
     private Map<String, BlueprintConfigurations> configurations;
 
     @JsonProperty("host_groups")
     private Set<HostGroup> hostGroups;
+
+    @JsonProperty("mpack_instances")
+    private Set<MpackInstance> mpackInstances;
 
     public Map<String, BlueprintConfigurations> getConfigurations() {
       return configurations;
@@ -123,6 +228,14 @@ public class MpackRecommendationResponse extends MpackAdvisorResponse {
 
     public void setHostGroups(Set<HostGroup> hostGroups) {
       this.hostGroups = hostGroups;
+    }
+
+    public void setMpackInstances(Set<MpackInstance> mpacks) {
+      this.mpackInstances = mpacks;
+    }
+
+    public Set<MpackInstance> getMpackInstances() {
+      return this.mpackInstances;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Background :** https://github.com/apache/ambari/pull/1296 covered : Implement 3.0 Mpack Advisor's Host Component Layout API Server code for : 'Recommendations' and 'Validations'.

Explanation on 3.0 Mpack Advisor in following slides :  
[3.0 Mpack Advisor.pptx](https://github.com/apache/ambari/files/2025718/3.0.Mpack.Advisor.pptx)



- This PULL request implements **"Mpack Advisor's Configuration Recommendation API Server code for 'Cluster Create'"**

- API **REQUEST** and **RESPONSE** body uses the following hierarchy :
     • blueprint -> mpack_instances -> service_instances, to distinguish one service and component instance from another of same kind.

## How was this patch tested?

API:

POST http://[AmbariServer]:8080/api/v1/mpacks/recommendations

Postman Scripts : 
[Mpack Advisor Config Recommendation APIs - Cluster Create.postman_collection.zip](https://github.com/apache/ambari/files/2025667/Mpack.Advisor.Config.Recommendation.APIs.-.Cluster.Create.postman_collection.zip)


which contains 2 examples : 

**1. Configuration Recommendations with 1 Mpack**
      
  -------
**2. Configuration Recommendations with 2 Mpacks:**

**Request Structure looks like this:**
**Request Body :** [RequestBody.txt](https://github.com/apache/ambari/files/2025756/RequestBody.txt)

![1](https://user-images.githubusercontent.com/1879146/40351295-e8702656-5d60-11e8-820a-df61e4deccb5.png)

**Response Structure looks like this:**

**Response Body:**  [ResponseBody.txt](https://github.com/apache/ambari/files/2025758/ResponseBody.txt)


![2](https://user-images.githubusercontent.com/1879146/40351324-fdb6522e-5d60-11e8-9ee2-13bea5ce1856.png)

**Created FS files as part of interaction b/w Java and Python code:**

[services.json.log](https://github.com/apache/ambari/files/2025705/services.json.log)
[hosts.json.log](https://github.com/apache/ambari/files/2025702/hosts.json.log)
[mpackadvisor.err.log](https://github.com/apache/ambari/files/2025703/mpackadvisor.err.log)
[mpackadvisor.out.log](https://github.com/apache/ambari/files/2025704/mpackadvisor.out.log)
[configurations.json.log](https://github.com/apache/ambari/files/2025701/configurations.json.log)





