### PR TITLE
[AMBARI-23937] Reassign Master Wizard issues

### DIFF
--- a/ambari-web/app/mixins/wizard/assign_master_components.js
+++ b/ambari-web/app/mixins/wizard/assign_master_components.js
@@ -822,7 +822,37 @@ App.AssignMasterComponents = Em.Mixin.create(App.HostComponentValidationMixin, A
 
     masterComponents.forEach(function (item) {
       var masterComponent = App.StackServiceComponent.find().findProperty('componentName', item.component_name);
-      var componentObj = Em.Object.create(item);
+      var componentObj = Em.Object.create(item, item.nameSpace ? {
+        allMasters: result,
+        /**
+         * Namespace of NameNode for enabled HDFS federation.
+         * If a new host is assigned to component, looking for other NameNodes
+         * to find which namespace has a 'free' host after this assignment.
+         * NameNodes with new host assigned are excluded from this process
+         * since moving more than one component at once is not allowed.
+         */
+        nameSpace: function () {
+          const hostComponent = App.HostComponent.find(`${this.get('component_name')}_${this.get('selectedHost')}`);
+          if (hostComponent.get('isLoaded')) {
+            return hostComponent.get('haNameSpace');
+          } else {
+            let nameSpacesCounts = {};
+            const allNameSpaces = this.get('allMasters').filter(masterComponent => {
+              return masterComponent.get('serviceComponentId') !== this.get('serviceComponentId')
+                && App.HostComponent.find(`${masterComponent.get('component_name')}_${masterComponent.get('selectedHost')}`).get('isLoaded')
+                && masterComponent.get('nameSpace');
+            }).mapProperty('nameSpace');
+            allNameSpaces.forEach(nameSpace => {
+              const currentCount = nameSpacesCounts[nameSpace];
+              nameSpacesCounts[nameSpace] = currentCount ? currentCount + 1 : 1;
+            });
+            const nameSpacesWithMissingHost = Object.keys(nameSpacesCounts).filter(key => nameSpacesCounts[key] === 1);
+            if (nameSpacesWithMissingHost.length === 1) {
+              return nameSpacesWithMissingHost[0];
+            }
+          }
+        }.property('allMasters.@each.selectedHost')
+      } : {});
       var showRemoveControl;
       if (masterComponent.get('isMasterWithMultipleInstances')) {
         showRemoveControl = installedServices.contains(masterComponent.get('stackService.serviceName')) &&

--- a/ambari-web/app/routes/reassign_master_routes.js
+++ b/ambari-web/app/routes/reassign_master_routes.js
@@ -302,7 +302,6 @@ module.exports = App.WizardRoute.extend({
     next: function (router) {
       var controller = router.get('reassignMasterController');
       controller.finish();
-      controller.get('popup').hide();
       App.clusterStatus.setClusterStatus({
         clusterName: router.get('reassignMasterController.content.cluster.name'),
         clusterState: 'DEFAULT',


### PR DESCRIPTION
## What changes were proposed in this pull request?

- On step 1, namespace ids are displayed next to hostname selects. When user selects hostname from other namespace, the displayed id isn't changed
- After completing the last step, page URL remains `#/main/service/reassign/step6`, with JS error thrown: `app.js:212117 Uncaught TypeError: Cannot read property 'modal' of undefined`. After page refresh user is broutght to the final step of wizard again, containing no relevant data

## How was this patch tested?

UI unit tests:
  21540 passing (22s)
  48 pending
