### PR TITLE
[AMBARI-24221] Add Service Wizard: Next Button is not enabled while adding Ranger after fixing an erroneous property

### DIFF
--- a/ambari-web/test/controllers/wizard/step7_test.js
+++ b/ambari-web/test/controllers/wizard/step7_test.js
@@ -2105,4 +2105,8 @@ describe('App.InstallerStep7Controller', function () {
 
   });
 
+  App.TestAliases.testAsComputedEqual(installerStep7Controller, 'isInstallWizard', 'content.controllerName', 'installerController');
+
+  App.TestAliases.testAsComputedEqual(installerStep7Controller, 'isAddServiceWizard', 'content.controllerName', 'addServiceController');
+
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Following are the steps performed
- On an already deployed cluster (without Ranger) setup ldap
- navigate to Add Service wizard to add ranger
- Use Authentication method as LDAP
- At customize services property populate all required fields
- Set one of the password to not meet the requirement (say set it as rangeradmin)
- Click Next. There will be a warning popup which says properties did not meet the requirements and user has to change it before proceeding
- Close the popup and find the property which has to be changed (It would be better if user is navigated to the property upon clicking on the warning popup itself)
- Fix this property, notice that there are no other properties which needs attention
- Still Next button is not enabled

## How was this patch tested?

Tested manually.
UI unit tests:
  21797 passing (28s)
  48 pending