### PR TITLE
[AMBARI-24158] Provide a way to disable topology validation in cluster creation request

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/BlueprintResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/BlueprintResourceDefinition.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.api.resources;
 
 import java.util.Collection;
 
+import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.spi.Resource;
 
 
@@ -48,8 +49,7 @@ public class BlueprintResourceDefinition extends BaseResourceDefinition {
   @Override
   public Collection<String> getCreateDirectives() {
     Collection<String> directives = super.getCreateDirectives();
-    directives.add("validate_topology");
-
+    directives.add(BlueprintResourceProvider.VALIDATE_TOPOLOGY_PROPERTY_ID);
     return directives;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ClusterResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ClusterResourceDefinition.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.ambari.server.api.query.render.ClusterBlueprintRenderer;
 import org.apache.ambari.server.api.query.render.Renderer;
 import org.apache.ambari.server.controller.KerberosHelper;
+import org.apache.ambari.server.controller.internal.BlueprintResourceProvider;
 import org.apache.ambari.server.controller.spi.Resource;
 
 /**
@@ -77,6 +78,13 @@ public class ClusterResourceDefinition extends BaseResourceDefinition {
     setChildren.add(new SubResourceDefinition(Resource.Type.Artifact));
 
     return setChildren;
+  }
+
+  @Override
+  public Collection<String> getCreateDirectives() {
+    Collection<String> directives = super.getCreateDirectives();
+    directives.add(BlueprintResourceProvider.VALIDATE_TOPOLOGY_PROPERTY_ID);
+    return directives;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintResourceProvider.java
@@ -561,8 +561,8 @@ public class BlueprintResourceProvider extends AbstractControllerResourceProvide
     };
   }
 
-  private static boolean shouldValidate(Map<String, String> requestInfoProps) {
-    String validateTopology = requestInfoProps.get("validate_topology");
+  public static boolean shouldValidate(Map<String, String> requestInfoProps) {
+    String validateTopology = requestInfoProps.get(VALIDATE_TOPOLOGY_PROPERTY_ID);
     return validateTopology == null || Boolean.parseBoolean(validateTopology);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
@@ -166,6 +166,7 @@ public class ClusterResourceProvider extends AbstractControllerResourceProvider 
     propertyIds.add(QUICKLINKS_PROFILE);
     propertyIds.add(MPACK_INSTANCES);
     propertyIds.add(CLUSTER_STATE_PROPERTY_ID);
+    propertyIds.add(BlueprintResourceProvider.VALIDATE_TOPOLOGY_PROPERTY_ID);
   }
 
 
@@ -511,16 +512,9 @@ public class ClusterResourceProvider extends AbstractControllerResourceProvider 
    * @param requestInfoProperties raw request body
    * @return asynchronous response information
    *
-   * @throws ResourceAlreadyExistsException if cluster already exists
    * @throws SystemException                if an unexpected exception occurs
-   * @throws UnsupportedPropertyException   if an invalid property is specified in the request
-   * @throws NoSuchParentResourceException  if a necessary parent resource doesn't exist
    */
-  @SuppressWarnings("unchecked")
-  private RequestStatusResponse processBlueprintCreate(Map<String, Object> properties, Map<String, String> requestInfoProperties)
-      throws ResourceAlreadyExistsException, SystemException, UnsupportedPropertyException,
-      NoSuchParentResourceException {
-
+  private RequestStatusResponse processBlueprintCreate(Map<String, Object> properties, Map<String, String> requestInfoProperties) throws SystemException {
     LOG.info("Creating Cluster '" + properties.get(CLUSTER_NAME_PROPERTY_ID) +
         "' based on blueprint '" + String.valueOf(properties.get(BLUEPRINT)) + "'.");
 
@@ -531,8 +525,9 @@ public class ClusterResourceProvider extends AbstractControllerResourceProvider 
 
     ProvisionClusterRequest createClusterRequest;
     try {
+      boolean validateTopology = BlueprintResourceProvider.shouldValidate(requestInfoProperties);
       createClusterRequest =
-        topologyRequestFactory.createProvisionClusterRequest(properties, securityConfiguration);
+        topologyRequestFactory.createProvisionClusterRequest(properties, securityConfiguration, validateTopology);
     } catch (InvalidTopologyTemplateException e) {
       throw new IllegalArgumentException("Invalid Cluster Creation Template: " + e, e);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ProvisionClusterRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ProvisionClusterRequest.java
@@ -156,6 +156,7 @@ public class ProvisionClusterRequest extends BaseClusterRequest implements Provi
 
   private final Collection<MpackInstance> mpackInstances;
   private final Set<StackId> stackIds;
+  private final boolean validateTopology;
 
   private final static Logger LOG = LoggerFactory.getLogger(ProvisionClusterRequest.class);
 
@@ -165,7 +166,7 @@ public class ProvisionClusterRequest extends BaseClusterRequest implements Provi
    * @param properties  request properties
    * @param securityConfiguration  security config related properties
    */
-  public ProvisionClusterRequest(Map<String, Object> properties, SecurityConfiguration securityConfiguration) throws
+  public ProvisionClusterRequest(Map<String, Object> properties, SecurityConfiguration securityConfiguration, boolean validateTopology) throws
       InvalidTopologyTemplateException {
 
     setClusterName(String.valueOf(properties.get(
@@ -189,6 +190,7 @@ public class ProvisionClusterRequest extends BaseClusterRequest implements Provi
 
     parseHostGroupInfo(properties);
 
+    this.validateTopology = validateTopology;
     this.securityConfiguration = securityConfiguration;
     credentialsMap = parseCredentials(properties);
     if (securityConfiguration != null && securityConfiguration.getType() == SecurityType.KERBEROS && getCredentialsMap().get(KDC_ADMIN_CREDENTIAL) == null) {
@@ -215,6 +217,7 @@ public class ProvisionClusterRequest extends BaseClusterRequest implements Provi
     quickLinksProfileJson = null;
     mpackInstances = ImmutableList.of();
     stackIds = ImmutableSet.of();
+    validateTopology = false;
     setBlueprint(blueprint);
     setConfiguration(configuration);
   }
@@ -515,6 +518,10 @@ public class ProvisionClusterRequest extends BaseClusterRequest implements Provi
     return mpackInstances;
   }
 
+  public boolean shouldValidateTopology() {
+    return validateTopology;
+  }
+
   /**
    * @return a set containing the mpacks in the provision request and the blueprint combined.
    */
@@ -534,6 +541,4 @@ public class ProvisionClusterRequest extends BaseClusterRequest implements Provi
       });
     return entity;
   }
-
-
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -294,7 +294,9 @@ public class TopologyManager {
     final String clusterName = request.getClusterName();
     final SecurityConfiguration securityConfiguration = provisionRequest.getSecurity();
 
-    final ClusterTopology topology = topologyValidatorService.validate(initialTopology); // FIXME known stacks validation is too late here
+    final ClusterTopology topology = request.shouldValidateTopology()
+      ? topologyValidatorService.validate(initialTopology) // FIXME known stacks validation is too late here
+      : initialTopology;
 
     // get the id prior to creating ambari resources which increments the counter
     final Long provisionId = ambariContext.getNextRequestId();

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyRequestFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyRequestFactory.java
@@ -28,6 +28,7 @@ import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
  */
 public interface TopologyRequestFactory {
 
-  ProvisionClusterRequest createProvisionClusterRequest(Map<String, Object> properties, SecurityConfiguration securityConfiguration) throws InvalidTopologyTemplateException;
-  // todo: use to create other request types
+  ProvisionClusterRequest createProvisionClusterRequest(Map<String, Object> properties, SecurityConfiguration securityConfiguration, boolean validateTopology)
+    throws InvalidTopologyTemplateException;
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyRequestFactoryImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyRequestFactoryImpl.java
@@ -29,7 +29,11 @@ import org.apache.ambari.server.controller.internal.ProvisionClusterRequest;
 public class TopologyRequestFactoryImpl implements TopologyRequestFactory {
 
   @Override
-  public ProvisionClusterRequest createProvisionClusterRequest(Map<String, Object> properties, SecurityConfiguration securityConfiguration) throws InvalidTopologyTemplateException {
-    return new ProvisionClusterRequest(properties, securityConfiguration);
+  public ProvisionClusterRequest createProvisionClusterRequest(
+    Map<String, Object> properties,
+    SecurityConfiguration securityConfiguration,
+    boolean validateTopology
+  ) throws InvalidTopologyTemplateException {
+    return new ProvisionClusterRequest(properties, securityConfiguration, validateTopology);
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ProvisionClusterRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ProvisionClusterRequestTest.java
@@ -47,7 +47,6 @@ import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.orm.entities.MpackInstanceEntity;
 import org.apache.ambari.server.orm.entities.TopologyRequestEntity;
 import org.apache.ambari.server.security.encryption.CredentialStoreType;
-import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.quicklinksprofile.QuickLinksProfileBuilderTest;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.BlueprintFactory;
@@ -115,7 +114,7 @@ public class ProvisionClusterRequestTest {
     replay(hostResourceProvider);
     Map<String, Object> properties = createBlueprintRequestPropertiesNameOnly(CLUSTER_NAME, BLUEPRINT_NAME);
 
-    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null, true);
 
     assertEquals(CLUSTER_NAME, provisionClusterRequest.getClusterName());
     assertEquals(TopologyRequest.Type.PROVISION, provisionClusterRequest.getType());
@@ -166,7 +165,7 @@ public class ProvisionClusterRequestTest {
     replay(hostResourceProvider);
     Map<String, Object> properties = createBlueprintRequestPropertiesCountOnly(CLUSTER_NAME, BLUEPRINT_NAME);
 
-    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null, true);
 
     assertEquals(CLUSTER_NAME, provisionClusterRequest.getClusterName());
     assertEquals(TopologyRequest.Type.PROVISION, provisionClusterRequest.getType());
@@ -217,7 +216,7 @@ public class ProvisionClusterRequestTest {
   @Test
   public void testMultipleGroups() throws Exception {
     Map<String, Object> properties = createBlueprintRequestProperties(CLUSTER_NAME, BLUEPRINT_NAME);
-    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null, true);
 
     assertEquals(CLUSTER_NAME, provisionClusterRequest.getClusterName());
     assertEquals(TopologyRequest.Type.PROVISION, provisionClusterRequest.getType());
@@ -292,11 +291,11 @@ public class ProvisionClusterRequestTest {
     reset(hostResourceProvider);
     replay(hostResourceProvider);
     // should result in an exception
-    new ProvisionClusterRequest(properties, null);
+    new ProvisionClusterRequest(properties, null, true);
   }
 
   @Test
-  public void test_Creditentials() throws Exception {
+  public void test_Credentials() throws Exception {
     Map<String, Object> properties = createBlueprintRequestProperties(CLUSTER_NAME, BLUEPRINT_NAME);
     HashMap<String, String> credentialHashMap = new HashMap<>();
     credentialHashMap.put("alias", "testAlias");
@@ -307,7 +306,7 @@ public class ProvisionClusterRequestTest {
     credentialsSet.add(credentialHashMap);
     properties.put("credentials", credentialsSet);
 
-    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null, true);
 
     assertEquals(provisionClusterRequest.getCredentialsMap().get("testAlias").getAlias(), "testAlias");
     assertEquals(provisionClusterRequest.getCredentialsMap().get("testAlias").getPrincipal(), "testPrincipal");
@@ -317,7 +316,7 @@ public class ProvisionClusterRequestTest {
 
 
   @Test
-  public void test_CreditentialsInvalidType() throws Exception {
+  public void test_CredentialsInvalidType() throws Exception {
     expectedException.expect(InvalidTopologyTemplateException.class);
     expectedException.expectMessage("credential.type [TESTTYPE] is invalid. acceptable values: " +
         Arrays.toString(CredentialStoreType.values()));
@@ -332,7 +331,7 @@ public class ProvisionClusterRequestTest {
     credentialsSet.add(credentialHashMap);
     properties.put("credentials", credentialsSet);
 
-    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest provisionClusterRequest = new ProvisionClusterRequest(properties, null, true);
   }
 
   @Test(expected= InvalidTopologyTemplateException.class)
@@ -344,7 +343,7 @@ public class ProvisionClusterRequestTest {
     reset(hostResourceProvider);
     replay(hostResourceProvider);
     // should result in an exception
-    new ProvisionClusterRequest(properties, null);
+    new ProvisionClusterRequest(properties, null, true);
   }
 
   @Test(expected= InvalidTopologyTemplateException.class)
@@ -356,7 +355,7 @@ public class ProvisionClusterRequestTest {
     reset(hostResourceProvider);
     replay(hostResourceProvider);
     // should result in an exception
-    new ProvisionClusterRequest(properties, null);
+    new ProvisionClusterRequest(properties, null, true);
   }
 
   @Test(expected = InvalidTopologyTemplateException.class)
@@ -376,7 +375,7 @@ public class ProvisionClusterRequestTest {
     reset(hostResourceProvider);
     replay(hostResourceProvider);
     // should result in an exception
-    new ProvisionClusterRequest(properties, null);
+    new ProvisionClusterRequest(properties, null, true);
   }
 
 
@@ -389,7 +388,7 @@ public class ProvisionClusterRequestTest {
     replay(hostResourceProvider);
 
     // should result in an exception due to invalid property in host predicate
-    new ProvisionClusterRequest(createBlueprintRequestProperties(CLUSTER_NAME, BLUEPRINT_NAME), null);
+    new ProvisionClusterRequest(createBlueprintRequestProperties(CLUSTER_NAME, BLUEPRINT_NAME), null, true);
   }
 
   @Test(expected = InvalidTopologyTemplateException.class)
@@ -401,7 +400,7 @@ public class ProvisionClusterRequestTest {
     Map<String, Object> properties = createBlueprintRequestPropertiesNameOnly(CLUSTER_NAME, BLUEPRINT_NAME);
     ((Map) ((List) properties.get("host_groups")).iterator().next()).put("host_count", "5");
     // should result in an exception due to both host name and host count being specified
-    new ProvisionClusterRequest(properties, null);
+    new ProvisionClusterRequest(properties, null, true);
   }
 
   @Test(expected = InvalidTopologyTemplateException.class)
@@ -413,13 +412,13 @@ public class ProvisionClusterRequestTest {
     Map<String, Object> properties = createBlueprintRequestPropertiesNameOnly(CLUSTER_NAME, BLUEPRINT_NAME);
     ((Map) ((List) properties.get("host_groups")).iterator().next()).put("host_predicate", "Hosts/host_name=myTestHost");
     // should result in an exception due to both host name and host count being specified
-    new ProvisionClusterRequest(properties, null);
+    new ProvisionClusterRequest(properties, null, true);
   }
 
   @Test
   public void testQuickLinksProfile_NoDataInRequest() throws Exception {
     Map<String, Object> properties = createBlueprintRequestProperties(CLUSTER_NAME, BLUEPRINT_NAME);
-    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null, true);
     assertNull("No quick links profile is expected", request.getQuickLinksProfileJson());
   }
 
@@ -430,7 +429,7 @@ public class ProvisionClusterRequestTest {
     properties.put(ProvisionClusterRequest.QUICKLINKS_PROFILE_FILTERS_PROPERTY,
         Sets.newHashSet(QuickLinksProfileBuilderTest.filter(null, null, true)));
 
-    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null, true);
     assertEquals("Quick links profile doesn't match expected",
         "{\"filters\":[{\"visible\":true}],\"services\":[]}",
         request.getQuickLinksProfileJson());
@@ -445,7 +444,7 @@ public class ProvisionClusterRequestTest {
     Set<Map<String, Object>> services = Sets.newHashSet(hdfs);
     properties.put(ProvisionClusterRequest.QUICKLINKS_PROFILE_SERVICES_PROPERTY, services);
 
-    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null, true);
     assertEquals("Quick links profile doesn't match expected",
         "{\"filters\":[],\"services\":[{\"name\":\"HDFS\",\"components\":[],\"filters\":[{\"visible\":true}]}]}",
         request.getQuickLinksProfileJson());
@@ -463,7 +462,7 @@ public class ProvisionClusterRequestTest {
     Set<Map<String, Object>> services = Sets.newHashSet(hdfs);
     properties.put(ProvisionClusterRequest.QUICKLINKS_PROFILE_SERVICES_PROPERTY, services);
 
-    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null, true);
     System.out.println(request.getQuickLinksProfileJson());
     assertEquals("Quick links profile doesn't match expected",
         "{\"filters\":[{\"visible\":true}],\"services\":[{\"name\":\"HDFS\",\"components\":[],\"filters\":[{\"visible\":true}]}]}",
@@ -476,7 +475,7 @@ public class ProvisionClusterRequestTest {
 
     properties.put(ProvisionClusterRequest.QUICKLINKS_PROFILE_SERVICES_PROPERTY, "Hello World!");
 
-    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null);
+    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, null, true);
   }
 
   public static Map<String, Object> createBlueprintRequestProperties(String clusterName, String blueprintName) {
@@ -621,9 +620,7 @@ public class ProvisionClusterRequestTest {
           "service_instances", ImmutableList.of(),
           "configurations", ImmutableList.of()));
     properties.put("mpack_instances", mpackInstances);
-    ProvisionClusterRequest request = new ProvisionClusterRequest(
-      properties,
-      new SecurityConfiguration(SecurityType.NONE));
+    ProvisionClusterRequest request = new ProvisionClusterRequest(properties, SecurityConfiguration.NONE, true);
     TopologyRequestEntity entity = request.toEntity();
     assertEquals(1, entity.getMpackInstances().size());
     MpackInstanceEntity mpack = entity.getMpackInstances().iterator().next();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterDeployWithStartOnlyTest.java
@@ -320,6 +320,7 @@ public class ClusterDeployWithStartOnlyTest extends EasyMockSupport {
     expect(request.getConfigRecommendationStrategy()).andReturn(ConfigRecommendationStrategy.NEVER_APPLY).anyTimes();
     expect(request.getProvisionAction()).andReturn(ProvisionAction.START_ONLY).anyTimes();
     expect(request.getSecurityConfiguration()).andReturn(null).anyTimes();
+    expect(request.shouldValidateTopology()).andReturn(true).anyTimes();
     expect(request.getStackIds()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getMpacks()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getAllMpacks()).andReturn(ImmutableSet.of()).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartOnComponentLevelTest.java
@@ -318,6 +318,7 @@ public class ClusterInstallWithoutStartOnComponentLevelTest extends EasyMockSupp
     expect(request.getConfigRecommendationStrategy()).andReturn(ConfigRecommendationStrategy.NEVER_APPLY).anyTimes();
     expect(request.getProvisionAction()).andReturn(INSTALL_AND_START).anyTimes();
     expect(request.getSecurityConfiguration()).andReturn(null).anyTimes();
+    expect(request.shouldValidateTopology()).andReturn(true).anyTimes();
     expect(request.getStackIds()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getMpacks()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getAllMpacks()).andReturn(ImmutableSet.of()).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterInstallWithoutStartTest.java
@@ -326,6 +326,7 @@ public class ClusterInstallWithoutStartTest extends EasyMockSupport {
     expect(request.getConfigRecommendationStrategy()).andReturn(ConfigRecommendationStrategy.NEVER_APPLY).anyTimes();
     expect(request.getProvisionAction()).andReturn(INSTALL_ONLY).anyTimes();
     expect(request.getSecurityConfiguration()).andReturn(null).anyTimes();
+    expect(request.shouldValidateTopology()).andReturn(true).anyTimes();
     expect(request.getStackIds()).andReturn(ImmutableSet.of(STACK_ID)).anyTimes();
     expect(request.getMpacks()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getAllMpacks()).andReturn(ImmutableSet.of()).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/TopologyManagerTest.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -352,6 +353,7 @@ public class TopologyManagerTest {
     expect(request.getHostGroupInfo()).andReturn(groupInfoMap).anyTimes();
     expect(request.getConfigRecommendationStrategy()).andReturn(ConfigRecommendationStrategy.NEVER_APPLY).anyTimes();
     expect(request.getSecurityConfiguration()).andReturn(null).anyTimes();
+    expect(request.shouldValidateTopology()).andStubReturn(true);
     expect(request.getStackIds()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getMpacks()).andReturn(ImmutableSet.of()).anyTimes();
     expect(request.getAllMpacks()).andReturn(ImmutableSet.of(mpack1, mpack2)).anyTimes();
@@ -709,6 +711,21 @@ public class TopologyManagerTest {
     PowerMock.replayAll();
 
     topologyManager.provisionCluster(request, "{}");
+  }
+
+  @Test
+  public void validationTurnedOff() throws Exception {
+    expect(persistedState.getAllRequests()).andReturn(Collections.emptyMap()).anyTimes();
+    expect(request.shouldValidateTopology()).andReturn(false);
+    TopologyValidatorService validator = createStrictMock(TopologyValidatorService.class);
+    Whitebox.setInternalState(topologyManager, "topologyValidatorService", validator);
+
+    replayAll();
+    replay(validator);
+
+    topologyManager.provisionCluster(request, "{}");
+
+    verify(validator);
   }
 
   private SettingEntity createQuickLinksSettingEntity(String content, long timeStamp) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow passing `?validate_topology=false` in the cluster creation request to disable topology validation.

https://issues.apache.org/jira/browse/AMBARI-24158

## How was this patch tested?

1. Tested with invalid blueprint:

   Submitted cluster creation request for a blueprint with invalid topology (HDFS components except `NAMENODE`).

   Result with validation:

   ```
   { "status" : 400, "message" : "Topology validation failed: org.apache.ambari.server.topology.InvalidTopologyException: Cluster Topology validation failed. Invalid service component count: [Component{name=NAMENODE, mpack_instance=null, service_instance=null, provision_action=INSTALL_AND_START} (actual=0, expected=1-2)]. To disable topology validation and create the blueprint, add the following to the end of the url: '?validate_topology=false'" }
   ```

   Result With validation disabled:

   ```
   { "Requests" : { "id" : 1, "status" : "Accepted" } }
   ```

   (Of course cluster creation fails later.)

2. Tested with a valid blueprint that triggers auto-deployment of some client component.  Verified that the client was not added when `validate_topology=false` was included.

3. Tested without specifying `validate_topology`.  Verified that validation is performed by default.