### PR TITLE
[AMBARI-24041] AMS truncates metric response quietly.

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
@@ -273,8 +273,8 @@ public abstract class AbstractTimelineAggregator implements TimelineMetricAggreg
       if (condition.doUpdate()) {
         conn.setAutoCommit(true);
         int rows = stmt.executeUpdate();
-        conn.setAutoCommit(false);
         conn.commit();
+        conn.setAutoCommit(false);
         LOG.info(rows + " row(s) updated in aggregation.");
 
         //TODO : Fix downsampling after UUID change.

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
@@ -271,6 +271,7 @@ public abstract class AbstractTimelineAggregator implements TimelineMetricAggreg
 
       LOG.debug("Query issued @: " + new Date());
       if (condition.doUpdate()) {
+        conn.setAutoCommit(true);
         int rows = stmt.executeUpdate();
         conn.commit();
         LOG.info(rows + " row(s) updated in aggregation.");

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
@@ -273,6 +273,7 @@ public abstract class AbstractTimelineAggregator implements TimelineMetricAggreg
       if (condition.doUpdate()) {
         conn.setAutoCommit(true);
         int rows = stmt.executeUpdate();
+        conn.setAutoCommit(false);
         conn.commit();
         LOG.info(rows + " row(s) updated in aggregation.");
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/query/PhoenixTransactSQL.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/query/PhoenixTransactSQL.java
@@ -508,6 +508,8 @@ public class PhoenixTransactSQL {
       String query;
       if (condition.getPrecision() == null) {
         condition.setPrecision(getBestPrecisionForCondition(condition));
+      } else {
+        condition.setNoLimit();
       }
       switch (condition.getPrecision()) {
         case DAYS:
@@ -703,6 +705,8 @@ public class PhoenixTransactSQL {
     String queryStmt;
     if (condition.getPrecision() == null) {
       condition.setPrecision(getBestPrecisionForCondition(condition));
+    } else {
+      condition.setNoLimit();
     }
     switch (condition.getPrecision()) {
       case DAYS:

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/TestPhoenixTransactSQL.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/TestPhoenixTransactSQL.java
@@ -155,6 +155,7 @@ public class TestPhoenixTransactSQL {
     PhoenixTransactSQL.prepareGetAggregateSqlStmt(connection, condition);
     String stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_AGGREGATE_MINUTE_UUID"));
+    Assert.assertNull(condition.getLimit());
     verify(connection, preparedStatement);
   }
 
@@ -220,6 +221,7 @@ public class TestPhoenixTransactSQL {
     PhoenixTransactSQL.prepareGetAggregateSqlStmt(connection, condition);
     stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_AGGREGATE_HOURLY_UUID"));
+    Assert.assertNotNull(condition.getLimit());
     Assert.assertEquals(Precision.HOURS, condition.getPrecision());
     verify(connection, preparedStatement);
 
@@ -257,6 +259,7 @@ public class TestPhoenixTransactSQL {
     PhoenixTransactSQL.prepareGetAggregateSqlStmt(connection, condition);
     String stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_AGGREGATE_HOURLY_UUID"));
+    Assert.assertNull(condition.getLimit());
     verify(connection, preparedStatement);
   }
 
@@ -275,6 +278,7 @@ public class TestPhoenixTransactSQL {
     PhoenixTransactSQL.prepareGetMetricsSqlStmt(connection, condition);
     String stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_RECORD_MINUTE_UUID"));
+    Assert.assertNull(condition.getLimit());
     verify(connection, preparedStatement);
   }
 
@@ -322,6 +326,7 @@ public class TestPhoenixTransactSQL {
     stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_RECORD_UUID"));
     Assert.assertEquals(Precision.SECONDS, condition.getPrecision());
+    Assert.assertNotNull(condition.getLimit());
     verify(connection, preparedStatement);
 
     // MINUTES precision
@@ -340,6 +345,7 @@ public class TestPhoenixTransactSQL {
     stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_RECORD_MINUTE_UUID"));
     Assert.assertEquals(Precision.MINUTES, condition.getPrecision());
+    Assert.assertNotNull(condition.getLimit());
     verify(connection, preparedStatement);
 
     // HOURS precision
@@ -357,6 +363,7 @@ public class TestPhoenixTransactSQL {
     stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_RECORD_HOURLY_UUID"));
     Assert.assertEquals(Precision.HOURS, condition.getPrecision());
+    Assert.assertNotNull(condition.getLimit());
     verify(connection, preparedStatement);
 
     // DAYS precision
@@ -374,6 +381,7 @@ public class TestPhoenixTransactSQL {
     stmt = stmtCapture.getValue();
     Assert.assertTrue(stmt.contains("FROM METRIC_RECORD_DAILY_UUID"));
     Assert.assertEquals(Precision.DAYS, condition.getPrecision());
+    Assert.assertNotNull(condition.getLimit());
     verify(connection, preparedStatement);
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed an issue where the SELECT query limit should be set to NULL when the user specifies a precision. 
Set autocommit to be true for UPSERT aggregation.
Batch write records such that phoenix mutate batch size is not exceeded.
 
## How was this patch tested?
Manually tested.
mvn clean install.