### PR TITLE
[AMBARI-23920] Ambari 2way SSL does not work if CA signed certs are used

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -544,6 +544,13 @@ public class Configuration {
       "security.server.cert_name", "ca.crt");
 
   /**
+   * The name of the file that contains the CA certificate chain for certificate validation during 2-way SSL communication.
+   */
+  @Markdown(description = "The name of the file located in the `security.server.keys_dir` directory containing the CA certificate chain used to verify certificates during 2-way SSL communications.")
+  public static final ConfigurationProperty<String> SRVR_CRT_CHAIN_NAME = new ConfigurationProperty<>(
+      "security.server.cert_chain_name", "ca_chain.pem");
+
+  /**
    * The name of the certificate request file used when generating certificates.
    */
   @Markdown(description = "The name of the certificate request file used when generating certificates.")
@@ -2726,6 +2733,7 @@ public class Configuration {
     configsMap.put(SRVR_ONE_WAY_SSL_PORT.getKey(), getProperty(SRVR_ONE_WAY_SSL_PORT));
     configsMap.put(SRVR_KSTR_DIR.getKey(), getProperty(SRVR_KSTR_DIR));
     configsMap.put(SRVR_CRT_NAME.getKey(), getProperty(SRVR_CRT_NAME));
+    configsMap.put(SRVR_CRT_CHAIN_NAME.getKey(), getProperty(SRVR_CRT_CHAIN_NAME));
     configsMap.put(SRVR_KEY_NAME.getKey(), getProperty(SRVR_KEY_NAME));
     configsMap.put(SRVR_CSR_NAME.getKey(), getProperty(SRVR_CSR_NAME));
     configsMap.put(KSTR_NAME.getKey(), getProperty(KSTR_NAME));

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/CertificateManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/CertificateManager.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.Map;
 
@@ -145,7 +146,7 @@ public class CertificateManager {
     Map<String, String> configsMap = configs.getConfigsMap();
     String srvrKstrDir = configsMap.get(Configuration.SRVR_KSTR_DIR.getKey());
     String srvrCrtName = configsMap.get(Configuration.SRVR_CRT_NAME.getKey());
-    String srvrCsrName = configsMap.get(Configuration.SRVR_CSR_NAME.getKey());;
+    String srvrCsrName = configsMap.get(Configuration.SRVR_CSR_NAME.getKey());
     String srvrKeyName = configsMap.get(Configuration.SRVR_KEY_NAME.getKey());
     String kstrName = configsMap.get(Configuration.KSTR_NAME.getKey());
     String srvrCrtPass = configsMap.get(Configuration.SRVR_CRT_PASS.getKey());
@@ -174,20 +175,37 @@ public class CertificateManager {
   }
 
   /**
-   * Returns server certificate content
-   * @return string with server certificate content
+   * Returns server's PEM-encoded CA chain file content
+   * @return string server's PEM-encoded CA chain file content
    */
-  public String getServerCert() {
-    Map<String, String> configsMap = configs.getConfigsMap();
-    File certFile = new File(configsMap.get(Configuration.SRVR_KSTR_DIR.getKey()) +
-        File.separator + configsMap.get(Configuration.SRVR_CRT_NAME.getKey()));
-    String srvrCrtContent = null;
-    try {
-      srvrCrtContent = FileUtils.readFileToString(certFile);
-    } catch (IOException e) {
-      LOG.error(e.getMessage());
+  public String getCACertificateChainContent() {
+    String serverCertDir = configs.getProperty(Configuration.SRVR_KSTR_DIR);
+
+    // Attempt to send the explicit CA certificate chain file.
+    String serverCertChainName = configs.getProperty(Configuration.SRVR_CRT_CHAIN_NAME);
+    File certChainFile = new File(serverCertDir, serverCertChainName);
+    if(certChainFile.exists()) {
+      try {
+        return new String(Files.readAllBytes(certChainFile.toPath()));
+      } catch (IOException e) {
+        LOG.error(e.getMessage());
+      }
     }
-    return srvrCrtContent;
+
+    // Fall back to the original way things were done and send the server's SSL certificate as the
+    // Certificate chain file.
+    String serverCertName = configs.getProperty(Configuration.SRVR_CRT_NAME);
+    File certFile = new File(serverCertDir, serverCertName);
+    if(certFile.canRead()) {
+      try {
+        return new String(Files.readAllBytes(certFile.toPath()));
+      } catch (IOException e) {
+        LOG.error(e.getMessage());
+      }
+    }
+
+    // If all else fails, send nothing...
+    return null;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/unsecured/rest/CertificateDownload.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/unsecured/rest/CertificateDownload.java
@@ -41,8 +41,8 @@ public class CertificateDownload {
 
   @GET @ApiIgnore // until documented
   @Produces({MediaType.TEXT_PLAIN})
-  public String downloadSrvrCrt() {
-    return certMan.getServerCert();
+  public String downloadCACertificateChainFile() {
+    return certMan.getCACertificateChainContent();
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added new (optional) property in `ambari.properites` to allow a user to specific the location of a CA certificate chain file.  This file should contain all of the relevant PEM encoded certificates needed to verify the Ambari CA certificate which is used to sign the client-side certificates it signed  when agents register to Ambari when 2way SSL enabled. 

The property is named "security.server.cert_chain_name", defaulting to "ca_chain.pem" if not set.  The logic will provide this file as the content when agents request the CA certificate using the `/cert/ca` entry point. If the file does not exist or cannot be read, Ambari will fall back to the original behavior and send the Ambari's CA cert. 

## How was this patch tested?

Added new unit test

```
mvn clean test package  -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 26:52 min
[INFO] Finished at: 2018-05-26T19:51:16-04:00
[INFO] Final Memory: 106M/1325M
[INFO] ------------------------------------------------------------------------
```

Manually tested various scenarios. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.