### PR TITLE
AMBARI-23974: Add hidden attribute to mpack module, stack services and cluster services

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -4284,6 +4284,18 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     try {
       // Refresh stacks API endpoint and refresh archives
       ambariMetaInfo.init();
+
+      // Update service info from corresponding module info
+      for(StackInfo stackInfo: ambariMetaInfo.getStacks()) {
+        StackEntity stackEntity = stackDAO.find(stackInfo.getName(), stackInfo.getVersion());
+        if(stackEntity.getMpackId() != null) {
+          Mpack mpack = ambariMetaInfo.getMpack(stackEntity.getMpackId());
+          for (ServiceInfo serviceInfo : stackInfo.getServices()) {
+            Module module = mpack.getModule(serviceInfo.getName());
+            serviceInfo.setHidden(module.isHidden());
+          }
+        }
+      }
       // Add "refreshCache" command in the next agent hearbeat for all hosts
       AgentResource.addRefreshCacheForHosts(clusters.getHosts());
     } catch (AmbariException e) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceResponse.java
@@ -34,6 +34,7 @@ public class ServiceResponse {
   private StackId desiredStackId;
   private String desiredState;
   private String maintenanceState;
+  private final boolean hidden;
   private boolean credentialStoreSupported;
   private boolean credentialStoreEnabled;
   private final boolean ssoIntegrationSupported;
@@ -45,7 +46,7 @@ public class ServiceResponse {
       StackId desiredStackId, String desiredRepositoryVersion, String desiredState,
       boolean credentialStoreSupported, boolean credentialStoreEnabled,
       boolean ssoIntegrationSupported, boolean ssoIntegrationDesired,
-      boolean ssoIntegrationEnabled) {
+      boolean ssoIntegrationEnabled, boolean hidden) {
     this.clusterId = clusterId;
     this.clusterName = clusterName;
     this.serviceGroupId = serviceGroupId;
@@ -60,6 +61,7 @@ public class ServiceResponse {
     setDesiredState(desiredState);
     this.credentialStoreSupported = credentialStoreSupported;
     this.credentialStoreEnabled = credentialStoreEnabled;
+    this.hidden = hidden;
   }
 
   /**
@@ -170,6 +172,11 @@ public class ServiceResponse {
   public String getDesiredStackId() {
     return desiredStackId.getStackId();
 
+  }
+
+  @ApiModelProperty(name = "hidden")
+  public boolean isHidden() {
+    return hidden;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
@@ -68,6 +68,8 @@ public class StackServiceResponse {
    */
   private boolean credentialStoreSupported;
 
+  private boolean hidden;
+
   /**
    * Indicates if the stack definition says this service is enabled
    * for credential store use. If not specified, this will be false.
@@ -121,6 +123,7 @@ public class StackServiceResponse {
     credentialStoreEnabled = service.isCredentialStoreEnabled();
     isSupportDeleteViaUI = service.isSupportDeleteViaUI();
     ssoIntegrationSupported = service.isSingleSignOnSupported();
+    hidden = service.isHidden();
   }
 
   @ApiModelProperty(name = "selection")
@@ -341,6 +344,10 @@ public class StackServiceResponse {
    */
   public void setCredentialStoreRequired(boolean credentialStoreRequired) {
     this.credentialStoreRequired = credentialStoreRequired;
+  }
+
+  public boolean isHidden() {
+    return hidden;
   }
 
   @ApiModelProperty(hidden = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -100,6 +100,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   public static final String SERVICE_SERVICE_TYPE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "service_type";
   public static final String SERVICE_SERVICE_STATE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "state";
   public static final String SERVICE_MAINTENANCE_STATE_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "maintenance_state";
+  public static final String SERVICE_HIDDEN_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "hidden";
   public static final String SERVICE_CREDENTIAL_STORE_SUPPORTED_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "credential_store_supported";
   public static final String SERVICE_CREDENTIAL_STORE_ENABLED_PROPERTY_ID = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + "credential_store_enabled";
   public static final String SERVICE_ATTRIBUTES_PROPERTY_ID = "Services" + PropertyHelper.EXTERNAL_PATH_SEP + "attributes";
@@ -141,6 +142,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     PROPERTY_IDS.add(SERVICE_SERVICE_TYPE_PROPERTY_ID);
     PROPERTY_IDS.add(SERVICE_SERVICE_STATE_PROPERTY_ID);
     PROPERTY_IDS.add(SERVICE_MAINTENANCE_STATE_PROPERTY_ID);
+    PROPERTY_IDS.add(SERVICE_HIDDEN_PROPERTY_ID);
     PROPERTY_IDS.add(SERVICE_CREDENTIAL_STORE_SUPPORTED_PROPERTY_ID);
     PROPERTY_IDS.add(SERVICE_CREDENTIAL_STORE_ENABLED_PROPERTY_ID);
     PROPERTY_IDS.add(SERVICE_ATTRIBUTES_PROPERTY_ID);
@@ -226,6 +228,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
         resource.setProperty(SERVICE_SERVICE_TYPE_PROPERTY_ID, response.getServiceType());
         resource.setProperty(SERVICE_SERVICE_STATE_PROPERTY_ID, response.getDesiredState());
         resource.setProperty(SERVICE_MAINTENANCE_STATE_PROPERTY_ID, response.getMaintenanceState());
+        resource.setProperty(SERVICE_HIDDEN_PROPERTY_ID, response.isHidden());
         resource.setProperty(SERVICE_CREDENTIAL_STORE_SUPPORTED_PROPERTY_ID, response.isCredentialStoreSupported());
         resource.setProperty(SERVICE_CREDENTIAL_STORE_ENABLED_PROPERTY_ID, response.isCredentialStoreEnabled());
 
@@ -276,6 +279,8 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
           calculateServiceState(response.getClusterName(), response.getServiceType(), response.getServiceName()), requestedIds);
       setResourceProperty(resource, SERVICE_MAINTENANCE_STATE_PROPERTY_ID,
           response.getMaintenanceState(), requestedIds);
+      setResourceProperty(resource, SERVICE_HIDDEN_PROPERTY_ID,
+        String.valueOf(response.isHidden()), requestedIds);
       setResourceProperty(resource, SERVICE_CREDENTIAL_STORE_SUPPORTED_PROPERTY_ID,
           String.valueOf(response.isCredentialStoreSupported()), requestedIds);
       setResourceProperty(resource, SERVICE_CREDENTIAL_STORE_ENABLED_PROPERTY_ID,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
@@ -78,6 +78,9 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
   private static final String VERSION_PROPERTY_ID = PropertyHelper.getPropertyId(
       "StackServices", "service_version");
 
+  private static final String HIDDEN_PROPERTY_ID = PropertyHelper.getPropertyId(
+    "StackServices", "hidden");
+
   private static final String CONFIG_TYPES = PropertyHelper.getPropertyId(
       "StackServices", "config_types");
 
@@ -131,6 +134,7 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
       COMMENTS_PROPERTY_ID,
       SELECTION_PROPERTY_ID,
       VERSION_PROPERTY_ID,
+      HIDDEN_PROPERTY_ID,
       CONFIG_TYPES,
       REQUIRED_SERVICES_ID,
       SERVICE_CHECK_SUPPORTED_PROPERTY_ID,
@@ -219,6 +223,9 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
 
     setResourceProperty(resource, VERSION_PROPERTY_ID,
         response.getServiceVersion(), requestedIds);
+
+    setResourceProperty(resource, HIDDEN_PROPERTY_ID,
+      response.isHidden(), requestedIds);
 
     setResourceProperty(resource, SELECTION_PROPERTY_ID,
         response.getSelection(), requestedIds);

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Module.java
@@ -47,6 +47,8 @@ public class Module {
   private String name;
   @SerializedName("version")
   private String version;
+  @SerializedName("hidden")
+  private Boolean hidden = false;
   @SerializedName("definition")
   private String definition;
   @SerializedName("dependencies")
@@ -78,6 +80,14 @@ public class Module {
 
   public void setVersion(String version) {
     this.version = version;
+  }
+
+  public Boolean isHidden() {
+    return hidden;
+  }
+
+  public void setHidden(Boolean hidden) {
+    this.hidden = hidden;
   }
 
   public String getDefinition() {
@@ -154,13 +164,14 @@ public class Module {
 
     return Objects.equals(id, module.id) && Objects.equals(displayName, module.displayName) &&
             Objects.equals(description, module.description) && Objects.equals(category, module.category) &&
-            Objects.equals(name, module.name) && Objects.equals(version, module.version) && Objects.equals(definition, module.definition)
+            Objects.equals(name, module.name) && Objects.equals(version, module.version) &&
+            Objects.equals(hidden, module.hidden) && Objects.equals(definition, module.definition)
             && Objects.equals(dependencies, module.dependencies) && Objects.equals(components, module.components);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, displayName, description, category, name, version, definition, dependencies, components);
+    return Objects.hash(id, displayName, description, category, name, version, hidden, definition, dependencies, components);
   }
 
   @Override
@@ -172,6 +183,7 @@ public class Module {
             ", category=" + category +
             ", name='" + name + '\'' +
             ", version='" + version + '\'' +
+            ", hidden=" + hidden +
             ", definition='" + definition + '\'' +
             ", dependencies=" + dependencies +
             ", components=" + components +

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
@@ -458,7 +458,7 @@ public class ServiceImpl implements Service {
         serviceGroup.getServiceGroupId(), serviceGroup.getServiceGroupName(),
         getServiceId(), getName(), getServiceType(), serviceGroup.getStackId(), module.getVersion(),
         getDesiredState().toString(), isCredentialStoreSupported(), isCredentialStoreEnabled(),
-        ssoIntegrationSupported, isSsoIntegrationDesired(), isSsoIntegrationEnabled());
+        ssoIntegrationSupported, isSsoIntegrationDesired(), isSsoIntegrationEnabled(), module.isHidden());
 
     r.setMaintenanceState(getMaintenanceState().name());
     return r;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -191,6 +191,9 @@ public class ServiceInfo implements Validable {
   private StackRoleCommandOrder roleCommandOrder;
 
   @XmlTransient
+  private boolean hidden = false;
+
+  @XmlTransient
   private boolean valid = true;
 
   @XmlElementWrapper(name = "properties")
@@ -199,6 +202,20 @@ public class ServiceInfo implements Validable {
 
   @XmlTransient
   private Map<String, String> servicePropertyMap = ImmutableMap.copyOf(ensureMandatoryServiceProperties(Maps.newHashMap()));
+
+  /**
+   * @return hidden xml flag
+   */
+  public boolean isHidden() {
+    return hidden;
+  }
+
+  /**
+   * @param hidden hidden xml flag
+   */
+  public void setHidden(boolean hidden) {
+    this.hidden = hidden;
+  }
 
   /**
    * @return valid xml flag

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/MpackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/MpackTest.java
@@ -63,6 +63,7 @@ public class MpackTest {
           "    \"min-ambari-version\": \"3.0.0.0\"\n" +
           "  },\n" +
           "  \"version\": \"1.0.0-b16\"\n" +
+          "  \"hidden\": \"False\"\n" +
           "}";
 
   @Test
@@ -89,21 +90,22 @@ public class MpackTest {
     expectedPrereq.put("min-ambari-version","3.0.0.0");
     expectedPrereq.put("max-ambari-version","3.1.0.0");
     ArrayList<Module> expectedModules = new ArrayList<>();
-    Module zkfc = new Module();
-    zkfc.setVersion("3.4.0.0-b17");
-    zkfc.setDefinition("zookeeper-3.4.0.0-b17-definition.tar.gz");
-    zkfc.setName("ZOOKEEPER");
-    zkfc.setId("zookeeper");
-    zkfc.setDisplayName("ZooKeeper");
-    zkfc.setDescription("Centralized service which provides highly reliable distributed coordination");
-    zkfc.setCategory(Module.Category.SERVER);
+    Module zk = new Module();
+    zk.setVersion("3.4.0.0-b17");
+    zk.setDefinition("zookeeper-3.4.0.0-b17-definition.tar.gz");
+    zk.setName("ZOOKEEPER");
+    zk.setId("zookeeper");
+    zk.setDisplayName("ZooKeeper");
+    zk.setHidden(Boolean.FALSE);
+    zk.setDescription("Centralized service which provides highly reliable distributed coordination");
+    zk.setCategory(Module.Category.SERVER);
     ModuleDependency moduleDependency = new ModuleDependency();
     moduleDependency.setId("zookeeper_clients");
     moduleDependency.setName("ZOOKEEPER_CLIENTS");
     moduleDependency.setDependencyType(ModuleDependency.DependencyType.INSTALL);
     ArrayList moduleDepList = new ArrayList();
     moduleDepList.add(moduleDependency);
-    zkfc.setDependencies(moduleDepList);
+    zk.setDependencies(moduleDepList);
     ArrayList compList = new ArrayList();
     ModuleComponent zk_server = new ModuleComponent();
     zk_server.setId("zookeeper_server");
@@ -112,8 +114,8 @@ public class MpackTest {
     zk_server.setIsExternal(Boolean.FALSE);
     zk_server.setVersion("3.4.0.0-b17");
     compList.add(zk_server);
-    zkfc.setComponents(compList);
-    expectedModules.add(zkfc);
+    zk.setComponents(compList);
+    expectedModules.add(zk);
 
     Gson gson = new Gson();
     Mpack mpack = gson.fromJson(mpackJsonContents, Mpack.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/MpackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/MpackTest.java
@@ -62,7 +62,7 @@ public class MpackTest {
           "    \"max-ambari-version\": \"3.1.0.0\",\n" +
           "    \"min-ambari-version\": \"3.0.0.0\"\n" +
           "  },\n" +
-          "  \"version\": \"1.0.0-b16\"\n" +
+          "  \"version\": \"1.0.0-b16\",\n" +
           "  \"hidden\": \"False\"\n" +
           "}";
 


### PR DESCRIPTION
Change-Id: Ifb9a67ebaa1f4b9be82a8883f10ecc099f1b4875

## What changes were proposed in this pull request?
Some client modules in an mpack are not gateway clients and hence should be hidden in the UI. 

(Please fill in changes proposed in this fix)

## How was this patch tested?
Verified hidden attribute is added in 

- [ ] `/api/v1/mpacks/<mpack-id>`

`GET /api/v1/mpacks/1`
`{
  "MpackInfo" : {
    "id" : 1,
    "modules" : [
      {
        "id" : "hadoop_clients",
        "displayName" : "Hadoop Clients",
        "description" : "Clients for HDFS, YARN and MAPREDUCE services",
        "category" : "CLIENT",
        "name" : "HADOOP_CLIENTS",
        "version" : "3.0.0.0-b163",
        "hidden" : true,...`

- [ ] `/api/v1/stacks/<stack-name>/versions/<stack-version>/services/<service-name>`

`GET /api/v1/stacks/HDPCORE/versions/1.0.0-b395/services/HADOOP_CLIENTS`
`{
  "StackServices" : {
    "comments" : "Clients for HDFS, YARN and MAPREDUCE services",
    "credential_store_enabled" : false,
    "credential_store_required" : false,
    "credential_store_supported" : false,
    "custom_commands" : [ ],
    "display_name" : "Hadoop Clients",
    "hidden" : false,...`

- [ ] `/api/v1/clusters/<cluster-name>/servicegroups/<servicegroup-name>/services/<service-name>`

`GET /api/v1/clusters/cl1/servicegroups/HDPCORE/services/HADOOP_CLIENTS`
`{
  "ServiceInfo" : {
    "cluster_id" : 2,
    "cluster_name" : "cl1",
    "credential_store_enabled" : "false",
    "credential_store_supported" : "false",
    "hidden" : "true",...`

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.