### PR TITLE
Revert "[Ambari-23850] Use trustore details for Atlas/Ranger during collection creation (#1276)

### DIFF
--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
@@ -25,8 +25,6 @@ from resource_management import StackFeature
 from resource_management.core.resources.system import Directory, File, Execute
 from resource_management.core.source import StaticFile, InlineTemplate, Template
 from resource_management.core.exceptions import Fail
-from resource_management.libraries.script.script import Script
-from resource_management.libraries.functions.default import default
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.decorator import retry
 from resource_management.libraries.functions import solr_cloud_util
@@ -247,10 +245,7 @@ def create_collection(collection, config_set, jaasFile):
       java64_home=params.ambari_java_home,
       jaas_file=jaasFile,
       shards=params.atlas_solr_shards,
-      replication_factor = params.infra_solr_replication_factor,
-      trust_store_password =  params.truststore_password if params.credential_provider else None,
-      trust_store_type = "JKS" if params.credential_provider else None,
-      trust_store_location = params.truststore_location if params.credential_provider else None)
+      replication_factor = params.infra_solr_replication_factor)
 
 def secure_znode(znode, jaasFile):
   import params

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/params.py
@@ -26,9 +26,6 @@ from resource_management.libraries.functions.version import format_stack_version
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.default import default
-from resource_management.core.utils import PasswordString
-from ambari_commons.credential_store_helper import get_password_from_credential_store
-
 
 # Local Imports
 from status_params import *
@@ -134,19 +131,14 @@ java64_home = config['ambariLevelParams']['java_home']
 ambari_java_home = default("/ambariLevelParams/ambari_java_home", java64_home)
 java_exec = format("{java64_home}/bin/java")
 env_sh_template = config['configurations']['atlas-env']['content']
-jdk_location = config['ambariLevelParams']['jdk_location']
-
 
 # credential provider
-credential_provider = default("/configurations/application-properties/cert.stores.credential.provider.path", None)
+credential_provider = format( "jceks://file@{conf_dir}/atlas-site.jceks")
 
 # command line args
 ssl_enabled = default("/configurations/application-properties/atlas.enableTLS", False)
 http_port = default("/configurations/application-properties/atlas.server.http.port", "21000")
 https_port = default("/configurations/application-properties/atlas.server.https.port", "21443")
-truststore_location = default("/configurations/application-properties/truststore.file", None)
-keystore_location = default("/configurations/application-properties/keystore.file", None)
-
 if ssl_enabled:
   metadata_port = https_port
   metadata_protocol = 'https'
@@ -429,10 +421,3 @@ if stack_supports_atlas_ranger_plugin and enable_ranger_atlas:
 # atlas admin login username password
 atlas_admin_username = config['configurations']['atlas-env']['atlas.admin.username']
 atlas_admin_password = config['configurations']['atlas-env']['atlas.admin.password']
-
-# Atlas Passwords Extracted From Credential Store
-if credential_provider:
-    default_credential_shell_lib_path = jdk_location
-    truststore_password = PasswordString(get_password_from_credential_store('truststore.password', credential_provider, os.path.join(default_credential_shell_lib_path, '*'), java64_home, jdk_location))
-    keystore_password = PasswordString(get_password_from_credential_store('keystore.password', credential_provider, os.path.join(default_credential_shell_lib_path, '*'), java64_home, jdk_location))
-    key_password = PasswordString(get_password_from_credential_store('password', credential_provider, os.path.join(default_credential_shell_lib_path, '*'), java64_home, jdk_location))

--- a/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/setup_ranger_xml.py
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.4.0/package/scripts/setup_ranger_xml.py
@@ -167,7 +167,7 @@ def setup_ranger_admin(upgrade_type=None):
 
     Link('/usr/bin/ranger-admin',
     to=format('{ranger_home}/ews/ranger-admin-services.sh'))
-
+  
   if default("/configurations/ranger-admin-site/ranger.authentication.method", "") == 'PAM':
     d = '/etc/pam.d'
     if os.path.isdir(d):
@@ -254,7 +254,7 @@ def setup_ranger_admin(upgrade_type=None):
 
 def setup_ranger_db(stack_version=None):
   import params
-
+  
   ranger_home = params.ranger_home
 
   if stack_version is not None:
@@ -275,7 +275,7 @@ def setup_ranger_db(stack_version=None):
   if params.create_db_dbuser:
     Logger.info('Setting up Ranger DB and DB User')
     dba_setup = format('ambari-python-wrap {ranger_home}/dba_script.py -q')
-    Execute(dba_setup,
+    Execute(dba_setup, 
             environment=env_dict,
             logoutput=True,
             user=params.unix_user,
@@ -284,7 +284,7 @@ def setup_ranger_db(stack_version=None):
     Logger.info('Separate DBA property not set. Assuming Ranger DB and DB User exists!')
 
   db_setup = format('ambari-python-wrap {ranger_home}/db_setup.py')
-  Execute(db_setup,
+  Execute(db_setup, 
           environment=env_dict,
           logoutput=True,
           user=params.unix_user,
@@ -303,7 +303,7 @@ def setup_java_patch(stack_version=None):
     env_dict = {'RANGER_ADMIN_HOME':ranger_home, 'JAVA_HOME':params.java_home, 'LD_LIBRARY_PATH':params.ld_lib_path}
 
   setup_java_patch = format('ambari-python-wrap {ranger_home}/db_setup.py -javapatch')
-  Execute(setup_java_patch,
+  Execute(setup_java_patch, 
           environment=env_dict,
           logoutput=True,
           user=params.unix_user,
@@ -477,7 +477,7 @@ def setup_usersync(upgrade_type=None):
     group = params.unix_group,
     mode=0755
   )
-
+  
   Directory(format("{ranger_ugsync_conf}/"),
     owner = params.unix_user
   )
@@ -535,7 +535,7 @@ def setup_usersync(upgrade_type=None):
        group = params.unix_group,
        mode = 0640
   )
-
+  
   File([params.usersync_start, params.usersync_stop],
        owner = params.unix_user,
        group = params.unix_group
@@ -741,6 +741,8 @@ def setup_ranger_audit_solr():
       solr_cloud_util.add_solr_roles(params.config,
                                      roles = [params.infra_solr_role_ranger_audit, params.infra_solr_role_dev],
                                      new_service_principals = service_principals)
+
+
     solr_cloud_util.create_collection(
       zookeeper_quorum = params.zookeeper_quorum,
       solr_znode = params.solr_znode,
@@ -749,10 +751,7 @@ def setup_ranger_audit_solr():
       java64_home = params.ambari_java_home,
       shards = params.ranger_solr_shards,
       replication_factor = int(params.replication_factor),
-      jaas_file = params.solr_jaas_file,
-      trust_store_password = default('configurations/ranger-admin-site/ranger.truststore.file', None),
-      trust_store_type = "JKS" if default('configurations/ranger-admin-site/ranger.truststore.file', None) else None,
-      trust_store_location = default('configurations/ranger-admin-site/ranger.truststore.password', None))
+      jaas_file = params.solr_jaas_file)
 
     if params.security_enabled and params.has_infra_solr \
       and not params.is_external_solrCloud_enabled and params.stack_supports_ranger_kerberos:


### PR DESCRIPTION
This reverts commit 37475b1ad3eb9a8f97da15012819fa8c564d6f79.

This is needed since the original patch incorrectly sets the path to the credential store. Rather than looking in a local path on the file system, the path is set as the URL to obtain the CredentialUtil.jar file from Ambari's resources location: `https://ambari-server:8443/resources/CredentialUtil.jar`. Hence a failure to find the local path to `https://ambari-server:8443/resources`.

It appears that this change is not relevant to the issue outlined in AMBARI-23850.  

FYI: @amerissa 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.