### PR TITLE
[AMBARI-24069] Fix the error setting of estring

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/util/DownloadUtil.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/util/DownloadUtil.java
@@ -125,7 +125,7 @@ public class DownloadUtil {
     if (StringUtils.isBlank(excludeString)) {
       excludeString = "\"\"";
     } else {
-      List<String> exclude = Splitter.on(request.getIncludeMessage()).splitToList(LogSearchConstants.I_E_SEPRATOR);
+      List<String> exclude = Splitter.on(request.getExcludeMessage()).splitToList(LogSearchConstants.I_E_SEPRATOR);
       excludeString = "\"" + StringUtils.join(exclude, "\", \"") + "\"";
     }
     models.put("eString", excludeString);


### PR DESCRIPTION

## What changes were proposed in this pull request?

The exclude string in method named fillModelsForLogFile is seted by the include message of request.To fix this.

## How was this patch tested?
Tested by unit test

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.