### PR TITLE
[AMBARI-24026] - Service deletion requests get queued up in Background Ops during Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/annotations/ExperimentalFeature.java
+++ b/ambari-server/src/main/java/org/apache/ambari/annotations/ExperimentalFeature.java
@@ -42,5 +42,11 @@ public enum ExperimentalFeature {
   /**
    * Support for service-specific repos for custom services
    */
-  CUSTOM_SERVICE_REPOS
+  CUSTOM_SERVICE_REPOS,
+
+  /**
+   * Automatically removing Kerberos identities when a service or component is
+   * removed.
+   */
+  ORPHAN_KERBEROS_IDENTITY_REMOVAL;
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/KerberosIdentityCleaner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/KerberosIdentityCleaner.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ambari.server.controller.utilities;
 
+import org.apache.ambari.annotations.Experimental;
+import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.events.ServiceComponentUninstalledEvent;
 import org.apache.ambari.server.events.ServiceRemovedEvent;
@@ -32,6 +34,9 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 @Singleton
+@Experimental(
+    feature = ExperimentalFeature.ORPHAN_KERBEROS_IDENTITY_REMOVAL,
+    comment = "This might need to have a switch so that it can be turned off if it is found to be desctructive to certain clusters")
 public class KerberosIdentityCleaner {
   private final static Logger LOG = LoggerFactory.getLogger(KerberosIdentityCleaner.class);
   private final AmbariEventPublisher eventPublisher;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/RemovableIdentities.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/RemovableIdentities.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.ambari.annotations.Experimental;
+import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.utilities.UsedIdentities.ComponentExclude;
@@ -45,6 +47,7 @@ import org.apache.ambari.server.state.kerberos.KerberosServiceDescriptor;
  * I represent a group of kerberos identities which are to be deleted after a service or a component was removed.
  * My instances provide methods for removing the candidates, excluding those that are still used by other components or services.
  */
+@Experimental(feature = ExperimentalFeature.ORPHAN_KERBEROS_IDENTITY_REMOVAL)
 public class RemovableIdentities {
   private final List<KerberosIdentityDescriptor> candidateIdentities;
   private final UsedIdentities usedIdentities;

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/DeleteUnsupportedServicesAndComponents.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/DeleteUnsupportedServicesAndComponents.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 
+import org.apache.ambari.annotations.Experimental;
+import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
@@ -46,9 +48,18 @@ import org.apache.commons.lang.StringUtils;
 import com.google.inject.Inject;
 
 /**
- * Upgrade Server Action that deletes the components and services which are no longer supported in the target stack.
- * The deletable component or service should be in deletable state (stopped) before executing this.
+ * Upgrade Server Action that deletes the components and services which are no
+ * longer supported in the target stack. The deletable component or service
+ * should be in deletable state (stopped) before executing this.
+ * <p/>
+ * This will orphan Kerberos keytabs and identities that belonged to the removed
+ * services and components. Since removing these automatically is a new and
+ * untested feature, its best to leave this type of cleanup to a future
+ * implementation.
  */
+@Experimental(
+    feature = ExperimentalFeature.ORPHAN_KERBEROS_IDENTITY_REMOVAL,
+    comment = "Not removing identities yet")
 public class DeleteUnsupportedServicesAndComponents extends AbstractUpgradeServerAction {
   @Inject
   private ServiceComponentSupport serviceComponentSupport;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Automatically removing Kerberos identities was a feature which was added to Ambari 2.7 (which might not be very safe). It's triggered by events which are sent when removing a service or a component from a host. 

If an upgrade is in progress, we should be skipping this step and orphaning them (as prior versions of Ambari did) since there are too many ways this could break an upgrade. In theory, we could inject the cleanup steps into the upgrade, but this is a very invasive and brittle feature.

## How was this patch tested?

New unit tests written, ran an upgrade to ensure no new requests were created.