### PR TITLE
[AMBARI-24015] Add the dependency of slf4j-log4j12 to fix the lack of…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-portal/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-portal/pom.xml
@@ -569,6 +569,10 @@
     <version>1.2.17</version>
   </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
       <version>${solr.version}</version>


### PR DESCRIPTION
Fix the bug of lacking dependency of slf4j-log4j12

## What changes were proposed in this pull request?
Add the dependency of slf4j-log4j12 to pom.xml of ambari-logsearch-portal

## How was this patch tested?
The output of log4j changed to be full after adding this dependency.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.