### PR TITLE
[AMBARI-24140] Send name, version, and registry ID when registering mpacks.

### DIFF
--- a/ambari-web/app/controllers/wizard/downloadMpacks_controller.js
+++ b/ambari-web/app/controllers/wizard/downloadMpacks_controller.js
@@ -35,6 +35,7 @@ App.WizardDownloadMpacksController = App.WizardStepController.extend({
         version: mpack.version,
         displayName: mpack.displayName,
         url: mpack.downloadUrl,
+        registryId: mpack.registryId,
         inProgress: true,
         failed: false,
         succeeded: false,
@@ -54,11 +55,12 @@ App.WizardDownloadMpacksController = App.WizardStepController.extend({
   downloadMpack: function (mpack) {
     console.log("downloading mpacks");
     return App.ajax.send({
-      name: 'mpack.download_by_url',
+      name: 'mpack.download',
       sender: this,
       data: {
         name: mpack.name,
-        url: mpack.url
+        version: mpack.version,
+        registryId: mpack.registryId
       },
       success: 'downloadMpackSuccess',
       error: 'downloadMpackError',

--- a/ambari-web/app/controllers/wizard/selectMpacks_controller.js
+++ b/ambari-web/app/controllers/wizard/selectMpacks_controller.js
@@ -51,6 +51,7 @@ App.WizardSelectMpacksController = App.WizardStepController.extend({
             name: mpack.RegistryMpackInfo.mpack_name,
             displayName: mpack.RegistryMpackInfo.mpack_display_name,
             description: mpack.RegistryMpackInfo.mpack_description,
+            registryId: mpack.RegistryMpackInfo.registry_id,
             //this is the text that will be used to filter this mpack in the UI
             //at this point, this is just the text that comes from this mpack
             //but additional text will be appended to form the final filterOn value
@@ -214,7 +215,6 @@ App.WizardSelectMpacksController = App.WizardStepController.extend({
     const mpackVersions = this.get('content.mpackVersions');
     const mpackServices = this.get('content.mpackServices');
     const mpackServiceVersions = this.get('content.mpackServiceVersions');
-    const mpackUsecases = this.get('content.mpackUsecases');
 
     if (!mpacks || mpacks.length === 0
       || !mpackVersions || mpackVersions.length === 0
@@ -586,10 +586,11 @@ App.WizardSelectMpacksController = App.WizardStepController.extend({
         const selectedMpack = {
           id: `${mpackVersion.mpack.name}-${mpackVersion.version}`,
           name: mpackVersion.mpack.name,
+          version: mpackVersion.version,
           displayName: mpackVersion.mpack.displayName,
           publicUrl: mpackVersion.mpackUrl,
           downloadUrl: mpackVersion.mpackUrl,
-          version: mpackVersion.version
+          registryId: mpackVersion.mpack.registryId
         };
         
         const oldSelectedMpacks = this.get('content.selectedMpacks');

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -3067,7 +3067,7 @@ var urls = {
             "MpackInfo" : {
               "mpack_name" : data.name,
               "mpack_version" : data.version,
-              "registry_id" : data.registry
+              "registry_id" : data.registryId
             }
           }
         })

--- a/ambari-web/test/controllers/wizard/selectMpacks_test.js
+++ b/ambari-web/test/controllers/wizard/selectMpacks_test.js
@@ -1026,7 +1026,8 @@ describe('App.WizardSelectMpacksController', function () {
         {
           mpack: {
             name: "mpackName1",
-            displayName: "displayName1"
+            displayName: "displayName1",
+            registryId: 1
           },
           mpackUrl: "http://someurl.com/mpack1",
           version: "1.0.0.0"
@@ -1034,7 +1035,8 @@ describe('App.WizardSelectMpacksController', function () {
         {
           mpack: {
             name: "mpackName2",
-            displayName: "displayName2"
+            displayName: "displayName2",
+            registryId: 1
           },
           mpackUrl: "http://someurl.com/mpack2",
           version: "1.0.0.0"
@@ -1068,7 +1070,8 @@ describe('App.WizardSelectMpacksController', function () {
           displayName: "displayName1",
           publicUrl: "http://someurl.com/mpack1",
           downloadUrl: "http://someurl.com/mpack1",
-          version: "1.0.0.0"
+          version: "1.0.0.0",
+          registryId: 1
         },
         {
           id: "mpackName2-1.0.0.0",
@@ -1076,7 +1079,8 @@ describe('App.WizardSelectMpacksController', function () {
           displayName: "displayName2",
           publicUrl: "http://someurl.com/mpack2",
           downloadUrl: "http://someurl.com/mpack2",
-          version: "1.0.0.0"
+          version: "1.0.0.0",
+          registryId: 1
         }
       ];
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed mpack registration request to use name, version, and registry ID instead of registering by URL.

## How was this patch tested?

All unit tests passing.