### PR TITLE
[AMBARI-23996] Changing column type from timestamp to long in users.create_time and user_authentication.[create|update]_time

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserAuthenticationSourceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserAuthenticationSourceResourceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.ambari.server.controller.internal;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -388,8 +389,8 @@ public class UserAuthenticationSourceResourceProvider extends AbstractAuthorized
         entity.getUserAuthenticationId(),
         entity.getAuthenticationType(),
         entity.getAuthenticationKey(),
-        entity.getCreateTime(),
-        entity.getUpdateTime());
+        new Date(entity.getCreateTime()),
+        new Date(entity.getUpdateTime()));
   }
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.ambari.server.controller.internal;
 
 import java.text.NumberFormat;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -692,7 +693,7 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
         userEntity.getActive(),
         isAdmin,
         userEntity.getConsecutiveFailures(),
-        userEntity.getCreateTime());
+        new Date(userEntity.getCreateTime()));
     userResponse.setGroups(groups);
     return userResponse;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserAuthenticationEntity.java
@@ -17,8 +17,6 @@
  */
 package org.apache.ambari.server.orm.entities;
 
-import java.util.Date;
-
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -36,8 +34,6 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 
 import org.apache.ambari.server.security.authorization.UserAuthenticationType;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -78,13 +74,11 @@ public class UserAuthenticationEntity {
 
   @Column(name = "create_time", nullable = false)
   @Basic
-  @Temporal(value = TemporalType.TIMESTAMP)
-  private Date createTime = new Date();
+  private long createTime;
 
   @Column(name = "update_time", nullable = false)
   @Basic
-  @Temporal(value = TemporalType.TIMESTAMP)
-  private Date updateTime = new Date();
+  private long updateTime ;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false)
@@ -114,11 +108,11 @@ public class UserAuthenticationEntity {
     this.authenticationKey = authenticationKey;
   }
 
-  public Date getCreateTime() {
+  public long getCreateTime() {
     return createTime;
   }
 
-  public Date getUpdateTime() {
+  public long getUpdateTime() {
     return updateTime;
   }
 
@@ -145,8 +139,9 @@ public class UserAuthenticationEntity {
    */
   @PrePersist
   protected void onCreate() {
-    createTime = new Date();
-    updateTime = new Date();
+    final long now = System.currentTimeMillis();
+    createTime = now;
+    updateTime = now;
   }
 
   /**
@@ -154,7 +149,7 @@ public class UserAuthenticationEntity {
    */
   @PreUpdate
   protected void onUpdate() {
-    updateTime = new Date();
+    updateTime = System.currentTimeMillis();
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UserEntity.java
@@ -18,7 +18,6 @@
 package org.apache.ambari.server.orm.entities;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,10 +36,9 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
 
@@ -71,8 +69,7 @@ public class UserEntity {
 
   @Column(name = "create_time", nullable = false)
   @Basic
-  @Temporal(value = TemporalType.TIMESTAMP)
-  private Date createTime = new Date();
+  private long createTime;
 
   @Column(name = "active", nullable = false)
   private Integer active = 1;
@@ -211,11 +208,11 @@ public class UserEntity {
     this.localUsername = localUsername;
   }
 
-  public Date getCreateTime() {
+  public long getCreateTime() {
     return createTime;
   }
 
-  public void setCreateTime(Date createTime) {
+  public void setCreateTime(long createTime) {
     this.createTime = createTime;
   }
 
@@ -306,6 +303,14 @@ public class UserEntity {
         this.authenticationEntities.addAll(authenticationEntities);
       }
     }
+  }
+
+  /**
+   * Ensure the create time is set properly when the record is created.
+   */
+  @PrePersist
+  protected void onCreate() {
+    createTime = System.currentTimeMillis();
   }
 
   // ----- Object overrides --------------------------------------------------

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/User.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/User.java
@@ -48,7 +48,7 @@ public class User {
   public User(UserEntity userEntity) {
     userId = userEntity.getUserId();
     userName = userEntity.getUserName();
-    createTime = userEntity.getCreateTime();
+    createTime = new Date(userEntity.getCreateTime());
     active = userEntity.getActive();
 
     groups = new ArrayList<>();

--- a/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Derby-CREATE.sql
@@ -301,7 +301,7 @@ CREATE TABLE users (
   active_widget_layouts VARCHAR(1024) DEFAULT NULL,
   display_name VARCHAR(255) NOT NULL,
   local_username VARCHAR(255) NOT NULL,
-  create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  create_time BIGINT NOT NULL,
   version BIGINT NOT NULL DEFAULT 0,
   CONSTRAINT PK_users PRIMARY KEY (user_id),
   CONSTRAINT FK_users_principal_id FOREIGN KEY (principal_id) REFERENCES adminprincipal(principal_id),
@@ -312,8 +312,8 @@ CREATE TABLE user_authentication (
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
   authentication_key VARCHAR(2048),
-  create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  create_time BIGINT NOT NULL,
+  update_time BIGINT NOT NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id));
 
@@ -1270,12 +1270,12 @@ INSERT INTO adminprincipal (principal_id, principal_type_id)
 
 -- Insert the default administrator user.
 insert into users(user_id, principal_id, user_name, display_name, local_username, create_time)
-  SELECT 1, 1, 'admin', 'Administrator', 'admin', CURRENT_TIMESTAMP FROM SYSIBM.SYSDUMMY1;
+  SELECT 1, 1, 'admin', 'Administrator', 'admin', 0 FROM SYSIBM.SYSDUMMY1;
 
 -- Insert the LOCAL authentication data for the default administrator user.
 -- The authentication_key value is the salted digest of the password: admin
 insert into user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
-  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM SYSIBM.SYSDUMMY1;
+  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', 0, 0 FROM SYSIBM.SYSDUMMY1;
 
 insert into adminpermission(permission_id, permission_name, resource_type_id, permission_label, principal_id, sort_order)
   SELECT 1, 'AMBARI.ADMINISTRATOR', 1, 'Ambari Administrator', 7, 1 FROM SYSIBM.SYSDUMMY1

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -321,7 +321,7 @@ CREATE TABLE users (
   active_widget_layouts VARCHAR(1024) DEFAULT NULL,
   display_name VARCHAR(255) NOT NULL,
   local_username VARCHAR(255) NOT NULL,
-  create_time TIMESTAMP DEFAULT NOW(),
+  create_time BIGINT NOT NULL,
   version BIGINT NOT NULL DEFAULT 0,
   CONSTRAINT PK_users PRIMARY KEY (user_id),
   CONSTRAINT FK_users_principal_id FOREIGN KEY (principal_id) REFERENCES adminprincipal(principal_id),
@@ -332,8 +332,8 @@ CREATE TABLE user_authentication (
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
   authentication_key VARCHAR(2048),
-  create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  update_time TIMESTAMP DEFAULT NOW(),
+  create_time BIGINT NOT NULL,
+  update_time BIGINT NOT NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
@@ -1219,12 +1219,12 @@ INSERT INTO adminprincipal (principal_id, principal_type_id) VALUES
 
 -- Insert the default administrator user.
 INSERT INTO users(user_id, principal_id, user_name, display_name, local_username, create_time)
-  SELECT 1, 1, 'admin', 'Administrator', 'admin', NOW();
+  SELECT 1, 1, 'admin', 'Administrator', 'admin', UNIX_TIMESTAMP() * 1000;
 
 -- Insert the LOCAL authentication data for the default administrator user.
 -- The authentication_key value is the salted digest of the password: admin
 INSERT INTO user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
-  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', NOW(), NOW();
+  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000;
 
 INSERT INTO adminpermission(permission_id, permission_name, resource_type_id, permission_label, principal_id, sort_order)
   SELECT 1, 'AMBARI.ADMINISTRATOR', 1, 'Ambari Administrator', 7, 1 UNION ALL

--- a/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Oracle-CREATE.sql
@@ -301,7 +301,7 @@ CREATE TABLE users (
   active_widget_layouts VARCHAR2(1024) DEFAULT NULL,
   display_name VARCHAR2(255) NOT NULL,
   local_username VARCHAR2(255) NOT NULL,
-  create_time TIMESTAMP NULL,
+  create_time NUMBER(19) NOT NULL,
   version NUMBER(19) DEFAULT 0 NOT NULL,
   CONSTRAINT PK_users PRIMARY KEY (user_id),
   CONSTRAINT FK_users_principal_id FOREIGN KEY (principal_id) REFERENCES adminprincipal(principal_id),
@@ -312,8 +312,8 @@ CREATE TABLE user_authentication (
   user_id NUMBER(10) NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
   authentication_key VARCHAR(2048),
-  create_time TIMESTAMP NULL,
-  update_time TIMESTAMP NULL,
+  create_time NUMBER(19) NOT NULL,
+  update_time NUMBER(19) NOT NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
@@ -1211,12 +1211,12 @@ insert into adminprincipal (principal_id, principal_type_id)
 
 -- Insert the default administrator user.
 insert into users(user_id, principal_id, user_name, display_name, local_username, create_time)
-  SELECT 1, 1, 'admin', 'Administrator', 'admin', CURRENT_TIMESTAMP from dual;
+  SELECT 1, 1, 'admin', 'Administrator', 'admin', (SYSDATE - DATE '1970-01-01') * 86400000 from dual;
 
 -- Insert the LOCAL authentication data for the default administrator user.
 -- The authentication_key value is the salted digest of the password: admin
 insert into user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
-  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP from dual;
+  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', (SYSDATE - DATE '1970-01-01') * 86400000, (SYSDATE - DATE '1970-01-01') * 86400000 from dual;
 
 insert into adminpermission(permission_id, permission_name, resource_type_id, permission_label, principal_id, sort_order)
   select 1, 'AMBARI.ADMINISTRATOR', 1, 'Ambari Administrator', 7, 1 from dual

--- a/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-Postgres-CREATE.sql
@@ -303,7 +303,7 @@ CREATE TABLE users (
   active_widget_layouts VARCHAR(1024) DEFAULT NULL,
   display_name VARCHAR(255) NOT NULL,
   local_username VARCHAR(255) NOT NULL,
-  create_time TIMESTAMP DEFAULT NOW(),
+  create_time BIGINT NOT NULL,
   version BIGINT DEFAULT 0 NOT NULL,
   CONSTRAINT PK_users PRIMARY KEY (user_id),
   CONSTRAINT FK_users_principal_id FOREIGN KEY (principal_id) REFERENCES adminprincipal(principal_id),
@@ -314,8 +314,8 @@ CREATE TABLE user_authentication (
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
   authentication_key VARCHAR(2048),
-  create_time TIMESTAMP DEFAULT NOW(),
-  update_time TIMESTAMP DEFAULT NOW(),
+  create_time BIGINT NOT NULL,
+  update_time BIGINT NOT NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id));
 
@@ -1201,12 +1201,12 @@ INSERT INTO adminprincipal (principal_id, principal_type_id) VALUES
 
 -- Insert the default administrator user.
 INSERT INTO users(user_id, principal_id, user_name, display_name, local_username, create_time)
-  SELECT 1, 1, 'admin', 'Administrator', 'admin', NOW();
+  SELECT 1, 1, 'admin', 'Administrator', 'admin', CAST (extract(epoch FROM CURRENT_TIMESTAMP) AS bigint) * 1000;
 
 -- Insert the LOCAL authentication data for the default administrator user.
 -- The authentication_key value is the salted digest of the password: admin
 INSERT INTO user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
-  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', NOW(), NOW();
+  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', CAST (extract(epoch FROM CURRENT_TIMESTAMP) AS bigint) * 1000, CAST (extract(epoch FROM CURRENT_TIMESTAMP) AS bigint) * 1000;
 
 INSERT INTO adminpermission(permission_id, permission_name, resource_type_id, permission_label, principal_id, sort_order)
   SELECT 1, 'AMBARI.ADMINISTRATOR', 1, 'Ambari Administrator', 7, 1 UNION ALL

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLAnywhere-CREATE.sql
@@ -299,7 +299,7 @@ CREATE TABLE users (
   active_widget_layouts VARCHAR(1024) DEFAULT NULL,
   display_name VARCHAR(255) NOT NULL,
   local_username VARCHAR(255) NOT NULL,
-  create_time TIMESTAMP DEFAULT NOW(),
+  create_time NUMERIC(19) NOT NULL,
   version NUMERIC(19) NOT NULL DEFAULT 0,
   CONSTRAINT PK_users PRIMARY KEY (user_id),
   CONSTRAINT FK_users_principal_id FOREIGN KEY (principal_id) REFERENCES adminprincipal(principal_id),
@@ -310,8 +310,8 @@ CREATE TABLE user_authentication (
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
   authentication_key VARCHAR(2048),
-  create_time TIMESTAMP DEFAULT NOW(),
-  update_time TIMESTAMP DEFAULT NOW(),
+  create_time NUMERIC(19) NOT NULL,
+  update_time NUMERIC(19) NOT NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
@@ -1208,12 +1208,12 @@ insert into adminprincipal (principal_id, principal_type_id)
 
 -- Insert the default administrator user.
 insert into users(user_id, principal_id, user_name, display_name, local_username, create_time)
-  SELECT 1, 1, 'admin', 'Administrator', 'admin', NOW();
+  SELECT 1, 1, 'admin', 'Administrator', 'admin', 0;
 
 -- Insert the LOCAL authentication data for the default administrator user.
 -- The authentication_key value is the salted digest of the password: admin
 insert into user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
-  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', NOW(), NOW();
+  SELECT 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', 0, 0;
 
 
 insert into adminpermission(permission_id, permission_name, resource_type_id, permission_label, principal_id, sort_order)

--- a/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-SQLServer-CREATE.sql
@@ -305,7 +305,7 @@ CREATE TABLE users (
   active_widget_layouts VARCHAR(1024) DEFAULT NULL,
   display_name VARCHAR(255) NOT NULL,
   local_username VARCHAR(255) NOT NULL,
-  create_time DATETIME DEFAULT GETDATE(),
+  create_time BIGINT NOT NULL,
   version BIGINT NOT NULL DEFAULT 0,
   CONSTRAINT PK_users PRIMARY KEY (user_id),
   CONSTRAINT FK_users_principal_id FOREIGN KEY (principal_id) REFERENCES adminprincipal(principal_id),
@@ -316,8 +316,8 @@ CREATE TABLE user_authentication (
   user_id INTEGER NOT NULL,
   authentication_type VARCHAR(50) NOT NULL,
   authentication_key VARCHAR(2048),
-  create_time DATETIME DEFAULT GETDATE(),
-  update_time DATETIME DEFAULT GETDATE(),
+  create_time BIGINT NOT NULL,
+  update_time BIGINT NOT NULL,
   CONSTRAINT PK_user_authentication PRIMARY KEY (user_authentication_id),
   CONSTRAINT FK_user_authentication_users FOREIGN KEY (user_id) REFERENCES users (user_id)
 );
@@ -1227,12 +1227,12 @@ BEGIN TRANSACTION
 
   -- Insert the default administrator user.
   insert into users(user_id, principal_id, user_name, display_name, local_username, create_time)
-    select 1, 1, 'admin', 'Administrator', 'admin', GETDATE();
+    select 1, 1, 'admin', 'Administrator', 'admin', CAST(DATEDIFF(s, '1970-01-01T00:00:00Z', GETDATE()) as BIGINT) * 1000;
 
   -- Insert the LOCAL authentication data for the default administrator user.
   -- The authentication_key value is the salted digest of the password: admin
   insert into user_authentication(user_authentication_id, user_id, authentication_type, authentication_key, create_time, update_time)
-    select 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', GETDATE(), GETDATE();
+    select 1, 1, 'LOCAL', '538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00', CAST(DATEDIFF(s, '1970-01-01T00:00:00Z', GETDATE()) as BIGINT) * 1000, CAST(DATEDIFF(s, '1970-01-01T00:00:00Z', GETDATE()) as BIGINT) * 1000;
 
 
   insert into adminpermission(permission_id, permission_name, resource_type_id, permission_label, principal_id, sort_order)

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserAuthenticationSourceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserAuthenticationSourceResourceProviderTest.java
@@ -23,7 +23,6 @@ import static org.easymock.EasyMock.expectLastCall;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -73,8 +72,8 @@ import com.google.inject.Injector;
  */
 public class UserAuthenticationSourceResourceProviderTest extends EasyMockSupport {
 
-  private static final Date CREATE_TIME = Calendar.getInstance().getTime();
-  private static final Date UPDATE_TIME = Calendar.getInstance().getTime();
+  private static final long CREATE_TIME = Calendar.getInstance().getTime().getTime();
+  private static final long UPDATE_TIME = Calendar.getInstance().getTime().getTime();
 
   @Before
   public void resetMocks() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserResourceProviderTest.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -129,7 +128,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
  */
 public class UserResourceProviderTest extends EasyMockSupport {
 
-  private static final Date CREATE_TIME = Calendar.getInstance().getTime();
+  private static final long CREATE_TIME = Calendar.getInstance().getTime().getTime();
 
   @Before
   public void resetMocks() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
@@ -409,7 +409,7 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
     expect(userEntity.getActive()).andReturn(true).atLeastOnce();
     expect(userEntity.getUserId()).andReturn(1).atLeastOnce();
     expect(userEntity.getUserName()).andReturn("username").atLeastOnce();
-    expect(userEntity.getCreateTime()).andReturn(new Date()).atLeastOnce();
+    expect(userEntity.getCreateTime()).andReturn(new Date().getTime()).atLeastOnce();
     expect(userEntity.getMemberEntities()).andReturn(Collections.emptySet()).atLeastOnce();
     expect(userEntity.getAuthenticationEntities()).andReturn(Collections.singletonList(userAuthenticationEntity)).atLeastOnce();
     expect(userEntity.getPrincipal()).andReturn(principal).atLeastOnce();

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -2041,7 +2040,7 @@ public class AmbariLdapDataPopulatorTest {
     final UserEntity userEntity = new UserEntity();
     userEntity.setUserId(userIdCounter++);
     userEntity.setUserName(UserName.fromString(name).toString());
-    userEntity.setCreateTime(new Date());
+    userEntity.setCreateTime(0);
     userEntity.setActive(true);
     userEntity.setMemberEntities(new HashSet<>());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to support older versions of MySQL database we changed the type from TIMESTAMP to long (BIGINT, NUMERIC, etc..) in case of the following columns:

- users.create_time
- user_authentication.create_time
- user_authentication.update_time

Please note that according to the [official support matrix](https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.5/bk_support-matrices/content/ch_matrices-ambari.html#ambari_min-sys-req) Derby and SQL Anywhere are not supported so I set the value of the Ambari admin user in these DDL creation scripts to 0.

## How was this patch tested?

Updated unit tests to follow my changes; latest build result in `ambari-server`:
```
HW15069:ambari-server smolnar$ mvn clean install
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 46:54 min
[INFO] Finished at: 2018-06-04T14:23:47+02:00
[INFO] Final Memory: 164M/766M
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing the following test steps have been executed:

1. have an Ambari 2.7.0.0-568 with updated `ambari-server.jar`
2. properly configured DB
3. created Ambari schema with updated DDL creation scripts
4. created a test user
5. changed its password

Test results:
```
-- MariaDB

[root@c7401 ~]# mysql --version
mysql  Ver 15.1 Distrib 10.2.15-MariaDB, for Linux (x86_64) using readline 5.1

[root@c7401 ~]# mysql -u ambari -p
Enter password: 
...
MariaDB [(none)]> use ambari;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
MariaDB [ambari]> select * from users;
+---------+--------------+-------------------+--------+----------------------+-----------------------+-------------------+-------------------+---------------+---------+
| user_id | principal_id | user_name         | active | consecutive_failures | active_widget_layouts | display_name      | local_username    | create_time   | version |
+---------+--------------+-------------------+--------+----------------------+-----------------------+-------------------+-------------------+---------------+---------+
|       1 |            1 | admin             |      1 |                    0 | NULL                  | Administrator     | admin             | 1528104756000 |       0 |
|       3 |           14 | test_mariadb_user |      1 |                    0 | NULL                  | test_mariadb_user | test_mariadb_user | 1528109102915 |       1 |
+---------+--------------+-------------------+--------+----------------------+-----------------------+-------------------+-------------------+---------------+---------+
2 rows in set (0.00 sec)


MariaDB [ambari]> select * from user_authentication;
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
| user_authentication_id | user_id | authentication_type | authentication_key                                                               | create_time   | update_time   |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
|                      1 |       1 | LOCAL               | 538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00 | 1528104756000 | 1528104756000 |
|                      3 |       3 | LOCAL               | a6025181ad03518ab424d75e816e4f66382106d5ae6abe0e0ab0818f6d923b73b106e70cda5bdded | 1528109102972 | 1528109102972 |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
2 rows in set (0.00 sec)


MariaDB [ambari]> select * from user_authentication;
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
| user_authentication_id | user_id | authentication_type | authentication_key                                                               | create_time   | update_time   |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
|                      1 |       1 | LOCAL               | 538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00 | 1528104756000 | 1528104756000 |
|                      3 |       3 | LOCAL               | be6f6e8ee21a737c662414b94477d005d55e5dc5c1afcdafba5e4841d50edebd6d6a1720a01ef590 | 1528109102972 | 1528109675715 |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
2 rows in set (0.00 sec)


-- MySQL

[root@c7401 ~]# mysql --version
mysql  Ver 14.14 Distrib 5.7.22, for Linux (x86_64) using  EditLine wrapper

[root@c7401 ~]# mysql -u ambari -p
Enter password: 
...
mysql> use ambari;
Database changed

mysql> select * from users;
+---------+--------------+-----------------+--------+----------------------+-----------------------+-----------------+-----------------+---------------+---------+
| user_id | principal_id | user_name       | active | consecutive_failures | active_widget_layouts | display_name    | local_username  | create_time   | version |
+---------+--------------+-----------------+--------+----------------------+-----------------------+-----------------+-----------------+---------------+---------+
|       1 |            1 | admin           |      1 |                    0 | NULL                  | Administrator   | admin           | 1528111003000 |       0 |
|     503 |          514 | test_mysql_user |      1 |                    0 | NULL                  | test_mysql_user | test_mysql_user | 1528111479084 |       1 |
+---------+--------------+-----------------+--------+----------------------+-----------------------+-----------------+-----------------+---------------+---------+
2 rows in set (0.00 sec)

mysql> select * from user_authentication;
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
| user_authentication_id | user_id | authentication_type | authentication_key                                                               | create_time   | update_time   |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
|                      1 |       1 | LOCAL               | 538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00 | 1528111003000 | 1528111003000 |
|                      3 |     503 | LOCAL               | fc7a3e35609dcfe60b0a7fb606964fe54a7f001b438c316236c6108f3753c4959ed55c36fb28ba0d | 1528111479132 | 1528111479132 |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
2 rows in set (0.00 sec)

mysql> select * from user_authentication;
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
| user_authentication_id | user_id | authentication_type | authentication_key                                                               | create_time   | update_time   |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
|                      1 |       1 | LOCAL               | 538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00 | 1528111003000 | 1528111003000 |
|                      3 |     503 | LOCAL               | 24c3d8f33572fa0ef5f9646d07f33f432c275a6f120c315569aaff9d4a0fb4224e5163c02a0839e7 | 1528111479132 | 1528111558848 |
+------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------+
2 rows in set (0.00 sec)

-- Postgres

[root@c7401 ~]# psql -U ambari
Password for user ambari: 
psql (9.2.23)
Type "help" for help.

ambari=> select * from users;
 user_id | principal_id |    user_name     | active | consecutive_failures | active_widget_layouts |   display_name   |  local_username  |  create_time  | version 
---------+--------------+------------------+--------+----------------------+-----------------------+------------------+------------------+---------------+---------
       1 |            1 | admin            |      1 |                    0 |                       | Administrator    | admin            | 1527794342000 |       0
       3 |           14 | testuserpostgres |      1 |                    0 |                       | testuserpostgres | testuserpostgres | 1527794520844 |       1
(2 rows)

ambari=> select * from user_authentication;
 user_authentication_id | user_id | authentication_type |                                authentication_key                                |  create_time  |  update_time  
------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------
                      1 |       1 | LOCAL               | 538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00 | 1527794342000 | 1527794342000
                      3 |       3 | LOCAL               | 88b99700b06e23dde078b7986caf5592490ce31c1da0a19a8ba2e40c86e2800a8b8cae85776d2a90 | 1527794520878 | 1527794520878
(2 rows)

ambari=> select * from user_authentication;
 user_authentication_id | user_id | authentication_type |                                authentication_key                                |  create_time  |  update_time  
------------------------+---------+---------------------+----------------------------------------------------------------------------------+---------------+---------------
                      1 |       1 | LOCAL               | 538916f8943ec225d97a9a86a2c6ec0818c1cd400e09e03b660fdaaec4af29ddbb6f2b1033b81b00 | 1527794342000 | 1527794342000
                      3 |       3 | LOCAL               | ba1547dd0290b8fe399dab037ddafb8aa05c3ee0a200cd4810a1b8022eef50b0c33c74cea46abeab | 1527794520878 | 1527794590174
(2 rows)
```

Since I did not test the above scenario using Oracle I made sure I made the proper changes in the DDL script on http://sqlfiddle.com/ page (created a test schema and checked if I extract POSIX (epoch) time from the DB as desired). I did the same for all kind of DBs we support.

