### PR TITLE
[AMBARI-24196] Mpack Instance Manager Produces Bad JSON and Doesn't Li…

### DIFF
--- a/mpack-instance-manager/src/main/python/instance_manager/instance_manager.py
+++ b/mpack-instance-manager/src/main/python/instance_manager/instance_manager.py
@@ -339,7 +339,7 @@ class MetaMpack:
     if not self.mpack_json:
       return None
     for module in self.mpack_json['modules']:
-      result[module['id']] = module['category']
+      result[module['id']] = str(module['category'])
 
     return result
 
@@ -597,6 +597,9 @@ class ComponentInstance(Instance):
     self.name = name
     self.component_path = component_path
     self.path_exec = path_exec
+    self.module_path = os.readlink(path_exec)
+    self.mpack_version = os.path.basename(os.path.dirname(path_exec))
+    self.module_version = os.path.basename(self.module_path)
 
   def set_new_version(self, mpack_name, mpack_version, component_type):
     mpack_path = os.path.join(ROOT_FOLDER_PATH, MPACKS_FOLDER_NAME, mpack_name, mpack_version, component_type)
@@ -686,5 +689,12 @@ class ComponentInstance(Instance):
     if output_run_dir:
       result['run_dir'] = os.path.join(self.component_path, RUN_DIRECTORY_NAME)
     if output_path:
-      result['path'] = self.path_exec
+      result['mpack_path'] = self.path_exec
+      result['module_path'] = self.module_path
+      result['instance_path'] = os.path.join(self.component_path, CURRENT_SOFTLINK_NAME)
+      result['config_dir'] = os.path.join(self.component_path, CONFIGS_DIRECTORY_NAME)
+      result['log_dir'] = os.path.join(self.component_path, LOG_DIRECTORY_NAME)
+      result['run_dir'] = os.path.join(self.component_path, RUN_DIRECTORY_NAME)
+      result['mpack_version'] = self.mpack_version
+      result['module_version'] = self.module_version
     return result

--- a/mpack-instance-manager/src/main/python/instance_manager/mpack-instance-manager.py
+++ b/mpack-instance-manager/src/main/python/instance_manager/mpack-instance-manager.py
@@ -22,6 +22,7 @@ from instance_manager import *
 import optparse
 import sys
 import ast
+import json
 
 CREATE_MPACK_INSTANCE_ACTION = 'create-mpack-instance'
 SET_MPACK_INSTANCE_ACTION = 'set-mpack-instance'
@@ -29,6 +30,7 @@ GET_CONF_DIR_ACTION = 'get-conf-dir'
 GET_LOG_DIR_ACTION = 'get-log-dir'
 GET_RUN_DIR_ACTION = 'get-run-dir'
 LIST_INSTANCES_ACTION = 'list-instances'
+INDENT = 2
 
 
 def init_action_parser(action, parser):
@@ -119,7 +121,8 @@ def init_get_parser_options(parser):
   parser.add_option('--components-map', default=None,
                     help="map of 'component type' (eg: hive_server, metastore etc) as key and List of component instance name(s) to be given (eg: HS-1, finance_metastore) as value OR Empty map for all component instances present",
                     dest="components_map")
-
+  parser.add_option('-f', '--format', action="store_true",
+                    help='output json to readable text format')
 
 def main(options, args):
   action = sys.argv[1]
@@ -137,6 +140,8 @@ def main(options, args):
   except ValueError:
     raise ValueError("Components or components-map format is invalid.")
 
+  indent = INDENT if options.format else None
+
   if action == CREATE_MPACK_INSTANCE_ACTION:
     create_mpack(mpack_name=options.mpack, mpack_version=options.mpack_version,
                  mpack_instance=options.mpack_instance,
@@ -152,25 +157,24 @@ def main(options, args):
                        components_map=parsed_components_map)
 
   elif action == GET_CONF_DIR_ACTION:
-    print get_conf_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+    print json.dumps(get_conf_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
                        subgroup_name=options.subgroup_name, module_name=options.module_name,
-                       components_map=parsed_components_map)
+                       components_map=parsed_components_map), indent=indent)
 
   elif action == GET_LOG_DIR_ACTION:
-    print get_log_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+    print json.dumps(get_log_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
                        subgroup_name=options.subgroup_name, module_name=options.module_name,
-                       components_map=parsed_components_map)
+                       components_map=parsed_components_map), indent=indent)
 
   elif action == GET_RUN_DIR_ACTION:
-    print get_run_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+    print json.dumps(get_run_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
                        subgroup_name=options.subgroup_name, module_name=options.module_name,
-                       components_map=parsed_components_map)
+                       components_map=parsed_components_map), indent=indent)
 
   elif action == LIST_INSTANCES_ACTION:
-    print list_instances(mpack=options.mpack, mpack_instance=options.mpack_instance,
-                         subgroup_name=options.subgroup_name, module_name=options.module_name,
-                         components_map=parsed_components_map)
-
+    print json.dumps(list_instances(mpack=options.mpack, mpack_instance=options.mpack_instance,
+                                      subgroup_name=options.subgroup_name, module_name=options.module_name,
+                                      components_map=parsed_components_map), indent=indent)
 
 if __name__ == "__main__":
   if len(sys.argv) < 2:

--- a/mpack-instance-manager/src/main/python/instance_manager/mpack-instance-manager.py
+++ b/mpack-instance-manager/src/main/python/instance_manager/mpack-instance-manager.py
@@ -22,6 +22,7 @@ from instance_manager import *
 import optparse
 import sys
 import ast
+import json
 
 CREATE_MPACK_INSTANCE_ACTION = 'create-mpack-instance'
 SET_MPACK_INSTANCE_ACTION = 'set-mpack-instance'
@@ -29,6 +30,7 @@ GET_CONF_DIR_ACTION = 'get-conf-dir'
 GET_LOG_DIR_ACTION = 'get-log-dir'
 GET_RUN_DIR_ACTION = 'get-run-dir'
 LIST_INSTANCES_ACTION = 'list-instances'
+INDENT = 2
 
 
 def init_action_parser(action, parser):
@@ -119,7 +121,8 @@ def init_get_parser_options(parser):
   parser.add_option('--components-map', default=None,
                     help="map of 'component type' (eg: hive_server, metastore etc) as key and List of component instance name(s) to be given (eg: HS-1, finance_metastore) as value OR Empty map for all component instances present",
                     dest="components_map")
-
+  parser.add_option('-f', '--format', action="store_true",
+                    help='output json to readable text format')
 
 def main(options, args):
   action = sys.argv[1]
@@ -152,24 +155,44 @@ def main(options, args):
                        components_map=parsed_components_map)
 
   elif action == GET_CONF_DIR_ACTION:
-    print get_conf_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+    if options.format:
+      print json.dumps(get_conf_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
                        subgroup_name=options.subgroup_name, module_name=options.module_name,
-                       components_map=parsed_components_map)
+                       components_map=parsed_components_map), indent=INDENT)
+    else:
+      print json.dumps(get_conf_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+                                    subgroup_name=options.subgroup_name, module_name=options.module_name,
+                                    components_map=parsed_components_map))
 
   elif action == GET_LOG_DIR_ACTION:
-    print get_log_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+    if options.format:
+      print json.dumps(get_log_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
                        subgroup_name=options.subgroup_name, module_name=options.module_name,
-                       components_map=parsed_components_map)
+                       components_map=parsed_components_map), indent=INDENT)
+    else:
+      print json.dumps(get_log_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+                                   subgroup_name=options.subgroup_name, module_name=options.module_name,
+                                   components_map=parsed_components_map))
 
   elif action == GET_RUN_DIR_ACTION:
-    print get_run_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+    if options.format:
+      print json.dumps(get_run_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
                        subgroup_name=options.subgroup_name, module_name=options.module_name,
-                       components_map=parsed_components_map)
+                       components_map=parsed_components_map), indent=INDENT)
+    else:
+      print json.dumps(get_run_dir(mpack=options.mpack, mpack_instance=options.mpack_instance,
+                                   subgroup_name=options.subgroup_name, module_name=options.module_name,
+                                   components_map=parsed_components_map))
 
   elif action == LIST_INSTANCES_ACTION:
-    print list_instances(mpack=options.mpack, mpack_instance=options.mpack_instance,
-                         subgroup_name=options.subgroup_name, module_name=options.module_name,
-                         components_map=parsed_components_map)
+    if options.format:
+      print json.dumps(list_instances(mpack=options.mpack, mpack_instance=options.mpack_instance,
+                                      subgroup_name=options.subgroup_name, module_name=options.module_name,
+                                      components_map=parsed_components_map), indent=INDENT)
+    else:
+      print json.dumps(list_instances(mpack=options.mpack, mpack_instance=options.mpack_instance,
+                                      subgroup_name=options.subgroup_name, module_name=options.module_name,
+                                      components_map=parsed_components_map))
 
 
 if __name__ == "__main__":

--- a/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
+++ b/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
@@ -344,8 +344,15 @@ class TestInstanceManager(TestCase):
                         "hdfs_server": {
                           "component-instances": {
                             "server1": {
-                              "path": "/tmp/instance_manager_test/mpacks/hdpcore/1.0.0-b1/hdfs_server",
-                              "name": "server1"
+                              "run_dir": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/run",
+                              "module_version": "3.1.0.0-b1",
+                              "name": "server1",
+                              "mpack_path": "/tmp/instance_manager_test/mpacks/hdpcore/1.0.0-b1/hdfs_server",
+                              "mpack_version": "1.0.0-b1",
+                              "instance_path": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/current",
+                              "log_dir": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/log",
+                              "module_path": "/tmp/instance_manager_test/modules/hdfs/3.1.0.0-b1",
+                              "config_dir": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/conf"
                             }
                           }
                         }
@@ -357,10 +364,17 @@ class TestInstanceManager(TestCase):
                         "hdfs_client": {
                           "component-instances": {
                             "default": {
-                              "path": "/tmp/instance_manager_test/mpacks/hdpcore/1.0.0-b1/hdfs_client",
-                              "name": "default"
+                              "run_dir": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/run",
+                              "module_version": "3.1.0.0-b1",
+                              "name": "default",
+                              "mpack_path": "/tmp/instance_manager_test/mpacks/hdpcore/1.0.0-b1/hdfs_client",
+                              "mpack_version": "1.0.0-b1",
+                              "instance_path": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/current",
+                              "log_dir": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/log",
+                              "module_path": "/tmp/instance_manager_test/modules/hdfs-clients/3.1.0.0-b1",
+                              "config_dir": "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/conf"
                             }
-                           }
+                          }
                         }
                       },
                       "name": "hdfs-clients"
@@ -373,7 +387,7 @@ class TestInstanceManager(TestCase):
         }
       }
     }
-    self.assertEqual(conf_dir_json, expected_json)
+    self.assertDictEqual(conf_dir_json, expected_json)
 
   def test_granularity(self):
     create_mpack_with_defaults()
@@ -438,7 +452,7 @@ class TestInstanceManager(TestCase):
     expected_filter_result = {'mpacks': {'edw': {'mpack-instances': {'eCommerce': {'name': 'eCommerce', 'subgroups': {
       'default': {'modules': {'hdfs': {'category': 'SERVER', 'name': 'hdfs', 'components': {'hdfs_server': {
         'component-instances': {
-          'server2': {'path': '/tmp/instance_manager_test/mpacks/edw/1.0.0-b1/hdfs_server', 'name': 'server2'}}}}}}}}}}}}}
+          'server2': {'run_dir': '/tmp/instance_manager_test/instances/edw/eCommerce/default/hdfs/hdfs_server/server2/run', 'module_version': '3.1.0.0-b1', 'name': 'server2', 'mpack_path': '/tmp/instance_manager_test/mpacks/edw/1.0.0-b1/hdfs_server', 'mpack_version': '1.0.0-b1', 'instance_path': '/tmp/instance_manager_test/instances/edw/eCommerce/default/hdfs/hdfs_server/server2/current', 'log_dir': '/tmp/instance_manager_test/instances/edw/eCommerce/default/hdfs/hdfs_server/server2/log', 'module_path': '/tmp/instance_manager_test/modules/hdfs/3.1.0.0-b1', 'config_dir': '/tmp/instance_manager_test/instances/edw/eCommerce/default/hdfs/hdfs_server/server2/conf'}}}}}}}}}}}}}
     self.assertEquals(expected_filter_result, filter_by_component_instance_name_json)
 
   def test_validation(self):


### PR DESCRIPTION
…st Versions

## What changes were proposed in this pull request?

Update mpack-instance-manager code to list mpack instances with run_dir, log_dir, conf_dir, mpack_path, module_path, instance_path and mpack_version, module_version. Aslo fixed several bugs
(removed unicde str, change single quote to double quote etc)

## How was this patch tested?

(1) UT
(2) Manually Tested:

# mpack-instance-manager list-instances 
{"mpacks": {"ods": {"mpack-instances": {"ODS": {"name": "ODS", "subgroups": {"default": {"modules": {"hbase": {"category": "SERVER", "name": "hbase", "components": {"hbase_master": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/run", "module_version": "2.0.0.0-b243", "name": "default", "mpack_path": "/usr/hwx/mpacks/ods/1.0.0-b351/hbase_master", "mpack_version": "1.0.0-b351", "instance_path": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/current", "log_dir": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/log", "module_path": "/usr/hwx/modules/hbase/2.0.0.0-b243", "config_dir": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/conf"}}}}}, "hadoop_clients": {"category": "CLIENT", "name": "hadoop_clients", "components": {"hadoop_client": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/ods/ODS/default/hadoop_client/run", "module_version": "3.0.0.0-b213", "name": "default", "mpack_path": "/usr/hwx/mpacks/ods/1.0.0-b351/hadoop_client", "mpack_version": "1.0.0-b351", "instance_path": "/usr/hwx/instances/ods/ODS/default/hadoop_client/current", "log_dir": "/usr/hwx/instances/ods/ODS/default/hadoop_client/log", "module_path": "/usr/hwx/modules/hadoop_clients/3.0.0.0-b213", "config_dir": "/usr/hwx/instances/ods/ODS/default/hadoop_client/conf"}}}}}}}}}}}, "hdpcore": {"mpack-instances": {"HDPCORE": {"name": "HDPCORE", "subgroups": {"default": {"modules": {"hdfs": {"category": "SERVER", "name": "hdfs", "components": {"namenode": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/run", "module_version": "3.0.0.0-b213", "name": "default", "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/namenode", "mpack_version": "1.0.0-b486", "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/current", "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/log", "module_path": "/usr/hwx/modules/hdfs/3.0.0.0-b213", "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/conf"}}}}}, "hadoop_clients": {"category": "CLIENT", "name": "hadoop_clients", "components": {"hadoop_client": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/run", "module_version": "3.0.0.0-b213", "name": "default", "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/hadoop_client", "mpack_version": "1.0.0-b486", "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/current", "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/log", "module_path": "/usr/hwx/modules/hadoop_clients/3.0.0.0-b213", "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/conf"}}}}}, "yarn": {"category": "SERVER", "name": "yarn", "components": {"yarn_registry_dns": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/run", "module_version": "3.0.0.0-b213", "name": "default", "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/yarn_registry_dns", "mpack_version": "1.0.0-b486", "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/current", "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/log", "module_path": "/usr/hwx/modules/yarn/3.0.0.0-b213", "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/conf"}}}, "timeline_reader": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/run", "module_version": "3.0.0.0-b213", "name": "default", "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/timeline_reader", "mpack_version": "1.0.0-b486", "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/current", "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/log", "module_path": "/usr/hwx/modules/yarn/3.0.0.0-b213", "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/conf"}}}, "resourcemanager": {"component-instances": {"default": {"run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/run", "module_version": "3.0.0.0-b213", "name": "default", "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/resourcemanager", "mpack_version": "1.0.0-b486", "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/current", "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/log", "module_path": "/usr/hwx/modules/yarn/3.0.0.0-b213", "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/conf"}}}}}}}}}}}}}

===================================

# mpack-instance-manager list-instances --format
{
  "mpacks": {
    "ods": {
      "mpack-instances": {
        "ODS": {
          "name": "ODS", 
          "subgroups": {
            "default": {
              "modules": {
                "hbase": {
                  "category": "SERVER", 
                  "name": "hbase", 
                  "components": {
                    "hbase_master": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/run", 
                          "module_version": "2.0.0.0-b243", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/ods/1.0.0-b351/hbase_master", 
                          "mpack_version": "1.0.0-b351", 
                          "instance_path": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/current", 
                          "log_dir": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/log", 
                          "module_path": "/usr/hwx/modules/hbase/2.0.0.0-b243", 
                          "config_dir": "/usr/hwx/instances/ods/ODS/default/hbase/hbase_master/default/conf"
                        }
                      }
                    }
                  }
                }, 
                "hadoop_clients": {
                  "category": "CLIENT", 
                  "name": "hadoop_clients", 
                  "components": {
                    "hadoop_client": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/ods/ODS/default/hadoop_client/run", 
                          "module_version": "3.0.0.0-b213", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/ods/1.0.0-b351/hadoop_client", 
                          "mpack_version": "1.0.0-b351", 
                          "instance_path": "/usr/hwx/instances/ods/ODS/default/hadoop_client/current", 
                          "log_dir": "/usr/hwx/instances/ods/ODS/default/hadoop_client/log", 
                          "module_path": "/usr/hwx/modules/hadoop_clients/3.0.0.0-b213", 
                          "config_dir": "/usr/hwx/instances/ods/ODS/default/hadoop_client/conf"
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }, 
    "hdpcore": {
      "mpack-instances": {
        "HDPCORE": {
          "name": "HDPCORE", 
          "subgroups": {
            "default": {
              "modules": {
                "hdfs": {
                  "category": "SERVER", 
                  "name": "hdfs", 
                  "components": {
                    "namenode": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/run", 
                          "module_version": "3.0.0.0-b213", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/namenode", 
                          "mpack_version": "1.0.0-b486", 
                          "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/current", 
                          "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/log", 
                          "module_path": "/usr/hwx/modules/hdfs/3.0.0.0-b213", 
                          "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hdfs/namenode/default/conf"
                        }
                      }
                    }
                  }
                }, 
                "hadoop_clients": {
                  "category": "CLIENT", 
                  "name": "hadoop_clients", 
                  "components": {
                    "hadoop_client": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/run", 
                          "module_version": "3.0.0.0-b213", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/hadoop_client", 
                          "mpack_version": "1.0.0-b486", 
                          "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/current", 
                          "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/log", 
                          "module_path": "/usr/hwx/modules/hadoop_clients/3.0.0.0-b213", 
                          "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/hadoop_client/conf"
                        }
                      }
                    }
                  }
                }, 
                "yarn": {
                  "category": "SERVER", 
                  "name": "yarn", 
                  "components": {
                    "yarn_registry_dns": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/run", 
                          "module_version": "3.0.0.0-b213", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/yarn_registry_dns", 
                          "mpack_version": "1.0.0-b486", 
                          "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/current", 
                          "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/log", 
                          "module_path": "/usr/hwx/modules/yarn/3.0.0.0-b213", 
                          "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/yarn_registry_dns/default/conf"
                        }
                      }
                    }, 
                    "timeline_reader": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/run", 
                          "module_version": "3.0.0.0-b213", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/timeline_reader", 
                          "mpack_version": "1.0.0-b486", 
                          "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/current", 
                          "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/log", 
                          "module_path": "/usr/hwx/modules/yarn/3.0.0.0-b213", 
                          "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/timeline_reader/default/conf"
                        }
                      }
                    }, 
                    "resourcemanager": {
                      "component-instances": {
                        "default": {
                          "run_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/run", 
                          "module_version": "3.0.0.0-b213", 
                          "name": "default", 
                          "mpack_path": "/usr/hwx/mpacks/hdpcore/1.0.0-b486/resourcemanager", 
                          "mpack_version": "1.0.0-b486", 
                          "instance_path": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/current", 
                          "log_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/log", 
                          "module_path": "/usr/hwx/modules/yarn/3.0.0.0-b213", 
                          "config_dir": "/usr/hwx/instances/hdpcore/HDPCORE/default/yarn/resourcemanager/default/conf"
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
} 
