### PR TITLE
AMBARI-24166. Metric Collector goes down after HDFS restart post EU

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
+++ b/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
@@ -92,7 +92,7 @@ class InitializerModule:
     self.server_responses_listener = ServerResponsesListener(self)
     self.file_cache = FileCache(self.config)
     self.customServiceOrchestrator = CustomServiceOrchestrator(self)
-    self.recovery_manager = RecoveryManager()
+    self.recovery_manager = RecoveryManager(self)
     self.commandStatuses = CommandStatusDict(self)
 
     self.init_threads()

--- a/ambari-agent/src/main/python/ambari_agent/listeners/ConfigurationEventListener.py
+++ b/ambari-agent/src/main/python/ambari_agent/listeners/ConfigurationEventListener.py
@@ -33,6 +33,7 @@ class ConfigurationEventListener(EventListener):
   def __init__(self, initializer_module):
     super(ConfigurationEventListener, self).__init__(initializer_module)
     self.configurations_cache = initializer_module.configurations_cache
+    self.recovery_manager = initializer_module.recovery_manager
 
   def on_event(self, headers, message):
     """
@@ -48,6 +49,11 @@ class ConfigurationEventListener(EventListener):
       return
 
     self.configurations_cache.rewrite_cache(message['clusters'], message['hash'])
+
+    if message['clusters']:
+      # FIXME: Recovery manager does not support multiple cluster as of now.
+      self.recovery_manager.cluster_id = message['clusters'].keys()[0]
+      self.recovery_manager.on_config_update()
 
   def get_handled_path(self):
     return Constants.CONFIGURATIONS_TOPIC

--- a/ambari-agent/src/main/python/ambari_agent/listeners/HostLevelParamsEventListener.py
+++ b/ambari-agent/src/main/python/ambari_agent/listeners/HostLevelParamsEventListener.py
@@ -53,9 +53,9 @@ class HostLevelParamsEventListener(EventListener):
       cluster_id = message['clusters'].keys()[0]
 
       if 'recoveryConfig' in message['clusters'][cluster_id]:
-        logging.info("Updating recoveryConfig from metadata")
-        self.recovery_manager.update_recovery_config(self.host_level_params_cache[cluster_id])
+        logging.info("Updating recoveryConfig from hostLevelParams")
         self.recovery_manager.cluster_id = cluster_id
+        self.recovery_manager.update_recovery_config(self.host_level_params_cache[cluster_id])
 
   def get_handled_path(self):
     return Constants.HOST_LEVEL_PARAMS_TOPIC

--- a/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
@@ -508,7 +508,7 @@ class TestActionQueue(TestCase):
     initializer_module.init()
     initializer_module.config = config
     initializer_module.recovery_manager = RecoveryManager(tempfile.mktemp())
-    initializer_module.recovery_manager.update_config(5, 5, 1, 11, True, False, False, "")
+    initializer_module.recovery_manager.update_config(5, 5, 1, 11, True, False, False)
 
     with patch("__builtin__.open") as open_mock:
       # Make file read calls visible

--- a/ambari-agent/src/test/python/ambari_agent/TestRecoveryManager.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestRecoveryManager.py
@@ -117,7 +117,7 @@ class _TestRecoveryManager(TestCase):
   }
 
   def test_defaults(self):
-    rm = RecoveryManager()
+    rm = RecoveryManager(MagicMock())
     self.assertFalse(rm.enabled())
     self.assertEqual(None, rm.get_install_command("NODEMANAGER"))
     self.assertEqual(None, rm.get_start_command("NODEMANAGER"))
@@ -132,32 +132,32 @@ class _TestRecoveryManager(TestCase):
       [1000, 1001, 1002, 1003, 1004, 1071, 1150, 1151, 1152, 1153, 1400, 1401,
        1500, 1571, 1572, 1653, 1900, 1971, 2300, 2301]
 
-    rm = RecoveryManager(True, False)
+    rm = RecoveryManager(MagicMock(), True, False)
     self.assertTrue(rm.enabled())
 
-    config = rm.update_config(0, 60, 5, 12, True, False, False, "")
+    config = rm.update_config(0, 60, 5, 12, True, False, False)
     self.assertFalse(rm.enabled())
 
-    rm.update_config(6, 60, 5, 12, True, False, False, "")
+    rm.update_config(6, 60, 5, 12, True, False, False)
     self.assertTrue(rm.enabled())
 
-    rm.update_config(6, 0, 5, 12, True, False, False, "")
+    rm.update_config(6, 0, 5, 12, True, False, False)
     self.assertFalse(rm.enabled())
 
-    rm.update_config(6, 60, 0, 12, True, False, False, "")
+    rm.update_config(6, 60, 0, 12, True, False, False)
     self.assertFalse(rm.enabled())
 
-    rm.update_config(6, 60, 1, 12, True, False, False, None)
+    rm.update_config(6, 60, 1, 12, True, False, False)
     self.assertTrue(rm.enabled())
 
-    rm.update_config(6, 60, 61, 12, True, False, False, None)
+    rm.update_config(6, 60, 61, 12, True, False, False)
     self.assertFalse(rm.enabled())
 
-    rm.update_config(6, 60, 5, 4, True, False, False, "")
+    rm.update_config(6, 60, 5, 4, True, False, False)
     self.assertFalse(rm.enabled())
 
     # maximum 2 in 2 minutes and at least 1 minute wait
-    rm.update_config(2, 5, 1, 4, True, False, False, "")
+    rm.update_config(2, 5, 1, 4, True, False, False)
     self.assertTrue(rm.enabled())
 
     # T = 1000-2
@@ -183,7 +183,7 @@ class _TestRecoveryManager(TestCase):
     self.assertFalse(rm.may_execute("NODEMANAGER"))  # too soon
 
     # maximum 2 in 2 minutes and no min wait
-    rm.update_config(2, 5, 1, 5, True, True, False, "")
+    rm.update_config(2, 5, 1, 5, True, True, False)
 
     # T = 1500-3
     self.assertTrue(rm.execute("NODEMANAGER2"))
@@ -202,9 +202,11 @@ class _TestRecoveryManager(TestCase):
 
   def test_recovery_required(self):
     rm = RecoveryManager(True, False)
-    rm.update_config(12, 5, 1, 15, True, False, False, [
+    rm.update_config(12, 5, 1, 15, True, False, False, )
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'NODEMANAGER', 'service_name': 'YARN', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
+    
     rm.update_current_status("NODEMANAGER", "INSTALLED")
     rm.update_desired_status("NODEMANAGER", "INSTALLED")
     self.assertFalse(rm.requires_recovery("NODEMANAGER"))
@@ -250,17 +252,19 @@ class _TestRecoveryManager(TestCase):
   def test_recovery_required2(self):
 
     rm = RecoveryManager(True, True)
-    rm.update_config(15, 5, 1, 16, True, False, False, [
+    rm.update_config(15, 5, 1, 16, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'NODEMANAGER', 'service_name': 'YARN', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
     rm.update_current_status("NODEMANAGER", "INSTALLED")
     rm.update_desired_status("NODEMANAGER", "STARTED")
     self.assertTrue(rm.requires_recovery("NODEMANAGER"))
 
     rm = RecoveryManager( True, True)
-    rm.update_config(15, 5, 1, 16, True, False, False, [
+    rm.update_config(15, 5, 1, 16, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'NODEMANAGER', 'service_name': 'YARN', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
     rm.update_current_status("NODEMANAGER", "INSTALLED")
     rm.update_desired_status("NODEMANAGER", "STARTED")
     self.assertTrue(rm.requires_recovery("NODEMANAGER"))
@@ -270,7 +274,7 @@ class _TestRecoveryManager(TestCase):
     self.assertFalse(rm.requires_recovery("DATANODE"))
 
     rm = RecoveryManager(True, True)
-    rm.update_config(15, 5, 1, 16, True, False, False, "")
+    rm.update_config(15, 5, 1, 16, True, False, False)
     rm.update_current_status("NODEMANAGER", "INSTALLED")
     rm.update_desired_status("NODEMANAGER", "STARTED")
     self.assertFalse(rm.requires_recovery("NODEMANAGER"))
@@ -279,9 +283,10 @@ class _TestRecoveryManager(TestCase):
     rm.update_desired_status("DATANODE", "STARTED")
     self.assertFalse(rm.requires_recovery("DATANODE"))
 
-    rm.update_config(15, 5, 1, 16, True, False, False, [
+    rm.update_config(15, 5, 1, 16, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'NODEMANAGER', 'service_name': 'YARN', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
     rm.update_current_status("NODEMANAGER", "INSTALLED")
     rm.update_desired_status("NODEMANAGER", "STARTED")
     self.assertTrue(rm.requires_recovery("NODEMANAGER"))
@@ -290,83 +295,16 @@ class _TestRecoveryManager(TestCase):
     rm.update_desired_status("DATANODE", "STARTED")
     self.assertFalse(rm.requires_recovery("DATANODE"))
 
-  @patch.object(RecoveryManager, "update_config")
-  def test_update_rm_config(self, mock_uc):
-    rm = RecoveryManager()
-    rm.update_recovery_config(None)
-    mock_uc.assert_has_calls([call(6, 60, 5, 12, False, False, False, [])])
-
-    mock_uc.reset_mock()
-    rm.update_recovery_config({})
-    mock_uc.assert_has_calls([call(6, 60, 5, 12, False, False, False, [])])
-
-    mock_uc.reset_mock()
-    rm.update_recovery_config(
-      {"recoveryConfig": {
-      "type" : "DEFAULT"}}
-    )
-    mock_uc.assert_has_calls([call(6, 60, 5, 12, False, False, False, [])])
-
-    mock_uc.reset_mock()
-    rm.update_recovery_config(
-      {"recoveryConfig": {
-        "type" : "FULL"}}
-    )
-    mock_uc.assert_has_calls([call(6, 60, 5, 12, True, False, False, [])])
-
-    mock_uc.reset_mock()
-    rm.update_recovery_config(
-      {"recoveryConfig": {
-        "type" : "AUTO_START",
-        "max_count" : "med"}}
-    )
-    mock_uc.assert_has_calls([call(6, 60, 5, 12, True, True, False, [])])
-
-    mock_uc.reset_mock()
-    rm.update_recovery_config(
-      {"recoveryConfig": {
-        "type" : "AUTO_INSTALL_START",
-        "max_count" : "med"}}
-    )
-    mock_uc.assert_has_calls([call(6, 60, 5, 12, True, False, True, [])])
-
-    mock_uc.reset_mock()
-    rm.update_recovery_config(
-      {"recoveryConfig": {
-        "type": "AUTO_START",
-        "maxCount": "5",
-        "windowInMinutes" : 20,
-        "retryGap": 2,
-        "maxLifetimeCount" : 5,
-        "components": [
-          {
-            "service_name": "A",
-            "component_name": "A",
-            "desired_state": "INSTALLED"
-          },
-          {
-            "service_name": "B",
-            "component_name": "B",
-            "desired_state": "INSTALLED"
-          }
-        ],
-        "recoveryTimestamp": 1}}
-    )
-    mock_uc.assert_has_calls([call(5, 20, 2, 5, True, True, False, [
-      {'component_name': 'A', 'service_name': 'A', 'desired_state': 'INSTALLED'},
-      {'component_name': 'B', 'service_name': 'B', 'desired_state': 'INSTALLED'}
-    ])])
-
   @patch.object(RecoveryManager, "_now_")
   def test_recovery_report(self, time_mock):
     time_mock.side_effect = \
       [1000, 1071, 1072, 1470, 1471, 1472, 1543, 1644, 1815]
 
-    rm = RecoveryManager()
+    rm = RecoveryManager(MagicMock())
     rec_st = rm.get_recovery_status()
     self.assertEquals(rec_st, {"summary": "DISABLED"})
 
-    rm.update_config(2, 5, 1, 4, True, True, False, "")
+    rm.update_config(2, 5, 1, 4, True, True, False)
     rec_st = rm.get_recovery_status()
     self.assertEquals(rec_st, {"summary": "RECOVERABLE", "componentReports": []})
 
@@ -409,14 +347,15 @@ class _TestRecoveryManager(TestCase):
       [1000, 1001, 1104, 1105, 1106, 1807, 1808, 1809, 1810, 1811, 1812]
 
     rm = RecoveryManager(True)
-    rm.update_config(5, 5, 0, 11, True, False, False, "")
+    rm.update_config(5, 5, 0, 11, True, False, False)
 
     command1 = copy.deepcopy(self.command)
 
     #rm.store_or_update_command(command1)
-    rm.update_config(12, 5, 1, 15, True, False, False, [
-      {'component_name': 'NODEMANAGER', 'service_name': 'YARN', 'desired_state': 'INSTALLED'}
-    ])
+    rm.update_config(12, 5, 1, 15, True, False, False)
+    
+    rm.update_recovery_config({'recoveryConfig':{'components':[{'component_name': 'NODEMANAGER', 'service_name': 'YARN', 'desired_state': 'INSTALLED'}]}})
+    
     rm.update_current_status("NODEMANAGER", "INSTALLED")
     rm.update_desired_status("NODEMANAGER", "STARTED")
 
@@ -439,36 +378,45 @@ class _TestRecoveryManager(TestCase):
     self.assertEqual("START", commands[0]["roleCommand"])
 
   def test_configured_for_recovery(self):
-    rm = RecoveryManager(True)
-    rm.update_config(12, 5, 1, 15, True, False, False, [
+    rm = RecoveryManager(MagicMock(), True)
+    rm.update_config(12, 5, 1, 15, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'A', 'service_name': 'A', 'desired_state': 'INSTALLED'},
       {'component_name': 'B', 'service_name': 'B', 'desired_state': 'INSTALLED'},
-    ])
+    ]}})
+    
     self.assertTrue(rm.configured_for_recovery("A"))
     self.assertTrue(rm.configured_for_recovery("B"))
 
-    rm.update_config(5, 5, 1, 11, True, False, False, [])
+    rm.update_config(5, 5, 1, 11, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[]}})
+    
     self.assertFalse(rm.configured_for_recovery("A"))
     self.assertFalse(rm.configured_for_recovery("B"))
 
-    rm.update_config(5, 5, 1, 11, True, False, False, [
+    rm.update_config(5, 5, 1, 11, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'A', 'service_name': 'A', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
+    
     self.assertTrue(rm.configured_for_recovery("A"))
     self.assertFalse(rm.configured_for_recovery("B"))
 
-    rm.update_config(5, 5, 1, 11, True, False, False, [
+    rm.update_config(5, 5, 1, 11, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components': [
       {'component_name': 'A', 'service_name': 'A', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
+    
     self.assertTrue(rm.configured_for_recovery("A"))
     self.assertFalse(rm.configured_for_recovery("B"))
     self.assertFalse(rm.configured_for_recovery("C"))
 
-    rm.update_config(5, 5, 1, 11, True, False, False, [
+    rm.update_config(5, 5, 1, 11, True, False, False)
+    rm.update_recovery_config({'recoveryConfig':{'components':[
       {'component_name': 'A', 'service_name': 'A', 'desired_state': 'INSTALLED'},
       {'component_name': 'D', 'service_name': 'D', 'desired_state': 'INSTALLED'},
       {'component_name': 'F', 'service_name': 'F', 'desired_state': 'INSTALLED'}
-    ])
+    ]}})
     self.assertTrue(rm.configured_for_recovery("A"))
     self.assertFalse(rm.configured_for_recovery("B"))
     self.assertFalse(rm.configured_for_recovery("C"))
@@ -482,7 +430,7 @@ class _TestRecoveryManager(TestCase):
       [1000, 1071, 1372]
     rm = RecoveryManager(True)
 
-    rm.update_config(2, 5, 1, 4, True, True, False, "")
+    rm.update_config(2, 5, 1, 4, True, True, False)
 
     rm.execute("COMPONENT")
     actions = rm.get_actions_copy()["COMPONENT"]
@@ -500,7 +448,7 @@ class _TestRecoveryManager(TestCase):
   def test_is_action_info_stale(self, time_mock):
 
     rm = RecoveryManager(True)
-    rm.update_config(5, 60, 5, 16, True, False, False, "")
+    rm.update_config(5, 60, 5, 16, True, False, False)
 
     time_mock.return_value = 0
     self.assertFalse(rm.is_action_info_stale("COMPONENT_NAME"))

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/RecoveryConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/RecoveryConfig.java
@@ -34,26 +34,6 @@ public class RecoveryConfig {
   public RecoveryConfig() {
   }
 
-  @SerializedName("type")
-  @JsonProperty("type")
-  private String type;
-
-  @SerializedName("maxCount")
-  @JsonProperty("maxCount")
-  private String maxCount;
-
-  @SerializedName("windowInMinutes")
-  @JsonProperty("windowInMinutes")
-  private String windowInMinutes;
-
-  @SerializedName("retryGap")
-  @JsonProperty("retryGap")
-  private String retryGap;
-
-  @SerializedName("maxLifetimeCount")
-  @JsonProperty("maxLifetimeCount")
-  private String maxLifetimeCount;
-
   @SerializedName("components")
   @JsonProperty("components")
   private List<RecoveryConfigComponent> enabledComponents;
@@ -66,46 +46,6 @@ public class RecoveryConfig {
     this.enabledComponents = enabledComponents;
   }
 
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public String getMaxCount() {
-    return maxCount;
-  }
-
-  public void setMaxCount(String maxCount) {
-    this.maxCount = maxCount;
-  }
-
-  public String getWindowInMinutes() {
-    return windowInMinutes;
-  }
-
-  public void setWindowInMinutes(String windowInMinutes) {
-    this.windowInMinutes = windowInMinutes;
-  }
-
-  public String getRetryGap() {
-    return retryGap;
-  }
-
-  public void setRetryGap(String retryGap) {
-    this.retryGap = retryGap;
-  }
-
-  public String getMaxLifetimeCount() {
-    return maxLifetimeCount;
-  }
-
-  public void setMaxLifetimeCount(String maxLifetimeCount) {
-    this.maxLifetimeCount = maxLifetimeCount;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -113,35 +53,18 @@ public class RecoveryConfig {
 
     RecoveryConfig that = (RecoveryConfig) o;
 
-    if (type != null ? !type.equals(that.type) : that.type != null) return false;
-    if (maxCount != null ? !maxCount.equals(that.maxCount) : that.maxCount != null) return false;
-    if (windowInMinutes != null ? !windowInMinutes.equals(that.windowInMinutes) : that.windowInMinutes != null)
-      return false;
-    if (retryGap != null ? !retryGap.equals(that.retryGap) : that.retryGap != null) return false;
-    if (maxLifetimeCount != null ? !maxLifetimeCount.equals(that.maxLifetimeCount) : that.maxLifetimeCount != null)
-      return false;
     return enabledComponents != null ? enabledComponents.equals(that.enabledComponents) : that.enabledComponents == null;
   }
 
   @Override
   public int hashCode() {
-    int result = type != null ? type.hashCode() : 0;
-    result = 31 * result + (maxCount != null ? maxCount.hashCode() : 0);
-    result = 31 * result + (windowInMinutes != null ? windowInMinutes.hashCode() : 0);
-    result = 31 * result + (retryGap != null ? retryGap.hashCode() : 0);
-    result = 31 * result + (maxLifetimeCount != null ? maxLifetimeCount.hashCode() : 0);
-    result = 31 * result + (enabledComponents != null ? enabledComponents.hashCode() : 0);
+    int result = (enabledComponents != null ? enabledComponents.hashCode() : 0);
     return result;
   }
 
   @Override
   public String toString() {
     StringBuilder buffer = new StringBuilder("RecoveryConfig{");
-    buffer.append(", type=").append(type);
-    buffer.append(", maxCount=").append(maxCount);
-    buffer.append(", windowInMinutes=").append(windowInMinutes);
-    buffer.append(", retryGap=").append(retryGap);
-    buffer.append(", maxLifetimeCount=").append(maxLifetimeCount);
     buffer.append(", components=").append(enabledComponents);
     buffer.append('}');
     return buffer.toString();

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/RecoveryConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/RecoveryConfigHelper.java
@@ -102,14 +102,7 @@ public class RecoveryConfigHelper {
     AutoStartConfig autoStartConfig = new AutoStartConfig(clusterName);
 
     RecoveryConfig recoveryConfig = new RecoveryConfig();
-    recoveryConfig.setMaxCount(autoStartConfig.getNodeRecoveryMaxCount());
-    recoveryConfig.setMaxLifetimeCount(autoStartConfig.getNodeRecoveryLifetimeMaxCount());
-    recoveryConfig.setRetryGap(autoStartConfig.getNodeRecoveryRetryGap());
-    recoveryConfig.setType(autoStartConfig.getNodeRecoveryType());
-    recoveryConfig.setWindowInMinutes(autoStartConfig.getNodeRecoveryWindowInMin());
-    if (autoStartConfig.isRecoveryEnabled()) {
-      recoveryConfig.setEnabledComponents(autoStartConfig.getEnabledComponents(hostname));
-    }
+    recoveryConfig.setEnabledComponents(autoStartConfig.getEnabledComponents(hostname));
 
     return recoveryConfig;
   }
@@ -367,48 +360,6 @@ public class RecoveryConfigHelper {
      */
     private boolean isRecoveryEnabled() {
       return Boolean.parseBoolean(getProperty(RECOVERY_ENABLED_KEY, "false"));
-    }
-
-    /**
-     * Get the node recovery type. The only supported value is AUTO_START.
-     * @return
-     */
-    private String getNodeRecoveryType() {
-      return getProperty(RECOVERY_TYPE_KEY, RECOVERY_TYPE_DEFAULT);
-    }
-
-    /**
-     * Get configured max count of recovery attempt allowed per host component in a window
-     * This is reset when agent is restarted.
-     * @return
-     */
-    private String getNodeRecoveryMaxCount() {
-      return getProperty(RECOVERY_MAX_COUNT_KEY, RECOVERY_MAX_COUNT_DEFAULT);
-    }
-
-    /**
-     * Get configured max lifetime count of recovery attempt allowed per host component.
-     * This is reset when agent is restarted.
-     * @return
-     */
-    private String getNodeRecoveryLifetimeMaxCount() {
-      return getProperty(RECOVERY_LIFETIME_MAX_COUNT_KEY, RECOVERY_LIFETIME_MAX_COUNT_DEFAULT);
-    }
-
-    /**
-     * Get configured window size in minutes
-     * @return
-     */
-    private String getNodeRecoveryWindowInMin() {
-      return getProperty(RECOVERY_WINDOW_IN_MIN_KEY, RECOVERY_WINDOW_IN_MIN_DEFAULT);
-    }
-
-    /**
-     * Get the configured retry gap between tries per host component
-     * @return
-     */
-    private String getNodeRecoveryRetryGap() {
-      return getProperty(RECOVERY_RETRY_GAP_KEY, RECOVERY_RETRY_GAP_DEFAULT);
     }
 
     /**


### PR DESCRIPTION
STR

Deployed cluster with Ambari version: 2.6.1.5-3 and HDP version: 2.6.1.0-129
Upgrade Ambari to Target Version: 2.7.0.0-709
Upgrade AMS and Smartsense (keeping them stopped)
Perform EU to HDP-3.0 and let it complete
Restart HDFS
Observe state of Metrics Collectors (AMS is configured in distributed mode)
Result
Both metrics collectors are down (auto start is enabled for Metrics Collector)
