### PR TITLE
[AMBARI-24126]. Ambari setup-ldap does not prompt for ldaps cert path, …

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -570,6 +570,10 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-force-setup', action="store_true", default=False, help="Forces the use of LDAP even if other (i.e. PAM) authentication method is configured already or if there is no authentication method configured at all", dest="ldap_force_setup")
   parser.add_option('--ambari-admin-username', default=None, help="Ambari administrator username for accessing Ambari's REST API", dest="ambari_admin_username")
   parser.add_option('--ambari-admin-password', default=None, help="Ambari administrator password for accessing Ambari's REST API", dest="ambari_admin_password")
+  parser.add_option('--truststore-type', default=None, help="Type of TrustStore (jks|jceks|pkcs12)", dest="trust_store_type")
+  parser.add_option('--truststore-path', default=None, help="Path of TrustStore", dest="trust_store_path")
+  parser.add_option('--truststore-password', default=None, help="Password for TrustStore", dest="trust_store_password")
+  parser.add_option('--truststore-reconfigure', action="store_true", default=None, help="Force to reconfigure TrustStore if exits", dest="trust_store_reconfigure")
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_setup_sso_options(parser):


### PR DESCRIPTION
…even when use-ssl is set to true (amagyar)

## What changes were proposed in this pull request?

Running ambari-server setup-ldap with use SSL option gave the following error:

```
Traceback (most recent call last):
  File "/usr/sbin/ambari-server.py", line 1056, in <module>
    mainBody()
  File "/usr/sbin/ambari-server.py", line 1026, in mainBody
    main(options, args, parser)
  File "/usr/sbin/ambari-server.py", line 976, in main
    action_obj.execute()
  File "/usr/sbin/ambari-server.py", line 79, in execute
    self.fn(*self.args, **self.kwargs)
  File "/usr/lib/ambari-server/lib/ambari_server/setupSecurity.py", line 799, in setup_ldap
    if get_YN_input("Do you want to remove these properties [y/n] (y)? ", True, options.trust_store_reconfigure):
AttributeError: Values instance has no attribute 'trust_store_reconfigure'
```

## How was this patch tested?

Executed ambari-server setup-ldap successfully with and without ssl.
