### PR TITLE
[AMBARI-24171] Fix issues in AMS aggregation and writes.

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
@@ -52,6 +52,7 @@ import org.apache.ambari.metrics.core.timeline.query.Condition;
 import org.apache.ambari.metrics.core.timeline.query.ConditionBuilder;
 import org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL;
 import org.apache.ambari.metrics.core.timeline.query.TopNCondition;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -455,9 +456,9 @@ public class HBaseTimelineMetricsService extends AbstractService implements Time
     for (TimelineMetricWithAggregatedValues entry : aggregationResult.getResult()) {
       aggregateMap.put(entry.getTimelineMetric(), entry.getMetricAggregate());
       hostname = hostname == null ? entry.getTimelineMetric().getHostName() : hostname;
-      break;
     }
     long timestamp = aggregationResult.getTimeInMilis();
+    LOG.info(String.format("Adding host %s to aggregated by in-memory aggregator. Timestamp : %s", hostname, timestamp));
     if (LOG.isDebugEnabled()) {
       LOG.debug(String.format("Adding host %s to aggregated by in-memory aggregator. Timestamp : %s", hostname, timestamp));
     }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
@@ -52,7 +52,6 @@ import org.apache.ambari.metrics.core.timeline.query.Condition;
 import org.apache.ambari.metrics.core.timeline.query.ConditionBuilder;
 import org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL;
 import org.apache.ambari.metrics.core.timeline.query.TopNCondition;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -458,7 +457,6 @@ public class HBaseTimelineMetricsService extends AbstractService implements Time
       hostname = hostname == null ? entry.getTimelineMetric().getHostName() : hostname;
     }
     long timestamp = aggregationResult.getTimeInMilis();
-    LOG.info(String.format("Adding host %s to aggregated by in-memory aggregator. Timestamp : %s", hostname, timestamp));
     if (LOG.isDebugEnabled()) {
       LOG.debug(String.format("Adding host %s to aggregated by in-memory aggregator. Timestamp : %s", hostname, timestamp));
     }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/PhoenixHBaseAccessor.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/PhoenixHBaseAccessor.java
@@ -129,7 +129,6 @@ import org.apache.ambari.metrics.core.timeline.source.InternalSourceProvider;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/PhoenixHBaseAccessor.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/PhoenixHBaseAccessor.java
@@ -129,6 +129,7 @@ import org.apache.ambari.metrics.core.timeline.source.InternalSourceProvider;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -358,8 +359,11 @@ public class PhoenixHBaseAccessor {
 
             try {
               int rows = metricRecordStmt.executeUpdate();
-            } catch (SQLException sql) {
-              LOG.error("Failed on insert records to store.", sql);
+            } catch (SQLException | NumberFormatException ex) {
+              LOG.warn("Failed on insert records to store : " + ex.getMessage());
+              LOG.warn("Metric that cannot be stored : [" + metric.getMetricName() + "," + metric.getAppId() + "]" +
+                metric.getMetricValues().toString());
+              continue;
             }
 
             if (rowCount >= PHOENIX_MAX_MUTATION_STATE_SIZE - 1) {
@@ -1469,7 +1473,7 @@ public class PhoenixHBaseAccessor {
         }
 
         rowCount++;
-        byte[] uuid =  metadataManagerInstance.getUuid(clusterMetric, false);
+        byte[] uuid =  metadataManagerInstance.getUuid(clusterMetric, true);
         if (uuid == null) {
           LOG.error("Error computing UUID for metric. Cannot write metrics : " + clusterMetric.toString());
           continue;

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/TimelineMetricConfiguration.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/TimelineMetricConfiguration.java
@@ -17,6 +17,16 @@
  */
 package org.apache.ambari.metrics.core.timeline;
 
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.CONTAINER_METRICS_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_AGGREGATE_DAILY_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_AGGREGATE_HOURLY_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_AGGREGATE_MINUTE_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_CLUSTER_AGGREGATE_DAILY_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_CLUSTER_AGGREGATE_HOURLY_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_CLUSTER_AGGREGATE_MINUTE_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_CLUSTER_AGGREGATE_TABLE_NAME;
+import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_RECORD_TABLE_NAME;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -331,7 +341,7 @@ public class TimelineMetricConfiguration {
   public static final String BLOCKING_STORE_FILES_KEY = "hbase.hstore.blockingStoreFiles";
 
   private Configuration hbaseConf;
-  private Configuration metricsConf;
+  private Configuration metricsConf = new Configuration();
   private Configuration metricsSslConf;
   private Configuration amsEnvConf;
   private volatile boolean isInitialized = false;
@@ -698,4 +708,34 @@ public class TimelineMetricConfiguration {
     return StringUtils.EMPTY;
   }
 
+  public long getTableTtl(String tableName) {
+
+    if (StringUtils.isEmpty(tableName)) {
+      return Long.MAX_VALUE;
+    }
+
+    switch (tableName) {
+
+      case METRICS_RECORD_TABLE_NAME:
+        return metricsConf.getInt(PRECISION_TABLE_TTL, 1 * 86400);
+      case METRICS_AGGREGATE_MINUTE_TABLE_NAME:
+        return metricsConf.getInt(HOST_MINUTE_TABLE_TTL, 7 * 86400);
+      case METRICS_AGGREGATE_HOURLY_TABLE_NAME:
+        return metricsConf.getInt(HOST_HOUR_TABLE_TTL, 30 * 86400);
+      case METRICS_AGGREGATE_DAILY_TABLE_NAME:
+        return metricsConf.getInt(HOST_DAILY_TABLE_TTL, 365 * 86400);
+      case METRICS_CLUSTER_AGGREGATE_TABLE_NAME:
+        return metricsConf.getInt(CLUSTER_SECOND_TABLE_TTL, 7 * 86400);
+      case METRICS_CLUSTER_AGGREGATE_MINUTE_TABLE_NAME:
+        return metricsConf.getInt(CLUSTER_MINUTE_TABLE_TTL, 30 * 86400);
+      case METRICS_CLUSTER_AGGREGATE_HOURLY_TABLE_NAME:
+        return metricsConf.getInt(CLUSTER_HOUR_TABLE_TTL, 365 * 86400);
+      case METRICS_CLUSTER_AGGREGATE_DAILY_TABLE_NAME:
+        return metricsConf.getInt(CLUSTER_DAILY_TABLE_TTL, 730 * 86400);
+      case CONTAINER_METRICS_TABLE_NAME:
+        return metricsConf.getInt(CONTAINER_METRICS_TTL, 14 * 86400);
+      default:
+        return Long.MAX_VALUE;
+    }
+  }
 }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/TestPhoenixTransactSQL.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/TestPhoenixTransactSQL.java
@@ -167,7 +167,7 @@ public class TestPhoenixTransactSQL {
     long hour = 60 * minute;
     long day = 24 * hour;
 
-    Long endTime = 1407959918000L;
+    Long endTime = System.currentTimeMillis();
     Long startTime = endTime - 200 * second;
 
     //SECONDS precision
@@ -289,7 +289,7 @@ public class TestPhoenixTransactSQL {
     long minute = 60 * second;
     long hour = 60 * minute;
 
-    Long endTime = 1407959918000L;
+    Long endTime = System.currentTimeMillis();
     Long startTime = endTime - 200 * second;
     // SECONDS precision
     // 2 Metrics, 1 Host, Time = 200 seconds
@@ -349,7 +349,7 @@ public class TestPhoenixTransactSQL {
     verify(connection, preparedStatement);
 
     // HOURS precision
-    startTime = endTime - 30 * 24 * hour;
+    startTime = endTime - 29 * 24 * hour;
     condition = new DefaultCondition(
       new ArrayList<>(Arrays.asList("cpu_user", "mem_free")), Collections.singletonList("h1"),
       "a1", "i1", startTime, endTime, null, null, false);
@@ -472,9 +472,16 @@ public class TestPhoenixTransactSQL {
       hosts.add("TestHost"+i);
     }
 
+    long second = 1000;
+    long minute = 60 * second;
+    long hour = 60 * minute;
+
+    Long endTime = System.currentTimeMillis();
+    Long startTime = endTime - hour;
+
     Condition condition = new DefaultCondition(
       metrics, hosts,
-      "a1", "i1", 1407950000L, 1407953600L, Precision.SECONDS, null, false);
+      "a1", "i1", startTime, endTime, Precision.SECONDS, null, false);
     Connection connection = createNiceMock(Connection.class);
     PreparedStatement preparedStatement = createNiceMock(PreparedStatement.class);
     Capture<String> stmtCapture = new Capture<String>();
@@ -490,7 +497,7 @@ public class TestPhoenixTransactSQL {
     //Check without passing precision. Should be OK!
     condition = new DefaultCondition(
       metrics, hosts,
-      "a1", "i1", 1407950000L, 1407953600L, null, null, false);
+      "a1", "i1", startTime, endTime, null, null, false);
     connection = createNiceMock(Connection.class);
     preparedStatement = createNiceMock(PreparedStatement.class);
     stmtCapture = new Capture<String>();
@@ -516,7 +523,7 @@ public class TestPhoenixTransactSQL {
     }
     condition = new DefaultCondition(
       metrics, hosts,
-      "a1", "i1", 1407867200L, 1407953600L, null, null, false);
+      "a1", "i1", endTime - 24*hour, endTime, null, null, false);
     connection = createNiceMock(Connection.class);
     preparedStatement = createNiceMock(PreparedStatement.class);
     stmtCapture = new Capture<String>();
@@ -538,7 +545,7 @@ public class TestPhoenixTransactSQL {
     }
     condition = new DefaultCondition(
       metrics, hosts,
-      "a1", "i1", 1407867200L, 1407953600L, null, null, false);
+      "a1", "i1", endTime - 24*hour, endTime, null, null, false);
     connection = createNiceMock(Connection.class);
     preparedStatement = createNiceMock(PreparedStatement.class);
     stmtCapture = new Capture<String>();
@@ -562,10 +569,9 @@ public class TestPhoenixTransactSQL {
     for (int i = 0; i < numHosts; i++) {
       hosts.add("TestHost"+i);
     }
-    long endtime = 1407953600L;
     condition = new DefaultCondition(
       metrics, hosts,
-      "a1", "i1", endtime - 5 * 60 * 60, endtime, Precision.SECONDS, null, false);
+      "a1", "i1", endTime - 5 * hour, endTime, Precision.SECONDS, null, false);
     boolean exceptionThrown = false;
     boolean requestedSizeFoundInMessage = false;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- AMS cluster aggregation does not work when metrics have instanceId defined. 
   This issue is because we do not allow creation of UUIDs during aggregation phase. This is not true when instanceId is defined in raw metrics and is discarded during cluster aggregation.
- Fix bug in distributed 5-min host aggregator.
   Issue was an invalid 'break' statement after identifying the host which sent the metrics. The break caused only the first metric to be stored. 
- Fix issues where AMS discards whole set of metrics even when 1 of them has NaN values.
- Fix issues in precision calculation whereby the table TTL is also taken into account.

## How was this patch tested?
Manually tested.
Added unit tests.