### PR TITLE
[AMBARI-24175] Error processing agent reports due to wrong stack usage

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
@@ -1236,13 +1236,10 @@ public class HostImpl implements Host {
     int slaveCount = 0;
     int slavesRunning = 0;
 
-    StackId stackId;
     Cluster cluster = clusters.getCluster(clusterId);
-    stackId = cluster.getDesiredStackVersion();
-
-
     List<ServiceComponentHost> scHosts = cluster.getServiceComponentHosts(hostName);
     for (ServiceComponentHost scHost : scHosts) {
+      StackId stackId = scHost.getDesiredStackId();
       ComponentInfo componentInfo =
           ambariMetaInfo.getComponent(stackId.getStackName(),
               stackId.getStackVersion(), scHost.getServiceName(),

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/host/HostImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/host/HostImplTest.java
@@ -17,25 +17,43 @@
  */
 package org.apache.ambari.server.state.host;
 
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
 import java.util.Map;
 
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.controller.MaintenanceStateHelper;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.HostDAO;
 import org.apache.ambari.server.orm.dao.HostStateDAO;
 import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.HostStateEntity;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.ComponentInfo;
+import org.apache.ambari.server.state.HostHealthStatus;
+import org.apache.ambari.server.state.MaintenanceState;
+import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.State;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 
 public class HostImplTest extends EasyMockSupport {
 
-  @Test
-  public void testGetHostAttributes() throws Exception {
+  private AmbariMetaInfo ambariMetaInfo = createNiceMock(AmbariMetaInfo.class);
 
+  @Test
+  public void testGetHostAttributes() {
     HostEntity hostEntity = createNiceMock(HostEntity.class);
     HostStateEntity hostStateEntity = createNiceMock(HostStateEntity.class);
     HostDAO hostDAO  = createNiceMock(HostDAO.class);
@@ -66,7 +84,7 @@ public class HostImplTest extends EasyMockSupport {
   }
 
   @Test
-  public void testGetHealthStatus() throws Exception {
+  public void testGetHealthStatus() {
 
     HostEntity hostEntity = createNiceMock(HostEntity.class);
     HostStateEntity hostStateEntity = createNiceMock(HostStateEntity.class);
@@ -92,5 +110,69 @@ public class HostImplTest extends EasyMockSupport {
     host.getHealthStatus();
 
     verifyAll();
+  }
+
+  @Test
+  public void canProcessComponentsFromMultipleStacks() throws AmbariException {
+    // GIVEN
+    Long clusterId = 1L;
+    StackId hdpCore = new StackId("HDPCORE", "1.0.0");
+    StackId ods = new StackId("ODS", "2.0.0");
+    String hostName = "c7401.ambari.apache.org";
+
+    Clusters clusters = createNiceMock(Clusters.class);
+    Cluster cluster = createNiceMock(Cluster.class);
+    HostEntity entity = createNiceMock(HostEntity.class);
+    Gson gson = new Gson();
+    HostDAO hostDAO = createNiceMock(HostDAO.class);
+    HostStateDAO hostStateDAO = createNiceMock(HostStateDAO.class);
+    HostStateEntity hostStateEntity = createNiceMock(HostStateEntity.class);
+    MaintenanceStateHelper maintenanceStateHelper = createNiceMock(MaintenanceStateHelper.class);
+    AmbariEventPublisher ambariEventPublisher = createNiceMock(AmbariEventPublisher.class);
+
+    expect(clusters.getCluster(clusterId)).andReturn(cluster).anyTimes();
+    expect(entity.getHostStateEntity()).andReturn(hostStateEntity).anyTimes();
+    expect(entity.getClusterEntities()).andReturn(ImmutableList.of()).anyTimes();
+    expect(entity.getHostId()).andReturn(1L).anyTimes();
+    expect(entity.getHostName()).andReturn(hostName).anyTimes();
+    expect(cluster.getDesiredStackVersion()).andReturn(hdpCore).anyTimes();
+    expect(maintenanceStateHelper.getEffectiveState(anyObject(), anyObject())).andReturn(MaintenanceState.OFF).anyTimes();
+    ambariEventPublisher.publish(anyObject());
+    expectLastCall().anyTimes();
+
+    List<ServiceComponentHost> components = ImmutableList.of(
+      aComponent(hdpCore, "HDFS", "NAMENODE"),
+      aComponent(ods, "HBASE", "HBASE_MASTER"),
+      aComponent(hdpCore, "ZOOKEEPER", "ZOOKEEPER_SERVER"),
+      aComponent(ods, "HBASE", "HBASE_REGIONSERVER")
+    );
+    expect(cluster.getServiceComponentHosts(hostName)).andReturn(components).anyTimes();
+
+    replayAll();
+
+    HostImpl subject = new HostImpl(entity, gson, hostDAO, hostStateDAO);
+    Whitebox.setInternalState(subject, "ambariEventPublisher", ambariEventPublisher);
+    Whitebox.setInternalState(subject, "clusters", clusters);
+    Whitebox.setInternalState(subject, "ambariMetaInfo", ambariMetaInfo);
+    Whitebox.setInternalState(subject, "maintenanceStateHelper", maintenanceStateHelper);
+    subject.setStatus("INIT");
+
+    // WHEN
+    subject.calculateHostStatus(clusterId);
+
+    // THEN
+    assertEquals(HostHealthStatus.HealthStatus.HEALTHY.name(), subject.getStatus());
+  }
+
+  private ServiceComponentHost aComponent(StackId stackId, String service, String component) throws AmbariException {
+    ServiceComponentHost sch = createNiceMock(ServiceComponentHost.class);
+    expect(sch.getDesiredStackId()).andReturn(stackId).anyTimes();
+    expect(sch.getServiceName()).andReturn(service).anyTimes();
+    expect(sch.getServiceComponentName()).andReturn(component).anyTimes();
+    expect(sch.getState()).andReturn(State.STARTED).anyTimes();
+    ComponentInfo componentInfo = createNiceMock(ComponentInfo.class);
+    expect(componentInfo.getCategory()).andReturn("MASTER").anyTimes();
+    expect(ambariMetaInfo.getComponent(stackId.getStackName(), stackId.getStackVersion(), service, component)).andReturn(componentInfo);
+    return sch;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following exception, which happens after cluster with multiple mpacks is deployed:

```
ERROR [agent-report-processor-0] AgentReportsProcessor:90 - Error processing agent reports
org.apache.ambari.server.StackAccessException: Stack data, stackName=HDPCORE, stackVersion=1.0.0-b368, stackServiceName=HBASE
        at org.apache.ambari.server.api.services.AmbariMetaInfo.getService(AmbariMetaInfo.java:604)
        at org.apache.ambari.server.api.services.AmbariMetaInfo.getComponent(AmbariMetaInfo.java:357)
        at org.apache.ambari.server.state.host.HostImpl.calculateHostStatus(HostImpl.java:1247)
        at org.apache.ambari.server.agent.HeartbeatProcessor.processHostStatus(HeartbeatProcessor.java:300)
        at org.apache.ambari.server.agent.HeartBeatHandler.handleCommandReportStatus(HeartBeatHandler.java:275)
        at org.apache.ambari.server.agent.AgentReportsProcessor$AgentReportProcessingTask.run(AgentReportsProcessor.java:83)
```

Stack ID was taken from cluster instead of host component.  Correct behavior was already [implemented](https://github.com/apache/ambari/blob/a45f5427b08fc354e8b54481e7da3d6083112345/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatProcessor.java#L296-L306) once for [AMBARI-21059](https://issues.apache.org/jira/browse/AMBARI-21059), but has been [broken](https://github.com/apache/ambari/blob/6e849e91e751439c79bd44a614ded9aaf43ce094/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java#L1246-L1255) in [AMBARI-22063](https://issues.apache.org/jira/browse/AMBARI-22063).

## How was this patch tested?

Deployed multi-mpack cluster via blueprint.

Added test case in `HostImplTest`.