### PR TITLE
[AMBARI-24054] Making queries against kerberos_principal.principal_name and kerberos_keytab_principal.principal name case sensitive in MySQL/MariaDB

### DIFF
--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -969,7 +969,7 @@ ALTER TABLE clusters ADD CONSTRAINT FK_clusters_upgrade_id FOREIGN KEY (upgrade_
 
 -- Kerberos
 CREATE TABLE kerberos_principal (
-  principal_name VARCHAR(255) NOT NULL,
+  principal_name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   is_service SMALLINT NOT NULL DEFAULT 1,
   cached_keytab_path VARCHAR(255),
   CONSTRAINT PK_kerberos_principal PRIMARY KEY (principal_name)
@@ -989,7 +989,7 @@ CREATE TABLE kerberos_keytab (
 CREATE TABLE kerberos_keytab_principal (
   kkp_id BIGINT NOT NULL DEFAULT 0,
   keytab_path VARCHAR(255) NOT NULL,
-  principal_name VARCHAR(255) NOT NULL,
+  principal_name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   host_id BIGINT,
   is_distributed SMALLINT NOT NULL DEFAULT 0,
   CONSTRAINT PK_kkp PRIMARY KEY (kkp_id),


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default string searches on non-binary columns in MySQL/MariaDB are case-insensitive which caused an issue while looking up Kerberos principals in the DB (the query returned something where nothing should be found).
Making the queries against the affected field (principal name) case-sensitive solves this issue.

Please note this is a MySQL/MariaDB specific issue; it's not happening with Postgres and Oracle (I have not checked MS SQL).

## How was this patch tested?

Manually tested using MySQL 5.7 and MariaDB 10.3; the test steps were the same as described in the related JIRA's description (tried Kerberizing the cluster with wrong realm name and then re-tried with the correct one; they differed in capitalization only).