### PR TITLE
AMBARI-24046. Fix the incorrect string from config_name to config-name in mpack_advisor.py

### DIFF
--- a/ambari-server/src/main/resources/stacks/mpack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/mpack_advisor.py
@@ -1548,13 +1548,13 @@ class MpackAdvisorImpl(MpackAdvisor):
               userValue = convertToNumber(configurations[configName]["properties"][propertyName])
               maxValue = convertToNumber(recommendedDefaults[configName]["property_attributes"][propertyName]["maximum"])
               if userValue > maxValue:
-                validationItems.extend([{"config_name": propertyName, "item": self.getWarnItem("Value is greater than the recommended maximum of {0} ".format(maxValue))}])
+                validationItems.extend([{"config-name": propertyName, "item": self.getWarnItem("Value is greater than the recommended maximum of {0} ".format(maxValue))}])
             if "minimum" in recommendedDefaults[configName]["property_attributes"][propertyName] and \
                     propertyName in recommendedDefaults[configName]["properties"]:
               userValue = convertToNumber(configurations[configName]["properties"][propertyName])
               minValue = convertToNumber(recommendedDefaults[configName]["property_attributes"][propertyName]["minimum"])
               if userValue < minValue:
-                validationItems.extend([{"config_name": propertyName, "item": self.getWarnItem("Value is less than the recommended minimum of {0} ".format(minValue))}])
+                validationItems.extend([{"config-name": propertyName, "item": self.getWarnItem("Value is less than the recommended minimum of {0} ".format(minValue))}])
       validatedItems = self.toConfigurationValidationProblems(validationItems, configName)
       for validatedItem in validatedItems:
         item = dict(itemHead.items() + validatedItem.items())


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Issue:**
Call to function toConfigurationValidationProblems() breaks for following :
```
Traceback (most recent call last):
  File "/var/lib/ambari-server/resources/scripts/mpack_advisor_wrapper.py", line 148, in <module>
    main(sys.argv)
  File "/var/lib/ambari-server/resources/scripts/mpack_advisor_wrapper.py", line 126, in main
    result = mpackAdvisor.validateConfigurations()
  File "/var/lib/ambari-server/resources/scripts/../stacks/mpack_advisor.py", line 1149, in validateConfigurations
    validationItems = self.getConfigurationsValidationItems()
  File "/var/lib/ambari-server/resources/scripts/../stacks/mpack_advisor.py", line 1588, in getConfigurationsValidationItems
    self.validateMinMax(items, itemHead, recommendedDefaults, configurations)
  File "/var/lib/ambari-server/resources/scripts/../stacks/mpack_advisor.py", line 1563, in validateMinMax
    validatedItems = self.toConfigurationValidationProblems(validationItems, configName)
  File "/var/lib/ambari-server/resources/scripts/../stacks/mpack_advisor.py", line 1518, in toConfigurationValidationProblems
    "config_type": siteName, "config_name": validationProblem["config-name"] }
KeyError: 'config-name'
```

**Reason :** In *validateMinMax()* fn, when adding to validationItems, the string should be "config-name" instead of "config_name".

**Fix** : Updated "config_name" to "config-name".

## How was this patch tested?

On live cluster.