### PR TITLE
[AMBARI-24038 HDFS] Metrics shows all blocks as 'Corrupt Replicas'

### DIFF
--- a/ambari-web/app/views/main/service/info/summary/hdfs/widgets.js
+++ b/ambari-web/app/views/main/service/info/summary/hdfs/widgets.js
@@ -63,7 +63,7 @@ App.HDFSSummaryWidgetsView = Em.View.extend(App.NameNodeWidgetMixin, App.HDFSSum
 
   dfsTotalBlocks: Em.computed.formatUnavailable('dfsTotalBlocksValue'),
 
-  dfsCorruptBlocksValue: Em.computed.getByKey('model.dfsTotalBlocksValues', 'hostName'),
+  dfsCorruptBlocksValue: Em.computed.getByKey('model.dfsCorruptBlocksValues', 'hostName'),
 
   dfsCorruptBlocks: Em.computed.formatUnavailable('dfsCorruptBlocksValue'),
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

*STR*
1. Deployed a cluster with HDP-3.0 and Ambari-2.7 (or upgrade from HDP-2.6 to HDP-3.0)
2. Go to HDFS Summary page
3. Observe the count of blocks under 'Corrupt Replica'

*Result*
All blocks show as corrupt

## How was this patch tested?

UI unit tests:
  21800 passing (30s)
  48 pending
