### PR TITLE
AMBARI-24011: Add workaround to hide client modules in the dashboard

### DIFF
--- a/ambari-web/app/mappers/service_mapper.js
+++ b/ambari-web/app/mappers/service_mapper.js
@@ -33,24 +33,26 @@ App.serviceMapper = App.QuickDataMapper.create({
     var self = this;
     var passiveStateMap = this.get('passiveStateMap');
     json.items.forEach(function (service) {
-      var cachedService = App.cache['services'].findProperty('ServiceInfo.service_name', service.ServiceInfo.service_name);
-      if (cachedService) {
-        // restore service workStatus
-        App.Service.find(cachedService.ServiceInfo.service_name).set('workStatus', service.ServiceInfo.state);
-        cachedService.ServiceInfo.state = service.ServiceInfo.state;
-      } else {
-        var serviceData = {
-          ServiceInfo: {
-            service_name: service.ServiceInfo.service_name,
-            service_group_name: service.ServiceInfo.service_group_name,
-            state: service.ServiceInfo.state
-          },
-          host_components: [],
-          components: []
-        };
-        App.cache['services'].push(serviceData);
+      if(!service.ServiceInfo.service_name.includes('CLIENT')) {
+        var cachedService = App.cache['services'].findProperty('ServiceInfo.service_name', service.ServiceInfo.service_name);
+        if (cachedService) {
+          // restore service workStatus
+          App.Service.find(cachedService.ServiceInfo.service_name).set('workStatus', service.ServiceInfo.state);
+          cachedService.ServiceInfo.state = service.ServiceInfo.state;
+        } else {
+          var serviceData = {
+            ServiceInfo: {
+              service_name: service.ServiceInfo.service_name,
+              service_group_name: service.ServiceInfo.service_group_name,
+              state: service.ServiceInfo.state
+            },
+            host_components: [],
+            components: []
+          };
+          App.cache['services'].push(serviceData);
+        }
+        passiveStateMap[service.ServiceInfo.service_name] = service.ServiceInfo.maintenance_state;
       }
-      passiveStateMap[service.ServiceInfo.service_name] = service.ServiceInfo.maintenance_state;
     });
 
     if (!this.get('initialAppLoad')) {


### PR DESCRIPTION
Change-Id: Ie69b4e0ca654d59952807694cf2f3f24d6b74c0d

## What changes were proposed in this pull request?
Add workaround to hide client modules in the dashboard until we figure out how to represent client modules across mpacks. 

## How was this patch tested?
**mvn clean test**
  `19688 passing (20s)`
  `46 pending`

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.