### PR TITLE
[AMBARI-23946]. Stack upgrade from 2.6.5 to 3.0.0 fails because WebHC…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentReportsController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentReportsController.java
@@ -105,7 +105,7 @@ public class AgentReportsController {
   public ReportsResponse handleAlertsStatus(@Header String simpSessionId, Alert[] message) throws AmbariException {
     String hostName = agentSessionManager.getHost(simpSessionId).getHostName();
     List<Alert> alerts = Arrays.asList(message);
-    LOG.info("Handling {} alerts status for host {}", alerts.size(), hostName);
+    LOG.debug("Handling {} alerts status for host {}", alerts.size(), hostName);
     hh.getHeartbeatProcessor().processAlerts(hostName, alerts);
     return new ReportsResponse();
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ActionExecutionContext.java
@@ -27,7 +27,7 @@ import org.apache.ambari.server.actionmanager.TargetHostType;
 import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.RequestResourceFilter;
-import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
+import org.apache.ambari.server.state.StackId;
 
 /**
  * The context required to create tasks and stages for a custom action
@@ -44,7 +44,7 @@ public class ActionExecutionContext {
   private String expectedComponentName;
   private boolean hostsInMaintenanceModeExcluded = true;
   private boolean allowRetry = false;
-  private RepositoryVersionEntity repositoryVersion;
+  private StackId stackId;
 
   /**
    * If {@code true}, instructs Ambari not to worry about whether or not the
@@ -182,30 +182,29 @@ public class ActionExecutionContext {
   }
 
   /**
-   * Gets the stack/version to use for generating stack-associated values for a
+   * Gets the stack to use for generating stack-associated values for a
    * command. In some cases the cluster's stack is not the correct one to use,
    * such as when distributing a repository.
    *
-   * @return the repository for the stack/version to use when generating
+   * @return the stack to use when generating
    *         stack-specific content for the command.
-   *
-   * @return
    */
-  public RepositoryVersionEntity getRepositoryVersion() {
-    return repositoryVersion;
+  public StackId getStackId() {
+    return stackId;
   }
 
   /**
-   * Sets the stack/version to use for generating stack-associated values for a
+   * Sets the stack to use for generating stack-associated values for a
    * command. In some cases the cluster's stack is not the correct one to use,
    * such as when distributing a repository.
    *
    * @param stackId
    *          the stackId to use for stack-based properties on the command.
    */
-  public void setRepositoryVersion(RepositoryVersionEntity repositoryVersion) {
-    this.repositoryVersion = repositoryVersion;
+  public void setStackId(StackId stackId) {
+    this.stackId = stackId;
   }
+
 
   /**
    * Adds a command visitor that will be invoked after a command is created.  Provides access

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -321,8 +321,8 @@ public class AmbariCustomCommandExecutionHelper {
 
     // grab the stack ID from the service first, and use the context's if it's set
     StackId stackId = service.getDesiredStackId();
-    if (null != actionExecutionContext.getRepositoryVersion()) {
-      stackId = actionExecutionContext.getRepositoryVersion().getStackId();
+    if (null != actionExecutionContext.getStackId()) {
+      stackId = actionExecutionContext.getStackId();
     }
 
     AmbariMetaInfo ambariMetaInfo = managementController.getAmbariMetaInfo();

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
@@ -722,10 +722,10 @@ public class ClusterStackVersionResourceProvider extends AbstractControllerResou
     ActionExecutionContext actionContext = new ActionExecutionContext(cluster.getClusterName(),
         INSTALL_PACKAGES_ACTION, Collections.singletonList(filter), roleParams);
 
-    actionContext.setRepositoryVersion(repoVersion);
+    actionContext.setStackId(repoVersion.getStackId());
     actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
 
-    repoVersionHelper.addCommandRepositoryToContext(actionContext, osEntity);
+    repoVersionHelper.addCommandRepositoryToContext(actionContext, repoVersion, osEntity);
 
     return actionContext;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
@@ -446,9 +446,9 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
             Collections.singletonList(filter),
             roleParams);
     actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
-    actionContext.setRepositoryVersion(repoVersionEnt);
+    actionContext.setStackId(repoVersionEnt.getStackId());
 
-    repoVersionHelper.addCommandRepositoryToContext(actionContext, osEntity);
+    repoVersionHelper.addCommandRepositoryToContext(actionContext, repoVersionEnt, osEntity);
 
     String caption = String.format(INSTALL_PACKAGES_FULL_NAME + " on host %s", hostName);
     RequestStageContainer req = createRequest(caption);

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -870,6 +870,12 @@ public class ConfigHelper {
     }
 
     for (Service service : cluster.getServices().values()) {
+      // !!! the services map is from the stack, which may not contain services in the cluster.
+      // This is the case for upgrades where the target stack may remove services
+      if (!servicesMap.containsKey(service.getName())) {
+        continue;
+      }
+
       Set<PropertyInfo> serviceProperties = new HashSet<>(servicesMap.get(service.getName()).getProperties());
       for (PropertyInfo serviceProperty : serviceProperties) {
         if (serviceProperty.getPropertyTypes().contains(propertyType)) {
@@ -1476,7 +1482,7 @@ public class ConfigHelper {
       }
       stale = stale | staleEntry;
     }
-    
+
     String refreshCommand = calculateRefreshCommand(stackInfo.getRefreshCommandConfiguration(), sch, changedProperties);
 
     if (STALE_CONFIGS_CACHE_ENABLED) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -998,6 +998,33 @@ public class UpgradeContext {
   }
 
   /**
+   * Gets the single target stack for the upgrade.  By definition, ALL the targets,
+   * despite the versions, should have the same stack.  The source stacks may be different
+   * from the target, but all the source stacks must also be the same.
+   * <p/>
+   *
+   * @return the target stack for this upgrade (never {@code null}).
+   */
+  public StackId getTargetStack() {
+    RepositoryVersionEntity repo = m_targetRepositoryMap.values().iterator().next();
+    return repo.getStackId();
+  }
+
+  /**
+   * Gets the single source stack for the upgrade depending on the
+   * direction.  By definition, ALL the source stacks, despite the versions, should have
+   * the same stack.  The target stacks may be different from the source, but all the target
+   * stacks must also be the same.
+   * <p/>
+   *
+   * @return the source stack for this upgrade (never {@code null}).
+   */
+  public StackId getSourceStack() {
+    RepositoryVersionEntity repo = m_sourceRepositoryMap.values().iterator().next();
+    return repo.getStackId();
+  }
+
+  /**
    * Gets the set of services which will participate in the upgrade. The
    * services available in the repository are comapred against those installed
    * in the cluster to arrive at the final subset.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -453,8 +453,8 @@ public class RepositoryVersionHelper {
     // host params and then return
     if (null == repositoryVersion) {
       // see if the action context has a repository set to use for the command
-      if (null != actionContext.getRepositoryVersion()) {
-        StackId stackId = actionContext.getRepositoryVersion().getStackId();
+      if (null != actionContext.getStackId()) {
+        StackId stackId = actionContext.getStackId();
         hostLevelParams.put(KeyNames.STACK_NAME, stackId.getStackName());
         hostLevelParams.put(KeyNames.STACK_VERSION, stackId.getStackVersion());
       }
@@ -574,9 +574,8 @@ public class RepositoryVersionHelper {
    * @param osEntity      the OS family
    */
   public void addCommandRepositoryToContext(ActionExecutionContext context,
-                                            RepoOsEntity osEntity) throws SystemException {
+      final RepositoryVersionEntity repoVersion, RepoOsEntity osEntity) throws SystemException {
 
-    final RepositoryVersionEntity repoVersion = context.getRepositoryVersion();
     final CommandRepository commandRepo = getCommandRepository(repoVersion, osEntity);
 
     ClusterVersionSummary summary = null;
@@ -593,7 +592,6 @@ public class RepositoryVersionHelper {
     }
 
     final ClusterVersionSummary clusterSummary = summary;
-
 
     context.addVisitor(command -> {
       if (null == command.getRepositoryFile()) {


### PR DESCRIPTION
…at component doesn't exist

There are places in the code that use the incorrect stack when generating commands, finding configs etc.  This bug was discovered because we are now in the business of removing components as part of the upgrade.  As such, components now no longer exist in the target stack.

## How was this patch tested?

Manual testing on cluster that included Hive.  Automated testing showed upgrade processing was not affected.

```
[ERROR] Tests run: 5116, Failures: 0, Errors: 0, Skipped: 68
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 45:17 min
[INFO] Finished at: 2018-05-24T11:32:45-04:00
[INFO] Final Memory: 58M/1957M
[INFO] ------------------------------------------------------------------------
```
