### PR TITLE
AMBARI-24016. Log Search: java.lang.RuntimeException: Could not creat…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/resources/default.properties
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/resources/default.properties
@@ -22,7 +22,7 @@ logsearch.auth.simple.enable=false
 #login config
 logsearch.login.credentials.file=user_pass.json
 
-logsearch.cert.folder.location=/etc/ambari-logsearch-portal/conf/keys
+logsearch.cert.folder.location=/usr/lib/ambari-logsearch-portal/conf/keys
 logsearch.cert.algorithm=sha256WithRSAEncryption
 
 management.security.enabled=false


### PR DESCRIPTION
…e directory /etc/ambari-logsearch-portal/conf/keys (if SSL enabled)

## What changes were proposed in this pull request?
If SSL is enabled for Log Search, it tries to create a directory on a wrong place as parent directories do not exist (now everything moved under /usr/lib/ambari-logsearch):

```bash
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'containerFactory' defined in class path resource [org/apache/ambari/logsearch/conf/LogSearchServletConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.boot.context.embedded.EmbeddedServletContainerFactory]: Factory method 'containerFactory' threw exception; nested exception is java.lang.RuntimeException: java.lang.RuntimeException: Could not create directory /etc/ambari-logsearch-portal/conf/keys
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:599)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1181)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1075)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:513)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:483)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.getEmbeddedServletContainerFactory(EmbeddedWebApplicationContext.java:199)
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.createEmbeddedServletContainer(EmbeddedWebApplicationContext.java:162)
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.onRefresh(EmbeddedWebApplicationContext.java:134)
	... 7 more
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.boot.context.embedded.EmbeddedServletContainerFactory]: Factory method 'containerFactory' threw exception; nested exception is java.lang.RuntimeException: java.lang.RuntimeException: Could not create directory /etc/ambari-logsearch-portal/conf/keys
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588)
	... 18 more
Caused by: java.lang.RuntimeException: java.lang.RuntimeException: Could not create directory /etc/ambari-logsearch-portal/conf/keys
	at org.apache.ambari.logsearch.configurer.SslConfigurer.loadKeystore(SslConfigurer.java:359)
	at org.apache.ambari.logsearch.conf.LogSearchServletConfig.containerFactory(LogSearchServletConfig.java:83)
	at org.apache.ambari.logsearch.conf.LogSearchServletConfig$$EnhancerBySpringCGLIB$$36529215.CGLIB$containerFactory$0(<generated>)
	at org.apache.ambari.logsearch.conf.LogSearchServletConfig$$EnhancerBySpringCGLIB$$36529215$$FastClassBySpringCGLIB$$68f33629.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:358)
	at org.apache.ambari.logsearch.conf.LogSearchServletConfig$$EnhancerBySpringCGLIB$$36529215.containerFactory(<generated>)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162)
	... 19 more
Caused by: java.lang.RuntimeException: Could not create directory /etc/ambari-logsearch-portal/conf/keys
	at org.apache.ambari.logsearch.util.FileUtil.createDirectory(FileUtil.java:57)
	at org.apache.ambari.logsearch.configurer.SslConfigurer.loadKeystore(SslConfigurer.java:335)
	... 30 more
```

## How was this patch tested?
in progress...

Please review @swagle @adoroszlai @kasakrisz 