### PR TITLE
[AMBARI-24007] Components are getting down immediately after autostart

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/ServiceComponentRecoveryChangedEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/ServiceComponentRecoveryChangedEvent.java
@@ -24,18 +24,24 @@ package org.apache.ambari.server.events;
  * component is enabled or disabled for auto start.
  */
 public class ServiceComponentRecoveryChangedEvent extends AmbariEvent {
-  private String m_clusterName;
-  private String m_serviceName;
-  private String m_componentName;
-  private boolean m_recoveryEnabled;
+  private final long m_clusterId;
+  private final String m_clusterName;
+  private final String m_serviceName;
+  private final String m_componentName;
+  private final boolean m_recoveryEnabled;
 
   public ServiceComponentRecoveryChangedEvent(
-          String clusterName, String serviceName, String componentName, boolean recoveryEnabled) {
+          long clusterId, String clusterName, String serviceName, String componentName, boolean recoveryEnabled) {
     super(AmbariEventType.SERVICE_COMPONENT_RECOVERY_CHANGED);
+    m_clusterId = clusterId;
     m_clusterName = clusterName;
     m_serviceName = serviceName;
     m_componentName = componentName;
     m_recoveryEnabled = recoveryEnabled;
+  }
+
+  public long getClusterId() {
+    return m_clusterId;
   }
 
   /**
@@ -80,7 +86,8 @@ public class ServiceComponentRecoveryChangedEvent extends AmbariEvent {
   @Override
   public String toString() {
     StringBuilder buffer = new StringBuilder("ServiceComponentRecoveryChangeEvent{");
-    buffer.append("clusterName=").append(getClusterName());
+    buffer.append("clusterId=").append(getClusterId());
+    buffer.append(", clusterName=").append(getClusterName());
     buffer.append(", serviceName=").append(getServiceName());
     buffer.append(", componentName=").append(getComponentName());
     buffer.append(", recoveryEnabled=").append(isRecoveryEnabled());

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
@@ -248,7 +248,7 @@ public class ServiceComponentImpl implements ServiceComponent {
 
       // broadcast the change
       ServiceComponentRecoveryChangedEvent event = new ServiceComponentRecoveryChangedEvent(
-          getClusterName(), getServiceName(), getName(), isRecoveryEnabled());
+              getClusterId(), getClusterName(), getServiceName(), getName(), isRecoveryEnabled());
       eventPublisher.publish(event);
 
     } else {


### PR DESCRIPTION
…rt) RecoveryManager.py is making them start.

## What changes were proposed in this pull request?

Ambari Server caches Recovery configurations and it is not updated when settings are saved on Ambari UI. Also Ambari Agent is not notified about the changes.
Fix: Subscribe to ServiceComponentRecoveryChangedEvent and update data stored in HostLevelParamsHolder. Since HostLevelParamsHolder extends AgentHostDataHolder calling AgentHostDataHolder.updateData also publish a STOMP event which notifies the agents.

## How was this patch tested?

mvn clean install ambari-server

Manually:
1. Install Ambari and deploy a HDP cluster at least 2 hosts.
2. Enable autostart for all the components
3. Restart all the hosts except ambari-server
4. Waiting for autostart to take effect. 
5. After hosts are rebooted all components must be started. Run service checks. 

Please review
@swagle @mpapirkovskyy @adoroszlai @hapylestat 