### PR TITLE
[AMBARI-23951] Selection information disappears when a filter is applied

### DIFF
--- a/ambari-web/app/mixins/common/table_server_view_mixin.js
+++ b/ambari-web/app/mixins/common/table_server_view_mixin.js
@@ -65,9 +65,8 @@ App.TableServerViewMixin = Em.Mixin.create({
    * @param iColumn
    * @param value
    * @param type
-   * @param preserveSelection
    */
-  updateFilter: function (iColumn, value, type, preserveSelection) {
+  updateFilter: function (iColumn, value, type) {
     // Do not even trigger update flow if it's a blank update
     if (this.isBlankFilterUpdate(iColumn, value, type)) { return; }
 
@@ -83,7 +82,7 @@ App.TableServerViewMixin = Em.Mixin.create({
       this.set('controller.resetStartIndex', true);
       //save filter only when it's applied
       this.saveFilterConditions(iColumn, value, type, false);
-      this.refresh(preserveSelection);
+      this.refresh();
     }
     return true;
   },

--- a/ambari-web/app/templates/main/host.hbs
+++ b/ambari-web/app/templates/main/host.hbs
@@ -132,11 +132,11 @@
         <td colspan="13">
           {{#if view.showSelectedFilter}}
             <div class="display-inline-block">
-              <a {{action filterSelected target="view"}} href="#">
+              <a {{action filterSelected target="view"}} {{QAAttr "selected-hosts-count"}} href="#">
                 {{view.selectedHosts.length}}
                 {{pluralize view.selectedHostsCount singular="t:hosts.filters.selectedHostInfo" plural="t:hosts.filters.selectedHostsInfo"}}
               </a>
-              - <a {{action clearSelection target="view"}} href="#">{{t hosts.filters.clearSelection}}</a>
+              - <a {{action clearSelection target="view"}} {{QAAttr "clear-hosts-selection"}}  href="#">{{t hosts.filters.clearSelection}}</a>
             </div>
           {{/if}}
           {{view App.PaginationView isDataLoadedBinding="view.filteringComplete" rowsPerPageSelectViewBinding="view.rowsPerPageSelectView"}}

--- a/ambari-web/app/views/main/host.js
+++ b/ambari-web/app/views/main/host.js
@@ -79,14 +79,11 @@ App.MainHostView = App.TableView.extend(App.TableServerViewMixin, {
    * request latest data filtered by new parameters
    * called when trigger property(<code>refreshTriggers</code>) is changed
    */
-  refresh: function (preserveSelection) {
+  refresh: function () {
     App.loadTimer.start('Hosts Page');
     this.set('filteringComplete', false);
     var updaterMethodName = this.get('updater.tableUpdaterMap')[this.get('tableName')];
     this.get('updater')[updaterMethodName](this.updaterSuccessCb.bind(this), this.updaterErrorCb.bind(this), true);
-    if (!preserveSelection) {
-      this.clearSelection();
-    }
     return true;
   },
 
@@ -283,7 +280,7 @@ App.MainHostView = App.TableView.extend(App.TableServerViewMixin, {
    */
   filterSelected: function() {
     //10 is an index of selected column
-    this.updateFilter(10, this.get('selectedHosts'), 'multiple', true);
+    this.updateFilter(10, this.get('selectedHosts'), 'multiple');
   },
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of AMBARI-23911, selection information was added back to Ambari. But when a filter is applied, the selected hosts section is removed and refreshed. In previous versions, the selection information persisted even when a filter was applied.
Another issue faced while automating is that there is no unique xpath to the selection information. It would be great if a class/data-qa attribute is added to the anchor tag.

## How was this patch tested?

UI unit tests:
  21540 passing (25s)
  48 pending
