### PR TITLE
[AMBARI-24027] Missing name for the request related to EU pre-check for Hadoop sink version

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCompatibilityCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCompatibilityCheck.java
@@ -163,8 +163,7 @@ public class AmbariMetricsHadoopSinkVersionCompatibilityCheck extends AbstractCh
 
     Map<String, String> requestInfoProperties = new HashMap<>();
     requestInfoProperties.put(RequestResourceProvider.COMMAND_ID, "CHECK_HADOOP_SINK_VERSION");
-    requestInfoProperties.put(RequestResourceProvider.REQUEST_CONTEXT_ID, "Pre Upgrade check for compatible Hadoop Metric " +
-      "Sink version on all hosts.");
+    requestInfoProperties.put(RequestResourceProvider.CONTEXT, "Pre Upgrade check for Hadoop Metric Sink version");
 
     Request request = PropertyHelper.getCreateRequest(propertiesSet, requestInfoProperties);
     try {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceProvider.java
@@ -138,6 +138,7 @@ public class RequestResourceProvider extends AbstractControllerResourceProvider 
   public static final String INPUTS_ID = "parameters";
   public static final String EXCLUSIVE_ID = "exclusive";
   public static final String HAS_RESOURCE_FILTERS = "HAS_RESOURCE_FILTERS";
+  public static final String CONTEXT = "context";
 
   private static final Set<String> PK_PROPERTY_IDS = ImmutableSet.of(REQUEST_ID_PROPERTY_ID);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the issue of request name not showing up.

## How was this patch tested?

Manual testing on cluster.
