### PR TITLE
[AMBARI-24042]. Kafka Service Check failed on https enabled/WE cluster …

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/params.py
@@ -71,6 +71,8 @@ zookeeper_connect = default("/configurations/kafka-broker/zookeeper.connect", No
 kafka_user_nofile_limit = default('/configurations/kafka-env/kafka_user_nofile_limit', 128000)
 kafka_user_nproc_limit = default('/configurations/kafka-env/kafka_user_nproc_limit', 65536)
 
+kafka_delete_topic_enable = default('/configurations/kafka-broker/delete.topic.enable', True)
+
 # parameters for 2.2+
 if stack_version_formatted and check_stack_feature(StackFeature.ROLLING_UPGRADE, stack_version_formatted):
   kafka_home = os.path.join(stack_root,  "current", "kafka-broker")

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
@@ -44,6 +44,9 @@ class ServiceCheck(Script):
     if topic_exists_cmd_code > 0:
       raise Fail("Error encountered when attempting to list topics: {0}".format(topic_exists_cmd_out))
 
+    if not params.kafka_delete_topic_enable:
+      Logger.info('Kafka delete.topic.enable is not enabled. Skipping topic creation: %s' % topic)
+      return
 
   # run create topic command only if the topic doesn't exists
     


### PR DESCRIPTION
…after Ambari Upgrade. Error : Failed to check that topic exists (amagyar)

## What changes were proposed in this pull request?

There is a kafka property (kafka-broker/delete.topic.enable) that controls whether deleting a topic via the admin tool is allowed or not. If this property is set to false, ambari service check is not able to delete a test topic and fails.

I added a check which makes the service to skip the topic create/delete operations and only list topic will be used to check if kafka is ok.

## How was this patch tested?

- set delete.topic.enable to false and verified that the service check returned early without trying to create/delete the topic
- set delete.topic.enabled to true and verified that the service check worked as before