### PR TITLE
[AMBARI-24037] Alerts label isn't clickable at the service page after turning on mm for service

### DIFF
--- a/ambari-web/app/models/alerts/alert_definition.js
+++ b/ambari-web/app/models/alerts/alert_definition.js
@@ -155,7 +155,7 @@ App.AlertDefinition = DS.Model.extend({
     order.forEach(function (state) {
       var cnt = summary[state] ? summary[state].count + summary[state].maintenanceCount : 0;
       if (cnt > 0) {
-        text = summary[state].latestText;
+        text = Em.getWithDefault(summary[state], 'latestText', '');
       }
     });
     return text;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Alerts label isn't clickable at the service page after turning on mm for service

STR:
1. Go to the service page
2. Enable mm for service
3. Try to click alerts(bell) icon for the current service

Expected:
Will open alerts window

Actual
Nothing happens

## How was this patch tested?

UI unit tests:
  21800 passing (25s)
  48 pending