### PR TITLE
[AMBARI-24039] Quicklinks for HBASE are not displayed.

### DIFF
--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -2564,6 +2564,7 @@ a.abort-icon:hover {
     }
   }
   .mpack-summary {
+    padding-bottom: 20px;
     .col-md-2 {
       top: 0;
     }

--- a/ambari-web/app/templates/main/service/service.hbs
+++ b/ambari-web/app/templates/main/service/service.hbs
@@ -20,7 +20,7 @@
   <div class="summary-info">
     <div class="row mpack-summary">
       <div class="col-md-12">
-        <div class="col-md-2">{{t common.mpack.short}}:</div>
+        <div class="col-md-2">{{t common.mpack.short}}</div>
         <div class="col-md-10 main-info summary-value">{{view.mpackVersion}}</div>
       </div>
     </div>

--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -175,12 +175,14 @@ App.QuickLinksView = Em.View.extend({
    */
   loadQuickLinksConfigurations: function () {
     var serviceName = this.get('content.serviceName');
+    let serviceStackName = App.StackService.find().findProperty('serviceName', serviceName).get('stackName');
+    let serviceStackVersion = App.StackService.find().findProperty('serviceName', serviceName).get('stackVersion');
     return App.ajax.send({
       name: 'configs.quicklinksconfig',
       sender: this,
       data: {
         serviceName: serviceName,
-        stackVersionUrl: App.get('stackVersionURL')
+        stackVersionUrl: App.getStackVersionUrl(serviceStackName, serviceStackVersion)
       },
       success: 'loadQuickLinksConfigSuccessCallback'
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Replaced cluster stack version with the service stack versions to show quiclinks.
- Fixed mpack display info in the service summary page

## How was this patch tested?
  19688 passing (16s)
  46 pending
Manually tested on cluster.