### PR TITLE
AMBARI-24043. Increase outbound message buffer size.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -1862,11 +1862,18 @@ public class Configuration {
       "api.heartbeat.interval", 10000);
 
   /**
-   * The maximum size of a stomp text message. Default is 2 MB.
+   * The maximum size of an incoming stomp text message. Default is 2 MB.
    */
-  @Markdown(description = "The maximum size of a stomp text message. Default is 2 MB.")
-  public static final ConfigurationProperty<Integer> STOMP_MAX_MESSAGE_SIZE = new ConfigurationProperty<>(
+  @Markdown(description = "The maximum size of an incoming stomp text message. Default is 2 MB.")
+  public static final ConfigurationProperty<Integer> STOMP_MAX_INCOMING_MESSAGE_SIZE = new ConfigurationProperty<>(
       "stomp.max.message.size", 2*1024*1024);
+
+  /**
+   * The maximum size of a buffer for stomp message sending. Default is 5 MB.
+   */
+  @Markdown(description = "The maximum size of a buffer for stomp message sending. Default is 5 MB.")
+  public static final ConfigurationProperty<Integer> STOMP_MAX_BUFFER_MESSAGE_SIZE = new ConfigurationProperty<>(
+      "stomp.max.message.size", 5*1024*1024);
 
   /**
    * The maximum number of threads used to extract Ambari Views when Ambari
@@ -4577,10 +4584,17 @@ public class Configuration {
   }
 
   /**
-   * @return the maximum size of a stomp text message. Default is 2 MB.
+   * @return the maximum size of an incoming stomp text message. Default is 2 MB.
    */
-  public int getStompMaxMessageSize() {
-    return Integer.parseInt(getProperty(STOMP_MAX_MESSAGE_SIZE));
+  public int getStompMaxIncomingMessageSize() {
+    return Integer.parseInt(getProperty(STOMP_MAX_INCOMING_MESSAGE_SIZE));
+  }
+
+  /**
+   * @return the maximum size of a buffer for stomp message sending. Default is 5 MB.
+   */
+  public int getStompMaxBufferMessageSize() {
+    return Integer.parseInt(getProperty(STOMP_MAX_BUFFER_MESSAGE_SIZE));
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/AgentStompConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/AgentStompConfig.java
@@ -55,7 +55,7 @@ public class AgentStompConfig extends AbstractWebSocketMessageBrokerConfigurer {
 
   public DefaultHandshakeHandler getHandshakeHandler() {
     WebSocketServerFactory webSocketServerFactory = new WebSocketServerFactory(servletContext);
-    webSocketServerFactory.getPolicy().setMaxTextMessageSize(configuration.getStompMaxMessageSize());
+    webSocketServerFactory.getPolicy().setMaxTextMessageSize(configuration.getStompMaxIncomingMessageSize());
 
     return new DefaultHandshakeHandler(
         new JettyRequestUpgradeStrategy(webSocketServerFactory));
@@ -81,6 +81,7 @@ public class AgentStompConfig extends AbstractWebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
-    registration.setMessageSizeLimit(configuration.getStompMaxMessageSize());
+    registration.setMessageSizeLimit(configuration.getStompMaxIncomingMessageSize());
+    registration.setSendBufferSizeLimit(configuration.getStompMaxBufferMessageSize());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The outbound message buffer size was made configurable. Spring default (512KB) was exceeded by agent configurations update (about 750KB). Current default set to 5MB.

## How was this patch tested?

Manual testing.
