### PR TITLE
[AMBARI-24084] - The livy2 Package in stack_packages is Wrong for conf-select

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/properties/stack_packages.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/properties/stack_packages.json
@@ -1106,12 +1106,6 @@
           "component": "livy2-client"
         }
       ],
-      "livy2": [
-        {
-          "conf_dir": "/etc/livy2/conf",
-          "current_dir": "{0}/current/livy2-client/conf"
-        }
-      ],
       "mahout": [
         {
           "conf_dir": "/etc/mahout/conf",


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are 2 {{livy2}} instances in {{stack_packages}}

```
      "livy2": [
        {
          "conf_dir": "/etc/livy2/conf",
          "current_dir": "{0}/current/livy2-client/conf",
          "component": "livy2-client"
        }
      ],
      "livy2": [
        {
          "conf_dir": "/etc/livy2/conf",
          "current_dir": "{0}/current/livy2-client/conf"
        }
```

## How was this patch tested?

Manual installation of livy2 to verify conf-select structure