### PR TITLE
AMBARI-23977. Slider service check fails with error "ValueError: need more than 3 values to unpack" after Ambari Upgrade

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/copy_tarball.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/copy_tarball.py
@@ -204,6 +204,11 @@ def _prepare_mapreduce_tarball():
 # especially since it is an attribute of a stack and becomes
 # complicated to change during a Rolling/Express upgrade.
 TARBALL_MAP = {
+  "slider": {
+    "dirs": ("{0}/{1}/slider/lib/slider.tar.gz".format(STACK_ROOT_PATTERN, STACK_VERSION_PATTERN),
+              "/{0}/apps/{1}/slider/slider.tar.gz".format(STACK_NAME_PATTERN, STACK_VERSION_PATTERN)),
+    "service": "SLIDER"
+  },
   "yarn": {
     "dirs": ("{0}/{1}/hadoop-yarn/lib/service-dep.tar.gz".format(STACK_ROOT_PATTERN, STACK_VERSION_PATTERN),
              "/{0}/apps/{1}/yarn/service-dep.tar.gz".format(STACK_NAME_PATTERN, STACK_VERSION_PATTERN)),
@@ -268,6 +273,7 @@ TARBALL_MAP = {
 }
 
 SERVICE_TO_CONFIG_MAP = {
+  "slider": "slider-env",
   "yarn": "yarn-env",
   "tez": "tez-env",
   "pig": "pig-env",

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceModule.java
@@ -205,6 +205,9 @@ public class ServiceModule extends BaseModule<ServiceModule, ServiceInfo> implem
     if (serviceInfo.getDisplayName() == null) {
       serviceInfo.setDisplayName(parent.getDisplayName());
     }
+    if (serviceInfo.getServiceType() == null) {
+      serviceInfo.setServiceType(parent.getServiceType());
+    }
     if (serviceInfo.getServiceAdvisorType() == null) {
       ServiceInfo.ServiceAdvisorType serviceAdvisorType = parent.getServiceAdvisorType();
       serviceInfo.setServiceAdvisorType(serviceAdvisorType == null ? ServiceInfo.ServiceAdvisorType.PYTHON : serviceAdvisorType);


### PR DESCRIPTION
STR

1) Upgrade Ambari from 2.6.1.5(GA Build) and HDP-2.6.4.0(GA) to Ambari-2.7(2.7.0.0-602)
2) Upgrade Ambari Infra Solr/Logsearch and restart required services
3) Run Slider service check. It fails with below error:

Due to the same reason:
MR2 History Server start fails.

Error For Slider Service Check

2018-05-28 04:11:21,567 - Cannot copy tarball to HDFS because slider is not supported in stack HDP for this operation.
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/SLIDER/0.60.0.2.2/package/scripts/service_check.py", line 62, in <module>
    SliderServiceCheck().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/usr/lib/ambari-agent/lib/ambari_commons/os_family_impl.py", line 89, in thunk
    return fn(*args, **kwargs)
  File "/var/lib/ambari-agent/cache/common-services/SLIDER/0.60.0.2.2/package/scripts/service_check.py", line 46, in service_check
    copy_to_hdfs("slider", params.user_group, params.hdfs_user, skip=params.sysprep_skip_copy_tarballs_hdfs)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/copy_tarball.py", line 443, in copy_to_hdfs
    custom_source_file, custom_dest_file)
ValueError: need more than 3 values to unpack
STDOUT for Slider Service Check

2018-05-28 04:11:21,562 - Using hadoop conf dir: /usr/hdp/2.6.4.0-91/hadoop/conf
2018-05-28 04:11:21,564 - Using hadoop conf dir: /usr/hdp/2.6.4.0-91/hadoop/conf
2018-05-28 04:11:21,567 - Called copy_to_hdfs tarball: slider
2018-05-28 04:11:21,567 - Cannot copy tarball to HDFS because slider is not supported in stack HDP for this operation.

Command failed after 1 tries
Error For Yarn MR2 History Server start failure

2018-05-28 03:50:15,524 - Cannot copy tarball to HDFS because slider is not supported in stack HDP for this operation.
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/YARN/2.1.0.2.0/package/scripts/historyserver.py", line 132, in <module>
    HistoryServer().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/common-services/YARN/2.1.0.2.0/package/scripts/historyserver.py", line 105, in start
    skip=params.sysprep_skip_copy_tarballs_hdfs) or resource_created
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/copy_tarball.py", line 443, in copy_to_hdfs
    custom_source_file, custom_dest_file)
ValueError: need more than 3 values to unpack