### PR TITLE
[AMBARI-24055] - INFRA_SOLR START failed

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
+++ b/ambari-infra/ambari-infra-solr-client/src/main/java/org/apache/ambari/infra/solr/AmbariSolrCloudCLI.java
@@ -19,6 +19,10 @@
 
 package org.apache.ambari.infra.solr;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -29,16 +33,12 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 public class AmbariSolrCloudCLI {
 
   private static final Logger LOG = LoggerFactory.getLogger(AmbariSolrCloudCLI.class);
 
-  private static final int ZK_CLIENT_TIMEOUT = 15000;
-  private static final int ZK_CLIENT_CONNECT_TIMEOUT = 15000;
+  private static final int ZK_CLIENT_TIMEOUT = 60000; // 1 minute
+  private static final int ZK_CLIENT_CONNECT_TIMEOUT = 60000; // 1 minute
   private static final String CREATE_COLLECTION_COMMAND = "create-collection";
   private static final String UPLOAD_CONFIG_COMMAND = "upload-config";
   private static final String DOWNLOAD_CONFIG_COMMAND = "download-config";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase Infra Solr Zookeeper Client connection timeout.

## How was this patch tested?

manually:
1. install Ambari
2. copy and install infra-solr-client rpm to hosts
3. deploy a cluster: zookeeper, infra-solr, logsearch
4. check if solr started after the cluster deployment wizard finished
5. Logsearch should display logs on UI

Please review
@oleewere @swagle @zeroflag 