### PR TITLE
[AMBARI-24229] - Prevent Configuration Changes During Keytab Regeneration in an Upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -857,6 +857,8 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
               Map<String, String> requestProperties = new HashMap<>();
               requestProperties.put(SupportedCustomOperation.REGENERATE_KEYTABS.name().toLowerCase(), "missing");
               requestProperties.put(KerberosHelper.ALLOW_RETRY, Boolean.TRUE.toString().toLowerCase());
+              requestProperties.put(KerberosHelper.DIRECTIVE_IGNORE_CONFIGS,
+                  Boolean.TRUE.toString().toLowerCase());
 
               // add stages to the upgrade which will regenerate missing keytabs only
               req = s_kerberosHelper.get().executeCustomOperations(cluster, requestProperties, req, null);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeResourceProviderTest.java
@@ -2213,7 +2213,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     Map<String, String> requestPropertyMap = requestPropertyMapCapture.getValue();
     assertEquals("true", requestPropertyMap.get(KerberosHelper.ALLOW_RETRY));
     assertEquals("true", requestPropertyMap.get(KerberosHelper.DIRECTIVE_IGNORE_CONFIGS));
-    assertEquals("missing", SupportedCustomOperation.REGENERATE_KEYTABS.name().toLowerCase());
+    assertEquals("missing", requestPropertyMap.get(SupportedCustomOperation.REGENERATE_KEYTABS.name().toLowerCase()));
 
     verifyAll();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's too dangerous to have the {{KerberosHelper}} reach out to the service advisor during an upgrade and alter configurations. We should prevent this from happening. It can cause reversions of properties which were specifically set by the upgrade.

## How was this patch tested?

Manually upgraded a Kerberized cluster to verify that the configurations were not changed by Kerberos. Added test coverage as well.