### PR TITLE
[AMBARI-24205] Disable flaky test: TestHeartbeatHandler.testComponents

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
@@ -1301,17 +1301,14 @@ public class TestHeartbeatHandler {
 
   }
 
-  @Test
-  public void testComponents() throws Exception,
-      InvalidStateTransitionException {
+  @Test @Ignore
+  public void testComponents() throws Exception {
 
     ComponentsResponse expected = new ComponentsResponse();
     StackId dummyStackId = new StackId(DummyStackId);
     Map<String, Map<String, String>> dummyComponents = new HashMap<>();
 
     Map<String, String> dummyCategoryMap = new HashMap<>();
-
-    dummyCategoryMap = new HashMap<>();
     dummyCategoryMap.put("NAMENODE", "MASTER");
     dummyComponents.put("HDFS", dummyCategoryMap);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestHeartbeatHandler.testComponents` is flaky, failing about 15% of the time in pull request builds.  For now just disabling it, until the root cause can be identified.

## How was this patch tested?

Compiled and ran `TestHeartbeatHandler`.