### PR TITLE
AMBARI-24097. Canceling task during blueprint install results in agent not responding to any other tasks

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -329,11 +329,14 @@ class ActionQueue(threading.Thread):
 
         command['agentLevelParams']['commandBeingRetried'] = "true"
         self.cancelEvent.wait(delay) # wake up if something was canceled
+
         continue
       else:
         logger.info("Quit retrying for command with taskId = {cid}. Status: {status}, retryAble: {retryAble}, retryDuration (sec): {retryDuration}, last delay (sec): {delay}"
                     .format(cid=taskId, status=status, retryAble=retryAble, retryDuration=retryDuration, delay=delay))
         break
+
+    self.cancelEvent.clear()
 
     # do not fail task which was rescheduled from server
     if command_canceled:


### PR DESCRIPTION
If failing operation which is in retry cycle is canceled during blueprint install. The agent will still continue to execute the canceled task. Resulting in ActionQueue being stuck and no other task being able to start execution