### PR TITLE
[AMBARI-24098] Filter have incorrect name on host page

### DIFF
--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -275,7 +275,7 @@ App.HostComponentStatus = {
       case this.disabled:
         return 'Disabled';
       case this.init:
-        return 'Install Pending';
+        return 'Install Pending...';
     }
     return 'Unknown';
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

Actual result: some filter for components has an incorrect name "Install Pending" but should be "Install Pending..."