### PR TITLE
AMBARI-23987. Set 'skip.service.checks' = true during deploy.

### DIFF
--- a/ambari-server/conf/unix/ambari.properties
+++ b/ambari-server/conf/unix/ambari.properties
@@ -113,7 +113,7 @@ user.inactivity.timeout.default=0
 user.inactivity.timeout.role.readonly.default=0
 
 # to skip service checks during deploy
-skip.service.checks=false
+skip.service.checks=true
 
 rolling.upgrade.skip.packages.prefixes=
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need review/fix the Service Checks for the Services before turning them on. ([AMBARI-23988](https://issues.apache.org/jira/browse/AMBARI-23988) tracks the issue).

Thus, making the global **'skip.service.checks' = true** in ambari.properties so that SC don't get scheduled as of now.

## How was this patch tested?

Tested on 2 node Live Cluster

No Service Check Scheduled as seen below.

<img width="1258" alt="screen shot 2018-05-30 at 1 13 37 pm" src="https://user-images.githubusercontent.com/1879146/40746214-acda93e2-640e-11e8-8c31-88299a2ce351.png">

<img width="1270" alt="screen shot 2018-05-30 at 1 13 29 pm" src="https://user-images.githubusercontent.com/1879146/40746220-b10fbf5a-640e-11e8-98af-9ef5b7fdbc86.png">


