### PR TITLE
AMBARI-24072.  NN cannot start due do not have permission

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
@@ -195,6 +195,7 @@ if has_namenode or dfs_type == 'HCFS':
   task_log4j_properties_location = os.path.join(hadoop_conf_dir, "task-log4j.properties")
 
 hadoop_pid_dir_prefix = config['configurations']['hadoop-env']['hadoop_pid_dir_prefix']
+hdfs_pid_dir = format("{hadoop_pid_dir_prefix}/{hdfs_user}")
 hdfs_log_dir_prefix = config['configurations']['hadoop-env']['hdfs_log_dir_prefix']
 hbase_tmp_dir = "/tmp/hbase-hbase"
 #db params

--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/shared_initialization.py
@@ -51,6 +51,11 @@ def setup_hadoop():
               group='root',
               cd_access='a',
       )
+      Directory(params.hdfs_pid_dir,
+              owner=params.hdfs_user,
+              cd_access='a',
+      )
+
     Directory(params.hadoop_tmp_dir,
               create_parents = True,
               owner=params.hdfs_user,

--- a/ambari-server/src/test/python/stacks/2.0.6/hooks/before-START/test_before_start.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/hooks/before-START/test_before_start.py
@@ -55,6 +55,10 @@ class TestHookBeforeStart(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('Directory', '/var/run/hadoop/hdfs',
+        owner = 'hdfs',
+        cd_access = 'a',
+    )                
     self.assertResourceCalled('Directory', '/tmp/hadoop-hdfs',
                               owner = 'hdfs',
                               create_parents = True,
@@ -136,6 +140,10 @@ class TestHookBeforeStart(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('Directory', '/var/run/hadoop/hdfs',
+        owner = 'hdfs',
+        cd_access = 'a',
+    )            
     self.assertResourceCalled('Directory', '/tmp/hadoop-hdfs',
                               owner = 'hdfs',
                               create_parents = True,
@@ -222,11 +230,15 @@ class TestHookBeforeStart(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('Directory', '/var/run/hadoop/hdfs',
+        owner = 'hdfs',
+        cd_access = 'a',
+    )                
     self.assertResourceCalled('Directory', '/tmp/hadoop-hdfs',
                               owner = 'hdfs',
                               create_parents = True,
                               cd_access = 'a',
-                              )
+                              )             
     self.assertResourceCalled('File', '/var/lib/ambari-agent/lib/fast-hdfs-resource.jar',
         content = StaticFile('fast-hdfs-resource.jar'),
         mode = 0644,
@@ -310,11 +322,15 @@ class TestHookBeforeStart(RMFTestCase):
                               create_parents = True,
                               cd_access = 'a',
                               )
+    self.assertResourceCalled('Directory', '/var/run/hadoop/hdfs',
+        owner = 'hdfs',
+        cd_access = 'a',
+    )                                 
     self.assertResourceCalled('Directory', '/tmp/hadoop-hdfs',
                               owner = 'hdfs',
                               create_parents = True,
                               cd_access = 'a',
-                              )
+                              )                       
     self.assertResourceCalled('File', '/var/lib/ambari-agent/lib/fast-hdfs-resource.jar',
         content = StaticFile('fast-hdfs-resource.jar'),
         mode = 0644,


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/namenode.py", line 414, in 
    NameNode().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/namenode.py", line 138, in start
    upgrade_suspended=params.upgrade_suspended, env=env)
  File "/usr/lib/ambari-agent/lib/ambari_commons/os_family_impl.py", line 89, in thunk
    return fn(*args, **kwargs)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/hdfs_namenode.py", line 115, in namenode
    format_namenode()
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/HDFS/package/scripts/hdfs_namenode.py", line 369, in format_namenode
    logoutput=True
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/system.py", line 263, in action_run
    returns=self.resource.returns)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 72, in inner
    result = function(command, **kwargs)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 102, in checked_call
    tries=tries, try_sleep=try_sleep, timeout_kill_strategy=timeout_kill_strategy, returns=returns)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 150, in _call_wrapper
    result = _call(command, **kwargs_copy)
  File "/usr/lib/ambari-agent/lib/resource_management/core/shell.py", line 314, in _call
    raise ExecutionFailed(err_msg, code, out, err)
resource_management.core.exceptions.ExecutionFailed: Execution of 'hdfs --config /usr/hdp/3.0.0.0-1469/hadoop/conf namenode -format -nonInteractive' returned 1. ######## Hortonworks #############
This is MOTD message, added for testing in qe infra
WARNING: /var/run/hadoop/cstm-hdfs does not exist. Creating.
mkdir: cannot create directory ‘/var/run/hadoop/cstm-hdfs’: Permission denied
ERROR: Unable to create /var/run/hadoop/cstm-hdfs. Aborting.