### PR TITLE
ambari: Add jdeb support

### DIFF
--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -24,6 +24,28 @@
   <description>Ambari Functional Tests</description>
   <build>
     <plugins>
+       <plugin>
+         <groupId>org.vafer</groupId>
+         <artifactId>jdeb</artifactId>
+         <version>1.0.1</version>
+         <executions>
+           <execution>
+             <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+             <id>stub-execution</id>
+             <phase>none</phase>
+             <goals>
+               <goal>jdeb</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <skip>true</skip>
+           <attach>false</attach>
+           <submodules>false</submodules>
+           <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+         </configuration>
+      </plugin>
+
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -127,6 +127,28 @@
       </plugins>
     </pluginManagement>
     <plugins>
+       <plugin>
+         <groupId>org.vafer</groupId>
+         <artifactId>jdeb</artifactId>
+         <version>1.0.1</version>
+         <executions>
+           <execution>
+             <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+             <id>stub-execution</id>
+             <phase>none</phase>
+             <goals>
+               <goal>jdeb</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <skip>true</skip>
+           <attach>false</attach>
+           <submodules>false</submodules>
+           <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+         </configuration>
+       </plugin>
+
       <plugin>
         <inherited>false</inherited>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/ambari-metrics/ambari-metrics-grafana/pom.xml
+++ b/ambari-metrics/ambari-metrics-grafana/pom.xml
@@ -33,6 +33,28 @@
 
   <build>
     <plugins>
+       <plugin>
+         <groupId>org.vafer</groupId>
+         <artifactId>jdeb</artifactId>
+         <version>1.0.1</version>
+         <executions>
+           <execution>
+             <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+             <id>stub-execution</id>
+             <phase>none</phase>
+             <goals>
+               <goal>jdeb</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <skip>true</skip>
+           <attach>false</attach>
+           <submodules>false</submodules>
+           <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+         </configuration>
+       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
This patch add jdeb (debian) package creation support for the following
packages.
-ambari-funtest
-ambari-logsearch
-ambari-metrics-grafana

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>

## What changes were proposed in this pull request?

Add jdeb support patch for trunk

## How was this patch tested?

The patch has been applied, built and tested on Debian 9 stretch.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.