### PR TITLE
AMBARI-24186 Run Hive PreUpgradeTool with propert user

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
@@ -93,7 +93,7 @@ class HivePreUpgrade(Script):
     
     classpath = format("{source_dir}/hive2/lib/*:{source_dir}/hadoop/*:{source_dir}/hadoop/lib/*:{source_dir}/hadoop-mapreduce/*:{source_dir}/hadoop-mapreduce/lib/*:{target_dir}/hive/lib/hive-pre-upgrade.jar:{source_dir}/hive/conf")
     cmd = format("{java64_home}/bin/java -Djavax.security.auth.useSubjectCredsOnly=false -cp {classpath} org.apache.hadoop.hive.upgrade.acid.PreUpgradeTool -execute")
-    Execute(cmd, user = "hive")
+    Execute(cmd, user = params.hive_user)
 
 if __name__ == "__main__":
   HivePreUpgrade().execute()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive PreUpgradeTool is now running with the actual hive user, not hard coded "hive"

## How was this patch tested?

Tested on test cluster where custom hive user was set.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.