### PR TITLE
AMBARI-24176. Deleting a service fails to remove keytabs (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
@@ -53,10 +53,10 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
   }
 
   public T initializeDataIfNeeded(Long hostId, boolean regenerateHash) throws AmbariException {
-    T hostData = data.get(hostId);
-    if (hostData == null) {
-      updateLock.lock();
-      try {
+    updateLock.lock();
+    try {
+      T hostData = data.get(hostId);
+      if (hostData == null) {
         hostData = data.get(hostId);
         if (hostData == null) {
           hostData = getCurrentData(hostId);
@@ -65,11 +65,11 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
           }
           data.put(hostId, hostData);
         }
-      } finally {
-        updateLock.unlock();
       }
+      return hostData;
+    } finally {
+      updateLock.unlock();
     }
-    return hostData;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following error was observed on a test cluster:

```text
Caught an exception while executing custom service command: : Command requires configs with timestamp=1529647351404 but configs on agent have timestamp=1529647350969; Command requires configs with timestamp=1529647351404 but configs on agent have timestamp=1529647350969
```

Each agent command has a requiredConfigTimestamp parameter which defines the minimum timestamp of the config that is required by the command. If the agent has an older config than the required then the command will fail.

The reason was most likely a race condition in the server. When we send a config update, we store its timestamp before publishing the config. The stored timestamp is used to initialize the requiredConfigTimestamp field of the commands. In other words, the timestamp becomes available too soon, before the config was published.

## How was this patch tested?

I tested general cluster operations to see if everything still works because I couldn't reproduce the exact issue.