### PR TITLE
[AMBARI-24181] Build failure due to bower version deprecation.

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/.bowerrc
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/.bowerrc
@@ -1,0 +1,5 @@
+ {
+   "directory": "bower_components",
+   "analytics": false,
+   "registry": "https://registry.bower.io"
+ }

--- a/contrib/views/commons/src/main/resources/ui/hdfs-directory-viewer/.bowerrc
+++ b/contrib/views/commons/src/main/resources/ui/hdfs-directory-viewer/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
-  "analytics": false
+  "analytics": false,
+  "registry": "https://registry.bower.io"
 }

--- a/contrib/views/files/src/main/resources/ui/.bowerrc
+++ b/contrib/views/files/src/main/resources/ui/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
-  "analytics": false
+  "analytics": false,
+  "registry": "https://registry.bower.io"
 }

--- a/contrib/views/pig/src/main/resources/ui/pig-web/.bowerrc
+++ b/contrib/views/pig/src/main/resources/ui/pig-web/.bowerrc
@@ -1,0 +1,5 @@
+ {
+   "directory": "bower_components",
+   "analytics": false,
+   "registry": "https://registry.bower.io"
+ }

--- a/contrib/views/wfmanager/src/main/resources/ui/.bowerrc
+++ b/contrib/views/wfmanager/src/main/resources/ui/.bowerrc
@@ -1,0 +1,5 @@
+ {
+   "directory": "bower_components",
+   "analytics": false,
+   "registry": "https://registry.bower.io"
+ }


### PR DESCRIPTION
## What changes were proposed in this pull request?
bowerrc file points to new Bower registry "registry": "https://registry.bower.io" for views using bower
