### PR TITLE
[AMBARI-24015] Add the dependency of slf4j-log4j12 to fix the lack of log4j output

### DIFF
--- a/ambari-logsearch/ambari-logsearch-portal/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-portal/pom.xml
@@ -529,6 +529,10 @@
     <artifactId>log4j</artifactId>
     <version>1.2.17</version>
   </dependency>
+     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>


### PR DESCRIPTION
[AMBARI-24015] Add the dependency of slf4j-log4j12 to fix the lack of log4j output

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.