### PR TITLE
[AMBARI-24137] Fixed mpack display on service summary view.

### DIFF
--- a/ambari-web/app/controllers/main/service.js
+++ b/ambari-web/app/controllers/main/service.js
@@ -30,7 +30,7 @@ App.MainServiceController = Em.ArrayController.extend(App.SupportClientConfigsDo
     if (!App.router.get('clusterController.isLoaded')) {
       return [];
     }
-    return misc.sortByOrder(App.StackService.find().mapProperty('serviceName'), App.Service.find().toArray());
+    return misc.sortByOrder(App.StackService.find().mapProperty('serviceName'), App.Service.find().toArray(), s => s.get('serviceName'));
   }.property('App.router.clusterController.isLoaded').volatile(),
 
   /**

--- a/ambari-web/app/models/service.js
+++ b/ambari-web/app/models/service.js
@@ -24,6 +24,8 @@ App.Service = DS.Model.extend({
   serviceName: DS.attr('string'),
   displayName: Em.computed.formatRole('serviceName', true),
   serviceGroupName: DS.attr('string'),
+  mpackName: DS.attr('string'),
+  mpackVersion: DS.attr('string'),
   passiveState: DS.attr('string', {defaultValue: "OFF"}),
   workStatus: DS.attr('string'),
   rand: DS.attr('string'),

--- a/ambari-web/app/styles/bootstrap_overrides.less
+++ b/ambari-web/app/styles/bootstrap_overrides.less
@@ -85,7 +85,6 @@ select.form-control {
   background-color: #fff;
   border-radius: 0;
   .panel-heading {
-    padding: 0;
     margin-bottom: 15px;
     .panel-title {
       line-height: 34px;
@@ -94,7 +93,6 @@ select.form-control {
 }
 
 .panel .panel-body {
-  padding: 0;
   position: relative;
   min-height: 200px;
   height: 100%;

--- a/ambari-web/app/utils/misc.js
+++ b/ambari-web/app/utils/misc.js
@@ -54,11 +54,14 @@ module.exports = {
     return ((((((+d[0])*256)+(+d[1]))*256)+(+d[2]))*256)+(+d[3]);
   },
 
-  sortByOrder: function (sortOrder, array) {
+  sortByOrder: function (sortOrder, array, sortOn) {
+    //provide default sortOn function if one is not passed in
+    sortOn = sortOn || (item => Em.get(item, 'id'));
+
     var sorted = [];
     for (var i = 0; i < sortOrder.length; i++)
       for (var j = 0; j < array.length; j++) {
-        if (sortOrder[i] == Em.get(array[j], 'id')) {
+        if (sortOrder[i] == sortOn(array[j])) {
           sorted.push(array[j]);
         }
       }

--- a/ambari-web/app/views/main/service/service.js
+++ b/ambari-web/app/views/main/service/service.js
@@ -124,9 +124,9 @@ App.MainDashboardServiceViewWrapper = Em.Mixin.create({
   layoutName: require('templates/main/service/service'),
 
   mpackVersion: function() {
-    const stackService = App.StackService.find(this.get('controller.content.serviceName'));
-    return `${stackService.get('stackName')} (${stackService.get('stackVersion')})`;
-  }.property('controller.content.serviceName'),
+    const service = this.get('controller.content');
+    return `${service.get('mpackName')} (${service.get('mpackVersion')})`;
+  }.property('controller.content'),
 });
 
 App.MainDashboardServiceView = Em.View.extend(App.MainDashboardServiceViewWrapper, {

--- a/ambari-web/test/mixins/common/widgets/widget_section_test.js
+++ b/ambari-web/test/mixins/common/widgets/widget_section_test.js
@@ -38,9 +38,9 @@ describe('App.WidgetSectionMixin', function () {
       },
       {
         services: [
-          {
+          Em.Object.create({
             serviceName: 'AMBARI_METRICS'
-          }
+          })
         ],
         isAmbariMetricsInstalled: true,
         title: 'Ambari Metrics installed'


### PR DESCRIPTION
## What changes were proposed in this pull request?

The approach to locating the mpack information was wrong. Services must always be differentiated by service group from now on. Looking up information about a service by name alone is no longer a viable approach.

The problem was fixed by providing the mpack information along with the rest of the service information shown on the page, rather than trying to look it up by service name after the fact. I also added the service group name to a tooltip displayed in the left nav menu so that the user can tell which instance of a service they are clicking on.

## How was this patch tested?

All unit tests passing.