### PR TITLE
[AMBARI-24024] - Logsearch: service advisor does not set recommended nu…

### DIFF
--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/service_advisor.py
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/service_advisor.py
@@ -21,13 +21,6 @@ limitations under the License.
 import imp
 import os
 import traceback
-import re
-import socket
-import fnmatch
-import math
-
-
-from resource_management.core.logger import Logger
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 STACKS_DIR = os.path.join(SCRIPT_DIR, '../../../stacks/')
@@ -140,34 +133,25 @@ class LogSearchServiceAdvisor(service_advisor.ServiceAdvisor):
       infraSolrHosts = self.getComponentHostNames(services, "AMBARI_INFRA_SOLR", "INFRA_SOLR")
       # if there is AMBARI_INFRA, calculate the min/max shards and recommendations based on the number of infra solr hosts
       if infraSolrHosts is not None and len(infraSolrHosts) > 0 and "logsearch-properties" in services["configurations"]:
-        replicationReccomendFloat = math.log(len(infraSolrHosts), 5)
-        recommendedReplicationFactor = int(1 + math.floor(replicationReccomendFloat))
-        
         recommendedMinShards = len(infraSolrHosts)
         recommendedShards = 2 * len(infraSolrHosts)
-        recommendedMaxShards = max(3 * len(infraSolrHosts), 5)
-      # if there is no AMBARI_INFRA (i.e. external solr is used), use default values for min/max shards and recommendations
+        recommendedMaxShards = 10 * len(infraSolrHosts)
       else:
-        recommendedReplicationFactor = 2
-        
+        # if there is no AMBARI_INFRA (i.e. external solr is used), use default values for min/max shards and recommendations
         recommendedMinShards = 1
         recommendedShards = 1
         recommendedMaxShards = 100
-        
         putLogSearchCommonEnvProperty('logsearch_use_external_solr', 'true')
         
-        # recommend number of shard
-        putLogSearchAttribute('logsearch.collection.service.logs.numshards', 'minimum', recommendedMinShards)
-        putLogSearchAttribute('logsearch.collection.service.logs.numshards', 'maximum', recommendedMaxShards)
-        putLogSearchProperty("logsearch.collection.service.logs.numshards", recommendedShards)
-      
-        putLogSearchAttribute('logsearch.collection.audit.logs.numshards', 'minimum', recommendedMinShards)
-        putLogSearchAttribute('logsearch.collection.audit.logs.numshards', 'maximum', recommendedMaxShards)
-        putLogSearchProperty("logsearch.collection.audit.logs.numshards", recommendedShards)
-        # recommend replication factor
-        putLogSearchProperty("logsearch.collection.service.logs.replication.factor", recommendedReplicationFactor)
-        putLogSearchProperty("logsearch.collection.audit.logs.replication.factor", recommendedReplicationFactor)
-      
+      # recommend number of shard
+      putLogSearchAttribute('logsearch.collection.service.logs.numshards', 'minimum', recommendedMinShards)
+      putLogSearchAttribute('logsearch.collection.service.logs.numshards', 'maximum', recommendedMaxShards)
+      putLogSearchProperty("logsearch.collection.service.logs.numshards", recommendedShards)
+
+      putLogSearchAttribute('logsearch.collection.audit.logs.numshards', 'minimum', recommendedMinShards)
+      putLogSearchAttribute('logsearch.collection.audit.logs.numshards', 'maximum', recommendedMaxShards)
+      putLogSearchProperty("logsearch.collection.audit.logs.numshards", recommendedShards)
+
     kerberos_authentication_enabled = self.isSecurityEnabled(services)
     # if there is no kerberos enabled hide kerberor related properties
     if not kerberos_authentication_enabled:


### PR DESCRIPTION
…mber of shards

## What changes were proposed in this pull request?

- When installing Logsearch using the Ambari deployment wizard the configuration page of Logsearch offers us to set the number of solr shards for hadoop and audit logs. It also recommends a value. This recommendation function was not working.
- Use the default value for ReplicationFactor
- Set the max number of solr chards to 10x<number of solr hosts>

## How was this patch tested?

Manually:
1. Install Ambari and deploy a cluster including zookeeper and infra-solr
2. Add service: Logsearch
3. Check the configuration page offers the right number of shards.

Please review
@oleewere @swagle @zeroflag 