### PR TITLE
[AMBARI-24191] Typo in div class name at CustomizeServicespage - Accounts tab

### DIFF
--- a/ambari-web/app/styles/wizard.less
+++ b/ambari-web/app/styles/wizard.less
@@ -1211,7 +1211,7 @@
       }
     }
   }
-  .use-ambari-chekboxes {
+  .use-ambari-checkboxes {
     margin-top: 20px;
     padding-left: 10px;
   }

--- a/ambari-web/app/templates/wizard/step7/accounts_tab.hbs
+++ b/ambari-web/app/templates/wizard/step7/accounts_tab.hbs
@@ -18,7 +18,7 @@
 
 <div class="col-md-7">
   <p class="step-description">{{t installer.step7.accountsTab.body}}</p>
-  <div class="use-ambari-chekboxes">
+  <div class="use-ambari-checkboxes">
     {{#each checkbox in view.checkboxes}}
       <div>
         {{view checkbox.viewClass serviceConfigBinding="checkbox" labelBinding="checkbox.displayName"}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix class name use-ambari-chekboxes to be use-ambari-checkboxes

