### PR TITLE
[AMBARI-23953] YARN start failed during EU with IllegalArgumentException

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -1246,6 +1246,7 @@ public class UpgradeCatalog270Test {
 
     //there is HIVE -> WEBHCAT_SERVER -> configurations -> core-site -> hadoop.proxyuser.HTTP.hosts
     assertTrue(kerberosDescriptorJson.contains("${clusterHostInfo/webhcat_server_host|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\\\\\,, true)}"));
+    assertTrue(kerberosDescriptorJson.contains("${clusterHostInfo/rm_host}"));
 
     ArtifactEntity artifactEntity = new ArtifactEntity();
     artifactEntity.setArtifactName("kerberos_descriptor");
@@ -1266,6 +1267,7 @@ public class UpgradeCatalog270Test {
     assertThat(newCount, is(oldCount));
 
     assertTrue(newKerberosDescriptorJson.contains("${clusterHostInfo/webhcat_server_hosts|append(core-site/hadoop.proxyuser.HTTP.hosts, \\\\,, true)}"));
+    assertTrue(newKerberosDescriptorJson.contains("${clusterHostInfo/resourcemanager_hosts}"));
 
     verify(upgradeCatalog270);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

**STR**
1. Deployed cluster with Ambari version: 2.6.0.0-267 and HDP version: 2.6.0.3-8 (UI based install and cluster was kerberized)
2. Upgrade Ambari to Target Version: 2.7.0.0-588
3. Start EU to HDP-3.0.0.0-1390

**Result**
Observed following error at Timeline Reader v2 start:
```
2018-05-25 11:47:44,940 INFO  timeline.RollingLevelDBTimelineStore (RollingLevelDBTimelineStore.java:run(404)) - Deletion thread received interrupt, exiting
2018-05-25 11:47:44,941 ERROR applicationhistoryservice.ApplicationHistoryServer (ApplicationHistoryServer.java:launchAppHistoryServer(180)) - Error starting ApplicationHistoryServer
org.apache.hadoop.yarn.exceptions.YarnRuntimeException: AHSWebApp failed to start.
        at org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistoryServer.startWebApp(ApplicationHistoryServer.java:322)
        at org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistoryServer.serviceStart(ApplicationHistoryServer.java:121)
        at org.apache.hadoop.service.AbstractService.start(AbstractService.java:194)
        at org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistoryServer.launchAppHistoryServer(ApplicationHistoryServer.java:178)
        at org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistoryServer.main(ApplicationHistoryServer.java:187)
Caused by: java.io.IOException: Problem starting http server
        at org.apache.hadoop.http.HttpServer2.start(HttpServer2.java:1165)
        at org.apache.hadoop.yarn.server.applicationhistoryservice.ApplicationHistoryServer.startWebApp(ApplicationHistoryServer.java:313)
        ... 4 more
Caused by: java.lang.IllegalArgumentException: Could not parse [${clusterHostInfo/rm_host}]
        at org.apache.commons.net.util.SubnetUtils.calculate(SubnetUtils.java:275)
        at org.apache.commons.net.util.SubnetUtils.<init>(SubnetUtils.java:51)
        at org.apache.hadoop.util.MachineList.<init>(MachineList.java:108)
        at org.apache.hadoop.util.MachineList.<init>(MachineList.java:82)
        at org.apache.hadoop.util.MachineList.<init>(MachineList.java:74)
        at org.apache.hadoop.security.authorize.DefaultImpersonationProvider.init(DefaultImpersonationProvider.java:98)
        at org.apache.hadoop.security.authorize.ProxyUsers.refreshSuperUserGroupsConfiguration(ProxyUsers.java:75)
        at org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthenticationFilter.init(DelegationTokenAuthenticationFilter.java:202)
        at org.apache.hadoop.yarn.server.timeline.security.TimelineAuthenticationFilter.init(TimelineAuthenticationFilter.java:47)
        at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:139)
        at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:873)
```

**Cause**
During the Ambari upgrade, the user-defined Kerberos descriptor needs to be updated to reflect the change from _host to _hosts in the cluster host info data.  In this case, the rm_host value needs to change to resourcemanager_hosts in the line that reads:

```
"hadoop.proxyuser.${yarn-env/yarn_user}.hosts": "${clusterHostInfo/rm_host}"
```

## How was this patch tested?

Manually tested upgrade as outlined in the steps to reproduce (STR), above. 

Added unit test passed:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 33:26 min
[INFO] Finished at: 2018-05-25T14:28:26-04:00
[INFO] Final Memory: 80M/1268M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.