### PR TITLE
AMBARI-23925 - Zeppelin is not respecting the absolute hdfs path for notebooks

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.6.0/package/scripts/master.py
@@ -186,11 +186,12 @@ class Master(Script):
                 mode=0644)
 
   def check_and_copy_notebook_in_hdfs(self, params):
-    if params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir'].startswith("/"):
-      notebook_directory = params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir']
+    notebook_dir = params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir']
+    
+    if notebook_dir.startswith("/") or '://' in notebook_dir:
+      notebook_directory = notebook_dir
     else:
-      notebook_directory = "/user/" + format("{zeppelin_user}") + "/" + \
-                           params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir']
+      notebook_directory = "/user/" + format("{zeppelin_user}") + "/" + notebook_dir
 
     kinit_path_local = get_kinit_path(default('/configurations/kerberos-env/executable_search_paths', None))
     kinit_if_needed = format("{kinit_path_local} -kt {zeppelin_kerberos_keytab} {zeppelin_kerberos_principal};")

--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
@@ -194,11 +194,12 @@ class Master(Script):
                 mode=0644)
 
   def check_and_copy_notebook_in_hdfs(self, params):
-    if params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir'].startswith("/"):
-      notebook_directory = params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir']
+
+    notebook_dir = params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir']
+    if notebook_dir.startswith("/") or '://' in notebook_dir:
+      notebook_directory = notebook_dir
     else:
-      notebook_directory = "/user/" + format("{zeppelin_user}") + "/" + \
-                           params.config['configurations']['zeppelin-config']['zeppelin.notebook.dir']
+      notebook_directory = "/user/" + format("{zeppelin_user}") + "/" + notebook_dir
 
     if not self.is_directory_exists_in_HDFS(notebook_directory, params.zeppelin_user):
       # hdfs dfs -mkdir {notebook_directory}


### PR DESCRIPTION

## What changes were proposed in this pull request?

Zeppelin was appending /user/<zeppelin_user> to user provided notebook directory even when user provides the absolute hdfs path

The issue is happening since check for 'hdfs' path is missing for zeppelin.notebook.dir.

So added the similar check which exists for zeppelin.config.dir https://github.com/apache/ambari/blob/trunk/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py#L349

## How was this patch tested?

Manually tested the fix. Manually made the changes to master.py and tested below scenarios :
1) HDFS path is respected when an absolute path is  provided
2) Path is unaltered if it starts with '/' ie when a complete path is provided
3) User provided path is appended with '/user/<zeppelin_user>' when the user provides a relative path. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.