### PR TITLE
[AMBARI-24119]. TaskWrapper should only wrap a single task

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -786,23 +786,23 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
           // is a bug that prevents one stage with multiple tasks assigned for
           // the same host, break them out into individual stages.
           for (TaskWrapper taskWrapper : wrapper.getTasks()) {
-            for (Task task : taskWrapper.getTasks()) {
-              if (upgradeContext.isManualVerificationAutoSkipped()
-                  && task.getType() == Task.Type.MANUAL) {
-                continue;
-              }
+            Task task = taskWrapper.getTask();
 
-              UpgradeItemEntity itemEntity = new UpgradeItemEntity();
+            if (upgradeContext.isManualVerificationAutoSkipped()
+                && task.getType() == Task.Type.MANUAL) {
+              continue;
+            }
 
-              itemEntity.setText(wrapper.getText());
-              itemEntity.setTasks(wrapper.getTasksJson());
-              itemEntity.setHosts(wrapper.getHostsJson());
+            UpgradeItemEntity itemEntity = new UpgradeItemEntity();
 
-              injectVariables(configHelper, cluster, itemEntity);
-              if (makeServerSideStage(group, upgradeContext, null, req,
-                  itemEntity, (ServerSideActionTask) task, configUpgradePack)) {
-                itemEntities.add(itemEntity);
-              }
+            itemEntity.setText(wrapper.getText());
+            itemEntity.setTasks(wrapper.getTasksJson());
+            itemEntity.setHosts(wrapper.getHostsJson());
+
+            injectVariables(configHelper, cluster, itemEntity);
+            if (makeServerSideStage(group, upgradeContext, null, req,
+                itemEntity, (ServerSideActionTask) task, configUpgradePack)) {
+              itemEntities.add(itemEntity);
             }
           }
         } else {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -616,19 +616,18 @@ public class UpgradeHelper {
       }
 
       for (TaskWrapper taskWrapper : stageWrapper.getTasks()) {
-        for (Task task : taskWrapper.getTasks()) {
-          if (null != task.summary) {
-            task.summary = tokenReplace(ctx, task.summary, null, null);
-          }
+        Task task = taskWrapper.getTask();
+        if (null != task.summary) {
+          task.summary = tokenReplace(ctx, task.summary, null, null);
+        }
 
-          if (task.getType() == Type.MANUAL) {
-            ManualTask mt = (ManualTask) task;
-            if(null != mt.messages && !mt.messages.isEmpty()){
-              for(int i = 0; i < mt.messages.size(); i++){
-                String message =  mt.messages.get(i);
-                message = tokenReplace(ctx, message, taskWrapper.getService(), taskWrapper.getComponent());
-                mt.messages.set(i, message);
-              }
+        if (task.getType() == Type.MANUAL) {
+          ManualTask mt = (ManualTask) task;
+          if(null != mt.messages && !mt.messages.isEmpty()){
+            for(int i = 0; i < mt.messages.size(); i++){
+              String message =  mt.messages.get(i);
+              message = tokenReplace(ctx, message, taskWrapper.getService(), taskWrapper.getComponent());
+              mt.messages.set(i, message);
             }
           }
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ColocatedGrouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/ColocatedGrouping.java
@@ -18,7 +18,6 @@
 package org.apache.ambari.server.state.stack.upgrade;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,14 +35,12 @@ import org.apache.ambari.server.stack.HostsType;
 import org.apache.ambari.server.state.UpgradeContext;
 import org.apache.ambari.server.state.stack.UpgradePack.ProcessingComponent;
 import org.apache.ambari.server.state.stack.upgrade.StageWrapper.Type;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
@@ -380,7 +377,7 @@ public class ColocatedGrouping extends Grouping {
     public String toString() {
       String s = "";
       for (TaskWrapper t : tasks) {
-        s += component + "/" + t.getTasks() + " ";
+        s += component + "/" + t.getTask() + " ";
       }
 
       return s;
@@ -400,9 +397,7 @@ public class ColocatedGrouping extends Grouping {
       List<TaskWrapper> interim = new ArrayList<>();
 
       for (TaskWrapper wrapper : tasks) {
-        Collection<Task> filtered = Collections2.filter(wrapper.getTasks(), predicate);
-
-        if (CollectionUtils.isNotEmpty(filtered)) {
+        if (predicate.apply(wrapper.getTask())) {
           interim.add(wrapper);
         }
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/StageWrapper.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.gson.Gson;
 
 /**
@@ -95,7 +95,7 @@ public class StageWrapper {
   public String getTasksJson() {
     List<Task> realTasks = new ArrayList<>();
     for (TaskWrapper tw : tasks) {
-      realTasks.addAll(tw.getTasks());
+      realTasks.add(tw.getTask());
     }
 
     return gson.toJson(realTasks);
@@ -167,7 +167,7 @@ public class StageWrapper {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", type)
+    return MoreObjects.toStringHelper(this).add("type", type)
         .add("text",text)
         .omitNullValues().toString();
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/TaskWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/TaskWrapper.java
@@ -17,16 +17,14 @@
  */
 package org.apache.ambari.server.state.stack.upgrade;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Aggregates all upgrade tasks for a HostComponent into one wrapper.
@@ -37,8 +35,7 @@ public class TaskWrapper {
   private String component;
   private Set<String> hosts; // all the hosts that all the tasks must run
   private Map<String, String> params;
-  /* FIXME a TaskWrapper really should be wrapping ONLY ONE task */
-  private List<Task> tasks; // all the tasks defined for the hostcomponent
+  private Task task;
   private Set<String> timeoutKeys = new HashSet<>();
 
   /**
@@ -51,38 +48,22 @@ public class TaskWrapper {
     this(s, c, hosts, null, task);
   }
 
-
-  /**
-   * @param s the service name for the tasks
-   * @param c the component name for the tasks
-   * @param hosts the set of hosts that the tasks are for
-   * @param params additional command parameters
-   * @param tasks an array of tasks as a convenience
-   */
-  public TaskWrapper(String s, String c, Set<String> hosts, Map<String, String> params, Task... tasks) {
-    this(s, c, hosts, params, Arrays.asList(tasks));
-  }
-
-
   /**
    * @param s the service name for the tasks
    * @param c the component name for the tasks
    * @param hosts the set of hosts for the
    * @param tasks the list of tasks
    */
-  public TaskWrapper(String s, String c, Set<String> hosts, Map<String, String> params, List<Task> tasks) {
+  public TaskWrapper(String s, String c, Set<String> hosts, Map<String, String> params, Task task) {
     service = s;
     component = c;
 
     this.hosts = hosts;
     this.params = (params == null) ? new HashMap<>() : params;
-    this.tasks = tasks;
+    this.task = task;
 
-    // !!! FIXME there should only be one task
-    for (Task task : tasks) {
-      if (StringUtils.isNotBlank(task.timeoutConfig)) {
-        timeoutKeys.add(task.timeoutConfig);
-      }
+    if (StringUtils.isNotBlank(task.timeoutConfig)) {
+      timeoutKeys.add(task.timeoutConfig);
     }
   }
 
@@ -96,8 +77,8 @@ public class TaskWrapper {
   /**
    * @return the tasks associated with this wrapper
    */
-  public List<Task> getTasks() {
-    return tasks;
+  public Task getTask() {
+    return task;
   }
 
   /**
@@ -112,9 +93,9 @@ public class TaskWrapper {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("service", service)
+    return MoreObjects.toStringHelper(this).add("service", service)
         .add("component", component)
-        .add("tasks", tasks)
+        .add("task", task)
         .add("hosts", hosts)
         .omitNullValues().toString();
   }
@@ -136,14 +117,8 @@ public class TaskWrapper {
   /**
    * @return true if any task is sequential, otherwise, return false.
    */
-  public boolean isAnyTaskSequential() {
-    for (Task t : getTasks()) {
-      if (t.isSequential) {
-        return true;
-      }
-    }
-
-    return false;
+  public boolean isSequential() {
+    return getTask().isSequential;
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/stack/upgrade/StageWrapperBuilderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/stack/upgrade/StageWrapperBuilderTest.java
@@ -114,7 +114,7 @@ public class StageWrapperBuilderTest extends EasyMockSupport {
     StageWrapper skipSummaryWrapper = stageWrappers.get(1);
     Assert.assertEquals(StageWrapper.Type.SERVER_SIDE_ACTION, skipSummaryWrapper.getType());
 
-    ServerActionTask task = (ServerActionTask)(skipSummaryWrapper.getTasks().get(0).getTasks().get(0));
+    ServerActionTask task = (ServerActionTask)(skipSummaryWrapper.getTasks().get(0).getTask());
     Assert.assertEquals(AutoSkipFailedSummaryAction.class.getName(), task.implClass);
     Assert.assertEquals(1, task.messages.size());
     Assert.assertTrue(task.messages.get(0).contains("There are failures that were automatically skipped"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TaskWrapper` should be holding one and only task - the hosts are the multiplicity of the wrapper, not the task.

## How was this patch tested?

Manual testing + unit tests.  No more tests broken than previous to this patch.

```
[ERROR] Tests run: 4795, Failures: 11, Errors: 58, Skipped: 94
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 30:54 min
[INFO] Finished at: 2018-06-14T09:08:27-04:00
[INFO] Final Memory: 108M/1891M
[INFO] ------------------------------------------------------------------------
```
