### PR TITLE
[AMBARI-24023] Make "/hdp/apps/3.0.0.0-X/spark2/spark2-hdp-hive-archi…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/copy_tarball.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/copy_tarball.py
@@ -269,6 +269,13 @@ TARBALL_MAP = {
     "dirs": ("/tmp/spark2/spark2-{0}-yarn-archive.tar.gz".format(STACK_NAME_PATTERN),
              "/{0}/apps/{1}/spark2/spark2-{0}-yarn-archive.tar.gz".format(STACK_NAME_PATTERN, STACK_VERSION_PATTERN)),
     "service": "SPARK2"
+  },
+
+  "spark2hive": {
+    "dirs":  ("/tmp/spark2/spark2-{0}-hive-archive.tar.gz".format(STACK_NAME_PATTERN),
+              "/{0}/apps/{1}/spark2/spark2-{0}-hive-archive.tar.gz".format(STACK_NAME_PATTERN, STACK_VERSION_PATTERN)),
+
+    "service": "SPARK2"
   }
 }
 
@@ -283,7 +290,8 @@ SERVICE_TO_CONFIG_MAP = {
   "hadoop_streaming": "mapred-env",
   "tez_hive2": "hive-env",
   "spark": "spark-env",
-  "spark2": "spark2-env"
+  "spark2": "spark2-env",
+  "spark2hive": "spark2-env"
 }
 
 def get_sysprep_skip_copy_tarballs_hdfs():


### PR DESCRIPTION
…ve.tar.gz"(vbrodetskyi)

Added one more mapping for SPARK2 to copy tar.gz lib to HDFS.

(Please fill in changes proposed in this fix)

Deployed cluster, checked that tar.gz is in HDFS, downloaded it and checked that there is correct jar inside.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.