### PR TITLE
[AMBARI-24002] - Set All Versions only on Upgrades which cannot be Downgraded

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/upgrade_summary.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/upgrade_summary.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.constants import Direction
 
-UpgradeSummary = namedtuple("UpgradeSummary", "type direction orchestration is_revert services is_downgrade_allowed is_switch_bits")
+UpgradeSummary = namedtuple("UpgradeSummary", "type direction orchestration is_revert services is_downgrade_allowed is_switch_bits associated_stack associated_version")
 UpgradeServiceSummary = namedtuple("UpgradeServiceSummary", "service_name source_stack source_version target_stack target_version")
 
 
@@ -102,7 +102,9 @@ def get_upgrade_summary():
     orchestration=upgrade_summary["orchestration"], is_revert = upgrade_summary["isRevert"],
     services = service_summary_dict,
     is_downgrade_allowed=upgrade_summary["isDowngradeAllowed"],
-    is_switch_bits=upgrade_summary["isSwitchBits"])
+    is_switch_bits=upgrade_summary["isSwitchBits"],
+    associated_stack=upgrade_summary["associatedStackId"],
+    associated_version = upgrade_summary["associatedVersion"])
 
 
 def get_downgrade_from_version(service_name = None):

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
@@ -105,7 +105,7 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
   protected static final String COMPONENT_NAME_PROPERTY_ID = "name";
 
   protected static final String INSTALL_PACKAGES_ACTION = "install_packages";
-  protected static final String STACK_SELECT_ACTION = "ru_set_all";
+  protected static final String STACK_SELECT_ACTION = "stack_select_set_all";
   protected static final String INSTALL_PACKAGES_FULL_NAME = "Install Version";
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -971,6 +971,10 @@ public class UpgradeContext {
 
     summary.isDowngradeAllowed = isDowngradeAllowed();
 
+    summary.associatedRepositoryId = m_repositoryVersion.getId();
+    summary.associatedStackId = m_repositoryVersion.getStackId().getStackId();
+    summary.associatedVersion = m_repositoryVersion.getVersion();
+
     // !!! a) if we are reverting, that can only happen via PATCH or MAINT
     //     b) if orchestration is a revertible type (on upgrade)
     summary.isSwitchBits = m_isRevert || m_orchestration.isRevertable();
@@ -1439,6 +1443,33 @@ public class UpgradeContext {
 
     @SerializedName("services")
     public Map<String, UpgradeServiceSummary> services;
+
+    /**
+     * The ID of the repository associated with the upgrade. For an
+     * {@link Direction#UPGRADE}, this is the target repository, for a
+     * {@link Direction#DOWNGRADE} this was the repository being downgraded
+     * from.
+     */
+    @SerializedName("associatedRepositoryId")
+    public long associatedRepositoryId;
+
+    /**
+     * The ID of the repository associated with the upgrade. For an
+     * {@link Direction#UPGRADE}, this is the target stack, for a
+     * {@link Direction#DOWNGRADE} this was the stack that is being downgraded
+     * from.
+     */
+    @SerializedName("associatedStackId")
+    public String associatedStackId;
+
+    /**
+     * The ID of the repository associated with the upgrade. For an
+     * {@link Direction#UPGRADE}, this is the target versopm, for a
+     * {@link Direction#DOWNGRADE} this was the version that is being downgraded
+     * from.
+     */
+    @SerializedName("associatedVersion")
+    public String associatedVersion;
 
     /**
      * MAINT or PATCH upgrades are meant to just be switching the bits and no other

--- a/ambari-server/src/main/resources/custom_actions/scripts/stack_select_set_all.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/stack_select_set_all.py
@@ -21,20 +21,14 @@ Ambari Agent
 """
 
 import os
-import shutil
 import socket
 from ambari_commons.os_check import OSCheck
 from resource_management.libraries.script import Script
-from resource_management.libraries.functions import conf_select
 from resource_management.libraries.functions import stack_tools
-from resource_management.libraries.functions.default import default
-from resource_management.libraries.functions.version import format_stack_version
+from resource_management.libraries.functions import upgrade_summary
+from resource_management.libraries.functions.constants import Direction
 from resource_management.core import shell
-from resource_management.core.exceptions import Fail
 from resource_management.core.logger import Logger
-from resource_management.core.resources.system import Execute, Link, Directory
-from resource_management.libraries.functions.stack_features import check_stack_feature
-from resource_management.libraries.functions import StackFeature
 from resource_management.libraries.functions.decorator import experimental
 
 class UpgradeSetAll(Script):
@@ -42,48 +36,49 @@ class UpgradeSetAll(Script):
   This script is a part of stack upgrade workflow and is used to set the
   all of the component versions as a final step in the upgrade process
   """
-  @experimental(feature="PATCH_UPGRADES", disable = True, comment = "Skipping stack-select set all")
+  @experimental(feature="PATCH_UPGRADES", disable = False, comment = "The stack-select tool will only be invoked if this is a standard upgrade which cannot be downgraded.")
   def actionexecute(self, env):
-    version = default('/commandParams/version', None)
+    summary = upgrade_summary.get_upgrade_summary()
+    if summary is None:
+      Logger.warning("There is no upgrade in progress")
+      return
 
-    if not version:
-      raise Fail("Value is required for '/commandParams/version'")
-  
+    if summary.associated_version is None:
+      Logger.warning("There is no version associated with the upgrade in progress")
+      return
+
+    if summary.orchestration != "STANDARD":
+      Logger.warning("The 'stack-select set all' command can only be invoked during STANDARD upgrades")
+      return
+
+    if summary.direction.lower() != Direction.UPGRADE or summary.is_downgrade_allowed or summary.is_revert:
+      Logger.warning("The 'stack-select set all' command can only be invoked during an UPGRADE which cannot be downgraded")
+      return
+
     # other os?
     if OSCheck.is_redhat_family():
       cmd = ('/usr/bin/yum', 'clean', 'all')
       code, out = shell.call(cmd, sudo=True)
-
-    formatted_version = format_stack_version(version)
-    if not formatted_version:
-      raise Fail("Unable to determine a properly formatted stack version from {0}".format(version))
 
     stack_selector_path = stack_tools.get_stack_tool_path(stack_tools.STACK_SELECTOR_NAME)
 
     # this script runs on all hosts; if this host doesn't have stack components,
     # then don't invoke the stack tool
     # (no need to log that it's skipped - the function will do that)
-    if is_host_skippable(stack_selector_path, formatted_version):
+    if is_host_skippable(stack_selector_path):
       return
 
     # invoke "set all"
-    cmd = ('ambari-python-wrap', stack_selector_path, 'set', 'all', version)
+    cmd = ('ambari-python-wrap', stack_selector_path, 'set', 'all', summary.associated_version)
     code, out = shell.call(cmd, sudo=True)
     if code != 0:
       raise Exception("Command '{0}' exit code is nonzero".format(cmd))
 
-    if check_stack_feature(StackFeature.CONFIG_VERSIONING, formatted_version):
-      # backup the old and symlink /etc/[component]/conf to <stack-root>/current/[component]
-      for k, v in conf_select.get_package_dirs().iteritems():
-        for dir_def in v:
-          link_config(dir_def['conf_dir'], dir_def['current_dir'])
 
-
-def is_host_skippable(stack_selector_path, formatted_version):
+def is_host_skippable(stack_selector_path):
   """
   Gets whether this host should not have the stack select tool called.
   :param stack_selector_path  the path to the stack selector tool.
-  :param formatted_version: the version to use with the stack selector tool.
   :return: True if this host should be skipped, False otherwise.
   """
   if not os.path.exists(stack_selector_path):
@@ -108,43 +103,6 @@ def is_host_skippable(stack_selector_path, formatted_version):
     return True
 
   return False
-
-
-def link_config(old_conf, link_conf):
-  """
-  Creates a config link following:
-  1. Checks if the old_conf location exists
-  2. If it does, check if it's a link already
-  3. Make a copy to /etc/[component]/conf.backup
-  4. Remove the old directory and create a symlink to link_conf
-
-  :old_conf: the old config directory, ie /etc/[component]/conf
-  :link_conf: the new target for the config directory, ie <stack-root>/current/[component-dir]/conf
-  """
-  if os.path.islink(old_conf):
-    # if the link exists but is wrong, then change it
-    if os.path.realpath(old_conf) != link_conf:
-      Link(old_conf, to = link_conf)
-    else:
-      Logger.debug("Skipping {0}; it is already a link".format(old_conf))
-    return
-
-  if not os.path.exists(old_conf):
-    Logger.debug("Skipping {0}; it does not exist".format(old_conf))
-    return
-
-  old_parent = os.path.abspath(os.path.join(old_conf, os.pardir))
-
-  Logger.info("Linking {0} to {1}".format(old_conf, link_conf))
-
-  old_conf_copy = os.path.join(old_parent, "conf.backup")
-  if not os.path.exists(old_conf_copy):
-    Execute(("cp", "-R", "-p", old_conf, old_conf_copy), sudo=True, logoutput=True)
-
-  shutil.rmtree(old_conf, ignore_errors=True)
-
-  # link /etc/[component]/conf -> <stack-root>/current/[component]-client/conf
-  Link(old_conf, to = link_conf)
 
 
 if __name__ == "__main__":

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.3.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.3.xml
@@ -305,23 +305,6 @@
 
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.4.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.4.xml
@@ -449,23 +449,6 @@
 
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.5.xml
@@ -605,23 +605,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.6.xml
@@ -707,23 +707,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.3.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.3.xml
@@ -381,16 +381,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
       

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.4.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.4.xml
@@ -426,16 +426,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.5.xml
@@ -494,16 +494,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.6.xml
@@ -497,16 +497,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.4.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.4.xml
@@ -294,23 +294,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.5.xml
@@ -564,24 +564,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.6.xml
@@ -661,24 +661,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.4.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.4.xml
@@ -377,16 +377,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
       

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.5.xml
@@ -479,16 +479,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.6.xml
@@ -486,16 +486,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/host-upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/host-upgrade-2.5.xml
@@ -80,9 +80,10 @@
 
     <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
       <scope>COMPLETE</scope>
+      <direction>UPGRADE</direction>
       <execute-stage title="Update remaining HDP stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.5.xml
@@ -358,23 +358,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.6.xml
@@ -722,23 +722,6 @@
       </execute-stage>
     </group>
 
-    <!--
-    Invoke "hdp-select set all" to change any components we may have missed
-    that are installed on the hosts but not known by Ambari.
-    -->
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Set Version On All Hosts">
-      <scope>COMPLETE</scope>
-      <skippable>true</skippable>
-      <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
-      <execute-stage title="Update stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <!-- Now, restart all of the services. -->
     <group xsi:type="restart" name="ZOOKEEPER" title="ZooKeeper">
       <service-check>false</service-check>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.5.xml
@@ -421,16 +421,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
       

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
@@ -446,16 +446,6 @@
       </service>
     </group>
 
-    <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
-      <scope>COMPLETE</scope>
-      <execute-stage title="Update remaining HDP stack to {{version}}">
-        <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
-          <function>actionexecute</function>
-        </task>
-      </execute-stage>
-    </group>
-
     <group xsi:type="cluster" name="FINALIZE_PRE_CHECK" title="Finalize {{direction.text.proper}} Pre-Check">
       <direction>UPGRADE</direction>
 

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/upgrades/nonrolling-upgrade-2.0.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/upgrades/nonrolling-upgrade-2.0.xml
@@ -101,7 +101,7 @@
 
       <execute-stage title="Update stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/upgrades/upgrade-2.0.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/upgrades/upgrade-2.0.xml
@@ -147,7 +147,7 @@
     <group xsi:type="cluster" name="ALL_HOST_OPS" title="Finalize Hosts">
       <execute-stage title="Update remaining HDP stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/test/python/TestStackFeature.py
+++ b/ambari-server/src/test/python/TestStackFeature.py
@@ -196,6 +196,8 @@ class TestStackFeature(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }
@@ -235,6 +237,8 @@ class TestStackFeature(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }
@@ -275,6 +279,8 @@ class TestStackFeature(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }
@@ -314,7 +320,9 @@ class TestStackFeature(TestCase):
         "direction":"DOWNGRADE",
         "type":"rolling_upgrade",
         "isRevert":False,
-        "orchestration":"STANDARD"
+        "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999"
       }
     }
 

--- a/ambari-server/src/test/python/TestStackSelect.py
+++ b/ambari-server/src/test/python/TestStackSelect.py
@@ -161,6 +161,8 @@ class TestStackSelect(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }
@@ -201,6 +203,8 @@ class TestStackSelect(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }

--- a/ambari-server/src/test/python/TestUpgradeSummary.py
+++ b/ambari-server/src/test/python/TestUpgradeSummary.py
@@ -97,6 +97,8 @@ class TestUpgradeSummary(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }
@@ -135,6 +137,8 @@ class TestUpgradeSummary(TestCase):
         "type":"rolling_upgrade",
         "isRevert":False,
         "orchestration":"STANDARD",
+        "associatedStackId":"HDP-2.5",
+        "associatedVersion":"2.5.9.9-9999",
         "isDowngradeAllowed": True,
         "isSwitchBits": False
       }

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_nonrolling_new_stack.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_nonrolling_new_stack.xml
@@ -230,7 +230,7 @@
       <direction>DOWNGRADE</direction>
       <execute-stage title="Restore configuration directories and remove HDP 2.3 symlinks">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>foo_function</function>
         </task>
       </execute-stage>
@@ -574,7 +574,7 @@
 
       <execute-stage title="Update stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test_nonrolling.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test_nonrolling.xml
@@ -118,7 +118,7 @@
       <skippable>true</skippable>
       <execute-stage title="Update stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test.xml
@@ -111,7 +111,7 @@
       </execute-stage>
       <execute-stage title="Update remaining HDP stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test_15388.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test_15388.xml
@@ -122,7 +122,7 @@
       </execute-stage>
       <execute-stage title="Update remaining HDP stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>

--- a/ambari-server/src/test/resources/stacks_with_upgrade_cycle/HDP/2.2.0/upgrades/upgrade_test_15388.xml
+++ b/ambari-server/src/test/resources/stacks_with_upgrade_cycle/HDP/2.2.0/upgrades/upgrade_test_15388.xml
@@ -122,7 +122,7 @@
       </execute-stage>
       <execute-stage title="Update remaining HDP stack to {{version}}">
         <task xsi:type="execute">
-          <script>scripts/ru_set_all.py</script>
+          <script>scripts/stack_select_set_all.py</script>
           <function>actionexecute</function>
         </task>
       </execute-stage>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The legacy `ru_set_all.py` was deprecated a long time ago. It no longer makes sense now that clusters can have services and components on different versions. 

However, it still might be nice on a full upgrade (which cannot be downgraded) to allow it to run in order to reset all symlink pointers.

- Renamed `ru_set_all` to `stack_select_set_all`
- Removing `stack_select_set_all` from most upgrade packs
- Scoped `stack_select_set_all` to only work on upgrades with are non-downgradeable

## How was this patch tested?

New python tests and manually ran through an upgrade.