### PR TITLE
[AMBARI-23550] Ambari Metrics references outdated jars

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -34,9 +34,9 @@
     <!-- Needed for generating FindBugs warnings using parent pom -->
     <!--<yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>-->
     <protobuf.version>2.5.0</protobuf.version>
-    <hadoop.version>3.0.0.3.0.0.0-1181</hadoop.version>
-    <phoenix.version>5.0.0.3.0.0.0-1181</phoenix.version>
-    <hbase.version>2.0.0.3.0.0.0-1181</hbase.version>
+    <hadoop.version>3.0.0.3.0.0.0-1414</hadoop.version>
+    <phoenix.version>5.0.0.3.0.0.0-1414</phoenix.version>
+    <hbase.version>2.0.0.3.0.0.0-1414</hbase.version>
   </properties>
 
   <build>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -40,14 +40,14 @@
     <python.ver>python &gt;= 2.6</python.ver>
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>
     <!--TODO change to HDP URL-->
-    <hbase.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1181/tars/hbase/hbase-2.0.0.3.0.0.0-1181-bin.tar.gz</hbase.tar>
-    <hbase.folder>hbase-2.0.0.3.0.0.0-1181</hbase.folder>
-    <hadoop.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1181/tars/hadoop/hadoop-3.0.0.3.0.0.0-1181.tar.gz</hadoop.tar>
-    <hadoop.folder>hadoop-3.0.0.3.0.0.0-1181</hadoop.folder>
+    <hbase.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1414/tars/hbase/hbase-2.0.0.3.0.0.0-1414-bin.tar.gz</hbase.tar>
+    <hbase.folder>hbase-2.0.0.3.0.0.0-1414</hbase.folder>
+    <hadoop.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1414/tars/hadoop/hadoop-3.0.0.3.0.0.0-1414.tar.gz</hadoop.tar>
+    <hadoop.folder>hadoop-3.0.0.3.0.0.0-1414</hadoop.folder>
     <grafana.folder>grafana-2.6.0</grafana.folder>
     <grafana.tar>https://grafanarel.s3.amazonaws.com/builds/grafana-2.6.0.linux-x64.tar.gz</grafana.tar>
-    <phoenix.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1181/tars/phoenix/phoenix-5.0.0.3.0.0.0-1181.tar.gz</phoenix.tar>
-    <phoenix.folder>phoenix-5.0.0.3.0.0.0-1181</phoenix.folder>
+    <phoenix.tar>http://dev.hortonworks.com.s3.amazonaws.com/HDP/centos7/3.x/BUILDS/3.0.0.0-1414/tars/phoenix/phoenix-5.0.0.3.0.0.0-1414.tar.gz</phoenix.tar>
+    <phoenix.folder>phoenix-5.0.0.3.0.0.0-1414</phoenix.folder>
     <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
     <powermock.version>1.6.2</powermock.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update `hadoop.version`, etc. to reference more recent builds (again).

https://issues.apache.org/jira/browse/AMBARI-23550

## How was this patch tested?

```
$ cd ambari-metrics && mvn -DskipTests -Drat.skip clean package
...
[INFO] BUILD SUCCESS
```