### PR TITLE
AMBARI-23991. Log Search: cleanup Ambari audits collection / schema.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
@@ -121,7 +121,7 @@
   <dynamicField name="ngram_*" type="n_gram" multiValued="false" stored="true"/>
   <dynamicField name="std_*" type="text_std_token_lower_case" multiValued="false" stored="true"/>
   <dynamicField name="key_*" type="key_lower_case" multiValued="false" stored="true"/>
-  <dynamicField name="ws_*" type="text_ws" omitNorms="false" multiValued="false" stored="true"/>
+  <dynamicField name="ws_*" type="string" indexed="true" multiValued="false" stored="true"/>
 
   <dynamicField name="*_i"  type="tint" indexed="true"  stored="true"/>
   <dynamicField name="*_is" type="tints" indexed="true"  stored="true"/>

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/input.config-ambari.json.j2
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/input.config-ambari.json.j2
@@ -309,6 +309,11 @@
             "new_fieldname":"action"
           }
         },
+        "Service":{
+          "map_fieldname":{
+            "new_fieldname":"ws_service"
+          }
+        },
         "url":{
           "map_fieldname":{
             "new_fieldname":"resource"
@@ -324,12 +329,27 @@
             "new_fieldname":"cluster"
           }
         },
+        "Old name":{
+          "map_fieldname":{
+            "new_fieldname":"ws_old_name"
+          }
+        },
+        "New name":{
+          "map_fieldname":{
+            "new_fieldname":"ws_new_name"
+          }
+        },
         "Reason":{
           "map_fieldname":{
             "new_fieldname":"reason"
           }
         },
         "Base URL":{
+          "map_fieldname":{
+            "new_fieldname":"ws_base_url"
+          }
+        },
+        "Base url":{
           "map_fieldname":{
             "new_fieldname":"ws_base_url"
           }
@@ -348,9 +368,144 @@
             "new_fieldname":"ws_component"
           }
         },
+        "Type":{
+          "map_fieldname":{
+            "new_fieldname":"ws_type"
+          }
+        },
+        "Consecutive failures": {
+          "map_fieldname":{
+            "new_fieldname":"ws_consecutive_failures"
+          }
+        },
+        "Created Username": {
+          "map_fieldname":{
+            "new_fieldname":"ws_username"
+          }
+        },
+        "Affected username": {
+          "map_fieldname":{
+            "new_fieldname":"ws_username"
+          }
+        },
+        "Deleted Username": {
+          "map_fieldname":{
+            "new_fieldname":"ws_username"
+          }
+        },
+        "Alert group name": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_group_name"
+          }
+        },
+        "Alert group ID": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_group_id"
+          }
+        },
+        "Definition IDs": {
+          "map_fieldname":{
+            "new_fieldname":"std_alert_definition_ids"
+          }
+        },
+        "Notification ID": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_notification_id"
+          }
+        },
+        "Notification IDs": {
+          "map_fieldname":{
+            "new_fieldname":"std_alert_notification_ids"
+          }
+        },
+        "Notification name": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_notification_name"
+          }
+        },
+        "Notification type": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_notification_type"
+          }
+        },
+        "Members": {
+          "map_fieldname":{
+            "new_fieldname":"std_members"
+          }
+        },
+        "Description": {
+          "map_fieldname":{
+            "new_fieldname":"ws_description"
+          }
+        },
+        "Email from": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_email_from"
+          }
+        },
+        "Email to": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alert_email_to"
+          }
+        },
+        "Group": {
+          "map_fieldname":{
+            "new_fieldname":"ws_group"
+          }
+        },
+        "Group IDs": {
+          "map_fieldname":{
+            "new_fieldname":"std_alert_group_ids"
+          }
+        },
+        "Alert states": {
+          "map_fieldname":{
+            "new_fieldname":"std_alert_states"
+          }
+        },
+        "Blueprint": {
+          "map_fieldname":{
+            "new_fieldname":"ws_blueprint"
+          }
+        },
+        "Blueprint name": {
+          "map_fieldname":{
+            "new_fieldname":"ws_blueprint_name"
+          }
+        },
+        "State": {
+          "map_fieldname":{
+            "new_fieldname":"ws_state"
+          }
+        },
+        "Principal": {
+          "map_fieldname":{
+            "new_fieldname":"ws_principal"
+          }
+        },
+        "Alias": {
+          "map_fieldname":{
+            "new_fieldname":"ws_alias"
+          }
+        },
+        "Keytab file": {
+          "map_fieldname":{
+            "new_fieldname":"ws_keytab_file"
+          }
+        },
+        "Upgrade type":{
+          "map_fieldname":{
+            "new_fieldname":"ws_upgrade_type"
+          }
+        },
         "Details":{
           "map_fieldname":{
             "new_fieldname":"ws_details"
+          }
+        },
+        "Name":{
+          "map_fieldname":{
+            "new_fieldname":"ws_name"
           }
         },
         "Display name":{
@@ -381,6 +536,11 @@
             "new_fieldname":"ws_repo_version"
           }
         },
+        "Repo version ID":{
+          "map_fieldname":{
+            "new_fieldname":"ws_repo_version_id"
+          }
+        },
         "Repositories":{
           "map_fieldname":{
             "new_fieldname":"ws_repositories"
@@ -391,9 +551,29 @@
             "new_fieldname":"ws_request_id"
           }
         },
+        "Request id":{
+          "map_fieldname":{
+            "new_fieldname":"ws_request_id"
+          }
+        },
+        "Repository ID":{
+          "map_fieldname":{
+            "new_fieldname":"ws_repo_id"
+          }
+        },
+        "Repository name":{
+          "map_fieldname":{
+            "new_fieldname":"ws_repo_name"
+          }
+        },
         "Roles":{
           "map_fieldname":{
             "new_fieldname":"ws_roles"
+          }
+        },
+        "Permissions":{
+          "map_fieldname":{
+            "new_fieldname":"std_permissions"
           }
         },
         "Stack":{
@@ -404,6 +584,42 @@
         "Stack version":{
           "map_fieldname":{
             "new_fieldname":"ws_stack_version"
+          }
+        },
+        "Stage id":{
+          "map_fieldname":{
+            "new_fieldname":"ws_stage_id"
+          }
+        },
+        "Administrator":{
+          "map_fieldvalue":{
+            "pre_value":"yes",
+            "post_value":"1"
+          },
+          "map_fieldvalue":{
+            "pre_value":"no",
+            "post_value":"0"
+          },
+          "map_fieldname":{
+            "new_fieldname":"ws_admin"
+          }
+        },
+        "Active":{
+          "map_fieldvalue":{
+            "pre_value":"y",
+            "post_value":"1"
+          },
+          "map_fieldvalue":{
+            "pre_value":"n",
+            "post_value":"0"
+          },
+          "map_fieldname":{
+            "new_fieldname":"ws_active"
+          }
+        },
+        "Version":{
+          "map_fieldname":{
+            "new_fieldname":"ws_version"
           }
         },
         "VersionNote":{


### PR DESCRIPTION
## What changes were proposed in this pull request?
cleanup ambari audit schema. make ws_* type to be string instead of tokenized type
use tokenized (std_*) where we have lists-like string // note ws_* and std_* are dynamic solr fields

Also add missing mappings based on ambari audit events

## How was this patch tested?
in progress...

Please review @swagle @adoroszlai @kasakrisz @g-boros 