### PR TITLE
[AMBARI-24060] Sys-prepped Hosts do not Install and Finalize correctly

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -187,7 +187,7 @@ class AptManager(GenericManager):
             filtered_packages.append(package[0])
 
       if len(filtered_packages) > 0:
-        Logger.debug("Found packages for repo {}".format(str(filtered_packages)))
+        Logger.info("Found packages for repo {}".format(str(filtered_packages)))
         return filtered_packages
       else:
         return [package[0] for package in packages]

--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -177,7 +177,20 @@ class AptManager(GenericManager):
       return filtered_packages
     else:
       Logger.info("Packages will be queried using all available repositories on the system.")
-      return [package[0] for package in packages]
+
+      # this is the case where the hosts are marked as sysprepped, but
+      # search the repos on-system anyway.  the url specified in ambari must match the one
+      # in the list file for this to work
+      for repo_id in repo_ids:
+        for package in packages:
+          if repo_id in package[2]:
+            filtered_packages.append(package[0])
+
+      if len(filtered_packages) > 0:
+        Logger.debug("Found packages for repo {}".format(str(filtered_packages)))
+        return filtered_packages
+      else:
+        return [package[0] for package in packages]
 
   def package_manager_configuration(self):
     """

--- a/ambari-server/src/main/resources/custom_actions/scripts/stack_select_set_all.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/stack_select_set_all.py
@@ -65,7 +65,7 @@ class UpgradeSetAll(Script):
     # this script runs on all hosts; if this host doesn't have stack components,
     # then don't invoke the stack tool
     # (no need to log that it's skipped - the function will do that)
-    if is_host_skippable(stack_selector_path):
+    if is_host_skippable(stack_selector_path, summary.associated_version):
       return
 
     # invoke "set all"
@@ -75,10 +75,11 @@ class UpgradeSetAll(Script):
       raise Exception("Command '{0}' exit code is nonzero".format(cmd))
 
 
-def is_host_skippable(stack_selector_path):
+def is_host_skippable(stack_selector_path, associated_version):
   """
   Gets whether this host should not have the stack select tool called.
   :param stack_selector_path  the path to the stack selector tool.
+  :param associated_version: the version to use with the stack selector tool.
   :return: True if this host should be skipped, False otherwise.
   """
   if not os.path.exists(stack_selector_path):
@@ -100,6 +101,12 @@ def is_host_skippable(stack_selector_path):
   # check to see if the output is empty, indicating no versions installed
   if not out.strip():
     Logger.info("{0} has no stack versions installed".format(socket.gethostname()))
+    return True
+
+  # some pre-prepped systems may have a version, so there may be a version, so
+  # add the extra check if it is available
+  if not associated_version in out:
+    Logger.info("{0} is not found in the list of versions {1}".format(associated_version, out))
     return True
 
   return False


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Installation of packages using a host that is sys-prepped is choosing package names in a non-deterministic way on ubuntu14/16
* Finalization is failing when there are no packages installed on-system.

## How was this patch tested?

Manual testing + update python unit test.