### PR TITLE
[AMBARI-24193] - Upgrade Packs Do Not Allow Downgrade by Default

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
@@ -102,7 +102,7 @@ public class UpgradePack {
    * Tag is optional and can be {@code null}, use {@code isDowngradeAllowed} getter instead.
    */
   @XmlElement(name = "downgrade-allowed", required = false, defaultValue = "true")
-  private boolean downgradeAllowed;
+  private boolean downgradeAllowed = true;
 
   /**
    * {@code true} to automatically skip service check failures. The default is

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/stack/UpgradePackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/stack/UpgradePackTest.java
@@ -89,6 +89,33 @@ public class UpgradePackTest {
     H2DatabaseCleaner.clearDatabaseAndStopPersistenceService(injector);
   }
 
+  /**
+   * Tests that boolean values are property serialized in the upgrade pack.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testIsDowngradeAllowed() throws Exception {
+    Map<String, UpgradePack> upgrades = ambariMetaInfo.getUpgradePacks("HDP", "2.2.0");
+    assertTrue(upgrades.size() > 0);
+
+    String upgradePackWithoutDowngrade = "upgrade_test_no_downgrade";
+    boolean foundAtLeastOnePackWithoutDowngrade = false;
+
+    for (String key : upgrades.keySet()) {
+      UpgradePack upgradePack = upgrades.get(key);
+      if (upgradePack.getName().equals(upgradePackWithoutDowngrade)) {
+        foundAtLeastOnePackWithoutDowngrade = true;
+        assertFalse(upgradePack.isDowngradeAllowed());
+        continue;
+      }
+
+      assertTrue(upgradePack.isDowngradeAllowed());
+    }
+
+    assertTrue(foundAtLeastOnePackWithoutDowngrade);
+  }
+
   @Test
   public void testExistence() throws Exception {
     Map<String, UpgradePack> upgrades = ambariMetaInfo.getUpgradePacks("foo", "bar");

--- a/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test_no_downgrade.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.2.0/upgrades/upgrade_test_no_downgrade.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<upgrade xsi:noNamespaceSchemaLocation="upgrade-pack.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5.0</target-stack>
+  <downgrade-allowed>false</downgrade-allowed>
+  <type>ROLLING</type>  
+
+  <order>
+    <group xsi:type="stop" name="STOP_HIVE" title="Stop Hive Server">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <service name="HIVE">
+        <component>HIVE_SERVER</component>
+      </service>
+    </group>    
+
+    <group xsi:type="restart" name="RESTART_HIVE" title="Restart Hive Server">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <service name="HIVE">
+        <component>HIVE_SERVER</component>
+      </service>
+    </group>    
+  </order>
+  
+  <processing>
+    <service name="HIVE">
+      <component name="HIVE_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task"/>
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Noticed on a recent upgrade that should have allowed a downgrade that the option was not present in the UI. Looks like the UpgradePack class needs to default the boolean to true if it's not specified.

## How was this patch tested?

New unit test written to cover this case.