### PR TITLE
AMBARI-24189. Remove reference to JDK 1.7 in ambari-server setup (aon…

### DIFF
--- a/ambari-server/conf/unix/ambari.properties
+++ b/ambari-server/conf/unix/ambari.properties
@@ -23,16 +23,9 @@ resources.dir = $ROOT/var/lib/ambari-server/resources
 shared.resources.dir = $ROOT/usr/lib/ambari-server/lib/ambari_commons/resources
 custom.action.definitions = $ROOT/var/lib/ambari-server/resources/custom_action_definitions
 
-java.releases=jdk1.8,jdk1.7
+java.releases=jdk1.8
 java.releases.ppc64le=
 
-jdk1.7.desc=Oracle JDK 1.7 + Java Cryptography Extension (JCE) Policy Files 7
-jdk1.7.url=http://public-repo-1.hortonworks.com/ARTIFACTS/jdk-7u67-linux-x64.tar.gz
-jdk1.7.dest-file=jdk-7u67-linux-x64.tar.gz
-jdk1.7.jcpol-url=http://public-repo-1.hortonworks.com/ARTIFACTS/UnlimitedJCEPolicyJDK7.zip
-jdk1.7.jcpol-file=UnlimitedJCEPolicyJDK7.zip
-jdk1.7.home=$ROOT/usr/jdk64/
-jdk1.7.re=(jdk.*)/jre
 jdk1.8.desc=Oracle JDK 1.8 + Java Cryptography Extension (JCE) Policy Files 8
 jdk1.8.url=http://public-repo-1.hortonworks.com/ARTIFACTS/jdk-8u112-linux-x64.tar.gz
 jdk1.8.dest-file=jdk-8u112-linux-x64.tar.gz


### PR DESCRIPTION
We need to remove the reference to JDK 1.7, as it's not supported with HDP 3.0. We still see the following in ambari-server setup:

[2] Oracle JDK 1.7 + Java Cryptography Extension (JCE) Policy Files 7