### PR TITLE
AMBARI-24104: Host component creation fails when hadoop client from multiple mpacks is installed

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -806,11 +806,12 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     TreeMap<String, TopologyCluster> topologyUpdates = new TreeMap<>();
     Set<String> hostsToUpdate = new HashSet<>();
     for (ServiceComponentHostRequest request : requests) {
+      String serviceGroupName = request.getServiceGroupName();
       String serviceName = request.getServiceName();
       String componentName = request.getComponentName();
       Cluster cluster = clusters.getCluster(request.getClusterName());
       Collection<Host> clusterHosts = cluster.getHosts();
-      Service s = cluster.getService(serviceName);
+      Service s = cluster.getService(serviceGroupName, serviceName);
       ServiceComponent sc = s.getServiceComponent(componentName);
       String hostName = request.getHostname();
       hostsToUpdate.add(hostName);


### PR DESCRIPTION
Host component creation fails because of a call to cluster.getService(serviceName) instead of cluster.getService(serviceGroupName, serviceName). 

Change-Id: I6c4621159dcbe5e253d9d101fd523931be71b4a7

## What changes were proposed in this pull request?
(Please fill in changes proposed in this fix)

## How was this patch tested?
On live cluster

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.