### PR TITLE
[AMBARI-23957] Spark2 Thrift Server fails to start if LLAP and parallel execution are enabled

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/role_command_order.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/role_command_order.json
@@ -21,7 +21,7 @@
   "_comment" : "Dependencies that are used when GLUSTERFS is not present in cluster",
   "optional_no_glusterfs": {
     "SPARK2_JOBHISTORYSERVER-START" : ["NAMENODE-START", "DATANODE-START"],
-    "SPARK2_THRIFTSERVER-START" : ["NAMENODE-START", "DATANODE-START", "HIVE_SERVER-START"]
+    "SPARK2_THRIFTSERVER-START" : ["NAMENODE-START", "DATANODE-START", "HIVE_SERVER-START", "HIVE_SERVER_INTERACTIVE-START"]
   },
   "_comment" : "Dependencies that are used during a Host-Ordered Stack Upgrade",
   "host_ordered_upgrade" : {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark2 Thrift Server start should come after Hive Server Interactive start.

## How was this patch tested?

Tested blueprint deployment (both with and without HSI).