### PR TITLE
[AMBARI-24203] - Check for under-replicated partitions in Kafka service check

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
@@ -60,7 +60,7 @@ class ServiceCheck(Script):
 
     if under_rep_cmd_code > 0:
       raise Fail("Error encountered when attempting find under replicated partitions: {0}".format(under_rep_cmd_out))
-    elif len(under_rep_cmd_out) > 0 and "TOPIC" in under_rep_cmd_out:
+    elif len(under_rep_cmd_out) > 0 and "Topic" in under_rep_cmd_out:
       raise Fail("Under replicated partitions found: {0}".format(under_rep_cmd_out))
 
   def read_kafka_config(self):

--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
@@ -48,22 +48,24 @@ class ServiceCheck(Script):
       Logger.info('Kafka delete.topic.enable is not enabled. Skipping topic creation: %s' % topic)
       return
 
-  # run create topic command only if the topic doesn't exists
-    
-    delete_topic_cmd = format("{kafka_home}/bin/kafka-topics.sh --zookeeper {kafka_config[zookeeper.connect]} --delete --topic {topic}")
-    create_topic_cmd = format("{kafka_home}/bin/kafka-topics.sh --zookeeper {kafka_config[zookeeper.connect]} --create --topic {topic} --partitions 1 --replication-factor 1")
-    if topic in topic_exists_cmd_out:
-      # run delete topic and recreate the topic command only if the topic exists
-      command = source_cmd + " ; " + delete_topic_cmd + ";" + create_topic_cmd
-    else:
-      # run create topic command 
+    # run create topic command only if the topic doesn't exists
+    if topic not in topic_exists_cmd_out:
+      create_topic_cmd = format("{kafka_home}/bin/kafka-topics.sh --zookeeper {kafka_config[zookeeper.connect]} --create --topic {topic} --partitions 1 --replication-factor 1")
       command = source_cmd + " ; " + create_topic_cmd
-    Logger.info("Running kafka create topic command: %s" % command)
-    call_and_match_output(command, format("({create_topic_cmd_created_output})|({create_topic_cmd_exists_output})"), "Failed to check that topic exists", user=params.kafka_user)
+      Logger.info("Running kafka create topic command: %s" % command)
+      call_and_match_output(command, format("({create_topic_cmd_created_output})|({create_topic_cmd_exists_output})"), "Failed to check that topic exists", user=params.kafka_user)
+
+    under_rep_cmd = format("{kafka_home}/bin/kafka-topics.sh --describe --zookeeper {kafka_config[zookeeper.connect]} --under-replicated-partitions")
+    under_rep_cmd_code, under_rep_cmd_out = shell.call(under_rep_cmd, logoutput=True, quiet=False, user=params.kafka_user)
+
+    if under_rep_cmd_code > 0:
+      raise Fail("Error encountered when attempting find under replicated partitions: {0}".format(under_rep_cmd_out))
+    elif len(under_rep_cmd_out) > 0 and "TOPIC" in under_rep_cmd_out:
+      raise Fail("Under replicated partitions found: {0}".format(under_rep_cmd_out))
 
   def read_kafka_config(self):
     import params
-    
+
     kafka_config = {}
     content = sudo.read_file(params.conf_dir + "/server.properties")
     for line in content.splitlines():
@@ -72,7 +74,7 @@ class ServiceCheck(Script):
 
       key, value = line.split("=")
       kafka_config[key] = value.replace("\n", "")
-    
+
     return kafka_config
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) Ensure that updates applied to Kafka service check in 2.6 are carried into trunk
2) Apply an additional health check using kafka-topic.sh script to detect any under replicated partitions 

## How was this patch tested?

Manual cluster test

