### PR TITLE
[AMBARI-24082] Reordering of dashboard widgets doesn't work after enabling NN federation

### DIFF
--- a/ambari-web/app/views/main/dashboard/widgets.js
+++ b/ambari-web/app/views/main/dashboard/widgets.js
@@ -255,6 +255,25 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
         });
       });
     }
+    this.get('widgetGroups').forEach(group => {
+      const groupName = group.get('name');
+      group.get('allWidgets').forEach(widgetsSubGroup => {
+        const subGroupName = widgetsSubGroup.get('subGroupName'),
+          widgets = widgetsSubGroup.get('widgets'),
+          arrayFromSettings = newSettings.groups[groupName][subGroupName].visible,
+          isSubGroupForAll = subGroupName === '*',
+          orderedArray = isSubGroupForAll
+            ? arrayFromSettings.map(widget => `${widget.id}-${groupName}-${widget.subGroup}-*`)
+            : arrayFromSettings;
+        widgetsSubGroup.set('widgets', widgets.sort((widgetA, widgetB) => {
+          const idA = isSubGroupForAll ? widgetA.get('id') : parseInt(widgetA.get('id')),
+            idB = isSubGroupForAll ? widgetB.get('id') : parseInt(widgetB.get('id')),
+            indexA = orderedArray.indexOf(idA),
+            indexB = orderedArray.indexOf(idB);
+          return indexA > -1 && indexB > -1 ? indexA - indexB : 0;
+        }));
+      });
+    });
     this.set('userPreferences', newSettings);
     this.setDBProperty(this.get('persistKey'), newSettings);
     this.postUserPref(this.get('persistKey'), newSettings);
@@ -336,8 +355,9 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
           if (!existingEntry) {
             preferences.groups[widgetGroupName] = currentEntry;
           }
+        } else {
+          preferences[state].push(id);
         }
-        preferences[state].push(id);
       }
       preferences.threshold[id] = widget.threshold;
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

**STR**
1. Enable NameNode federation
2. Go to dashboard
3. Try to reorder some widgets (common or namespace-specific ones)

**Expected result**
New widgets order is persisted

**Actual result**
- JS error is thrown: `app.js:237946 Uncaught TypeError: Cannot read property 'getAttribute' of undefined`
- New order isn't persisted

## How was this patch tested?

UI unit tests:
  21800 passing (32s)
  48 pending
