### PR TITLE
AMBARI-23922 - PERF 1.0 package not installed in the cluster

### DIFF
--- a/ambari-server/src/main/resources/stacks/PERF/install_packages.sed
+++ b/ambari-server/src/main/resources/stacks/PERF/install_packages.sed
@@ -14,12 +14,25 @@
 # limitations under the License.
 /actionexecute/{i\
   def actionexecute(self, env):\
+    from resource_management.core.resources.system import Execute\
     # Parse parameters\
     config = Script.get_config()\
-    repository_version = config['roleParams']['repository_version']\
+    try:\
+      command_repository = CommandRepository(config['repositoryFile'])\
+    except KeyError:\
+      raise Fail("The command repository indicated by 'repositoryFile' was not found")\
+    self.repository_version = command_repository.version_string\
+    if self.repository_version is None:\
+      raise Fail("Cannot determine the repository version to install")\
+    self.repository_version = self.repository_version.strip()\
     (stack_selector_name, stack_selector_path, stack_selector_package) = stack_tools.get_stack_tool(stack_tools.STACK_SELECTOR_NAME)\
-    command = 'ambari-python-wrap {0} install {1}'.format(stack_selector_path, repository_version)\
+    command = 'ambari-python-wrap {0} install {1}'.format(stack_selector_path, self.repository_version)\
     Execute(command)\
+    self.structured_output = {\
+      'package_installation_result': 'SUCCESS',\
+      'repository_version_id': command_repository.version_id\
+    }\
+    self.put_structured_out(self.structured_output)\
   def actionexecute_old(self, env):
 d
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari 2.7.0 server does not send roleParams/repository_version in the command.json to the agent when installing PERF 1.0 stack but it is a required field for the distro-select called by before-INSTALL hook.
Fix: repository_version can be extracted using the CommandRepository class version_string field.
Also the structured_output of the InstallPackages.actionexecute should contains the package_installation_result and repository_version_id fields.

## How was this patch tested?

manually:
1. Deploy ambari-server and agent to vm
2. Copy PERF stack code to vm and activate in metainfo.xml
3. Patch install_packages.py using install_packages.sed
4. set stack.hooks.folder=stacks/PERF/1.0/hooks in ambari-server properties
5. Patch PythonExecutor.py using PythonExecutor.sed
6. Start Ambari Server and deploy a PERF 1.0 stack using the Cluster creation wizard
7. On UI go to Hosts->For each hosts->Versions tab->Install
8. Stop and Start all services
9. Stack and Versions->Versions tab should show PERF-1.0 is the Current

Please review
@swagle @aonishuk @zeroflag @adoroszlai 
