### PR TITLE
[AMBARI-24105] Jackson library version mismatch casue MR jobs to fail.

### DIFF
--- a/ambari-metrics/ambari-metrics-common/pom.xml
+++ b/ambari-metrics/ambari-metrics-common/pom.xml
@@ -111,7 +111,11 @@
                 </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
-                  <shadedPattern>org.apache.hadoop.metrics2.sink.relocated.apache.http</shadedPattern>
+                  <shadedPattern>org.apache.ambari.metrics.sink.relocated.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.jackson</pattern>
+                  <shadedPattern>org.apache.ambari.metrics.sink.relocated.jackson</shadedPattern>
                 </relocation>
               </relocations>
               <filters>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shaded the jackson dependency used internally.

## How was this patch tested?

mvn clean install.
Manually tested by deploying HDFS and HBase from HDP 3.0 stack.