### PR TITLE
[AMBARI-24184]Add alert for ams_hbase_regionserver process.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/alerts.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/alerts.json
@@ -106,6 +106,31 @@
         }
       },
       {
+        "name": "ams_metrics_collector_hbase_regionserver_process",
+        "label": "Metrics Collector - HBase Regionserver Process",
+        "description": "This alert is triggered if the Metrics Collector's HBase regionserver processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "interval": 1,
+        "scope": "ANY",
+        "source": {
+          "type": "PORT",
+          "uri": "{{ams-hbase-site/hbase.regionserver.info.port}}",
+          "default_port": 61330,
+          "reporting": {
+            "ok": {
+              "text": "TCP OK - {0:.3f}s response on port {1}"
+            },
+            "warning": {
+              "text": "TCP OK - {0:.3f}s response on port {1}",
+              "value": 1.5
+            },
+            "critical": {
+              "text": "Connection failed: {0} to {1}:{2}",
+              "value": 5.0
+            }
+          }
+        }
+      },
+      {
         "name": "ams_metrics_collector_hbase_master_cpu",
         "label": "Metrics Collector - HBase Master CPU Utilization",
         "description": "This host-level alert is triggered if CPU utilization of the Metrics Collector's HBase Master exceeds certain warning and critical thresholds. It checks the HBase Master JMX Servlet for the SystemCPULoad property. The threshold values are in percent.",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since distributed mode is used for AMS  by default,we can add alert for ams_hbase_regionserver process.
Add alert for ams_hbase_regionserver process in alerts.json of ams.

## How was this patch tested?
Manually tested.