### PR TITLE
[AMBARI-23994]. "Ambari persisted credential store" pre check appearing in Patch Upgrade. (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ComponentsExistInRepoCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ComponentsExistInRepoCheck.java
@@ -30,6 +30,7 @@ import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.PrerequisiteCheck;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.upgrade.ClusterGrouping;
+import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.ServerActionTask;
 import org.apache.ambari.server.state.stack.upgrade.Task;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
@@ -87,7 +88,7 @@ public class ComponentsExistInRepoCheck extends AbstractCheckDescriptor {
       request.getClusterName(),
       request.getSourceStackId(),
       request.getTargetRepositoryVersion().getStackId(),
-      request.getDirection(),
+      Direction.UPGRADE,
       request.getUpgradeType(),
       null);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/PrereqCheckRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/PrereqCheckRequest.java
@@ -25,7 +25,6 @@ import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
 import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.UpgradePack.PrerequisiteCheckConfig;
-import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 
 /**
@@ -150,15 +149,5 @@ public class PrereqCheckRequest {
    */
   public boolean isRevert() {
     return m_revert;
-  }
-
-  public Direction getDirection() {
-    int direction = m_sourceStackId.compareTo(m_targetRepositoryVersion.getStackId());
-    if (direction < 0) {
-      return Direction.UPGRADE;
-    } else if (direction > 0) {
-      return Direction.DOWNGRADE;
-    }
-    throw new RuntimeException("Invalid upgrade direction. Source and target version is the same.");
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.xml.bind.Unmarshaller;
@@ -779,4 +780,14 @@ public class UpgradePack {
     private List<Task> tasks = new ArrayList<>();
   }
 
+  /**
+   * @return true if this upgrade pack contains a group with a task that matches the given predicate
+   */
+  public boolean anyGroupTaskMatch(Predicate<Task> taskPredicate) {
+    return getAllGroups().stream()
+      .filter(ClusterGrouping.class::isInstance)
+      .flatMap(group -> ((ClusterGrouping) group).executionStages.stream())
+      .map(executeStage -> executeStage.task)
+      .anyMatch(taskPredicate);
+  }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
@@ -38,6 +38,7 @@ import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.PrerequisiteCheck;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.upgrade.ClusterGrouping;
+import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.ServerActionTask;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
@@ -113,7 +114,7 @@ public class ComponentExistsInRepoCheckTest extends EasyMockSupport {
       "cluster",
       request.getSourceStackId(),
       request.getTargetRepositoryVersion().getStackId(),
-      request.getDirection(),
+      Direction.UPGRADE,
       request.getUpgradeType(),
       null)).andReturn(upgradePack).anyTimes();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Precheck for Ambari persisted credential store shouldn't run when there is no regen_keytabs task in the upgrade pack.

## How was this patch tested?

- triggered precheck manually on the UI
- checked if the precheck was executed or not depending on the present or absent of regen task in the upgrade xml