### PR TITLE
AMBARI-24174. Agent failed to process execution command

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -278,6 +278,8 @@ class ActionQueue(threading.Thread):
     logger.info("Command execution metadata - taskId = {taskId}, retry enabled = {retryAble}, max retry duration (sec) = {retryDuration}, log_output = {log_command_output}".
                  format(taskId=taskId, retryAble=retryAble, retryDuration=retryDuration, log_command_output=log_command_output))
     command_canceled = False
+    self.cancelEvent.clear()
+
     while retryDuration >= 0:
       if taskId in self.taskIdsToCancel:
         logger.info('Command with taskId = {0} canceled'.format(taskId))
@@ -336,7 +338,7 @@ class ActionQueue(threading.Thread):
                     .format(cid=taskId, status=status, retryAble=retryAble, retryDuration=retryDuration, delay=delay))
         break
 
-    self.cancelEvent.clear()
+    self.taskIdsToCancel.discard(taskId)
 
     # do not fail task which was rescheduled from server
     if command_canceled:


### PR DESCRIPTION
Some execution commands were failed during blueprint deploy:

ERROR 2018-06-19 22:29:28,058 ActionQueue.py:221 - Exception while processing EXECUTION_COMMAND command
 Traceback (most recent call last):
   File "/usr/lib/ambari-agent/lib/ambari_agent/ActionQueue.py", line 214, in process_command
     self.execute_command(command)
   File "/usr/lib/ambari-agent/lib/ambari_agent/ActionQueue.py", line 352, in execute_command
     commandresult['stdout'] += '\n\nCommand completed successfully!\n' if status == self.COMPLETED_STATUS else '\n\nCommand failed after ' + str(numAttempts) + ' tries\n'
 UnboundLocalError: local variable 'commandresult' referenced before assignment
 INFO 2018-06-19 22:29:28,100 ActionQueue.py:238 - Executing command with id = 4-0, taskId = 5 for role = MAPREDUCE2_CLIENT of cluster_id 2.