### PR TITLE
AMBARI-24100. Websocket connection. Port is hardcoded

### DIFF
--- a/ambari-web/app/utils/stomp_client.js
+++ b/ambari-web/app/utils/stomp_client.js
@@ -39,22 +39,12 @@ module.exports = Em.Object.extend({
   /**
    * @type {string}
    */
-  webSocketUrl: '{protocol}://{hostname}:{port}/api/stomp/v1/websocket',
+  webSocketUrl: '{protocol}://{hostname}{port}/api/stomp/v1/websocket',
 
   /**
    * @type {string}
    */
-  sockJsUrl: '{protocol}://{hostname}:{port}/api/stomp/v1',
-
-  /**
-   * @const
-   */
-  PORT: '8080',
-
-  /**
-   * @const
-   */
-  SECURE_PORT: '8443',
+  sockJsUrl: '{protocol}://{hostname}{port}/api/stomp/v1',
 
   /**
    * sockJs should use only alternative options as transport in case when websocket supported but connection fails
@@ -134,11 +124,23 @@ module.exports = Em.Object.extend({
    * @returns {string}
    */
   getSocketUrl: function(template, isWebsocket) {
-    const hostname = window.location.hostname;
-    const isSecure = window.location.protocol === 'https:';
+    const hostname = this.getHostName();
+    const isSecure = this.isSecure();
     const protocol = isWebsocket ? (isSecure ? 'wss' : 'ws') : (isSecure ? 'https' : 'http');
-    const port = isSecure ? this.get('SECURE_PORT') : this.get('PORT');
+    const port = this.getPort();
     return template.replace('{hostname}', hostname).replace('{protocol}', protocol).replace('{port}', port);
+  },
+
+  getHostName: function () {
+    return window.location.hostname;
+  },
+
+  isSecure: function () {
+    return window.location.protocol === 'https:';
+  },
+
+  getPort: function () {
+    return window.location.port ? (':' + window.location.port) : '';
   },
 
   onConnectionSuccess: function() {

--- a/ambari-web/test/utils/stomp_client_test.js
+++ b/ambari-web/test/utils/stomp_client_test.js
@@ -65,20 +65,42 @@ describe('App.StompClient', function () {
   });
 
   describe('#getSocket', function() {
+    beforeEach(function () {
+      sinon.stub(stomp, 'getHostName').returns('test');
+      sinon.stub(stomp, 'isSecure').returns(false);
+    });
+    afterEach(function () {
+      stomp.getHostName.restore();
+      stomp.isSecure.restore();
+      stomp.getPort.restore();
+    });
     it('should return WebSocket instance', function() {
-      expect(stomp.getSocket().URL).to.be.equal('ws://:8080/api/stomp/v1/websocket');
+      sinon.stub(stomp, 'getPort').returns(':8080');
+      expect(stomp.getSocket().URL).to.be.equal('ws://test:8080/api/stomp/v1/websocket');
     });
     it('should return SockJS instance', function() {
-      expect(stomp.getSocket(true).url).to.be.equal('http://:8080/api/stomp/v1');
+      sinon.stub(stomp, 'getPort').returns('');
+      expect(stomp.getSocket(true).url).to.be.equal('http://test/api/stomp/v1');
     });
   });
 
   describe('#getSocketUrl', function() {
+    beforeEach(function () {
+      sinon.stub(stomp, 'getHostName').returns('test');
+      sinon.stub(stomp, 'isSecure').returns(false);
+    });
+    afterEach(function () {
+      stomp.getHostName.restore();
+      stomp.isSecure.restore();
+      stomp.getPort.restore();
+    });
     it('should return socket url for websocket', function() {
-      expect(stomp.getSocketUrl('{protocol}://{hostname}:{port}', true)).to.equal('ws://:8080');
+      sinon.stub(stomp, 'getPort').returns(':8080');
+      expect(stomp.getSocketUrl('{protocol}://{hostname}{port}', true)).to.equal('ws://test:8080');
     });
     it('should return socket url for sockjs', function() {
-      expect(stomp.getSocketUrl('{protocol}://{hostname}:{port}', false)).to.equal('http://:8080');
+      sinon.stub(stomp, 'getPort').returns('');
+      expect(stomp.getSocketUrl('{protocol}://{hostname}{port}', false)).to.equal('http://test');
     });
   });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the URL does not contain port then the protocol defines the port in case of http it is 80, in case of https it is 443, if it contains it we should use it.

## How was this patch tested?
Unit tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.