### PR TITLE
[AMBARI-24155] Ranger and KMS tab still present in Customize ServicesPage even after going back and deselecting them from Choose ServicesPage

### DIFF
--- a/ambari-web/app/views/wizard/step7/databases_tab_view.js
+++ b/ambari-web/app/views/wizard/step7/databases_tab_view.js
@@ -43,6 +43,7 @@ App.DatabasesTabOnStep7View = Em.View.extend({
       supportsConfigLayout: true,
       willDestroyElement: function () {
         $('.loading').append(Em.I18n.t('app.loadingPlaceholder'));
+        App.store.fastCommit();
       },
       didInsertElement: function () {
         $('.loading').empty();


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Navigate to Customize ServicePage of UI install wizard by selecting all services from ChooseServicesPage. 
- Populate credentials tab
- Switch to Databases tab, Noticed that Ranger and Ranger KMS have multiple properties to be filled in
- Now go back to Choose Services page and deselect Ranger and Ranger KMS
- Proceed through wizard to reach Customize ServicesPage
- Ranger and KMS sub tabs are still present with errors at Databases tab. 
(None of the ranger/KMS credential properties are present in Credential tabs)

- Now even if we go back and choose Ranger and KMS - update all necessary properties for Ranger - Test Connection is hung with error

## How was this patch tested?

UI unit tests:
  21791 passing (23s)
  48 pending
