### PR TITLE
[AMBARI-24128] Add notification to the Alert Groups not working

### DIFF
--- a/ambari-web/app/mappers/socket/alert_groups_mapper_adapter.js
+++ b/ambari-web/app/mappers/socket/alert_groups_mapper_adapter.js
@@ -25,11 +25,12 @@ App.alertGroupsMapperAdapter = App.QuickDataMapper.create({
   map: function(event) {
     event.groups.forEach((alertGroup) => {
       if (event.updateType === 'UPDATE' || event.updateType === 'CREATE') {
-        const {definitions} = alertGroup;
+        const {definitions, targets} = alertGroup;
         if (definitions) {
-          alertGroup.definitions = definitions.map(id => ({
-            id
-          }));
+          alertGroup.definitions = this.convertIdsToObjects(definitions);
+        }
+        if (targets) {
+          alertGroup.targets = this.convertIdsToObjects(targets);
         }
         App.alertGroupsMapper.map({
           items: [
@@ -43,5 +44,11 @@ App.alertGroupsMapperAdapter = App.QuickDataMapper.create({
       }
     });
     App.router.get('manageAlertGroupsController').toggleProperty('changeTrigger');
+  },
+
+  convertIdsToObjects: function (arr) {
+    return arr.map(id => ({
+      id
+    }));
   }
 });

--- a/ambari-web/app/templates/main/alerts/manage_alert_groups_popup.hbs
+++ b/ambari-web/app/templates/main/alerts/manage_alert_groups_popup.hbs
@@ -80,6 +80,7 @@
           itemsBinding="selectedAlertGroup.notifications"
           resourcesBinding="controller.alertNotifications"
           nameBinding="selectedAlertGroup.displayName"
+          isCaseSensitive=false
         }}
       </div>
     </div>

--- a/ambari-web/app/views/common/editable_list.js
+++ b/ambari-web/app/views/common/editable_list.js
@@ -31,6 +31,8 @@ App.EditableList = Ember.View.extend({
   typeahead: [],
   selectedTypeahed: 0,
 
+  isCaseSensitive: true,
+
   init: function () {
     this._super();
     this.updateItemsOriginal();
@@ -73,11 +75,13 @@ App.EditableList = Ember.View.extend({
    */
   availableItemsToAdd: function () {
     var allItems = Em.copy(this.get('resources'));
-    var input = this.get('input');
+    var isCaseSensitive = this.get('isCaseSensitive');
+    var input = isCaseSensitive ? this.get('input') : this.get('input').toLowerCase();
     var toRemove = [];
     var existed = this.get('items');
     allItems.forEach(function(item) {
-      if (item.name.indexOf(input) < 0 || existed.findProperty('name', item.name)) {
+      var nameToCompare = isCaseSensitive ? item.name : item.name.toLowerCase();
+      if (nameToCompare.indexOf(input) < 0 || existed.findProperty('name', item.name)) {
         toRemove.push(item);
       }
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add notification to the Alert Groups not working.

STR:
1. Navigate to alerts page
2. Open Manage Alert Groups
3. Select an Alert Group
4. Add Notification by clicking Add and selecting a 'pre created' Alert Notification
5. Click Save and close the popup, the alert group should be saved with selected notification type, but only an empty String is being saved.

E.g API being invoked:

```
PUT https://<host>:<port>/api/v1/clusters/<cluster>/alert_groups/4

{"AlertGroup":{"name":"AMBARI_INFRA_SOLR","definitions":[14],"targets":[4]}}: 
```

Notes:
1. Observed that the auto fill for the notification is case sensitive, which is not ideal.
2. Also observed trying to add another notification after performing the steps in STR, a 500 server error is thrown.

## How was this patch tested?

UI unit tests:
  21802 passing (26s)
  48 pending