### PR TITLE
AMBARI-24108. Adding a New Component to a Host Doesn't Get Reflected …

### DIFF
--- a/ambari-web/app/mappers/socket/topology_mapper.js
+++ b/ambari-web/app/mappers/socket/topology_mapper.js
@@ -53,7 +53,7 @@ App.topologyMapper = App.QuickDataMapper.create({
   applyComponentTopologyChanges: function(components, eventType) {
     components.forEach((component) => {
       component.hostNames.forEach((hostName, index) => {
-        if (eventType === 'UPDATE') {
+        if (eventType === 'UPDATE' && !component.commandParams.version) {
           this.addServiceIfNew(component.serviceName);
           this.createHostComponent(component, hostName, component.publicHostNames[index]);
           App.componentsStateMapper.updateComponentCountOnCreate(component);

--- a/ambari-web/test/mappers/socket/topology_mapper_test.js
+++ b/ambari-web/test/mappers/socket/topology_mapper_test.js
@@ -77,7 +77,7 @@ describe('App.topologyMapper', function () {
         {
           hostNames: ['host1'],
           serviceName: 'S1',
-          version: 'UNKNOWN',
+          commandParams: {},
           publicHostNames: ['public1']
         }
       ];


### PR DESCRIPTION
…Without a Hard Refresh

## What changes were proposed in this pull request?
Adding a New Component to a Host Doesn't Get Reflected Without a Hard Refresh	

## How was this patch tested?
Manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.