### PR TITLE
AMBARI-23985. Change the default shard/replica numbers for Log Search collections.

### DIFF
--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logsearch-properties.xml
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/configuration/logsearch-properties.xml
@@ -43,7 +43,7 @@
   </property>
   <property>
     <name>logsearch.collection.service.logs.numshards</name>
-    <value>5</value>
+    <value>4</value>
     <display-name>Log Search Solr Service Logs Shards</display-name>
     <description>Number of shards for Service Logs collection</description>
     <value-attributes>
@@ -57,7 +57,7 @@
   </property>
   <property>
     <name>logsearch.collection.service.logs.replication.factor</name>
-    <value>1</value>
+    <value>2</value>
     <display-name>Log Search Solr Service Logs Replication Factor</display-name>
     <description>Replication factor for Service Logs Solr collection</description>
     <value-attributes>
@@ -71,7 +71,7 @@
   </property>
   <property>
     <name>logsearch.collection.audit.logs.numshards</name>
-    <value>5</value>
+    <value>4</value>
     <display-name>Log Search Solr Audit Logs Shards</display-name>
     <description>Number of shards for Audit Logs collection</description>
     <value-attributes>
@@ -85,7 +85,7 @@
   </property>
   <property>
     <name>logsearch.collection.audit.logs.replication.factor</name>
-    <value>1</value>
+    <value>2</value>
     <display-name>Log Search Solr Audit Logs Replication Factor</display-name>
     <description>Replication factor for Audit Logs Solr collection</description>
     <value-attributes>

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
@@ -259,7 +259,7 @@ logsearch_properties['logsearch.solr.audit.logs.zk_connect_string'] = logsearch_
 
 logsearch_properties['logsearch.solr.collection.history'] = 'history'
 logsearch_properties['logsearch.solr.history.config.name'] = 'history'
-logsearch_properties['logsearch.collection.history.replication.factor'] = '1'
+logsearch_properties['logsearch.collection.history.replication.factor'] = '2'
 
 logsearch_properties['logsearch.solr.jmx.port'] = infra_solr_jmx_port
 

--- a/ambari-server/src/test/python/stacks/2.4/LOGSEARCH/test_logsearch.py
+++ b/ambari-server/src/test/python/stacks/2.4/LOGSEARCH/test_logsearch.py
@@ -95,7 +95,7 @@ class TestLogSearch(RMFTestCase):
                                             'logsearch.auth.simple.enabled': 'false',
                                             'logsearch.collection.audit.logs.numshards': '10',
                                             'logsearch.collection.audit.logs.replication.factor': '1',
-                                            'logsearch.collection.history.replication.factor': '1',
+                                            'logsearch.collection.history.replication.factor': '2',
                                             'logsearch.collection.service.logs.numshards': '10',
                                             'logsearch.collection.service.logs.replication.factor': '1',
                                             'logsearch.config.zk_connect_string': 'c6401.ambari.apache.org:2181',


### PR DESCRIPTION
## What changes were proposed in this pull request?
change the default shards + replicas (could be useful for blueprint deployments, if hosts goes down, shards could be still up)

## How was this patch tested?
UTs passed after UT test input changes.

Please review @swagle @kasakrisz @adoroszlai @g-boros 