### PR TITLE
[AMBARI-24021]. Atlas fails to start in an unsecure cluster after Ambari Upgrade . Error - Unable to run the custom hook script (amagyar)

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/livy2-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/livy2-env.xml
@@ -28,6 +28,16 @@
         <value-attributes>
             <type>user</type>
             <overridable>false</overridable>
+            <user-groups>
+                <property>
+                    <type>cluster-env</type>
+                    <name>user_group</name>
+                </property>
+                <property>
+                    <type>livy2-env</type>
+                    <name>livy2_group</name>
+                </property>
+            </user-groups>
         </value-attributes>
         <on-ambari-upgrade add="false"/>
     </property>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Creating livy user failed because group information was missing from user_groups param.

```text
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stack-hooks/before-ANY/scripts/hook.py", line 35, in <module>
    BeforeAnyHook().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stack-hooks/before-ANY/scripts/hook.py", line 29, in hook
    setup_users()
  File "/var/lib/ambari-agent/cache/stack-hooks/before-ANY/scripts/shared_initialization.py", line 50, in setup_users
    groups = params.user_to_groups_dict[user],
KeyError: u'livy'
```

## How was this patch tested?

created a cluster with spark2 and checked if livy user was created successfully.