### PR TITLE
[AMBARI-24087] Fix `test_missing_configs` in `test_alert_datanode_unmounted_data_dir`

### DIFF
--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_alert_datanode_unmounted_data_dir.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_alert_datanode_unmounted_data_dir.py
@@ -54,8 +54,9 @@ class TestAlertDataNodeUnmountedDataDir(RMFTestCase):
     sys.path.append(file_path)
     global alert
     import alert_datanode_unmounted_data_dir as alert
-  
-  def test_missing_configs(self):
+
+  @patch("resource_management.libraries.functions.file_system.get_and_cache_mount_points")
+  def test_missing_configs(self, get_and_cache_mount_points_mock):
     """
     Check that the status is UNKNOWN when configs are missing.
     """


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following Python unit test failure ran into locally:

```
ERROR: test_missing_configs (test_alert_datanode_unmounted_data_dir.TestAlertDataNodeUnmountedDataDir)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ambari-server/src/test/python/stacks/2.0.6/HDFS/test_alert_datanode_unmounted_data_dir.py", line 71, in test_missing_configs
    [status, messages] = alert.execute(configurations=configs)
  File "ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/alerts/alert_datanode_unmounted_data_dir.py", line 110, in execute
    file_system.get_and_cache_mount_points(refresh=True)
  File "ambari-common/src/main/python/resource_management/libraries/functions/file_system.py", line 46, in get_and_cache_mount_points
    Logger.info("Host contains mounts: %s." % str([m["mount_point"] for m in mounts]))
  File "ambari-common/src/main/python/resource_management/core/logger.py", line 75, in info
    Logger.logger.info(Logger.filter_text(text))
AttributeError: 'NoneType' object has no attribute 'info'
```

## How was this patch tested?

```
$ mvn -am -pl ambari-server -DskipSurefireTests -Del.log=WARN clean test
...
Total run:1199
Total errors:0
Total failures:0
OK
```