### PR TITLE
[AMBARI-23993-2] Add get_log_dir and get_run_dir to import in mpack_manager_helper.py

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
@@ -20,7 +20,7 @@ Ambari Agent
 """
 
 import os
-from instance_manager import create_mpack, set_mpack_instance, get_conf_dir, list_instances
+from instance_manager import create_mpack, set_mpack_instance, get_conf_dir, get_log_dir, get_run_dir, list_instances
 
 CONFIG_DIR_KEY_NAME = 'config_dir'
 LOG_DIR_KEY_NAME = 'log_dir'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Forget to update mpack_manager_helper.py for get_log_dir and get_run_dir

## How was this patch tested?
e2e test