### PR TITLE
[AMBARI-24073] Adding alerts to alert groups not working

### DIFF
--- a/ambari-web/app/mappers/socket/alert_groups_mapper_adapter.js
+++ b/ambari-web/app/mappers/socket/alert_groups_mapper_adapter.js
@@ -25,6 +25,12 @@ App.alertGroupsMapperAdapter = App.QuickDataMapper.create({
   map: function(event) {
     event.groups.forEach((alertGroup) => {
       if (event.updateType === 'UPDATE' || event.updateType === 'CREATE') {
+        const {definitions} = alertGroup;
+        if (definitions) {
+          alertGroup.definitions = definitions.map(id => ({
+            id
+          }));
+        }
         App.alertGroupsMapper.map({
           items: [
             {

--- a/ambari-web/test/mappers/socket/alert_groups_mapper_adapter_test.js
+++ b/ambari-web/test/mappers/socket/alert_groups_mapper_adapter_test.js
@@ -40,7 +40,8 @@ describe('App.alertGroupsMapperAdapter', function () {
         updateType: 'UPDATE',
         groups: [
           {
-            id: 1
+            id: 1,
+            definitions: [2]
           }
         ]
       };
@@ -48,7 +49,12 @@ describe('App.alertGroupsMapperAdapter', function () {
       expect(App.alertGroupsMapper.map.getCall(0).args[0]).to.be.eql({
         items: [{
           AlertGroup: {
-            id: 1
+            id: 1,
+            definitions: [
+              {
+                id: 2
+              }
+            ]
           }
         }]
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:
1. Navigate to Alerts> Manage Alert groups >  Create alert group e.g Test_group
2. Add alerts to the alert groups and click Save button
3. Navigate to Alerts> Manage Alert groups > Select Test_group and the alerts selected should be listed in the alert group, but only empty entry is available.

## How was this patch tested?

UI unit tests:
  21800 passing (25s)
  48 pending