### PR TITLE
[AMBARI-24080] [UI] Ambari label do not navigate to Dashboard page

### DIFF
--- a/ambari-web/app/controllers/application.js
+++ b/ambari-web/app/controllers/application.js
@@ -132,6 +132,12 @@ App.ApplicationController = Em.Controller.extend(App.Persist, {
     App.router.route("adminView");
   },
 
+  goToDashboard: function () {
+    if (this.get('enableLinks')) {
+      App.router.route("main/dashboard");
+    }
+  },
+
   showAboutPopup: function() {
     App.ModalPopup.show({
       header: Em.I18n.t('common.aboutAmbari'),

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -594,7 +594,6 @@ Em.I18n.translations = {
   'services.summary.selectHostForComponent': 'Select the host to add {0} component',
   'services.summary.allHostsAlreadyRunComponent': 'All hosts already running {0} component',
 
-  'topnav.logo.href':'/#/main/dashboard',
   'topnav.help.href':'https://cwiki.apache.org/confluence/display/AMBARI/Ambari',
 
   'installer.header':'Cluster Install Wizard',

--- a/ambari-web/app/templates/application.hbs
+++ b/ambari-web/app/templates/application.hbs
@@ -25,16 +25,10 @@
     <div class="navigation-bar-container">
     <ul class="side-nav-header nav nav-pills nav-stacked">
       <li class="navigation-header">
-        {{#if enableLinks}}
-          <a {{translateAttr href="topnav.logo.href"}} class="ambari-logo">
-            <img src="/img/ambari-logo.png" alt="Apache Ambari" title="Apache Ambari" {{QAAttr "ambari-logo"}}>
-          </a>
-        {{else}}
-          <a class="ambari-logo">
-            <img src="/img/ambari-logo.png" alt="Apache Ambari" title="Apache Ambari" {{QAAttr "ambari-logo"}}>
-          </a>
-        {{/if}}
-        <div class="btn-group">
+        <a href="#" {{action goToDashboard target="controller"}} class="ambari-logo">
+          <img src="/img/ambari-logo.png" alt="Apache Ambari" title="Apache Ambari" {{QAAttr "ambari-logo"}}>
+        </a>
+        <div class="btn-group" {{action goToDashboard target="controller"}}>
           <span class="ambari-header" title="Apache Ambari" {{QAAttr "ambari-title"}}>{{t app.name}}</span>
         </div>
       </li>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari label(not img) do not navigate to Dashboard page.

## How was this patch tested?

  21800 passing (39s)
  48 pending