### PR TITLE
AMBARI-23930 - Provide a Framework For Regenerating Keytabs During Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
@@ -132,6 +132,13 @@ public interface KerberosHelper {
   String PRECONFIGURE_SERVICES = "preconfigure_services";
 
   /**
+   * If {@code true}, then this will create the stages and tasks as being
+   * retry-able. A failure during Kerberos operations will not cause the entire
+   * request to be aborted.
+   */
+  String ALLOW_RETRY = "allow_retry_on_failure";
+
+  /**
    * Toggles Kerberos security to enable it or remove it depending on the state of the cluster.
    * <p/>
    * The cluster "security_type" property is used to determine the security state of the cluster.

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/AddComponentAction.java
@@ -81,7 +81,7 @@ public class AddComponentAction extends AbstractUpgradeServerAction {
     if (candidates.isEmpty()) {
       return createCommandReport(0, HostRoleStatus.FAILED, "{}", "", String.format(
           "Unable to add a new component to the cluster as there are no hosts which contain %s's %s",
-          task.service, task.component));
+          task.hostService, task.hostComponent));
     }
 
     Service service = cluster.getService(task.service);

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
@@ -176,7 +176,7 @@ public class MasterHostResolver {
       String serviceName, String componentName) {
     Collection<Host> candidates = cluster.getHosts();
     if (StringUtils.isNotBlank(serviceName) && StringUtils.isNotBlank(componentName)) {
-      List<ServiceComponentHost> schs = cluster.getServiceComponentHosts(serviceName,componentName);      
+      List<ServiceComponentHost> schs = cluster.getServiceComponentHosts(serviceName,componentName);
       candidates = schs.stream().map(sch -> sch.getHost()).collect(Collectors.toList());
     }
 
@@ -185,23 +185,23 @@ public class MasterHostResolver {
     }
 
     // figure out where to add the new component
-    List<Host> hosts = Lists.newArrayList();
+    List<Host> winners = Lists.newArrayList();
     switch (executeHostType) {
       case ALL:
-        hosts.addAll(candidates);
+        winners.addAll(candidates);
         break;
       case FIRST:
-        hosts.add(candidates.iterator().next());
+        winners.add(candidates.iterator().next());
         break;
       case MASTER:
-        hosts.add(candidates.iterator().next());
+        winners.add(candidates.iterator().next());
         break;
       case ANY:
-        hosts.add(candidates.iterator().next());
+        winners.add(candidates.iterator().next());
         break;
     }
 
-    return candidates;
+    return winners;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ClusterGrouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ClusterGrouping.java
@@ -222,6 +222,10 @@ public class ClusterGrouping extends Grouping {
               wrapper = getExecuteStageWrapper(upgradeContext, execution);
               break;
 
+            case REGENERATE_KEYTABS:
+              wrapper = getRegenerateKeytabsWrapper(upgradeContext, execution);
+              break;
+
             default:
               break;
           }
@@ -274,10 +278,32 @@ public class ClusterGrouping extends Grouping {
   }
 
   /**
-   * Return a Stage Wrapper for a task meant to execute code, typically on Ambari Server.
-   * @param ctx Upgrade Context
-   * @param execution Execution Stage
-   * @return Returns a Stage Wrapper, or null if a valid one could not be created.
+   * Return a {@link StageWrapper} for regeneration of keytabs.
+   *
+   * @param ctx
+   *          Upgrade Context
+   * @param execution
+   *          Execution Stage
+   * @return a {@link StageWrapper} which will regenerate keytabs on all hosts.
+   */
+  private StageWrapper getRegenerateKeytabsWrapper(UpgradeContext ctx, ExecuteStage execution) {
+    Task task = execution.task;
+    HostsType hosts = HostsType.healthy(ctx.getCluster());
+
+    return new StageWrapper(StageWrapper.Type.REGENERATE_KEYTABS, execution.title,
+        new TaskWrapper(null, null, hosts.getHosts(), task));
+  }
+
+  /**
+   * Return a Stage Wrapper for a task meant to execute code, typically on
+   * Ambari Server.
+   *
+   * @param ctx
+   *          Upgrade Context
+   * @param execution
+   *          Execution Stage
+   * @return Returns a Stage Wrapper, or null if a valid one could not be
+   *         created.
    */
   private StageWrapper getExecuteStageWrapper(UpgradeContext ctx, ExecuteStage execution) {
     String service   = execution.service;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -349,6 +349,9 @@ public class Grouping {
         case SERVICE_CHECK:
           type = StageWrapper.Type.SERVICE_CHECK;
           break;
+        case REGENERATE_KEYTABS:
+          type = StageWrapper.Type.REGENERATE_KEYTABS;
+          break;
       }
       tasks.add(initial);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RegenerateKeytabsTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RegenerateKeytabsTask.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.state.stack.upgrade;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * The {@link RegenerateKeytabsTask} is used for injection Kerberos tasks into
+ * an upgrade which will regenerate keytabs. The regeneration is always partial,
+ * opting to only regenerate missing keytabs.
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "regenerate_keytabs")
+public class RegenerateKeytabsTask extends Task {
+
+  @Expose
+  @XmlTransient
+  private Task.Type type = Type.REGENERATE_KEYTABS;
+
+  /**
+   * Constructor.
+   *
+   */
+  public RegenerateKeytabsTask() {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Task.Type getType() {
+    return type;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public StageWrapper.Type getStageWrapperType() {
+    return StageWrapper.Type.REGENERATE_KEYTABS;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getActionVerb() {
+    return "Regenerating Keytabs";
+  }
+
+  /**
+   * Gets a JSON representation of this task.
+   *
+   * @return a JSON representation of this task.
+   */
+  public String toJson() {
+    return GSON.toJson(this);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapper.java
@@ -159,7 +159,8 @@ public class StageWrapper {
     SERVICE_CHECK,
     STOP,
     START,
-    CONFIGURE
+    CONFIGURE, 
+    REGENERATE_KEYTABS;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Task.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Task.java
@@ -34,7 +34,8 @@ import com.google.gson.annotations.Expose;
 @XmlSeeAlso(
     value = { ExecuteTask.class, CreateAndConfigureTask.class, ConfigureTask.class,
         ManualTask.class, RestartTask.class, StartTask.class, StopTask.class,
-        ServerActionTask.class, ConfigureFunction.class, AddComponentTask.class })
+        ServerActionTask.class, ConfigureFunction.class, AddComponentTask.class,
+        RegenerateKeytabsTask.class })
 public abstract class Task {
 
   /**
@@ -161,7 +162,12 @@ public abstract class Task {
     /**
      * A task which adds new components to the cluster during the upgrade.
      */
-    ADD_COMPONENT;
+    ADD_COMPONENT,
+
+    /**
+     * Create keytab regeneration steps as part of the upgrade.
+     */
+    REGENERATE_KEYTABS;
 
     /**
      * Commands which run on the server.
@@ -173,7 +179,7 @@ public abstract class Task {
      * Commands which are run on agents.
      */
     public static final EnumSet<Type> COMMANDS = EnumSet.of(RESTART, START, CONFIGURE_FUNCTION,
-        STOP, SERVICE_CHECK);
+        STOP, SERVICE_CHECK, REGENERATE_KEYTABS);
 
     /**
      * @return {@code true} if the task is manual or automated.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/TaskWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/TaskWrapper.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Aggregates all upgrade tasks for a HostComponent into one wrapper.
@@ -112,7 +112,7 @@ public class TaskWrapper {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("service", service)
+    return MoreObjects.toStringHelper(this).add("service", service)
         .add("component", component)
         .add("tasks", tasks)
         .add("hosts", hosts)

--- a/ambari-server/src/main/resources/stack-hooks/before-SET_KEYTAB/scripts/hook.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-SET_KEYTAB/scripts/hook.py
@@ -1,0 +1,38 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management import *
+
+class BeforeSetKeytabHook(Hook):
+
+  def hook(self, env):
+    """
+    This will invoke the before-ANY hook which contains all of the user and group creation logic.
+    Keytab regeneration requires all users are already created, which is usually done by the
+    before-INSTALL hook. However, if the keytab regeneration is executed as part of an upgrade,
+    then the before-INSTALL hook never ran.
+
+    :param env:
+    :return:
+    """
+    self.run_custom_hook('before-ANY')
+
+if __name__ == "__main__":
+  BeforeSetKeytabHook().execute()
+

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -374,7 +374,14 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
+
+  <xs:complexType name="regenerate_keytabs">
+    <xs:complexContent>
+      <xs:extension base="abstract-server-task-type">
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
   <xs:complexType name="order-type">
     <xs:sequence>
       <xs:element name="group" minOccurs="1" maxOccurs="unbounded" />

--- a/ambari-server/src/test/python/stacks/2.0.6/hooks/before-SET_KEYTAB/test_before_set_keytab.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/hooks/before-SET_KEYTAB/test_before_set_keytab.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+from stacks.utils.RMFTestCase import *
+from mock.mock import MagicMock, patch
+from resource_management import Hook
+import itertools
+
+@patch("platform.linux_distribution", new = MagicMock(return_value="Linux"))
+@patch("os.path.exists", new = MagicMock(return_value=True))
+@patch.object(Hook, "run_custom_hook")
+class TestHookBeforeSetKeytab(RMFTestCase):
+  STACK_VERSION = '2.0.6'
+  def test_hook_default(self, run_custom_hook_mock):
+    self.executeScript("before-SET_KEYTAB/scripts/hook.py",
+                       classname="BeforeSetKeytabHook",
+                       command="hook",
+                       stack_version = self.STACK_VERSION,
+                       target=RMFTestCase.TARGET_STACK_HOOKS,
+                       config_file="default.json",
+                       call_mocks=itertools.cycle([(0, "1000")])
+    )
+
+    run_custom_hook_mock.assert_called_with('before-ANY')

--- a/ambari-server/src/test/python/stacks/2.2/KERBEROS/test_kerberos_client.py
+++ b/ambari-server/src/test/python/stacks/2.2/KERBEROS/test_kerberos_client.py
@@ -18,7 +18,7 @@ limitations under the License.
 """
 
 import json
-from mock.mock import MagicMock, patch
+from mock.mock import patch
 import os
 import sys
 import use_cases

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test_regenerate_keytabs.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test_regenerate_keytabs.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.2.*.*</target>
+  <target-stack>HDP-2.2.0</target-stack>
+  <type>ROLLING</type>
+  <prerequisite-checks/>
+
+  <order>
+    <group xsi:type="cluster" name="REGENERATE_KEYTABS" title="Regenerate Missing Keytabs">
+      <condition xsi:type="security" type="kerberos"/>
+      <direction>UPGRADE</direction>
+      <execute-stage title="Regenerate Missing Keytabs">
+        <task xsi:type="regenerate_keytabs"/>
+      </execute-stage>
+    </group>
+  </order>
+  
+  <processing>
+    <service name="ZOOKEEPER">
+      <component name="ZOOKEEPER_SERVER">
+        <upgrade />
+      </component>
+    </service>
+  </processing>
+</upgrade>


### PR DESCRIPTION
## What changes were proposed in this pull request?

There have been cases in the past where a manual step required after performing a stack upgrade was to regenerate keytabs. This was necessary for a variety of reasons, but it wasn't problematic enough to warrant Ambari doing this as part of an upgrade.

With the stack upgrade from HDP 2.6 to 3.0, 2 new components are added: Registry DNS and ATR. If the cluster is kerberized, these new components won't start until keytabs have been generated for them.

The follow will be able to be added to an upgrade pack in order to instruct the upgrade to regenerate missing keytabs for the new components:

```
    <group xsi:type="cluster" name="REGENERATE_KEYTABS" title="Regenerate Missing Keytabs">
      <condition xsi:type="security" type="kerberos"/>
      <direction>UPGRADE</direction>
      <execute-stage title="Regenerate Missing Keytabs">
        <task xsi:type="regenerate_keytabs"/>
      </execute-stage>
    </group>
```

A credential store will need to be setup before hand so that the kerberos credentials are available when this step in the upgrade runs.

## How was this patch tested?
Added some tests, still adding more. I also went through an upgrade with and without Kerberos. With Kerberos enabled, I verified that errors during the keytab generation phase do not abort the upgrade and are retry-able.