### PR TITLE
AMBARI-23997. Server metadata cache does not have valid hash after updates with no any registered agent.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentClusterDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentClusterDataHolder.java
@@ -76,6 +76,11 @@ public abstract class AgentClusterDataHolder<T extends STOMPEvent & Hashable> ex
       regenerateHash();
       update.setHash(getData().getHash());
       STOMPUpdatePublisher.publish(update);
+    } else {
+      // in case update does not have changes empty identifiers should be populated anyway
+      if (!isIdentifierValid(data)) {
+        regenerateHash();
+      }
     }
     return changed;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -5174,7 +5174,12 @@ public class Configuration {
   }
 
   public Boolean getGplLicenseAccepted(){
-    return Boolean.valueOf(getProperty(GPL_LICENSE_ACCEPTED));
+    Properties actualProps = readConfigFile();
+    String defaultGPLAcceptedValue = null;
+    if (null != GPL_LICENSE_ACCEPTED.getDefaultValue()) {
+      defaultGPLAcceptedValue = String.valueOf(GPL_LICENSE_ACCEPTED.getDefaultValue());
+    }
+    return Boolean.valueOf(actualProps.getProperty(GPL_LICENSE_ACCEPTED.getKey(), defaultGPLAcceptedValue));
   }
 
   public String getAgentStackRetryOnInstallCount(){


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server guarantees hash relevance for metadata cache. Also metadata cache contains actual info about GPL acceptance.

## How was this patch tested?

Manual testing.