### PR TITLE
[AMBARI-24035] - Autostart is not obeying Maintenance Mode

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolder.java
@@ -146,15 +146,15 @@ public class HostLevelParamsHolder extends AgentHostDataHolder<HostLevelParamsUp
   }
 
   @Subscribe
-  public void onServiceComponentRecoveryChanged(MaintenanceModeEvent event) throws AmbariException {
+  public void onMaintenanceModeChanged(MaintenanceModeEvent event) throws AmbariException {
     long clusterId = event.getClusterId();
     Cluster cluster = clusters.getCluster(clusterId);
     if (event.getHost() != null || event.getServiceComponentHost() != null) {
-      Host host = event.getHost() != null ? event.getHost() : cluster.getHost(event.getServiceComponentHost().getHostName());
+      Host host = event.getHost() != null ? event.getHost() : event.getServiceComponentHost().getHost();
       updateDataOfHost(clusterId, cluster, host);
     }
     else if (event.getService() != null) {
-      for (String hostName : cluster.getService(event.getService().getName()).getServiceHosts()) {
+      for (String hostName : event.getService().getServiceHosts()) {
         updateDataOfHost(clusterId, cluster, cluster.getHost(hostName));
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When turning on/off host/service/component level maintenance mode on Ambari UI Ambari agents are not notified. If autostart is enabled before turning on maintenance mode for any service component the components are restarted.
Fix: re-send recovery configurations to agents when turning on/off maintenance mode.

## How was this patch tested?

mvn clean install ambari-server

Manually:
1. Install Ambari and deploy a HDP cluster at least 2 hosts.
2. Enable autostart for all the components
3. Turn on maintenance mode for the host not contains ambari server
4. Restart the host.
After the host is rebooted components shouldn't be started.

Or 
3. Turn on maintenance mode for a service or component not installed the host where ambari server is located

Please review
@swagle @mpapirkovskyy @hapylestat @adoroszlai 