### PR TITLE
[AMBARI-20886] Make AzureDB schema generator work with Python 3

### DIFF
--- a/ambari-server/src/main/python/azuredb_create_generator.py
+++ b/ambari-server/src/main/python/azuredb_create_generator.py
@@ -21,6 +21,7 @@ limitations under the License.
 # This script transforms SQLServer "create" SQL to idempotent SQL for AzureDB.
 # It is a filter, ie. it expects input on stdin, and prints output on stdout.
 
+from __future__ import print_function
 import fileinput
 import re
 from textwrap import dedent
@@ -82,4 +83,4 @@ deletes.reverse()
 delete_sql = "\n".join(deletes)
 sql = re.sub("BEGIN TRANSACTION", "\g<0>\n" + delete_sql, sql, count=1)
 
-print sql
+print(sql)


### PR DESCRIPTION
## What changes were proposed in this pull request?

With Python 3, Ambari build gives error:

```
  File "ambari-server/src/main/python/azuredb_create_generator.py", line 86
    print sql
            ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(sql)?
```

## How was this patch tested?

Ran using both Python 2 and 3.  Verified they both produce the same output file.

```
bash ambari-server/src/main/sh/azuredb_create_generator.sh ambari-server
```