### PR TITLE
AMBARI-24216 Updating admin user password field value for Ranger and Atlas (mugdha)

### DIFF
--- a/ambari-server/src/main/resources/common-services/RANGER/0.4.0/configuration/ranger-env.xml
+++ b/ambari-server/src/main/resources/common-services/RANGER/0.4.0/configuration/ranger-env.xml
@@ -103,7 +103,7 @@
   </property>
   <property>
     <name>admin_password</name>
-    <value>admin</value>
+    <value></value>
     <property-type>PASSWORD</property-type>
     <description>This is the password for default admin user that is used for creating ambari user in Ranger Admin</description>
     <value-attributes>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/ATLAS/configuration/atlas-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/ATLAS/configuration/atlas-env.xml
@@ -31,7 +31,7 @@
     <name>atlas.admin.password</name>
     <display-name>Admin password</display-name>
     <description>Admin Login password</description>
-    <value>admin</value>
+    <value></value>
     <property-type>PASSWORD</property-type>
     <value-attributes>
       <type>password</type>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updating below admin user password configs in stack.
Ranger: `admin_password/ranger-env`
Atlas: `atlas.admin.password/atlas-env`

## How was this patch tested?
Unit Test Report:
Ran 244 tests in 8.030s

OK

Total run:1200
Total errors:0
Total failures:0
OK
