### PR TITLE
[AMBARI-24091] Blueprint should add dependencies from specific mpack

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -80,6 +80,21 @@ public class CompositeStack implements StackDefinition {
   }
 
   @Override
+  public Stream<Pair<StackId, ServiceInfo>> getServices(String serviceName) {
+    return stacks.stream()
+      .flatMap(each -> each.getServices(serviceName));
+  }
+
+  @Override
+  public Optional<ServiceInfo> getService(StackId stackId, String serviceName) {
+    return stacks.stream()
+      .map(each -> each.getService(stackId, serviceName))
+      .filter(Optional::isPresent)
+      .findAny()
+      .map(o -> o.orElse(null));
+  }
+
+  @Override
   public Set<StackId> getStackIds() {
     return stacks.stream()
       .map(Stack::getStackId)

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -205,6 +207,22 @@ public class Stack implements StackDefinition {
   @Override
   public Collection<String> getServices() {
     return serviceComponents.keySet();
+  }
+
+  @Override
+  public Stream<Pair<StackId, ServiceInfo>> getServices(String serviceName) {
+    ServiceInfo serviceInfo = stackInfo.getService(serviceName);
+    return serviceInfo != null
+      ? Stream.of(Pair.of(getStackId(), serviceInfo))
+      : Stream.empty();
+  }
+
+  @Override
+  public Optional<ServiceInfo> getService(StackId stackId, String serviceName) {
+    ServiceInfo serviceInfo = stackInfo.getService(serviceName);
+    return Objects.equals(stackId, getStackId())
+      ? Optional.ofNullable(serviceInfo)
+      : Optional.empty();
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.controller.internal;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -68,6 +69,9 @@ public interface StackDefinition {
    * @return collection of all services for the stack
    */
   Collection<String> getServices();
+
+  Stream<Pair<StackId, ServiceInfo>> getServices(String serviceName);
+  Optional<ServiceInfo> getService(StackId stackId, String serviceName);
 
   /**
    * Get components contained in the stack for the specified service.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/DependencyInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/DependencyInfo.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.state;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -181,11 +182,27 @@ public class DependencyInfo {
     return !CollectionUtils.isEmpty(dependencyConditions);
   }
 
+  /** @return true if dependency scope is host-level */
+  public boolean isHostLevel() {
+    return "host".equals(getScope());
+  }
+
+  /** @return true if auto-deploy is enabled */
+  public boolean isAutoDeployable() {
+    return m_autoDeploy != null && m_autoDeploy.isEnabled();
+  }
+
+  /** @return true if all dependency conditions are resolved */
+  public boolean areDependencyConditionsResolved(Map<String, Map<String, String>> properties) {
+    return getDependencyConditions().stream()
+      .allMatch(condition -> condition.isResolved(properties));
+  }
+
   @Override
   public String toString() {
     return "DependencyInfo[name=" + getName() +
            ", scope=" + getScope() +
-           ", auto-deploy=" + m_autoDeploy.isEnabled() +
+           ", auto-deploy=" + isAutoDeployable() +
            "]";
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbiguousComponentException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbiguousComponentException.java
@@ -17,24 +17,24 @@
  */
 package org.apache.ambari.server.topology;
 
-import java.util.Collection;
 import java.util.Set;
 
-import org.apache.ambari.server.controller.internal.ProvisionAction;
+import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
+import org.apache.commons.lang3.tuple.Pair;
 
-/**
- * Request for provisioning the cluster.  This interface is extracted
- * from ProvisionClusterRequest so that we can have a unified view of the
- * blueprint and the request in BlueprintBasedClusterProvisionRequest.
- */
-public interface ProvisionRequest extends TopologyRequest {
+public class AmbiguousComponentException extends IllegalStateException {
 
-  ConfigRecommendationStrategy getConfigRecommendationStrategy();
-  ProvisionAction getProvisionAction();
-  String getDefaultPassword();
-  Set<StackId> getStackIds();
-  Collection<MpackInstance> getMpacks();
-  SecurityConfiguration getSecurityConfiguration();
+  AmbiguousComponentException(Set<Pair<StackId, ServiceInfo>> serviceMatches) {
+    super(formatResolutionProblemMessage(serviceMatches));
+  }
+
+  private static String formatResolutionProblemMessage(Set<Pair<StackId, ServiceInfo>> serviceMatches) {
+    if (serviceMatches.isEmpty()) {
+      return "No service found";
+    }
+
+    return "Multiple services found: " + serviceMatches;
+  }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintBasedClusterProvisionRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintBasedClusterProvisionRequest.java
@@ -17,17 +17,13 @@
  */
 package org.apache.ambari.server.topology;
 
-import static java.util.stream.Collectors.toMap;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
-import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
 import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.orm.entities.BlueprintEntity;
 import org.apache.ambari.server.state.SecurityType;
@@ -39,20 +35,20 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 /**
- * I am the Blueprint and ProvisionClusterRequest combined.
+ * I am the Blueprint and ProvisionRequest combined.
  */
 public class BlueprintBasedClusterProvisionRequest implements Blueprint, ProvisionRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(BlueprintBasedClusterProvisionRequest.class);
 
   private final Blueprint blueprint;
-  private final ProvisionClusterRequest request;
+  private final ProvisionRequest request;
   private final Set<StackId> stackIds;
   private final StackDefinition stack;
   private final Set<MpackInstance> mpacks;
   private final SecurityConfiguration securityConfiguration;
 
-  public BlueprintBasedClusterProvisionRequest(AmbariContext ambariContext, SecurityConfigurationFactory securityConfigurationFactory, Blueprint blueprint, ProvisionClusterRequest request) {
+  public BlueprintBasedClusterProvisionRequest(AmbariContext ambariContext, SecurityConfigurationFactory securityConfigurationFactory, Blueprint blueprint, ProvisionRequest request) {
     this.blueprint = blueprint;
     this.request = request;
 
@@ -105,6 +101,11 @@ public class BlueprintBasedClusterProvisionRequest implements Blueprint, Provisi
   }
 
   @Override
+  public SecurityConfiguration getSecurityConfiguration() {
+    return securityConfiguration;
+  }
+
+  @Override
   public Collection<HostGroup> getHostGroupsForComponent(String component) {
     return blueprint.getHostGroupsForComponent(component);
   }
@@ -145,32 +146,23 @@ public class BlueprintBasedClusterProvisionRequest implements Blueprint, Provisi
     return request.getDescription();
   }
 
+  @Override
   public String getDefaultPassword() {
     return request.getDefaultPassword();
   }
 
+  @Override
   public ConfigRecommendationStrategy getConfigRecommendationStrategy() {
     return request.getConfigRecommendationStrategy();
   }
 
+  @Override
   public ProvisionAction getProvisionAction() {
     return request.getProvisionAction();
   }
 
   public StackDefinition getStack() {
     return stack;
-  }
-
-  /**
-   * @return service instances defined in the topology, mapped by service name,
-   * whose name is unique across all mpacks.
-   */
-  public Map<String, ServiceInstance> getUniqueServices() {
-    Map<String, ServiceInstance> map = mpacks.stream()
-      .flatMap(mpack -> mpack.getServiceInstances().stream())
-      .collect(toMap(ServiceInstance::getName, Function.identity(), (s1, s2) -> null));
-    map.entrySet().removeIf(e -> e.getValue() == null); // remove non-unique names mapped to null
-    return map;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Cardinality.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Cardinality.java
@@ -18,15 +18,27 @@
 
 package org.apache.ambari.server.topology;
 
+import java.util.Objects;
+
 /**
  * Component cardinality representation.
  */
 public class Cardinality {
-  String cardinality;
-  int min = 0;
-  int max = Integer.MAX_VALUE;
-  int exact = -1;
-  boolean isAll = false;
+
+  public static final Cardinality ALL = new Cardinality("ALL");
+
+  private final String cardinality;
+  private int min = 0;
+  private int max = Integer.MAX_VALUE;
+  private int exact = -1;
+  private boolean isAll = false;
+
+  public static Cardinality of(String cardinality) {
+    if ("ALL".equals(cardinality)) {
+      return ALL;
+    }
+    return new Cardinality(cardinality);
+  }
 
   public Cardinality(String cardinality) {
     this.cardinality = cardinality;
@@ -85,6 +97,29 @@ public class Cardinality {
   }
 
   public String getValue() {
+    return cardinality;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    Cardinality other = (Cardinality) obj;
+    return Objects.equals(cardinality, other.cardinality);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(cardinality);
+  }
+
+  @Override
+  public String toString() {
     return cardinality;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
@@ -44,6 +44,11 @@ public interface ClusterTopology {
   Long getClusterId();
 
   /**
+   * @throws IllegalStateException if the topology already has a clusterId associated with it
+   */
+  void setClusterId(Long clusterId);
+
+  /**
    * Get the blueprint associated with the cluster.
    *
    * @return associated blueprint
@@ -106,6 +111,7 @@ public interface ClusterTopology {
    */
   @Deprecated // 1. component name is not enough, 2. only used for stack-specific checks/updates
   Collection<String> getHostGroupsForComponent(String component);
+  Set<String> getHostGroupsForComponent(ResolvedComponent component);
 
   /**
    * Get the name of the host group which is mapped to the specified host.
@@ -225,10 +231,13 @@ public interface ClusterTopology {
    */
   boolean containsMasterComponent(String hostGroup);
 
-  Collection<HostGroup> getHostGroups();
+  Set<String> getHostGroups();
 
   /*
    * @return true if the given component belongs to a service that has serviceType=HCFS
    */
   boolean isComponentHadoopCompatible(String component);
+
+  ClusterTopology withAdditionalComponents(Map<String, Set<ResolvedComponent>> additionalComponents) throws InvalidTopologyException;
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
@@ -238,6 +238,16 @@ public interface ClusterTopology {
    */
   boolean isComponentHadoopCompatible(String component);
 
+  /**
+   * Creates a new, updated @{code ClusterTopology} with components combined from the current topology
+   * and the given additional ones.
+   * Note that parts of the returned topology may be shallow copies of the one passed in, which should no
+   * longer be used.
+   *
+   * @param additionalComponents additional components to be deployed, grouped by host group name
+   * @return the new, combined topology (may be the same object, if no additional components are provided)
+   * @throws InvalidTopologyException if any unknown host groups are encountered
+   */
   ClusterTopology withAdditionalComponents(Map<String, Set<ResolvedComponent>> additionalComponents) throws InvalidTopologyException;
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
@@ -118,16 +118,6 @@ public class ClusterTopologyImpl implements ClusterTopology {
     registerHostGroupInfo(request.getHostGroupInfo());
   }
 
-  ClusterTopologyImpl copy() {
-    try {
-      return new ClusterTopologyImpl(ambariContext, provisionRequest, resolvedComponents);
-    } catch (InvalidTopologyException e) {
-      // cannot happen, since already validated
-      LOG.error("Failed to copy cluster topology {}", this);
-      return null;
-    }
-  }
-
   public ClusterTopologyImpl withAdditionalComponents(Map<String, Set<ResolvedComponent>> additionalComponents) throws InvalidTopologyException {
     if (additionalComponents.isEmpty()) {
       return this;

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -88,6 +89,7 @@ public class ClusterTopologyImpl implements ClusterTopology {
     stack = ambariContext.composeStacks(stackIds);
     resolvedComponents = ImmutableMap.of();
 
+    checkForDuplicateHosts(topologyRequest.getHostGroupInfo());
     registerHostGroupInfo(topologyRequest.getHostGroupInfo());
   }
 
@@ -111,11 +113,42 @@ public class ClusterTopologyImpl implements ClusterTopology {
     stack = request.getStack();
     setting = request.getSetting();
     blueprint.getConfiguration().setParentConfiguration(stack.getConfiguration(getServices()));
+
+    checkForDuplicateHosts(request.getHostGroupInfo());
     registerHostGroupInfo(request.getHostGroupInfo());
+  }
+
+  ClusterTopologyImpl copy() {
+    try {
+      return new ClusterTopologyImpl(ambariContext, provisionRequest, resolvedComponents);
+    } catch (InvalidTopologyException e) {
+      // cannot happen, since already validated
+      LOG.error("Failed to copy cluster topology {}", this);
+      return null;
+    }
+  }
+
+  public ClusterTopologyImpl withAdditionalComponents(Map<String, Set<ResolvedComponent>> additionalComponents) throws InvalidTopologyException {
+    if (additionalComponents.isEmpty()) {
+      return this;
+    }
+
+    Map<String, Set<ResolvedComponent>> allComponents = new HashMap<>(resolvedComponents);
+    for (Map.Entry<String, Set<ResolvedComponent>> entry : additionalComponents.entrySet()) {
+      allComponents.computeIfAbsent(entry.getKey(), __ -> new HashSet<>())
+        .addAll(entry.getValue());
+    }
+    return withComponents(allComponents);
+  }
+
+  public ClusterTopologyImpl withComponents(Map<String, Set<ResolvedComponent>> resolvedComponents) throws InvalidTopologyException {
+    return new ClusterTopologyImpl(ambariContext, provisionRequest, resolvedComponents);
   }
 
   @Override
   public void update(TopologyRequest topologyRequest) throws InvalidTopologyException {
+    checkForDuplicateHosts(topologyRequest.getHostGroupInfo());
+    verifyHostGroupsExist(topologyRequest.getHostGroupInfo());
     registerHostGroupInfo(topologyRequest.getHostGroupInfo());
   }
 
@@ -124,7 +157,11 @@ public class ClusterTopologyImpl implements ClusterTopology {
     return clusterId;
   }
 
+  @Override
   public void setClusterId(Long clusterId) {
+    if (this.clusterId != null) {
+      throw new IllegalStateException(String.format("ClusterID %s already set in topology, cannot set %s ", this.clusterId, clusterId));
+    }
     this.clusterId = clusterId;
   }
 
@@ -164,14 +201,23 @@ public class ClusterTopologyImpl implements ClusterTopology {
   }
 
   @Override
-  public Collection<HostGroup> getHostGroups() {
-    return blueprint.getHostGroups().values();
+  public Set<String> getHostGroups() {
+    return blueprint.getHostGroups().keySet();
   }
 
   @Override
   public Collection<String> getHostGroupsForComponent(String component) {
     return resolvedComponents.entrySet().stream()
       .filter(e -> e.getValue().stream().anyMatch(c -> component.equals(c.componentName())))
+      .map(Map.Entry::getKey)
+      .collect(toSet());
+  }
+
+  @Override
+  public Set<String> getHostGroupsForComponent(ResolvedComponent component) {
+    return resolvedComponents.entrySet().stream()
+      .filter(e -> e.getValue().stream()
+        .anyMatch(each -> Objects.equals(each, component)))
       .map(Map.Entry::getKey)
       .collect(toSet());
   }
@@ -219,7 +265,6 @@ public class ClusterTopologyImpl implements ClusterTopology {
 
   @Override
   public Collection<String> getHostAssignmentsForComponent(String component) {
-    //todo: ordering requirements?
     Collection<String> hosts = new ArrayList<>();
     Collection<String> hostGroups = getHostGroupsForComponent(component);
     for (String group : hostGroups) {
@@ -377,8 +422,7 @@ public class ClusterTopologyImpl implements ClusterTopology {
   }
 
   private void registerHostGroupInfo(Map<String, HostGroupInfo> requestedHostGroupInfoMap) throws InvalidTopologyException {
-    LOG.debug("Registering requested host group information for {} hostgroups", requestedHostGroupInfoMap.size());
-    checkForDuplicateHosts(requestedHostGroupInfoMap);
+    LOG.debug("Registering requested host group information for {} host groups", requestedHostGroupInfoMap.size());
 
     for (HostGroupInfo requestedHostGroupInfo : requestedHostGroupInfoMap.values()) {
       String hostGroupName = requestedHostGroupInfo.getHostGroupName();
@@ -436,11 +480,17 @@ public class ClusterTopologyImpl implements ClusterTopology {
     }
   }
 
+  private void verifyHostGroupsExist(Map<String, HostGroupInfo> hostGroupUpdates) throws InvalidTopologyException {
+    Set<String> unknownGroups = Sets.difference(hostGroupUpdates.keySet(), hostGroupInfoMap.keySet());
+    if (!unknownGroups.isEmpty()) {
+      throw new InvalidTopologyException("Attempted to add hosts to unknown host groups: " + unknownGroups);
+    }
+  }
 
-  private void checkForDuplicateHosts(Map<String, HostGroupInfo> groupInfoMap) throws InvalidTopologyException {
+  private void checkForDuplicateHosts(Map<String, HostGroupInfo> hostGroupUpdates) throws InvalidTopologyException {
     Set<String> hosts = new HashSet<>();
     Set<String> duplicates = new HashSet<>();
-    for (HostGroupInfo group : groupInfoMap.values()) {
+    for (HostGroupInfo group : hostGroupUpdates.values()) {
       // check for duplicates within the new groups
       Collection<String> groupHosts = group.getHostNames();
       Collection<String> groupHostsCopy = new HashSet<>(group.getHostNames());
@@ -457,7 +507,7 @@ public class ClusterTopologyImpl implements ClusterTopology {
     }
     if (! duplicates.isEmpty()) {
       throw new InvalidTopologyException("The following hosts are mapped to multiple host groups: " + duplicates + "." +
-        " Be aware that host names are converted to lowercase, case differences do not matter in Ambari deployments.");
+        " Be aware that host names are converted to lowercase, case differences are ignored in Ambari deployments.");
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Component.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Component.java
@@ -82,9 +82,9 @@ public class Component {
   public String toString() {
     return MoreObjects.toStringHelper(this)
       .add("name", name)
-      .add("mpackInstance", mpackInstance)
-      .add("serviceInstance", serviceInstance)
-      .add("provisionAction", provisionAction)
+      .add("mpack_instance", mpackInstance)
+      .add("service_instance", serviceInstance)
+      .add("provision_action", provisionAction)
       .toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ResolvedComponent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ResolvedComponent.java
@@ -19,6 +19,8 @@ package org.apache.ambari.server.topology;
 
 import java.util.Optional;
 
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 
 /**
@@ -29,15 +31,25 @@ public interface ResolvedComponent {
 
   StackId stackId();
   Optional<String> serviceGroupName();
-  String serviceType();
   Optional<String> serviceName();
   String componentName();
-  boolean masterComponent();
+  ServiceInfo serviceInfo();
+  ComponentInfo componentInfo();
 
   /**
    * @return the component as specified in the blueprint
    */
   Component component();
+
+  Builder toBuilder();
+
+  default String serviceType() {
+    return serviceInfo().getName();
+  }
+
+  default boolean masterComponent() {
+    return componentInfo().isMaster();
+  }
 
   /**
    * @return service group name if it set, otherwise defaults to the stack name
@@ -72,8 +84,9 @@ public interface ResolvedComponent {
   }
 
   class Builder extends ResolvedComponent_Builder {
-    protected Builder() {
-      masterComponent(false);
+    @Override
+    public Builder toBuilder() {
+      return this;
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ResolvedComponent_Builder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ResolvedComponent_Builder.java
@@ -24,6 +24,8 @@ import java.util.function.UnaryOperator;
 
 import javax.annotation.Nullable;
 
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.StackId;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -45,8 +47,9 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
 
   private enum Property {
     STACK_ID("stackId"),
-    SERVICE_TYPE("serviceType"),
     COMPONENT_NAME("componentName"),
+    SERVICE_INFO("serviceInfo"),
+    COMPONENT_INFO("componentInfo"),
     COMPONENT("component"),
     ;
 
@@ -67,15 +70,15 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
   // allows the JVM to optimize away the Optional objects created by and
   // passed to our API.
   private String serviceGroupName = null;
-  private String serviceType;
   // Store a nullable object instead of an Optional. Escape analysis then
   // allows the JVM to optimize away the Optional objects created by and
   // passed to our API.
   private String serviceName = null;
   private String componentName;
-  private boolean masterComponent;
+  private ServiceInfo serviceInfo;
+  private ComponentInfo componentInfo;
   private Component component;
-  private final EnumSet<Property> _unsetProperties =
+  private final EnumSet<ResolvedComponent_Builder.Property> _unsetProperties =
       EnumSet.allOf(ResolvedComponent_Builder.Property.class);
 
   /**
@@ -178,43 +181,6 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
   /** Returns the value that will be returned by {@link ResolvedComponent#serviceGroupName()}. */
   public Optional<String> serviceGroupName() {
     return Optional.ofNullable(serviceGroupName);
-  }
-
-  /**
-   * Sets the value to be returned by {@link ResolvedComponent#serviceType()}.
-   *
-   * @return this {@code Builder} object
-   * @throws NullPointerException if {@code serviceType} is null
-   */
-  public ResolvedComponent.Builder serviceType(String serviceType) {
-    this.serviceType = Preconditions.checkNotNull(serviceType);
-    _unsetProperties.remove(ResolvedComponent_Builder.Property.SERVICE_TYPE);
-    return (ResolvedComponent.Builder) this;
-  }
-
-  /**
-   * Replaces the value to be returned by {@link ResolvedComponent#serviceType()} by applying {@code
-   * mapper} to it and using the result.
-   *
-   * @return this {@code Builder} object
-   * @throws NullPointerException if {@code mapper} is null or returns null
-   * @throws IllegalStateException if the field has not been set
-   */
-  public ResolvedComponent.Builder mapServiceType(UnaryOperator<String> mapper) {
-    Preconditions.checkNotNull(mapper);
-    return serviceType(mapper.apply(serviceType()));
-  }
-
-  /**
-   * Returns the value that will be returned by {@link ResolvedComponent#serviceType()}.
-   *
-   * @throws IllegalStateException if the field has not been set
-   */
-  public String serviceType() {
-    Preconditions.checkState(
-        !_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_TYPE),
-        "serviceType not set");
-    return serviceType;
   }
 
   /**
@@ -321,29 +287,77 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
   }
 
   /**
-   * Sets the value to be returned by {@link ResolvedComponent#masterComponent()}.
+   * Sets the value to be returned by {@link ResolvedComponent#serviceInfo()}.
    *
    * @return this {@code Builder} object
+   * @throws NullPointerException if {@code serviceInfo} is null
    */
-  public ResolvedComponent.Builder masterComponent(boolean masterComponent) {
-    this.masterComponent = masterComponent;
+  public ResolvedComponent.Builder serviceInfo(ServiceInfo serviceInfo) {
+    this.serviceInfo = Preconditions.checkNotNull(serviceInfo);
+    _unsetProperties.remove(ResolvedComponent_Builder.Property.SERVICE_INFO);
     return (ResolvedComponent.Builder) this;
   }
 
   /**
-   * Replaces the value to be returned by {@link ResolvedComponent#masterComponent()} by applying
+   * Replaces the value to be returned by {@link ResolvedComponent#serviceInfo()} by applying {@code
+   * mapper} to it and using the result.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
+   */
+  public ResolvedComponent.Builder mapServiceInfo(UnaryOperator<ServiceInfo> mapper) {
+    Preconditions.checkNotNull(mapper);
+    return serviceInfo(mapper.apply(serviceInfo()));
+  }
+
+  /**
+   * Returns the value that will be returned by {@link ResolvedComponent#serviceInfo()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public ServiceInfo serviceInfo() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO),
+        "serviceInfo not set");
+    return serviceInfo;
+  }
+
+  /**
+   * Sets the value to be returned by {@link ResolvedComponent#componentInfo()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code componentInfo} is null
+   */
+  public ResolvedComponent.Builder componentInfo(ComponentInfo componentInfo) {
+    this.componentInfo = Preconditions.checkNotNull(componentInfo);
+    _unsetProperties.remove(ResolvedComponent_Builder.Property.COMPONENT_INFO);
+    return (ResolvedComponent.Builder) this;
+  }
+
+  /**
+   * Replaces the value to be returned by {@link ResolvedComponent#componentInfo()} by applying
    * {@code mapper} to it and using the result.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
    */
-  public ResolvedComponent.Builder mapMasterComponent(UnaryOperator<Boolean> mapper) {
-    return masterComponent(mapper.apply(masterComponent()));
+  public ResolvedComponent.Builder mapComponentInfo(UnaryOperator<ComponentInfo> mapper) {
+    Preconditions.checkNotNull(mapper);
+    return componentInfo(mapper.apply(componentInfo()));
   }
 
-  /** Returns the value that will be returned by {@link ResolvedComponent#masterComponent()}. */
-  public boolean masterComponent() {
-    return masterComponent;
+  /**
+   * Returns the value that will be returned by {@link ResolvedComponent#componentInfo()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public ComponentInfo componentInfo() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO),
+        "componentInfo not set");
+    return componentInfo;
   }
 
   /**
@@ -391,17 +405,18 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       stackId(value.stackId());
     }
     value.serviceGroupName().ifPresent(this::serviceGroupName);
-    if (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_TYPE)
-        || !Objects.equals(value.serviceType(), _defaults.serviceType())) {
-      serviceType(value.serviceType());
-    }
     value.serviceName().ifPresent(this::serviceName);
     if (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_NAME)
         || !Objects.equals(value.componentName(), _defaults.componentName())) {
       componentName(value.componentName());
     }
-    if (!Objects.equals(value.masterComponent(), _defaults.masterComponent())) {
-      masterComponent(value.masterComponent());
+    if (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO)
+        || !Objects.equals(value.serviceInfo(), _defaults.serviceInfo())) {
+      serviceInfo(value.serviceInfo());
+    }
+    if (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO)
+        || !Objects.equals(value.componentInfo(), _defaults.componentInfo())) {
+      componentInfo(value.componentInfo());
     }
     if (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT)
         || !Objects.equals(value.component(), _defaults.component())) {
@@ -424,19 +439,21 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       stackId(template.stackId());
     }
     template.serviceGroupName().ifPresent(this::serviceGroupName);
-    if (!base._unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_TYPE)
-        && (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_TYPE)
-            || !Objects.equals(template.serviceType(), _defaults.serviceType()))) {
-      serviceType(template.serviceType());
-    }
     template.serviceName().ifPresent(this::serviceName);
     if (!base._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_NAME)
         && (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_NAME)
             || !Objects.equals(template.componentName(), _defaults.componentName()))) {
       componentName(template.componentName());
     }
-    if (!Objects.equals(template.masterComponent(), _defaults.masterComponent())) {
-      masterComponent(template.masterComponent());
+    if (!base._unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO)
+        && (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO)
+            || !Objects.equals(template.serviceInfo(), _defaults.serviceInfo()))) {
+      serviceInfo(template.serviceInfo());
+    }
+    if (!base._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO)
+        && (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO)
+            || !Objects.equals(template.componentInfo(), _defaults.componentInfo()))) {
+      componentInfo(template.componentInfo());
     }
     if (!base._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT)
         && (_defaults._unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT)
@@ -451,10 +468,10 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     ResolvedComponent_Builder _defaults = new ResolvedComponent.Builder();
     stackId = _defaults.stackId;
     serviceGroupName = _defaults.serviceGroupName;
-    serviceType = _defaults.serviceType;
     serviceName = _defaults.serviceName;
     componentName = _defaults.componentName;
-    masterComponent = _defaults.masterComponent;
+    serviceInfo = _defaults.serviceInfo;
+    componentInfo = _defaults.componentInfo;
     component = _defaults.component;
     _unsetProperties.clear();
     _unsetProperties.addAll(_defaults._unsetProperties);
@@ -491,22 +508,22 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final String serviceGroupName;
-    private final String serviceType;
     // Store a nullable object instead of an Optional. Escape analysis then
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final String serviceName;
     private final String componentName;
-    private final boolean masterComponent;
+    private final ServiceInfo serviceInfo;
+    private final ComponentInfo componentInfo;
     private final Component component;
 
     private Value(ResolvedComponent_Builder builder) {
       this.stackId = builder.stackId;
       this.serviceGroupName = builder.serviceGroupName;
-      this.serviceType = builder.serviceType;
       this.serviceName = builder.serviceName;
       this.componentName = builder.componentName;
-      this.masterComponent = builder.masterComponent;
+      this.serviceInfo = builder.serviceInfo;
+      this.componentInfo = builder.componentInfo;
       this.component = builder.component;
     }
 
@@ -521,11 +538,6 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     }
 
     @Override
-    public String serviceType() {
-      return serviceType;
-    }
-
-    @Override
     public Optional<String> serviceName() {
       return Optional.ofNullable(serviceName);
     }
@@ -536,13 +548,23 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     }
 
     @Override
-    public boolean masterComponent() {
-      return masterComponent;
+    public ServiceInfo serviceInfo() {
+      return serviceInfo;
+    }
+
+    @Override
+    public ComponentInfo componentInfo() {
+      return componentInfo;
     }
 
     @Override
     public Component component() {
       return component;
+    }
+
+    @Override
+    public ResolvedComponent.Builder toBuilder() {
+      return new ResolvedComponent.Builder().mergeFrom(this);
     }
 
     @Override
@@ -552,24 +574,26 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       }
       ResolvedComponent_Builder.Value other = (ResolvedComponent_Builder.Value) obj;
       return Objects.equals(stackId, other.stackId)
-          && Objects.equals(serviceGroupName, other.serviceGroupName)
-          && Objects.equals(serviceType, other.serviceType)
-          && Objects.equals(serviceName, other.serviceName)
+          //&& Objects.equals(serviceGroupName, other.serviceGroupName)
+          //&& Objects.equals(serviceName, other.serviceName)
           && Objects.equals(componentName, other.componentName)
-          && Objects.equals(masterComponent, other.masterComponent)
-          && Objects.equals(component, other.component);
+          && Objects.equals(serviceInfo, other.serviceInfo)
+          //&& Objects.equals(componentInfo, other.componentInfo)
+          //&& Objects.equals(component, other.component)
+        ;
     }
 
     @Override
     public int hashCode() {
       return Objects.hash(
           stackId,
-          serviceGroupName,
-          serviceType,
-          serviceName,
+          //serviceGroupName,
+          //serviceName,
           componentName,
-          masterComponent,
-          component);
+          serviceInfo
+          //componentInfo,
+          //component
+      );
     }
 
     @Override
@@ -578,11 +602,11 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
           + COMMA_JOINER.join(
               "stackId=" + stackId,
               (serviceGroupName != null ? "serviceGroupName=" + serviceGroupName : null),
-              "serviceType=" + serviceType,
               (serviceName != null ? "serviceName=" + serviceName : null),
-              "componentName=" + componentName,
-              "masterComponent=" + masterComponent,
-              "component=" + component)
+              //"componentName=" + componentName,
+              "service=" + serviceInfo.getName(),
+              "component=" + componentInfo.getName(),
+              "input=" + component)
           + "}";
     }
   }
@@ -593,23 +617,23 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final String serviceGroupName;
-    private final String serviceType;
     // Store a nullable object instead of an Optional. Escape analysis then
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final String serviceName;
     private final String componentName;
-    private final boolean masterComponent;
+    private final ServiceInfo serviceInfo;
+    private final ComponentInfo componentInfo;
     private final Component component;
     private final EnumSet<ResolvedComponent_Builder.Property> _unsetProperties;
 
     Partial(ResolvedComponent_Builder builder) {
       this.stackId = builder.stackId;
       this.serviceGroupName = builder.serviceGroupName;
-      this.serviceType = builder.serviceType;
       this.serviceName = builder.serviceName;
       this.componentName = builder.componentName;
-      this.masterComponent = builder.masterComponent;
+      this.serviceInfo = builder.serviceInfo;
+      this.componentInfo = builder.componentInfo;
       this.component = builder.component;
       this._unsetProperties = builder._unsetProperties.clone();
     }
@@ -628,14 +652,6 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     }
 
     @Override
-    public String serviceType() {
-      if (_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_TYPE)) {
-        throw new UnsupportedOperationException("serviceType not set");
-      }
-      return serviceType;
-    }
-
-    @Override
     public Optional<String> serviceName() {
       return Optional.ofNullable(serviceName);
     }
@@ -649,8 +665,19 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     }
 
     @Override
-    public boolean masterComponent() {
-      return masterComponent;
+    public ServiceInfo serviceInfo() {
+      if (_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO)) {
+        throw new UnsupportedOperationException("serviceInfo not set");
+      }
+      return serviceInfo;
+    }
+
+    @Override
+    public ComponentInfo componentInfo() {
+      if (_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO)) {
+        throw new UnsupportedOperationException("componentInfo not set");
+      }
+      return componentInfo;
     }
 
     @Override
@@ -661,6 +688,36 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       return component;
     }
 
+    private static class PartialBuilder extends ResolvedComponent.Builder {
+      @Override
+      public ResolvedComponent build() {
+        return buildPartial();
+      }
+    }
+
+    @Override
+    public ResolvedComponent.Builder toBuilder() {
+      ResolvedComponent.Builder builder = new PartialBuilder();
+      if (!_unsetProperties.contains(ResolvedComponent_Builder.Property.STACK_ID)) {
+        builder.stackId(stackId);
+      }
+      builder.nullableServiceGroupName(serviceGroupName);
+      builder.nullableServiceName(serviceName);
+      if (!_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_NAME)) {
+        builder.componentName(componentName);
+      }
+      if (!_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO)) {
+        builder.serviceInfo(serviceInfo);
+      }
+      if (!_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO)) {
+        builder.componentInfo(componentInfo);
+      }
+      if (!_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT)) {
+        builder.component(component);
+      }
+      return builder;
+    }
+
     @Override
     public boolean equals(Object obj) {
       if (!(obj instanceof ResolvedComponent_Builder.Partial)) {
@@ -669,10 +726,10 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       ResolvedComponent_Builder.Partial other = (ResolvedComponent_Builder.Partial) obj;
       return Objects.equals(stackId, other.stackId)
           && Objects.equals(serviceGroupName, other.serviceGroupName)
-          && Objects.equals(serviceType, other.serviceType)
           && Objects.equals(serviceName, other.serviceName)
           && Objects.equals(componentName, other.componentName)
-          && Objects.equals(masterComponent, other.masterComponent)
+          && Objects.equals(serviceInfo, other.serviceInfo)
+          && Objects.equals(componentInfo, other.componentInfo)
           && Objects.equals(component, other.component)
           && Objects.equals(_unsetProperties, other._unsetProperties);
     }
@@ -682,10 +739,10 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       return Objects.hash(
           stackId,
           serviceGroupName,
-          serviceType,
           serviceName,
           componentName,
-          masterComponent,
+          serviceInfo,
+          componentInfo,
           component,
           _unsetProperties);
     }
@@ -698,14 +755,16 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
                   ? "stackId=" + stackId
                   : null),
               (serviceGroupName != null ? "serviceGroupName=" + serviceGroupName : null),
-              (!_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_TYPE)
-                  ? "serviceType=" + serviceType
-                  : null),
               (serviceName != null ? "serviceName=" + serviceName : null),
               (!_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_NAME)
                   ? "componentName=" + componentName
                   : null),
-              "masterComponent=" + masterComponent,
+              (!_unsetProperties.contains(ResolvedComponent_Builder.Property.SERVICE_INFO)
+                  ? "serviceInfo=" + serviceInfo
+                  : null),
+              (!_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT_INFO)
+                  ? "componentInfo=" + componentInfo
+                  : null),
               (!_unsetProperties.contains(ResolvedComponent_Builder.Property.COMPONENT)
                   ? "component=" + component
                   : null))

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ResolvedComponent_Builder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ResolvedComponent_Builder.java
@@ -574,12 +574,8 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
       }
       ResolvedComponent_Builder.Value other = (ResolvedComponent_Builder.Value) obj;
       return Objects.equals(stackId, other.stackId)
-          //&& Objects.equals(serviceGroupName, other.serviceGroupName)
-          //&& Objects.equals(serviceName, other.serviceName)
           && Objects.equals(componentName, other.componentName)
           && Objects.equals(serviceInfo, other.serviceInfo)
-          //&& Objects.equals(componentInfo, other.componentInfo)
-          //&& Objects.equals(component, other.component)
         ;
     }
 
@@ -587,12 +583,8 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
     public int hashCode() {
       return Objects.hash(
           stackId,
-          //serviceGroupName,
-          //serviceName,
           componentName,
           serviceInfo
-          //componentInfo,
-          //component
       );
     }
 
@@ -603,7 +595,6 @@ abstract class ResolvedComponent_Builder implements ResolvedComponent {
               "stackId=" + stackId,
               (serviceGroupName != null ? "serviceGroupName=" + serviceGroupName : null),
               (serviceName != null ? "serviceName=" + serviceName : null),
-              //"componentName=" + componentName,
               "service=" + serviceInfo.getName(),
               "component=" + componentInfo.getName(),
               "input=" + component)

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -290,11 +290,11 @@ public class TopologyManager {
     BlueprintBasedClusterProvisionRequest provisionRequest = new BlueprintBasedClusterProvisionRequest(ambariContext, securityConfigurationFactory, request.getBlueprint(), request);
     Map<String, Set<ResolvedComponent>> resolved = resolver.resolveComponents(provisionRequest);
 
-    final ClusterTopologyImpl topology = new ClusterTopologyImpl(ambariContext, provisionRequest, resolved);
+    ClusterTopology initialTopology = new ClusterTopologyImpl(ambariContext, provisionRequest, resolved);
     final String clusterName = request.getClusterName();
     final SecurityConfiguration securityConfiguration = provisionRequest.getSecurity();
 
-    topologyValidatorService.validateTopologyConfiguration(topology); // FIXME known stacks validation is too late here
+    final ClusterTopology topology = topologyValidatorService.validate(initialTopology); // FIXME known stacks validation is too late here
 
     // get the id prior to creating ambari resources which increments the counter
     final Long provisionId = ambariContext.getNextRequestId();

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/ChainedTopologyValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/ChainedTopologyValidator.java
@@ -48,10 +48,11 @@ public class ChainedTopologyValidator implements TopologyValidator {
   }
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
     for (TopologyValidator validator : validators) {
       LOGGER.info("Performing topology validation: {}", validator.getClass());
-      validator.validate(topology);
+      topology = validator.validate(topology);
     }
+    return topology;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/ClusterConfigTypeValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/ClusterConfigTypeValidator.java
@@ -30,7 +30,7 @@ public class ClusterConfigTypeValidator implements TopologyValidator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterConfigTypeValidator.class);
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
 
     // config types in from the request / configuration is always set in the request instance
     Set<String> topologyClusterConfigTypes = new HashSet<>(topology.getConfiguration().getAllConfigTypes());
@@ -38,7 +38,7 @@ public class ClusterConfigTypeValidator implements TopologyValidator {
 
     if (topologyClusterConfigTypes.isEmpty()) {
       LOGGER.debug("No config types to be checked.");
-      return;
+      return topology;
     }
 
     // collecting all config types for services in the blueprint (from the related stack)
@@ -60,5 +60,6 @@ public class ClusterConfigTypeValidator implements TopologyValidator {
       LOGGER.error("The following config typess are wrong: {}", invalidConfigTypes);
       throw new InvalidTopologyException("The following configuration types are invalid: " + invalidConfigTypes);
     }
+    return topology;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/GplPropertiesValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/GplPropertiesValidator.java
@@ -61,13 +61,13 @@ public class GplPropertiesValidator implements TopologyValidator {
   }
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
     // need to reject blueprints that have LZO enabled if the Ambari Server hasn't been configured for it
     boolean gplEnabled = configuration.getGplLicenseAccepted();
 
     if (gplEnabled) {
       LOG.info("GPL license accepted, skipping config check");
-      return;
+      return topology;
     }
 
     // we don't want to include default stack properties so we can't use full properties
@@ -84,5 +84,6 @@ public class GplPropertiesValidator implements TopologyValidator {
         }
       }
     }
+    return topology;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/HiveServiceValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/HiveServiceValidator.java
@@ -34,11 +34,11 @@ public class HiveServiceValidator implements TopologyValidator {
 
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
     // there is no hive configured in the blueprint, nothing to do (does the validator apply?)
     if (!topology.getServices().contains(HIVE_SERVICE)) {
       LOGGER.info(" [{}] service is not listed in the blueprint, skipping hive service validation.", HIVE_SERVICE);
-      return;
+      return topology;
     }
 
     Configuration clusterConfiguration = topology.getConfiguration();
@@ -69,6 +69,7 @@ public class HiveServiceValidator implements TopologyValidator {
       LOGGER.error(errorMessage);
       throw new InvalidTopologyException(errorMessage);
     }
+    return topology;
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/NameNodeHighAvailabilityValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/NameNodeHighAvailabilityValidator.java
@@ -29,7 +29,6 @@ import org.apache.ambari.server.controller.internal.BlueprintConfigurationProces
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.HostGroup;
-import org.apache.ambari.server.topology.InvalidTopologyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,14 +41,14 @@ public class NameNodeHighAvailabilityValidator implements TopologyValidator {
   private static final Logger LOG = LoggerFactory.getLogger(NameNodeHighAvailabilityValidator.class);
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) {
     Blueprint blueprint = topology.getBlueprint();
 
     Map<String, Map<String, String>> clusterConfigurations = topology.getConfiguration().getProperties();
 
     if (!BlueprintConfigurationProcessor.isNameNodeHAEnabled(clusterConfigurations)) {
       LOG.info("NAMENODE HA is not enabled, skipping validation of {}", blueprint.getName());
-      return;
+      return topology;
     }
 
     LOG.info("Validating NAMENODE HA for blueprint: {}", blueprint.getName());
@@ -81,6 +80,7 @@ public class NameNodeHighAvailabilityValidator implements TopologyValidator {
         }
       }
     }
+    return topology;
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RejectUnknownComponents.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RejectUnknownComponents.java
@@ -31,7 +31,7 @@ public class RejectUnknownComponents implements TopologyValidator {
   private static final Logger LOG = LoggerFactory.getLogger(RejectUnknownComponents.class);
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
     String unknownComponents = topology.getComponents()
       .map(ResolvedComponent::componentName)
       .filter(c -> !RootComponent.AMBARI_SERVER.name().equals(c))
@@ -43,5 +43,6 @@ public class RejectUnknownComponents implements TopologyValidator {
       LOG.info(msg);
       throw new InvalidTopologyException(msg);
     }
+    return topology;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RejectUnknownStacks.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RejectUnknownStacks.java
@@ -37,7 +37,7 @@ public class RejectUnknownStacks implements TopologyValidator {
   }
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
     String unknownStacks = topology.getStackIds().stream()
       .filter(stackId -> !metaInfo.get().isKnownStack(stackId))
       .sorted()
@@ -47,5 +47,6 @@ public class RejectUnknownStacks implements TopologyValidator {
     if (!unknownStacks.isEmpty()) {
       throw new InvalidTopologyException("Unknown stacks found in cluster creation request: " + unknownStacks);
     }
+    return topology;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredConfigPropertiesValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredConfigPropertiesValidator.java
@@ -48,7 +48,7 @@ public class RequiredConfigPropertiesValidator implements TopologyValidator {
    * @throws InvalidTopologyException when there are missing configuration types or properties related to services in the blueprint
    */
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
 
     // collect required properties
     Map<String, Map<String, Collection<String>>> requiredPropertiesByService = getRequiredPropertiesByService(topology);
@@ -103,6 +103,7 @@ public class RequiredConfigPropertiesValidator implements TopologyValidator {
         "properties in the blueprint or cluster creation template configuration. " + missingProperties);
     }
 
+    return topology;
   }
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidator.java
@@ -42,7 +42,7 @@ public class RequiredPasswordValidator implements TopologyValidator {
    * @throws InvalidTopologyException if required password properties are missing and no
    *                                  default is specified via 'default_password'
    */
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
 
     Map<String, Map<String, Set<String>>> missingPasswords = validateRequiredPasswords(topology);
 
@@ -51,6 +51,7 @@ public class RequiredPasswordValidator implements TopologyValidator {
           "properties in the cluster or host group configurations or include 'default_password' field in request. " +
           missingPasswords);
     }
+    return topology;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/SecretReferenceValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/SecretReferenceValidator.java
@@ -30,7 +30,7 @@ import org.apache.ambari.server.utils.SecretReference;
 public class SecretReferenceValidator implements TopologyValidator {
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
     // we don't want to include default stack properties so we can't use full properties
     Map<String, Map<String, String>> clusterConfigurations = topology.getConfiguration().getProperties();
 
@@ -57,6 +57,7 @@ public class SecretReferenceValidator implements TopologyValidator {
           "replace following properties with real passwords:\n" + errorMessage);
       }
     }
+    return topology;
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/StackConfigTypeValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/StackConfigTypeValidator.java
@@ -30,18 +30,15 @@ import org.slf4j.LoggerFactory;
 public class StackConfigTypeValidator implements TopologyValidator {
   private static final Logger LOGGER = LoggerFactory.getLogger(StackConfigTypeValidator.class);
 
-  public StackConfigTypeValidator() {
-  }
-
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException {
 
     // get the config types form the request
     Set<String> incomingConfigTypes = new HashSet<>(topology.getConfiguration().getAllConfigTypes());
 
     if (incomingConfigTypes.isEmpty()) {
       LOGGER.debug("No config types to be checked.");
-      return;
+      return topology;
     }
 
     Set<String> stackConfigTypes = new HashSet<>(topology.getStack().getConfiguration().getAllConfigTypes());
@@ -55,5 +52,6 @@ public class StackConfigTypeValidator implements TopologyValidator {
       LOGGER.error(message);
       throw new InvalidTopologyException(message);
     }
+    return topology;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidator.java
@@ -25,5 +25,5 @@ import org.apache.ambari.server.topology.InvalidTopologyException;
  * Performs topology validation.
  */
 public interface TopologyValidator {
-  void validate(ClusterTopology topology) throws InvalidTopologyException;
+  ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException;
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidator.java
@@ -25,5 +25,14 @@ import org.apache.ambari.server.topology.InvalidTopologyException;
  * Performs topology validation.
  */
 public interface TopologyValidator {
+
+  /**
+   * Performs some validation on {@code topology}.
+   *
+   * @return The given topology, or a new updated one if some changes are necessary and can be performed automatically
+   *         (eg. {@link DependencyAndCardinalityValidator} may add some auto-deployable components)
+   * @throws InvalidTopologyException if validation fails (most validators)
+   * @throws IllegalArgumentException if validation fails (some validators)
+   */
   ClusterTopology validate(ClusterTopology topology) throws InvalidTopologyException;
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidatorService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidatorService.java
@@ -28,19 +28,17 @@ import org.slf4j.LoggerFactory;
  *
  * Ideally this service should be used as instead of directly use validator implementations.
  */
-public class TopologyValidatorService {
+public class TopologyValidatorService implements TopologyValidator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TopologyValidatorService.class);
 
   @Inject
   private TopologyValidatorFactory topologyValidatorFactory;
 
-  public TopologyValidatorService() {
-  }
-
-  public void validateTopologyConfiguration(ClusterTopology clusterTopology) throws InvalidTopologyException {
+  @Override
+  public ClusterTopology validate(ClusterTopology clusterTopology) throws InvalidTopologyException {
     LOGGER.info("Validating cluster topology: {}", clusterTopology);
-    topologyValidatorFactory.createConfigurationValidatorChain().validate(clusterTopology);
+    return topologyValidatorFactory.createConfigurationValidatorChain().validate(clusterTopology);
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/UnitValidator.java
@@ -26,7 +26,6 @@ import org.apache.ambari.server.controller.internal.StackDefinition;
 import org.apache.ambari.server.controller.internal.UnitUpdater.PropertyUnit;
 import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.HostGroupInfo;
-import org.apache.ambari.server.topology.InvalidTopologyException;
 
 /**
  * I validate the unit of properties by checking if it matches to the stack defined unit.
@@ -40,12 +39,13 @@ public class UnitValidator implements TopologyValidator {
   }
 
   @Override
-  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+  public ClusterTopology validate(ClusterTopology topology) {
     StackDefinition stack = topology.getStack();
     validateConfig(topology.getConfiguration().getFullProperties(), stack);
     for (HostGroupInfo hostGroup : topology.getHostGroupInfo().values()) {
       validateConfig(hostGroup.getConfiguration().getFullProperties(), stack);
     }
+    return topology;
   }
 
   private void validateConfig(Map<String, Map<String, String>> configuration, StackDefinition stack) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.apache.ambari.server.topology.ConfigRecommendationStrategy.ALWAYS_APPLY;
 import static org.apache.ambari.server.topology.ConfigRecommendationStrategy.NEVER_APPLY;
 import static org.apache.ambari.server.topology.ConfigRecommendationStrategy.ONLY_STACK_DEFAULTS_APPLY;
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
@@ -109,6 +110,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
   private static final Configuration EMPTY_CONFIG = new Configuration(Collections.emptyMap(), Collections.emptyMap());
   private final Map<String, Collection<String>> serviceComponents = new HashMap<>();
+  private final Map<String, String> serviceByComponent = new HashMap<>();
   private final Map<String, Map<String, String>> stackProperties = new HashMap<>();
   private final Map<String, String> defaultClusterEnvProperties = new HashMap<>();
 
@@ -165,7 +167,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     expect(stack.getVersion()).andReturn(STACK_VERSION).atLeastOnce();
     // return false for all components since for this test we don't care about the value
     expect(stack.isMasterComponent(anyObject())).andReturn(false).anyTimes();
-    expect(stack.getServicesForComponent(anyObject())).andAnswer(() -> Stream.empty()).anyTimes();
+    expect(stack.getServicesForComponent(anyObject())).andAnswer(Stream::empty).anyTimes();
     expect(stack.getConfigurationPropertiesWithMetadata(anyObject(String.class), anyObject(String.class))).andReturn(Collections.emptyMap()).anyTimes();
 
     expect(serviceInfo.getRequiredProperties()).andReturn(Collections.emptyMap()).anyTimes();
@@ -267,6 +269,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
       String service = entry.getKey();
       for (String component : entry.getValue()) {
         expect(stack.getServiceForComponent(component)).andReturn(service).anyTimes();
+        serviceByComponent.put(component, service);
       }
     }
   }
@@ -6691,17 +6694,15 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Collection<String> rangerComponents = new HashSet<>();
     rangerComponents.add("RANGER_ADMIN");
     rangerComponents.add("RANGER_USERSYNC");
+    rangerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
     hdfsComponents.add("DATANODE");
 
     TestHostGroup group1 = new TestHostGroup("group1", rangerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
-
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("nn_host"));
-
 
     Collection<TestHostGroup> hostGroups = Lists.newArrayList(group1, group2);
 
@@ -6755,9 +6756,9 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Collection<String> rangerComponents = new HashSet<>();
     rangerComponents.add("RANGER_ADMIN");
     rangerComponents.add("RANGER_USERSYNC");
+    rangerComponents.add("OOZIE_SERVER");
 
     TestHostGroup group1 = new TestHostGroup("group1", rangerComponents, Collections.singleton("host1"));
-    group1.components.add("OOZIE_SERVER");
 
 
     expect(stack.getCardinality("NAMENODE")).andReturn(new Cardinality("1+")).anyTimes();
@@ -6816,14 +6817,13 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Collection<String> rangerComponents = new HashSet<>();
     rangerComponents.add("RANGER_ADMIN");
     rangerComponents.add("RANGER_USERSYNC");
+    rangerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
     hdfsComponents.add("DATANODE");
 
     TestHostGroup group1 = new TestHostGroup("group1", rangerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
-
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("nn_host"));
 
@@ -6887,16 +6887,16 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Configuration parentClusterConfig = new Configuration(parentProperties, new HashMap<>());
     Configuration clusterConfig = new Configuration(clusterConfigProperties, new HashMap<>(), parentClusterConfig);
 
-    Collection<String> rangerComponents = new HashSet<>();
-    rangerComponents.add("RANGER_ADMIN");
-    rangerComponents.add("RANGER_USERSYNC");
-
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
     hdfsComponents.add("DATANODE");
 
+    Collection<String> rangerComponents = new HashSet<>();
+    rangerComponents.add("RANGER_ADMIN");
+    rangerComponents.add("RANGER_USERSYNC");
+    rangerComponents.addAll(hdfsComponents);
+
     TestHostGroup group1 = new TestHostGroup("group1", rangerComponents, Collections.singleton("host1"));
-    group1.components.addAll(hdfsComponents);
 
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
@@ -6956,17 +6956,14 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Collection<String> rangerComponents = new HashSet<>();
     rangerComponents.add("RANGER_ADMIN");
     rangerComponents.add("RANGER_USERSYNC");
+    rangerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
     hdfsComponents.add("DATANODE");
 
     TestHostGroup group1 = new TestHostGroup("group1", rangerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
-
-
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("nn_host"));
-
 
     Collection<TestHostGroup> hostGroups = Lists.newArrayList(group1, group2);
 
@@ -7025,18 +7022,16 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Configuration parentClusterConfig = new Configuration(parentProperties, new HashMap<>());
     Configuration clusterConfig = new Configuration(clusterConfigProperties, new HashMap<>(), parentClusterConfig);
 
-    Collection<String> rangerComponents = new HashSet<>();
-    rangerComponents.add("RANGER_ADMIN");
-    rangerComponents.add("RANGER_USERSYNC");
-
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
     hdfsComponents.add("DATANODE");
 
+    Collection<String> rangerComponents = new HashSet<>();
+    rangerComponents.add("RANGER_ADMIN");
+    rangerComponents.add("RANGER_USERSYNC");
+    rangerComponents.addAll(hdfsComponents);
+
     TestHostGroup group1 = new TestHostGroup("group1", rangerComponents, Collections.singleton("host1"));
-    group1.components.addAll(hdfsComponents);
-
-
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
 
 
@@ -7165,6 +7160,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Collection<String> kmsServerComponents = new HashSet<>();
     kmsServerComponents.add("RANGER_KMS_SERVER");
+    kmsServerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
@@ -7172,7 +7168,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
 
     TestHostGroup group1 = new TestHostGroup("group1", kmsServerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
 
@@ -7264,6 +7259,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Collection<String> kmsServerComponents = new HashSet<>();
     kmsServerComponents.add("RANGER_KMS_SERVER");
+    kmsServerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
@@ -7271,7 +7267,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
 
     TestHostGroup group1 = new TestHostGroup("group1", kmsServerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
 
@@ -7307,6 +7302,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Collection<String> kmsServerComponents = new HashSet<>();
     kmsServerComponents.add("RANGER_KMS_SERVER");
+    kmsServerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
@@ -7317,7 +7313,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     hosts.add("host2");
 
     TestHostGroup group1 = new TestHostGroup("group1", kmsServerComponents, hosts);
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host3"));
 
@@ -7361,6 +7356,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Collection<String> kmsServerComponents = new HashSet<>();
     kmsServerComponents.add("RANGER_KMS_SERVER");
+    kmsServerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
@@ -7371,7 +7367,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     hosts.add("host2");
 
     TestHostGroup group1 = new TestHostGroup("group1", kmsServerComponents, hosts);
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host3"));
 
@@ -7421,13 +7416,13 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Collection<String> stormComponents = new HashSet<>();
     stormComponents.add("NIMBUS");
     stormComponents.add("DRPC_SERVER");
+    stormComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
 
 
     TestHostGroup group1 = new TestHostGroup("group1", stormComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
 
@@ -7464,6 +7459,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Collection<String> kmsServerComponents = new HashSet<>();
     kmsServerComponents.add("RANGER_KMS_SERVER");
+    kmsServerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
@@ -7471,7 +7467,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
 
     TestHostGroup group1 = new TestHostGroup("group1", kmsServerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
 
@@ -7553,6 +7548,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Collection<String> kmsServerComponents = new HashSet<>();
     kmsServerComponents.add("RANGER_KMS_SERVER");
+    kmsServerComponents.add("DATANODE");
 
     Collection<String> hdfsComponents = new HashSet<>();
     hdfsComponents.add("NAMENODE");
@@ -7560,7 +7556,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
 
     TestHostGroup group1 = new TestHostGroup("group1", kmsServerComponents, Collections.singleton("host1"));
-    group1.components.add("DATANODE");
 
     TestHostGroup group2 = new TestHostGroup("group2", hdfsComponents, Collections.singleton("host2"));
 
@@ -8233,18 +8228,14 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
       //todo: HG configs
       groupInfo.setConfiguration(hostGroup.configuration);
 
-      Set<ResolvedComponent> components = hostGroup.components.stream()
-        .map(name -> ResolvedComponent.builder(new Component(name)).stackId(STACK_ID).serviceType(stack.getServiceForComponent(name)).buildPartial())
-        .collect(toSet());
-
-      List<Component> componentList = components.stream()
+      List<Component> componentList = hostGroup.components.stream()
         .map(ResolvedComponent::component)
         .collect(toList());
 
       //create host group which is set on topology
       allHostGroups.put(hostGroup.name, new HostGroupImpl(hostGroup.name, componentList, EMPTY_CONFIG, "1"));
       hostGroupInfo.put(hostGroup.name, groupInfo);
-      resolvedComponents.put(hostGroup.name, components);
+      resolvedComponents.put(hostGroup.name, hostGroup.components);
     }
 
     for (HostGroup group : allHostGroups.values()) {
@@ -8277,22 +8268,23 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
   }
 
   private class TestHostGroup {
-    private String name;
-    private Collection<String> components;
-    private Collection<String> hosts;
-    private Configuration configuration;
+    private final String name;
+    private final Set<ResolvedComponent> components;
+    private final Collection<String> hosts;
+    private final Configuration configuration;
 
     public TestHostGroup(String name, Collection<String> components, Collection<String> hosts) {
-      this.name = name;
-      this.components = components;
-      this.hosts = hosts;
-      configuration = new Configuration(Collections.emptyMap(),
-        Collections.emptyMap());
+      this(name, components, hosts, Configuration.createEmpty());
     }
 
     public TestHostGroup(String name, Collection<String> components, Collection<String> hosts, Configuration configuration) {
       this.name = name;
-      this.components = components;
+      this.components = components.stream()
+        .map(component -> builderFor(serviceByComponent.get(component), component)
+          .component(new Component(component))
+          .stackId(STACK_ID)
+          .buildPartial())
+        .collect(toSet());
       this.hosts = hosts;
       this.configuration = configuration;
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.topology;
 
 import static java.util.Collections.emptySet;
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
@@ -242,9 +243,9 @@ public class AmbariContextTest {
     expect(topology.getStackIds()).andReturn(Collections.singleton(STACK_ID)).anyTimes();
     expect(topology.getServices()).andReturn(blueprintServices).anyTimes();
     expect(topology.getComponents()).andAnswer(() -> Stream.of(
-      ResolvedComponent.builder(new Component("s1Component1")).stackId(STACK_ID).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("s1Component2")).stackId(STACK_ID).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("s2Component1")).stackId(STACK_ID).serviceType("service2").buildPartial()
+      builderFor("service1", "s1Component1").stackId(STACK_ID).buildPartial(),
+      builderFor("service1", "s1Component2").stackId(STACK_ID).buildPartial(),
+      builderFor("service2", "s2Component1").stackId(STACK_ID).buildPartial()
     )).anyTimes();
     expect(topology.getConfiguration()).andReturn(bpConfiguration).anyTimes();
     expect(topology.getSetting()).andReturn(setting).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.topology;
 
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
@@ -250,9 +251,9 @@ public class ClusterConfigurationRequestTest {
     expect(stack.getConfiguration(services)).andReturn(stackDefaultConfig).once();
 
     expect(topology.getComponents()).andAnswer(() -> Stream.of(
-      ResolvedComponent.builder(new Component("NAMENODE")).serviceType("HDFS").buildPartial(),
-      ResolvedComponent.builder(new Component("KERBEROS")).serviceType("KERBEROS_CLIENT").buildPartial(),
-      ResolvedComponent.builder(new Component("ZOOKEEPER_SERVER")).serviceType("ZOOKEEPER").buildPartial()
+      builderFor("HDFS", "NAMENODE").buildPartial(),
+      builderFor("KERBEROS_CLIENT", "KERBEROS").buildPartial(),
+      builderFor("ZOOKEEPER", "ZOOKEEPER_SERVER").buildPartial()
     )).anyTimes();
 
     expect(topology.getAmbariContext()).andReturn(ambariContext).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.topology;
 
 import static java.util.stream.Collectors.toSet;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_AND_START;
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
@@ -31,7 +32,6 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.newCapture;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,7 +71,6 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidator;
-import org.apache.ambari.server.topology.validators.TopologyValidatorService;
 import org.easymock.Capture;
 import org.easymock.EasyMockRule;
 import org.easymock.EasyMockSupport;
@@ -86,6 +85,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -174,9 +174,6 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
 
   @Mock(type = MockType.STRICT)
   private Future mockFuture;
-
-  @Mock
-  private TopologyValidatorService topologyValidatorServiceMock;
 
   @Mock
   private ComponentResolver componentResolver;
@@ -327,12 +324,12 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
 
     expect(componentResolver.resolveComponents(anyObject())).andReturn(ImmutableMap.of(
       "group1", ImmutableSet.of(
-        ResolvedComponent.builder(new Component("component1")).serviceType("service1").buildPartial(),
-        ResolvedComponent.builder(new Component("component2")).serviceType("service2").buildPartial()
+        builderFor("service1", "component1").buildPartial(),
+        builderFor("service2", "component2").buildPartial()
       ),
       "group2", ImmutableSet.of(
-        ResolvedComponent.builder(new Component("component3")).serviceType("service2").buildPartial(),
-        ResolvedComponent.builder(new Component("component4")).serviceType("service2").buildPartial()
+        builderFor("service2", "component3").buildPartial(),
+        builderFor("service2", "component4").buildPartial()
       )
     )).anyTimes();
 
@@ -361,9 +358,8 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
       LogicalRequestFactory.class.getMethod("createRequest",
         Long.class, TopologyRequest.class, ClusterTopology.class,
         TopologyLogicalRequestEntity.class)).createMock();
-    Field f = TopologyManager.class.getDeclaredField("logicalRequestFactory");
-    f.setAccessible(true);
-    f.set(topologyManager, logicalRequestFactory);
+    Whitebox.setInternalState(topologyManager, "logicalRequestFactory", logicalRequestFactory);
+    Whitebox.setInternalState(topologyManager, "topologyValidatorService", TopologyManagerTest.NO_VALIDATION);
 
     PowerMock.mockStatic(AmbariServer.class);
     expect(AmbariServer.getController()).andReturn(managementController).anyTimes();
@@ -422,16 +418,9 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     persistedState.persistLogicalRequest((LogicalRequest) anyObject(), anyLong());
     expectLastCall().once();
 
-    topologyValidatorServiceMock.validateTopologyConfiguration(anyObject(ClusterTopology.class));
-
     replayAll();
 
-    Class clazz = TopologyManager.class;
-
-    f = clazz.getDeclaredField("executor");
-    f.setAccessible(true);
-    f.set(topologyManager, executor);
-
+    Whitebox.setInternalState(topologyManager, "executor", executor);
     EasyMockSupport.injectMocks(topologyManager);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.topology;
 
 import static java.util.stream.Collectors.toSet;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_ONLY;
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
@@ -31,7 +32,6 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.newCapture;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,7 +71,6 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTask;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
 import org.apache.ambari.server.topology.validators.TopologyValidator;
-import org.apache.ambari.server.topology.validators.TopologyValidatorService;
 import org.easymock.Capture;
 import org.easymock.EasyMockRule;
 import org.easymock.EasyMockSupport;
@@ -86,6 +85,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -176,9 +176,6 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
 
   @Mock(type = MockType.STRICT)
   private Future mockFuture;
-
-  @Mock
-  private TopologyValidatorService topologyValidatorServiceMock;
 
   @Mock
   private ComponentResolver componentResolver;
@@ -334,12 +331,12 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
 
     expect(componentResolver.resolveComponents(anyObject())).andReturn(ImmutableMap.of(
       "group1", ImmutableSet.of(
-        ResolvedComponent.builder(new Component("component1")).serviceType("service1").buildPartial(),
-        ResolvedComponent.builder(new Component("component2")).serviceType("service2").buildPartial()
+        builderFor("service1", "component1").buildPartial(),
+        builderFor("service2", "component2").buildPartial()
       ),
       "group2", ImmutableSet.of(
-        ResolvedComponent.builder(new Component("component3")).serviceType("service2").buildPartial(),
-        ResolvedComponent.builder(new Component("component4")).serviceType("service2").buildPartial()
+        builderFor("service2", "component3").buildPartial(),
+        builderFor("service2", "component4").buildPartial()
       )
     )).anyTimes();
 
@@ -363,9 +360,8 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
       LogicalRequestFactory.class.getMethod("createRequest",
         Long.class, TopologyRequest.class, ClusterTopology.class,
         TopologyLogicalRequestEntity.class)).createMock();
-    Field f = TopologyManager.class.getDeclaredField("logicalRequestFactory");
-    f.setAccessible(true);
-    f.set(topologyManager, logicalRequestFactory);
+    Whitebox.setInternalState(topologyManager, "logicalRequestFactory", logicalRequestFactory);
+    Whitebox.setInternalState(topologyManager, "topologyValidatorService", TopologyManagerTest.NO_VALIDATION);
 
     PowerMock.mockStatic(AmbariServer.class);
     expect(AmbariServer.getController()).andReturn(managementController).anyTimes();
@@ -422,16 +418,9 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     persistedState.persistLogicalRequest((LogicalRequest) anyObject(), anyLong());
     expectLastCall().once();
 
-    topologyValidatorServiceMock.validateTopologyConfiguration(anyObject(ClusterTopology.class));
-
     replayAll();
 
-    Class clazz = TopologyManager.class;
-
-    f = clazz.getDeclaredField("executor");
-    f.setAccessible(true);
-    f.set(topologyManager, executor);
-
+    Whitebox.setInternalState(topologyManager, "executor", executor);
     EasyMockSupport.injectMocks(topologyManager);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/StackBuilder.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/StackBuilder.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology;
+
+import org.apache.ambari.server.state.AutoDeployInfo;
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.DependencyInfo;
+import org.apache.ambari.server.state.ServiceInfo;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.StackInfo;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Helps build stack definitions for testing.
+ */
+public class StackBuilder {
+
+  private final StackInfo stackInfo = new StackInfo();
+  private final StackId stackId;
+  private ServiceInfo currentService;
+  private ComponentInfo currentComponent;
+  private DependencyInfo currentDependency;
+
+  public StackBuilder(StackId stackId) {
+    this.stackId = stackId;
+    stackInfo.setName(stackId.getStackName());
+    stackInfo.setVersion(stackId.getStackVersion());
+  }
+
+  public StackBuilder addService(String service) {
+    ServiceInfo previousService = currentService;
+    currentService = getOrCreateService(service);
+    if (currentService != previousService) {
+      currentComponent = null;
+      currentDependency = null;
+    }
+    return this;
+  }
+
+  public StackBuilder addComponent(String component) {
+    Preconditions.checkNotNull(currentService);
+    ComponentInfo previousComponent = currentComponent;
+    currentComponent = getOrCreateComponent(component, currentService);
+    if (currentComponent != previousComponent) {
+      currentDependency = null;
+    }
+    return this;
+  }
+
+  public StackBuilder withCardinality(String cardinality) {
+    Preconditions.checkNotNull(currentComponent);
+    currentComponent.setCardinality(cardinality);
+    return this;
+  }
+
+  public StackBuilder dependsOn(String component) {
+    Preconditions.checkNotNull(currentService);
+    Preconditions.checkNotNull(currentComponent);
+    currentDependency = createDependency(currentComponent, currentService.getName(), component);
+    return this;
+  }
+
+  public StackBuilder dependsOn(String service, String component) {
+    Preconditions.checkNotNull(currentComponent);
+    currentDependency = createDependency(currentComponent, service, component);
+    return this;
+  }
+
+  public StackBuilder withScope(String scope, boolean autoDeployEnabled) {
+    Preconditions.checkNotNull(currentDependency);
+    currentDependency.setScope(scope);
+    if (currentDependency.getAutoDeploy() == null) {
+      currentDependency.setAutoDeploy(new AutoDeployInfo());
+    }
+    currentDependency.getAutoDeploy().setEnabled(autoDeployEnabled);
+    return this;
+  }
+
+  public StackBuilder autoDeploy(boolean enabled) {
+    Preconditions.checkNotNull(currentComponent);
+    getOrCreateAutoDeployInfo(currentComponent).setEnabled(enabled);
+    return this;
+  }
+
+  public StackBuilder coLocateWith(String component) {
+    Preconditions.checkNotNull(currentService);
+    coLocateWith(currentService.getName(), component);
+    return this;
+  }
+
+  public StackBuilder coLocateWith(String service, String component) {
+    Preconditions.checkNotNull(currentComponent);
+    getOrCreateAutoDeployInfo(currentComponent).setCoLocate(String.format("%s/%s", service, component));
+    getOrCreateComponent(component, getOrCreateService(service));
+    return this;
+  }
+
+  public StackInfo stackInfo() {
+    return stackInfo;
+  }
+
+  public ResolvedComponent lastAddedComponent() {
+    Preconditions.checkNotNull(currentService);
+    Preconditions.checkNotNull(currentComponent);
+    return resolveComponent(currentComponent, currentService, stackId);
+  }
+
+  public ResolvedComponent componentToBeCoLocatedWith() {
+    Preconditions.checkNotNull(currentComponent);
+    Preconditions.checkNotNull(currentComponent.getAutoDeploy());
+    Preconditions.checkNotNull(currentComponent.getAutoDeploy().getCoLocate());
+    String[] parts = currentComponent.getAutoDeploy().getCoLocate().split("/");
+    return componentOfType(parts[0], parts[1]);
+  }
+
+  public ResolvedComponent componentOfType(String component) {
+    Preconditions.checkNotNull(currentService);
+    ComponentInfo componentInfo = currentService.getComponentByName(component);
+    return resolveComponent(componentInfo, currentService, stackId);
+  }
+
+  public ResolvedComponent componentOfType(String service, String component) {
+    ServiceInfo serviceInfo = stackInfo.getService(service);
+    ComponentInfo componentInfo = serviceInfo.getComponentByName(component);
+    return resolveComponent(componentInfo, serviceInfo, stackId);
+  }
+
+  private static ResolvedComponent resolveComponent(ComponentInfo componentInfo, ServiceInfo serviceInfo, StackId stackId) {
+    return ResolvedComponent.builder(new Component(componentInfo.getName()))
+      .componentInfo(componentInfo)
+      .serviceInfo(serviceInfo)
+      .stackId(stackId)
+      .build();
+  }
+
+  private DependencyInfo createDependency(ComponentInfo component, String dependencyServiceName, String dependencyComponentName) {
+    getOrCreateComponent(dependencyComponentName, getOrCreateService(dependencyServiceName));
+
+    DependencyInfo dependency = new DependencyInfo();
+    dependency.setName(String.format("%s/%s", dependencyServiceName, dependencyComponentName));
+    component.getDependencies().add(dependency);
+
+    return dependency;
+  }
+
+  private ServiceInfo getOrCreateService(String stackServiceName) {
+    ServiceInfo serviceInfo = stackInfo.getService(stackServiceName);
+    if (serviceInfo == null) {
+      serviceInfo = new ServiceInfo();
+      serviceInfo.setName(stackServiceName);
+      stackInfo.getServices().add(serviceInfo);
+    }
+    return serviceInfo;
+  }
+
+  private static ComponentInfo getOrCreateComponent(String componentName, ServiceInfo serviceInfo) {
+    ComponentInfo componentInfo = serviceInfo.getComponentByName(componentName);
+    if (componentInfo == null) {
+      componentInfo = new ComponentInfo();
+      componentInfo.setName(componentName);
+      componentInfo.setCardinality("0+");
+      serviceInfo.getComponents().add(componentInfo);
+    }
+    return componentInfo;
+  }
+
+  private static AutoDeployInfo getOrCreateAutoDeployInfo(ComponentInfo componentInfo) {
+    if (componentInfo.getAutoDeploy() == null) {
+      componentInfo.setAutoDeploy(new AutoDeployInfo());
+    }
+    return componentInfo.getAutoDeploy();
+  }
+
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.topology;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.capture;
@@ -119,6 +120,13 @@ public class TopologyManagerTest {
   private static final String SAMPLE_QUICKLINKS_PROFILE_2 =
       "{\"filters\":[],\"services\":[{\"name\":\"HDFS\",\"components\":[],\"filters\":[{\"visible\":true}]}]}";
 
+  static final TopologyValidatorService NO_VALIDATION = new TopologyValidatorService() {
+    @Override
+    public ClusterTopology validate(ClusterTopology clusterTopology) {
+      return clusterTopology;
+    }
+  };
+
   @Rule
   public EasyMockRule mocks = new EasyMockRule(this);
 
@@ -188,9 +196,6 @@ public class TopologyManagerTest {
 
   @Mock(type = MockType.STRICT)
   private Future mockFuture;
-
-  @Mock
-  private TopologyValidatorService topologyValidatorService;
 
   @Mock
   private ComponentResolver componentResolver;
@@ -283,10 +288,10 @@ public class TopologyManagerTest {
     expect(blueprint.getHostGroup("group1")).andReturn(group1).anyTimes();
     expect(blueprint.getHostGroup("group2")).andReturn(group2).anyTimes();
     expect(clusterTopologyMock.getComponents()).andReturn(Stream.of(
-      ResolvedComponent.builder(new Component("component1")).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("component2")).serviceType("service2").buildPartial(),
-      ResolvedComponent.builder(new Component("component3")).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("component4")).serviceType("service2").buildPartial()
+      builderFor("service1", "component1").buildPartial(),
+      builderFor("service2", "component2").buildPartial(),
+      builderFor("service1", "component3").buildPartial(),
+      builderFor("service2", "component4").buildPartial()
     )).anyTimes();
     expect(blueprint.getConfiguration()).andReturn(bpConfiguration).anyTimes();
     expect(blueprint.getHostGroups()).andReturn(groupMap).anyTimes();
@@ -421,6 +426,7 @@ public class TopologyManagerTest {
     PowerMock.replay(AmbariContext.class);
 
     Whitebox.setInternalState(topologyManager, "executor", executor);
+    Whitebox.setInternalState(topologyManager, "topologyValidatorService", NO_VALIDATION);
     EasyMockSupport.injectMocks(topologyManager);
 
     Whitebox.setInternalState(topologyManagerReplay, "executor", executor);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/DependencyAndCardinalityValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/DependencyAndCardinalityValidatorTest.java
@@ -18,372 +18,254 @@
 
 package org.apache.ambari.server.topology.validators;
 
-import static java.util.stream.Collectors.toList;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
-import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertSame;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.ambari.server.controller.internal.Stack;
-import org.apache.ambari.server.state.AutoDeployInfo;
-import org.apache.ambari.server.state.ComponentInfo;
-import org.apache.ambari.server.state.DependencyConditionInfo;
-import org.apache.ambari.server.state.DependencyInfo;
-import org.apache.ambari.server.state.StackId;
-import org.apache.ambari.server.topology.Blueprint;
-import org.apache.ambari.server.topology.Cardinality;
-import org.apache.ambari.server.topology.ClusterTopology;
 import org.apache.ambari.server.topology.Component;
-import org.apache.ambari.server.topology.Configuration;
-import org.apache.ambari.server.topology.HostGroup;
 import org.apache.ambari.server.topology.InvalidTopologyException;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRule;
-import org.easymock.Mock;
-import org.easymock.MockType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.apache.ambari.server.topology.ResolvedComponent;
+import org.apache.ambari.server.topology.StackBuilder;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-public class DependencyAndCardinalityValidatorTest {
+public class DependencyAndCardinalityValidatorTest extends TopologyValidatorTest {
 
-  private final Map<String, HostGroup> hostGroups = new LinkedHashMap<>();
-  @Rule
-  public EasyMockRule mocks = new EasyMockRule(this);
-
-  @Mock(type = MockType.NICE)
-  private ClusterTopology topology;
-
-  @Mock(type = MockType.NICE)
-  private Blueprint blueprint;
-
-  @Mock(type = MockType.NICE)
-  private Stack stack;
-
-  @Mock(type = MockType.NICE)
-  private HostGroup group1;
-
-  @Mock(type = MockType.NICE)
-  private HostGroup group2;
-
-  @Mock(type = MockType.NICE)
-  private DependencyInfo dependency1;
-  @Mock(type = MockType.NICE)
-  private DependencyInfo dependency2;
-
-  @Mock(type = MockType.NICE)
-  private ComponentInfo dependencyComponentInfo;
-  @Mock(type = MockType.NICE)
-  private DependencyConditionInfo dependencyConditionInfo1;
-  @Mock(type = MockType.NICE)
-  private DependencyConditionInfo dependencyConditionInfo2;
-
-  private final Collection<String> group1Components = new ArrayList<>();
-  private final Collection<String> group2Components = new ArrayList<>();
-  private final Collection<String> services = new ArrayList<>();
-
-  private Collection<DependencyInfo> dependencies1 = new ArrayList<>();
-  private List<DependencyConditionInfo> dependenciesConditionInfos1 = new ArrayList<>();
-  private AutoDeployInfo autoDeploy = new AutoDeployInfo();
-  private Map<String, Map<String, String>> configProperties = new HashMap<>();
-  private Configuration configuration = new Configuration(configProperties, Collections.emptyMap());
-
-
-  @Before
-  public void setup() {
-    hostGroups.put("group1", group1);
-    hostGroups.put("group2", group2);
-
-    autoDeploy.setEnabled(true);
-    autoDeploy.setCoLocate("service1/component2");
-
-    expect(blueprint.getName()).andReturn("blueprint-1").anyTimes();
-    expect(blueprint.getStackIds()).andReturn(ImmutableSet.of(new StackId("HDP", "2.2"))).anyTimes();
-    expect(topology.getStack()).andReturn(stack).anyTimes();
-    expect(blueprint.getHostGroups()).andReturn(hostGroups).anyTimes();
-    expect(topology.getBlueprint()).andReturn(blueprint).anyTimes();
-    expect(topology.getServices()).andReturn(services).anyTimes();
-
-    expect(group1.getComponentNames()).andReturn(group1Components).anyTimes();
-    expect(group1.getComponents()).
-      andAnswer(() -> group1Components.stream().map(comp -> new Component(comp)).collect(toList())).anyTimes();
-    expect(group1.getName()).andReturn("host-group-1").anyTimes();
-    expect(group2.getComponentNames()).andReturn(group2Components).anyTimes();
-    expect(group2.getComponents()).
-      andAnswer(() -> group2Components.stream().map(comp -> new Component(comp)).collect(toList())).anyTimes();
-    expect(group2.getName()).andReturn("host-group-2").anyTimes();
-
-    expect(stack.getDependenciesForComponent("component1")).andReturn(dependencies1).anyTimes();
-    expect(stack.getDependenciesForComponent("component2")).andReturn(dependencies1).anyTimes();
-    expect(stack.getDependenciesForComponent("component3")).andReturn(dependencies1).anyTimes();
-    expect(stack.getDependenciesForComponent("component4")).andReturn(dependencies1).anyTimes();
-
-    expect(stack.getCardinality("component1")).andReturn(new Cardinality("1"));
-    expect(stack.getCardinality("component2")).andReturn(new Cardinality("1+"));
-    expect(stack.getCardinality("component3")).andReturn(new Cardinality("1+"));
-    dependenciesConditionInfos1.add(dependencyConditionInfo1);
-    dependenciesConditionInfos1.add(dependencyConditionInfo2);
-
-    expect(topology.getConfiguration()).andReturn(configuration).anyTimes();
-  }
-
-  @After
-  public void tearDown() {
-    reset(blueprint, stack, group1, group2, dependency1, dependency2, dependencyConditionInfo1, dependencyConditionInfo2);
+  public DependencyAndCardinalityValidatorTest() {
+    subject = new DependencyAndCardinalityValidator();
   }
 
   @Test
-  public void testValidateTopology_basic() throws Exception {
-    group1Components.add("component1");
-    group1Components.add("component1");
+  public void acceptsSpecifiedNumberOfInstances() throws InvalidTopologyException {
+    topologyHas(2, aComponent().withCardinality("2"));
+    replayAll();
 
-    services.addAll(Arrays.asList("service1", "service2"));
+    assertSame(topology, subject.validate(topology));
+  }
 
-    expect(stack.getComponents("service1")).andReturn(Collections.singleton("component1")).anyTimes();
-    expect(stack.getComponents("service2")).andReturn(Collections.singleton("component2")).anyTimes();
+  @Test
+  public void acceptsComponentWithMpackInstanceSpecified() throws InvalidTopologyException {
+    ResolvedComponent component = aComponent().withCardinality("2").lastAddedComponent();
+    component = component.toBuilder()
+      .component(new Component(component.componentName(), "mpack_instance", "service_instance", null))
+      .build();
+    topologyHas(2, component);
+    replayAll();
 
-    expect(blueprint.getHostGroupsForComponent("component1")).andReturn(Collections.singleton(group1)).anyTimes();
-    expect(blueprint.getHostGroupsForComponent("component2")).andReturn(Arrays.asList(group1, group2)).anyTimes();
+    assertSame(topology, subject.validate(topology));
+  }
 
-    replay(blueprint, topology, stack, group1, group2, dependency1);
+  @Test
+  public void acceptsInstancesOnAllHosts() throws InvalidTopologyException {
+    topologyHas(3, aComponent().withCardinality("ALL"));
+    replayAll();
 
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
+    assertSame(topology, subject.validate(topology));
+  }
+
+  @Test
+  public void acceptsAbsentOptionalComponent() throws InvalidTopologyException {
+    topologyHas(0, aComponent().withCardinality("0-1"), 1);
+    replayAll();
+
+    assertSame(topology, subject.validate(topology));
   }
 
   @Test(expected = InvalidTopologyException.class)
-  public void testValidateTopology_basic_negative() throws Exception {
-    group1Components.add("component2");
+  public void rejectsComponentMissingFromHostGroup() throws InvalidTopologyException {
+    topologyHas(2, aComponent().withCardinality("ALL"), 1);
+    replayAll();
 
-    services.addAll(Collections.singleton("service1"));
+    subject.validate(topology);
+  }
 
-    expect(stack.getComponents("service1")).andReturn(Arrays.asList("component1", "component2")).anyTimes();
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsTooFewInstances() throws InvalidTopologyException {
+    topologyHas(1, aComponent().withCardinality("2"));
+    replayAll();
 
-    expect(blueprint.getHostGroupsForComponent("component1")).andReturn(Collections.emptyList()).anyTimes();
-    expect(blueprint.getHostGroupsForComponent("component2")).andReturn(Arrays.asList(group1, group2)).anyTimes();
+    subject.validate(topology);
+  }
 
-    replay(blueprint, topology, stack, group1, group2, dependency1);
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsTooManyInstances() throws InvalidTopologyException {
+    topologyHas(2, aComponent().withCardinality("1"));
+    replayAll();
 
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
+    subject.validate(topology);
   }
 
   @Test
-  public void testValidateTopology_autoDeploy() throws Exception {
-    group1Components.add("component2");
-    services.addAll(Collections.singleton("service1"));
+  public void addsAutoDeployableComponentToAllHostGroups() throws InvalidTopologyException {
+    StackBuilder stack = aComponent().withCardinality("ALL").autoDeploy(true);
+    ResolvedComponent autoDeployable = stack.lastAddedComponent();
+    topologyHas(2, stack.addComponent("component_in_same_service"));
 
-    expect(blueprint.getHostGroupsForComponent("component1")).andReturn(Collections.emptyList()).anyTimes();
-    expect(blueprint.getHostGroupsForComponent("component2")).andReturn(Arrays.asList(group1, group2)).anyTimes();
-
-    expect(stack.getComponents("service1")).andReturn(Arrays.asList("component1", "component2")).anyTimes();
-    expect(stack.getAutoDeployInfo("component1")).andReturn(autoDeploy).anyTimes();
-
-    expect(group1.addComponent(new Component("component1"))).andReturn(true).once();
-
-    replay(blueprint, topology, stack, group1, group2, dependency1);
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
-
-    verify(group1);
+    verifyAddedToAllHostGroupsWhereMissing(autoDeployable);
   }
 
   @Test
-  public void testValidateTopology_autoDeploy_hasDependency() throws Exception {
-    group1Components.add("component2");
-    dependencies1.add(dependency1);
-    services.addAll(Collections.singleton("service1"));
+  public void addsAutoDeployableComponentToAllRemainingHostGroups() throws InvalidTopologyException {
+    StackBuilder stack = aComponent().withCardinality("ALL").autoDeploy(true);
+    ResolvedComponent component = stack.lastAddedComponent();
+    topologyHas(2, stack, 3);
 
-    expect(blueprint.getHostGroupsForComponent("component1")).andReturn(Collections.emptyList()).anyTimes();
-    expect(blueprint.getHostGroupsForComponent("component2")).andReturn(Arrays.asList(group1, group2)).anyTimes();
-    expect(blueprint.getHostGroupsForComponent("component3")).andReturn(Collections.emptyList()).anyTimes();
-
-    expect(stack.getComponents("service1")).andReturn(Arrays.asList("component1", "component2")).anyTimes();
-    expect(stack.getComponents("service2")).andReturn(Collections.singleton("component3")).anyTimes();
-    expect(stack.getAutoDeployInfo("component1")).andReturn(autoDeploy).anyTimes();
-
-    AutoDeployInfo dependencyAutoDeploy = new AutoDeployInfo();
-    dependencyAutoDeploy.setEnabled(true);
-    dependencyAutoDeploy.setCoLocate("service1/component1");
-
-    expect(dependency1.getScope()).andReturn("host").anyTimes();
-    expect(dependency1.getAutoDeploy()).andReturn(dependencyAutoDeploy).anyTimes();
-    expect(dependency1.getComponentName()).andReturn("component3").anyTimes();
-    expect(dependency1.getServiceName()).andReturn("service1").anyTimes();
-    expect(dependency1.getName()).andReturn("dependency1").anyTimes();
-
-    expect(dependencyComponentInfo.isClient()).andReturn(true).anyTimes();
-    expect(stack.getComponentInfo("component3")).andReturn(dependencyComponentInfo).anyTimes();
-
-    expect(group1.addComponent(new Component("component1"))).andReturn(true).once();
-    expect(group1.addComponent(new Component("component3"))).andReturn(true).once();
-
-    replay(blueprint, topology, stack, group1, group2, dependency1, dependencyComponentInfo);
-
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
-
-    verify(group1);
+    verifyAddedToAllHostGroupsWhereMissing(component);
   }
 
   @Test
-  public void testShouldDependencyBeExcludedWenRelatedServiceIsNotInBlueprint() throws Exception {
-    // GIVEN
-    hostGroups.clear();
-    hostGroups.put("group1", group1);
+  public void doesNotAddAutoDeployableComponentIfServiceAbsentFromTopology() throws InvalidTopologyException {
+    topologyHas(aComponent().withCardinality("1").autoDeploy(true).coLocateWith("other_service", "other_component").componentToBeCoLocatedWith());
+    replayAll();
 
-    group1Components.add("component-1");
-    dependencies1.add(dependency1);
-    services.addAll(Collections.singleton("service-1"));
-
-
-    expect(blueprint.getHostGroupsForComponent("component-1")).andReturn(Arrays.asList(group1)).anyTimes();
-
-    Cardinality cardinality = new Cardinality("1");
-
-    expect(stack.getComponents("service-1")).andReturn(Arrays.asList("component-1")).anyTimes();
-    expect(stack.getAutoDeployInfo("component-1")).andReturn(autoDeploy).anyTimes();
-    expect(stack.getDependenciesForComponent("component-1")).andReturn(dependencies1).anyTimes();
-    expect(stack.getCardinality("component-1")).andReturn(cardinality).anyTimes();
-
-
-    AutoDeployInfo dependencyAutoDeploy = new AutoDeployInfo();
-    dependencyAutoDeploy.setEnabled(true);
-    dependencyAutoDeploy.setCoLocate("service1/component1");
-
-    expect(dependency1.getScope()).andReturn("host").anyTimes();
-    expect(dependency1.getAutoDeploy()).andReturn(dependencyAutoDeploy).anyTimes();
-    expect(dependency1.getComponentName()).andReturn("component-d").anyTimes();
-    expect(dependency1.getServiceName()).andReturn("service-d").anyTimes();
-    expect(dependency1.getName()).andReturn("dependency-1").anyTimes();
-
-
-    expect(dependencyComponentInfo.isClient()).andReturn(true).anyTimes();
-    expect(stack.getComponentInfo("component-d")).andReturn(dependencyComponentInfo).anyTimes();
-
-    replay(blueprint, topology, stack, group1, group2, dependency1, dependencyComponentInfo);
-
-    // WHEN
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
-
-    // THEN
-    verify(group1);
-
+    assertSame(topology, subject.validate(topology));
   }
-  @Test(expected=InvalidTopologyException.class)
-  public void testShouldThrowErrorWhenDependentComponentIsNotInBlueprint() throws Exception {
-    // GIVEN
-    hostGroups.clear();
-    hostGroups.put("group1", group1);
 
-    group1Components.add("component-1");
-    dependencies1.add(dependency1);
-    services.addAll(Collections.singleton("service-1"));
+  @Test
+  public void omitsNotAutoDeployableComponent() throws InvalidTopologyException {
+    topologyHas(aComponent().autoDeploy(false).addComponent("other_component").lastAddedComponent());
+    replayAll();
 
-
-    expect(blueprint.getHostGroupsForComponent("component-1")).andReturn(Arrays.asList(group1)).anyTimes();
-
-    Cardinality cardinality = new Cardinality("1");
-
-    expect(stack.getComponents("service-1")).andReturn(Arrays.asList("component-1")).anyTimes();
-    expect(stack.getAutoDeployInfo("component-1")).andReturn(autoDeploy).anyTimes();
-    expect(stack.getDependenciesForComponent("component-1")).andReturn(dependencies1).anyTimes();
-    expect(stack.getCardinality("component-1")).andReturn(cardinality).anyTimes();
-
-
-    AutoDeployInfo dependencyAutoDeploy = null;
-
-    expect(dependency1.getScope()).andReturn("host").anyTimes();
-    expect(dependency1.getAutoDeploy()).andReturn(dependencyAutoDeploy).anyTimes();
-    expect(dependency1.getComponentName()).andReturn("component-d").anyTimes();
-    expect(dependency1.getServiceName()).andReturn("service-d").anyTimes();
-    expect(dependency1.getName()).andReturn("dependency-1").anyTimes();
-
-
-    expect(stack.getComponentInfo("component-d")).andReturn(dependencyComponentInfo).anyTimes();
-
-    replay(blueprint, topology, stack, group1, group2, dependency1, dependencyComponentInfo);
-
-    // WHEN
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
-
-    // THEN
-    verify(group1);
-
+    assertSame(topology, subject.validate(topology));
   }
-  @Test(expected=InvalidTopologyException.class)
-  public void testWhenComponentIsConditionallyDependentAndOnlyOneOfTheConditionsIsSatisfied() throws Exception {
-    // GIVEN
-    hostGroups.clear();
-    hostGroups.put("group1", group1);
 
-    group1Components.add("component-1");
-    dependencies1.add(dependency1);
-    dependencies1.add(dependency2);
-    services.addAll(Collections.singleton("service-1"));
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsAutoDeployableComponentIfColocationUnspecified() throws InvalidTopologyException {
+    topologyHas(aComponent().withCardinality("1").autoDeploy(true).addComponent("in_same_service").lastAddedComponent());
+    replayAll();
 
-
-    expect(blueprint.getHostGroupsForComponent("component-1")).andReturn(Arrays.asList(group1)).anyTimes();
-    Map<String, Map<String, String>> properties = new HashMap<>();
-    Map<String, String> typeProps = new HashMap<>();
-    typeProps.put("yarn.resourcemanager.hostname", "testhost");
-    properties.put("yarn-site", typeProps);
-
-    Configuration clusterConfig = new Configuration(properties,
-       Collections.emptyMap());
-
-    Cardinality cardinality = new Cardinality("1");
-
-    expect(stack.getComponents("service-1")).andReturn(Arrays.asList("component-1")).anyTimes();
-    expect(stack.getAutoDeployInfo("component-1")).andReturn(autoDeploy).anyTimes();
-    expect(stack.getDependenciesForComponent("component-1")).andReturn(dependencies1).anyTimes();
-    expect(stack.getCardinality("component-1")).andReturn(cardinality).anyTimes();
-
-    AutoDeployInfo dependencyAutoDeploy = null;
-
-    expect(dependency1.getScope()).andReturn("host").anyTimes();
-    expect(dependency1.getAutoDeploy()).andReturn(dependencyAutoDeploy).anyTimes();
-    expect(dependency1.getComponentName()).andReturn("component-d").anyTimes();
-    expect(dependency1.getServiceName()).andReturn("service-d").anyTimes();
-    expect(dependency1.getName()).andReturn("dependency-1").anyTimes();
-    expect(dependency1.hasDependencyConditions()).andReturn(true).anyTimes();
-    expect(dependency1.getDependencyConditions()).andReturn(dependenciesConditionInfos1).anyTimes();
-    expect(dependency2.getScope()).andReturn("host").anyTimes();
-    expect(dependency2.getAutoDeploy()).andReturn(dependencyAutoDeploy).anyTimes();
-    expect(dependency2.getComponentName()).andReturn("component-d").anyTimes();
-    expect(dependency2.getServiceName()).andReturn("service-d").anyTimes();
-    expect(dependency2.getName()).andReturn("dependency-2").anyTimes();
-    expect(dependency2.hasDependencyConditions()).andReturn(false).anyTimes();
-
-    expect(dependencyConditionInfo1.isResolved(EasyMock.anyObject())).andReturn(true).anyTimes();
-    expect(dependencyConditionInfo2.isResolved(EasyMock.anyObject())).andReturn(false).anyTimes();
-
-
-    expect(dependencyComponentInfo.isClient()).andReturn(false).anyTimes();
-    expect(stack.getComponentInfo("component-d")).andReturn(dependencyComponentInfo).anyTimes();
-
-    replay(blueprint, topology, stack, group1, group2, dependency1, dependency2, dependencyComponentInfo,dependencyConditionInfo1,dependencyConditionInfo2);
-
-    // WHEN
-    TopologyValidator validator = new DependencyAndCardinalityValidator();
-    validator.validate(topology);
-
-    // THEN
-    verify(group1);
-
+    subject.validate(topology);
   }
+
+  @Test
+  public void addsAutoDeployableComponentInSameService() throws InvalidTopologyException {
+    StackBuilder stack = aComponent().withCardinality("1").autoDeploy(true).coLocateWith("other_component");
+    ResolvedComponent toBeAdded = stack.lastAddedComponent();
+    ResolvedComponent otherComponent = stack.componentToBeCoLocatedWith();
+    topologyHas(otherComponent);
+
+    verifyAddedToFirstHostGroupWith(otherComponent, toBeAdded);
+  }
+
+  @Test
+  public void addsAutoDeployableComponentToSingleHostGroup() throws InvalidTopologyException {
+    String otherService = "other_service", otherComponent = "other_component";
+    StackBuilder stack = aComponent().withCardinality("1").autoDeploy(true).coLocateWith(otherService, otherComponent);
+    ResolvedComponent toBeAdded = stack.lastAddedComponent();
+    ResolvedComponent component = stack.addComponent("in_same_service").lastAddedComponent();
+    ResolvedComponent other = stack.componentOfType(otherService, otherComponent);
+    topologyHas(ImmutableList.of(
+      ImmutableSet.of(other),
+      ImmutableSet.of(component),
+      ImmutableSet.of()
+    ));
+    verifyAddedToFirstHostGroupWith(other, toBeAdded);
+  }
+
+  @Test
+  public void addsAutoDeployableComponentToFirstHostGroup() throws InvalidTopologyException {
+    String otherService = "other_service", otherComponent = "other_component";
+    StackBuilder stack = aComponent().withCardinality("1").coLocateWith(otherService, otherComponent).autoDeploy(true);
+    ResolvedComponent toBeAdded = stack.lastAddedComponent();
+    ResolvedComponent component = stack.addComponent("in_same_service").lastAddedComponent();
+    ResolvedComponent other = stack.componentOfType(otherService, otherComponent);
+    topologyHas(ImmutableList.of(
+      ImmutableSet.of(other),
+      ImmutableSet.of(other),
+      ImmutableSet.of(other),
+      ImmutableSet.of(component)
+    ));
+    verifyAddedToFirstHostGroupWith(other, toBeAdded);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsAutoDeployableWithUnsupportedCardinality() throws InvalidTopologyException {
+    ResolvedComponent otherComponent = aComponent().withCardinality("2").autoDeploy(true)
+      .addComponent("other_component").lastAddedComponent();
+    topologyHas(2, otherComponent);
+    replayAll();
+
+    subject.validate(topology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsAutoDeployableWithoutCoLocatedComponent() throws InvalidTopologyException {
+    topologyHas(1, aComponent().withCardinality("1").coLocateWith("missing_from_topology")
+      .addComponent("present_in_topology"));
+    replayAll();
+
+    subject.validate(topology);
+  }
+
+  @Test
+  public void addsDependencyToSameHostGroup() throws InvalidTopologyException {
+    String dependencyName = "dependency";
+    StackBuilder stack = aComponent().dependsOn(dependencyName).withScope("host", true);
+    ResolvedComponent dependent = stack.lastAddedComponent();
+    ResolvedComponent dependency = stack.componentOfType(dependencyName);
+    topologyHas(3, stack, 2);
+    verifyAddedToAllHostGroupsWith(dependent, dependency);
+  }
+
+  @Test
+  public void addsCommonDependencyOnlyOnce() throws InvalidTopologyException {
+    String dependency = "common_dependency";
+    StackBuilder service = stack(STACK_ID).addService(SERVICE_NAME);
+    topologyHas(
+      service.addComponent("some_component").dependsOn(dependency).withScope("host", true).lastAddedComponent(),
+      service.addComponent("other_component").dependsOn(dependency).withScope("host", true).lastAddedComponent()
+    );
+
+    verifyAddedToAllHostGroupsWhereMissing(service.componentOfType(dependency));
+  }
+
+  @Test
+  public void addsDependencyFromEachStack() throws InvalidTopologyException {
+    String dependencyService = "dependency_service", dependencyComponent = "common_dependency";
+    StackBuilder someStack = stack(STACK_ID).addService("some_service").addComponent("some_component")
+      .dependsOn(dependencyService, dependencyComponent).withScope("host", true);
+    StackBuilder otherStack = stack(OTHER_STACK_ID).addService("other_service").addComponent("other_component")
+      .dependsOn(dependencyService, dependencyComponent).withScope("host", true);
+    topologyHas(
+      someStack.lastAddedComponent(),
+      otherStack.lastAddedComponent()
+    );
+
+    verifyAddedToAllHostGroupsWhereMissing(
+      someStack.componentOfType(dependencyService, dependencyComponent),
+      otherStack.componentOfType(dependencyService, dependencyComponent)
+    );
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsMissingDependencyDueToLackOfAutoDeploy() throws InvalidTopologyException {
+    topologyHas(1, aComponent().dependsOn("dependency").withScope("host", false));
+    replayAll();
+
+    subject.validate(topology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void rejectsMissingClusterLevelDependency() throws InvalidTopologyException {
+    topologyHas(1, aComponent().dependsOn("dependency").withScope("cluster", true));
+    replayAll();
+
+    subject.validate(topology);
+  }
+
+  @Test
+  public void acceptsSatisfiedClusterLevelDependency() throws InvalidTopologyException {
+    String dependency = "dependency";
+    StackBuilder stack = aComponent().dependsOn(dependency).withScope("cluster", false);
+    ResolvedComponent dependent = stack.lastAddedComponent();
+    ResolvedComponent other = stack.componentOfType(dependency);
+    topologyHas(ImmutableList.of(
+      ImmutableSet.of(dependent),
+      ImmutableSet.of(other)
+    ));
+    replayAll();
+
+    assertSame(topology, subject.validate(topology));
+  }
+
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/HiveServiceValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/HiveServiceValidatorTest.java
@@ -14,16 +14,15 @@
 
 package org.apache.ambari.server.topology.validators;
 
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 
 import java.util.Arrays;
 
 import org.apache.ambari.server.topology.ClusterTopology;
-import org.apache.ambari.server.topology.Component;
 import org.apache.ambari.server.topology.Configuration;
 import org.apache.ambari.server.topology.InvalidTopologyException;
-import org.apache.ambari.server.topology.ResolvedComponent;
 import org.easymock.EasyMockRule;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
@@ -55,7 +54,7 @@ public class HiveServiceValidatorTest extends EasyMockSupport {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     resetAll();
   }
 
@@ -135,7 +134,7 @@ public class HiveServiceValidatorTest extends EasyMockSupport {
       components.add("MYSQL_SERVER");
     }
     expect(topology.getComponents()).andReturn(components.build().stream()
-      .map(name -> ResolvedComponent.builder(new Component(name)).serviceType("HIVE").buildPartial())
+      .map(component -> builderFor("HIVE", component).buildPartial())
     ).anyTimes();
     expect(topology.getServices()).andReturn(ImmutableSet.of("HDFS", "YARN", "HIVE")).anyTimes();
     replay(topology);

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/RequiredPasswordValidatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.topology.validators;
 
 import static junit.framework.Assert.assertEquals;
+import static org.apache.ambari.server.topology.StackComponentResolverTest.builderFor;
 import static org.easymock.EasyMock.expect;
 
 import java.util.Collection;
@@ -32,12 +33,10 @@ import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.state.PropertyInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.ClusterTopology;
-import org.apache.ambari.server.topology.Component;
 import org.apache.ambari.server.topology.Configuration;
 import org.apache.ambari.server.topology.HostGroup;
 import org.apache.ambari.server.topology.HostGroupInfo;
 import org.apache.ambari.server.topology.InvalidTopologyException;
-import org.apache.ambari.server.topology.ResolvedComponent;
 import org.easymock.EasyMockRule;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
@@ -81,10 +80,6 @@ public class RequiredPasswordValidatorTest extends EasyMockSupport {
   private static final Map<String, HostGroup> hostGroups = new HashMap<>();
   private static final Map<String, HostGroupInfo> hostGroupInfo = new HashMap<>();
 
-  private static final Collection<String> service1Components = new HashSet<>();
-  private static final Collection<String> service2Components = new HashSet<>();
-  private static final Collection<String> service3Components = new HashSet<>();
-
   private static final Collection<Stack.ConfigProperty> service1RequiredPwdConfigs = new HashSet<>();
   private static final Collection<Stack.ConfigProperty> service2RequiredPwdConfigs = new HashSet<>();
   private static final Collection<Stack.ConfigProperty> service3RequiredPwdConfigs = new HashSet<>();
@@ -124,11 +119,6 @@ public class RequiredPasswordValidatorTest extends EasyMockSupport {
     hostGroups.put("group1", group1);
     hostGroups.put("group2", group2);
 
-    service1Components.add("component1");
-    service1Components.add("component2");
-    service2Components.add("component3");
-    service3Components.add("component4");
-
     HostGroupInfo hostGroup1Info = new HostGroupInfo("group1");
     hostGroup1Info.setConfiguration(topoGroup1Config);
     HostGroupInfo hostGroup2Info = new HostGroupInfo("group2");
@@ -146,13 +136,13 @@ public class RequiredPasswordValidatorTest extends EasyMockSupport {
     expect(topology.getStack()).andReturn(stack).anyTimes();
 
     expect(topology.getComponentsInHostGroup("group1")).andReturn(Stream.of(
-      ResolvedComponent.builder(new Component("component1")).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("component2")).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("component3")).serviceType("service2").buildPartial()
+      builderFor("service1", "component1").buildPartial(),
+      builderFor("service1", "component2").buildPartial(),
+      builderFor("service2", "component3").buildPartial()
     )).anyTimes();
     expect(topology.getComponentsInHostGroup("group2")).andReturn(Stream.of(
-      ResolvedComponent.builder(new Component("component1")).serviceType("service1").buildPartial(),
-      ResolvedComponent.builder(new Component("component4")).serviceType("service3").buildPartial()
+      builderFor("service1", "component1").buildPartial(),
+      builderFor("service3", "component4").buildPartial()
     )).anyTimes();
 
     expect(stack.getRequiredConfigurationProperties("service1", PropertyInfo.PropertyType.PASSWORD)).andReturn(service1RequiredPwdConfigs).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/TopologyValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/TopologyValidatorTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology.validators;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.newCapture;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.controller.internal.StackDefinition;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.topology.ClusterTopology;
+import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.topology.InvalidTopologyException;
+import org.apache.ambari.server.topology.ResolvedComponent;
+import org.apache.ambari.server.topology.StackBuilder;
+import org.easymock.Capture;
+import org.easymock.EasyMockRule;
+import org.easymock.EasyMockSupport;
+import org.easymock.IAnswer;
+import org.easymock.Mock;
+import org.easymock.MockType;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+/**
+ * Base class for TopologyValidator tests.
+ */
+public class TopologyValidatorTest extends EasyMockSupport {
+
+  protected static final StackId STACK_ID = new StackId("HDP", "2.6");
+  protected static final StackId OTHER_STACK_ID = new StackId("BigData", "1.0");
+  protected static final String SERVICE_NAME = "service";
+  protected static final String COMPONENT_NAME = "component";
+  private final Map<StackId, StackBuilder> stackMap = new LinkedHashMap<>();
+
+  @Rule
+  public EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock(type = MockType.NICE)
+  protected ClusterTopology topology;
+
+  @TestSubject
+  protected TopologyValidator subject;
+
+  @Before
+  public void setup() throws Exception {
+    stackMap.clear();
+
+    expect(topology.getBlueprintName()).andReturn("blue").anyTimes();
+    expect(topology.getConfiguration()).andReturn(Configuration.createEmpty()).anyTimes();
+    expect(topology.withAdditionalComponents(ImmutableMap.of())).andReturn(topology).anyTimes();
+  }
+
+  protected StackBuilder aComponent() {
+    return stack(STACK_ID).addService(SERVICE_NAME).addComponent(COMPONENT_NAME);
+  }
+
+  /**
+   * Creates a topology with one kind of host group: {@code hostGroupsWith} groups have {@code onlyComponent}.
+   */
+  protected void topologyHas(int hostGroupsWith, ResolvedComponent onlyComponent) {
+    topologyHas(hostGroupsWith, ImmutableSet.of(onlyComponent), 0, ImmutableSet.of());
+  }
+
+  /**
+   * Creates a topology with 2 kinds of host groups: {@code hostGroupsWith} groups have {@code components},
+   * while {@code otherHostGroups} groups have {@code otherComponents}.
+   */
+  protected void topologyHas(int hostGroupsWith, Set<ResolvedComponent> components, int otherHostGroups, Set<ResolvedComponent> otherComponents) {
+    Stream<Set<ResolvedComponent>> hostGroupStream = IntStream.range(0, hostGroupsWith)
+      .mapToObj(__ -> components);
+
+    if (otherHostGroups > 0) {
+      hostGroupStream = Stream.concat(hostGroupStream,
+        IntStream.range(0, otherHostGroups)
+          .mapToObj(__ -> otherComponents));
+    }
+
+    topologyHas(hostGroupStream.collect(toList()));
+  }
+
+  /**
+   * Creates a topology with one kind of host group: {@code hostGroupsWith} groups have the last component
+   * added to the {@code stack}.
+   */
+  protected void topologyHas(int hostGroupsWith, StackBuilder stack) {
+    topologyHas(hostGroupsWith, stack.lastAddedComponent());
+  }
+
+  /**
+   * Creates a topology with 2 kinds of host groups: {@code hostGroupsWith} groups have the last component
+   * added to the {@code stack}, while {@code otherHostGroups} groups have some newly defined component
+   * from the same service.
+   */
+  protected void topologyHas(int hostGroupsWith, StackBuilder stack, int otherHostGroups) {
+    ResolvedComponent component = stack.lastAddedComponent();
+    ResolvedComponent other = stack.addComponent("don't_care").lastAddedComponent();
+    topologyHas(hostGroupsWith, ImmutableSet.of(component), otherHostGroups, ImmutableSet.of(other));
+  }
+
+  /**
+   * Creates a topology with a single host group with the given components.
+   */
+  protected void topologyHas(ResolvedComponent... components) {
+    topologyHas(ImmutableSet.copyOf(components));
+  }
+
+  /**
+   * Creates a topology with a single host group with the given set of components.
+   */
+  protected void topologyHas(Set<ResolvedComponent> components) {
+    topologyHas(ImmutableList.of(ImmutableSet.copyOf(components)));
+  }
+
+  /**
+   * Sets up expectations for the ClusterTopology to be validated.
+   * Each host group is given with a set of components.  Group names will be assigned sequentially.
+   */
+  protected void topologyHas(List<Set<ResolvedComponent>> components) {
+    Map<String, Set<ResolvedComponent>> hostGroups = IntStream.range(0, components.size())
+      .collect(HashMap::new, (map, i) -> map.put("host_group_" + i, components.get(i)), Map::putAll);
+
+    expect(topology.getComponents())
+      .andAnswer(() -> components.stream().flatMap(Collection::stream))
+      .anyTimes();
+    Capture<ResolvedComponent> componentCapture = newCapture();
+    expect(topology.getHostGroupsForComponent(capture(componentCapture)))
+      .andAnswer(() -> hostGroups.entrySet().stream().filter(each -> each.getValue().contains(componentCapture.getValue())).map(Map.Entry::getKey).collect(toSet()))
+      .anyTimes();
+    expect(topology.getHostGroups()).andReturn(hostGroups.keySet()).anyTimes();
+
+    Capture<String> hostGroupCapture = newCapture();
+    expect(topology.getComponentsInHostGroup(capture(hostGroupCapture)))
+      .andAnswer(() -> hostGroups.get(hostGroupCapture.getValue()).stream())
+      .anyTimes();
+
+    Set<StackId> stackIds = components.stream()
+      .flatMap(Collection::stream)
+      .map(ResolvedComponent::stackId)
+      .collect(toSet());
+    expect(topology.getStack()).andAnswer(cachedStackDefinition(stackIds)).anyTimes();
+  }
+
+  // verification helpers
+
+  protected void verifyAddedToAllHostGroupsWhereMissing(ResolvedComponent... components) throws InvalidTopologyException {
+    verifyTopologyUpdated(() -> {
+      Map<String, Set<ResolvedComponent>> expectedAdditionalComponents = new TreeMap<>();
+      for (ResolvedComponent component : components) {
+        Set<String> hostGroupsWhereMissing = Sets.difference(topology.getHostGroups(), topology.getHostGroupsForComponent(component));
+        for (String hostGroup : hostGroupsWhereMissing) {
+          expectedAdditionalComponents.computeIfAbsent(hostGroup, __ -> new LinkedHashSet<>())
+            .add(component);
+        }
+      }
+      return expectedAdditionalComponents;
+    });
+  }
+
+  protected void verifyAddedToFirstHostGroupWith(ResolvedComponent existingComponent, ResolvedComponent toBeAdded) throws InvalidTopologyException {
+    verifyTopologyUpdated(() -> {
+      String firstHostGroup = topology.getHostGroupsForComponent(existingComponent).iterator().next();
+      return ImmutableMap.of(firstHostGroup, ImmutableSet.of(toBeAdded));
+    });
+  }
+
+  protected void verifyAddedToAllHostGroupsWith(ResolvedComponent existingComponent, ResolvedComponent toBeAdded) throws InvalidTopologyException {
+    verifyTopologyUpdated(() ->
+      topology.getHostGroupsForComponent(existingComponent).stream()
+        .collect(toMap(Function.identity(), __ -> ImmutableSet.of(toBeAdded)))
+    );
+  }
+
+  protected void verifyTopologyUpdated(Supplier<Map<String, Set<ResolvedComponent>>> topologyUpdateSupplier) throws InvalidTopologyException {
+    // WHEN
+    ClusterTopology updatedTopology = createNiceMock(ClusterTopology.class);
+    Capture<Map<String, Set<ResolvedComponent>>> additionalComponentsCapture = newCapture();
+    expect(topology.withAdditionalComponents(capture(additionalComponentsCapture))).andReturn(updatedTopology);
+    replayAll();
+    // expected update needs to be calculated after mock topology was replayed
+    Map<String, Set<ResolvedComponent>> expectedAdditionalComponents = topologyUpdateSupplier.get();
+
+    // WHEN
+    subject.validate(topology);
+
+    // THEN
+    assertEquals(expectedAdditionalComponents, additionalComponentsCapture.getValue());
+  }
+
+  protected IAnswer<StackDefinition> cachedStackDefinition(Set<StackId> stackIds) {
+    // stack definition needs to be created lazily,
+    // because Stack copies data from StackInfo,
+    // and StackInfo is only populated later in each test case
+    return new IAnswer<StackDefinition>() {
+      private StackDefinition stackDefinition;
+      @Override
+      public StackDefinition answer() {
+        if (stackDefinition == null) {
+          Set<Stack> stacks = stackMap.entrySet().stream()
+            .filter(each -> stackIds.contains(each.getKey()))
+            .map(each -> new Stack(each.getValue().stackInfo()))
+            .collect(toSet());
+          stackDefinition = StackDefinition.of(stacks);
+        }
+        return stackDefinition;
+      }
+    };
+  }
+
+  /**
+   * Creates a new builder for the given stack, if not already present.
+   */
+  protected StackBuilder stack(StackId stackId) {
+    return stackMap.computeIfAbsent(stackId, __ -> new StackBuilder(stackId));
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make dependency/cardinality validation aware of mpack-specific components.

https://issues.apache.org/jira/browse/AMBARI-24091

## How was this patch tested?

Tested deployment using blueprint with components from two different mpacks, both of which depend on a common service present in both mpacks.  Verified that the common dependency was added from each specific mpack.

Improved unit tests.