### PR TITLE
AMBARI-24199 : Fix Atlas HA support in Ambari via blueprint deployment.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -3153,7 +3153,6 @@ public class BlueprintConfigurationProcessor {
     multiOozieSiteMap.put("oozie.service.ProxyUserService.proxyuser.knox.hosts", new MultipleHostTopologyUpdater("KNOX_GATEWAY"));
 
     // ATLAS
-    atlasPropsMap.put("atlas.server.bind.address", new SingleHostTopologyUpdater("ATLAS_SERVER"));
     atlasPropsMap.put("atlas.kafka.bootstrap.servers", new MultipleHostTopologyUpdater("KAFKA_BROKER"));
     atlasPropsMap.put("atlas.kafka.zookeeper.connect", new MultipleHostTopologyUpdater("ZOOKEEPER_SERVER"));
     atlasPropsMap.put("atlas.graph.index.search.solr.zookeeper-url", new MultipleHostTopologyUpdater("ZOOKEEPER_SERVER", ',', false, true, true));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -7064,7 +7064,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Map<String, String> atlasProperties = new HashMap<>();
     atlasProperties.put("atlas.enableTLS", "false");
-    atlasProperties.put("atlas.server.bind.address", "localhost");
     atlasProperties.put("atlas.server.http.port", "21000");
     properties.put("application-properties", atlasProperties);
 
@@ -7109,7 +7108,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     assertEquals("org.apache.atlas.hive.hook.HiveHook", clusterConfig.getPropertyValue("hive-site", "hive.exec.post.hooks"));
     assertEquals(null, clusterConfig.getPropertyValue("hive-site", "atlas.cluster.name"));
     assertEquals(null, clusterConfig.getPropertyValue("hive-site", "atlas.rest.address"));
-    assertEquals("host1", clusterConfig.getPropertyValue("application-properties", "atlas.server.bind.address"));
   }
 
   @Test
@@ -7120,7 +7118,6 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     properties.put("application-properties", atlasProperties);
     // use https
     atlasProperties.put("atlas.enableTLS", "true");
-    atlasProperties.put("atlas.server.bind.address", "localhost");
     atlasProperties.put("atlas.server.https.port", "99999");
     Map<String, String> atlasEnv = new HashMap<>();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently deploying Atlas in HA mode via blueprint is not possible due to property atlas.server.bind.address being set by Blueprint Processor, need to remove the property from being processed in Blueprint Processor and let the default value to be effective.


## How was this patch tested?
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.server.controller.internal.BlueprintConfigurationProcessorTest
[INFO] Tests run: 185, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.656 s - in org.apache.ambari.server.controller.internal.BlueprintConfigurationProcessorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 185, Failures: 0, Errors: 0, Skipped: 0


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.