### PR TITLE
[AMBARI-22734] Wrong placeholder in MessageDestinationIsNotDefinedException

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/MessageDestinationIsNotDefinedException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/MessageDestinationIsNotDefinedException.java
@@ -24,6 +24,6 @@ import org.apache.ambari.server.events.STOMPEvent;
 public class MessageDestinationIsNotDefinedException extends ObjectNotFoundException {
 
   public MessageDestinationIsNotDefinedException(STOMPEvent.Type eventType) {
-    super(String.format("No destination defined for message with {} type", eventType));
+    super(String.format("No destination defined for message with %s type", eventType));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed wrong placeholder being used in format string (`{}` instead of `%s`) in `MessageDestinationIsNotDefinedException`.

```
format string "No destination defined for message with {} type" wants 0 arguments but is given 1
```

## How was this patch tested?

Verified that the warning for `MessageDestinationIsNotDefinedException` is no longer present in findbugs output.