### PR TITLE
Even though REST call to start Timeline Server was issued, start command was never sent to ambari-agent

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/ComponentStatusReport.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/ComponentStatusReport.java
@@ -77,8 +77,7 @@ public class ComponentStatusReport {
   }
 
   public enum CommandStatusCommand {
-    STATUS,
-    SECURITY_STATUS
+    STATUS
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/MetadataCluster.java
@@ -47,9 +47,6 @@ public class MetadataCluster {
     this.statusCommandsToRun  = new HashSet<>();
     if (securityType != null) {
       this.statusCommandsToRun.add("STATUS");
-      if (SecurityType.KERBEROS.equals(securityType)) {
-        this.statusCommandsToRun.add("SECURITY_STATUS");
-      }
     }
     this.fullServiceLevelMetadata = fullServiceLevelMetadata;
     this.serviceLevelParams = serviceLevelParams;


### PR DESCRIPTION
Ambari-server confuses SECURITY_STATUS and STATUS:

Agent said:
INFO 2018-06-04 04:57:58,477 security.py:118 - Event to server at /reports/component_status (correlation_id=2230): {'clusters': defaultdict(<function <lambda> at 0x7f5d4c6a7500>, {u'2': [{'status': 'STARTED', 'componentName': u'APP_TIMELINE_SERVER', 'serviceName': u'YARN', 'clusterId': u'2', 'command': u'SECURITY_STATUS'}]})}
INFO 2018-06-04 04:57:58,481 __init__.py:49 - Event from server at /user/ (correlation_id=2230): {u'status': u'OK'}
Server did:
2018-06-04 04:57:58,487  INFO [agent-report-processor-1] HeartbeatProcessor:581 - State of service component APP_TIMELINE_SERVER of service YARN of cluster 2 has changed from INSTALLED to STARTED at host ctr-e138-1518143905142-343971-02-000003.hwx.site according to STATUS_COMMAND report

Security_status was removed long time ago. But by perf changes it was re-introuduced while not being supported. Removing it again.