### PR TITLE
[AMBARI-23989] Provide Patch or Maint Flag to Command JSON

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/upgrade_summary.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/upgrade_summary.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.constants import Direction
 
-UpgradeSummary = namedtuple("UpgradeSummary", "type direction orchestration is_revert services is_downgrade_allowed")
+UpgradeSummary = namedtuple("UpgradeSummary", "type direction orchestration is_revert services is_downgrade_allowed is_switch_bits")
 UpgradeServiceSummary = namedtuple("UpgradeServiceSummary", "service_name source_stack source_version target_stack target_version")
 
 
@@ -101,7 +101,8 @@ def get_upgrade_summary():
   return UpgradeSummary(type=upgrade_summary["type"], direction=upgrade_summary["direction"],
     orchestration=upgrade_summary["orchestration"], is_revert = upgrade_summary["isRevert"],
     services = service_summary_dict,
-    is_downgrade_allowed=upgrade_summary["isDowngradeAllowed"])
+    is_downgrade_allowed=upgrade_summary["isDowngradeAllowed"],
+    is_switch_bits=upgrade_summary["isSwitchBits"])
 
 
 def get_downgrade_from_version(service_name = None):

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -971,6 +971,10 @@ public class UpgradeContext {
 
     summary.isDowngradeAllowed = isDowngradeAllowed();
 
+    // !!! a) if we are reverting, that can only happen via PATCH or MAINT
+    //     b) if orchestration is a revertible type (on upgrade)
+    summary.isSwitchBits = m_isRevert || m_orchestration.isRevertable();
+
     summary.services = new HashMap<>();
 
     for (String serviceName : m_services) {
@@ -1435,6 +1439,13 @@ public class UpgradeContext {
 
     @SerializedName("services")
     public Map<String, UpgradeServiceSummary> services;
+
+    /**
+     * MAINT or PATCH upgrades are meant to just be switching the bits and no other
+     * incompatible changes.
+     */
+    @SerializedName("isSwitchBits")
+    public boolean isSwitchBits = false;
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeContextTest.java
@@ -127,8 +127,11 @@ public class UpgradeContextTest extends EasyMockSupport {
 
     expect(m_sourceRepositoryVersion.getId()).andReturn(1L).anyTimes();
     expect(m_sourceRepositoryVersion.getStackId()).andReturn(new StackId("HDP", "2.6")).anyTimes();
+    expect(m_sourceRepositoryVersion.getVersion()).andReturn("2.6.0.0").anyTimes();
+
     expect(m_targetRepositoryVersion.getId()).andReturn(99L).anyTimes();
     expect(m_targetRepositoryVersion.getStackId()).andReturn(new StackId("HDP", "2.6")).anyTimes();
+    expect(m_targetRepositoryVersion.getVersion()).andReturn("2.6.0.2").anyTimes();
 
     UpgradeHistoryEntity upgradeHistoryEntity = createNiceMock(UpgradeHistoryEntity.class);
     expect(upgradeHistoryEntity.getServiceName()).andReturn(HDFS_SERVICE_NAME).anyTimes();
@@ -153,7 +156,8 @@ public class UpgradeContextTest extends EasyMockSupport {
     expect(m_completedRevertableUpgrade.getUpgradePackage()).andReturn(null).anyTimes();
 
     RepositoryVersionEntity hdfsRepositoryVersion = createNiceMock(RepositoryVersionEntity.class);
-
+    expect(hdfsRepositoryVersion.getId()).andReturn(1L).anyTimes();
+    expect(hdfsRepositoryVersion.getStackId()).andReturn(new StackId("HDP-2.6")).anyTimes();
     expect(m_hdfsService.getDesiredRepositoryVersion()).andReturn(hdfsRepositoryVersion).anyTimes();
     expect(m_zookeeperService.getDesiredRepositoryVersion()).andReturn(hdfsRepositoryVersion).anyTimes();
     expect(m_cluster.getService(HDFS_SERVICE_NAME)).andReturn(m_hdfsService).anyTimes();
@@ -202,6 +206,7 @@ public class UpgradeContextTest extends EasyMockSupport {
     assertEquals(RepositoryType.STANDARD, context.getOrchestrationType());
     assertEquals(1, context.getSupportedServices().size());
     assertFalse(context.isPatchRevert());
+    assertFalse(context.getUpgradeSummary().isSwitchBits);
 
     verifyAll();
   }
@@ -248,6 +253,7 @@ public class UpgradeContextTest extends EasyMockSupport {
     assertEquals(RepositoryType.PATCH, context.getOrchestrationType());
     assertEquals(1, context.getSupportedServices().size());
     assertFalse(context.isPatchRevert());
+    assertTrue(context.getUpgradeSummary().isSwitchBits);
 
     verifyAll();
   }
@@ -332,6 +338,7 @@ public class UpgradeContextTest extends EasyMockSupport {
     assertEquals(RepositoryType.PATCH, context.getOrchestrationType());
     assertEquals(1, context.getSupportedServices().size());
     assertTrue(context.isPatchRevert());
+    assertTrue(context.getUpgradeSummary().isSwitchBits);
 
     verifyAll();
   }

--- a/ambari-server/src/test/python/TestStackFeature.py
+++ b/ambari-server/src/test/python/TestStackFeature.py
@@ -196,7 +196,8 @@ class TestStackFeature(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }
 
@@ -234,7 +235,8 @@ class TestStackFeature(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }
 
@@ -273,7 +275,8 @@ class TestStackFeature(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }
 

--- a/ambari-server/src/test/python/TestStackSelect.py
+++ b/ambari-server/src/test/python/TestStackSelect.py
@@ -161,7 +161,8 @@ class TestStackSelect(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }
 
@@ -200,7 +201,8 @@ class TestStackSelect(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }
 

--- a/ambari-server/src/test/python/TestUpgradeSummary.py
+++ b/ambari-server/src/test/python/TestUpgradeSummary.py
@@ -97,7 +97,8 @@ class TestUpgradeSummary(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }
 
@@ -134,6 +135,7 @@ class TestUpgradeSummary(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
-        "isDowngradeAllowed": True
+        "isDowngradeAllowed": True,
+        "isSwitchBits": False
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide information for either Upgrade or Downgrade that indicates when the bits only are switched. This means some commands may be omitted if they won't affect the state of the cluster.

## How was this patch tested?
Manual testing with HDFS on patch, then revert after.  Confirmed that bit switching only occurred and that the cluster was still functional.

Unit tests:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 36:11 min
[INFO] Finished at: 2018-05-30T17:42:48-04:00
[INFO] Final Memory: 75M/1957M
[INFO] ------------------------------------------------------------------------
```