### PR TITLE
[AMBARI-24053] Do not move configs to Misc

### DIFF
--- a/ambari-web/app/controllers/wizard.js
+++ b/ambari-web/app/controllers/wizard.js
@@ -1758,27 +1758,22 @@ App.WizardController = Em.Controller.extend(App.LocalStorage, App.ThemesMappingM
    * Returns configs specific to the given service, stack, and stack version formatted as a blueprint fragment.
    * This is used to build out the Mpack Advisor config recommendation/validation request.
    * This is also used to get the "MISC" configs (configs not specific to a service).
-   * If we want to filter these down to just a subset, such as the "cluster-setttings.xml" configs, pass the corresponding "fileName" value.
    * 
    * @param {string} serviceName The name/type of the service to get configs for.
    * @param {string} stackName The name of the stack/mpack to get configs for.
    * @param {string} stackVersion The version of the stack/mpack to get configs for.
-   * @param {string} filename The file where the configs originate, such as "cluster-settings.xml". Ignored if set to null.
    * @param {array} configs List of configs to be filtered. This is typically all configs loaded from the stack information.
    */
-  getConfigsForServiceInstance: function (serviceName, stackName, stackVersion, fileName, configs) {
+  getConfigsForServiceInstance: function (serviceName, stackName, stackVersion, configs) {
     const serviceConfigs = configs.findProperty('serviceName', serviceName);
     
     if (serviceConfigs) {
       let serviceInstanceConfigs;
+      
       if (stackName && stackVersion) {
         serviceInstanceConfigs = serviceConfigs.configs.filter(config => (config.stackName === stackName && config.stackVersion === stackVersion) || config.stackName === undefined);
       } else {
         serviceInstanceConfigs = serviceConfigs.configs;
-      }  
-
-      if (fileName) {
-        serviceInstanceConfigs = serviceInstanceConfigs.filterProperty('fileName', fileName);
       }  
 
       serviceConfigs.set('configs', serviceInstanceConfigs);

--- a/ambari-web/app/mappers/configs/stack_config_properties_mapper.js
+++ b/ambari-web/app/mappers/configs/stack_config_properties_mapper.js
@@ -143,11 +143,7 @@ App.stackConfigPropertiesMapper = App.QuickDataMapper.create({
               }
             });
           }
-          /**
-           * merging stack info with that is stored on UI
-           * for now is not used; uncomment in will be needed
-           * this.mergeWithUI(config);
-           */
+
           if (this.isMiscService(config.StackConfigurations.property_type)) {
             this.handleSpecialProperties(config);
           } else {
@@ -224,17 +220,18 @@ App.stackConfigPropertiesMapper = App.QuickDataMapper.create({
   },
 
   /**
-   * defines if property should refer to MISC tab
-   * @param type
+   * Returns true if property type should be in the MISC category and appear on the Misc tab in the UI.
+   * 
+   * @param type property type to check
    * @returns {Boolean}
    */
   isMiscService: function(type) {
-    return type.length &&
-      (type.contains('USER')
-      || type.contains('GROUP')
-      || type.contains('ADDITIONAL_USER_PROPERTY')
-      || type.contains('UID')
-      || type.contains('GID'));
+    // return type.length &&
+    //   (type.contains('USER')
+    //   || type.contains('GROUP')
+    //   || type.contains('ADDITIONAL_USER_PROPERTY')
+    //   || type.contains('UID')
+    //   || type.contains('GID'));
   },
 
   /**

--- a/ambari-web/app/mixins/common/configs/enhanced_configs.js
+++ b/ambari-web/app/mixins/common/configs/enhanced_configs.js
@@ -240,7 +240,7 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
     const wizardController = this.get('wizardController');
 
     if (wizardController) {
-      recommendations.blueprint.configurations = wizardController.getConfigsForServiceInstance('MISC', null, null, 'cluster-settings.xml', configs);
+      recommendations.blueprint.configurations = wizardController.getConfigsForServiceInstance('MISC', null, null, configs);
       recommendations.blueprint.mpack_instances = wizardController.getMpackInstances(configs);
     } else {
       App.get('mpackInstances'); //TODO: implement this property on the App object along with a routine to populate it at startup, similar to App.allHostNames


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disabled moving certain configs, including user settings, to the Misc section.

## How was this patch tested?

Manually tested. Will fix unit tests later.