### PR TITLE
[AMBARI-24101] more detailed error reporting in DownloadMpacksTask (benyoka)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/DownloadMpacksTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/DownloadMpacksTask.java
@@ -75,8 +75,8 @@ public class DownloadMpacksTask {
       catch (Exception ex) {
         Throwable rootCause = ExceptionUtils.getRootCause(ex);
         throw new RuntimeException(
-          String.format("Error occured while registering mpack: %s. Caused by %s: %s", mpack.getStackId(),
-            rootCause.getClass().getName(), rootCause.getMessage(),
+          String.format("Error occured while registering mpack: %s (uri: %s). Caused by %s: %s", mpack.getStackId(),
+            mpack.getUrl(), rootCause.getClass().getName(), rootCause.getMessage(),
           rootCause));
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/DownloadMpacksTask.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/DownloadMpacksTask.java
@@ -29,6 +29,7 @@ import org.apache.ambari.server.controller.internal.MpackResourceProvider;
 import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.RequestStatus;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,9 +73,11 @@ public class DownloadMpacksTask {
         }
       }
       catch (Exception ex) {
-        throw ex instanceof RuntimeException ?
-          (RuntimeException)ex :
-          new RuntimeException("Error occured while registering mpack: " + mpack.getStackId(), ex);
+        Throwable rootCause = ExceptionUtils.getRootCause(ex);
+        throw new RuntimeException(
+          String.format("Error occured while registering mpack: %s. Caused by %s: %s", mpack.getStackId(),
+            rootCause.getClass().getName(), rootCause.getMessage(),
+          rootCause));
       }
     }
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/DownloadMpacksTaskTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/DownloadMpacksTaskTest.java
@@ -131,7 +131,8 @@ public class DownloadMpacksTaskTest {
     // then
     expectedException.expect(RuntimeException.class);
     expectedException.expectMessage(
-      "Error occured while registering mpack: EDW-1.0.0. Caused by java.net.UnknownHostException: mpacks.org");
+      "Error occured while registering mpack: EDW-1.0.0 (uri: http://mpacks.org/EDW.1.0.0). " +
+        "Caused by java.net.UnknownHostException: mpacks.org");
 
     // given
     reset(resourceProvider);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/DownloadMpacksTaskTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/DownloadMpacksTaskTest.java
@@ -28,10 +28,12 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Set;
 
@@ -40,15 +42,21 @@ import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.controller.internal.MpackResourceProvider;
 import org.apache.ambari.server.controller.internal.RequestStatusImpl;
 import org.apache.ambari.server.controller.spi.Request;
+import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.state.StackId;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.google.common.collect.ImmutableList;
 
 public class DownloadMpacksTaskTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   private static final List<MpackInstance> INSTALLED_MPACKS = ImmutableList.of(
     mpack("HDPCORE", "1.0.0.0"),
@@ -116,6 +124,23 @@ public class DownloadMpacksTaskTest {
 
     // when
     downloadMpacksTask.downloadMissingMpacks(ImmutableList.of(brokenMpack));
+  }
+
+  @Test
+  public void testDownloadMissingMpacks_errorReporting() throws Exception {
+    // then
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage(
+      "Error occured while registering mpack: EDW-1.0.0. Caused by java.net.UnknownHostException: mpacks.org");
+
+    // given
+    reset(resourceProvider);
+    expect(resourceProvider.createResources(anyObject()))
+      .andThrow(new SystemException("", new UnknownHostException("mpacks.org")));
+    replay(resourceProvider);
+
+    // when
+    downloadMpacksTask.downloadMissingMpacks(MISSING_MPACKS.subList(0, 1));
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added more detailed error reporting to DownloadMpackTask.
Examples of new error messages:
- An exception occurred during cluster provisioning: Error occured while registering mpack: HDPCORE-1.0.0-b406 (uri: http://dev.hortonworks.com.s3.amazonaws.com/HDPCORE/centos7/1.x/BUILDS/1.0.0-b406/mpack.jsonx). Caused by java.io.FileNotFoundException: http://dev.hortonworks.com.s3.amazonaws.com/HDPCORE/centos7/1.x/BUILDS/1.0.0-b406/mpack.jsonx
- An exception occurred during cluster provisioning: Error occured while registering mpack: HDPCORE-1.0.0-b406 (uri: http://dev.hortonworks.com.s3.amazonaws.org/HDPCORE/centos7/1.x/BUILDS/1.0.0-b406/mpack.json). Caused by java.net.UnknownHostException: dev.hortonworks.com.s3.amazonaws.org
- An exception occurred during cluster provisioning: Error occured while registering mpack: HDPCORE-1.0.0-b406 (uri: http://dev.hortonworks.com.s3.amazonaws.com:12345/HDPCORE/centos7/1.x/BUILDS/1.0.0-b406/mpack.json). Caused by java.net.ConnectException: Connection timed out (Connection timed out)

## How was this patch tested?
- Tested manually
- Wrote a new unit test
- Unit test run pending
