### PR TITLE
[AMBARI-24014] Python Mpack Advisor should return MpackInstance block during Host Component Layout Recommendation

### DIFF
--- a/ambari-server/src/main/resources/stacks/mpack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/mpack_advisor.py
@@ -870,7 +870,8 @@ class MpackAdvisorImpl(MpackAdvisor):
 
     recommendations = {
       "blueprint": {
-        "host_groups": [ ]
+        "host_groups": [ ],
+        "mpack_instances": []
       },
       "blueprint_cluster_binding": {
         "host_groups": [ ]
@@ -949,6 +950,22 @@ class MpackAdvisorImpl(MpackAdvisor):
       host_group_name = "host-group-{0}".format(index)
       host_groups.append({"name": host_group_name, "components": hostsComponentsMap[key]})
       bindings.append({"name": host_group_name, "hosts": [{"fqdn": key}]})
+
+    """
+        Add mpack_instances block
+        """
+    mpackInstances = recommendations["blueprint"]["mpack_instances"]
+    for mpackInstanceName, serviceInstances in self.mpackServiceInstancesDict.items():
+      mpackInstance = {}
+      mpackInstance["name"] = mpackInstanceName
+      mpackInstance["version"] = serviceInstances[0].getMpackVersion()
+      mpackInstance["service_instances"] = []
+      mpackInstances.append(mpackInstance)
+      for serviceInstance in serviceInstances:
+        serviceName = serviceInstance.getType()
+        serviceInstanceConfigurations = {"name": serviceName, "type": serviceInstance.getType(), \
+                                         "version": serviceInstance.getVersion(), "configurations": {}}
+        mpackInstance.get("service_instances").append(serviceInstanceConfigurations)
 
     return recommendations
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add mpack_instance block in component-layout.json

## How was this patch tested?
Python UTs.

Tested on live cluster.
Response structure:

<img width="719" alt="screen shot 2018-06-01 at 4 11 50 pm" src="https://user-images.githubusercontent.com/1879146/40867095-89cc0224-65b6-11e8-9f91-ace26cec2709.png">
 
