### PR TITLE
AMBARI-23955. Implement 3.0 Mpack Advisor's Configuration 'Validations' and update code for Component Layout 'Validations'.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/MpackAdvisorHelper.java
@@ -29,6 +29,7 @@ import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackAdvisorC
 import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackComponentLayoutRecommendationCommand;
 import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackComponentLayoutValidationCommand;
 import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackConfigurationRecommendationCommand;
+import org.apache.ambari.server.api.services.mpackadvisor.commands.MpackConfigurationValidationCommand;
 import org.apache.ambari.server.api.services.mpackadvisor.recommendations.MpackRecommendationResponse;
 import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse;
 import org.apache.ambari.server.configuration.Configuration;
@@ -96,8 +97,10 @@ public class MpackAdvisorHelper {
     if (requestType == MpackAdvisorRequest.MpackAdvisorRequestType.HOST_GROUPS) {
           command = new MpackComponentLayoutValidationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
               requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
+    } else if (requestType == MpackAdvisorRequest.MpackAdvisorRequestType.CONFIGURATIONS) {
+      command = new MpackConfigurationValidationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
+              requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
     } else {
-      // TODO : for other MpackAdvisorRequestType's.
       throw new MpackAdvisorRequestException(String.format("Unsupported request type, type=%s",
           requestType));
     }
@@ -129,7 +132,6 @@ public class MpackAdvisorHelper {
       command = new MpackConfigurationRecommendationCommand(mpackRecommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType,
           requestId, maRunner, metaInfo, ambariServerConfigurationHandler);
     } else {
-      // TODO : for other MpackAdvisorRequestType's.
       throw new MpackAdvisorRequestException(String.format("Unsupported request type, type=%s",
           requestType));
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackConfigurationValidationCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/commands/MpackConfigurationValidationCommand.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.api.services.mpackadvisor.commands;
+
+import java.io.File;
+
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorException;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRequest;
+import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorRunner;
+import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerConfigurationHandler;
+import org.apache.ambari.server.state.ServiceInfo.ServiceAdvisorType;
+import org.apache.ambari.server.topology.MpackInstance;
+
+/**
+ * {@link MpackAdvisorCommand} implementation for configuration validation.
+ */
+public class MpackConfigurationValidationCommand extends MpackAdvisorCommand<MpackValidationResponse> {
+
+  public MpackConfigurationValidationCommand(File recommendationsDir,
+                                        String recommendationsArtifactsLifetime,
+                                        ServiceAdvisorType serviceAdvisorType,
+                                        int requestId,
+                                        MpackAdvisorRunner maRunner,
+                                        AmbariMetaInfo metaInfo,
+                                        AmbariServerConfigurationHandler ambariServerConfigurationHandler) {
+    super(recommendationsDir, recommendationsArtifactsLifetime, serviceAdvisorType, requestId, maRunner, metaInfo,
+          ambariServerConfigurationHandler);
+  }
+
+  @Override
+  protected MpackAdvisorCommandType getCommandType() {
+    return MpackAdvisorCommandType.VALIDATE_CONFIGURATIONS;
+  }
+
+  @Override
+  protected void validate(MpackAdvisorRequest request) throws MpackAdvisorException {
+    if (request.getHosts() == null || request.getHosts().isEmpty()) {
+      throw new MpackAdvisorException("Hosts must not be empty");
+    }
+
+    if (request.getMpackInstances() != null || !request.getMpackInstances().isEmpty()) {
+      for (MpackInstance mpackInstance : request.getMpackInstances()) {
+        if (mpackInstance.getServiceInstances() == null || mpackInstance.getServiceInstances().isEmpty()) {
+          throw new MpackAdvisorException("Service instances for Mpack Instance " + mpackInstance.getMpackName()
+              + " is empty.");
+        }
+      }
+    } else {
+      throw new MpackAdvisorException("Request's Mpack instances is null or empty.");
+    }
+  }
+
+  @Override
+  protected MpackValidationResponse updateResponse(MpackAdvisorRequest request,
+                                              MpackValidationResponse response) {
+    return response;
+  }
+
+  @Override
+  protected String getResultFileName() {
+    return "configurations-validation.json";
+  }
+}
+

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/validations/MpackValidationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/mpackadvisor/validations/MpackValidationResponse.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.api.services.mpackadvisor.validations;
 import java.util.Set;
 
 import org.apache.ambari.server.api.services.mpackadvisor.MpackAdvisorResponse;
+import org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
@@ -29,13 +30,13 @@ import org.codehaus.jackson.annotate.JsonProperty;
 public class MpackValidationResponse extends MpackAdvisorResponse {
 
   @JsonProperty
-  private Set<org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem> items;
+  private Set<ValidationItem> items;
 
-  public Set<org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem> getItems() {
+  public Set<ValidationItem> getItems() {
     return items;
   }
 
-  public void setItems(Set<org.apache.ambari.server.api.services.mpackadvisor.validations.MpackValidationResponse.ValidationItem> items) {
+  public void setItems(Set<ValidationItem> items) {
     this.items = items;
   }
 
@@ -49,22 +50,34 @@ public class MpackValidationResponse extends MpackAdvisorResponse {
     @JsonProperty
     private String message;
 
-    @JsonProperty("mpack-name")
-    private String mpackName;
+    @JsonProperty("mpack_instance_name")
+    private String mpackInstanceName;
 
-    @JsonProperty("mpack-version")
+    @JsonProperty("mpack_instance_type")
+    private String mpackInstanceType;
+
+    @JsonProperty("mpack_version")
     private String mpackVersion;
 
-    @JsonProperty("component-name")
-    private String componentName;
+    @JsonProperty("service_instance_name")
+    private String serviceInstanceName;
+
+    @JsonProperty("service_instance_type")
+    private String serviceInstanceType;
+
+    @JsonProperty("component_instance_name")
+    private String componentInstanceName;
+
+    @JsonProperty("component_instance_type")
+    private String componentInstanceType;
 
     @JsonProperty
     private String host;
 
-    @JsonProperty("config-type")
+    @JsonProperty("config_type")
     private String configType;
 
-    @JsonProperty("config-name")
+    @JsonProperty("config_name")
     private String configName;
 
     public String getType() {
@@ -91,12 +104,20 @@ public class MpackValidationResponse extends MpackAdvisorResponse {
       this.message = message;
     }
 
-    public String getMpackName() {
-      return mpackName;
+    public String getMpackInstanceName() {
+      return mpackInstanceName;
     }
 
-    public void setMpackName(String mpackName) {
-      this.mpackName = mpackName;
+    public void setMpackInstanceName(String mpackInstanceName) {
+      this.mpackInstanceName = mpackInstanceName;
+    }
+
+    public String getMpackInstanceType() {
+      return mpackInstanceType;
+    }
+
+    public void setMpackInstanceType(String mpackInstanceType) {
+      this.mpackInstanceType = mpackInstanceType;
     }
 
     public String getMpackVersion() {
@@ -107,12 +128,36 @@ public class MpackValidationResponse extends MpackAdvisorResponse {
       this.mpackVersion = mpackVersion;
     }
 
-    public String getComponentName() {
-      return componentName;
+    public String getServiceInstanceName() {
+      return serviceInstanceName;
     }
 
-    public void setComponentName(String componentName) {
-      this.componentName = componentName;
+    public void setServiceInstanceName(String serviceInstanceName) {
+      this.serviceInstanceName = serviceInstanceName;
+    }
+
+    public String getServiceInstanceType() {
+      return serviceInstanceType;
+    }
+
+    public void setServiceInstanceType(String serviceInstanceType) {
+      this.serviceInstanceType = serviceInstanceType;
+    }
+
+    public String getComponentInstanceName() {
+      return componentInstanceName;
+    }
+
+    public void setComponentInstanceName(String componentInstanceName) {
+      this.componentInstanceName = componentInstanceName;
+    }
+
+    public String getComponentInstanceType() {
+      return componentInstanceType;
+    }
+
+    public void setComponentInstanceType(String componentInstanceType) {
+      this.componentInstanceType = componentInstanceType;
     }
 
     public String getHost() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackValidationResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/MpackValidationResourceProvider.java
@@ -60,10 +60,16 @@ public class MpackValidationResourceProvider extends MpackAdvisorResourceProvide
   protected static final String TYPE_PROPERTY_ID = "type";
   protected static final String LEVE_PROPERTY_ID = "level";
   protected static final String MESSAGE_PROPERTY_ID = "message";
-  protected static final String COMPONENT_NAME_PROPERTY_ID = "component-name";
+  protected static final String MPACK_INSTANCE_NAME_PROPERTY_ID = "mpack_instance_name";
+  protected static final String MPACK_INSTANCE_TYPE_PROPERTY_ID = "mpack_instance_type";
+  protected static final String MPACK_INSTANCE_VERSION_PROPERTY_ID = "mpack_version";
+  protected static final String SERVICE_INSTANCE_NAME_PROPERTY_ID = "service_instance_name";
+  protected static final String SERVICE_INSTANCE_TYPE_PROPERTY_ID = "service_instance_type";
+  protected static final String COMPONENT_INSTANCE_NAME_PROPERTY_ID = "component_instance_name";
+  protected static final String COMPONENT_INSTANCE_TYPE_PROPERTY_ID = "component_instance_type";
   protected static final String HOST_PROPERTY_ID = "host";
-  protected static final String CONFIG_TYPE_PROPERTY_ID = "config-type";
-  protected static final String CONFIG_NAME_PROPERTY_ID = "config-name";
+  protected static final String CONFIG_TYPE_PROPERTY_ID = "config_type";
+  protected static final String CONFIG_NAME_PROPERTY_ID = "config_name";
   protected static final String HOST_GROUP_PROPERTY_ID = "host-group";
   protected static final String HOSTS_PROPERTY_ID = "hosts";
   protected static final String SERVICES_PROPERTY_ID = "services";
@@ -72,7 +78,13 @@ public class MpackValidationResourceProvider extends MpackAdvisorResourceProvide
   protected static final String ITEMS_TYPE_PROPERTY_ID = PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, TYPE_PROPERTY_ID);
   protected static final String ITEMS_LEVE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, LEVE_PROPERTY_ID);
   protected static final String ITEMS_MESSAGE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, MESSAGE_PROPERTY_ID);
-  protected static final String ITEMS_COMPONENT_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, COMPONENT_NAME_PROPERTY_ID);
+  protected static final String ITEMS_MPACK_INSTANCE_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, MPACK_INSTANCE_NAME_PROPERTY_ID);
+  protected static final String ITEMS_MPACK_INSTANCE_TYPE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, MPACK_INSTANCE_TYPE_PROPERTY_ID);
+  protected static final String ITEMS_MPACK_INSTANCE_VERSION_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, MPACK_INSTANCE_VERSION_PROPERTY_ID);
+  protected static final String ITEMS_SERVICE_INSTANCE_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, SERVICE_INSTANCE_NAME_PROPERTY_ID);
+  protected static final String ITEMS_SERVICE_INSTANCE_TYPE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, SERVICE_INSTANCE_TYPE_PROPERTY_ID);
+  protected static final String ITEMS_COMPONENT_INSTANCE_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, COMPONENT_INSTANCE_NAME_PROPERTY_ID);
+  protected static final String ITEMS_COMPONENT_INSTANCE_TYPE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, COMPONENT_INSTANCE_TYPE_PROPERTY_ID);
   protected static final String ITEMS_HOST_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, HOST_PROPERTY_ID);
   protected static final String ITEMS_CONFIG_TYPE_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, CONFIG_TYPE_PROPERTY_ID);
   protected static final String ITEMS_CONFIG_NAME_PROPERTY_ID =  PropertyHelper.getPropertyId(ITEMS_PROPERTY_ID, CONFIG_NAME_PROPERTY_ID);
@@ -95,7 +107,13 @@ public class MpackValidationResourceProvider extends MpackAdvisorResourceProvide
       ITEMS_TYPE_PROPERTY_ID,
       ITEMS_LEVE_PROPERTY_ID,
       ITEMS_MESSAGE_PROPERTY_ID,
-      ITEMS_COMPONENT_NAME_PROPERTY_ID,
+      ITEMS_MPACK_INSTANCE_NAME_PROPERTY_ID,
+      ITEMS_MPACK_INSTANCE_TYPE_PROPERTY_ID,
+      ITEMS_MPACK_INSTANCE_VERSION_PROPERTY_ID,
+      ITEMS_SERVICE_INSTANCE_NAME_PROPERTY_ID,
+      ITEMS_SERVICE_INSTANCE_TYPE_PROPERTY_ID,
+      ITEMS_COMPONENT_INSTANCE_NAME_PROPERTY_ID,
+      ITEMS_COMPONENT_INSTANCE_TYPE_PROPERTY_ID,
       ITEMS_HOST_PROPERTY_ID,
       ITEMS_CONFIG_TYPE_PROPERTY_ID,
       ITEMS_CONFIG_NAME_PROPERTY_ID,
@@ -145,8 +163,27 @@ public class MpackValidationResourceProvider extends MpackAdvisorResourceProvide
           mapItemProps.put(LEVE_PROPERTY_ID, item.getLevel());
           mapItemProps.put(MESSAGE_PROPERTY_ID, item.getMessage());
 
-          if (item.getComponentName() != null) {
-            mapItemProps.put(COMPONENT_NAME_PROPERTY_ID, item.getComponentName());
+          if (item.getMpackInstanceName() != null) {
+            mapItemProps.put(MPACK_INSTANCE_NAME_PROPERTY_ID, item.getMpackInstanceName());
+          }
+          if (item.getMpackInstanceType() != null) {
+            mapItemProps.put(MPACK_INSTANCE_TYPE_PROPERTY_ID, item.getMpackInstanceType());
+          }
+          if (item.getMpackVersion() != null) {
+            mapItemProps.put(MPACK_INSTANCE_VERSION_PROPERTY_ID, item.getMpackVersion());
+          }
+          if (item.getServiceInstanceName() != null) {
+            mapItemProps.put(SERVICE_INSTANCE_NAME_PROPERTY_ID, item.getServiceInstanceName());
+          }
+          if (item.getServiceInstanceType() != null) {
+            mapItemProps.put(SERVICE_INSTANCE_TYPE_PROPERTY_ID, item.getServiceInstanceType());
+          }
+
+          if (item.getComponentInstanceName() != null) {
+            mapItemProps.put(COMPONENT_INSTANCE_NAME_PROPERTY_ID, item.getComponentInstanceName());
+          }
+          if (item.getComponentInstanceType() != null) {
+            mapItemProps.put(COMPONENT_INSTANCE_TYPE_PROPERTY_ID, item.getComponentInstanceType());
           }
           if (item.getHost() != null) {
             mapItemProps.put(HOST_PROPERTY_ID, item.getHost());


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Background on Mpack Advisor:** 

AMBARI-23870 
   - Implemented 3.0 Mpack Advisor's Host Component Layout Recommendation and Validations API Server code.  
   - Pull Request: https://github.com/apache/ambari/pull/1296 

AMBARI-23923
   - Implement 3.0 Mpack Advisor's Configuration Recommendation API Server code for "Cluster Create".
   - https://github.com/apache/ambari/pull/1348
-----------------------------------------------------------------

**Current Task:**

Implements :
  -  3.0 Mpack Advisor's Configuration "Validations", and 
  - updates the code for Component Layout "Validations" checked in AMBARI-23870.
  - This Java Server code works based on code changes done in Python module 'Mpack Advisor' under Pull request : https://github.com/apache/ambari/pull/1332



### API : POST http://[AmbariServer]:8080/api/v1/mpacks/validations

**Request format for Configurations:**

![screen shot 2018-05-25 at 12 48 51 pm](https://user-images.githubusercontent.com/1879146/40563559-0a7334e4-601a-11e8-8ad2-18fe63edb439.png)

**Request format for Host Component:**

![screen shot 2018-05-25 at 12 50 32 pm](https://user-images.githubusercontent.com/1879146/40563608-3dd46ca4-601a-11e8-8ae8-1789148f75fa.png)


**Response is of following format for "Host Component Layout" and "Configuration" VALIDATIONS:**

![screen shot 2018-05-25 at 12 44 00 pm](https://user-images.githubusercontent.com/1879146/40563379-645779da-6019-11e8-8e5a-1ad57672631d.png)


## How was this patch tested?

Tested on live cluster using Postman APIs.

PostMan Scripts: 
[Updated Mpack Advisor APIs.postman_collection.zip](https://github.com/apache/ambari/files/2040710/Updated.Mpack.Advisor.APIs.postman_collection.zip)



**Configuration Validations:**

Response using Postman request in [Updated Mpack Advisor APIs.postman_collection.zip](https://github.com/apache/ambari/files/2040710/Updated.Mpack.Advisor.APIs.postman_collection.zip)
 named **"Configuration Validations (2 Mpacks) - 6 Errors"**

```
{
  "resources" : [
    {
      "href" : "http://172.22.82.235:8080/api/v1/mpacks/validations/3",
      "items" : [
        {
          "service_instance_type" : "HDFS",
          "config_name" : "dfs.datanode.du.reserved",
          "mpack_instance_name" : "HDPCORE",
          "level" : "WARN",
          "mpack_instance_type" : "HDPCORE",
          "type" : "configuration",
          "message" : "Value is less than the recommended default of 33011188224",
          "component_instance_type" : "null",
          "mpack_version" : "1.0.0-b366",
          "host" : "",
          "component_instance_name" : "null",
          "service_instance_name" : "HDFS",
          "config_type" : "hdfs-site"
        },
        {
          "service_instance_type" : "HBASE",
          "config_name" : "hbase_regionserver_heapsize",
          "mpack_instance_name" : "ODS",
          "level" : "ERROR",
          "mpack_instance_type" : "ODS",
          "type" : "configuration",
          "message" : "Value should be set",
          "component_instance_type" : "null",
          "mpack_version" : "1.0.0-b230",
          "host" : "",
          "component_instance_name" : "null",
          "service_instance_name" : "HBASE",
          "config_type" : "hbase-env"
        },
        {
          "service_instance_type" : "HBASE",
          "config_name" : "hbase.regionserver.global.memstore.size",
          "mpack_instance_name" : "ODS",
          "level" : "WARN",
          "mpack_instance_type" : "ODS",
          "type" : "configuration",
          "message" : "hbase.regionserver.global.memstore.size should be float value",
          "component_instance_type" : "null",
          "mpack_version" : "1.0.0-b230",
          "host" : "",
          "component_instance_name" : "null",
          "service_instance_name" : "HBASE",
          "config_type" : "hbase-site"
        },
        {
          "service_instance_type" : "HDFS",
          "config_name" : "hadoop.proxyuser.root.hosts",
          "mpack_instance_name" : "HDPCORE",
          "level" : "WARN",
          "mpack_instance_type" : "HDPCORE",
          "type" : "configuration",
          "message" : "Empty value for hadoop.proxyuser.root.hosts",
          "component_instance_type" : "null",
          "mpack_version" : "1.0.0-b366",
          "host" : "",
          "component_instance_name" : "null",
          "service_instance_name" : "HDFS",
          "config_type" : "core-site"
        },
        {
          "service_instance_type" : "HDFS",
          "config_name" : "hadoop.proxyuser.root.groups",
          "mpack_instance_name" : "HDPCORE",
          "level" : "WARN",
          "mpack_instance_type" : "HDPCORE",
          "type" : "configuration",
          "message" : "Empty value for hadoop.proxyuser.root.groups",
          "component_instance_type" : "null",
          "mpack_version" : "1.0.0-b366",
          "host" : "",
          "component_instance_name" : "null",
          "service_instance_name" : "HDFS",
          "config_type" : "core-site"
        },
        {
          "service_instance_type" : "HBASE",
          "config_name" : "hbase_regionserver_heapsize",
          "mpack_instance_name" : "ODS",
          "level" : "ERROR",
          "mpack_instance_type" : "ODS",
          "type" : "configuration",
          "message" : "Value should be set",
          "component_instance_type" : "null",
          "mpack_version" : "1.0.0-b230",
          "host" : "",
          "component_instance_name" : "null",
          "service_instance_name" : "HBASE",
          "config_type" : "hbase-env"
        }
      ],
      "MpackValidation" : {
        "id" : 3
      }
    }
  ]
}


```

**HostComponent Validations:**

Response using Postman request in [Updated Mpack Advisor APIs.postman_collection.zip](https://github.com/apache/ambari/files/2040710/Updated.Mpack.Advisor.APIs.postman_collection.zip)
 named **"Host Component Layout - Validations (2 Mpacks)"**

**Testing Caveat :** B/w HDPCore and ODS Services, I am not able create a scenario which says that component layout has an issue. But code should just work fine, if an issue is returned.

```
{
  "resources" : [
    {
      "href" : "http://[AmbariServer]:8080/api/v1/mpacks/validations/17",
      "items" : [ ],
      "MpackValidation" : {
        "id" : 17
      }
    }
  ]
}
```