### PR TITLE
Summary:Tip issue when turn on or off maintainance and there is no ho…

### DIFF
--- a/ambari-web/app/controllers/main/host/bulk_operations_controller.js
+++ b/ambari-web/app/controllers/main/host/bulk_operations_controller.js
@@ -173,7 +173,7 @@ App.BulkOperationsController = Em.Controller.extend({
     else {
       return App.ModalPopup.show({
         header: Em.I18n.t('rolling.nothingToDo.header'),
-        body: Em.I18n.t('rolling.nothingToDo.body').format(Em.I18n.t('hosts.host.maintainance.allComponents.context')),
+	body: operationData.state == 'OFF' ?Em.I18n.t('hosts.bulkOperation.noPassiveState.nothingToDo.body'):Em.I18n.t('hosts.bulkOperation.passiveState.nothingToDo.body'),
         secondary: false
       });
     }

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -2682,6 +2682,7 @@ Em.I18n.translations = {
   'hosts.bulkOperation.confirmation.delete.hosts':'Are you sure you want to delete the following {0} hosts?',
   'hosts.bulkOperation.confirmation.hostComponents':'Are you sure you want to <strong>{0} {1}</strong> on the following {2} hosts?',
   'hosts.bulkOperation.passiveState.nothingToDo.body':'All hosts that you selected are already in Maintenance Mode.',
+  'hosts.bulkOperation.noPassiveState.nothingToDo.body':'All hosts that you selected are not in Maintenance Mode.',
   'hosts.bulkOperation.warningInfo.body':'Components on these hosts are stopped so decommission will be skipped.',
   'hosts.bulkOperation.host_components.passiveState.nothingToDo.body':'All host components that you selected are already in Maintenance Mode',
   'hosts.bulkOperation.confirmation.add.component':'{0} will be added to the following hosts.',


### PR DESCRIPTION
Tip issue when turn on or off maintainance and there is no host in or off maintaince

Description:
Jira: #AMBARI-23558

## What changes were proposed in this pull request?
Tip should be ''All hosts that you selected are not in Maintenance Mode. when turning on maintainance and all hosts are not in maintaince.
And Tip should be ''All hosts that you selected are already in Maintenance Mode.' when turn on maintainance and all hosts are in maintaince.

@geksilla @aBabiichuk @Zangr @omalley @adoroszlai @billierinaldi @zjffdu 

