### PR TITLE
AMBARI-24125. Infra Solr: set hdfs kerberos principal in infra-solr-env.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -293,6 +293,17 @@
   </property>
 
   <property>
+    <name>infra_solr_extra_java_opts</name>
+    <value></value>
+    <display-name>Infra Solr extra java options</display-name>
+    <description>Extra Solr java options (e.g.: -Dproperty=value), that will be added to SOLR_OPTS environment variable</description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+
+  <property>
     <name>infra_solr_gc_log_opts</name>
     <value>-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime</value>
     <display-name>Infra Solr GC log options</display-name>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/params.py
@@ -124,6 +124,7 @@ if "infra-solr-env" in config['configurations']:
   solr_env_content = config['configurations']['infra-solr-env']['content']
   infra_solr_gc_log_opts = format(config['configurations']['infra-solr-env']['infra_solr_gc_log_opts'])
   infra_solr_gc_tune = format(config['configurations']['infra-solr-env']['infra_solr_gc_tune'])
+  infra_solr_extra_java_opts = format(default('configurations/infra-solr-env/infra_solr_extra_java_opts', ""))
 
   zk_quorum = format(default('configurations/infra-solr-env/infra_solr_zookeeper_quorum', zookeeper_quorum))
 

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
@@ -58,6 +58,9 @@ RMI_PORT={{infra_solr_jmx_port}}
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
 #SOLR_OPTS="$SOLR_OPTS -Dsolr.clustering.enabled=true"
 SOLR_OPTS="$SOLR_OPTS -Djava.rmi.server.hostname={{hostname}}"
+{% if infra_solr_extra_java_opts -%}
+SOLR_OPTS="$SOLR_OPTS {{infra_solr_extra_java_opts}}"
+{% endif %}
 
 # Location where the bin/solr script will save PID files for running instances
 # If not set, the script will create PID files in $SOLR_TIP/bin
@@ -97,6 +100,7 @@ SOLR_SSL_WANT_CLIENT_AUTH=false
 SOLR_JAAS_FILE={{infra_solr_jaas_file}}
 SOLR_KERB_KEYTAB={{infra_solr_web_kerberos_keytab}}
 SOLR_KERB_PRINCIPAL={{infra_solr_web_kerberos_principal}}
+SOLR_OPTS="$SOLR_OPTS -Dsolr.hdfs.security.kerberos.principal={{infra_solr_kerberos_principal}}"
 SOLR_OPTS="$SOLR_OPTS {{zk_security_opts}}"
 
 SOLR_AUTH_TYPE="kerberos"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Set solr hdfs kerberos principal in solr-env. that can be problematic after upgrade if services like ranger used hdfs for storing the index. (if that happens, users will need to manually re-add the hdfs principal property)...As if hdfs is not used for Infra solr, it does not hurt if the property is there, so we will add this by default for secure env.

Also i extended extra java opts in a new property, in order to not touch infra-solr env anymore as possible

## How was this patch tested?
done. manually

Please review @kasakrisz @swagle 