### PR TITLE
AMBARI-24132. Manage Config groups option is missing in add service w…

### DIFF
--- a/ambari-web/app/templates/common/configs/service_config_wizard.hbs
+++ b/ambari-web/app/templates/common/configs/service_config_wizard.hbs
@@ -34,6 +34,14 @@
               </a>
             </li>
           {{/each}}
+          {{#isAuthorized "SERVICE.MANAGE_CONFIG_GROUPS"}}
+            <li class="divider"></li>
+            <li>
+              <a href="#" {{action "manageConfigurationGroup" target="controller"}}>
+                <i class="glyphicon glyphicon-cog"></i>&nbsp;{{t services.service.actions.manage_configuration_groups.short}}
+              </a>
+            </li>
+          {{/isAuthorized}}
         </ul>
       </div>
       <div class="pull-right">


### PR DESCRIPTION
…izard

## What changes were proposed in this pull request?
Manage Config groups option is missing in add service wizard


## How was this patch tested?
Manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.