### PR TITLE
[AMBARI-24090] - Resuming a Paused Upgrade Attempts To Retry Tasks Which Were Already Passed

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -1555,8 +1555,12 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
 
     } else if (status == HostRoleStatus.PENDING) {
       List<Long> taskIds = new ArrayList<>();
+
+      // pull back only ABORTED tasks in order to set them to PENDING - other
+      // status (such as TIMEDOUT and FAILED) must remain since they are
+      // considered to have been completed
       List<HostRoleCommandEntity> hrcEntities = s_hostRoleCommandDAO.findByRequestIdAndStatuses(
-          requestId, Sets.newHashSet(HostRoleStatus.ABORTED, HostRoleStatus.TIMEDOUT));
+          requestId, Sets.newHashSet(HostRoleStatus.ABORTED));
 
       for (HostRoleCommandEntity hrcEntity : hrcEntities) {
         taskIds.add(hrcEntity.getTaskId());


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:
- Perform a stack upgrade where during the upgrade, there's a slave failure due to a timed out task
- Ignore and Proceed past this task and get to the Component Version Check. It should fail (since you had a timed out task on a slave)
- Pause the upgrade and then fix the version by restarting the component
- Resume the upgrade

The upgrade attempts to place the timed out task back into a PENDING state. 

I think I have an idea about what's going on here. Consider the following upgrade tasks:

- 1: COMPLETED
- 2: HOLDING_TIMEDOUT
- 3: PENDIND
- 4: PENDING
- 5: PENDING

When you "Ignore and Proceed", it sets the {{HOLDING_TIMEDOUT}} to {{TIMEDOUT}} which is technically a completed state:

- 1: COMPLETED
- 2: TIMEDOUT
- 3: COMPLETED
- 4: HOLDING_FAILED
- 5: PENDING

Now, you go to pause the upgrade and we set every "scheduled" state to {{ABORTED}}, so this preserves existing states:

- 1: COMPLETED
- 2: TIMEDOUT
- 3: COMPLETED
- 4: ABORTED
- 5: ABORTED

When you go to resume the upgrade, it searches for all {{ABORTED}} _AND_ {{TIMEDOUT}} to reset to {{PENDING}}

- 1: COMPLETED
- 2: PENDING
- 3: COMPLETED
- 4: PENDING
- 5: PENDING

So, because an earlier task is now set to {{PENDING}}, this causes the scheduler to barf.

## How was this patch tested?

Manually tested with an upgrade and verified new behavior with a new unit test.