### PR TITLE
[AMBARI-23975] - Logsearch: do not save downloaded configuration to tmp file when comp…

### DIFF
--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -244,6 +244,7 @@
             <exclude>**/*.txt</exclude>
             <exclude>**/*.story</exclude>
             <exclude>**/*.editorconfig</exclude>
+            <exclude>**/*.iml</exclude>
             <exclude>**/src/vendor/**</exclude>
             <exclude>**/yarn.lock</exclude>
             <exclude>**/docker/Profile</exclude>


### PR DESCRIPTION
…aring

## What changes were proposed in this pull request?

When Logsearch server tries to bootstrap collections and configurations at startup. During this it downloads the configurations from znode to a temp folder and compares it to the one stored in the local filesystem. In some cases it is also causes inode issues because the temp folders are not always deleted.
Fix: for comparing the configurations a memory representation would be enough instead of saving it to tmp files.

## How was this patch tested?

Run ambari-logsearch-it backend tests

Manually:
1. Setup ambari and deploy a cluster including logsearch
2. Restart Logsearch Server using Ambari UI
3. The UI indicates for some seconds that Logsearch Server is not running and this time Start Logsearch Server again.
4. Check /tmp folder content: search for folders with name like a UUID and the owner is logsearch 

Please review
@oleewere @swagle @zeroflag 