### PR TITLE
[AMBARI-24085] setup-sso in Ambari fails when SSL is enabled

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -46,7 +46,7 @@ from ambari_server.serverConfiguration import configDefaults, get_resources_loca
 from ambari_server.setupSecurity import adjust_directory_permissions, \
   generate_env, ensure_can_start_under_current_user
 from ambari_server.utils import compare_versions, get_json_url_from_repo_file, update_latest_in_repoinfos_for_all_stacks
-from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base
+from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base, get_ssl_context
 from ambari_server.userInput import get_validated_string_input, get_prompt_default, read_password, get_YN_input
 from ambari_server.serverClassPath import ServerClassPath
 from ambari_server.setupMpacks import replay_mpack_logs
@@ -391,7 +391,7 @@ def set_current(options):
   request.get_method = lambda: 'PUT'
 
   try:
-    response = urllib2.urlopen(request)
+    response = urllib2.urlopen(request, context=get_ssl_context(properties))
   except urllib2.HTTPError, e:
     code = e.getcode()
     content = e.read()

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -50,7 +50,8 @@ from ambari_server.serverConfiguration import configDefaults, parse_properties_f
   SSL_TRUSTSTORE_PASSWORD_PROPERTY, SSL_TRUSTSTORE_PATH_PROPERTY, SSL_TRUSTSTORE_TYPE_PROPERTY, \
   SSL_API, SSL_API_PORT, DEFAULT_SSL_API_PORT, CLIENT_API_PORT, JDK_NAME_PROPERTY, JCE_NAME_PROPERTY, JAVA_HOME_PROPERTY, \
   get_resources_location, SECURITY_MASTER_KEY_LOCATION, SETUP_OR_UPGRADE_MSG, CHECK_AMBARI_KRB_JAAS_CONFIGURATION_PROPERTY
-from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base, get_ambari_admin_username_password_pair, perform_changes_via_rest_api
+from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base, \
+  get_ambari_admin_username_password_pair, perform_changes_via_rest_api, get_ssl_context
 from ambari_server.setupActions import SETUP_ACTION, LDAP_SETUP_ACTION
 from ambari_server.userInput import get_validated_string_input, get_prompt_default, read_password, get_YN_input, quit_if_has_answer
 from ambari_server.serverClassPath import ServerClassPath
@@ -296,7 +297,7 @@ def getLdapPropertyFromDB(properties, admin_login, admin_password, property_name
     sys.stdout.flush()
 
     try:
-      with closing(urllib2.urlopen(request)) as response:
+      with closing(urllib2.urlopen(request, context=get_ssl_context(properties))) as response:
         response_status_code = response.getcode()
         if response_status_code != 200:
           request_in_progress = False
@@ -398,7 +399,7 @@ def sync_ldap(options):
   request.get_method = lambda: 'POST'
 
   try:
-    response = urllib2.urlopen(request)
+    response = urllib2.urlopen(request, context=get_ssl_context(properties))
   except Exception as e:
     err = 'Sync event creation failed. Error details: %s' % e
     raise FatalException(1, err)
@@ -423,7 +424,7 @@ def sync_ldap(options):
     sys.stdout.flush()
 
     try:
-      response = urllib2.urlopen(request)
+      response = urllib2.urlopen(request, context=get_ssl_context(properties))
     except Exception as e:
       request_in_progress = False
       err = 'Sync event check failed. Error details: %s' % e

--- a/ambari-server/src/test/python/TestServerUpgrade.py
+++ b/ambari-server/src/test/python/TestServerUpgrade.py
@@ -86,7 +86,7 @@ class TestServerUpgrade(TestCase):
     get_validated_string_input_mock.return_value = 'dummy_string'
 
     p = get_ambari_properties_mock.return_value
-    p.get_property.side_effect = ["8080", "false"]
+    p.get_property.side_effect = ["8080", "false", "false"]
 
     get_ambari_server_api_base_mock.return_value = 'http://127.0.0.1:8080/api/v1/'
     get_verbose_mock.retun_value = False
@@ -140,7 +140,7 @@ class TestServerUpgrade(TestCase):
     get_validated_string_input_mock.return_value = 'dummy_string'
 
     p = get_ambari_properties_mock.return_value
-    p.get_property.side_effect = ["8080", "false"]
+    p.get_property.side_effect = ["8080", "false", "false"]
 
     get_ambari_server_api_base_mock.return_value = 'http://127.0.0.1:8080/api/v1/'
     get_verbose_mock.retun_value = False


### PR DESCRIPTION
## What changes were proposed in this pull request?

When SSL is enabled and the python version is 2.7.14, accessing the Ambari server via the `ambari-server` CLI fails with CERTIFICATE_VERIFY_FAILED.
 
```
-bash-4.2# ambari-server setup-sso -v
Using python /usr/bin/python
Setting up SSO authentication properties...
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Setup SSO.
INFO: about to run command: ps -p 33705
INFO:
process_pid=107113
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
Enter Ambari Admin login: admin
Enter Ambari Admin password:
INFO: Fetching SSO configuration from DB
INFO: Fetching information from Ambari's REST API
Traceback (most recent call last):
 File "/usr/sbin/ambari-server.py", line 1056, in <module>
 mainBody()
 File "/usr/sbin/ambari-server.py", line 1026, in mainBody
 main(options, args, parser)
 File "/usr/sbin/ambari-server.py", line 976, in main
 action_obj.execute()
 File "/usr/sbin/ambari-server.py", line 90, in execute
 self.need_restart = self.fn(*self.args, **self.kwargs)
 File "/usr/lib/ambari-server/lib/ambari_server/setupSso.py", line 266, in setup_sso
 properties = get_sso_properties(ambari_properties, admin_login, admin_password)
 File "/usr/lib/ambari-server/lib/ambari_server/setupSso.py", line 221, in get_sso_properties
 response_code, json_data = get_json_via_rest_api(properties, admin_login, admin_password, SSO_CONFIG_API_ENTRYPOINT)
 File "/usr/lib/ambari-server/lib/ambari_server/serverUtils.py", line 206, in get_json_via_rest_api
 with closing(urllib2.urlopen(request)) as response:
 File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
 return opener.open(url, data, timeout)
 File "/usr/lib64/python2.7/urllib2.py", line 429, in open
 response = self._open(req, data)
 File "/usr/lib64/python2.7/urllib2.py", line 447, in _open
 '_open', req)
 File "/usr/lib64/python2.7/urllib2.py", line 407, in _call_chain
 result = func(*args)
 File "/usr/lib64/python2.7/urllib2.py", line 1243, in https_open
 context=self._context)
 File "/usr/lib64/python2.7/urllib2.py", line 1200, in do_open
 raise URLError(err)
urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)>
```

Solution force verification of the server's SSL certificate to not be validated.

## How was this patch tested?

Manually tested using an SSL and a non-SSL enabled Ambari server.

```
mvn clean test package -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 29:58 min
[INFO] Finished at: 2018-06-12T17:44:54-04:00
[INFO] Final Memory: 102M/1302M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.