### PR TITLE
[AMBARI-24115] Install all services and start all services with a single request each

### DIFF
--- a/ambari-web/app/controllers/wizard.js
+++ b/ambari-web/app/controllers/wizard.js
@@ -553,21 +553,13 @@ App.WizardController = Em.Controller.extend(App.LocalStorage, App.ThemesMappingM
     };
     this.saveClusterStatus(clusterStatus);
 
-    const serviceGroups = this.get('content.serviceGroups');
-    
-    const installPromises = serviceGroups.map(sg => {
-      data.serviceGroupName = sg;
-
-      return App.ajax.send({
-        name: isRetry ? 'common.host_components.update' : 'common.services.update',
-        sender: this,
-        data: data,
-        success: 'installServicesSuccessCallback',
-        error: 'installServicesErrorCallback'
-      })
-    })
-
-    $.when(...installPromises).then(callback, callback);
+    return App.ajax.send({
+      name: isRetry ? 'common.host_components.update' : 'common.services.update.all',
+      sender: this,
+      data: data,
+      success: 'installServicesSuccessCallback',
+      error: 'installServicesErrorCallback'
+    }).then(callback, callback);
   },
 
   installServicesSuccessCallback: function (jsonData) {

--- a/ambari-web/app/controllers/wizard/step9_controller.js
+++ b/ambari-web/app/controllers/wizard/step9_controller.js
@@ -508,7 +508,6 @@ App.WizardStep9Controller = App.WizardStepController.extend(App.ReloadPopupMixin
           success: 'launchStartServicesSuccessCallback',
           error: 'launchStartServicesErrorCallback'
         }).then(callback, callback);
-        break;
       case 'addServiceController':
         var servicesList = this.get('content.services').filterProperty('isSelected').filterProperty('isInstalled', false).mapProperty('serviceName');
         if (servicesList.contains('OOZIE')) {
@@ -520,21 +519,13 @@ App.WizardStep9Controller = App.WizardStepController.extend(App.ReloadPopupMixin
           "urlParams": "ServiceInfo/state=INSTALLED&ServiceInfo/service_name.in(" + servicesList.join(",") + ")&params/run_smoke_test=true&params/reconfigure_client=false"
         };
 
-        serviceGroups = this.get('content.serviceGroups');
-        promises = serviceGroups.map(sg => {
-          data.serviceGroupName = sg;
-
-          return App.ajax.send({
-            name: 'common.services.update', //TODO: This should change to use common.services.update.all when that is implemented on the back end.
-            sender: this,
-            data: data,
-            success: 'launchStartServicesSuccessCallback',
-            error: 'launchStartServicesErrorCallback'
-          })
-        })
-
-        return $.when(...promises).then(callback, callback);
-        break;
+        return App.ajax.send({
+          name: 'common.services.update.all',
+          sender: this,
+          data: data,
+          success: 'launchStartServicesSuccessCallback',
+          error: 'launchStartServicesErrorCallback'
+        }).then(callback, callback);
       default:
         data = {
           "context": Em.I18n.t("requestInfo.startServices"),
@@ -542,20 +533,13 @@ App.WizardStep9Controller = App.WizardStepController.extend(App.ReloadPopupMixin
           "urlParams": "ServiceInfo/state=INSTALLED&params/run_smoke_test=" + !this.get('skipServiceChecks') + "&params/reconfigure_client=false"
         };
 
-        serviceGroups = this.get('content.serviceGroups');
-        promises = serviceGroups.map(sg => {
-          data.serviceGroupName = sg;
-
-          return App.ajax.send({
-            name: 'common.services.update', //TODO: This should change to use common.services.update.all when that is implemented on the back end.
-            sender: this,
-            data: data,
-            success: 'launchStartServicesSuccessCallback',
-            error: 'launchStartServicesErrorCallback'
-          })
-        })
-
-        return $.when(...promises).then(callback, callback);
+        return App.ajax.send({
+          name: 'common.services.update.all',
+          sender: this,
+          data: data,
+          success: 'launchStartServicesSuccessCallback',
+          error: 'launchStartServicesErrorCallback'
+        }).then(callback, callback);
     }
 
     if (App.get('testMode')) {

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -57,7 +57,8 @@ var urls = {
   },
 
   'common.services.update.all' : {
-    'real': '/clusters/{clusterName}/servicegroups?{urlParams}',
+    //'real': '/clusters/{clusterName}/servicegroups?{urlParams}', //this is the new endpoint that should really be used for this but it isn't ready yet
+    'real': '/clusters/{clusterName}/services?{urlParams}', //this is the deprecated endpoint we have to use for now
     'format': function (data) {
       return {
         type: 'PUT',

--- a/ambari-web/test/controllers/wizard_test.js
+++ b/ambari-web/test/controllers/wizard_test.js
@@ -770,8 +770,7 @@ describe('App.WizardController', function () {
         ]
       }));
       wizardController.installServices(true);
-      expect(App.ajax.send.calledThrice).to.be.true;
-      expect($.when.calledOnce).to.be.true;
+      expect(App.ajax.send.calledOnce).to.be.true;
       expect(res).to.be.eql({
         "status": "PENDING"
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Made install services and start services operations at the end of the install wizard in to a single request each, although this currently uses the deprecated endpoint.

## How was this patch tested?

All unit tests passing.