### PR TITLE
[AMBARI-23981] HDFS Summary widgets disappear after changing widgets order

### DIFF
--- a/ambari-web/app/views/main/service/info/metrics_view.js
+++ b/ambari-web/app/views/main/service/info/metrics_view.js
@@ -97,7 +97,8 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
       var allServices = require('data/service_graph_config');
       this.constructGraphObjects(allServices[svcName.toLowerCase()]);
     }
-    this.makeSortable();
+    this.makeSortable('#widget_layout');
+    this.makeSortable('#ns_widget_layout', true);
     this.addWidgetTooltip();
   },
 
@@ -275,19 +276,21 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
   /**
    * Make widgets' list sortable on New Dashboard style
    */
-  makeSortable: function () {
+  makeSortable: function (selector, isNSLayout) {
     var self = this;
-    $('html').on('DOMNodeInserted', '#widget_layout', function () {
+    var controller = this.get('controller');
+    $('html').on('DOMNodeInserted', selector, function () {
       $(this).sortable({
         items: "> div",
         cursor: "move",
         tolerance: "pointer",
         scroll: false,
         update: function () {
-          var widgets = misc.sortByOrder($("#widget_layout .widget").map(function () {
+          var layout = isNSLayout ? controller.get('selectedNSWidgetLayout') : controller.get('activeWidgetLayout');
+          var widgets = misc.sortByOrder($(selector + " .widget").map(function () {
             return this.id;
-          }), self.get('controller.widgets'));
-          self.get('controller').saveWidgetLayout(widgets);
+          }), layout.get('widgets').toArray());
+          controller.saveWidgetLayout(widgets, layout);
         },
         activate: function () {
           self.set('isMoving', true);
@@ -296,28 +299,7 @@ App.MainServiceInfoMetricsView = Em.View.extend(App.Persist, App.TimeRangeMixin,
           self.set('isMoving', false);
         }
       }).disableSelection();
-      $('html').off('DOMNodeInserted', '#widget_layout');
-    });
-    $('html').on('DOMNodeInserted', '#ns_widget_layout', function () {
-      $(this).sortable({
-        items: "> div",
-        cursor: "move",
-        tolerance: "pointer",
-        scroll: false,
-        update: function () {
-          var widgets = misc.sortByOrder($("#ns_widget_layout .widget").map(function () {
-            return this.id;
-          }), self.get('controller.widgets'));
-          self.get('controller').saveWidgetLayout(widgets);
-        },
-        activate: function () {
-          self.set('isMoving', true);
-        },
-        deactivate: function () {
-          self.set('isMoving', false);
-        }
-      }).disableSelection();
-      $('html').off('DOMNodeInserted', '#ns_widget_layout');
+      $('html').off('DOMNodeInserted', selector);
     });
   }
 });

--- a/ambari-web/test/views/main/service/info/metrics_view_test.js
+++ b/ambari-web/test/views/main/service/info/metrics_view_test.js
@@ -206,7 +206,6 @@ describe('App.MainServiceInfoMetricsView', function() {
       sinon.spy(mock, 'on');
       sinon.spy(mock, 'off');
       sinon.spy(mock, 'sortable');
-      view.makeSortable();
     });
     afterEach(function() {
       window.$.restore();
@@ -216,14 +215,17 @@ describe('App.MainServiceInfoMetricsView', function() {
     });
 
     it("on() should be called", function() {
+      view.makeSortable('#widget_layout');
       expect(mock.on.calledWith('DOMNodeInserted', '#widget_layout')).to.be.true;
     });
 
     it("sortable() should be called", function() {
+      view.makeSortable('#widget_layout');
       expect(mock.sortable.called).to.be.true;
     });
 
     it("off() should be called", function() {
+      view.makeSortable('#widget_layout');
       expect(mock.off.calledWith('DOMNodeInserted', '#widget_layout')).to.be.true;
     });
   });
@@ -261,7 +263,7 @@ describe('App.MainServiceInfoMetricsView', function() {
     });
     it("makeSortable should be called", function() {
       view.didInsertElement();
-      expect(view.makeSortable.calledOnce).to.be.true;
+      expect(view.makeSortable.called).to.be.true;
     });
     it("loadActiveWidgetLayout should be called", function() {
       view.didInsertElement();


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:
1. Add Namespace.
2. Open HDFS service metrics page and change order of NS-specific widgets.
3. Refresh the page and check general widgets.

It should not be empty.

## How was this patch tested?

  21792 passing (34s)
  48 pending