### PR TITLE
AMBARI-24129. Log Search - Logs histogram query is not filtered by include/exclude fields.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/converter/AbstractOperationHolderConverter.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/converter/AbstractOperationHolderConverter.java
@@ -140,6 +140,23 @@ public abstract class AbstractOperationHolderConverter <REQUEST_TYPE, QUERY_TYPE
     return query;
   }
 
+  public SolrQuery addIncludeFieldValues(SolrQuery query, String fieldValuesMapStr) {
+    if (StringUtils.isNotEmpty(fieldValuesMapStr)) {
+      List<Map<String, String>> criterias = new Gson().fromJson(fieldValuesMapStr,
+        new TypeToken<List<HashMap<String, String>>>(){}.getType());
+      for (Map<String, String> criteriaMap : criterias) {
+        for (Map.Entry<String, String> fieldEntry : criteriaMap.entrySet()) {
+          if (fieldEntry.getKey().equalsIgnoreCase(LOG_MESSAGE)) {
+            addLogMessageFilter(query, fieldEntry.getValue(), false);
+          } else {
+            query.addFilterQuery(String.format("%s:%s", fieldEntry.getKey(), escapeNonLogMessageField(fieldEntry)));
+          }
+        }
+      }
+    }
+    return query;
+  }
+
   public Query addExcludeFieldValues(Query query, String fieldValuesMapStr) {
     if (StringUtils.isNotEmpty(fieldValuesMapStr)) {
       List<Map<String, String>> criterias = new Gson().fromJson(fieldValuesMapStr,
@@ -150,6 +167,23 @@ public abstract class AbstractOperationHolderConverter <REQUEST_TYPE, QUERY_TYPE
             addLogMessageFilter(query, fieldEntry.getValue(), true);
           } else {
             addFilterQuery(query, new Criteria(fieldEntry.getKey()).is(escapeNonLogMessageField(fieldEntry)), true);
+          }
+        }
+      }
+    }
+    return query;
+  }
+
+  public SolrQuery addExcludeFieldValues(SolrQuery query, String fieldValuesMapStr) {
+    if (StringUtils.isNotEmpty(fieldValuesMapStr)) {
+      List<Map<String, String>> criterias = new Gson().fromJson(fieldValuesMapStr,
+        new TypeToken<List<HashMap<String, String>>>(){}.getType());
+      for (Map<String, String> criteriaMap : criterias) {
+        for (Map.Entry<String, String> fieldEntry : criteriaMap.entrySet()) {
+          if (fieldEntry.getKey().equalsIgnoreCase(LOG_MESSAGE)) {
+            addLogMessageFilter(query, fieldEntry.getValue(), true);
+          } else {
+            query.addFilterQuery(String.format("-%s:%s", fieldEntry.getKey(), escapeNonLogMessageField(fieldEntry)));
           }
         }
       }
@@ -178,6 +212,26 @@ public abstract class AbstractOperationHolderConverter <REQUEST_TYPE, QUERY_TYPE
       } else if (!token.startsWith("*") && token.endsWith("*")) {
         String plainToken = StringUtils.substring(token, 0, -1);
         addFilterQuery(query, new Criteria(LOG_MESSAGE).startsWith(SolrUtil.escapeQueryChars(plainToken)), negate);
+      }
+    }
+  }
+
+  private void addLogMessageFilter(SolrQuery query, String value, boolean negate) {
+    StrTokenizer tokenizer = new StrTokenizer(value, ' ', '"');
+    String negateToken = negate ? "-" : "";
+    for (String token : tokenizer.getTokenArray()) {
+      token = token.trim();
+      if (token.contains(" ") || !token.startsWith("*") && !token.endsWith("*")) {
+        query.addFilterQuery(String.format("%s%s:%s", negateToken, LOG_MESSAGE, SolrUtil.escapeQueryChars(token)));
+      } else if (token.startsWith("*") && token.endsWith("*")) {
+        String plainToken = StringUtils.substring(token, 1, -1);
+        query.addFilterQuery(String.format("%s%s:%s", negateToken, LOG_MESSAGE, SolrUtil.escapeQueryChars(plainToken)));
+      } else if (token.startsWith("*") && !token.endsWith("*")) {
+        String plainToken = StringUtils.substring(token, 1);
+        query.addFilterQuery(String.format("%s%s:%s", negateToken, LOG_MESSAGE, SolrUtil.escapeQueryChars(plainToken)));
+      } else if (!token.startsWith("*") && token.endsWith("*")) {
+        String plainToken = StringUtils.substring(token, 0, -1);
+        query.addFilterQuery(String.format("%s%s:%s", negateToken, LOG_MESSAGE, SolrUtil.escapeQueryChars(plainToken)));
       }
     }
   }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/converter/AuditBarGraphRequestQueryConverter.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/converter/AuditBarGraphRequestQueryConverter.java
@@ -58,6 +58,8 @@ public class AuditBarGraphRequestQueryConverter extends AbstractDateRangeFacetQu
     addInFiltersIfNotNullAndEnabled(query, request.getUserList(),
       SolrConstants.AuditLogConstants.AUDIT_REQUEST_USER,
       StringUtils.isNotBlank(request.getUserList()));
+    addIncludeFieldValues(query, request.getIncludeQuery());
+    addExcludeFieldValues(query, request.getExcludeQuery());
     return query;
   }
 }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/converter/ServiceLogLevelDateRangeRequestQueryConverter.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/converter/ServiceLogLevelDateRangeRequestQueryConverter.java
@@ -61,6 +61,8 @@ public class ServiceLogLevelDateRangeRequestQueryConverter extends AbstractDateR
     }
     addListFilterToSolrQuery(solrQuery, CLUSTER, request.getClusters());
     addListFilterToSolrQuery(solrQuery, COMPONENT, request.getMustBe());
+    addIncludeFieldValues(solrQuery, request.getIncludeQuery());
+    addExcludeFieldValues(solrQuery, request.getExcludeQuery());
     return solrQuery;
   }
 

--- a/ambari-logsearch/ambari-logsearch-server/src/test/java/org/apache/ambari/logsearch/converter/AuditBarGraphRequestQueryConverterTest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/test/java/org/apache/ambari/logsearch/converter/AuditBarGraphRequestQueryConverterTest.java
@@ -45,9 +45,10 @@ public class AuditBarGraphRequestQueryConverterTest extends AbstractRequestConve
     request.setUnit("+1HOUR");
     // THEN
     SolrQuery query = underTest.convert(request);
-    assertEquals("?q=*%3A*&facet=true&facet.pivot=%7B%21range%3Dr1%7Drepo&facet.mincount=1&facet.limit=-1&facet.sort=index" +
-      "&facet.range=%7B%21tag%3Dr1%7DevtTime&f.evtTime.facet.range.start=2016-09-13T22%3A00%3A01.000Z&f.evtTime.facet.range.end=2016-09-14T22%3A00%3A01.000Z&f.evtTime.facet.range.gap=%2B1HOUR" +
-      "&rows=0&start=0&fq=cluster%3Acl1&fq=reqUser%3A%28joe+OR+steven%29",
+    assertEquals("?q=*%3A*&facet=true&facet.pivot=%7B%21range%3Dr1%7Drepo&facet.mincount=1&facet.limit=-1" +
+        "&facet.sort=index&facet.range=%7B%21tag%3Dr1%7DevtTime&f.evtTime.facet.range.start=2016-09-13T22%3A00%3A01.000Z" +
+        "&f.evtTime.facet.range.end=2016-09-14T22%3A00%3A01.000Z&f.evtTime.facet.range.gap=%2B1HOUR&rows=0&start=0" +
+        "&fq=cluster%3Acl1&fq=reqUser%3A%28joe+OR+steven%29&fq=log_message%3Amyincludemessage&fq=-log_message%3Amyexcludemessage",
       query.toQueryString());
   }
 

--- a/ambari-logsearch/ambari-logsearch-server/src/test/java/org/apache/ambari/logsearch/converter/ServiceLogLevelDateRangeRequestQueryConverterTest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/test/java/org/apache/ambari/logsearch/converter/ServiceLogLevelDateRangeRequestQueryConverterTest.java
@@ -47,8 +47,7 @@ public class ServiceLogLevelDateRangeRequestQueryConverterTest extends AbstractR
     // THEN
     assertEquals("?q=*%3A*&facet=true&facet.pivot=%7B%21range%3Dr1%7Dlevel&facet.mincount=1&facet.limit=-1" +
       "&facet.sort=index&facet.range=%7B%21tag%3Dr1%7Dlogtime&f.logtime.facet.range.start=2016-09-13T22%3A00%3A01.000Z" +
-      "&f.logtime.facet.range.end=2016-09-14T22%3A00%3A01.000Z&f.logtime.facet.range.gap=%2B1HOUR&rows=0&start=0" +
-      "&fq=level%3A%28WARN+OR+ERROR+OR+FATAL%29&fq=cluster%3Acl1&fq=type%3A%28logsearch_app+OR+secure_log%29", query.toQueryString());
+      "&f.logtime.facet.range.end=2016-09-14T22%3A00%3A01.000Z&f.logtime.facet.range.gap=%2B1HOUR&rows=0&start=0&fq=level%3A%28WARN+OR+ERROR+OR+FATAL%29&fq=cluster%3Acl1&fq=type%3A%28logsearch_app+OR+secure_log%29&fq=log_message%3Amyincludemessage&fq=-log_message%3Amyexcludemessage", query.toQueryString());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Include and exclude by specific fields are not applied on the histogram like queries. adding that in this PR (its implemented in the same way as it was implemented for SolrDataQuery (spring-data), just that is for SolrQuery)
## How was this patch tested?
manually with docker env

Please review @zeroflag @kasakrisz @swagle @miklosgergely 