### PR TITLE
[AMBARI-24117] Ambari "assign masters" should display available hosts in sorted order

### DIFF
--- a/ambari-web/app/mixins/wizard/selectHost.js
+++ b/ambari-web/app/mixins/wizard/selectHost.js
@@ -159,11 +159,11 @@ App.SelectHost = Em.Mixin.create({
         .without(this.get('component.selectedHost'));
 
     if (multipleComponents.contains(componentName)) {
-      return hosts.filter(function (host) {
+      hosts = hosts.filter(function (host) {
         return !occupiedHosts.contains(host.get('host_name'));
       }, this);
     }
-    return hosts;
+    return hosts.sortProperty('host_name');
   },
 
   /**


### PR DESCRIPTION
## How was this patch tested?

  21802 passing (50s)
  48 pending