### PR TITLE
AMBARI-24017. Ambari-server protocol passed wrongly for Log Search if SSL is enabled.

### DIFF
--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/package/scripts/params.py
@@ -237,7 +237,7 @@ logsearch_admin_content = config['configurations']['logsearch-admin-json']['cont
 if 'ambari_server_host' in config['ambariLevelParams']:
   ambari_server_host = config['ambariLevelParams']['ambari_server_host']
   ambari_server_port = config['ambariLevelParams']['ambari_server_port']
-  ambari_server_use_ssl = config['ambariLevelParams']['ambari_server_use_ssl'] == 'true'
+  ambari_server_use_ssl = config['ambariLevelParams']['ambari_server_use_ssl']
   
   ambari_server_protocol = 'https' if ambari_server_use_ssl else 'http'
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Although it worked in Ambari 2.6.x, it seems `ambari_server_use_ssl` is evaluated as a boolean (it still a string in command.json), so in case of ambari server was enabled http protocol was generated in logsearch.properties (but it should use https)

## How was this patch tested?
UTs passed.
FT: manually

Please review @adoroszlai @swagle @kasakrisz 