### PR TITLE
AMBARI-24063. ZooKeeper Server Start fail during cluster deployment v…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -3552,6 +3552,8 @@ public class KerberosHelperImpl implements KerberosHelper {
 
         customCommandExecutionHelper.addExecutionCommandsToStage(actionExecContext, stage,
           requestParams, null);
+      } else {
+        LOG.warn("Skipping {} command. No suitable hosts found", SET_KEYTAB);
       }
 
       RoleGraph roleGraph = roleGraphFactory.createNew(roleCommandOrder);


### PR DESCRIPTION
…ia api (amagyar)

## What changes were proposed in this pull request?

In a test cluster the keytab distribution didn't happen for an unknown reason. This patch just adds a log statement to make debugging easier.