### PR TITLE
[AMBARI-23986] Host components API call doesn't return all host components

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
@@ -806,7 +806,7 @@ public class Stage {
   /**
    * This method should be used only in stage planner. To add
    * a new execution command use
-   * {@link #addHostRoleExecutionCommand(String, Role, RoleCommand, ServiceComponentHostEvent, String, String, boolean, boolean)}
+   * {@link #addHostRoleExecutionCommand(String, Role, RoleCommand, ServiceComponentHostEvent, String, Long, String, String, boolean, boolean)}
    * @param origStage the stage
    * @param hostname  the hostname; {@code null} for a server-side stage
    * @param r         the role

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/StageHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/StageHelper.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.actionmanager;
+
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.ambari.server.Role;
+import org.apache.ambari.server.controller.internal.RequestStageContainer;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.State;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class StageHelper {
+
+  /**
+   * This method is a temporary workaround for the limitation that a stage cannot contain multiple instances of the same host-component pair.
+   * It is used by stage creation to assign client components, which may have an instance for each mpack, to different stages.
+   *
+   * It takes a map of host components in the format that matches the service component host map of
+   * {@link org.apache.ambari.server.controller.AmbariManagementControllerImpl#doStageCreation(RequestStageContainer, Cluster, Map, Map, Map, Set)},
+   * and creates a list of maps of the same structure.  Each map in the list will have only a single instance of each component type.
+   *
+   * Example: if the original map has 2 instances of ZOOKEEPER_CLIENT, 2 of HADOOP_CLIENT and 1 of HBASE_CLIENT, the first map in the list will have 1 of each,
+   * and the second map will have only 1 of ZOOKEEPER_CLIENT and 1 of HADOOP_CLIENT.
+   *
+   * The components are removed from the input map, which can be used to create a separate stage for the non-client components.
+   */
+  public static List<Map<String, Map<State, List<ServiceComponentHost>>>> deduplicateClients(
+    Map<String, ? extends Map<State, ? extends List<ServiceComponentHost>>> serviceComponentHostsByHost
+  ) {
+    Map<Pair<String, Role>, Deque<Pair<State, ServiceComponentHost>>> clientComponents = new HashMap<>();
+    for (Map.Entry<String, ? extends Map<State, ? extends List<ServiceComponentHost>>> byHost : serviceComponentHostsByHost.entrySet()) {
+      for (Map.Entry<State, ? extends List<ServiceComponentHost>> byState : byHost.getValue().entrySet()) {
+        for (ServiceComponentHost sch : byState.getValue()) {
+          if (sch.isClientComponent()) {
+            Role role = Role.valueOf(sch.getServiceComponentType());
+            String hostName = byHost.getKey();
+            State state = byState.getKey();
+            clientComponents
+              .computeIfAbsent(Pair.of(hostName, role), __ -> new LinkedList<>())
+              .add(Pair.of(state, sch));
+          }
+        }
+      }
+    }
+
+    List<Map<String, Map<State, List<ServiceComponentHost>>>> clientStages = new LinkedList<>();
+    while (!clientComponents.isEmpty()) {
+      Map<String, Map<State, List<ServiceComponentHost>>> stage = new HashMap<>();
+      for (Iterator<Map.Entry<Pair<String, Role>, Deque<Pair<State, ServiceComponentHost>>>> iter = clientComponents.entrySet().iterator(); iter.hasNext(); ) {
+        Map.Entry<Pair<String, Role>, Deque<Pair<State, ServiceComponentHost>>> entry = iter.next();
+        String hostName = entry.getKey().getLeft();
+        Deque<Pair<State, ServiceComponentHost>> list = entry.getValue();
+        Pair<State, ServiceComponentHost> first = list.removeFirst();
+        State state = first.getLeft();
+        ServiceComponentHost sch = first.getRight();
+        stage.computeIfAbsent(hostName, __ -> new TreeMap<>())
+          .computeIfAbsent(state, __ -> new LinkedList<>())
+          .add(sch);
+        if (list.isEmpty()) {
+          iter.remove();
+        }
+
+        Map<State, ? extends List<ServiceComponentHost>> byState = serviceComponentHostsByHost.get(hostName);
+        List<ServiceComponentHost> serviceComponentHosts = byState.get(state);
+        serviceComponentHosts.remove(sch);
+        if (serviceComponentHosts.isEmpty()) {
+          byState.remove(state);
+        }
+        if (byState.isEmpty()) {
+          serviceComponentHostsByHost.remove(hostName);
+        }
+      }
+      if (!stage.isEmpty()) {
+        clientStages.add(stage);
+      }
+    }
+    return clientStages;
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
@@ -428,7 +428,7 @@ public class HeartBeatHandler {
 
     Map<String, Map<String, String>> componentsMap = new HashMap<>();
 
-    for (org.apache.ambari.server.state.Service service : cluster.getServices().values()) {
+    for (org.apache.ambari.server.state.Service service : cluster.getServicesByName().values()) {
       componentsMap.put(service.getName(), new HashMap<>());
 
       for (ServiceComponent component : service.getServiceComponents().values()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeatHandler.java
@@ -428,7 +428,7 @@ public class HeartBeatHandler {
 
     Map<String, Map<String, String>> componentsMap = new HashMap<>();
 
-    for (org.apache.ambari.server.state.Service service : cluster.getServicesByName().values()) {
+    for (org.apache.ambari.server.state.Service service : cluster.getServices()) {
       componentsMap.put(service.getName(), new HashMap<>());
 
       for (ServiceComponent component : service.getServiceComponents().values()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/TopologyHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/TopologyHolder.java
@@ -83,7 +83,7 @@ public class TopologyHolder extends AgentClusterDataHolder<TopologyUpdateEvent> 
         topologyHosts.add(new TopologyHost(host.getHostId(), host.getHostName(),
             host.getRackInfo(), host.getIPv4()));
       }
-      for (Service service : cl.getServicesByName().values()) {
+      for (Service service : cl.getServices()) {
         for (ServiceComponent component : service.getServiceComponents().values()) {
           Map<String, ServiceComponentHost> componentsMap = component.getServiceComponentHosts();
           if (!componentsMap.isEmpty()) {
@@ -206,7 +206,7 @@ public class TopologyHolder extends AgentClusterDataHolder<TopologyUpdateEvent> 
   private Set<TopologyComponent> getTopologyComponentRepos(Long clusterId) throws AmbariException {
     Set<TopologyComponent> topologyComponents = new HashSet<>();
     Cluster cl = clusters.getCluster(clusterId);
-    for (Service service : cl.getServicesByName().values()) {
+    for (Service service : cl.getServices()) {
       for (ServiceComponent component : service.getServiceComponents().values()) {
         Map<String, ServiceComponentHost> componentsMap = component.getServiceComponentHosts();
         if (!componentsMap.isEmpty()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/TopologyHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/TopologyHolder.java
@@ -83,7 +83,7 @@ public class TopologyHolder extends AgentClusterDataHolder<TopologyUpdateEvent> 
         topologyHosts.add(new TopologyHost(host.getHostId(), host.getHostName(),
             host.getRackInfo(), host.getIPv4()));
       }
-      for (Service service : cl.getServices().values()) {
+      for (Service service : cl.getServicesByName().values()) {
         for (ServiceComponent component : service.getServiceComponents().values()) {
           Map<String, ServiceComponentHost> componentsMap = component.getServiceComponentHosts();
           if (!componentsMap.isEmpty()) {
@@ -206,7 +206,7 @@ public class TopologyHolder extends AgentClusterDataHolder<TopologyUpdateEvent> 
   private Set<TopologyComponent> getTopologyComponentRepos(Long clusterId) throws AmbariException {
     Set<TopologyComponent> topologyComponents = new HashSet<>();
     Cluster cl = clusters.getCluster(clusterId);
-    for (Service service : cl.getServices().values()) {
+    for (Service service : cl.getServicesByName().values()) {
       for (ServiceComponent component : service.getServiceComponents().values()) {
         Map<String, ServiceComponentHost> componentsMap = component.getServiceComponentHosts();
         if (!componentsMap.isEmpty()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
@@ -1267,7 +1267,7 @@ public class AmbariMetaInfo {
       // and off of that the alert definitions
       List<AlertDefinition> stackDefinitions = new ArrayList<>(50);
 
-      for (Service service : cluster.getServicesByName().values()) {
+      for (Service service : cluster.getServices()) {
         ServiceInfo stackService = getService(service.getStackId().getStackName(),
             service.getStackId().getStackVersion(), service.getServiceType());
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
@@ -1267,7 +1267,7 @@ public class AmbariMetaInfo {
       // and off of that the alert definitions
       List<AlertDefinition> stackDefinitions = new ArrayList<>(50);
 
-      for (Service service : cluster.getServices().values()) {
+      for (Service service : cluster.getServicesByName().values()) {
         ServiceInfo stackService = getService(service.getStackId().getStackName(),
             service.getStackId().getStackVersion(), service.getServiceType());
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/AbstractCheckDescriptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/AbstractCheckDescriptor.java
@@ -234,7 +234,7 @@ public abstract class AbstractCheckDescriptor {
         AmbariMetaInfo metaInfo = ambariMetaInfo.get();
 
         Cluster c = clusters.getCluster(request.getClusterName());
-        Map<String, Service> services = c.getServices();
+        Map<String, Service> services = c.getServicesByName();
 
         LinkedHashSet<String> displays = new LinkedHashSet<>();
         for (String name : names) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheck.java
@@ -91,7 +91,7 @@ public class HostsMasterMaintenanceCheck extends AbstractCheckDescriptor {
       componentsFromUpgradePack.addAll(task.keySet());
     }
 
-    for (Service service: cluster.getServicesByName().values()) {
+    for (Service service: cluster.getServices()) {
       for (ServiceComponent serviceComponent: service.getServiceComponents().values()) {
         if (serviceComponent.isMasterComponent() && componentsFromUpgradePack.contains(serviceComponent.getName())) {
           hostsWithMasterComponent.addAll(serviceComponent.getServiceComponentHosts().keySet());

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheck.java
@@ -91,7 +91,7 @@ public class HostsMasterMaintenanceCheck extends AbstractCheckDescriptor {
       componentsFromUpgradePack.addAll(task.keySet());
     }
 
-    for (Service service: cluster.getServices().values()) {
+    for (Service service: cluster.getServicesByName().values()) {
       for (ServiceComponent serviceComponent: service.getServiceComponents().values()) {
         if (serviceComponent.isMasterComponent() && componentsFromUpgradePack.contains(serviceComponent.getName())) {
           hostsWithMasterComponent.addAll(serviceComponent.getServiceComponentHosts().keySet());

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServiceCheckValidityCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServiceCheckValidityCheck.java
@@ -101,7 +101,7 @@ public class ServiceCheckValidityCheck extends AbstractCheckDescriptor {
 
     // build a mapping of the last config changes by service
     Map<String, Long> lastServiceConfigUpdates = new HashMap<>();
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       if (service.getMaintenanceState() != MaintenanceState.OFF || !hasAtLeastOneComponentVersionAdvertised(service)) {
         continue;
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServiceCheckValidityCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServiceCheckValidityCheck.java
@@ -101,7 +101,7 @@ public class ServiceCheckValidityCheck extends AbstractCheckDescriptor {
 
     // build a mapping of the last config changes by service
     Map<String, Long> lastServiceConfigUpdates = new HashMap<>();
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       if (service.getMaintenanceState() != MaintenanceState.OFF || !hasAtLeastOneComponentVersionAdvertised(service)) {
         continue;
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicePresenceCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicePresenceCheck.java
@@ -77,7 +77,7 @@ public class ServicePresenceCheck extends AbstractCheckDescriptor{
   @Override
   public void perform(PrerequisiteCheck prerequisiteCheck, PrereqCheckRequest request) throws AmbariException {
     final Cluster cluster = clustersProvider.get().getCluster(request.getClusterName());
-    Set<String> installedServices = cluster.getServices().keySet();
+    Set<String> installedServices = cluster.getServicesByName().keySet();
 
     List<String> noUpgradeSupportServices = getNoUpgradeSupportServices(request);
     Map<String, String> replacedServices = getReplacedServices(request);

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/VersionMismatchCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/VersionMismatchCheck.java
@@ -54,7 +54,7 @@ public class VersionMismatchCheck extends AbstractCheckDescriptor {
   public void perform(PrerequisiteCheck prerequisiteCheck, PrereqCheckRequest request) throws AmbariException {
     final String clusterName = request.getClusterName();
     final Cluster cluster = clustersProvider.get().getCluster(clusterName);
-    Map<String, Service> services = cluster.getServices();
+    Map<String, Service> services = cluster.getServicesByName();
     List<String> errorMessages = new ArrayList<>();
     for (Service service : services.values()) {
       validateService(service, prerequisiteCheck, errorMessages);

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/VersionMismatchCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/VersionMismatchCheck.java
@@ -54,9 +54,8 @@ public class VersionMismatchCheck extends AbstractCheckDescriptor {
   public void perform(PrerequisiteCheck prerequisiteCheck, PrereqCheckRequest request) throws AmbariException {
     final String clusterName = request.getClusterName();
     final Cluster cluster = clustersProvider.get().getCluster(clusterName);
-    Map<String, Service> services = cluster.getServicesByName();
     List<String> errorMessages = new ArrayList<>();
-    for (Service service : services.values()) {
+    for (Service service : cluster.getServices()) {
       validateService(service, prerequisiteCheck, errorMessages);
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -861,7 +861,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     for (ServiceComponentHostRequest request : requests) {
       Cluster cluster = clusters.getCluster(request.getClusterName());
 
-      for (Service service : cluster.getServices().values()) {
+      for (Service service : cluster.getServicesByName().values()) {
         ServiceInfo serviceInfo = ambariMetaInfo.getService(service);
 
         if (!BooleanUtils.toBoolean(serviceInfo.isMonitoringService())) {
@@ -915,7 +915,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   public void registerRackChange(String clusterName) throws AmbariException {
     Cluster cluster = clusters.getCluster(clusterName);
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       ServiceInfo serviceInfo = ambariMetaInfo.getService(service);
 
       if (!BooleanUtils.toBoolean(serviceInfo.isRestartRequiredAfterRackChange())) {
@@ -1053,7 +1053,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     Set<StackId> visitedStacks = new HashSet<>();
 
-    for (Service clusterService : cluster.getServices().values()) {
+    for (Service clusterService : cluster.getServicesByName().values()) {
       StackId stackId = clusterService.getStackId();
       StackInfo stackInfo = ambariMetaInfo.getStack(clusterService.getStackId());
 
@@ -1329,7 +1329,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     } else if (!Strings.isNullOrEmpty(request.getServiceGroupName())) {
       services = ImmutableList.copyOf(cluster.getServicesByServiceGroup(request.getServiceGroupName()));
     } else {
-      services = ImmutableList.copyOf(cluster.getServices().values());
+      services = ImmutableList.copyOf(cluster.getServicesByName().values());
     }
 
     Set<ServiceComponentHostResponse> response =
@@ -2503,7 +2503,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     HostEntity hostEntity = host.getHostEntity();
     Map<String, String> hostAttributes = gson.fromJson(hostEntity.getHostAttributes(), hostAttributesType);
     String osFamily = host.getOSFamilyFromHostAttributes(hostAttributes);
-    Map<String, Service> services = cluster.getServices();
+    Map<String, Service> services = cluster.getServicesByName();
     Map<String, ServiceInfo> servicesMap = new HashMap<>();
     for(String clusterServiceName : services.keySet() ){
       //TODO fix matainfo
@@ -2550,7 +2550,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
 
     // Propagate HCFS service type info
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       ServiceInfo serviceInfoInstance = servicesMap.get(service.getName());
       if(serviceInfoInstance != null){
         LOG.debug("Iterating service type Instance in createHostAction: {}", serviceInfoInstance.getName());

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -1383,7 +1383,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     // !!! FIXME in a per-service view, what does this become?
     Set<StackId> stackIds = new HashSet<>();
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       stackIds.add(service.getStackId());
     }
 
@@ -3639,7 +3639,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     }
 
     private void addDisableSecurityCommandToAllServices(Cluster cluster, Stage stage) throws AmbariException {
-      for (Service service : cluster.getServicesByName().values()) {
+      for (Service service : cluster.getServices()) {
         for (ServiceComponent component : service.getServiceComponents().values()) {
           if (!component.getServiceComponentHosts().isEmpty()) {
             String firstHost = component.getServiceComponentHosts().keySet().iterator().next(); // it is only necessary to send it to one host

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -716,7 +716,7 @@ public class KerberosHelperImpl implements KerberosHelper {
       }
 
       Set<StackId> visitedStacks = new HashSet<>();
-      Map<String, Service> installedServices = cluster.getServices();
+      Map<String, Service> installedServices = cluster.getServicesByName();
 
       for (String serviceName : services) {
         Service service = installedServices.get(serviceName);
@@ -1383,7 +1383,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     // !!! FIXME in a per-service view, what does this become?
     Set<StackId> stackIds = new HashSet<>();
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       stackIds.add(service.getStackId());
     }
 
@@ -1396,7 +1396,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     KerberosDescriptor kerberosDescriptor = getKerberosDescriptor(kerberosDescriptorType, cluster, stackId, includePreconfigureData);
 
     if (evaluateWhenClauses) {
-      Set<String> services = new HashSet<>(cluster.getServices().keySet());
+      Set<String> services = new HashSet<>(cluster.getServicesByName().keySet());
 
       if (additionalServices != null) {
         services.addAll(additionalServices);
@@ -1507,7 +1507,7 @@ public class KerberosHelperImpl implements KerberosHelper {
       // configurations may be needed while calculating the auth-to-local rules.
       Map<String, Map<String, String>> replacementsWithDefaults = addConfigurationsForPreProcessedServices(deepCopy(replacements), cluster, kerberosDescriptor, true);
 
-      Map<String, Service> existingServices = cluster.getServices();
+      Map<String, Service> existingServices = cluster.getServicesByName();
 
       for (KerberosServiceDescriptor serviceDescriptor : serviceDescriptors.values()) {
         String serviceName = serviceDescriptor.getName();
@@ -1785,7 +1785,7 @@ public class KerberosHelperImpl implements KerberosHelper {
         KerberosDescriptor kerberosDescriptor = getKerberosDescriptor(cluster, false);
 
         if (kerberosDescriptor != null) {
-          Set<String> existingServices = cluster.getServices().keySet();
+          Set<String> existingServices = cluster.getServicesByName().keySet();
 
           for (String hostname : hosts) {
             // Calculate the current host-specific configurations. These will be used to replace
@@ -3215,7 +3215,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     Map<String, KerberosServiceDescriptor> serviceDescriptorMap = kerberosDescriptor.getServices();
 
     if (serviceDescriptorMap != null) {
-      Map<String, Service> existingServices = cluster.getServices();
+      Map<String, Service> existingServices = cluster.getServicesByName();
       Set<String> allServices = new HashSet<>(existingServices.keySet());
       Set<String> componentFilter = new HashSet<>();
       StackId stackVersion = cluster.getCurrentStackVersion();
@@ -3639,7 +3639,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     }
 
     private void addDisableSecurityCommandToAllServices(Cluster cluster, Stage stage) throws AmbariException {
-      for (Service service : cluster.getServices().values()) {
+      for (Service service : cluster.getServicesByName().values()) {
         for (ServiceComponent component : service.getServiceComponents().values()) {
           if (!component.getServiceComponentHosts().isEmpty()) {
             String firstHost = component.getServiceComponentHosts().keySet().iterator().next(); // it is only necessary to send it to one host

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/MaintenanceStateHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/MaintenanceStateHelper.java
@@ -311,7 +311,7 @@ public class MaintenanceStateHelper {
 
     Map<String, Host> hosts = clusters.getHostsForCluster(cluster.getClusterName());
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       for (ServiceComponent sc : service.getServiceComponents().values()) {
         if (sc.isClientComponent()) {
           continue;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/MaintenanceStateHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/MaintenanceStateHelper.java
@@ -311,7 +311,7 @@ public class MaintenanceStateHelper {
 
     Map<String, Host> hosts = clusters.getHostsForCluster(cluster.getClusterName());
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       for (ServiceComponent sc : service.getServiceComponents().values()) {
         if (sc.isClientComponent()) {
           continue;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -557,7 +557,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     if (StringUtils.isNotEmpty(request.getServiceName())) {
       services.add(getServiceFromCluster(request, cluster));
     } else {
-      services.addAll(cluster.getServices().values());
+      services.addAll(cluster.getServicesByName().values());
     }
 
     final State desiredStateToCheck = getValidDesiredState(request);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -557,7 +557,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     if (StringUtils.isNotEmpty(request.getServiceName())) {
       services.add(getServiceFromCluster(request, cluster));
     } else {
-      services.addAll(cluster.getServicesByName().values());
+      services.addAll(cluster.getServices());
     }
 
     final State desiredStateToCheck = getValidDesiredState(request);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -612,7 +612,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
     Collection<ServiceComponentHost> ignoredScHosts = new ArrayList<>();
 
     Set<String> clusterNames = new HashSet<>();
-    Map<String, Map<String, Set<String>>> componentNames = new HashMap<>();
+    Map<String, Set<List<String>>> componentNames = new HashMap<>();
     Set<State> seenNewStates = new HashSet<>();
 
     Collection<ServiceComponent> recoveryEnabledComponents = new ArrayList<>();
@@ -647,17 +647,14 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
       Validate.isTrue(clusterNames.size() == 1, "Updates to multiple clusters is not supported");
 
-      if (!componentNames.containsKey(clusterName)) {
-        componentNames.put(clusterName, new HashMap<>());
-      }
-      if (!componentNames.get(clusterName).containsKey(serviceName)) {
-        componentNames.get(clusterName).put(serviceName, new HashSet<>());
-      }
-      if (componentNames.get(clusterName).get(serviceName).contains(componentName)){
-        // throw error later for dup
+      List<String> componentID = ImmutableList.of(request.getServiceGroupName(), request.getServiceName(), request.getComponentName());
+      boolean added = componentNames
+        .computeIfAbsent(request.getClusterName(), __ -> new HashSet<>())
+        .add(componentID);
+
+      if (!added) {
         throw new IllegalArgumentException("Invalid request contains duplicate service components");
       }
-      componentNames.get(clusterName).get(serviceName).add(componentName);
 
       Service s = cluster.getService(serviceGroupName, serviceName);
       ServiceComponent sc = s.getServiceComponent(componentName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -19,7 +19,6 @@ package org.apache.ambari.server.controller.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -412,15 +411,6 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       }
 
     return requestStages.getRequestStatusResponse();
-  }
-
-
-  // TODO, revisit this extra method, that appears to be used during Add Hosts
-  // TODO, How do we determine the component list for INSTALL_ONLY during an Add Hosts operation? rwn
-  public RequestStatusResponse start(String cluster, String hostName) throws  SystemException,
-    UnsupportedPropertyException, NoSuchParentResourceException {
-
-    return this.start(cluster, hostName, Collections.emptySet(), false);
   }
 
   public RequestStatusResponse start(String cluster, String hostName, Collection<String> installOnlyComponents, boolean skipFailure) throws  SystemException,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -68,6 +68,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -519,7 +520,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Map<String, Map<State, List<ServiceComponentHost>>> changedScHosts = new HashMap<>();
     Collection<ServiceComponentHost> ignoredScHosts = new ArrayList<>();
     Set<String> clusterNames = new HashSet<>();
-    Map<String, Map<String, Map<String, Set<String>>>> requestClusters = new HashMap<>();
+    Map<String, Set<List<String>>> requestClusters = new HashMap<>();
     Map<ServiceComponentHost, State> directTransitionScHosts = new HashMap<>();
 
     Resource.Type reqOpLvl = determineOperationLevel(requestProperties);
@@ -560,31 +561,14 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
             + " supported");
       }
 
-      // maps of cluster->services, services->components, components->hosts
-      Map<String, Map<String, Set<String>>> clusterServices = requestClusters.get(request.getClusterName());
-      if (clusterServices == null) {
-        clusterServices = new HashMap<>();
-        requestClusters.put(request.getClusterName(), clusterServices);
-      }
+      List<String> hostComponentID = ImmutableList.of(request.getServiceGroupName(), request.getServiceName(), request.getComponentName(), request.getHostname());
+      boolean added = requestClusters
+        .computeIfAbsent(request.getClusterName(), __ -> new HashSet<>())
+        .add(hostComponentID);
 
-      Map<String, Set<String>> serviceComponents = clusterServices.get(request.getServiceName());
-      if (serviceComponents == null) {
-        serviceComponents = new HashMap<>();
-        clusterServices.put(request.getServiceName(), serviceComponents);
-      }
-
-      Set<String> componentHosts = serviceComponents.get(request.getComponentName());
-      if (componentHosts == null) {
-        componentHosts = new HashSet<>();
-        serviceComponents.put(request.getComponentName(), componentHosts) ;
-      }
-
-      if (componentHosts.contains(request.getHostname())) {
+      if (!added) {
         throw new IllegalArgumentException("Invalid request contains duplicate hostcomponents");
       }
-
-      componentHosts.add(request.getHostname());
-
 
       ServiceComponentHost sch = sc.getServiceComponentHost(request.getHostname());
       State oldState = sch.getState();

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.controller.internal;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -697,27 +696,6 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
             + " clusterName=" + request.getClusterName());
       }
     }
-  }
-
-  public RequestStatusResponse install(final String cluster, final String hostname, Collection<String> skipInstallForComponents, Collection<String> dontSkipInstallForComponents, final boolean skipFailure)
-      throws ResourceAlreadyExistsException,
-      SystemException,
-      NoSuchParentResourceException,
-      UnsupportedPropertyException {
-
-
-    return ((HostComponentResourceProvider) getResourceProvider(Resource.Type.HostComponent)).
-        install(cluster, hostname, skipInstallForComponents, dontSkipInstallForComponents, skipFailure);
-  }
-
-  public RequestStatusResponse start(final String cluster, final String hostname)
-      throws ResourceAlreadyExistsException,
-      SystemException,
-      NoSuchParentResourceException,
-      UnsupportedPropertyException {
-
-    return ((HostComponentResourceProvider) getResourceProvider(Resource.Type.HostComponent)).
-        start(cluster, hostname);
   }
 
   protected Set<HostResponse> getHosts(Set<HostRequest> requests) throws AmbariException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceDependencyResourceProvider.java
@@ -416,7 +416,7 @@ public class ServiceDependencyResourceProvider extends AbstractControllerResourc
 
     Set<ServiceDependencyResponse> responses = new HashSet<>();
     if (request.getServiceName() != null) {
-      Collection<Service> services = cluster.getServicesById().values();
+      Collection<Service> services = cluster.getServices();
       for (Service service : services) {
         if (Objects.equals(service.getServiceGroupId(), serviceGroup.getServiceGroupId()) &&
                 service.getName().equals(request.getServiceName())) {
@@ -449,7 +449,7 @@ public class ServiceDependencyResourceProvider extends AbstractControllerResourc
         Cluster cluster = clusters.getCluster(serviceDependencyRequest.getClusterName());
         Service service = null;
 
-        for (Service srv : cluster.getServicesById().values()) {
+        for (Service srv : cluster.getServices()) {
           if (srv.getName().equals(serviceDependencyRequest.getServiceName()) &&
                   srv.getServiceGroupName().equals(serviceDependencyRequest.getServiceGroupName())) {
             service = srv;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -568,7 +568,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     if(request.getServiceGroupName() != null){
      clusterServices = cluster.getServicesByServiceGroup(serviceGroupName);
     }else{
-      clusterServices = cluster.getServices().values();
+      clusterServices = cluster.getServicesByName().values();
     }
     for (Service s : clusterServices) {
       if (checkDesiredState

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -568,7 +568,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     if(request.getServiceGroupName() != null){
      clusterServices = cluster.getServicesByServiceGroup(serviceGroupName);
     }else{
-      clusterServices = cluster.getServicesByName().values();
+      clusterServices = cluster.getServices();
     }
     for (Service s : clusterServices) {
       if (checkDesiredState

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -80,6 +80,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -617,7 +618,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
       new ArrayList<>();
 
     Set<String> clusterIds = new HashSet<>();
-    Map<String, Set<String>> serviceNames = new HashMap<>();
+    Map<String, Set<Pair<String, String>>> serviceNames = new HashMap<>();
     Set<State> seenNewStates = new HashSet<>();
     Map<Service, Boolean> serviceCredentialStoreEnabledMap = new HashMap<>();
 
@@ -639,41 +640,39 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     // We don't expect batch requests for different clusters, that's why
     // nothing bad should happen if value is overwritten few times
     for (ServiceRequest request : requests) {
-      if (request.getClusterName() == null
-          || request.getClusterName().isEmpty()
-          || request.getServiceName() == null
-          || request.getServiceName().isEmpty()) {
+      String clusterName = request.getClusterName();
+      String serviceGroupName = request.getServiceGroupName();
+      String serviceName = request.getServiceName();
+
+      if (Strings.isNullOrEmpty(clusterName) || Strings.isNullOrEmpty(serviceName)) {
         throw new IllegalArgumentException("Invalid arguments, cluster name"
             + " and/or service name should be provided to update services");
       }
 
       LOG.info("Received a updateService request"
-          + ", clusterName=" + request.getClusterName()
-          + ", serviceGroupName=" + request.getServiceGroupName()
-          + ", serviceName=" + request.getServiceName()
+          + ", clusterName=" + clusterName
+          + ", serviceGroupName=" + serviceGroupName
+          + ", serviceName=" + serviceName
           + ", request=" + request);
 
-      clusterIds.add(request.getClusterName());
+      clusterIds.add(clusterName);
 
       if (clusterIds.size() > 1) {
         throw new IllegalArgumentException("Updates to multiple clusters is not"
             + " supported");
       }
 
-      if (!serviceNames.containsKey(request.getClusterName())) {
-        serviceNames.put(request.getClusterName(), new HashSet<>());
-      }
+      Pair<String, String> serviceID = Pair.of(serviceGroupName, serviceName);
+      boolean added = serviceNames.computeIfAbsent(clusterName, __ -> new HashSet<>())
+        .add(serviceID);
 
-      if (serviceNames.get(request.getClusterName())
-          .contains(request.getServiceName())) {
+      if (!added) {
         // TODO throw single exception
-        throw new IllegalArgumentException("Invalid request contains duplicate"
-            + " service names");
+        throw new IllegalArgumentException("Invalid request, contains duplicate service names");
       }
-      serviceNames.get(request.getClusterName()).add(request.getServiceName());
 
-      Cluster cluster = clusters.getCluster(request.getClusterName());
-      Service s = cluster.getService(request.getServiceGroupName(), request.getServiceName());
+      Cluster cluster = clusters.getCluster(clusterName);
+      Service s = cluster.getService(serviceGroupName, serviceName);
       State oldState = s.getDesiredState();
       State newState = null;
       if (request.getDesiredState() != null) {
@@ -722,7 +721,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
         }
         serviceCredentialStoreEnabledMap.put(s, credentialStoreEnabled);
         LOG.info("Service: service_name = {}, service_type = {}, credential_store_enabled from request: {}",
-          request.getServiceName(), request.getServiceType(), credentialStoreEnabled);
+          serviceName, request.getServiceType(), credentialStoreEnabled);
       }
 
       if (StringUtils.isNotEmpty(request.getCredentialStoreSupported())) {
@@ -733,7 +732,8 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
       if (newState == null) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Nothing to do for new updateService request, clusterId={}, serviceName={}, newDesiredState=null",
-            request.getClusterName(), request.getServiceName());
+            clusterName, serviceName
+          );
         }
         continue;
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperFactoryImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperFactoryImpl.java
@@ -77,7 +77,7 @@ public class LoggingRequestHelperFactoryImpl implements LoggingRequestHelperFact
             ambariManagementController.getCredentialStoreService(), cluster, ambariServerConfiguration.getLogSearchPortalExternalAddress());
         } else {
           boolean isLogSearchEnabled =
-            cluster.getServices().containsKey(LOGSEARCH_SERVICE_NAME);
+            cluster.getServicesByName().containsKey(LOGSEARCH_SERVICE_NAME);
 
           if (!isLogSearchEnabled) {
             // log search not enabled, just return null, since no helper impl is necessary

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/UsedIdentities.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/UsedIdentities.java
@@ -52,7 +52,7 @@ public class UsedIdentities {
     List<KerberosIdentityDescriptor> result = new ArrayList<>();
     KerberosDescriptor root = kerberosHelper.getKerberosDescriptor(cluster, false);
     result.addAll(nullToEmpty(root.getIdentities()));
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       if (serviceExclude.shouldExclude(service.getName())) {
         continue;
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/UsedIdentities.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/UsedIdentities.java
@@ -52,7 +52,7 @@ public class UsedIdentities {
     List<KerberosIdentityDescriptor> result = new ArrayList<>();
     KerberosDescriptor root = kerberosHelper.getKerberosDescriptor(cluster, false);
     result.addAll(nullToEmpty(root.getIdentities()));
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       if (serviceExclude.shouldExclude(service.getName())) {
         continue;
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertReceivedListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertReceivedListener.java
@@ -562,7 +562,7 @@ public class AlertReceivedListener {
         return false;
       }
 
-      if (!cluster.getServices().containsKey(serviceName)) {
+      if (!cluster.getServicesByName().containsKey(serviceName)) {
         LOG.warn("Unable to process alert {} for an invalid service named {}",
             alert.getName(), serviceName);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/StackUpgradeFinishListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/StackUpgradeFinishListener.java
@@ -72,7 +72,7 @@ public class StackUpgradeFinishListener {
 
     Cluster cluster = event.getCluster();
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       try {
         //update service info due to new stack
         service.updateServiceInfo();

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/StackUpgradeFinishListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/StackUpgradeFinishListener.java
@@ -72,7 +72,7 @@ public class StackUpgradeFinishListener {
 
     Cluster cluster = event.getCluster();
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       try {
         //update service info due to new stack
         service.updateServiceInfo();

--- a/ambari-server/src/main/java/org/apache/ambari/server/metadata/ClusterMetadataGenerator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/metadata/ClusterMetadataGenerator.java
@@ -199,8 +199,7 @@ public class ClusterMetadataGenerator {
 
   public SortedMap<String, MetadataServiceInfo> getMetadataServiceLevelParams(Cluster cluster) throws AmbariException {
     SortedMap<String, MetadataServiceInfo> serviceLevelParams = new TreeMap<>();
-    for (Map.Entry<String, Service> serviceEntry : cluster.getServicesByName().entrySet()) {
-      Service service = serviceEntry.getValue();
+    for (Service service : cluster.getServices()) {
       serviceLevelParams.putAll(getMetadataServiceLevelParams(service));
     }
     return serviceLevelParams;

--- a/ambari-server/src/main/java/org/apache/ambari/server/metadata/ClusterMetadataGenerator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/metadata/ClusterMetadataGenerator.java
@@ -199,7 +199,7 @@ public class ClusterMetadataGenerator {
 
   public SortedMap<String, MetadataServiceInfo> getMetadataServiceLevelParams(Cluster cluster) throws AmbariException {
     SortedMap<String, MetadataServiceInfo> serviceLevelParams = new TreeMap<>();
-    for (Map.Entry<String, Service> serviceEntry : cluster.getServices().entrySet()) {
+    for (Map.Entry<String, Service> serviceEntry : cluster.getServicesByName().entrySet()) {
       Service service = serviceEntry.getValue();
       serviceLevelParams.putAll(getMetadataServiceLevelParams(service));
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/metadata/RoleCommandOrder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/metadata/RoleCommandOrder.java
@@ -138,10 +138,10 @@ public class RoleCommandOrder implements Cloneable {
     dependencies.clear();
 
     Set<StackId> stackIds = new HashSet<>();
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       stackIds.add(service.getStackId());
     }
-    Set<String> components = cluster.getServicesByName().values().stream()
+    Set<String> components = cluster.getServices().stream()
       .flatMap(s -> s.getServiceComponents().values().stream())
       .map(ServiceComponent::getName)
       .collect(toSet());
@@ -242,7 +242,7 @@ public class RoleCommandOrder implements Cloneable {
       }
     }
 
-    for (Service s : cluster.getServicesByName().values()) {
+    for (Service s : cluster.getServices()) {
       for (RoleCommandPair rcp : allDeps) {
         ServiceComponent sc = s.getServiceComponents().get(rcp.getRole().toString());
         if (sc != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/metadata/RoleCommandOrder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/metadata/RoleCommandOrder.java
@@ -138,10 +138,10 @@ public class RoleCommandOrder implements Cloneable {
     dependencies.clear();
 
     Set<StackId> stackIds = new HashSet<>();
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       stackIds.add(service.getStackId());
     }
-    Set<String> components = cluster.getServices().values().stream()
+    Set<String> components = cluster.getServicesByName().values().stream()
       .flatMap(s -> s.getServiceComponents().values().stream())
       .map(ServiceComponent::getName)
       .collect(toSet());
@@ -242,7 +242,7 @@ public class RoleCommandOrder implements Cloneable {
       }
     }
 
-    for (Service s : cluster.getServices().values()) {
+    for (Service s : cluster.getServicesByName().values()) {
       for (RoleCommandPair rcp : allDeps) {
         ServiceComponent sc = s.getServiceComponents().get(rcp.getRole().toString());
         if (sc != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/AlertDispatchDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/AlertDispatchDAO.java
@@ -487,7 +487,7 @@ public class AlertDispatchDAO {
     String ambariServiceName = RootService.AMBARI.name();
     if (!ambariServiceName.equals(serviceName)) {
       Cluster cluster = m_clusters.get().getClusterById(clusterId);
-      Map<String, Service> services = cluster.getServices();
+      Map<String, Service> services = cluster.getServicesByName();
 
       if (!services.containsKey(serviceName)) {
         String message = MessageFormat.format(

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerAction.java
@@ -112,7 +112,7 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
       // Create the context to use for filtering Kerberos Identities based on the state of the cluster
       Map<String, Object> filterContext = new HashMap<>();
       filterContext.put("configurations", currentConfigurations);
-      filterContext.put("services", cluster.getServices().keySet());
+      filterContext.put("services", cluster.getServicesByName().keySet());
 
       actionLog.writeStdOut(String.format("Writing Kerberos identity data metadata file to %s", identityDataFile.getAbsolutePath()));
       try {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareDisableKerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareDisableKerberosServerAction.java
@@ -98,7 +98,7 @@ public class PrepareDisableKerberosServerAction extends AbstractPrepareKerberosS
       actionLog.writeStdOut(String.format("Processing %d components", schCount));
     }
 
-    Set<String> services = cluster.getServices().keySet();
+    Set<String> services = cluster.getServicesByName().keySet();
     boolean includeAmbariIdentity = "true".equalsIgnoreCase(getCommandParameterValue(commandParameters, KerberosServerAction.INCLUDE_AMBARI_IDENTITY));
     Map<String, Set<String>> propertiesToIgnore = new HashMap<>();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareEnableKerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareEnableKerberosServerAction.java
@@ -102,7 +102,7 @@ public class PrepareEnableKerberosServerAction extends PrepareKerberosIdentities
 
     Map<String, Set<String>> propertiesToRemove = new HashMap<>();
     Map<String, Set<String>> propertiesToIgnore = new HashMap<>();
-    Set<String> services = cluster.getServices().keySet();
+    Set<String> services = cluster.getServicesByName().keySet();
 
     // Calculate the current host-specific configurations. These will be used to replace
     // variables within the Kerberos descriptor data

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareKerberosIdentitiesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareKerberosIdentitiesServerAction.java
@@ -101,7 +101,7 @@ public class PrepareKerberosIdentitiesServerAction extends AbstractPrepareKerber
       actionLog.writeStdOut(String.format("Processing %d components", schCount));
     }
 
-    Set<String> services = cluster.getServices().keySet();
+    Set<String> services = cluster.getServicesByName().keySet();
     Map<String, Set<String>> propertiesToRemove = new HashMap<>();
     Map<String, Set<String>> propertiesToIgnore = new HashMap<>();
     boolean includeAmbariIdentity = "true".equalsIgnoreCase(getCommandParameterValue(commandParameters, KerberosServerAction.INCLUDE_AMBARI_IDENTITY));

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
@@ -612,7 +612,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     // has the correct config type (ie oozie-site or hdfs-site) then add it to
     // the list of original stack propertiess
     Set<String> stackPropertiesForType = new HashSet<>(50);
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       Set<PropertyInfo> serviceProperties = m_ambariMetaInfo.get().getServiceProperties(
           oldStack.getStackName(), oldStack.getStackVersion(), service.getServiceType());
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/ConfigureAction.java
@@ -612,7 +612,7 @@ public class ConfigureAction extends AbstractUpgradeServerAction {
     // has the correct config type (ie oozie-site or hdfs-site) then add it to
     // the list of original stack propertiess
     Set<String> stackPropertiesForType = new HashSet<>(50);
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       Set<PropertyInfo> serviceProperties = m_ambariMetaInfo.get().getServiceProperties(
           oldStack.getStackName(), oldStack.getStackVersion(), service.getServiceType());
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosAction.java
@@ -185,7 +185,7 @@ public class PreconfigureKerberosAction extends AbstractUpgradeServerAction {
    */
   private Map<String, Set<String>> calculateInstalledServices(Cluster cluster) {
     Map<String, Set<String>> installedServices = new HashMap<>();
-    Map<String, Service> services = cluster.getServices();
+    Map<String, Service> services = cluster.getServicesByName();
 
     for (Service service : services.values()) {
       installedServices.put(service.getName(), service.getServiceComponents().keySet());
@@ -270,7 +270,7 @@ public class PreconfigureKerberosAction extends AbstractUpgradeServerAction {
     // !!! FIXME in a per-service view, what does this become?
     Set<StackId> stackIds = new HashSet<>();
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       RepositoryVersionEntity targetRepoVersion = upgradeContext.getTargetRepositoryVersion(service.getName());
       StackId targetStackId = targetRepoVersion.getStackId();
       stackIds.add(targetStackId);
@@ -305,7 +305,7 @@ public class PreconfigureKerberosAction extends AbstractUpgradeServerAction {
       // Create the context to use for filtering Kerberos Identities based on the state of the cluster
       Map<String, Object> filterContext = new HashMap<>();
       filterContext.put("configurations", currentConfigurations);
-      filterContext.put("services", cluster.getServices().keySet());
+      filterContext.put("services", cluster.getServicesByName().keySet());
 
       try {
         Map<String, Set<String>> propertiesToIgnore = null;
@@ -447,7 +447,7 @@ public class PreconfigureKerberosAction extends AbstractUpgradeServerAction {
     actionLog.writeStdOut("Determining configuration changes");
 
     if (!kerberosConfigurations.isEmpty()) {
-      Map<String, Service> installedServices = cluster.getServices();
+      Map<String, Service> installedServices = cluster.getServicesByName();
 
       // Build a map of configuration types to properties that indicate which properties should be altered
       // This map should contain only properties defined in service-level Kerberos descriptors that

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosAction.java
@@ -270,7 +270,7 @@ public class PreconfigureKerberosAction extends AbstractUpgradeServerAction {
     // !!! FIXME in a per-service view, what does this become?
     Set<StackId> stackIds = new HashSet<>();
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       RepositoryVersionEntity targetRepoVersion = upgradeContext.getTargetRepositoryVersion(service.getName());
       StackId targetStackId = targetRepoVersion.getStackId();
       stackIds.add(targetStackId);

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
@@ -239,7 +239,7 @@ public class MasterHostResolver {
    * @return true if has NameNode HA, otherwise, false.
    */
   public boolean isNameNodeHA() throws AmbariException {
-    Map<String, org.apache.ambari.server.state.Service> services = m_cluster.getServices();
+    Map<String, org.apache.ambari.server.state.Service> services = m_cluster.getServicesByName();
     if (services != null && services.containsKey("HDFS")) {
 
       Set<String> secondaryNameNodeHosts = m_cluster.getHosts("HDFS", "SECONDARY_NAMENODE");

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -180,12 +180,8 @@ public interface Cluster {
 
   ServiceComponentHost getHostComponentById(Long hostComponentId);
 
-  /**
-   * Get all services
-   *
-   * @return
-   */
-  Map<String, Service> getServices();
+  @Deprecated
+  Map<String, Service> getServicesByName();
 
   Map<Long, Service> getServicesById();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -185,6 +185,8 @@ public interface Cluster {
 
   Map<Long, Service> getServicesById();
 
+  Collection<Service> getServices();
+
   /**
    * Get a service group
    *

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -614,7 +614,7 @@ public class ConfigHelper {
 
     Set<String> result = new HashSet<>();
 
-    for (Service service : clusters.getCluster(clusterName).getServices().values()) {
+    for (Service service : clusters.getCluster(clusterName).getServicesByName().values()) {
       Set<PropertyInfo> stackProperties = ambariMetaInfo.getServiceProperties(stack.getName(), stack.getVersion(), service.getServiceType());
       Set<PropertyInfo> stackLevelProperties = ambariMetaInfo.getStackProperties(stack.getName(), stack.getVersion());
       stackProperties.addAll(stackLevelProperties);
@@ -791,7 +791,7 @@ public class ConfigHelper {
       actualConfigs.put(configType, cluster.getConfig(configType, desiredConfig.getTag()));
     }
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       if (servicesMap.containsKey(service.getName())) {
         Set<PropertyInfo> serviceProperties = new HashSet<>(servicesMap.get(service.getName()).getProperties());
         for (PropertyInfo serviceProperty : serviceProperties) {
@@ -880,7 +880,7 @@ public class ConfigHelper {
       actualConfigs.put(configType, cluster.getConfig(configType, desiredConfig.getTag()));
     }
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       if (servicesMap.containsKey(service.getName())) {
         Set<PropertyInfo> serviceProperties = new HashSet<>(servicesMap.get(service.getName()).getProperties());
         for (PropertyInfo serviceProperty : serviceProperties) {
@@ -959,7 +959,7 @@ public class ConfigHelper {
 
     Set<StackId> stackIds = new HashSet<>();
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       stackIds.add(service.getStackId());
     }
 
@@ -1040,7 +1040,7 @@ public class ConfigHelper {
 
   public ServiceInfo getPropertyOwnerService(Cluster cluster, String configType, String propertyName) throws AmbariException {
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       StackId stackId = service.getStackId();
       StackInfo stack = ambariMetaInfo.getStack(stackId.getStackName(), stackId.getStackVersion());
 
@@ -1117,7 +1117,7 @@ public class ConfigHelper {
   public Set<PropertyInfo> getStackProperties(Cluster cluster) throws AmbariException {
 
     Set<StackId> stackIds = new HashSet<>();
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       stackIds.add(service.getStackId());
     }
 
@@ -1531,7 +1531,7 @@ public class ConfigHelper {
       return;
     }
 
-    if (!clusters.getCluster(clusterId).getServices().keySet().contains(serviceName)) {
+    if (!clusters.getCluster(clusterId).getServicesByName().keySet().contains(serviceName)) {
       return;
     }
     Service service = clusters.getCluster(clusterId).getService(serviceName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -614,7 +614,7 @@ public class ConfigHelper {
 
     Set<String> result = new HashSet<>();
 
-    for (Service service : clusters.getCluster(clusterName).getServicesByName().values()) {
+    for (Service service : clusters.getCluster(clusterName).getServices()) {
       Set<PropertyInfo> stackProperties = ambariMetaInfo.getServiceProperties(stack.getName(), stack.getVersion(), service.getServiceType());
       Set<PropertyInfo> stackLevelProperties = ambariMetaInfo.getStackProperties(stack.getName(), stack.getVersion());
       stackProperties.addAll(stackLevelProperties);
@@ -791,7 +791,7 @@ public class ConfigHelper {
       actualConfigs.put(configType, cluster.getConfig(configType, desiredConfig.getTag()));
     }
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       if (servicesMap.containsKey(service.getName())) {
         Set<PropertyInfo> serviceProperties = new HashSet<>(servicesMap.get(service.getName()).getProperties());
         for (PropertyInfo serviceProperty : serviceProperties) {
@@ -880,7 +880,7 @@ public class ConfigHelper {
       actualConfigs.put(configType, cluster.getConfig(configType, desiredConfig.getTag()));
     }
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       if (servicesMap.containsKey(service.getName())) {
         Set<PropertyInfo> serviceProperties = new HashSet<>(servicesMap.get(service.getName()).getProperties());
         for (PropertyInfo serviceProperty : serviceProperties) {
@@ -959,7 +959,7 @@ public class ConfigHelper {
 
     Set<StackId> stackIds = new HashSet<>();
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       stackIds.add(service.getStackId());
     }
 
@@ -1040,7 +1040,7 @@ public class ConfigHelper {
 
   public ServiceInfo getPropertyOwnerService(Cluster cluster, String configType, String propertyName) throws AmbariException {
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       StackId stackId = service.getStackId();
       StackInfo stack = ambariMetaInfo.getStack(stackId.getStackName(), stackId.getStackVersion());
 
@@ -1060,12 +1060,10 @@ public class ConfigHelper {
     return null;
   }
 
-  public Set<PropertyInfo> getServiceProperties(Cluster cluster, String serviceName) throws AmbariException {
+  public Set<PropertyInfo> getServiceProperties(Cluster cluster, Service service) throws AmbariException {
     // The original implementation of this method is to return all properties regardless of whether
     // they should be excluded or not.  By setting removeExcluded to false in the method invocation
     // below, no attempt will be made to remove properties that exist in excluded types.
-    Service service = cluster.getService(serviceName);
-
     return getServiceProperties(service.getStackId(), service.getServiceType(), false);
   }
 
@@ -1117,7 +1115,7 @@ public class ConfigHelper {
   public Set<PropertyInfo> getStackProperties(Cluster cluster) throws AmbariException {
 
     Set<StackId> stackIds = new HashSet<>();
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       stackIds.add(service.getStackId());
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigMergeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigMergeHelper.java
@@ -59,8 +59,7 @@ public class ConfigMergeHelper {
     Map<String, Map<String, String>> newMap = new HashMap<>();
 
     // Collect service-level properties for old and new stack
-    for (String serviceName : cluster.getServicesByName().keySet()) {
-      Service service = cluster.getService(serviceName);
+    for (Service service : cluster.getServices()) {
       oldStack = service.getStackId();
       Set<PropertyInfo> oldStackProperties = m_ambariMetaInfo.get().getServiceProperties(
           oldStack.getStackName(), oldStack.getStackVersion(), service.getServiceType());

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigMergeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigMergeHelper.java
@@ -59,7 +59,7 @@ public class ConfigMergeHelper {
     Map<String, Map<String, String>> newMap = new HashMap<>();
 
     // Collect service-level properties for old and new stack
-    for (String serviceName : cluster.getServices().keySet()) {
+    for (String serviceName : cluster.getServicesByName().keySet()) {
       Service service = cluster.getService(serviceName);
       oldStack = service.getStackId();
       Set<PropertyInfo> oldStackProperties = m_ambariMetaInfo.get().getServiceProperties(

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -342,7 +342,7 @@ public class UpgradeContext {
 
       // !!! build all service-specific reversions
       Set<RepositoryVersionEntity> priors = new HashSet<>();
-      Map<String, Service> clusterServices = cluster.getServices();
+      Map<String, Service> clusterServices = cluster.getServicesByName();
       for (UpgradeHistoryEntity history : revertUpgrade.getHistory()) {
         String serviceName = history.getServiceName();
         String componentName = history.getComponentName();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertDefinitionHash.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertDefinitionHash.java
@@ -408,7 +408,7 @@ public class AlertDefinitionHash {
     }
 
     // get the service that this alert definition is associated with
-    Map<String, Service> services = cluster.getServices();
+    Map<String, Service> services = cluster.getServicesByName();
     Service service = services.get(definitionServiceName);
     if (null == service) {
       LOG.warn("The alert definition {} has an unknown service of {}",
@@ -643,7 +643,7 @@ public class AlertDefinitionHash {
         // for every service, get the master components and see if the host
         // is a master
         Set<String> services = new HashSet<>();
-        for (Entry<String, Service> entry : cluster.getServices().entrySet()) {
+        for (Entry<String, Service> entry : cluster.getServicesByName().entrySet()) {
           Service service = entry.getValue();
           Map<String, ServiceComponent> components = service.getServiceComponents();
           for (Entry<String, ServiceComponent> component : components.entrySet()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertDefinitionHash.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertDefinitionHash.java
@@ -643,8 +643,7 @@ public class AlertDefinitionHash {
         // for every service, get the master components and see if the host
         // is a master
         Set<String> services = new HashSet<>();
-        for (Entry<String, Service> entry : cluster.getServicesByName().entrySet()) {
-          Service service = entry.getValue();
+        for (Service service : cluster.getServices()) {
           Map<String, ServiceComponent> components = service.getServiceComponents();
           for (Entry<String, ServiceComponent> component : components.entrySet()) {
             if (component.getValue().isMasterComponent()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -1186,7 +1186,7 @@ public class ClusterImpl implements Cluster {
   }
 
   @Override
-  public Map<String, Service> getServices() {
+  public Map<String, Service> getServicesByName() {
     return new HashMap<>(services);
   }
 
@@ -2747,7 +2747,7 @@ public class ClusterImpl implements Cluster {
    */
   @Override
   public Set<String> getHosts(String serviceName, String componentName) {
-    Map<String, Service> clusterServices = getServices();
+    Map<String, Service> clusterServices = getServicesByName();
 
     if (!clusterServices.containsKey(serviceName)) {
       return Collections.emptySet();
@@ -3392,7 +3392,7 @@ public class ClusterImpl implements Cluster {
   public Map<String, Map<String, String>> getComponentVersionMap() {
     Map<String, Map<String, String>> componentVersionMap = new HashMap<>();
 
-    for (Service service : getServices().values()) {
+    for (Service service : getServicesByName().values()) {
       Map<String, String> componentMap = new HashMap<>();
       for (ServiceComponent component : service.getServiceComponents().values()) {
         // skip components which don't advertise a version

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -971,7 +971,7 @@ public class ClusterImpl implements Cluster {
   @Override
   public Service addDependencyToService(String  serviceGroupName, String serviceName, Long dependencyServiceId) throws AmbariException {
     Service currentService = null;
-    for (Service service : getServicesById().values()) {
+    for (Service service : getServices()) {
       if (service.getName().equals(serviceName) && service.getServiceGroupName().equals(serviceGroupName)) {
         currentService = service;
       }
@@ -1004,7 +1004,7 @@ public class ClusterImpl implements Cluster {
     clusterGlobalLock.writeLock().lock();
     try {
 
-      for (Service service : getServicesById().values()) {
+      for (Service service : getServices()) {
 
         if (service.getName().equals(serviceName) && service.getServiceGroupName().equals(serviceGroupName)) {
           currentService = service;
@@ -1193,6 +1193,11 @@ public class ClusterImpl implements Cluster {
   @Override
   public Map<Long, Service> getServicesById() {
     return new HashMap<>(servicesById);
+  }
+
+  @Override
+  public Collection<Service> getServices() {
+    return ImmutableList.copyOf(servicesById.values());
   }
 
   @Override
@@ -3392,7 +3397,7 @@ public class ClusterImpl implements Cluster {
   public Map<String, Map<String, String>> getComponentVersionMap() {
     Map<String, Map<String, String>> componentVersionMap = new HashMap<>();
 
-    for (Service service : getServicesByName().values()) {
+    for (Service service : getServices()) {
       Map<String, String> componentMap = new HashMap<>();
       for (ServiceComponent component : service.getServiceComponents().values()) {
         // skip components which don't advertise a version

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ServiceCheckGrouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ServiceCheckGrouping.java
@@ -135,7 +135,7 @@ public class ServiceCheckGrouping extends Grouping {
         return result;
       }
 
-      Map<String, Service> serviceMap = m_cluster.getServices();
+      Map<String, Service> serviceMap = m_cluster.getServicesByName();
 
       Set<String> clusterServices = new LinkedHashSet<>(serviceMap.keySet());
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -388,7 +388,7 @@ public class AmbariContext {
 
   public RequestStatusResponse installHost(String hostName, String clusterName, Collection<String> skipInstallForComponents, Collection<String> dontSkipInstallForComponents, boolean skipFailure) {
     try {
-      return getHostResourceProvider().install(clusterName, hostName, skipInstallForComponents,
+      return getHostComponentResourceProvider().install(clusterName, hostName, skipInstallForComponents,
         dontSkipInstallForComponents, skipFailure);
     } catch (Exception e) {
       LOG.error("INSTALL Host request submission failed:", e);

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
@@ -418,8 +418,8 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
 
 
         Set<PropertyInfo> stackProperties = configHelper.getStackProperties(cluster);
-        for(String serviceName: cluster.getServicesByName().keySet()) {
-          Set<PropertyInfo> properties = configHelper.getServiceProperties(cluster, serviceName);
+        for (Service service : cluster.getServices()) {
+          Set<PropertyInfo> properties = configHelper.getServiceProperties(cluster, service);
 
           if (properties == null) {
             continue;
@@ -1196,7 +1196,7 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
   @Experimental(feature = ExperimentalFeature.PATCH_UPGRADES,
       comment = "can only take the first stack we find until we can support multiple with Kerberos")
   private StackId getStackId(Cluster cluster) throws AmbariException {
-    return cluster.getServicesByName().values().iterator().next().getStackId();
+    return cluster.getServices().iterator().next().getStackId();
   }
 
   protected void setConfiguration(Configuration configuration) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalog.java
@@ -418,7 +418,7 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
 
 
         Set<PropertyInfo> stackProperties = configHelper.getStackProperties(cluster);
-        for(String serviceName: cluster.getServices().keySet()) {
+        for(String serviceName: cluster.getServicesByName().keySet()) {
           Set<PropertyInfo> properties = configHelper.getServiceProperties(cluster, serviceName);
 
           if (properties == null) {
@@ -544,7 +544,7 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
           }
 
           ServiceInfo propertyService = configHelper.getPropertyOwnerService(cluster, configType, propertyName);
-          if(propertyService != null && !cluster.getServices().containsKey(propertyService.getName())) {
+          if(propertyService != null && !cluster.getServicesByName().containsKey(propertyService.getName())) {
             LOG.info("Config " + propertyName + " from " + configType + " with value = " + propertyValue + " " +
                 "Is not added due to service " + propertyService.getName() + " is not in the cluster.");
             continue;
@@ -1118,7 +1118,7 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
     for (final Cluster cluster : clusterMap.values()) {
       long clusterID = cluster.getClusterId();
 
-      Service service = cluster.getServices().get(serviceName);
+      Service service = cluster.getServicesByName().get(serviceName);
       if (null == service) {
         continue;
       }
@@ -1196,7 +1196,7 @@ public abstract class AbstractUpgradeCatalog implements UpgradeCatalog {
   @Experimental(feature = ExperimentalFeature.PATCH_UPGRADES,
       comment = "can only take the first stack we find until we can support multiple with Kerberos")
   private StackId getStackId(Cluster cluster) throws AmbariException {
-    return cluster.getServices().values().iterator().next().getStackId();
+    return cluster.getServicesByName().values().iterator().next().getStackId();
   }
 
   protected void setConfiguration(Configuration configuration) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/FinalUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/FinalUpgradeCatalog.java
@@ -84,7 +84,7 @@ public class FinalUpgradeCatalog extends AbstractFinalUpgradeCatalog {
     for (final Cluster cluster : clusterMap.values()) {
 
       Set<StackId> stackIds = new HashSet<>();
-      for (Service service : cluster.getServices().values()) {
+      for (Service service : cluster.getServicesByName().values()) {
         stackIds.add(service.getStackId());
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/FinalUpgradeCatalog.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/FinalUpgradeCatalog.java
@@ -84,7 +84,7 @@ public class FinalUpgradeCatalog extends AbstractFinalUpgradeCatalog {
     for (final Cluster cluster : clusterMap.values()) {
 
       Set<StackId> stackIds = new HashSet<>();
-      for (Service service : cluster.getServicesByName().values()) {
+      for (Service service : cluster.getServices()) {
         stackIds.add(service.getStackId());
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog251.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog251.java
@@ -126,7 +126,7 @@ public class UpgradeCatalog251 extends AbstractUpgradeCatalog {
       Map<String, Cluster> clusterMap = getCheckedClusterMap(clusters);
       if (clusterMap != null && !clusterMap.isEmpty()) {
         for (final Cluster cluster : clusterMap.values()) {
-          Set<String> installedServices = cluster.getServices().keySet();
+          Set<String> installedServices = cluster.getServicesByName().keySet();
 
           if (installedServices.contains("KAFKA") && cluster.getSecurityType() == SecurityType.KERBEROS) {
             Config kafkaBroker = cluster.getDesiredConfigByType(KAFKA_BROKER_CONFIG);
@@ -182,7 +182,7 @@ public class UpgradeCatalog251 extends AbstractUpgradeCatalog {
       Map<String, Cluster> clusterMap = getCheckedClusterMap(clusters);
       if (clusterMap != null && !clusterMap.isEmpty()) {
         for (final Cluster cluster : clusterMap.values()) {
-          Set<String> installedServices = cluster.getServices().keySet();
+          Set<String> installedServices = cluster.getServicesByName().keySet();
 
           // Technically, this should be added when the cluster is Kerberized on HDP 2.6.1, but is safe to add even
           // without security or on an older stack version (such as HDP 2.5)

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -316,9 +316,7 @@ public class StageUtils {
 
     // Fill hosts for services
     Map<String, SortedSet<Integer>> hostRolesInfo = new HashMap<>();
-    for (Map.Entry<String, Service> serviceEntry : cluster.getServicesByName().entrySet()) {
-
-      Service service = serviceEntry.getValue();
+    for (Service service : cluster.getServices()) {
 
       for (Map.Entry<String, ServiceComponent> serviceComponentEntry : service.getServiceComponents().entrySet()) {
 
@@ -387,7 +385,7 @@ public class StageUtils {
         if (null == roleName) {
           // even though all mappings are being added, componentToClusterInfoKeyMap is
           // a higher priority lookup
-          for (Service service : cluster.getServicesByName().values()) {
+          for (Service service : cluster.getServices()) {
             for (ServiceComponent sc : service.getServiceComponents().values()) {
               if (!sc.isClientComponent() && sc.getName().equals(hostComponent)) {
                 roleName = hostComponent.toLowerCase() + "_hosts";

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -316,7 +316,7 @@ public class StageUtils {
 
     // Fill hosts for services
     Map<String, SortedSet<Integer>> hostRolesInfo = new HashMap<>();
-    for (Map.Entry<String, Service> serviceEntry : cluster.getServices().entrySet()) {
+    for (Map.Entry<String, Service> serviceEntry : cluster.getServicesByName().entrySet()) {
 
       Service service = serviceEntry.getValue();
 
@@ -387,7 +387,7 @@ public class StageUtils {
         if (null == roleName) {
           // even though all mappings are being added, componentToClusterInfoKeyMap is
           // a higher priority lookup
-          for (Service service : cluster.getServices().values()) {
+          for (Service service : cluster.getServicesByName().values()) {
             for (ServiceComponent sc : service.getServiceComponents().values()) {
               if (!sc.isClientComponent() && sc.getName().equals(hostComponent)) {
                 roleName = hostComponent.toLowerCase() + "_hosts";

--- a/ambari-server/src/main/java/org/apache/ambari/server/view/ViewRegistry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/ViewRegistry.java
@@ -968,8 +968,7 @@ public class ViewRegistry {
       Set<StackId> stackIds = new HashSet<>();
       Set<String> serviceNames = cluster.getServicesByName().keySet();
 
-      for (String serviceName : serviceNames) {
-        Service service = cluster.getService(serviceName);
+      for (Service service : cluster.getServices()) {
         stackIds.add(service.getStackId());
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/view/ViewRegistry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/ViewRegistry.java
@@ -966,7 +966,7 @@ public class ViewRegistry {
       String clusterName = cluster.getClusterName();
 
       Set<StackId> stackIds = new HashSet<>();
-      Set<String> serviceNames = cluster.getServices().keySet();
+      Set<String> serviceNames = cluster.getServicesByName().keySet();
 
       for (String serviceName : serviceNames) {
         Service service = cluster.getService(serviceName);
@@ -1942,7 +1942,7 @@ public class ViewRegistry {
 
       String clusterName = cluster.getClusterName();
       Long clusterId = cluster.getClusterId();
-      Set<String> serviceNames = cluster.getServices().keySet();
+      Set<String> serviceNames = cluster.getServicesByName().keySet();
 
       for (String service : services) {
         try {

--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/StageHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/StageHelperTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.actionmanager;
+
+import static java.util.stream.Collectors.toSet;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.ambari.server.Role;
+import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.State;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+public class StageHelperTest extends EasyMockSupport {
+
+  @Test
+  public void duplicateClientsExtractedToSeparateStage() {
+    String hostName1 = "c6401";
+    String hostName2 = "c6402";
+
+    Map<String, Map<State, List<ServiceComponentHost>>> serviceComponentHostsByHost = new TreeMap<>(ImmutableMap.of(
+      hostName1, new TreeMap<>(ImmutableMap.of(
+        State.INSTALLED, components(Role.HDFS_CLIENT, Role.ZOOKEEPER_CLIENT, Role.HDFS_CLIENT, Role.HIVE_SERVER),
+        State.STARTED, components(Role.NAMENODE, Role.ZOOKEEPER_SERVER),
+        State.INIT, components()
+      )),
+      hostName2, new TreeMap<>(ImmutableMap.of(
+        State.INSTALLED, components(Role.ZOOKEEPER_CLIENT, Role.ZOOKEEPER_CLIENT),
+        State.STARTED, components(Role.SECONDARY_NAMENODE),
+        State.INIT, components(Role.HBASE_CLIENT, Role.HDFS_CLIENT)
+      ))
+    ));
+
+    replayAll();
+
+    List<Map<String, Map<State, List<ServiceComponentHost>>>> clients = StageHelper.deduplicateClients(serviceComponentHostsByHost);
+    assertEquals(2, clients.size());
+    assertEquals(ImmutableSet.of(Role.HDFS_CLIENT, Role.ZOOKEEPER_CLIENT), toRoles(clients.get(0).get(hostName1).get(State.INSTALLED)));
+    assertNull(clients.get(0).get(hostName1).get(State.STARTED));
+    assertNull(clients.get(0).get(hostName1).get(State.INIT));
+    assertEquals(ImmutableSet.of(Role.ZOOKEEPER_CLIENT), toRoles(clients.get(0).get(hostName2).get(State.INSTALLED)));
+    assertNull(clients.get(0).get(hostName2).get(State.STARTED));
+    assertEquals(ImmutableSet.of(Role.HBASE_CLIENT, Role.HDFS_CLIENT), toRoles(clients.get(0).get(hostName2).get(State.INIT)));
+
+    assertEquals(ImmutableSet.of(Role.HDFS_CLIENT), toRoles(clients.get(1).get(hostName1).get(State.INSTALLED)));
+    assertEquals(ImmutableSet.of(Role.ZOOKEEPER_CLIENT), toRoles(clients.get(1).get(hostName2).get(State.INSTALLED)));
+
+    // make sure clients are no longer present
+    assertEquals(ImmutableSet.of(), serviceComponentHostsByHost.values().stream()
+      .flatMap(each -> each.values().stream())
+      .flatMap(Collection::stream)
+      .filter(ServiceComponentHost::isClientComponent)
+      .collect(toSet())
+    );
+  }
+
+  private static Set<Role> toRoles(Collection<ServiceComponentHost> serviceComponentHosts) {
+    return serviceComponentHosts.stream()
+      .map(ServiceComponentHost::getServiceComponentType)
+      .map(Role::valueOf)
+      .collect(toSet());
+  }
+
+  private List<ServiceComponentHost> components(Role... roles) {
+    List<ServiceComponentHost> components = new LinkedList<>();
+    for (Role role : roles) {
+      ServiceComponentHost sch = createNiceMock(ServiceComponentHost.class);
+      expect(sch.isClientComponent()).andReturn(role.name().endsWith("_CLIENT")).anyTimes();
+      expect(sch.getServiceComponentType()).andReturn(role.name()).anyTimes();
+      components.add(sch);
+    }
+    return components;
+  }
+
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AbstractCheckDescriptorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AbstractCheckDescriptorTest.java
@@ -113,7 +113,7 @@ public class AbstractCheckDescriptorTest extends EasyMockSupport {
     Set<String> missingServiceList = Sets.newHashSet("MISSING_SERVICE");
 
     expect(clusters.getCluster(anyString())).andReturn(cluster).atLeastOnce();
-    expect(cluster.getServices()).andReturn(services).atLeastOnce();
+    expect(cluster.getServicesByName()).andReturn(services).atLeastOnce();
 
     expect(m_clusterVersionSummary.getAvailableServiceNames()).andReturn(
         allServicesList).atLeastOnce();
@@ -156,7 +156,7 @@ public class AbstractCheckDescriptorTest extends EasyMockSupport {
     Set<String> oneServiceList = Sets.newHashSet("SERVICE1");
 
     expect(clusters.getCluster(anyString())).andReturn(cluster).atLeastOnce();
-    expect(cluster.getServices()).andReturn(services).atLeastOnce();
+    expect(cluster.getServicesByName()).andReturn(services).atLeastOnce();
 
     // the cluster summary will only return 1 service for the upgrade, even
     // though this cluster has 2 services installed

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AbstractCheckDescriptorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AbstractCheckDescriptorTest.java
@@ -114,6 +114,7 @@ public class AbstractCheckDescriptorTest extends EasyMockSupport {
 
     expect(clusters.getCluster(anyString())).andReturn(cluster).atLeastOnce();
     expect(cluster.getServicesByName()).andReturn(services).atLeastOnce();
+    expect(cluster.getServices()).andReturn(services.values()).anyTimes();
 
     expect(m_clusterVersionSummary.getAvailableServiceNames()).andReturn(
         allServicesList).atLeastOnce();
@@ -157,6 +158,7 @@ public class AbstractCheckDescriptorTest extends EasyMockSupport {
 
     expect(clusters.getCluster(anyString())).andReturn(cluster).atLeastOnce();
     expect(cluster.getServicesByName()).andReturn(services).atLeastOnce();
+    expect(cluster.getServices()).andReturn(services.values()).anyTimes();
 
     // the cluster summary will only return 1 service for the upgrade, even
     // though this cluster has 2 services installed

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
@@ -120,7 +120,7 @@ public class ComponentExistsInRepoCheckTest extends EasyMockSupport {
       }
     };
 
-    expect(m_cluster.getServices()).andReturn(CLUSTER_SERVICES).atLeastOnce();
+    expect(m_cluster.getServicesByName()).andReturn(CLUSTER_SERVICES).atLeastOnce();
     expect(m_cluster.getService("ZOOKEEPER")).andReturn(m_zookeeperService).anyTimes();
     expect(m_cluster.getService("FOO_SERVICE")).andReturn(m_fooService).anyTimes();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
@@ -141,7 +141,7 @@ public class ComponentsInstallationCheckTest {
     Mockito.when(tezService.isClientOnlyService()).thenReturn(true);
     Mockito.when(amsService.isClientOnlyService()).thenReturn(false);
 
-    Mockito.when(cluster.getServices()).thenReturn(m_services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(m_services);
 
     Mockito.when(cluster.getService("HDFS")).thenReturn(hdfsService);
     Mockito.when(cluster.getService("TEZ")).thenReturn(tezService);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ConfigurationMergeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ConfigurationMergeCheckTest.java
@@ -72,7 +72,7 @@ public class ConfigurationMergeCheckTest {
     expect(clusters.getCluster((String) anyObject())).andReturn(cluster).anyTimes();
 
     Service hdfs = EasyMock.createMock(Service.class);
-    expect(cluster.getServices()).andReturn(ImmutableMap.of("HDFS", hdfs)).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.of("HDFS", hdfs)).anyTimes();
     expect(cluster.getService("HDFS")).andReturn(hdfs).anyTimes();
     expect(hdfs.getServiceType()).andReturn("HDFS").anyTimes();
     expect(hdfs.getStackId()).andReturn(stackId_1_0).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
@@ -137,7 +137,7 @@ public class HostsMasterMaintenanceCheckTest {
     upgradePacks.put(upgradePack.getName(), upgradePack);
     Mockito.when(ambariMetaInfo.getUpgradePacks(Mockito.anyString(), Mockito.anyString())).thenReturn(upgradePacks);
     Mockito.when(upgradePack.getTasks()).thenReturn(new HashMap<>());
-    Mockito.when(cluster.getServices()).thenReturn(new HashMap<>());
+    Mockito.when(cluster.getServicesByName()).thenReturn(new HashMap<>());
     Mockito.when(clusters.getHostsForCluster(Mockito.anyString())).thenReturn(new HashMap<>());
 
     check = new PrerequisiteCheck(null, null);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
@@ -106,7 +106,7 @@ public class ServiceCheckValidityCheckTest {
     Cluster cluster = mock(Cluster.class);
     when(clusters.getCluster(CLUSTER_NAME)).thenReturn(cluster);
     when(cluster.getClusterId()).thenReturn(CLUSTER_ID);
-    when(cluster.getServices()).thenReturn(ImmutableMap.of(SERVICE_NAME, service));
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.of(SERVICE_NAME, service));
     when(cluster.getCurrentStackVersion()).thenReturn(new StackId("HDP", "2.2"));
     when(service.getName()).thenReturn(SERVICE_NAME);
     when(service.getServiceId()).thenReturn(SERVICE_ID);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provider;
 
 public class ServiceCheckValidityCheckTest {
@@ -106,7 +107,7 @@ public class ServiceCheckValidityCheckTest {
     Cluster cluster = mock(Cluster.class);
     when(clusters.getCluster(CLUSTER_NAME)).thenReturn(cluster);
     when(cluster.getClusterId()).thenReturn(CLUSTER_ID);
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.of(SERVICE_NAME, service));
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(service));
     when(cluster.getCurrentStackVersion()).thenReturn(new StackId("HDP", "2.2"));
     when(service.getName()).thenReturn(SERVICE_NAME);
     when(service.getServiceId()).thenReturn(SERVICE_ID);
@@ -192,7 +193,7 @@ public class ServiceCheckValidityCheckTest {
     serviceConfigEntity.setCreateTimestamp(CONFIG_CREATE_TIMESTAMP);
 
     when(serviceConfigDAO.getLastServiceConfig(eq(CLUSTER_ID), eq(SERVICE_ID))).thenReturn(serviceConfigEntity);
-    when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(Collections.<LastServiceCheckDTO>emptyList());
+    when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(Collections.emptyList());
 
     PrerequisiteCheck check = new PrerequisiteCheck(null, CLUSTER_NAME);
     serviceCheckValidityCheck.perform(check, new PrereqCheckRequest(CLUSTER_NAME));
@@ -230,8 +231,6 @@ public class ServiceCheckValidityCheckTest {
    * The specific test case here is that the FOO2 service was added a long time
    * ago and then removed. We don't want old service checks for FOO2 to match
    * when querying for FOO.
-   *
-   * @throws AmbariException
    */
   @Test
   public void testPassWhenSimilarlyNamedServiceIsOutdated() throws AmbariException {

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicePresenceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicePresenceCheckTest.java
@@ -93,7 +93,7 @@ public class ServicePresenceCheckTest {
 
     Map<String, Service> services = new HashMap<>();
     services.put("ATLAS", Mockito.mock(Service.class));
-    Mockito.when(cluster.getServices()).thenReturn(services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(services);
 
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.NO_UPGRADE_SUPPORT_SERVICES_PROPERTY_NAME,"Atlas, MyService");
@@ -118,7 +118,7 @@ public class ServicePresenceCheckTest {
     Map<String, Service> services = new HashMap<>();
     services.put("ATLAS", Mockito.mock(Service.class));
     services.put("OLDSERVICE", Mockito.mock(Service.class));
-    Mockito.when(cluster.getServices()).thenReturn(services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(services);
 
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.REPLACED_SERVICES_PROPERTY_NAME, "Atlas, OldService");
@@ -146,7 +146,7 @@ public class ServicePresenceCheckTest {
     Map<String, Service> services = new HashMap<>();
     services.put("ATLAS", Mockito.mock(Service.class));
     services.put("OLDSERVICE", Mockito.mock(Service.class));
-    Mockito.when(cluster.getServices()).thenReturn(services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(services);
 
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.REMOVED_SERVICES_PROPERTY_NAME, "OldService");
@@ -172,7 +172,7 @@ public class ServicePresenceCheckTest {
     Map<String, Service> services = new HashMap<>();
     services.put("ATLAS", Mockito.mock(Service.class));
     services.put("REMOVEDSERVICE", Mockito.mock(Service.class));
-    Mockito.when(cluster.getServices()).thenReturn(services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(services);
 
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.NO_UPGRADE_SUPPORT_SERVICES_PROPERTY_NAME,"MyServiceOne, MyServiceTwo");
@@ -200,7 +200,7 @@ public class ServicePresenceCheckTest {
 
     Map<String, Service> services = new HashMap<>();
     services.put("OLDSERVICE", Mockito.mock(Service.class));
-    Mockito.when(cluster.getServices()).thenReturn(services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(services);
 
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.NO_UPGRADE_SUPPORT_SERVICES_PROPERTY_NAME,"Atlas, MyService");
@@ -230,7 +230,7 @@ public class ServicePresenceCheckTest {
     services.put("HDFS", Mockito.mock(Service.class));
     services.put("STORM", Mockito.mock(Service.class));
     services.put("RANGER", Mockito.mock(Service.class));
-    Mockito.when(cluster.getServices()).thenReturn(services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(services);
 
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.NO_UPGRADE_SUPPORT_SERVICES_PROPERTY_NAME,"Atlas, HDFS");

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
@@ -104,7 +104,7 @@ public class ServicesMaintenanceModeCheckTest {
     Mockito.when(cluster.getCurrentStackVersion()).thenReturn(new StackId("HDP", "2.2"));
     Mockito.when(clusters.getCluster("cluster")).thenReturn(cluster);
     final Service service = Mockito.mock(Service.class);
-    Mockito.when(cluster.getServices()).thenReturn(Collections.singletonMap("service", service));
+    Mockito.when(cluster.getServicesByName()).thenReturn(Collections.singletonMap("service", service));
     Mockito.when(service.isClientOnlyService()).thenReturn(false);
 
     // We don't bother checking service desired state as it's performed by a separate check

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
@@ -158,7 +158,7 @@ public class ServicesUpCheckTest {
     Mockito.when(tezService.isClientOnlyService()).thenReturn(true);
     Mockito.when(amsService.isClientOnlyService()).thenReturn(false);
 
-    Mockito.when(cluster.getServices()).thenReturn(m_services);
+    Mockito.when(cluster.getServicesByName()).thenReturn(m_services);
 
     Mockito.when(cluster.getService("HDFS")).thenReturn(hdfsService);
     Mockito.when(cluster.getService("TEZ")).thenReturn(tezService);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provider;
 
 /**
@@ -66,8 +67,7 @@ public class VersionMismatchCheckTest {
     when(clusters.getCluster(CLUSTER_NAME)).thenReturn(cluster);
 
     Service firstService = mock(Service.class);
-    Map<String, Service> services = ImmutableMap.of(FIRST_SERVICE_NAME, firstService);
-    when(cluster.getServicesByName()).thenReturn(services);
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(firstService));
 
     ServiceComponent firstServiceComponent = mock(ServiceComponent.class);
     Map<String, ServiceComponent> components = ImmutableMap.of(FIRST_SERVICE_COMPONENT_NAME, firstServiceComponent);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
@@ -67,7 +67,7 @@ public class VersionMismatchCheckTest {
 
     Service firstService = mock(Service.class);
     Map<String, Service> services = ImmutableMap.of(FIRST_SERVICE_NAME, firstService);
-    when(cluster.getServices()).thenReturn(services);
+    when(cluster.getServicesByName()).thenReturn(services);
 
     ServiceComponent firstServiceComponent = mock(ServiceComponent.class);
     Map<String, ServiceComponent> components = ImmutableMap.of(FIRST_SERVICE_COMPONENT_NAME, firstServiceComponent);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -106,6 +106,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.inject.Binder;
@@ -903,7 +904,7 @@ public class AmbariManagementControllerImplTest {
         }}).anyTimes();
 
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getName()).andReturn("service1").anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
@@ -974,7 +975,7 @@ public class AmbariManagementControllerImplTest {
 //
 //    expect(ambariMetaInfo.getComponentToService("stackName", "stackVersion", "component1")).andReturn("service1");
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
     expect(component.getId()).andReturn(1L).anyTimes();
@@ -1063,7 +1064,7 @@ public class AmbariManagementControllerImplTest {
 //    expect(ambariMetaInfo.getComponentToService("stackName", "stackVersion", "component1")).andReturn("service1");
     expect(cluster.getClusterName()).andReturn("cl1");
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
     expect(service.getName()).andReturn("service1").anyTimes();
@@ -1139,7 +1140,7 @@ public class AmbariManagementControllerImplTest {
 
     expect(cluster.getClusterName()).andReturn("cl1");
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
     expect(service.getName()).andReturn("service1").anyTimes();
@@ -1225,7 +1226,7 @@ public class AmbariManagementControllerImplTest {
     expect(clusters.getCluster("cluster1")).andReturn(cluster).times(3);
     expect(clusters.getClustersForHost("host1")).andReturn(Collections.singleton(cluster)).anyTimes();
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
 
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component1);
@@ -1368,14 +1369,14 @@ public class AmbariManagementControllerImplTest {
 
 //    expect(ambariMetaInfo.getComponentToService("stackName", "stackVersion", "component1")).andReturn("service1");
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component1);
     expect(component1.getServiceComponentHosts()).andReturn(ImmutableMap.of("host1", componentHost1));
     expect(componentHost1.convertToResponse(null)).andReturn(response1);
     expect(componentHost1.getHostName()).andReturn("host1");
 
-    expect(cluster.getService("service2")).andThrow(new ServiceNotFoundException("cluster1", "service2"));
+    expect(cluster.getService("CORE", "service2")).andThrow(new ServiceNotFoundException("cluster1", "service2"));
 
     expect(service.getName()).andReturn("service1").anyTimes();
     expect(cluster.getServiceByComponentName("component3")).andReturn(service).anyTimes();
@@ -1504,7 +1505,7 @@ public class AmbariManagementControllerImplTest {
 
 //    expect(ambariMetaInfo.getComponentToService("stackName", "stackVersion", "component1")).andReturn("service1");
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service, service2)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
     expect(component.getServiceComponentHosts()).andReturn(ImmutableMap.<String, ServiceComponentHost>builder()
@@ -1514,7 +1515,7 @@ public class AmbariManagementControllerImplTest {
     expect(componentHost1.getHostName()).andReturn("host1");
 
 //    expect(ambariMetaInfo.getComponentToService("stackName", "stackVersion", "component2")).andReturn("service2");
-    expect(cluster.getService("service2")).andReturn(service2);
+    expect(cluster.getService("CORE", "service2")).andReturn(service2);
     expect(cluster.getServiceByComponentName("component2")).andReturn(service2).anyTimes();
     expect(service2.getServiceComponent("component2")).
         andThrow(new ServiceComponentNotFoundException("cluster1", "service2", "service2", "CORE", "component2"));
@@ -1646,7 +1647,7 @@ public class AmbariManagementControllerImplTest {
     expect(stack.getStackVersion()).andReturn("stackVersion").anyTimes();
 
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
     expect(service.getServiceComponent("component1")).andReturn(component);
     expect(service.getName()).andReturn("service1").anyTimes();
@@ -1882,7 +1883,7 @@ public class AmbariManagementControllerImplTest {
         }}).anyTimes();
 
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service)).anyTimes();
-    expect(cluster.getService("service1")).andReturn(service).anyTimes();
+    expect(cluster.getService("CORE", "service1")).andReturn(service).anyTimes();
     expect(service.getName()).andReturn("service1").anyTimes();
     expect(component.getName()).andReturn("component1").anyTimes();
     expect(cluster.getServiceByComponentName("component1")).andReturn(service).anyTimes();
@@ -1967,7 +1968,6 @@ public class AmbariManagementControllerImplTest {
     expect(clusters.getHostsForCluster("cluster1")).andReturn(ImmutableMap.of("host1", createNiceMock(Host.class))).anyTimes();
 
     expect(cluster.getClusterName()).andReturn("cluster1").anyTimes();
-    expect(cluster.getServicesByName()).andReturn(mapServices).anyTimes();
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service1, service2)).anyTimes();
     expect(service1.getServiceComponents()).andReturn(Collections.singletonMap("foo", component1));
     expect(service2.getServiceComponents()).andReturn(Collections.singletonMap("bar", component2));
@@ -2208,17 +2208,11 @@ public class AmbariManagementControllerImplTest {
 
     serviceComponentHost.setRestartRequired(true);
 
-    Set<String> services = new HashSet<>();
-    services.add("HDFS");
-
     ServiceInfo serviceInfo = new ServiceInfo();
     serviceInfo.setRestartRequiredAfterRackChange(true);
     expect(ambariMetaInfo.getService(service)).andReturn(serviceInfo);
 
-    Map<String, Service> serviceMap = new HashMap<>();
-
-    serviceMap.put("HDFS", service);
-    expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(service)).anyTimes();
 
     // replay mocks
     replay(injector, cluster, clusters, ambariMetaInfo, service, serviceComponent, serviceComponentHost, stackId);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -1967,7 +1967,7 @@ public class AmbariManagementControllerImplTest {
     expect(clusters.getHostsForCluster("cluster1")).andReturn(ImmutableMap.of("host1", createNiceMock(Host.class))).anyTimes();
 
     expect(cluster.getClusterName()).andReturn("cluster1").anyTimes();
-    expect(cluster.getServices()).andReturn(mapServices).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(mapServices).anyTimes();
     expect(cluster.getServicesByServiceGroup("CORE")).andReturn(ImmutableList.of(service1, service2)).anyTimes();
     expect(service1.getServiceComponents()).andReturn(Collections.singletonMap("foo", component1));
     expect(service2.getServiceComponents()).andReturn(Collections.singletonMap("bar", component2));
@@ -2218,7 +2218,7 @@ public class AmbariManagementControllerImplTest {
     Map<String, Service> serviceMap = new HashMap<>();
 
     serviceMap.put("HDFS", service);
-    expect(cluster.getServices()).andReturn(serviceMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
 
     // replay mocks
     replay(injector, cluster, clusters, ambariMetaInfo, service, serviceComponent, serviceComponentHost, stackId);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -757,8 +757,8 @@ public class AmbariManagementControllerTest {
 
     try {
       set1.clear();
-      ServiceRequest valid1 = new ServiceRequest(cluster1, serviceGroupName, "HDFS", null, null, null);
-      ServiceRequest valid2 = new ServiceRequest(cluster1, serviceGroupName, "HDFS", null, null, null);
+      ServiceRequest valid1 = new ServiceRequest(cluster1, serviceGroupName, "HDFS", null, null, "true");
+      ServiceRequest valid2 = new ServiceRequest(cluster1, serviceGroupName, "HDFS", null, null, "false");
       set1.add(valid1);
       set1.add(valid2);
       ServiceResourceProviderTest.createServices(controller, set1);
@@ -1032,9 +1032,9 @@ public class AmbariManagementControllerTest {
     try {
       set1.clear();
       ServiceComponentRequest rInvalid1 =
-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
+          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", State.INSTALLED.name());
       ServiceComponentRequest rInvalid2 =
-          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", null);
+          new ServiceComponentRequest(cluster1, serviceGroupName, "HDFS", "HDFS_CLIENT", "HDFS_CLIENT", State.STARTED.name());
       set1.add(rInvalid1);
       set1.add(rInvalid2);
       ComponentResourceProviderTest.createComponents(controller, set1);
@@ -8571,7 +8571,7 @@ public class AmbariManagementControllerTest {
 
     // getServices
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
-    expect(cluster.getService("service1")).andReturn(service);
+    expect(cluster.getService(null, "service1")).andReturn(service);
 
     HostComponentStateDAO hostComponentStateDAO = createMock(HostComponentStateDAO.class);
     ServiceComponentDesiredStateDAO serviceComponentDesiredStateDAO = createMock(ServiceComponentDesiredStateDAO.class);
@@ -8621,7 +8621,7 @@ public class AmbariManagementControllerTest {
 
     // getServices
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
-    expect(cluster.getService("service1")).andThrow(new ServiceNotFoundException("custer1", "service1"));
+    expect(cluster.getService(null, "service1")).andThrow(new ServiceNotFoundException("custer1", "service1"));
 
     HostComponentStateDAO hostComponentStateDAO = createMock(HostComponentStateDAO.class);
     ServiceComponentDesiredStateDAO serviceComponentDesiredStateDAO = createMock(ServiceComponentDesiredStateDAO.class);
@@ -8685,10 +8685,10 @@ public class AmbariManagementControllerTest {
 
     // getServices
     expect(clusters.getCluster("cluster1")).andReturn(cluster).times(4);
-    expect(cluster.getService("service1")).andReturn(service1);
-    expect(cluster.getService("service2")).andThrow(new ServiceNotFoundException("cluster1", "service2"));
-    expect(cluster.getService("service3")).andThrow(new ServiceNotFoundException("cluster1", "service3"));
-    expect(cluster.getService("service4")).andReturn(service2);
+    expect(cluster.getService(null, "service1")).andReturn(service1);
+    expect(cluster.getService(null, "service2")).andThrow(new ServiceNotFoundException("cluster1", "service2"));
+    expect(cluster.getService(null, "service3")).andThrow(new ServiceNotFoundException("cluster1", "service3"));
+    expect(cluster.getService(null, "service4")).andReturn(service2);
 
     expect(service1.convertToResponse()).andReturn(response);
     expect(service2.convertToResponse()).andReturn(response2);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -529,7 +529,7 @@ public class AmbariManagementControllerTest {
         if (!scName.endsWith("CHECK")) {
           Cluster cluster = clusters.getCluster(clusterName);
           String hostname = cmd.getHostName();
-          for (Service s : cluster.getServicesByName().values()) {
+          for (Service s : cluster.getServices()) {
             if (s.getServiceComponents().containsKey(scName) &&
               !s.getServiceComponent(scName).isClientComponent()) {
               s.getServiceComponent(scName).getServiceComponentHost(hostname).
@@ -791,7 +791,7 @@ public class AmbariManagementControllerTest {
     }
 
     Assert.assertNotNull(clusters.getCluster(cluster1));
-    Assert.assertEquals(0, clusters.getCluster(cluster1).getServicesByName().size());
+    Assert.assertEquals(0, clusters.getCluster(cluster1).getServices().size());
 
     set1.clear();
     ServiceRequest valid = new ServiceRequest(cluster1, serviceGroupName, "HDFS", null, null, null);
@@ -810,7 +810,7 @@ public class AmbariManagementControllerTest {
       // Expected
     }
 
-    Assert.assertEquals(1, clusters.getCluster(cluster1).getServicesByName().size());
+    Assert.assertEquals(1, clusters.getCluster(cluster1).getServices().size());
 
   }
 
@@ -886,7 +886,7 @@ public class AmbariManagementControllerTest {
     }
 
     Assert.assertNotNull(clusters.getCluster(cluster1));
-    Assert.assertEquals(2, clusters.getCluster(cluster1).getServicesByName().size());
+    Assert.assertEquals(2, clusters.getCluster(cluster1).getServices().size());
     Assert.assertNotNull(clusters.getCluster(cluster1).getService("HDFS"));
     Assert.assertNotNull(clusters.getCluster(cluster1).getService("MAPREDUCE"));
   }
@@ -8509,11 +8509,11 @@ public class AmbariManagementControllerTest {
 
     Cluster cluster = clusters.getCluster(CLUSTER_NAME);
 
-    for (String serviceName : cluster.getServicesByName().keySet() ) {
+    for (Service service : cluster.getServices()) {
 
-      for(String componentName: cluster.getService(serviceName).getServiceComponents().keySet()) {
+      for(String componentName : service.getServiceComponents().keySet()) {
 
-        Map<String, ServiceComponentHost> serviceComponentHosts = cluster.getService(serviceName).getServiceComponent(componentName).getServiceComponentHosts();
+        Map<String, ServiceComponentHost> serviceComponentHosts = service.getServiceComponent(componentName).getServiceComponentHosts();
 
         for (Map.Entry<String, ServiceComponentHost> entry : serviceComponentHosts.entrySet()) {
           ServiceComponentHost cHost = entry.getValue();
@@ -9382,7 +9382,7 @@ public class AmbariManagementControllerTest {
 
     Cluster cluster = clusters.getCluster(cluster1);
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       Assert.assertEquals(State.STARTED, service.getDesiredState());
     }
 
@@ -9401,7 +9401,7 @@ public class AmbariManagementControllerTest {
       Assert.assertFalse(role.equals(componentName2_2));
     }
 
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       if (service.getName().equals(serviceName2)) {
         Assert.assertEquals(State.STARTED, service.getDesiredState());
       } else {
@@ -9412,7 +9412,7 @@ public class AmbariManagementControllerTest {
     service2.setMaintenanceState(MaintenanceState.OFF);
     ServiceResourceProviderTest.updateServices(controller, srs, requestProperties,
             false, false, maintenanceStateHelper);
-    for (Service service : cluster.getServicesByName().values()) {
+    for (Service service : cluster.getServices()) {
       Assert.assertEquals(State.INSTALLED, service.getDesiredState());
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -529,7 +529,7 @@ public class AmbariManagementControllerTest {
         if (!scName.endsWith("CHECK")) {
           Cluster cluster = clusters.getCluster(clusterName);
           String hostname = cmd.getHostName();
-          for (Service s : cluster.getServices().values()) {
+          for (Service s : cluster.getServicesByName().values()) {
             if (s.getServiceComponents().containsKey(scName) &&
               !s.getServiceComponent(scName).isClientComponent()) {
               s.getServiceComponent(scName).getServiceComponentHost(hostname).
@@ -791,7 +791,7 @@ public class AmbariManagementControllerTest {
     }
 
     Assert.assertNotNull(clusters.getCluster(cluster1));
-    Assert.assertEquals(0, clusters.getCluster(cluster1).getServices().size());
+    Assert.assertEquals(0, clusters.getCluster(cluster1).getServicesByName().size());
 
     set1.clear();
     ServiceRequest valid = new ServiceRequest(cluster1, serviceGroupName, "HDFS", null, null, null);
@@ -810,7 +810,7 @@ public class AmbariManagementControllerTest {
       // Expected
     }
 
-    Assert.assertEquals(1, clusters.getCluster(cluster1).getServices().size());
+    Assert.assertEquals(1, clusters.getCluster(cluster1).getServicesByName().size());
 
   }
 
@@ -886,7 +886,7 @@ public class AmbariManagementControllerTest {
     }
 
     Assert.assertNotNull(clusters.getCluster(cluster1));
-    Assert.assertEquals(2, clusters.getCluster(cluster1).getServices().size());
+    Assert.assertEquals(2, clusters.getCluster(cluster1).getServicesByName().size());
     Assert.assertNotNull(clusters.getCluster(cluster1).getService("HDFS"));
     Assert.assertNotNull(clusters.getCluster(cluster1).getService("MAPREDUCE"));
   }
@@ -8509,7 +8509,7 @@ public class AmbariManagementControllerTest {
 
     Cluster cluster = clusters.getCluster(CLUSTER_NAME);
 
-    for (String serviceName : cluster.getServices().keySet() ) {
+    for (String serviceName : cluster.getServicesByName().keySet() ) {
 
       for(String componentName: cluster.getService(serviceName).getServiceComponents().keySet()) {
 
@@ -9382,7 +9382,7 @@ public class AmbariManagementControllerTest {
 
     Cluster cluster = clusters.getCluster(cluster1);
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       Assert.assertEquals(State.STARTED, service.getDesiredState());
     }
 
@@ -9401,7 +9401,7 @@ public class AmbariManagementControllerTest {
       Assert.assertFalse(role.equals(componentName2_2));
     }
 
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       if (service.getName().equals(serviceName2)) {
         Assert.assertEquals(State.STARTED, service.getDesiredState());
       } else {
@@ -9412,7 +9412,7 @@ public class AmbariManagementControllerTest {
     service2.setMaintenanceState(MaintenanceState.OFF);
     ServiceResourceProviderTest.updateServices(controller, srs, requestProperties,
             false, false, maintenanceStateHelper);
-    for (Service service : cluster.getServices().values()) {
+    for (Service service : cluster.getServicesByName().values()) {
       Assert.assertEquals(State.INSTALLED, service.getDesiredState());
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -159,6 +159,7 @@ import org.junit.rules.TemporaryFolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.password.StandardPasswordEncoder;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -1055,6 +1056,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
@@ -1231,6 +1233,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.NONE, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
@@ -1447,6 +1450,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", hosts, SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
@@ -1845,6 +1849,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     final Cluster cluster = createMockCluster("c1", Collections.<Host>emptyList(), SecurityType.KERBEROS, null, null);
     if (includePreconfiguredServices) {
       expect(cluster.getServicesByName()).andReturn(serviceMap).once();
+      expect(cluster.getServices()).andReturn(serviceMap.values()).anyTimes();
     }
 
     Map<String, Set<String>> installedServices = Collections.singletonMap("SERVICE1", Collections.singleton("COMPONENT1"));
@@ -2018,6 +2023,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     Cluster cluster = createMockCluster("c1", Collections.<Host>emptyList(), SecurityType.KERBEROS, null, null);
     expect(cluster.getServicesByName()).andReturn(services).times(2);
+    expect(cluster.getServices()).andReturn(services.values()).anyTimes();
     expect(cluster.getServiceComponentHostMap(null, serviceNames)).andReturn(hostMap).once();
 
     KerberosDescriptor kerberosDescriptor = createKerberosDescriptor();
@@ -2404,6 +2410,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", hosts, SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getServicesByName()).andReturn(services).anyTimes();
+    expect(cluster.getServices()).andReturn(services.values()).anyTimes();
     expect(cluster.getServiceComponentHostMap(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(serviceComponentHostMap).anyTimes();
 
     final Map<String, Map<String, String>> existingConfigurations = new HashMap<String, Map<String, String>>() {
@@ -2643,6 +2650,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     Cluster cluster = createMockCluster(clusterName, Arrays.asList(host1, host2, host3), SecurityType.KERBEROS, configKrb5Conf, configKerberosEnv);
     expect(cluster.getServicesByName()).andReturn(servicesMap).anyTimes();
+    expect(cluster.getServices()).andReturn(servicesMap.values()).anyTimes();
 
     Map<String, String> kerberosDescriptorProperties = new HashMap<>();
     kerberosDescriptorProperties.put("additional_realms", "");
@@ -2857,6 +2865,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     Cluster cluster = createMockCluster("c1", Collections.singletonList(host1), SecurityType.KERBEROS, configKrb5Conf, configKerberosEnv);
     expect(cluster.getServicesByName()).andReturn(servicesMap).anyTimes();
+    expect(cluster.getServices()).andReturn(servicesMap.values()).anyTimes();
 
     Map<String, String> kerberosDescriptorProperties = new HashMap<>();
     kerberosDescriptorProperties.put("additional_realms", "");
@@ -3062,6 +3071,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Arrays.asList(hostA, hostB, hostC), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
@@ -3322,6 +3332,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
@@ -3532,6 +3543,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
       expect(cluster.getClusterName()).andReturn("c1").anyTimes();
       expect(cluster.getClusterId()).andReturn(1L).anyTimes();
+      expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
       expect(cluster.getServicesByName())
           .andReturn(new HashMap<String, Service>() {
             {
@@ -3731,6 +3743,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
@@ -3952,6 +3965,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     expect(cluster.getCurrentStackVersion())
         .andReturn(new StackId("HDP", "2.2"))
         .anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(serviceKerberos, service1, service2)).anyTimes();
     expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -1055,7 +1055,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -1231,7 +1231,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.NONE, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -1447,7 +1447,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", hosts, SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -1844,7 +1844,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.<Host>emptyList(), SecurityType.KERBEROS, null, null);
     if (includePreconfiguredServices) {
-      expect(cluster.getServices()).andReturn(serviceMap).once();
+      expect(cluster.getServicesByName()).andReturn(serviceMap).once();
     }
 
     Map<String, Set<String>> installedServices = Collections.singletonMap("SERVICE1", Collections.singleton("COMPONENT1"));
@@ -2017,7 +2017,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     Map<String, Service> services = new HashMap<>();
 
     Cluster cluster = createMockCluster("c1", Collections.<Host>emptyList(), SecurityType.KERBEROS, null, null);
-    expect(cluster.getServices()).andReturn(services).times(2);
+    expect(cluster.getServicesByName()).andReturn(services).times(2);
     expect(cluster.getServiceComponentHostMap(null, serviceNames)).andReturn(hostMap).once();
 
     KerberosDescriptor kerberosDescriptor = createKerberosDescriptor();
@@ -2403,7 +2403,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     serviceComponentHostMap.put("COMPONEN3A", Collections.singleton("hostA"));
 
     final Cluster cluster = createMockCluster("c1", hosts, SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
-    expect(cluster.getServices()).andReturn(services).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(services).anyTimes();
     expect(cluster.getServiceComponentHostMap(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(serviceComponentHostMap).anyTimes();
 
     final Map<String, Map<String, String>> existingConfigurations = new HashMap<String, Map<String, String>>() {
@@ -2642,7 +2642,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     servicesMap.put("SERVICE2", service2);
 
     Cluster cluster = createMockCluster(clusterName, Arrays.asList(host1, host2, host3), SecurityType.KERBEROS, configKrb5Conf, configKerberosEnv);
-    expect(cluster.getServices()).andReturn(servicesMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(servicesMap).anyTimes();
 
     Map<String, String> kerberosDescriptorProperties = new HashMap<>();
     kerberosDescriptorProperties.put("additional_realms", "");
@@ -2856,7 +2856,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     servicesMap.put("SERVICE1", service1);
 
     Cluster cluster = createMockCluster("c1", Collections.singletonList(host1), SecurityType.KERBEROS, configKrb5Conf, configKerberosEnv);
-    expect(cluster.getServices()).andReturn(servicesMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(servicesMap).anyTimes();
 
     Map<String, String> kerberosDescriptorProperties = new HashMap<>();
     kerberosDescriptorProperties.put("additional_realms", "");
@@ -3062,7 +3062,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Arrays.asList(hostA, hostB, hostC), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -3322,7 +3322,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -3532,7 +3532,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
       expect(cluster.getClusterName()).andReturn("c1").anyTimes();
       expect(cluster.getClusterId()).andReturn(1L).anyTimes();
-      expect(cluster.getServices())
+      expect(cluster.getServicesByName())
           .andReturn(new HashMap<String, Service>() {
             {
               put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -3731,7 +3731,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final Cluster cluster = createMockCluster("c1", Collections.singleton(host), SecurityType.KERBEROS, krb5ConfConfig, kerberosEnvConfig);
     expect(cluster.getDesiredStackVersion()).andReturn(new StackId("HDP-2.2")).anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);
@@ -3952,7 +3952,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     expect(cluster.getCurrentStackVersion())
         .andReturn(new StackId("HDP", "2.2"))
         .anyTimes();
-    expect(cluster.getServices())
+    expect(cluster.getServicesByName())
         .andReturn(new HashMap<String, Service>() {
           {
             put(Service.Type.KERBEROS.name(), serviceKerberos);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -248,7 +248,7 @@ public class ComponentResourceProviderTest {
     expect(serviceComponent3.getType()).andReturn("Component102");
     expect(serviceComponent3.getStackId()).andReturn(stackId).anyTimes();
 
-    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
+    expect(cluster.getServices()).andReturn(Collections.singleton(service)).anyTimes();
 
     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
 
@@ -416,7 +416,7 @@ public class ComponentResourceProviderTest {
     expect(serviceComponent3.getType()).andReturn("Component103").anyTimes();
     expect(serviceComponent3.getStackId()).andReturn(stackId).anyTimes();
 
-    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
+    expect(cluster.getServices()).andReturn(Collections.singleton(service)).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
 
     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
@@ -736,7 +736,7 @@ public class ComponentResourceProviderTest {
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
     expect(cluster.getResourceId()).andReturn(4l).atLeastOnce();
-    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
+    expect(cluster.getServices()).andReturn(Collections.singleton(service)).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
 
     String serviceGroupName = "CORE";

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -248,7 +248,7 @@ public class ComponentResourceProviderTest {
     expect(serviceComponent3.getType()).andReturn("Component102");
     expect(serviceComponent3.getStackId()).andReturn(stackId).anyTimes();
 
-    expect(cluster.getServices()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
 
     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
 
@@ -416,7 +416,7 @@ public class ComponentResourceProviderTest {
     expect(serviceComponent3.getType()).andReturn("Component103").anyTimes();
     expect(serviceComponent3.getStackId()).andReturn(stackId).anyTimes();
 
-    expect(cluster.getServices()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
 
     expect(service.getServiceComponents()).andReturn(serviceComponentMap).anyTimes();
@@ -736,7 +736,7 @@ public class ComponentResourceProviderTest {
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
     expect(cluster.getResourceId()).andReturn(4l).atLeastOnce();
-    expect(cluster.getServices()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("Service100", service)).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
 
     String serviceGroupName = "CORE";

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -113,7 +113,7 @@ public class PreUpgradeCheckResourceProviderTest {
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
-    expect(cluster.getServices()).andReturn(allServiceMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(allServiceMap).anyTimes();
     expect(cluster.getService("Service100")).andReturn(service).anyTimes();
     expect(cluster.getCurrentStackVersion()).andReturn(currentStackId).anyTimes();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
@@ -142,7 +142,7 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServicesById()).andReturn(Collections.emptyMap()).anyTimes();
+    expect(cluster.getServices()).andReturn(Collections.emptySet()).anyTimes();
     String serviceGroupName = "SERVICE_GROUP";
     expect(cluster.getService(serviceGroupName, "Service100")).andReturn(null);
     expect(cluster.getDesiredStackVersion()).andReturn(stackId).anyTimes();
@@ -346,7 +346,7 @@ public class ServiceResourceProviderTest {
 
     Map<Long, Service> servicesById = ImmutableMap.of(1L, service0, 2L, service1, 3L, service2, 4L, service3, 5L, service4);
     expect(cluster.getServicesById()).andReturn(servicesById).anyTimes();
-    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
+    expect(cluster.getServices()).andReturn(servicesById.values()).anyTimes();
     expect(cluster.getService(null, "Service102")).andReturn(service2).anyTimes();
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -453,9 +453,6 @@ public class ServiceResourceProviderTest {
     AmbariMetaInfo ambariMetaInfo = createNiceMock(AmbariMetaInfo.class);
     KerberosHelper kerberosHeper = createStrictMock(KerberosHelper.class);
 
-    Map<String, Service> allResponseMap = new HashMap<>();
-    allResponseMap.put("KERBEROS", service0);
-
     // set expectations
     expect(managementController.getClusters()).andReturn(clusters).anyTimes();
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
@@ -464,7 +461,6 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -521,9 +517,6 @@ public class ServiceResourceProviderTest {
     AmbariMetaInfo ambariMetaInfo = createNiceMock(AmbariMetaInfo.class);
     KerberosHelper kerberosHelper = createStrictMock(KerberosHelper.class);
 
-    Map<String, Service> allResponseMap = new HashMap<>();
-    allResponseMap.put("KERBEROS", service0);
-
     // set expectations
     expect(managementController.getClusters()).andReturn(clusters).anyTimes();
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
@@ -532,7 +525,6 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -588,9 +580,6 @@ public class ServiceResourceProviderTest {
     AmbariMetaInfo ambariMetaInfo = createNiceMock(AmbariMetaInfo.class);
     KerberosHelper kerberosHeper = createStrictMock(KerberosHelper.class);
 
-    Map<String, Service> allResponseMap = new HashMap<>();
-    allResponseMap.put("KERBEROS", service0);
-
     // set expectations
     expect(managementController.getClusters()).andReturn(clusters).anyTimes();
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
@@ -599,7 +588,6 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -657,9 +645,6 @@ public class ServiceResourceProviderTest {
     AmbariMetaInfo ambariMetaInfo = createNiceMock(AmbariMetaInfo.class);
     KerberosHelper kerberosHeper = createStrictMock(KerberosHelper.class);
 
-    Map<String, Service> allResponseMap = new HashMap<>();
-    allResponseMap.put("KERBEROS", service0);
-
     // set expectations
     expect(managementController.getClusters()).andReturn(clusters).anyTimes();
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
@@ -668,7 +653,6 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -754,6 +738,7 @@ public class ServiceResourceProviderTest {
 
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();
     expect(cluster.getServicesById()).andReturn(ImmutableMap.of(1L, service0)).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(service0)).anyTimes();
     expect(cluster.getService(null, "Service102")).andReturn(service0).anyTimes();
 
     expect(service0.getDesiredState()).andReturn(State.INSTALLED).anyTimes();
@@ -1371,11 +1356,6 @@ public class ServiceResourceProviderTest {
     expect(managementController.getAmbariMetaInfo()).andReturn(ambariMetaInfo).anyTimes();
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
-
-    expect(cluster.getServicesByName()).andReturn(
-        ImmutableMap.<String, Service>builder()
-          .put("Service100", service1)
-          .put("Service200", service2).build()).anyTimes();
 
     expect(cluster.getDesiredStackVersion()).andReturn(stackId).anyTimes();
     expect(cluster.getClusterId()).andReturn(2L).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ServiceResourceProviderTest.java
@@ -346,7 +346,7 @@ public class ServiceResourceProviderTest {
 
     Map<Long, Service> servicesById = ImmutableMap.of(1L, service0, 2L, service1, 3L, service2, 4L, service3, 5L, service4);
     expect(cluster.getServicesById()).andReturn(servicesById).anyTimes();
-    expect(cluster.getServices()).andReturn(allResponseMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "Service102")).andReturn(service2).anyTimes();
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -464,7 +464,7 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServices()).andReturn(allResponseMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -532,7 +532,7 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServices()).andReturn(allResponseMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -599,7 +599,7 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServices()).andReturn(allResponseMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -668,7 +668,7 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServices()).andReturn(allResponseMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(allResponseMap).anyTimes();
     expect(cluster.getService(null, "KERBEROS")).andReturn(service0);
 
     expect(service0.convertToResponse()).andReturn(serviceResponse0).anyTimes();
@@ -1372,7 +1372,7 @@ public class ServiceResourceProviderTest {
 
     expect(clusters.getCluster("Cluster100")).andReturn(cluster).anyTimes();
 
-    expect(cluster.getServices()).andReturn(
+    expect(cluster.getServicesByName()).andReturn(
         ImmutableMap.<String, Service>builder()
           .put("Service100", service1)
           .put("Service200", service2).build()).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperFactoryImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperFactoryImplTest.java
@@ -84,7 +84,7 @@ public class LoggingRequestHelperFactoryImplTest {
     expect(clustersMock.getCluster(expectedClusterName)).andReturn(clusterMock).atLeastOnce();
     expect(clusterMock.getDesiredConfigByType("logsearch-properties")).andReturn(logSearchEnvConfig).atLeastOnce();
     expect(clusterMock.getServiceComponentHosts("LOGSEARCH", "LOGSEARCH_SERVER")).andReturn(Collections.singletonList(serviceComponentHostMock)).atLeastOnce();
-    expect(clusterMock.getServices()).andReturn(Collections.singletonMap("LOGSEARCH", (Service) null)).atLeastOnce();
+    expect(clusterMock.getServicesByName()).andReturn(Collections.singletonMap("LOGSEARCH", (Service) null)).atLeastOnce();
     expect(logSearchEnvConfig.getProperties()).andReturn(testProperties).atLeastOnce();
     expect(serviceComponentHostMock.getHostName()).andReturn(expectedHostName).atLeastOnce();
     expect(serviceComponentHostMock.getState()).andReturn(State.STARTED).atLeastOnce();
@@ -152,7 +152,7 @@ public class LoggingRequestHelperFactoryImplTest {
     expect(clustersMock.getCluster(expectedClusterName)).andReturn(clusterMock).atLeastOnce();
     expect(clusterMock.getDesiredConfigByType("logsearch-properties")).andReturn(logSearchEnvConfig).atLeastOnce();
     expect(clusterMock.getServiceComponentHosts("LOGSEARCH", "LOGSEARCH_SERVER")).andReturn(Collections.singletonList(serviceComponentHostMock)).atLeastOnce();
-    expect(clusterMock.getServices()).andReturn(Collections.singletonMap("LOGSEARCH", (Service) null)).atLeastOnce();
+    expect(clusterMock.getServicesByName()).andReturn(Collections.singletonMap("LOGSEARCH", (Service) null)).atLeastOnce();
     expect(serverConfigMock.getLogSearchPortalExternalAddress()).andReturn("");
 
     // set the LOGSEARCH_SERVER's state to INSTALLED, to simulate the case where
@@ -202,7 +202,7 @@ public class LoggingRequestHelperFactoryImplTest {
     expect(clustersMock.getCluster(expectedClusterName)).andReturn(clusterMock).atLeastOnce();
     expect(clusterMock.getDesiredConfigByType("logsearch-properties")).andReturn(logSearchEnvConfig).atLeastOnce();
     expect(clusterMock.getServiceComponentHosts("LOGSEARCH", "LOGSEARCH_SERVER")).andReturn(Collections.emptyList()).atLeastOnce();
-    expect(clusterMock.getServices()).andReturn(Collections.singletonMap("LOGSEARCH", (Service)null)).atLeastOnce();
+    expect(clusterMock.getServicesByName()).andReturn(Collections.singletonMap("LOGSEARCH", (Service)null)).atLeastOnce();
     expect(serverConfigMock.getLogSearchPortalExternalAddress()).andReturn("");
 
     mockSupport.replayAll();
@@ -243,7 +243,7 @@ public class LoggingRequestHelperFactoryImplTest {
     expect(controllerMock.getClusters()).andReturn(clustersMock).atLeastOnce();
     expect(clustersMock.getCluster(expectedClusterName)).andReturn(clusterMock).atLeastOnce();
     // do not include LOGSEARCH in this map, to simulate the case when LogSearch is not deployed
-    expect(clusterMock.getServices()).andReturn(Collections.singletonMap("HDFS", (Service)null)).atLeastOnce();
+    expect(clusterMock.getServicesByName()).andReturn(Collections.singletonMap("HDFS", (Service)null)).atLeastOnce();
     expect(serverConfigMock.getLogSearchPortalExternalAddress()).andReturn("");
 
     mockSupport.replayAll();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/KerberosIdentityCleanerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/KerberosIdentityCleanerTest.java
@@ -279,6 +279,6 @@ public class KerberosIdentityCleanerTest extends EasyMockSupport {
     expect(clusters.getCluster(CLUSTER_ID)).andReturn(cluster).anyTimes();
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
     expect(kerberosHelper.getKerberosDescriptor(cluster, false)).andReturn(kerberosDescriptor).anyTimes();
-    expect(cluster.getServices()).andReturn(installedServices).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(installedServices).anyTimes();
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/KerberosIdentityCleanerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/utilities/KerberosIdentityCleanerTest.java
@@ -280,5 +280,6 @@ public class KerberosIdentityCleanerTest extends EasyMockSupport {
     expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
     expect(kerberosHelper.getKerberosDescriptor(cluster, false)).andReturn(kerberosDescriptor).anyTimes();
     expect(cluster.getServicesByName()).andReturn(installedServices).anyTimes();
+    expect(cluster.getServices()).andReturn(installedServices.values()).anyTimes();
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
@@ -60,7 +60,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -103,9 +103,7 @@ public class RoleCommandOrderTest {
     expect(cluster.getService("HDFS")).andReturn(null);
     expect(cluster.getService("YARN")).andReturn(null);
 
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("GLUSTERFS", service)
-        .build()).atLeastOnce();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(service)).atLeastOnce();
 
     replay(cluster, service);
 
@@ -154,9 +152,7 @@ public class RoleCommandOrderTest {
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.0.6"));
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .build()).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsService)).anyTimes();
 
     replay(cluster, hdfsService);
 
@@ -202,9 +198,7 @@ public class RoleCommandOrderTest {
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(journalnodeSC);
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.0.6"));
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .build()).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsService)).anyTimes();
 
     replay(cluster, hdfsService);
 
@@ -253,9 +247,7 @@ public class RoleCommandOrderTest {
     expect(resourcemanagerSC.getServiceComponentHosts()).andReturn(hostComponents).anyTimes();
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
     expect(yarnService.getStackId()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("YARN", yarnService)
-        .build()).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(yarnService)).anyTimes();
 
     replay(cluster, yarnService, sch1, sch2, resourcemanagerSC);
 
@@ -310,9 +302,7 @@ public class RoleCommandOrderTest {
     expect(yarnService.getStackId()).andReturn(new StackId("HDP", "2.0.6")).anyTimes();
     expect(resourcemanagerSC.getServiceComponentHosts()).andReturn(hostComponents).anyTimes();
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("YARN", yarnService)
-        .build()).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(yarnService)).anyTimes();
 
     replay(cluster, yarnService, sch1, sch2, resourcemanagerSC);
 
@@ -408,9 +398,7 @@ public class RoleCommandOrderTest {
     //There is no rco file in this stack, should use default
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.5"));
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.0.5"));
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .build()).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsService)).anyTimes();
 
     replay(cluster);
     replay(hdfsService);
@@ -445,10 +433,7 @@ public class RoleCommandOrderTest {
         "HBASE_MASTER", hbaseMaster);
     expect(hbaseService.getServiceComponents()).andReturn(hbaseComponents).anyTimes();
 
-    Map<String, Service> installedServices = new HashMap<>();
-    installedServices.put("HDFS", hdfsService);
-    installedServices.put("HBASE", hbaseService);
-    expect(cluster.getServicesByName()).andReturn(installedServices).atLeastOnce();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsService, hbaseService)).atLeastOnce();
 
     expect(cluster.getService("HDFS")).andReturn(hdfsService).atLeastOnce();
     expect(cluster.getService("GLUSTERFS")).andReturn(null);
@@ -499,9 +484,7 @@ public class RoleCommandOrderTest {
     expect(hdfsService.getServiceComponents()).andReturn(Collections.emptyMap()).anyTimes();
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.2.0")).anyTimes();
-    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .build()).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsService)).anyTimes();
 
     // There is no rco file in this stack, should use default
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.2.0")).atLeastOnce();

--- a/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
@@ -103,7 +103,7 @@ public class RoleCommandOrderTest {
     expect(cluster.getService("HDFS")).andReturn(null);
     expect(cluster.getService("YARN")).andReturn(null);
 
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("GLUSTERFS", service)
         .build()).atLeastOnce();
 
@@ -154,7 +154,7 @@ public class RoleCommandOrderTest {
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.0.6"));
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .build()).anyTimes();
 
@@ -202,7 +202,7 @@ public class RoleCommandOrderTest {
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(journalnodeSC);
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.0.6"));
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .build()).anyTimes();
 
@@ -253,7 +253,7 @@ public class RoleCommandOrderTest {
     expect(resourcemanagerSC.getServiceComponentHosts()).andReturn(hostComponents).anyTimes();
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
     expect(yarnService.getStackId()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("YARN", yarnService)
         .build()).anyTimes();
 
@@ -310,7 +310,7 @@ public class RoleCommandOrderTest {
     expect(yarnService.getStackId()).andReturn(new StackId("HDP", "2.0.6")).anyTimes();
     expect(resourcemanagerSC.getServiceComponentHosts()).andReturn(hostComponents).anyTimes();
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.6"));
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("YARN", yarnService)
         .build()).anyTimes();
 
@@ -408,7 +408,7 @@ public class RoleCommandOrderTest {
     //There is no rco file in this stack, should use default
 //    expect(cluster.getCurrentStackVersion()).andReturn(new StackId("HDP", "2.0.5"));
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.0.5"));
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .build()).anyTimes();
 
@@ -448,7 +448,7 @@ public class RoleCommandOrderTest {
     Map<String, Service> installedServices = new HashMap<>();
     installedServices.put("HDFS", hdfsService);
     installedServices.put("HBASE", hbaseService);
-    expect(cluster.getServices()).andReturn(installedServices).atLeastOnce();
+    expect(cluster.getServicesByName()).andReturn(installedServices).atLeastOnce();
 
     expect(cluster.getService("HDFS")).andReturn(hdfsService).atLeastOnce();
     expect(cluster.getService("GLUSTERFS")).andReturn(null);
@@ -499,7 +499,7 @@ public class RoleCommandOrderTest {
     expect(hdfsService.getServiceComponents()).andReturn(Collections.emptyMap()).anyTimes();
     expect(hdfsService.getServiceComponent("JOURNALNODE")).andReturn(null);
     expect(hdfsService.getStackId()).andReturn(new StackId("HDP", "2.2.0")).anyTimes();
-    expect(cluster.getServices()).andReturn(ImmutableMap.<String, Service>builder()
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .build()).anyTimes();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleGraphTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleGraphTest.java
@@ -46,7 +46,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -82,9 +82,7 @@ public class RoleGraphTest {
 
     Service hdfsService = mock(Service.class);
     when(hdfsService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
-    when (cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .build());
+    when (cluster.getServices()).thenReturn(ImmutableSet.of(hdfsService));
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
 
@@ -182,11 +180,7 @@ public class RoleGraphTest {
     Service hbaseService = mock(Service.class);
     when(hbaseService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .put("ZOOKEEPER", zkService)
-        .put("HBASE", hbaseService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hdfsService, zkService, hbaseService));
 
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);

--- a/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleGraphTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleGraphTest.java
@@ -82,7 +82,7 @@ public class RoleGraphTest {
 
     Service hdfsService = mock(Service.class);
     when(hdfsService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
-    when (cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when (cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .build());
 
@@ -182,7 +182,7 @@ public class RoleGraphTest {
     Service hbaseService = mock(Service.class);
     when(hbaseService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .put("ZOOKEEPER", zkService)
         .put("HBASE", hbaseService)

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
@@ -133,7 +133,7 @@ public class AbstractPrepareKerberosServerActionTest {
     expect(kerberosDescriptor.getProperties()).andReturn(descriptorProperties).atLeastOnce();
     expect(kerberosIdentityDataFileWriterFactory.createKerberosIdentityDataFileWriter((File)anyObject())).andReturn(kerberosIdentityDataFileWriter);
     // it's important to pass a copy of clusterServices
-    expect(cluster.getServices()).andReturn(new HashMap<>(clusterServices)).atLeastOnce();
+    expect(cluster.getServicesByName()).andReturn(new HashMap<>(clusterServices)).atLeastOnce();
 
     expect(serviceComponentHostHDFS.getHostName()).andReturn(hostName).atLeastOnce();
     expect(serviceComponentHostHDFS.getServiceName()).andReturn(hdfsService).atLeastOnce();

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
@@ -313,14 +313,12 @@ public class CreateAndConfigureActionTest {
     upgradeEntity.setUpgradePackage("");
     upgradeEntity.setUpgradeType(UpgradeType.EXPRESS);
 
-    Map<String, Service> services = cluster.getServicesByName();
-    for (String serviceName : services.keySet()) {
-      Service service = services.get(serviceName);
+    for (Service service : cluster.getServices()) {
       Map<String, ServiceComponent> components = service.getServiceComponents();
       for (String componentName : components.keySet()) {
         UpgradeHistoryEntity history = new UpgradeHistoryEntity();
         history.setUpgrade(upgradeEntity);
-        history.setServiceName(serviceName);
+        history.setServiceName(service.getName());
         history.setComponentName(componentName);
         upgradeEntity.addHistory(history);
       }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/CreateAndConfigureActionTest.java
@@ -313,7 +313,7 @@ public class CreateAndConfigureActionTest {
     upgradeEntity.setUpgradePackage("");
     upgradeEntity.setUpgradeType(UpgradeType.EXPRESS);
 
-    Map<String, Service> services = cluster.getServices();
+    Map<String, Service> services = cluster.getServicesByName();
     for (String serviceName : services.keySet()) {
       Service service = services.get(serviceName);
       Map<String, ServiceComponent> components = service.getServiceComponents();

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
@@ -532,7 +532,7 @@ public class PreconfigureKerberosActionTest extends EasyMockSupport {
     expect(cluster.getClusterName()).andReturn(CLUSTER_NAME).anyTimes();
     expect(cluster.getClusterId()).andReturn(1L).anyTimes();
     expect(cluster.getHosts()).andReturn(hosts).anyTimes();
-    expect(cluster.getServices()).andReturn(services).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(services).anyTimes();
     expect(cluster.getCurrentStackVersion()).andReturn(currentStackId).anyTimes();
 
     for (Map.Entry<String, List<ServiceComponentHost>> entry : serviceComponentHosts.entrySet()) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/stageplanner/TestStagePlanner.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stageplanner/TestStagePlanner.java
@@ -110,7 +110,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6.1"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HBASE", hbaseService)
         .put("ZOOKEEPER", zkService)
         .build());
@@ -148,7 +148,7 @@ public class TestStagePlanner {
     Service yarnService = mock(Service.class);
     when(yarnService.getStackId()).thenReturn(new StackId("HDP-2.0.6.1"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HBASE", hbaseService)
         .put("ZOOKEEPER", zkService)
         .put("YARN", yarnService)
@@ -189,7 +189,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6.1"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HBASE", hbaseService)
         .put("ZOOKEEPER", zkService)
         .build());
@@ -229,7 +229,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HBASE", hbaseService)
         .put("ZOOKEEPER", zkService)
         .build());
@@ -268,7 +268,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HBASE", hbaseService)
         .put("ZOOKEEPER", zkService)
         .build());
@@ -303,7 +303,7 @@ public class TestStagePlanner {
     Service hiveService = mock(Service.class);
     when(hiveService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HIVE", hiveService)
         .build());
 
@@ -358,7 +358,7 @@ public class TestStagePlanner {
     Service gangliaService = mock(Service.class);
     when(gangliaService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServices()).thenReturn(ImmutableMap.<String, Service>builder()
+    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
         .put("HDFS", hdfsService)
         .put("HBASE", hbaseService)
         .put("ZOOKEEPER", zkService)

--- a/ambari-server/src/test/java/org/apache/ambari/server/stageplanner/TestStagePlanner.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stageplanner/TestStagePlanner.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -110,10 +110,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6.1"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HBASE", hbaseService)
-        .put("ZOOKEEPER", zkService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hbaseService, zkService));
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
     RoleGraph rg = roleGraphFactory.createNew(rco);
@@ -148,11 +145,7 @@ public class TestStagePlanner {
     Service yarnService = mock(Service.class);
     when(yarnService.getStackId()).thenReturn(new StackId("HDP-2.0.6.1"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HBASE", hbaseService)
-        .put("ZOOKEEPER", zkService)
-        .put("YARN", yarnService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hbaseService, zkService, yarnService));
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
     RoleGraph rg = roleGraphFactory.createNew(rco);
@@ -189,10 +182,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6.1"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HBASE", hbaseService)
-        .put("ZOOKEEPER", zkService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hbaseService, zkService));
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
     RoleGraph rg = roleGraphFactory.createNew(rco);
@@ -229,10 +219,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HBASE", hbaseService)
-        .put("ZOOKEEPER", zkService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hbaseService, zkService));
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
     RoleGraph rg = roleGraphFactory.createNew(rco);
@@ -268,10 +255,7 @@ public class TestStagePlanner {
     Service zkService = mock(Service.class);
     when(zkService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HBASE", hbaseService)
-        .put("ZOOKEEPER", zkService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hbaseService, zkService));
 
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
@@ -303,9 +287,7 @@ public class TestStagePlanner {
     Service hiveService = mock(Service.class);
     when(hiveService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HIVE", hiveService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hiveService));
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);
     RoleGraph rg = roleGraphFactory.createNew(rco);
@@ -358,15 +340,7 @@ public class TestStagePlanner {
     Service gangliaService = mock(Service.class);
     when(gangliaService.getStackId()).thenReturn(new StackId("HDP-2.0.6"));
 
-    when(cluster.getServicesByName()).thenReturn(ImmutableMap.<String, Service>builder()
-        .put("HDFS", hdfsService)
-        .put("HBASE", hbaseService)
-        .put("ZOOKEEPER", zkService)
-        .put("MAPREDUCE", mrService)
-        .put("OOZIE", oozieService)
-        .put("WEBHCAT", webhcatService)
-        .put("GANGLIA", gangliaService)
-        .build());
+    when(cluster.getServices()).thenReturn(ImmutableSet.of(hdfsService, hbaseService, zkService, mrService, oozieService, webhcatService, gangliaService));
 
 
     RoleCommandOrder rco = roleCommandOrderProvider.getRoleCommandOrder(cluster);

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/CheckHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/CheckHelperTest.java
@@ -111,7 +111,7 @@ public class CheckHelperTest {
 
     m_services.put("KAFKA", service);
 
-    Mockito.when(cluster.getServices()).thenReturn(new HashMap<>());
+    Mockito.when(cluster.getServicesByName()).thenReturn(new HashMap<>());
     Mockito.when(cluster.getClusterId()).thenReturn(1L);
     Mockito.when(clusters.getCluster("cluster")).thenReturn(cluster);
 
@@ -184,7 +184,7 @@ public class CheckHelperTest {
 
     m_services.put("KAFKA", service);
 
-    Mockito.when(cluster.getServices()).thenReturn(new HashMap<>());
+    Mockito.when(cluster.getServicesByName()).thenReturn(new HashMap<>());
     Mockito.when(cluster.getClusterId()).thenReturn(1L);
 
     Mockito.when(clusters.getCluster(Mockito.anyString())).thenReturn(cluster);

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ConfigHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ConfigHelperTest.java
@@ -1135,7 +1135,6 @@ public class ConfigHelperTest {
 
       List<PropertyInfo> serviceProperties = Arrays.asList(mockPropertyInfo1, mockPropertyInfo2);
 
-      expect(mockCluster.getService("SERVICE")).andReturn(mockService).once();
       expect(mockService.getStackId()).andReturn(mockStackVersion).once();
       expect(mockService.getServiceType()).andReturn("SERVICE").once();
       expect(mockStackVersion.getStackName()).andReturn("HDP").once();
@@ -1150,7 +1149,7 @@ public class ConfigHelperTest {
       mockAmbariMetaInfo.init();
 
       Set<PropertyInfo> result = injector.getInstance(ConfigHelper.class)
-          .getServiceProperties(mockCluster, "SERVICE");
+          .getServiceProperties(mockCluster, mockService);
 
       Assert.assertNotNull(result);
       Assert.assertEquals(2, result.size());

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertDefinitionHashTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertDefinitionHashTest.java
@@ -20,6 +20,11 @@ package org.apache.ambari.server.state.alerts;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -46,7 +51,6 @@ import org.apache.ambari.server.state.alert.Scope;
 import org.apache.ambari.server.state.alert.SourceType;
 import org.apache.commons.codec.binary.Hex;
 import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -57,13 +61,11 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-import junit.framework.TestCase;
-
 /**
  * Tests for {@link AlertDefinitionHash}.
  */
 @Category({ category.AlertTest.class})
-public class AlertDefinitionHashTest extends TestCase {
+public class AlertDefinitionHashTest {
 
   private AlertDefinitionHash m_hash;
   private Clusters m_mockClusters;
@@ -79,15 +81,8 @@ public class AlertDefinitionHashTest extends TestCase {
   AlertDefinitionEntity m_hdfsHost;
   private ConfigHelper m_configHelper;
 
-  /**
-   *
-   */
-  @Override
   @Before
-  @SuppressWarnings("unchecked")
-  protected void setUp() throws Exception {
-    super.setUp();
-
+  public void setUp() throws Exception {
     m_injector = Guice.createInjector(Modules.override(
         new InMemoryDefaultTestModule()).with(new MockModule()));
 
@@ -150,9 +145,10 @@ public class AlertDefinitionHashTest extends TestCase {
         clusterHosts).anyTimes();
 
     // cluster mock
-    expect(m_mockCluster.getClusterId()).andReturn(Long.valueOf(1)).anyTimes();
+    expect(m_mockCluster.getClusterId()).andReturn(1L).anyTimes();
     expect(m_mockCluster.getClusterName()).andReturn(CLUSTERNAME).anyTimes();
     expect(m_mockCluster.getServicesByName()).andReturn(services).anyTimes();
+    expect(m_mockCluster.getServices()).andReturn(services.values()).anyTimes();
     expect(
         m_mockCluster.getServiceComponentHosts(EasyMock.anyObject(String.class))).andReturn(
         serviceComponentHosts).anyTimes();
@@ -186,7 +182,7 @@ public class AlertDefinitionHashTest extends TestCase {
 
     EasyMock.expect(
         m_mockDao.findByServiceMaster(EasyMock.anyInt(),
-            (Set<String>) EasyMock.anyObject())).andReturn(
+            EasyMock.anyObject())).andReturn(
         Collections.singletonList(m_hdfsService)).anyTimes();
 
     EasyMock.expect(
@@ -204,18 +200,10 @@ public class AlertDefinitionHashTest extends TestCase {
 
     // configHelper mock
     m_configHelper = m_injector.getInstance(ConfigHelper.class);
-    EasyMock.expect(m_configHelper.getEffectiveDesiredTags((Cluster) anyObject(), EasyMock.anyString())).andReturn(new HashMap<>()).anyTimes();
-    EasyMock.expect(m_configHelper.getEffectiveConfigProperties((Cluster) anyObject(), (Map<String, Map<String, String>>) anyObject())).andReturn(new HashMap<>()).anyTimes();
+    EasyMock.expect(m_configHelper.getEffectiveDesiredTags(anyObject(), EasyMock.anyString())).andReturn(new HashMap<>()).anyTimes();
+    Map<String, Map<String, String>> desiredTags = anyObject();
+    EasyMock.expect(m_configHelper.getEffectiveConfigProperties(anyObject(), desiredTags)).andReturn(new HashMap<>()).anyTimes();
     EasyMock.replay(m_configHelper);
-  }
-
-  /**
-   *
-   */
-  @Override
-  @After
-  protected void tearDown() throws Exception {
-    super.tearDown();
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertDefinitionHashTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertDefinitionHashTest.java
@@ -152,7 +152,7 @@ public class AlertDefinitionHashTest extends TestCase {
     // cluster mock
     expect(m_mockCluster.getClusterId()).andReturn(Long.valueOf(1)).anyTimes();
     expect(m_mockCluster.getClusterName()).andReturn(CLUSTERNAME).anyTimes();
-    expect(m_mockCluster.getServices()).andReturn(services).anyTimes();
+    expect(m_mockCluster.getServicesByName()).andReturn(services).anyTimes();
     expect(
         m_mockCluster.getServiceComponentHosts(EasyMock.anyObject(String.class))).andReturn(
         serviceComponentHosts).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/InitialAlertEventTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/InitialAlertEventTest.java
@@ -113,7 +113,7 @@ public class InitialAlertEventTest {
 
     // install HDFS to get 6 definitions
     installHdfsService();
-    Assert.assertEquals(1, m_cluster.getServices().size());
+    Assert.assertEquals(1, m_cluster.getServicesByName().size());
     Assert.assertEquals(6, m_definitionDao.findAll().size());
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/InitialAlertEventTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/InitialAlertEventTest.java
@@ -113,7 +113,7 @@ public class InitialAlertEventTest {
 
     // install HDFS to get 6 definitions
     installHdfsService();
-    Assert.assertEquals(1, m_cluster.getServicesByName().size());
+    Assert.assertEquals(1, m_cluster.getServices().size());
     Assert.assertEquals(6, m_definitionDao.findAll().size());
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterImplTest.java
@@ -260,7 +260,7 @@ public class ClusterImplTest {
     cluster.deleteService(serviceToDelete, new DeleteHostComponentStatusMetaData());
 
     // Then
-    assertFalse("Deleted service should be removed from the service collection !", cluster.getServices().containsKey(serviceToDelete));
+    assertFalse("Deleted service should be removed from the service collection !", cluster.getServicesByName().containsKey(serviceToDelete));
 
     assertEquals("All components of the deleted service should be removed from all hosts", 0, cluster.getServiceComponentHosts(serviceToDelete, null).size());
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClusterTest.java
@@ -392,7 +392,7 @@ public class ClusterTest {
       // Expected
     }
 
-    Map<String, Service> services = c1.getServices();
+    Map<String, Service> services = c1.getServicesByName();
     Assert.assertEquals(2, services.size());
     Assert.assertTrue(services.containsKey("HDFS"));
     Assert.assertTrue(services.containsKey("MAPREDUCE"));
@@ -838,13 +838,13 @@ public class ClusterTest {
     Service hdfs = c1.addService(serviceGroup, "HDFS", "HDFS");
     hdfs.addServiceComponent("NAMENODE", "NAMENODE");
 
-    assertEquals(2, c1.getServices().size());
+    assertEquals(2, c1.getServicesByName().size());
     assertEquals(2, injector.getProvider(EntityManager.class).get().
         createQuery("SELECT service FROM ClusterServiceEntity service").getResultList().size());
 
     c1.deleteService("HDFS", new DeleteHostComponentStatusMetaData());
 
-    assertEquals(1, c1.getServices().size());
+    assertEquals(1, c1.getServicesByName().size());
     assertEquals(1, injector.getProvider(EntityManager.class).get().
         createQuery("SELECT service FROM ClusterServiceEntity service").getResultList().size());
   }
@@ -881,7 +881,7 @@ public class ClusterTest {
 
     c1.deleteService("HDFS", new DeleteHostComponentStatusMetaData());
 
-    Assert.assertEquals(0, c1.getServices().size());
+    Assert.assertEquals(0, c1.getServicesByName().size());
     Assert.assertEquals(0, c1.getServiceConfigVersions().size());
 
     EntityManager em = injector.getProvider(EntityManager.class).get();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -305,7 +305,7 @@ public class AmbariContextTest {
     controller.createCluster(capture(clusterRequestCapture));
     expectLastCall().once();
     expect(cluster.getServiceGroups()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(cluster.getServices()).andReturn(clusterServices).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(clusterServices).anyTimes();
 
     Capture<Set<ServiceGroupRequest>> serviceGroupRequestCapture = EasyMock.newCapture();
     Capture<Set<ServiceRequest>> serviceRequestCapture = EasyMock.newCapture();
@@ -395,7 +395,7 @@ public class AmbariContextTest {
   @Test
   public void testCreateAmbariHostResources() throws Exception {
     // expectations
-    expect(cluster.getServices()).andReturn(clusterServices).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(clusterServices).anyTimes();
 
     hostResourceProvider.createHosts(anyObject(Request.class));
     expectLastCall().once();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -131,7 +131,6 @@ public class AmbariContextTest {
   private static final Service mockService1 = createStrictMock(Service.class);
 
   private static final Collection<String> blueprintServices = new HashSet<>();
-  private static final Map<String, Service> clusterServices = new HashMap<>();
   private static final Map<Long, ConfigGroup> configGroups = new HashMap<>();
   private Configuration bpConfiguration = null;
   private Configuration group1Configuration = null;
@@ -305,7 +304,7 @@ public class AmbariContextTest {
     controller.createCluster(capture(clusterRequestCapture));
     expectLastCall().once();
     expect(cluster.getServiceGroups()).andReturn(Collections.emptyMap()).anyTimes();
-    expect(cluster.getServicesByName()).andReturn(clusterServices).anyTimes();
+    expect(cluster.getServices()).andReturn(emptySet()).anyTimes();
 
     Capture<Set<ServiceGroupRequest>> serviceGroupRequestCapture = EasyMock.newCapture();
     Capture<Set<ServiceRequest>> serviceRequestCapture = EasyMock.newCapture();
@@ -395,7 +394,7 @@ public class AmbariContextTest {
   @Test
   public void testCreateAmbariHostResources() throws Exception {
     // expectations
-    expect(cluster.getServicesByName()).andReturn(clusterServices).anyTimes();
+    expect(cluster.getServices()).andReturn(emptySet()).anyTimes();
 
     hostResourceProvider.createHosts(anyObject(Request.class));
     expectLastCall().once();

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalogTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalogTest.java
@@ -86,9 +86,6 @@ public class AbstractUpgradeCatalogTest {
     HashSet<PropertyInfo> stackProperties = new HashSet<>();
     expect(configHelper.getStackProperties(cluster)).andReturn(stackProperties).anyTimes();
 
-    HashMap<String, Service> serviceMap = new HashMap<>();
-    serviceMap.put(SERVICE_NAME, null);
-    expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
     expect(cluster.getServiceByConfigType("hdfs-site")).andReturn(hdfsMock).atLeastOnce();
     expect(hdfsMock.getName()).andReturn("HDFS").atLeastOnce();
 
@@ -98,7 +95,7 @@ public class AbstractUpgradeCatalogTest {
     serviceProperties.add(createProperty(CONFIG_TYPE, "prop3", false, false, true));
     serviceProperties.add(createProperty(CONFIG_TYPE, "prop4", true, false, false));
 
-    expect(configHelper.getServiceProperties(cluster, SERVICE_NAME)).andReturn(serviceProperties).anyTimes();
+    expect(configHelper.getServiceProperties(anyObject(), anyObject())).andReturn(serviceProperties).anyTimes();
 
     expect(configHelper.getPropertyValueFromStackDefinitions(cluster, "hdfs-site", "prop1")).andReturn("v1").anyTimes();
     expect(configHelper.getPropertyValueFromStackDefinitions(cluster, "hdfs-site", "prop2")).andReturn("v2").anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalogTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalogTest.java
@@ -27,7 +27,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
-import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,12 +46,14 @@ import org.apache.ambari.server.state.StackId;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 
 public class AbstractUpgradeCatalogTest {
   private static final String CONFIG_TYPE = "hdfs-site.xml";
-  private final String CLUSTER_NAME = "c1";
-  private final String SERVICE_NAME = "HDFS";
+  private static final String CLUSTER_NAME = "c1";
+  private static final String SERVICE_NAME = "HDFS";
   private AmbariManagementController amc;
   private ConfigHelper configHelper;
   private Injector injector;
@@ -87,7 +88,9 @@ public class AbstractUpgradeCatalogTest {
     expect(configHelper.getStackProperties(cluster)).andReturn(stackProperties).anyTimes();
 
     expect(cluster.getServiceByConfigType("hdfs-site")).andReturn(hdfsMock).atLeastOnce();
-    expect(hdfsMock.getName()).andReturn("HDFS").atLeastOnce();
+    expect(cluster.getServicesByName()).andReturn(ImmutableMap.of(SERVICE_NAME, hdfsMock)).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsMock)).anyTimes();
+    expect(hdfsMock.getName()).andReturn(SERVICE_NAME).atLeastOnce();
 
     HashSet<PropertyInfo> serviceProperties = new HashSet<>();
     serviceProperties.add(createProperty(CONFIG_TYPE, "prop1", true, false, false));
@@ -110,13 +113,13 @@ public class AbstractUpgradeCatalogTest {
 
     upgradeCatalog = new AbstractUpgradeCatalog(injector) {
       @Override
-      protected void executeDDLUpdates() throws AmbariException, SQLException { }
+      protected void executeDDLUpdates() { }
 
       @Override
-      protected void executePreDMLUpdates() throws AmbariException, SQLException { }
+      protected void executePreDMLUpdates() { }
 
       @Override
-      protected void executeDMLUpdates() throws AmbariException, SQLException { }
+      protected void executeDMLUpdates() { }
 
       @Override
       public String getTargetVersion() { return null; }

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalogTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/AbstractUpgradeCatalogTest.java
@@ -88,7 +88,7 @@ public class AbstractUpgradeCatalogTest {
 
     HashMap<String, Service> serviceMap = new HashMap<>();
     serviceMap.put(SERVICE_NAME, null);
-    expect(cluster.getServices()).andReturn(serviceMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
     expect(cluster.getServiceByConfigType("hdfs-site")).andReturn(hdfsMock).atLeastOnce();
     expect(hdfsMock.getName()).andReturn("HDFS").atLeastOnce();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog251Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog251Test.java
@@ -260,7 +260,7 @@ public class UpgradeCatalog251Test {
     expect(mockClusters.getClusters()).andReturn(Collections.singletonMap("normal", mockClusterExpected)).atLeastOnce();
     expect(mockClusterExpected.getDesiredConfigByType("kafka-broker")).andReturn(kafkaBroker).atLeastOnce();
     expect(mockClusterExpected.getSecurityType()).andReturn(SecurityType.KERBEROS).atLeastOnce();
-    expect(mockClusterExpected.getServices()).andReturn(Collections.singletonMap("KAFKA", null)).atLeastOnce();
+    expect(mockClusterExpected.getServicesByName()).andReturn(Collections.singletonMap("KAFKA", null)).atLeastOnce();
 
     UpgradeCatalog251 upgradeCatalog251 = createMockBuilder(UpgradeCatalog251.class)
         .withConstructor(Injector.class)

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
@@ -1076,7 +1076,7 @@ public class UpgradeCatalog260Test {
     expect(clusters.getClusters()).andReturn(new HashMap<String, Cluster>() {{
       put("normal", cluster);
     }}).anyTimes();
-    expect(cluster.getServices()).andReturn(Collections.singletonMap("HDFS", service)).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(Collections.singletonMap("HDFS", service)).anyTimes();
     expect(cluster.getClusterId()).andReturn(1L).anyTimes();
     expect(service.getStackId()).andReturn(stackId).anyTimes();
     expect(stackInfo.getService("HDFS")).andReturn(serviceInfo);

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -77,6 +77,7 @@ import org.junit.Test;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.gson.Gson;
@@ -495,12 +496,7 @@ public class StageUtilsTest extends EasyMockSupport {
 
     Cluster cluster = createMock(Cluster.class);
     expect(cluster.getHosts()).andReturn(hosts).anyTimes();
-    expect(cluster.getServicesByName()).andReturn(new HashMap<String, Service>() {{
-      put("HDFS", hdfsService);
-      put("HBASE", hbaseService);
-      put("MAPREDUCE", mrService);
-      put("NONAME", nnService);
-    }}).anyTimes();
+    expect(cluster.getServices()).andReturn(ImmutableSet.of(hdfsService, hbaseService, mrService, nnService)).anyTimes();
 
 
     final TopologyManager topologyManager = injector.getInstance(TopologyManager.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -495,7 +495,7 @@ public class StageUtilsTest extends EasyMockSupport {
 
     Cluster cluster = createMock(Cluster.class);
     expect(cluster.getHosts()).andReturn(hosts).anyTimes();
-    expect(cluster.getServices()).andReturn(new HashMap<String, Service>() {{
+    expect(cluster.getServicesByName()).andReturn(new HashMap<String, Service>() {{
       put("HDFS", hdfsService);
       put("HBASE", hbaseService);
       put("MAPREDUCE", mrService);

--- a/ambari-server/src/test/java/org/apache/ambari/server/view/ViewRegistryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/view/ViewRegistryTest.java
@@ -427,7 +427,7 @@ public class ViewRegistryTest {
       Map<String, Cluster> allClusters = new HashMap<>();
       expect(cluster.getClusterName()).andReturn("c1").anyTimes();
       expect(cluster.getCurrentStackVersion()).andReturn(stackId).anyTimes();
-      expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
+      expect(cluster.getServices()).andReturn(serviceMap.values()).anyTimes();
       allClusters.put("c1", cluster);
       expect(clusters.getClusters()).andReturn(allClusters);
 
@@ -1896,13 +1896,14 @@ public class ViewRegistryTest {
     Map<String, Service> serviceMap = new HashMap<>();
     for (String serviceName : serviceNames) {
       serviceMap.put(serviceName, service);
-      expect(cluster.getService(serviceName)).andReturn(service);
+      expect(cluster.getService(serviceName)).andReturn(service).anyTimes();
     }
 
     expect(clusters.getClusterById(99L)).andReturn(cluster);
     expect(cluster.getClusterName()).andReturn("c1").anyTimes();
     expect(cluster.getCurrentStackVersion()).andReturn(stackId).anyTimes();
     expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
+    expect(cluster.getServices()).andReturn(serviceMap.values()).anyTimes();
     expect(service.getStackId()).andReturn(stackId).anyTimes();
 
     Capture<ViewInstanceEntity> viewInstanceCapture = EasyMock.newCapture();

--- a/ambari-server/src/test/java/org/apache/ambari/server/view/ViewRegistryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/view/ViewRegistryTest.java
@@ -427,7 +427,7 @@ public class ViewRegistryTest {
       Map<String, Cluster> allClusters = new HashMap<>();
       expect(cluster.getClusterName()).andReturn("c1").anyTimes();
       expect(cluster.getCurrentStackVersion()).andReturn(stackId).anyTimes();
-      expect(cluster.getServices()).andReturn(serviceMap).anyTimes();
+      expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
       allClusters.put("c1", cluster);
       expect(clusters.getClusters()).andReturn(allClusters);
 
@@ -1902,7 +1902,7 @@ public class ViewRegistryTest {
     expect(clusters.getClusterById(99L)).andReturn(cluster);
     expect(cluster.getClusterName()).andReturn("c1").anyTimes();
     expect(cluster.getCurrentStackVersion()).andReturn(stackId).anyTimes();
-    expect(cluster.getServices()).andReturn(serviceMap).anyTimes();
+    expect(cluster.getServicesByName()).andReturn(serviceMap).anyTimes();
     expect(service.getStackId()).andReturn(stackId).anyTimes();
 
     Capture<ViewInstanceEntity> viewInstanceCapture = EasyMock.newCapture();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Cluster.getServices` returns a `Map` where the keys are service names.  This causes problems, since service names are not necessarily unique across the entires cluster.  There is an existing method `Cluster.getServicesById`.

 * rename `getServices` to `getServicesByName` and deprecate it
 * add `getServices`, which returns only the `values()` of the map (the one keyed by IDs)
 * replace calls `getServicesBy*().values()` to use the new method directly

The above resolved the host components API bug.  However, it exposed another problem, where commands for client components from multiple mpacks couldn't be created in the same stage.  Worked around it by extracting clients into separate stages (as many as necessary to ensure components are unique).

## How was this patch tested?

Deployed cluster with common client services from multiple mpacks.  Verified host component and other APIs.

Added unit test for the workaround.  Other unit tests are no worse than before.