### PR TITLE
AMBARI-24086. Start of components fails if HDFS is not installed

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
@@ -195,7 +195,6 @@ if has_namenode or dfs_type == 'HCFS':
   task_log4j_properties_location = os.path.join(hadoop_conf_dir, "task-log4j.properties")
 
 hadoop_pid_dir_prefix = config['configurations']['hadoop-env']['hadoop_pid_dir_prefix']
-hdfs_pid_dir = format("{hadoop_pid_dir_prefix}/{hdfs_user}")
 hdfs_log_dir_prefix = config['configurations']['hadoop-env']['hdfs_log_dir_prefix']
 hbase_tmp_dir = "/tmp/hbase-hbase"
 #db params

--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/shared_initialization.py
@@ -51,7 +51,7 @@ def setup_hadoop():
               group='root',
               cd_access='a',
       )
-      Directory(params.hdfs_pid_dir,
+      Directory(format("{hadoop_pid_dir_prefix}/{hdfs_user}"),
               owner=params.hdfs_user,
               cd_access='a',
       )


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stack-hooks/before-START/scripts/hook.py", line 43, in <module>
    BeforeStartHook().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stack-hooks/before-START/scripts/hook.py", line 29, in hook
    import params
  File "/var/lib/ambari-agent/cache/stack-hooks/before-START/scripts/params.py", line 198, in <module>
    hdfs_pid_dir = format("{hadoop_pid_dir_prefix}/{hdfs_user}")
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/format.py", line 95, in format
    return ConfigurationFormatter().format(format_string, args, **result)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/format.py", line 59, in format
    result_protected = self.vformat(format_string, args, all_params)
  File "/usr/lib64/python2.7/string.py", line 549, in vformat
    result = self._vformat(format_string, args, kwargs, used_args, 2)
  File "/usr/lib64/python2.7/string.py", line 582, in _vformat
    result.append(self.format_field(obj, format_spec))
  File "/usr/lib64/python2.7/string.py", line 599, in format_field
    return format(value, format_spec)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/config_dictionary.py", line 73, in __getattr__
    raise Fail("Configuration parameter '" + self.name + "' was not found in configurations dictionary!")
resource_management.core.exceptions.Fail: Configuration parameter 'hadoop-env' was not found in configurations dictionary!