### PR TITLE
[AMBARI-24111] Enable configs originating from mpack advisor to be added

### DIFF
--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -763,7 +763,7 @@ App.config = Em.Object.create({
    */
   getStepConfigForProperty: function (stepConfigs, fileName) {
     return stepConfigs.find(function (s) {
-      return s.get('configTypes').contains(App.config.getConfigTagFromFileName(fileName));
+      return !!s.get('configTypes')[App.config.getConfigTagFromFileName(fileName)];
     });
   },
 
@@ -797,6 +797,7 @@ App.config = Em.Object.create({
       serviceName: preDefinedServiceConfig.get('serviceName'),
       displayName: preDefinedServiceConfig.get('displayName'),
       configCategories: preDefinedServiceConfig.get('configCategories'),
+      configTypes: preDefinedServiceConfig.get('configTypes'),
       configs: configs || [],
       configGroups: configGroups || [],
       initConfigsLength: initConfigsLength || 0

--- a/ambari-web/test/utils/config_test.js
+++ b/ambari-web/test/utils/config_test.js
@@ -1500,8 +1500,17 @@ describe('App.config', function() {
   });
 
   describe('#getStepConfigForProperty', function () {
-    var input = [Em.Object.create({ configTypes: ['f1'] }), Em.Object.create({ configTypes: ['f2'] })];
+    var input = [
+      Em.Object.create({
+        configTypes: { f1: 'f1' }
+      }),
+      Em.Object.create({
+        configTypes: { f2: 'f2' }
+      })
+    ];
+    
     var output = input[0];
+
     it('returns stepConfig for fileName', function () {
       expect(App.config.getStepConfigForProperty(input, 'f1')).to.eql(output);
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Populated configTypes property so that configs coming from mpack advisory can get added to the overall list of configs in the UI.

## How was this patch tested?

All unit tests passing.