### PR TITLE
[AMBARI-24020] Remove HDFS Disk Usage widget from host summary page

### DIFF
--- a/ambari-web/app/templates/main/host/summary.hbs
+++ b/ambari-web/app/templates/main/host/summary.hbs
@@ -153,9 +153,9 @@
             {{/if}}
             {{#if view.hasNameNode}}
               <div class="namenode-metrics dashboard-widgets">
-                <h5 class="text-uppercase">
+                <h5>
                   {{#if App.isHaEnabled}}
-                    {{t dashboard.widgets.nameSpace}}{{#if view.nameNodeComponent.haNameSpace}}: {{view.nameNodeComponent.haNameSpace}}{{/if}}
+                    <span class="text-uppercase">{{t dashboard.widgets.nameSpace}}</span>{{#if view.nameNodeComponent.haNameSpace}}: {{view.nameNodeComponent.haNameSpace}}{{/if}}
                   {{/if}}
                 </h5>
                 <div class="thumbnails">

--- a/ambari-web/app/views/main/host/summary.js
+++ b/ambari-web/app/views/main/host/summary.js
@@ -80,16 +80,6 @@ App.MainHostSummaryView = Em.View.extend(App.TimeRangeMixin, {
             threshold: widgetsDefinitions.NameNodeHeapPieChartView.threshold,
           }
         }),
-        App.NameNodeCapacityPieChartView.extend({
-          model,
-          hostName,
-          widgetHtmlId: 'nn-capacity',
-          title: Em.I18n.t('dashboard.widgets.HDFSDiskUsage'),
-          showActions: false,
-          widget: {
-            threshold: widgetsDefinitions.NameNodeCapacityPieChartView.threshold
-          }
-        }),
         App.NameNodeCpuPieChartView.extend({
           widgetHtmlId: 'nn-cpu',
           title: Em.I18n.t('dashboard.widgets.NameNodeCpu'),


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are NameNode widgets on host summary page which are specific for the namespace containing this host. Since HDFS DIsk Usage metrics is an aggregate from all the namespaces, the corresponding widget on host page is confusing and should be removed from there.

## How was this patch tested?

UI unit tests:
  21798 passing (26s)
  48 pending