### PR TITLE
AMBARI-24067. Log Search: indexed string field could be too large for audit_logs.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
@@ -44,6 +44,7 @@
     <analyzer>
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.LengthFilterFactory" min="0" max="2500"/>
     </analyzer>
   </fieldType>
   <fieldType name="n_gram" class="solr.TextField" omitNorms="true" sortMissingLast="true">


### PR DESCRIPTION
## What changes were proposed in this pull request?
Although logfeeder can limit the max size of the messages for service logs, its not the case with audit logs (as we can n number of columns)..we can handle this on solr side.
## How was this patch tested?
FT done. manually

Please review @swagle @kasakrisz @adoroszlai 