### PR TITLE
[AMBARI-24114] Ranger server password checks are not performed during Cluster Install Wizard

### DIFF
--- a/ambari-web/app/controllers/wizard/step7_controller.js
+++ b/ambari-web/app/controllers/wizard/step7_controller.js
@@ -1900,6 +1900,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
         isActive: false,
         isDisabled: false,
         isSkipped: false,
+        validateOnSwitch: false,
         tabView: App.CredentialsTabOnStep7View
       }),
       Em.Object.create({
@@ -1909,6 +1910,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
         isActive: false,
         isDisabled: false,
         isSkipped: false,
+        validateOnSwitch: false,
         tabView: App.DatabasesTabOnStep7View
       }),
       Em.Object.create({
@@ -1918,6 +1920,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
         isActive: false,
         isDisabled: false,
         isSkipped: false,
+        validateOnSwitch: false,
         selectedServiceName: null,
         tabView: App.DirectoriesTabOnStep7View
       }),
@@ -1928,6 +1931,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
         isActive: false,
         isDisabled: false,
         isSkipped: false,
+        validateOnSwitch: false,
         tabView: App.AccountsTabOnStep7View
       }),
       Em.Object.create({
@@ -1937,6 +1941,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
         isActive: false,
         isDisabled: false,
         isSkipped: false,
+        validateOnSwitch: true,
         selectedServiceName: null,
         tabView: App.ServicesConfigView
       })
@@ -2117,6 +2122,23 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
 
   updateConfigAttributesFromThemes: function () {
     this.get('allSelectedServiceNames').forEach(serviceName => this.updateAttributesFromTheme(serviceName));
-  }
+  },
+
+  validateOnTabSwitch: function () {
+    const activeTab = this.get('tabs')[this.get('currentTabIndex')];
+    if (activeTab && activeTab.get('validateOnSwitch')) {
+      if (this.get('requestTimer')) {
+        clearTimeout(this.get('requestTimer'));
+      }
+      if (this.get('validationRequest')) {
+        this.get('validationRequest').abort();
+      }
+      if (this.get('recommendationsInProgress')) {
+        this.valueObserver();
+      } else {
+        this.runServerSideValidation().done(() => this.set('validationRequest', null));
+      }
+    }
+  }.observes('currentTabIndex')
 
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

While installing a new cluster, if the Ranger-specific passwords do not meet the (non-obvious) requirements, failures will occur during the install Ranger task. Once this happens, there is no way for the user to go back and fix the issue. So the issue needs to be caught sooner.

STR
1. Create new Ambari 2.7.0 cluster
2. Include Ranger
3. Set simple passwords when prompted - for example: hadoop
4. Proceed to install
5. See failure

## How was this patch tested?

UI unit tests:
  21802 passing (32s)
  48 pending