### PR TITLE
[AMBARI-24065] Ranger Kms service smart config tab - KMS HSM not show…

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/RANGER_KMS/themes/theme_version_2.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/RANGER_KMS/themes/theme_version_2.json
@@ -1,4 +1,5 @@
 {
+  "name": "default",
   "configuration": {
     "layouts": [
       {


### PR DESCRIPTION
…n after upgraded to Ambari-2.7.0.0.

## What changes were proposed in this pull request?
Added name to the theme file

## How was this patch tested?
Manually tested on a cluster