### PR TITLE
AMBARI-24087. The alert "DataNode Unmounted Data Dir" did not appear …

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/alerts/alert_datanode_unmounted_data_dir.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/alerts/alert_datanode_unmounted_data_dir.py
@@ -107,6 +107,7 @@ def execute(configurations={}, parameters={}, host_name=None):
 
   # Sort the data dirs, which is needed for deterministic behavior when running the unit tests.
   normalized_data_dirs = sorted(normalized_data_dirs)
+  file_system.get_and_cache_mount_points(refresh=True)
   for data_dir in normalized_data_dirs:
     # This follows symlinks and will return False for a broken link (even in the middle of the linked list)
     if os.path.isdir(data_dir):

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_alert_datanode_unmounted_data_dir.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_alert_datanode_unmounted_data_dir.py
@@ -71,10 +71,11 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     [status, messages] = alert.execute(configurations=configs)
     self.assertNotEqual(status, RESULT_STATE_UNKNOWN)
 
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
   @patch("resource_management.libraries.functions.file_system.get_mount_point_for_dir")
   @patch("os.path.exists")
   @patch("os.path.isdir")
-  def test_mount_history_file_does_not_exist(self, is_dir_mock, exists_mock, get_mount_mock):
+  def test_mount_history_file_does_not_exist(self, is_dir_mock, exists_mock, get_mount_mock, get_and_cache_mount_points_mock):
     """
     Test that the status is WARNING when the data dirs are mounted on root, but the mount history file
     does not exist.
@@ -93,11 +94,12 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     self.assertTrue(messages is not None and len(messages) == 1)
     self.assertTrue("{0} was not found".format(DATA_DIR_MOUNT_HIST_FILE_PATH) in messages[0])
 
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
   @patch("resource_management.libraries.functions.mounted_dirs_helper.get_dir_to_mount_from_file")
   @patch("resource_management.libraries.functions.file_system.get_mount_point_for_dir")
   @patch("os.path.exists")
   @patch("os.path.isdir")
-  def test_all_dirs_on_root(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock):
+  def test_all_dirs_on_root(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock, get_and_cache_mount_points_mock):
     """
     Test that the status is OK when all drives are mounted on the root partition
     and this coincides with the expected values.
@@ -119,11 +121,12 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     self.assertTrue(messages is not None and len(messages) == 1)
     self.assertTrue("The following data dir(s) are valid" in messages[0])
 
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
   @patch("resource_management.libraries.functions.mounted_dirs_helper.get_dir_to_mount_from_file")
   @patch("resource_management.libraries.functions.file_system.get_mount_point_for_dir")
   @patch("os.path.exists")
   @patch("os.path.isdir")
-  def test_match_expected(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock):
+  def test_match_expected(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock, get_and_cache_mount_points_mock):
     """
     Test that the status is OK when the mount points match the expected values.
     """
@@ -144,11 +147,12 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     self.assertTrue(messages is not None and len(messages) == 1)
     self.assertTrue("The following data dir(s) are valid" in messages[0])
 
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
   @patch("resource_management.libraries.functions.mounted_dirs_helper.get_dir_to_mount_from_file")
   @patch("resource_management.libraries.functions.file_system.get_mount_point_for_dir")
   @patch("os.path.exists")
   @patch("os.path.isdir")
-  def test_critical_one_root_one_mounted(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock):
+  def test_critical_one_root_one_mounted(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock, get_and_cache_mount_points_mock):
     """
     Test that the status is CRITICAL when the history file is missing
     and at least one data dir is on a mount and at least one data dir is on the root partition.
@@ -168,11 +172,12 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     self.assertTrue(messages is not None and len(messages) == 1)
     self.assertTrue("Detected at least one data dir on a mount point, but these are writing to the root partition:\n/grid/0/data\n/grid/1/data" in messages[0])
 
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
   @patch("resource_management.libraries.functions.mounted_dirs_helper.get_dir_to_mount_from_file")
   @patch("resource_management.libraries.functions.file_system.get_mount_point_for_dir")
   @patch("os.path.exists")
   @patch("os.path.isdir")
-  def test_critical_unmounted(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock):
+  def test_critical_unmounted(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock, get_and_cache_mount_points_mock):
     """
     Test that the status is CRITICAL when the history file exists and one of the dirs
     became unmounted.
@@ -196,11 +201,12 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     self.assertTrue("Detected data dir(s) that became unmounted and are now writing to the root partition:\n/grid/1/data" in messages[0])
 
 
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
   @patch("resource_management.libraries.functions.mounted_dirs_helper.get_dir_to_mount_from_file")
   @patch("resource_management.libraries.functions.file_system.get_mount_point_for_dir")
   @patch("os.path.exists")
   @patch("os.path.isdir")
-  def test_file_uri_and_meta_tags(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock):
+  def test_file_uri_and_meta_tags(self, is_dir_mock, exists_mock, get_mount_mock, get_data_dir_to_mount_from_file_mock, get_and_cache_mount_points_mock):
     """
     Test that the status is OK when the locations include file:// schemes and meta tags.
     """


### PR DESCRIPTION
…(amagyar)

## What changes were proposed in this pull request?

DataNode Unmounted Data Dir alert did not show up after unmounting a datanode data directory because the cache cointaining the mount points was not refreshed.

## How was this patch tested?

1) execute commands on hosts:
```bash
dd if=/dev/zero of=/grid/0/fs bs=1 count=0 seek=10G
mkfs.ext3 -F /grid/0/fs
mkdir /grid/1/
mount -o loop,rw /grid/0/fs /grid/1/
chown cstm-hdfs:hadoop /grid/1/
```
2) set DN dir property (dfs.datanode.data.dir) to "/grid/0/hadoop/hdfs/data,/newdndir,/grid/1/hadoop/hdfs" and restart needed services 
3) check that alert is not present "DataNode Unmounted Data Dir" (after 2 min)
4) Stop DN(s)
5) umount /grid/1/
6) Start DN(s)
7) check that alert is present