### PR TITLE
AMBARI-23968. Log Search portal has too many open sessions with Ambari.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
@@ -97,11 +97,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   protected void configure(HttpSecurity http) throws Exception {
     http
       .csrf().disable()
-      .sessionManagement()
-         .sessionFixation()
-         .newSession()
-         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-      .and()
       .authorizeRequests()
         .requestMatchers(requestMatcher()).permitAll()
         .antMatchers("/**").authenticated()
@@ -137,7 +132,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Bean
   public LogsearchKRBAuthenticationFilter logsearchKRBAuthenticationFilter() {
-    return new LogsearchKRBAuthenticationFilter();
+    return new LogsearchKRBAuthenticationFilter(requestMatcher());
   }
 
   @Bean


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ambari web alerts opened new logsearch sessions every time they accessed the rest api (/api/v1/info endpoint), spnego filter opened these sessions, solution: this open endpoints should be filtered out by the spnego filter

## How was this patch tested?
UTs passed + manually

Please review @kasakrisz @swagle @g-boros 