### PR TITLE
[AMBARI-23941] Updating serviceLevelParams and clusterLevelParams in server-side metadata holder both when adding and removing a service/property

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/MetadataHolder.java
@@ -88,7 +88,7 @@ public class MetadataHolder extends AgentClusterDataHolder<MetadataUpdateEvent> 
             if (cluster.updateClusterLevelParams(updatedCluster.getClusterLevelParams())) {
               changed = true;
             }
-            if (cluster.updateServiceLevelParams(updatedCluster.getServiceLevelParams())) {
+            if (cluster.updateServiceLevelParams(updatedCluster.getServiceLevelParams(), updatedCluster.isFullServiceLevelMetadata())) {
               changed = true;
             }
             if (CollectionUtils.isNotEmpty(updatedCluster.getStatusCommandsToRun())

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
@@ -87,7 +87,16 @@ public class MetadataCluster {
         break;
       }
     }
+
+    for (String key : serviceLevelParams.keySet()) {
+      if (!update.containsKey(key) || !update.get(key).equals(update.get(key))) {
+        changed = true;
+        break;
+      }
+    }
+
     if (changed) {
+      serviceLevelParams.clear();
       serviceLevelParams.putAll(update);
     }
     return changed;
@@ -101,7 +110,16 @@ public class MetadataCluster {
         break;
       }
     }
+
+    for (String key : clusterLevelParams.keySet()) {
+      if (!update.containsKey(key) || !StringUtils.equals(update.get(key), clusterLevelParams.get(key))) {
+        changed = true;
+        break;
+      }
+    }
+
     if (changed) {
+      clusterLevelParams.clear();
       clusterLevelParams.putAll(update);
     }
     return changed;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -5583,10 +5583,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
       SecurityType securityType = cl.getSecurityType();
 
-      MetadataCluster metadataCluster = new MetadataCluster(securityType,
-          getMetadataServiceLevelParams(cl),
-          getMetadataClusterLevelParams(cl, stackId),
-          null);
+      MetadataCluster metadataCluster = new MetadataCluster(securityType, getMetadataServiceLevelParams(cl), true, getMetadataClusterLevelParams(cl, stackId), null);
       metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
     }
 
@@ -5596,50 +5593,23 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   }
 
   public MetadataUpdateEvent getClusterMetadata(Cluster cl) throws AmbariException {
-    TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
-    StackId stackId = cl.getDesiredStackVersion();
-
-    SecurityType securityType = cl.getSecurityType();
-
-    MetadataCluster metadataCluster = new MetadataCluster(securityType,
-        getMetadataServiceLevelParams(cl),
-        getMetadataClusterLevelParams(cl, stackId),
-        null);
+    final TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
+    MetadataCluster metadataCluster = new MetadataCluster(cl.getSecurityType(), getMetadataServiceLevelParams(cl), true, getMetadataClusterLevelParams(cl, cl.getDesiredStackVersion()), null);
     metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
-
-    MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
-    return metadataUpdateEvent;
+    return new MetadataUpdateEvent(metadataClusters, null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
   }
 
   @Override
   public MetadataUpdateEvent getClusterMetadataOnConfigsUpdate(Cluster cl) throws AmbariException {
-    TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
-    StackId stackId = cl.getDesiredStackVersion();
-
-    MetadataCluster metadataCluster = new MetadataCluster(null,
-        new TreeMap<>(),
-        getMetadataClusterLevelConfigsParams(cl, stackId),
-        null);
-    metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
-
-    MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
-    return metadataUpdateEvent;
+    final TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
+    metadataClusters.put(Long.toString(cl.getClusterId()), MetadataCluster.clusterLevelParamsMetadataCluster(null, getMetadataClusterLevelParams(cl, cl.getDesiredStackVersion())));
+    return new MetadataUpdateEvent(metadataClusters, null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
   }
 
   public MetadataUpdateEvent getClusterMetadataOnRepoUpdate(Cluster cl) throws AmbariException {
     TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
-
-    MetadataCluster metadataCluster = new MetadataCluster(null,
-        getMetadataServiceLevelParams(cl),
-        new TreeMap<>(),
-        null);
-    metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
-
-    MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
-    return metadataUpdateEvent;
+    metadataClusters.put(Long.toString(cl.getClusterId()), MetadataCluster.serviceLevelParamsMetadataCluster(null, getMetadataServiceLevelParams(cl), true));
+    return new MetadataUpdateEvent(metadataClusters, null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
   }
 
   public MetadataUpdateEvent getClusterMetadataOnServiceInstall(Cluster cl, String serviceName) throws AmbariException {
@@ -5647,17 +5617,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   }
 
   public MetadataUpdateEvent getClusterMetadataOnServiceCredentialStoreUpdate(Cluster cl, String serviceName) throws AmbariException {
-    TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
-
-    MetadataCluster metadataCluster = new MetadataCluster(null,
-        getMetadataServiceLevelParams(cl.getService(serviceName)),
-        new TreeMap<>(),
-        null);
-    metadataClusters.put(Long.toString(cl.getClusterId()), metadataCluster);
-
-    MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(metadataClusters,
-        null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
-    return metadataUpdateEvent;
+    final TreeMap<String, MetadataCluster> metadataClusters = new TreeMap<>();
+    metadataClusters.put(Long.toString(cl.getClusterId()), MetadataCluster.serviceLevelParamsMetadataCluster(null, getMetadataServiceLevelParams(cl), false));
+    return new MetadataUpdateEvent(metadataClusters, null, getMetadataAgentConfigs(), UpdateEventType.UPDATE);
   }
 
   private String getClientsToUpdateConfigs(ComponentInfo componentInfo) {
@@ -5779,7 +5741,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     return clusterLevelParams;
   }
 
-  public TreeMap<String, String> getMetadataClusterLevelConfigsParams(Cluster cluster, StackId stackId) throws AmbariException {
+  private TreeMap<String, String> getMetadataClusterLevelConfigsParams(Cluster cluster, StackId stackId) throws AmbariException {
     TreeMap<String, String> clusterLevelParams = new TreeMap<>();
 
     Map<String, DesiredConfig> desiredConfigs = cluster.getDesiredConfigs(false);

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/MetadataUpdateEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/MetadataUpdateEvent.java
@@ -19,7 +19,6 @@ package org.apache.ambari.server.events;
 
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.ambari.server.agent.stomp.dto.Hashable;
 import org.apache.ambari.server.agent.stomp.dto.MetadataCluster;
@@ -64,7 +63,7 @@ public class MetadataUpdateEvent extends STOMPEvent implements Hashable {
     super(Type.METADATA);
     this.metadataClusters = metadataClusters;
     if (ambariLevelParams != null) {
-      this.metadataClusters.put(AMBARI_LEVEL_CLUSTER_ID, new MetadataCluster(null, new TreeMap<>(), ambariLevelParams, metadataAgentConfigs));
+      this.metadataClusters.put(AMBARI_LEVEL_CLUSTER_ID, new MetadataCluster(null, null, false, ambariLevelParams, metadataAgentConfigs));
     }
     this.eventType = eventType;
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/dto/MetadataClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/dto/MetadataClusterTest.java
@@ -35,9 +35,9 @@ public class MetadataClusterTest {
     current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
     current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
     current.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
-    final MetadataCluster metadataCluster = new MetadataCluster(null, current, null, null);
+    final MetadataCluster metadataCluster = MetadataCluster.serviceLevelParamsMetadataCluster(null, current, true);
     final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>(current);
-    assertFalse(metadataCluster.updateServiceLevelParams(updated));
+    assertFalse(metadataCluster.updateServiceLevelParams(updated, true));
     assertEquals(current, metadataCluster.getServiceLevelParams());
   }
 
@@ -46,10 +46,10 @@ public class MetadataClusterTest {
     final SortedMap<String, MetadataServiceInfo> current = new TreeMap<>();
     current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
     current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
-    final MetadataCluster metadataCluster = new MetadataCluster(null, current, null, null);
+    final MetadataCluster metadataCluster = MetadataCluster.serviceLevelParamsMetadataCluster(null, current, true);
     final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>(current);
     updated.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
-    assertTrue(metadataCluster.updateServiceLevelParams(updated));
+    assertTrue(metadataCluster.updateServiceLevelParams(updated, true));
     assertEquals(updated, metadataCluster.getServiceLevelParams());
   }
 
@@ -59,11 +59,38 @@ public class MetadataClusterTest {
     current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
     current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
     current.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
-    final MetadataCluster metadataCluster = new MetadataCluster(null, current, null, null);
+    final MetadataCluster metadataCluster = MetadataCluster.serviceLevelParamsMetadataCluster(null, current, true);
     final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>(current);
     updated.remove("service2");
-    assertTrue(metadataCluster.updateServiceLevelParams(updated));
+    assertTrue(metadataCluster.updateServiceLevelParams(updated, true));
     assertEquals(updated, metadataCluster.getServiceLevelParams());
+  }
+
+  @Test
+  public void shouldReturnFalseWhenNullServiceLevelParamsArePassedBecauseOfPartialConfigurationUpdate() throws Exception {
+    final SortedMap<String, MetadataServiceInfo> current = new TreeMap<>();
+    current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    final MetadataCluster metadataCluster = MetadataCluster.serviceLevelParamsMetadataCluster(null, current, true);
+    assertFalse(metadataCluster.updateServiceLevelParams(null, true));
+    assertEquals(current, metadataCluster.getServiceLevelParams());
+  }
+
+  @Test
+  public void shouldReturnTrueWhenUpdatingServiceLevelParamsWithoutFullServiceLevelMetadata() throws Exception {
+    final SortedMap<String, MetadataServiceInfo> current = new TreeMap<>();
+    current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    final MetadataCluster metadataCluster = MetadataCluster.serviceLevelParamsMetadataCluster(null, current, true);
+    final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>();
+    updated.put("service3", new MetadataServiceInfo("v2", Boolean.TRUE, null, 2L, "servicePackageFolder2"));
+    updated.put("service4", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    assertTrue(metadataCluster.updateServiceLevelParams(updated, false));
+    final SortedMap<String, MetadataServiceInfo> expected = current;
+    expected.putAll(updated);
+    assertEquals(expected, metadataCluster.getServiceLevelParams());
   }
 
   @Test
@@ -72,7 +99,7 @@ public class MetadataClusterTest {
     current.put("param1", "value1");
     current.put("param2", "value2");
     current.put("param3", "value3");
-    final MetadataCluster metadataCluster = new MetadataCluster(null, null, current, null);
+    final MetadataCluster metadataCluster = MetadataCluster.clusterLevelParamsMetadataCluster(null, current);
     final SortedMap<String, String> updated = new TreeMap<>(current);
     assertFalse(metadataCluster.updateClusterLevelParams(updated));
     assertEquals(current, metadataCluster.getClusterLevelParams());
@@ -83,7 +110,7 @@ public class MetadataClusterTest {
     final SortedMap<String, String> current = new TreeMap<>();
     current.put("param1", "value1");
     current.put("param2", "value2");
-    final MetadataCluster metadataCluster = new MetadataCluster(null, null, current, null);
+    final MetadataCluster metadataCluster = MetadataCluster.clusterLevelParamsMetadataCluster(null, current);
     final SortedMap<String, String> updated = new TreeMap<>(current);
     updated.put("param3", "value3");
     assertTrue(metadataCluster.updateClusterLevelParams(updated));
@@ -96,11 +123,22 @@ public class MetadataClusterTest {
     current.put("param1", "value1");
     current.put("param2", "value2");
     current.put("param3", "value3");
-    final MetadataCluster metadataCluster = new MetadataCluster(null, null, current, null);
+    final MetadataCluster metadataCluster = MetadataCluster.clusterLevelParamsMetadataCluster(null, current);
     final SortedMap<String, String> updated = new TreeMap<>(current);
     updated.remove("param2");
     assertTrue(metadataCluster.updateClusterLevelParams(updated));
     assertEquals(updated, metadataCluster.getClusterLevelParams());
+  }
+
+  @Test
+  public void shouldReturnFalseWhenNullClusterLevelParamsArePassedBecauseOfPartialConfigurationUpdate() throws Exception {
+    final SortedMap<String, String> current = new TreeMap<>();
+    current.put("param1", "value1");
+    current.put("param2", "value2");
+    current.put("param3", "value3");
+    final MetadataCluster metadataCluster = MetadataCluster.clusterLevelParamsMetadataCluster(null, current);
+    assertFalse(metadataCluster.updateClusterLevelParams(null));
+    assertEquals(current, metadataCluster.getClusterLevelParams());
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/dto/MetadataClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/dto/MetadataClusterTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.agent.stomp.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.junit.Test;
+
+public class MetadataClusterTest {
+
+  @Test
+  public void shouldReturnFalseWhenUpdatingServiceLevelParamsWithoutNewOrRemovedServices() throws Exception {
+    final SortedMap<String, MetadataServiceInfo> current = new TreeMap<>();
+    current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    final MetadataCluster metadataCluster = new MetadataCluster(null, current, null, null);
+    final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>(current);
+    assertFalse(metadataCluster.updateServiceLevelParams(updated));
+    assertEquals(current, metadataCluster.getServiceLevelParams());
+  }
+
+  @Test
+  public void shouldReturnTrueWhenUpdatingServiceLevelParamsUponServiceAddition() throws Exception {
+    final SortedMap<String, MetadataServiceInfo> current = new TreeMap<>();
+    current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    final MetadataCluster metadataCluster = new MetadataCluster(null, current, null, null);
+    final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>(current);
+    updated.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    assertTrue(metadataCluster.updateServiceLevelParams(updated));
+    assertEquals(updated, metadataCluster.getServiceLevelParams());
+  }
+
+  @Test
+  public void shouldReturnTrueWhenUpdatingServiceLevelParamsUponServiceRemoval() throws Exception {
+    final SortedMap<String, MetadataServiceInfo> current = new TreeMap<>();
+    current.put("service1", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service2", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    current.put("service3", new MetadataServiceInfo("v1", Boolean.FALSE, null, 1L, "servicePackageFolder"));
+    final MetadataCluster metadataCluster = new MetadataCluster(null, current, null, null);
+    final SortedMap<String, MetadataServiceInfo> updated = new TreeMap<>(current);
+    updated.remove("service2");
+    assertTrue(metadataCluster.updateServiceLevelParams(updated));
+    assertEquals(updated, metadataCluster.getServiceLevelParams());
+  }
+
+  @Test
+  public void shouldReturnFalseWhenUpdatingClusterLevelParamsWithoutClusterLevelParameterAdditionOrRemoval() throws Exception {
+    final SortedMap<String, String> current = new TreeMap<>();
+    current.put("param1", "value1");
+    current.put("param2", "value2");
+    current.put("param3", "value3");
+    final MetadataCluster metadataCluster = new MetadataCluster(null, null, current, null);
+    final SortedMap<String, String> updated = new TreeMap<>(current);
+    assertFalse(metadataCluster.updateClusterLevelParams(updated));
+    assertEquals(current, metadataCluster.getClusterLevelParams());
+  }
+
+  @Test
+  public void shouldReturnTrueWhenUpdatingClusterLevelParamsUponClusterLevelParameterAddition() throws Exception {
+    final SortedMap<String, String> current = new TreeMap<>();
+    current.put("param1", "value1");
+    current.put("param2", "value2");
+    final MetadataCluster metadataCluster = new MetadataCluster(null, null, current, null);
+    final SortedMap<String, String> updated = new TreeMap<>(current);
+    updated.put("param3", "value3");
+    assertTrue(metadataCluster.updateClusterLevelParams(updated));
+    assertEquals(updated, metadataCluster.getClusterLevelParams());
+  }
+
+  @Test
+  public void shouldReturnTrueWhenUpdatingClusterLevelParamsUponClusterLevelParameterRemoval() throws Exception {
+    final SortedMap<String, String> current = new TreeMap<>();
+    current.put("param1", "value1");
+    current.put("param2", "value2");
+    current.put("param3", "value3");
+    final MetadataCluster metadataCluster = new MetadataCluster(null, null, current, null);
+    final SortedMap<String, String> updated = new TreeMap<>(current);
+    updated.remove("param2");
+    assertTrue(metadataCluster.updateClusterLevelParams(updated));
+    assertEquals(updated, metadataCluster.getClusterLevelParams());
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a service has been removed from the cluster its `serviceLevelParams` stayed in server side's metadata holder but removed from the agent side cache. Next time when someone wanted to re-install the same service there were no metadata change event triggered so that the agent side code failed due to missing `serviceLevelParams` for that service (the same is true for `clusterLevelParams` metadata).

## How was this patch tested?

Added unit test code to cover these cases; latest JUnit test results in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:12 h
[INFO] Finished at: 2018-05-24T03:33:29+02:00
[INFO] Final Memory: 107M/1592M
[INFO] ------------------------------------------------------------------------
```

In addition to uni testing the following integration test steps were executed:

1. installed Ambari 2.7.0.0-562
2. replaced `ambari-server.jar` with mine after modifying and building the code 
3. deployed a cluster: HDFS via BP and then ZK and Kafka on UI
4. removed ZK and Kafka
5. added ZK and Kafka again without any issue (when reproducing the issue I as not able to re-install any of them)
