### PR TITLE
[AMBARI-23990] credential_store_helper.get_password_from_credential_store does not return the correct password string

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/credential_store_helper.py
+++ b/ambari-common/src/main/python/ambari_commons/credential_store_helper.py
@@ -52,7 +52,7 @@ def get_password_from_credential_store(alias, provider_path, cs_lib_path, java_h
     cmd = (java_bin, '-cp', cs_lib_path, credential_util_cmd, 'get', alias, '-provider', provider_path)
     cmd_result, std_out_msg  = checked_call(cmd)
     std_out_lines = std_out_msg.split('\n')
-    return(removeloglines(std_out_lines)[0]) # Get the last line of the output, to skip warnings if any.
+    return(std_out_lines[-1]) # Get the last line of the output, to skip warnings if any.
 
 
 def list_aliases_from_credential_store(provider_path, cs_lib_path, java_home, jdk_location):


### PR DESCRIPTION
## What changes were proposed in this pull request?
Due to changes from [AMBARI-23962](https://issues.apache.org/jira/browse/AMBARI-23962) retrieving the password from a credential store returns an incorrect value.  This patch reverts the line that returns the data but leaves the rest of the added code which appears to be working fine. 

## How was this patch tested?

Manually tested

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.