### PR TITLE
AMBARI-24214. Log Search: config api validator in Configuration Edito…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerFilterGrok.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerFilterGrok.java
@@ -33,7 +33,6 @@ public class LSServerFilterGrok extends LSServerFilter {
   @JsonProperty("log4j_format")
   private String log4jFormat;
 
-  @NotNull
   @JsonProperty("multiline_pattern")
   private String multilinePattern;
 


### PR DESCRIPTION
…r throws 'IllegalArgumentException'

## What changes were proposed in this pull request?

Issue:
1. Login to logsearch portal
2. Navigate to Configuration Editor
3. Select a valid component in the Validator drop down, and Type in some sample test data in the Sample Data text area, click Test. This should validate the sample data and show valid response to the user, but throws a illegalArgumentException.


```bash
java.lang.IllegalArgumentException: Error validating shipper config:
[ConstraintViolationImpl{interpolatedMessage='may not be null', propertyPath=filter[3].multilinePattern, rootBeanClass=class org.apache.ambari.logsearch.model.common.LSServerInputConfig, messageTemplate='{javax.validation.constraints.NotNull.message}'}]
```

That can happen as we are not using multiline pattern for every grok filter (as sometimes we are chaining them with different filters)

## How was this patch tested?
manually with docker env.

Please review @g-boros @kasakrisz @swagle 