### PR TITLE
AMBARI-23992. Log Feeder: NullPointer during file check in.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/InputFileMarker.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/InputFileMarker.java
@@ -37,7 +37,7 @@ public class InputFileMarker implements InputMarker {
     this.base64FileKey = base64FileKey;
     this.lineNumber = lineNumber;
     properties.put("line_number", lineNumber);
-    properties.put("base64_file_key", base64FileKey);
+    properties.put("file_key", base64FileKey);
   }
 
   @Override

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
@@ -486,7 +486,7 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> implements C
               Level.ERROR);
         }
       }
-      latestInputMarkers.put(outputData.inputMarker.getAllProperties().get("base64_file_key").toString(),
+      latestInputMarkers.put(outputData.inputMarker.getAllProperties().get("file_key").toString(),
         outputData.inputMarker);
       localBuffer.add(document);
     }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
@@ -121,7 +121,7 @@ public class FileUtil {
             return files;
           }
         } catch (Exception e) {
-          LOG.warn("Input file was not found by pattern (exception thrown); {}, message: {}", searchPath, e.getMessage());
+          LOG.info("Input file was not found by pattern (exception thrown); {}, message: {}", searchPath, e.getMessage());
         }
 
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
NullPointer during file check in as a wrong json value is referenced from the file.

Also if a file is not found (like as basedir does not exist), do not show as warning, as if a service is not installed on a cluster, it will be logged as warn during every scan. (in every 30 seconds)

## How was this patch tested?

Please review @swagle @kasakrisz @g-boros 