### PR TITLE
[AMBARI-24058] - Infra Solr: Add GC options properties

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -292,6 +292,21 @@
     <on-ambari-upgrade add="true"/>
   </property>
 
+  <property>
+    <name>infra_solr_gc_log_opts</name>
+    <value>-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime</value>
+    <display-name>Infra Solr GC log options</display-name>
+    <description>Infra Solr GC log options</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
+    <name>infra_solr_gc_tune</name>
+    <value>-XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled</value>
+    <display-name>Infra Solr GC Tune</display-name>
+    <description>Infra Solr GC Tune</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+
   <!-- infra-solr-env.sh -->
   <property>
     <name>content</name>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -122,6 +122,8 @@ if "infra-solr-env" in config['configurations']:
   infra_solr_log_dir = config['configurations']['infra-solr-env']['infra_solr_log_dir']
   infra_solr_log = format("{infra_solr_log_dir}/solr-install.log")
   solr_env_content = config['configurations']['infra-solr-env']['content']
+  infra_solr_gc_log_opts = format(config['configurations']['infra-solr-env']['infra_solr_gc_log_opts'])
+  infra_solr_gc_tune = format(config['configurations']['infra-solr-env']['infra_solr_gc_tune'])
 
   zk_quorum = format(default('configurations/infra-solr-env/infra_solr_zookeeper_quorum', zookeeper_quorum))
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
@@ -24,25 +24,9 @@ SOLR_JAVA_MEM="-Xms{{infra_solr_min_mem}}m -Xmx{{infra_solr_max_mem}}m"
 
 SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}m"
 
-# Enable verbose GC logging
-GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
--XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
+GC_LOG_OPTS="{{infra_solr_gc_log_opts}}"
 
-# These GC settings have shown to work well for a number of common Solr workloads
-GC_TUNE="-XX:NewRatio=3 \
--XX:SurvivorRatio=4 \
--XX:TargetSurvivorRatio=90 \
--XX:MaxTenuringThreshold=8 \
--XX:+UseConcMarkSweepGC \
--XX:+UseParNewGC \
--XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 \
--XX:+CMSScavengeBeforeRemark \
--XX:PretenureSizeThreshold=64m \
--XX:+UseCMSInitiatingOccupancyOnly \
--XX:CMSInitiatingOccupancyFraction=50 \
--XX:CMSMaxAbortablePrecleanTime=6000 \
--XX:+CMSParallelRemarkEnabled \
--XX:+ParallelRefProcEnabled"
+GC_TUNE="{{infra_solr_gc_tune}}"
 
 # Set the ZooKeeper connection string if using an external ZooKeeper ensemble
 # e.g. host1:2181,host2:2181/chroot


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding two new properties to infra-solr-env config type

## How was this patch tested?

manually:
1. Install Ambari 2.6.2 and deploy a cluster: zookeeper, ambari-infra, logsearch
2. Upgrade Ambari to 2.7.0
3. Before ambari-server upgrade, update the common-services stack definition with the new infra-solr stack code
4. ambari-server upgrade
5. start ambari server and agents and check the new properties are appear in the infra-solr-env config section

Please review
@oleewere @swagle @zeroflag 