### PR TITLE
[AMBARI-24061] Clicking on 'Details' button in Upgrade wizard shows no data

### DIFF
--- a/ambari-web/app/views/main/admin/stack_upgrade/upgrade_task_view.js
+++ b/ambari-web/app/views/main/admin/stack_upgrade/upgrade_task_view.js
@@ -79,12 +79,19 @@ App.upgradeTaskView = Em.View.extend({
    */
   isContentLoaded: false,
 
+  didInsertElement: function() {
+    if (this.get('outsideView') && this.get('content')) {
+      this.toggleExpanded({context: this.get('content')});
+    }
+  },
+
   toggleExpanded: function (event) {
     var isExpanded = event.context.get('isExpanded');
     event.context.toggleProperty('isExpanded', !isExpanded);
     if (!isExpanded) {
-      event.context.set('isContentLoaded', false);
       this.doPolling(event.context);
+    } else {
+      this.set('isContentLoaded', true);
     }
   },
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When clicked on 'show details' button while Upgrade is in progress, it shows a spinning icon and no data underneath.

## How was this patch tested?

  21800 passing (34s)
  48 pending