### PR TITLE
AMBARI-24112. Requests failed after Ambari upgrade with exception while executing custom service command.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentClusterDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentClusterDataHolder.java
@@ -60,17 +60,12 @@ public abstract class AgentClusterDataHolder<T extends STOMPEvent & Hashable> ex
    * @return true if the update introduced any change
    */
   public boolean updateData(T update) throws AmbariException {
-    initializeDataIfNeeded(false);
+    initializeDataIfNeeded(true);
     boolean changed = handleUpdate(update);
     if (changed) {
       regenerateDataIdentifiers(data);
       update.setHash(getData().getHash());
       STOMPUpdatePublisher.publish(update);
-    } else {
-      // in case update does not have changes empty identifiers should be populated anyway
-      if (!isIdentifierValid(data)) {
-        regenerateDataIdentifiers(data);
-      }
     }
     return changed;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
@@ -69,7 +69,7 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
    * event to listeners.
    */
   public final void updateData(T update) throws AmbariException {
-    initializeDataIfNeeded(update.getHostId(), false);
+    initializeDataIfNeeded(update.getHostId(), true);
     if (handleUpdate(update)) {
       T hostData = getData(update.getHostId());
       regenerateDataIdentifiers(hostData);
@@ -78,12 +78,6 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
         LOG.info("Configs update with hash {} will be sent to host {}", update.getHash(), hostData.getHostId());
       }
       STOMPUpdatePublisher.publish(update);
-    } else {
-      // in case update does not have changes empty identifiers should be populated anyway
-      T hostData = getData(update.getHostId());
-      if (!isIdentifierValid(hostData)) {
-        regenerateDataIdentifiers(hostData);
-      }
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -5830,7 +5830,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     return serviceLevelParams;
   }
 
-  public TreeMap<String, String> getMetadataAmbariLevelParams() throws AmbariException {
+  public TreeMap<String, String> getMetadataAmbariLevelParams() {
     TreeMap<String, String> clusterLevelParams = new TreeMap<>();
     clusterLevelParams.put(JDK_LOCATION, getJdkResourceUrl());
     clusterLevelParams.put(JAVA_HOME, getJavaHome());

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -280,45 +280,43 @@ public class ClustersImpl implements Clusters {
   private void loadClustersAndHosts() {
     LOG.info("Initializing cluster and host data.");
 
-    clustersByName = new ConcurrentHashMap<>();
-    clustersById = new ConcurrentHashMap<>();
-    hostsByName = new ConcurrentHashMap<>();
-    hostsById = new ConcurrentHashMap<>();
-    hostClustersMap = new ConcurrentHashMap<>();
-    clusterHostsMap1 = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Cluster> clustersByNameTemp = new ConcurrentHashMap<>();
+    ConcurrentHashMap<Long, Cluster> clustersByIdTemp = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Host> hostsByNameTemp = new ConcurrentHashMap<>();
+    ConcurrentHashMap<Long, Host> hostsByIdTemp = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Set<Cluster>> hostClustersMapTemp = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Set<Host>> clusterHostsMap1Temp = new ConcurrentHashMap<>();
 
     List<HostEntity> hostEntities = hostDAO.findAll();
     for (HostEntity hostEntity : hostEntities) {
       Host host = hostFactory.create(hostEntity);
-      hostsByName.put(hostEntity.getHostName(), host);
-      hostsById.put(hostEntity.getHostId(), host);
+      hostsByNameTemp.put(hostEntity.getHostName(), host);
+      hostsByIdTemp.put(hostEntity.getHostId(), host);
     }
+    hostsByName = hostsByNameTemp;
+    hostsById = hostsByIdTemp;
 
     for (ClusterEntity clusterEntity : clusterDAO.findAll()) {
       Cluster currentCluster = clusterFactory.create(clusterEntity);
-      clustersByName.put(clusterEntity.getClusterName(), currentCluster);
-      clustersById.put(currentCluster.getClusterId(), currentCluster);
-      clusterHostsMap1.put(currentCluster.getClusterName(), Collections.newSetFromMap(new ConcurrentHashMap<>()));
+      clustersByNameTemp.put(clusterEntity.getClusterName(), currentCluster);
+      clustersByIdTemp.put(currentCluster.getClusterId(), currentCluster);
+      clusterHostsMap1Temp.put(currentCluster.getClusterName(), Collections.newSetFromMap(new ConcurrentHashMap<>()));
     }
+    clustersByName = clustersByNameTemp;
+    clustersById = clustersByIdTemp;
 
     for (HostEntity hostEntity : hostEntities) {
       Set<Cluster> cSet = Collections.newSetFromMap(new ConcurrentHashMap<Cluster, Boolean>());
-      hostClustersMap.put(hostEntity.getHostName(), cSet);
+      hostClustersMapTemp.put(hostEntity.getHostName(), cSet);
 
       Host host = getHostsByName().get(hostEntity.getHostName());
       for (ClusterEntity clusterEntity : hostEntity.getClusterEntities()) {
-        clusterHostsMap1.get(clusterEntity.getClusterName()).add(host);
+        clusterHostsMap1Temp.get(clusterEntity.getClusterName()).add(host);
         cSet.add(clustersByName.get(clusterEntity.getClusterName()));
       }
     }
-    // init host configs
-    for (Long hostId : hostsById.keySet()) {
-      try {
-        m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true);
-      } catch (AmbariException e) {
-        LOG.error("Agent configs initialization was failed", e);
-      }
-    }
+    hostClustersMap = hostClustersMapTemp;
+    clusterHostsMap1 = clusterHostsMap1Temp;
   }
 
   @Override
@@ -491,12 +489,6 @@ public class ClustersImpl implements Clusters {
 
     if (null != hostId) {
       getHostsById().put(hostId, host);
-      // init host configs
-      try {
-        m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true);
-      } catch (AmbariException e) {
-        LOG.error("Agent configs initialization was failed for host with id %s", hostId, e);
-      }
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -317,6 +317,14 @@ public class ClustersImpl implements Clusters {
     }
     hostClustersMap = hostClustersMapTemp;
     clusterHostsMap1 = clusterHostsMap1Temp;
+    // init host configs
+    for (Long hostId : hostsById.keySet()) {
+      try {
+        m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true);
+      } catch (AmbariException e) {
+        LOG.error("Agent configs initialization was failed", e);
+      }
+    }
   }
 
   @Override
@@ -489,6 +497,12 @@ public class ClustersImpl implements Clusters {
 
     if (null != hostId) {
       getHostsById().put(hostId, host);
+      // init host configs
+      try {
+        m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true);
+      } catch (AmbariException e) {
+        LOG.error("Agent configs initialization was failed for host with id %s", hostId, e);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server initialize STOMP cache with pre-generated hash on cache update. This avoids the situation when stomp cache is already available for agents, but has null hash.

## How was this patch tested?

Manual testing.