### PR TITLE
AMBARI-24177. Ambari gets stuck at host checks (after successful registration) when installing more number of nodes via UI.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentReportsController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentReportsController.java
@@ -120,10 +120,11 @@ public class AgentReportsController {
   }
 
   @MessageMapping("/responses")
-  public ReportsResponse handleReceiveReport(AckReport ackReport) throws HostNotRegisteredException {
+  public ReportsResponse handleReceiveReport(@Header String simpSessionId, AckReport ackReport) throws HostNotRegisteredException {
+    Long hostId = agentSessionManager.getHost(simpSessionId).getHostId();
     LOG.debug("Handling agent receive report for execution message with messageId {}, status {}, reason {}",
         ackReport.getMessageId(), ackReport.getStatus(), ackReport.getReason());
-    defaultMessageEmitterProvider.get().processReceiveReport(ackReport);
+    defaultMessageEmitterProvider.get().processReceiveReport(hostId, ackReport);
     return new ReportsResponse();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/DefaultMessageEmitter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/DefaultMessageEmitter.java
@@ -83,7 +83,7 @@ public class DefaultMessageEmitter extends MessageEmitter {
   }
 
   @Override
-  public void emitMessage(STOMPEvent event) throws AmbariException, InterruptedException {
+  public void emitMessage(STOMPEvent event) throws AmbariException {
     if (StringUtils.isEmpty(getDestination(event))) {
       throw new MessageDestinationIsNotDefinedException(event.getType());
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/STOMPEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/STOMPEvent.java
@@ -25,11 +25,6 @@ import java.beans.Transient;
 public abstract class STOMPEvent {
 
   /**
-   * Message id is unique for original messages, but the same for all re-emitted messages.
-   */
-  private Long messageId;
-
-  /**
    * Update type.
    */
   protected final Type type;
@@ -46,15 +41,6 @@ public abstract class STOMPEvent {
   @Transient
   public String getMetricName() {
     return type.getMetricName();
-  }
-
-  @Transient
-  public Long getMessageId() {
-    return messageId;
-  }
-
-  public void setMessageId(Long messageId) {
-    this.messageId = messageId;
   }
 
   public enum Type {

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/ScheduledExecutorCompletionService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/ScheduledExecutorCompletionService.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.utils;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ScheduledExecutorCompletionService<V> extends ExecutorCompletionService<V> {
+  private final ScheduledExecutorService scheduledExecutor;
+  private final BlockingQueue<Future<V>> queue;
+
+  private class QueueingFuture extends FutureTask<Void> {
+    QueueingFuture(RunnableFuture<V> task) {
+      super(task, null);
+      this.task = task;
+    }
+    protected void done() { queue.add(task); }
+    private final Future<V> task;
+  }
+
+  public ScheduledExecutorCompletionService(ScheduledExecutorService scheduledExecutor, BlockingQueue<Future<V>> queue) {
+    super(scheduledExecutor, queue);
+    this.scheduledExecutor = scheduledExecutor;
+    this.queue = queue;
+  }
+
+  public Future<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
+    if (task == null) throw new NullPointerException();
+    RunnableFuture<V> f = newTaskFor(task);
+    scheduledExecutor.schedule(new QueueingFuture(f), delay, unit);
+    return f;
+  }
+
+  private RunnableFuture<V> newTaskFor(Callable<V> task) {
+    return new FutureTask<V>(task);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Execution commands emitting retry workflow was changed. Now server uses one first emit commands monitor and retry monitor for all hosts.

## How was this patch tested?

Manual testing.