### PR TITLE
[AMBARI-22642] LDAPS Connection Pooling

### DIFF
--- a/ambari-server/conf/unix/ambari-env.sh
+++ b/ambari-server/conf/unix/ambari-env.sh
@@ -15,7 +15,7 @@
 
 
 AMBARI_PASSHPHRASE="DEV"
-export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false"
+export AMBARI_JVM_ARGS="$AMBARI_JVM_ARGS -Xms512m -Xmx2048m -XX:MaxPermSize=128m -Djava.security.auth.login.config=$ROOT/etc/ambari-server/conf/krb5JAASLogin.conf -Djava.security.krb5.conf=/etc/krb5.conf -Djavax.security.auth.useSubjectCredsOnly=false -Dcom.sun.jndi.ldap.connect.pool.protocol=\"plain ssl\" -Dcom.sun.jndi.ldap.connect.pool.maxsize=20 -Dcom.sun.jndi.ldap.connect.pool.timeout=300000"
 export PATH=$PATH:$ROOT/var/lib/ambari-server
 export PYTHONPATH=$ROOT/usr/lib/ambari-server/lib:$PYTHONPATH
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add com.sun.jndi.ldap.connect.pool.* settings to AMBARI_JVM_ARGS to enable connection pooling for LDAPS (secure LDAP, LDAP over SSL) connections.
We saw errors when attempting to sync a large number of groups (50+) against LDAPS, enabling connection pooling resolved this.

## How was this patch tested?

In PR #1281 there were issues in using single quotes in the settings. 
To test the use of escaped double quotes (as recommended), in addition to python unit tests, I used local VMs (ambari-vagrant) to test the change to `ambari-env.sh` on an installed Ambari-server for CentOS7.4, Ubuntu16. 4. This change was also applied to our cluster, which is SLES12. 
