### PR TITLE
[AMBARI-24213] Enabling RM HA should not be allowed if YARN is stopped

### DIFF
--- a/ambari-web/app/controllers/main/admin/highAvailability_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability_controller.js
@@ -65,6 +65,10 @@ App.MainAdminHighAvailabilityController = App.WizardController.extend({
   enableRMHighAvailability: function () {
     //Prerequisite Checks
     var message = [];
+
+    if (hostComponents.findProperty('componentName', 'RESOURCEMANAGER').get('workStatus') !== 'STARTED') {
+      message.push(Em.I18n.t('admin.rm_highAvailability.error.resourceManagerStarted'));
+    }
     if (App.HostComponent.find().filterProperty('componentName', 'ZOOKEEPER_SERVER').length < 3) {
       message.push(Em.I18n.t('admin.rm_highAvailability.error.zooKeeperNum'));
     }

--- a/ambari-web/app/controllers/main/admin/highAvailability_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability_controller.js
@@ -66,7 +66,7 @@ App.MainAdminHighAvailabilityController = App.WizardController.extend({
     //Prerequisite Checks
     var message = [];
 
-    if (hostComponents.findProperty('componentName', 'RESOURCEMANAGER').get('workStatus') !== 'STARTED') {
+    if (App.HostComponent.find().findProperty('componentName', 'RESOURCEMANAGER').get('workStatus') !== 'STARTED') {
       message.push(Em.I18n.t('admin.rm_highAvailability.error.resourceManagerStarted'));
     }
     if (App.HostComponent.find().filterProperty('componentName', 'ZOOKEEPER_SERVER').length < 3) {

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -1457,6 +1457,7 @@ Em.I18n.translations = {
   'admin.highAvailability.error.zooKeeperNum':'You must have at least 3 ZooKeeper Servers in your cluster to enable NameNode HA.',
   'admin.rm_highAvailability.error.hostsNum':'You must have at least 3 hosts in your cluster to enable ResourceManager HA.',
   'admin.rm_highAvailability.error.zooKeeperNum':'You must have at least 3 ZooKeeper Servers in your cluster to enable ResourceManager HA.',
+  'admin.rm_highAvailability.error.resourceManagerStarted':'ResourceManager must be running before you enable ResourceManager HA.',
   'admin.rm_highAvailability.closePopup':'Enable ResourceManager HA Wizard is in progress. You must allow the wizard to complete for Ambari to be in usable state. If you choose to quit, you must follow manual instructions to complete or revert enabling ResourceManager HA as documented in the Ambari User Guide. Are you sure you want to exit the wizard?',
 
   'admin.highAvailability.wizard.header':'Enable NameNode HA Wizard',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enabling RM HA should not be allowed if YARN is stopped. There should be a popup message saying RM should be up before enabling HA, similar to NN HA wizard warning

## How was this patch tested?

  21797 passing (32s)
  48 pending