### PR TITLE
[AMBARI-24004] [Logsearch UI] Add hosts link in log index filter popup is not working

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.html
@@ -49,7 +49,7 @@
           <label attr.for="{{getCheckBoxId(component.name, levelName)}}">&nbsp;</label>
         </td>
         <td class="override-column">
-          <span class="overrides-toggle">{{'logIndexFilter.addHosts' | translate}}</span>
+          <!-- <span class="overrides-toggle">{{'logIndexFilter.addHosts' | translate}}</span> -->
         </td>
       </tr>
       <tr> <!--overrides row -->

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.less
@@ -43,11 +43,16 @@ table {
     padding-right: 0;
   }
 
+  th.override-column {
+    padding-left: 20px;
+  }
+
   .overrides-toggle {
     .clickable-item;
   }
 
   input[type=checkbox] + label {
     font-size: @table-font-size;
+    top: 0;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since the backend currently does not support to have multiple host overrides we temporary remove the link.

## How was this patch tested?

Manually and by unit tests.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.