### PR TITLE
[AMBARI-24066] Metrics Collector issues modify HTable descriptor calls every time it restarts.

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
@@ -310,7 +310,7 @@ public class HBaseTimelineMetricsService extends AbstractService implements Time
         Function function = new Function(readFunction, null);
         conditionBuilder.topNFunction(function);
       } else {
-        LOG.info("Invalid Input for TopN query. Ignoring TopN Request.");
+        LOG.debug("Invalid Input for TopN query. Ignoring TopN Request.");
       }
     }
   }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/TimelineMetricConfiguration.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/TimelineMetricConfiguration.java
@@ -258,6 +258,9 @@ public class TimelineMetricConfiguration {
   public static final String TIMELINE_METRICS_WHITELIST_ENABLED =
     "timeline.metrics.whitelisting.enabled";
 
+  public static final String TIMELINE_METRICS_BLACKLIST_FILE =
+        "timeline.metrics.blacklist.file";
+
   public static final String TIMELINE_METRICS_WHITELIST_FILE =
     "timeline.metrics.whitelist.file";
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AbstractTimelineAggregator.java
@@ -451,29 +451,7 @@ public abstract class AbstractTimelineAggregator implements TimelineMetricAggreg
    * @return
    */
   protected String getDownsampledMetricSkipClause() {
-
-    //TODO Fix downsampling for UUID change.
     return StringUtils.EMPTY;
-
-//    if (CollectionUtils.isEmpty(this.downsampleMetricPatterns)) {
-//      return StringUtils.EMPTY;
-//    }
-//
-//    StringBuilder sb = new StringBuilder();
-//
-//    for (int i = 0; i < downsampleMetricPatterns.size(); i++) {
-//      sb.append(" METRIC_NAME");
-//      sb.append(" NOT");
-//      sb.append(" LIKE ");
-//      sb.append("'" + downsampleMetricPatterns.get(i) + "'");
-//
-//      if (i < downsampleMetricPatterns.size() - 1) {
-//        sb.append(" AND ");
-//      }
-//    }
-//
-//    sb.append(" AND ");
-//    return sb.toString();
   }
 
   /**

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/AbstractMiniHBaseClusterTest.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/AbstractMiniHBaseClusterTest.java
@@ -26,6 +26,7 @@ import static org.apache.phoenix.util.TestUtil.TEST_PROPERTIES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -98,6 +99,14 @@ public abstract class AbstractMiniHBaseClusterTest extends BaseTest {
   public void setUp() throws Exception {
     Logger.getLogger("org.apache.ambari.metrics.core.timeline").setLevel(Level.DEBUG);
     hdb = createTestableHBaseAccessor();
+
+    //Change default precision table ttl.
+    Field f = PhoenixHBaseAccessor.class.getDeclaredField("tableTTL");
+    f.setAccessible(true);
+    Map<String, Integer> precisionValues = (Map<String, Integer>) f.get(hdb);
+    precisionValues.put(METRICS_RECORD_TABLE_NAME, 2 * 86400);
+    f.set(hdb, precisionValues);
+
     // inits connection, starts mini cluster
     conn = getConnection(getUrl());
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/resources/test_data/metric_blacklist.dat
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/resources/test_data/metric_blacklist.dat
@@ -1,0 +1,2 @@
+cpu_idle
+._p_jvm.HeapMetrics*

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1804,6 +1804,12 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
                   LOG.warn("Error updating Container metrics TTL for ams-site (AMBARI_METRICS)");
                 }
               }
+              String topnDownsamplerMetricPatternsKey = "timeline.metrics.downsampler.topn.metric.patterns";
+              if (oldAmsSite.containsKey(topnDownsamplerMetricPatternsKey) &&
+                StringUtils.isNotEmpty(oldAmsSite.get(topnDownsamplerMetricPatternsKey))) {
+                LOG.info("Updating ams-site:timeline.metrics.downsampler.topn.metric.patterns to empty.");
+                newProperties.put(topnDownsamplerMetricPatternsKey, "");
+              }
             }
           }
           LOG.info("Removing ams-site host and aggregate cluster split points.");

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-site.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-site.xml
@@ -707,7 +707,7 @@
   </property>
   <property>
     <name>timeline.metrics.downsampler.topn.metric.patterns</name>
-    <value>dfs.NNTopUserOpCounts.windowMs=60000.op=__%.user=%,dfs.NNTopUserOpCounts.windowMs=300000.op=__%.user=%,dfs.NNTopUserOpCounts.windowMs=1500000.op=__%.user=%</value>
+    <value></value>
     <description>
       Commas separated list of metric name regular expressions that are candidates for Top N downsampling.
     </description>
@@ -734,7 +734,7 @@
   </property>
   <property>
     <name>timeline.metrics.downsampler.event.metric.patterns</name>
-    <value>topology\.%</value>
+    <value></value>
     <description>
       Commas separated list of metric name regular expressions that are like events. No interpolation will be done for such
       metrics, and the downsampling SUM aggregators will sum the values across time instead of averaging them out.
@@ -812,7 +812,7 @@
   </property>
   <property>
     <name>timeline.metrics.transient.metric.patterns</name>
-    <value>topology\.%</value>
+    <value>topology\.%,dfs.NNTopUserOpCounts.windowMs=60000.op=__%.user=%,dfs.NNTopUserOpCounts.windowMs=300000.op=__%.user=%,dfs.NNTopUserOpCounts.windowMs=1500000.op=__%.user=%</value>
     <description>
       Comma separated list of metric patterns that will enable them to be stored, queried, aggregated and purged
       separately so as to decrease pressure on low volume high density metrics aggregation.

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -222,6 +222,7 @@ import org.apache.ambari.server.testutils.PartialNiceMockBinder;
 import org.apache.ambari.server.topology.PersistedState;
 import org.apache.ambari.server.topology.PersistedStateImpl;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
@@ -1399,12 +1400,15 @@ public class UpgradeCatalog270Test {
         put("timeline.container-metrics.ttl", "2592000");
         put("timeline.metrics.cluster.aggregate.splitpoints", "cpu_user,mem_free");
         put("timeline.metrics.host.aggregate.splitpoints", "kafka.metric,nimbus.metric");
+        put("timeline.metrics.downsampler.topn.metric.patterns", "dfs.NNTopUserOpCounts.windowMs=60000.op=__%.user=%," +
+          "dfs.NNTopUserOpCounts.windowMs=300000.op=__%.user=%,dfs.NNTopUserOpCounts.windowMs=1500000.op=__%.user=%");
       }
     };
     Map<String, String> newProperties = new HashMap<String, String>() {
       {
         put("timeline.metrics.service.default.result.limit", "5760");
         put("timeline.container-metrics.ttl", "1209600");
+        put("timeline.metrics.downsampler.topn.metric.patterns", StringUtils.EMPTY);
       }
     };
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Fix issues in AMS HBase tables policies initialization.
- Cleanup downsampling code and config.
- Add ability to blacklist metrics through a file.

## How was this patch tested?
Manually tested.
Added unit tests for all changes.