### PR TITLE
[AMBARI-24095] Fixed usages of App.StackService.find(serviceName) since serviceName is no longer used as the value of the StackService model id.

### DIFF
--- a/ambari-web/app/controllers/main/service/info/configs.js
+++ b/ambari-web/app/controllers/main/service/info/configs.js
@@ -324,10 +324,10 @@ App.MainServiceInfoConfigsController = Em.Controller.extend(App.AddSecurityConfi
    * @returns {String[]}
    */
   getServicesDependencies: function(serviceName) {
-    var dependencies = Em.getWithDefault(App.StackService.find(serviceName), 'dependentServiceNames', []);
+    var dependencies = Em.getWithDefault(App.StackService.find().findProperty('serviceName', serviceName), 'dependentServiceNames', []);
     var loop = function(dependentServices, allDependencies) {
       return dependentServices.reduce(function(all, name) {
-        var service = App.StackService.find(name);
+        var service = App.StackService.find().findProperty('serviceName', name);
         if (!service) {
           return all;
         }
@@ -589,7 +589,7 @@ App.MainServiceInfoConfigsController = Em.Controller.extend(App.AddSecurityConfi
   onLoadOverrides: function (allConfigs) {
     this.get('servicesToLoad').forEach(function(serviceName) {
       var configGroups = serviceName === this.get('content.serviceName') ? this.get('configGroups') : this.get('dependentConfigGroups').filterProperty('serviceName', serviceName);
-      var configTypes = App.StackService.find(serviceName).get('configTypeList');
+      var configTypes = App.StackService.find().findProperty('serviceName', serviceName).get('configTypeList');
       var configsByService = this.get('allConfigs').filter(function (c) {
         return configTypes.contains(App.config.getConfigTagFromFileName(c.get('filename')));
       });

--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -127,8 +127,8 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
    */
   interDependentServices: function() {
     var serviceName = this.get('content.serviceName'), interDependentServices = [];
-    App.StackService.find(serviceName).get('requiredServices').forEach(function(requiredService) {
-      if (App.StackService.find(requiredService).get('requiredServices').contains(serviceName)) {
+    App.StackService.find().findProperty('serviceName', serviceName).get('requiredServices').forEach(function(requiredService) {
+      if (App.StackService.find().findProperty('serviceName', requiredService).get('requiredServices').contains(serviceName)) {
         interDependentServices.push(requiredService);
       }
     });
@@ -149,11 +149,11 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
    */
   dependentServiceNames: function() {
     return App.get('router.clusterController.isConfigsPropertiesLoaded') ?
-      App.StackService.find(this.get('content.serviceName')).get('dependentServiceNames') : [];
+      App.StackService.find().findProperty('serviceName', this.get('content.serviceName')).get('dependentServiceNames') : [];
   }.property('content.serviceName', 'App.router.clusterController.isConfigsPropertiesLoaded'),
 
   configDependentServiceNames: function() {
-    return this.get('dependentServiceNames').concat(App.StackService.find(this.get('content.serviceName')).get('requiredServices'))
+    return this.get('dependentServiceNames').concat(App.StackService.find().findProperty('serviceName', this.get('content.serviceName')).get('requiredServices'))
   }.property('dependentServiceNames'),
 
   /**
@@ -244,7 +244,7 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
         });
 
         self.get('configDependentServiceNames').forEach(function(serviceName) {
-          var configTypes = App.StackService.find(serviceName.name).get('configTypeList');
+          var configTypes = App.StackService.find().findProperty('serviceName', serviceName.name).get('configTypeList');
           if (configTypes) {
             var configsByService = allConfigs.filter(function (c) {
               return configTypes.contains(App.config.getConfigTagFromFileName(c.get('filename')));
@@ -1393,7 +1393,7 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
 
     App.Service.find().forEach(function (service) {
       if (!serviceNamesToDelete.contains(service.get('serviceName'))) {
-        var requiredServices = App.StackService.find(service.get('serviceName')).get('requiredServices');
+        var requiredServices = App.StackService.find().findProperty('serviceName', service.get('serviceName')).get('requiredServices');
         serviceNamesToDelete.forEach(function (dependsOnService) {
           if (requiredServices.contains(dependsOnService)) {
             dependentServices.push(service.get('serviceName'));

--- a/ambari-web/app/controllers/main/service/widgets/create/wizard_controller.js
+++ b/ambari-web/app/controllers/main/service/widgets/create/wizard_controller.js
@@ -210,7 +210,7 @@ App.WidgetWizardController = App.WizardController.extend({
       data: {
         stackVersionURL: App.get('stackVersionURL'),
         serviceNames: App.Service.find().filter(function (item) {
-          return App.StackService.find(item.get('id')).get('isServiceWithWidgets');
+          return App.StackService.find().findProperty('serviceName', item.get('id')).get('isServiceWithWidgets');
         }).mapProperty('serviceName').join(',')
       },
       callback: callback,

--- a/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
+++ b/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
@@ -357,7 +357,7 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
     return dependentServices.filter(function (item) {
       return !App.Service.find().findProperty('serviceName', item);
     }).map(function (item) {
-      return App.StackService.find(item).get('displayName');
+      return App.StackService.find().findProperty('serviceName', item).get('displayName');
     });
   },
 

--- a/ambari-web/app/controllers/wizard/step7_controller.js
+++ b/ambari-web/app/controllers/wizard/step7_controller.js
@@ -754,7 +754,13 @@ App.WizardStep7Controller = App.WizardStepController.extend(App.ServerValidatorM
       var serviceName = service.get('serviceName');
       if (['MISC'].concat(this.get('allSelectedServiceNames')).contains(serviceName)) {
         var serviceConfig = App.config.createServiceConfig(serviceName);
-        serviceConfig.set('showConfig', App.StackService.find().findProperty('serviceName', serviceName).get('isInstallable'));
+        let stackService;
+        if (serviceName === 'MISC') {
+          stackService = App.StackService.find('MISC');
+        } else {
+          stackService = App.StackService.find().findProperty('serviceName', serviceName);
+        }
+        serviceConfig.set('showConfig', stackService.get('isInstallable'));
         if (this.get('wizardController.name') === 'addServiceController') {
           serviceConfig.set('selected', !this.get('installedServiceNames').concat('MISC').contains(serviceName));
           if (serviceName === 'MISC') {

--- a/ambari-web/app/controllers/wizard/step7_controller.js
+++ b/ambari-web/app/controllers/wizard/step7_controller.js
@@ -754,7 +754,7 @@ App.WizardStep7Controller = App.WizardStepController.extend(App.ServerValidatorM
       var serviceName = service.get('serviceName');
       if (['MISC'].concat(this.get('allSelectedServiceNames')).contains(serviceName)) {
         var serviceConfig = App.config.createServiceConfig(serviceName);
-        serviceConfig.set('showConfig', App.StackService.find(serviceName).get('isInstallable'));
+        serviceConfig.set('showConfig', App.StackService.find().findProperty('serviceName', serviceName).get('isInstallable'));
         if (this.get('wizardController.name') === 'addServiceController') {
           serviceConfig.set('selected', !this.get('installedServiceNames').concat('MISC').contains(serviceName));
           if (serviceName === 'MISC') {

--- a/ambari-web/app/mixins/common/configs/configs_saver.js
+++ b/ambari-web/app/mixins/common/configs/configs_saver.js
@@ -75,7 +75,7 @@ App.ConfigsSaverMixin = Em.Mixin.create({
    * @type {App.StackService[]}
    */
   currentServices: function() {
-    return [App.StackService.find(this.get('content.serviceName'))];
+    return [App.StackService.find().findProperty('serviceName', this.get('content.serviceName'))];
   }.property('content.serviceName'),
 
   /**
@@ -327,7 +327,7 @@ App.ConfigsSaverMixin = Em.Mixin.create({
 
     //generates list of properties that was changed
     var modifiedConfigs = this.getModifiedConfigs(configs);
-    var serviceFileNames = Object.keys(App.StackService.find(serviceName).get('configTypes')).map(function (type) {
+    var serviceFileNames = Object.keys(App.StackService.find().findProperty('serviceName', serviceName).get('configTypes')).map(function (type) {
       return App.config.getOriginalFileName(type);
     });
 
@@ -439,7 +439,7 @@ App.ConfigsSaverMixin = Em.Mixin.create({
    *
    * @returns {boolean}
    */
-  allowSaveCoreSite: function() {
+  allowSaveCoreSite: function () {
     return this.get('currentServices').some(function(service) {
       return (this.get('coreSiteServiceNames').contains(service.get('serviceName'))
         || this.get('coreSiteServiceType') === service.get('serviceType'));

--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -1085,7 +1085,7 @@ App.config = Em.Object.create({
     if (!serviceName || unsupportedServiceNames.contains(serviceName) || !filename) {
       return false;
     } else {
-      var stackService = App.StackService.find(serviceName);
+      var stackService = App.StackService.find().findProperty('serviceName', serviceName);
       if (!stackService) {
         return false;
       }
@@ -1104,7 +1104,7 @@ App.config = Em.Object.create({
       if (!stackServiceName) {
         return false;
       }
-      var stackService = App.StackService.find(serviceName);
+      var stackService = App.StackService.find().findProperty('serviceName', serviceName);
       return !!this.getConfigTypesInfoFromService(stackService).supportsAddingForbidden.find(function (configType) {
         return filename.startsWith(configType);
       });

--- a/ambari-web/app/views/main/dashboard/widgets/hbase_links.js
+++ b/ambari-web/app/views/main/dashboard/widgets/hbase_links.js
@@ -23,7 +23,7 @@ App.HBaseLinksView = App.LinkDashboardWidgetView.extend({
   templateName: require('templates/main/dashboard/widgets/hbase_links'),
 
   port: function() {
-    return App.StackService.find('HBASE').compareCurrentVersion('1.1') > -1 ? '16010' : '60010';
+    return App.StackService.find().findProperty('serviceName', 'HBASE').compareCurrentVersion('1.1') > -1 ? '16010' : '60010';
   }.property(),
 
   componentName: 'HBASE_REGIONSERVER',

--- a/ambari-web/app/views/main/service/item.js
+++ b/ambari-web/app/views/main/service/item.js
@@ -353,7 +353,7 @@ App.MainServiceItemView = Em.View.extend({
   hasMetricTab: function() {
     let serviceName = this.get('controller.content.serviceName');
     let graphs = require('data/service_graph_config')[serviceName.toLowerCase()];
-    return graphs || App.StackService.find(serviceName).get('isServiceWithWidgets');
+    return graphs || App.StackService.find().findProperty('serviceName', serviceName).get('isServiceWithWidgets');
   }.property('controller.content.serviceName'),
 
   didInsertElement: function () {

--- a/ambari-web/app/views/main/service/reassign/step5_view.js
+++ b/ambari-web/app/views/main/service/reassign/step5_view.js
@@ -29,7 +29,7 @@ App.ReassignMasterWizardStep5View = Em.View.extend({
       return '';
     }
     var
-      atsDir = App.StackService.find('YARN').compareCurrentVersion('2.7') > -1 ? "timeline-state-store.ldb" : "leveldb-timeline-store.ldb",
+      atsDir = App.StackService.find().findProperty('serviceName', 'YARN').compareCurrentVersion('2.7') > -1 ? "timeline-state-store.ldb" : "leveldb-timeline-store.ldb",
       componentDir = this.get('controller.content.componentDir') || '',
       componentDirCmd = componentDir.replace(/,/g, ' '),
       sourceHost = this.get('controller.content.reassignHosts.source'),

--- a/ambari-web/app/views/main/service/widgets/create/expression_view.js
+++ b/ambari-web/app/views/main/service/widgets/create/expression_view.js
@@ -390,7 +390,7 @@ App.AddMetricExpressionView = Em.View.extend({
         serviceName: serviceName,
         //in order to support panel lists
         href: '#' + serviceName,
-        displayName: App.StackService.find(serviceName).get('displayName'),
+        displayName: App.StackService.find().findProperty('serviceName', serviceName).get('displayName'),
         count: servicesMap[serviceName].count,
         components: components
       }));

--- a/ambari-web/test/controllers/main/host/configs_service_test.js
+++ b/ambari-web/test/controllers/main/host/configs_service_test.js
@@ -108,12 +108,20 @@ describe('App.MainHostServiceConfigsController', function () {
         return { always: Em.K };
       });
       sinon.stub(controller, 'trackRequest');
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function () {
+          return Em.Object.create({
+            dependentServiceNames: []
+          });
+        }
+      });
     });
     afterEach(function() {
       controller.loadCurrentVersions.restore();
       controller.loadConfigTheme.restore();
       App.themesMapper.generateAdvancedTabs.restore();
       controller.trackRequest.restore();
+      App.StackService.find.restore();
     });
 		it("should set host", function () {
 			controller.set('content', {

--- a/ambari-web/test/controllers/main/service/info/config_test.js
+++ b/ambari-web/test/controllers/main/service/info/config_test.js
@@ -1069,8 +1069,10 @@ describe("App.MainServiceInfoConfigsController", function () {
       createService('YARN', ['HIVE'])
     ];
     beforeEach(function() {
-      sinon.stub(App.StackService, 'find', function(serviceName) {
-        return stackServices.findProperty('serviceName', serviceName);
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function (prop, serviceName) {
+          return stackServices.findProperty('serviceName', serviceName);
+        }
       });
     });
     afterEach(function() {

--- a/ambari-web/test/controllers/main/service/item_test.js
+++ b/ambari-web/test/controllers/main/service/item_test.js
@@ -1387,8 +1387,10 @@ describe('App.MainServiceItemController', function () {
 
     beforeEach(function() {
       mainServiceItemController = App.MainServiceItemController.create({});
-      sinon.stub(App.StackService, 'find', function (serviceName) {
-        return stackServiceModel[serviceName];
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function (prop, serviceName) {
+          return stackServiceModel[serviceName];
+        }
       });
       this.mockService = sinon.stub(App.Service, 'find');
     });
@@ -1679,8 +1681,10 @@ describe('App.MainServiceItemController', function () {
     var mainServiceItemController;
 
     beforeEach(function() {
-      sinon.stub(App.StackService, 'find', function (serviceName) {
-        return stackServiceModel[serviceName];
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function (prop, serviceName) {
+          return stackServiceModel[serviceName];
+        }
       });
       mainServiceItemController = App.MainServiceItemController.create({
         content: {}
@@ -1939,9 +1943,13 @@ describe('App.MainServiceItemController', function () {
           serviceName: serviceName
         }
       });
-      sinon.stub(App.StackService, 'find').returns(Em.Object.create({
-        dependentServiceNames: dependentServiceNames
-      }));
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function () {
+          return Em.Object.create({
+            dependentServiceNames: dependentServiceNames
+          });
+        }
+      });
     });
 
     afterEach(function () {

--- a/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
+++ b/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
@@ -307,8 +307,10 @@ describe('App.AssignMasterOnStep7Controller', function () {
       sinon.stub(App.Service, 'find').returns([
         {serviceName: 'S1'}
       ]);
-      sinon.stub(App.StackService, 'find', function(input) {
-        return Em.Object.create({displayName: input});
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function (prop, input) {
+          return Em.Object.create({ displayName: input });
+        }
       });
     });
 

--- a/ambari-web/test/mixins/common/configs/configs_saver_test.js
+++ b/ambari-web/test/mixins/common/configs/configs_saver_test.js
@@ -33,9 +33,12 @@ describe('App.ConfigsSaverMixin', function() {
   });
 
   describe("#currentServices", function () {
+    var findProperty = sinon.stub().returns({});
 
     beforeEach(function() {
-      sinon.stub(App.StackService, 'find').returns({});
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: findProperty
+      });
     });
 
     afterEach(function() {
@@ -45,7 +48,7 @@ describe('App.ConfigsSaverMixin', function() {
     it("should return currentServices", function() {
       mixin.set('content.serviceName', 'S1');
       expect(mixin.get('currentServices')).to.be.eql([{}]);
-      expect(App.StackService.find.calledWith('S1')).to.be.true;
+      expect(findProperty.calledWith('serviceName', 'S1')).to.be.true;
     });
   });
 
@@ -614,7 +617,9 @@ describe('App.ConfigsSaverMixin', function() {
   describe("#allowSaveCoreSite()", function () {
 
     it("empty currentServices", function() {
-      mixin.set('currentServices', []);
+      mixin.reopen({
+        currentServices: []
+      });
       expect(mixin.allowSaveCoreSite()).to.be.false;
     });
 
@@ -1129,9 +1134,13 @@ describe('App.ConfigsSaverMixin', function() {
 
     beforeEach(function() {
       sinon.stub(App.config, 'textareaIntoFileConfigs');
-      sinon.stub(App.StackService, 'find').returns(Em.Object.create({
-        configTypes: {'k1': 't1'}
-      }));
+      sinon.stub(App.StackService, 'find').returns({
+        findProperty: function () {
+          return Em.Object.create({
+            configTypes: { 'k1': 't1' }
+          });
+        }
+      });
       sinon.stub(App.config, 'getOriginalFileName').returns('file1');
       this.mockSave = sinon.stub(mixin, 'saveSiteConfigs');
       this.mockJSON = sinon.stub(mixin, 'generateDesiredConfigsJSON');


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to the earlier change to the value used for the id of the StackService model, code that tried to use App.StackService.find() and passed the serviceName, expecting to get back a record with a matching ID would fail. I updated these instances to use App.StackService.find().findProperty() instead, as this will at least return a matching record (assuming there is an instance of the service to find). Of course, this does not address the fact that there may be multiple instances of a service present in the future. At that point, this will need to be further revised to make a more specific query.

## How was this patch tested?

All unit tests passing.