### PR TITLE
[AMBARI-23826] Save button is inactive for changed filtered property after configs comparing - addendum

### DIFF
--- a/ambari-web/app/controllers/main/service/info/configs.js
+++ b/ambari-web/app/controllers/main/service/info/configs.js
@@ -403,12 +403,12 @@ App.MainServiceInfoConfigsController = Em.Controller.extend(App.AddSecurityConfi
   },
 
   parseConfigData: function(data) {
-    var self = this;
-    this.loadKerberosIdentitiesConfigs().done(function(identityConfigs) {
-      self.prepareConfigObjects(data, identityConfigs);
-      self.loadCompareVersionConfigs(self.get('allConfigs')).done(function() {
-        self.addOverrides(data, self.get('allConfigs'));
-        self.onLoadOverrides(self.get('allConfigs'));
+    this.loadKerberosIdentitiesConfigs().done(identityConfigs => {
+      this.prepareConfigObjects(data, identityConfigs);
+      this.loadCompareVersionConfigs(this.get('allConfigs')).done(() => {
+        this.addOverrides(data, this.get('allConfigs'));
+        this.onLoadOverrides(this.get('allConfigs'));
+        this.updateAttributesFromTheme(this.get('content.serviceName'));
       });
     });
   },

--- a/ambari-web/app/controllers/wizard/step7_controller.js
+++ b/ambari-web/app/controllers/wizard/step7_controller.js
@@ -596,6 +596,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
     }
     this.set('stepConfigs', serviceConfigs);
     this.set('stepConfigsCreated', true);
+    this.updateConfigAttributesFromThemes();
     this.checkHostOverrideInstaller();
     this.selectProperService();
     var isInstallerWizard = (this.get("content.controllerName") === 'installerController');
@@ -2112,6 +2113,10 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
     } else {
       App.router.send('back');
     }
+  },
+
+  updateConfigAttributesFromThemes: function () {
+    this.get('allSelectedServiceNames').forEach(serviceName => this.updateAttributesFromTheme(serviceName));
   }
 
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

 1. Go to HIVE configs.
 2. Filter configs by hive.metastore.client.socket.timeout.
 3. Compare current version with some previous.
 4. Close comparing panel.
 5. Change filtered property.

Result: "Save" button is inactive. Was reproduced not for any service/property.

## How was this patch tested?

UI unit tests:
  21792 passing (28s)
  48 pending
