### PR TITLE
[AMBARI-24009] - Logsearch: fix backend IT

### DIFF
--- a/ambari-logsearch/ambari-logsearch-it/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-it/pom.xml
@@ -35,7 +35,7 @@
     <jbehave.version>4.0.5</jbehave.version>
     <jbehave-selenium>3.5.5</jbehave-selenium>
     <jersey.version>2.23.1</jersey.version>
-    <jackson-jaxrs.version>2.6.4</jackson-jaxrs.version>
+    <jackson-jaxrs.version>2.9.4</jackson-jaxrs.version>
     <failsafe-plugin.version>2.20</failsafe-plugin.version>
     <forkCount>1</forkCount>
     <docker.host>localhost</docker.host>
@@ -97,12 +97,22 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-logsearch-server</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>
@@ -113,6 +123,12 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-logsearch-logfeeder</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/AbstractLogSearchSteps.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/AbstractLogSearchSteps.java
@@ -18,18 +18,6 @@
  */
 package org.apache.ambari.logsearch.steps;
 
-import org.apache.ambari.logsearch.domain.StoryDataRegistry;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.LBHttpSolrClient;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.client.solrj.response.SolrPingResponse;
-import org.apache.solr.common.SolrDocumentList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +25,17 @@ import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URL;
+
+import org.apache.ambari.logsearch.domain.StoryDataRegistry;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.LBHttpSolrClient;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AbstractLogSearchSteps {
 
@@ -57,7 +56,7 @@ public class AbstractLogSearchSteps {
       LOG.info("Command output: {}", output);
       StoryDataRegistry.INSTANCE.setLogsearchContainerStarted(true);
 
-      String dockerHostFromUri = System.getProperty("docker.host") != null ? System.getProperty("docker.host") : "localhost";;
+      String dockerHostFromUri = System.getProperty("docker.host") != null ? System.getProperty("docker.host") : "localhost";
 
       StoryDataRegistry.INSTANCE.setDockerHost(dockerHostFromUri);
       checkHostAndPortReachable(dockerHostFromUri, StoryDataRegistry.INSTANCE.getLogsearchPort(), "LogSearch");
@@ -76,7 +75,7 @@ public class AbstractLogSearchSteps {
     for (int tries = 1; tries < maxTries; tries++) {
       try {
         SolrClient solrClient = new LBHttpSolrClient.Builder()
-          .withBaseSolrUrl(String.format("http://%s:%d/solr/%s_shard0_replica_n1",
+          .withBaseSolrUrl(String.format("http://%s:%d/solr/%s_shard1_replica_n1",
             StoryDataRegistry.INSTANCE.getDockerHost(),
             StoryDataRegistry.INSTANCE.getSolrPort(),
             StoryDataRegistry.INSTANCE.getServiceLogsCollection()))
@@ -103,7 +102,7 @@ public class AbstractLogSearchSteps {
     }
   }
 
-  protected void waitUntilSolrHasAnyData() throws IOException, SolrServerException, InterruptedException {
+  protected void waitUntilSolrHasAnyData() throws InterruptedException {
     boolean solrHasData = false;
     int maxTries = 60;
     String lastExceptionMessage = null;

--- a/ambari-logsearch/ambari-logsearch-it/src/test/resources/stories/backend/logfeeder_parsing_tests.story
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/resources/stories/backend/logfeeder_parsing_tests.story
@@ -16,5 +16,5 @@ Examples:
 |logsearch_app|1|
 |zookeeper|3|
 |hst_agent|4|
-|secure_log|11|
+|secure_log|8|
 |system_message|17|

--- a/ambari-logsearch/ambari-logsearch-it/src/test/resources/test-output/service-log-level-counts-values.json
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/resources/test-output/service-log-level-counts-values.json
@@ -6,15 +6,15 @@
     },
     {
       "name": "ERROR",
-      "value": "0"
+      "value": "1"
     },
     {
       "name": "WARN",
-      "value": "3"
+      "value": "7"
     },
     {
       "name": "INFO",
-      "value": "4"
+      "value": "8"
     },
     {
       "name": "DEBUG",
@@ -26,7 +26,7 @@
     },
     {
       "name": "UNKNOWN",
-      "value": "28"
+      "value": "25"
     }
   ],
   "listSize": 7


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to logsearch REST api changes some Integration tests failed.
Json parser library dependency conflict.

## How was this patch tested?

1. Build logsearch and docker containers: ambari-logsearch/docker/logsearch-docker.sh build-and-run 
2. Run integration tests: in folder ambari-logsearch/ambari-logsearch-it
mvn clean install -Dbackend-tests

Please review
@oleewere @swagle @zeroflag 