### PR TITLE
AMBARI-24230 - [Logsearch] Update hdfs configuration from Configurati…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputConfigGson.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputConfigGson.java
@@ -27,7 +27,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 /**
- * Helper class to convert betweeb json string and InputConfig class.
+ * Helper class to convert between json string and InputConfig class.
  */
 public class InputConfigGson {
   public static Gson gson;

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldCopyDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldCopyDescriptorImpl.java
@@ -33,7 +33,7 @@ import com.google.gson.annotations.SerializedName;
 public class MapFieldCopyDescriptorImpl extends MapFieldDescriptorImpl implements MapFieldCopyDescriptor {
   @Override
   public String getJsonName() {
-    return "map_fieldcopy";
+    return "map_field_copy";
   }
 
   @ShipperConfigElementDescription(

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldNameDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldNameDescriptorImpl.java
@@ -28,22 +28,22 @@ import com.google.gson.annotations.SerializedName;
 
 @ShipperConfigTypeDescription(
     name = "Map Field Name",
-    description = "The name of the mapping element should be map_fieldname. The value json element should contain the following parameter:"
+    description = "The name of the mapping element should be map_field_name. The value json element should contain the following parameter:"
 )
 public class MapFieldNameDescriptorImpl extends MapFieldDescriptorImpl implements MapFieldNameDescriptor {
   @Override
   public String getJsonName() {
-    return "map_fieldname";
+    return "map_field_name";
   }
 
   @ShipperConfigElementDescription(
-    path = "/filter/[]/post_map_values/{field_name}/[]/map_fieldname/new_field_name",
+    path = "/filter/[]/post_map_values/{field_name}/[]/map_field_name/new_field_name",
     type = "string",
     description = "The name of the renamed field",
     examples = {"new_name"}
   )
   @Expose
-  @SerializedName("new_fieldname")
+  @SerializedName("new_field_name")
   private String newFieldName;
 
   @Override

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldValueDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldValueDescriptorImpl.java
@@ -28,16 +28,16 @@ import com.google.gson.annotations.SerializedName;
 
 @ShipperConfigTypeDescription(
     name = "Map Field Value",
-    description = "The name of the mapping element should be map_fieldvalue. The value json element should contain the following parameter:"
+    description = "The name of the mapping element should be map_field_value. The value json element should contain the following parameter:"
 )
 public class MapFieldValueDescriptorImpl extends MapFieldDescriptorImpl implements MapFieldValueDescriptor {
   @Override
   public String getJsonName() {
-    return "map_fieldvalue";
+    return "map_field_value";
   }
 
   @ShipperConfigElementDescription(
-    path = "/filter/[]/post_map_values/{field_name}/[]/map_fieldvalue/pre_value",
+    path = "/filter/[]/post_map_values/{field_name}/[]/map_field_value/pre_value",
     type = "string",
     description = "The value that the field must match (ignoring case) to be mapped",
     examples = {"old_value"}
@@ -47,7 +47,7 @@ public class MapFieldValueDescriptorImpl extends MapFieldDescriptorImpl implemen
   private String preValue;
 
   @ShipperConfigElementDescription(
-      path = "/filter/[]/post_map_values/{field_name}/[]/map_fieldvalue/post_value",
+      path = "/filter/[]/post_map_values/{field_name}/[]/map_field_value/post_value",
       type = "string",
       description = "The value to which the field is modified to",
       examples = {"new_value"}

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/PostMapValuesAdapter.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/PostMapValuesAdapter.java
@@ -57,13 +57,13 @@ public class PostMapValuesAdapter implements JsonDeserializer<List<PostMapValues
         case "map_date":
           mappers.add(context.deserialize(m.getValue(), MapDateDescriptorImpl.class));
           break;
-        case "map_fieldcopy":
+        case "map_field_copy":
           mappers.add(context.deserialize(m.getValue(), MapFieldCopyDescriptorImpl.class));
           break;
-        case "map_fieldname":
+        case "map_field_name":
           mappers.add(context.deserialize(m.getValue(), MapFieldNameDescriptorImpl.class));
           break;
-        case "map_fieldvalue":
+        case "map_field_value":
           mappers.add(context.deserialize(m.getValue(), MapFieldValueDescriptorImpl.class));
           break;
         case "map_anonymize":
@@ -97,7 +97,7 @@ public class PostMapValuesAdapter implements JsonDeserializer<List<PostMapValues
   private JsonElement createMapperObject(PostMapValuesImpl postMapValues, JsonSerializationContext context) {
     JsonObject jsonObject = new JsonObject();
     for (MapFieldDescriptor m : postMapValues.getMappers()) {
-      jsonObject.add(((MapFieldDescriptorImpl)m).getJsonName(), context.serialize(m));
+      jsonObject.add(m.getJsonName(), context.serialize(m));
     }
     return jsonObject;
   }

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/StoryDataRegistry.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/StoryDataRegistry.java
@@ -18,11 +18,28 @@
  */
 package org.apache.ambari.logsearch.domain;
 
+import org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl.InputAdapter;
 import org.apache.solr.client.solrj.SolrClient;
 import org.jbehave.web.selenium.WebDriverProvider;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
 public class StoryDataRegistry {
   public static final StoryDataRegistry INSTANCE = new StoryDataRegistry();
+
+  public static final String CLUSTER = "cl1";
+  public static final String LOGSEARCH_GLOBAL_CONFIG = "[\n" +
+          "    {\n" +
+          "      \"add_fields\": {\n" +
+          "        \"cluster\": \""+ CLUSTER +"\"\n" +
+          "      },\n" +
+          "      \"source\": \"file\",\n" +
+          "      \"tail\": \"true\",\n" +
+          "      \"gen_event_md5\": \"true\"\n" +
+          "    }\n" +
+          "]";
+
 
   private SolrClient solrClient;
   private boolean logsearchContainerStarted = false;
@@ -38,6 +55,9 @@ public class StoryDataRegistry {
   private WebDriverProvider webDriverProvider;
 
   private StoryDataRegistry() {
+    JsonParser jsonParser = new JsonParser();
+    JsonElement globalConfigJsonElement = jsonParser.parse(LOGSEARCH_GLOBAL_CONFIG);
+    InputAdapter.setGlobalConfigs(globalConfigJsonElement.getAsJsonArray());
   }
 
   public String getDockerHost() {
@@ -114,5 +134,9 @@ public class StoryDataRegistry {
 
   public void setShellScriptFolder(String shellScriptFolder) {
     this.shellScriptFolder = shellScriptFolder;
+  }
+
+  public WebClient logsearchClient() {
+    return new WebClient(dockerHost, logsearchPort);
   }
 }

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/WebClient.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/WebClient.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.domain;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebClient {
+  private static Logger LOG = LoggerFactory.getLogger(WebClient.class);
+
+  private final String host;
+  private final int port;
+
+  public WebClient(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  public String get(String path) {
+    JerseyClient jerseyClient = JerseyClientBuilder.createClient();
+    HttpAuthenticationFeature authFeature = HttpAuthenticationFeature.basicBuilder()
+            .credentials("admin", "admin")
+            .build();
+    jerseyClient.register(authFeature);
+
+    String url = String.format("http://%s:%d%s", host, port, path);
+
+    LOG.info("Url: {}", url);
+
+    WebTarget target = jerseyClient.target(url);
+    Invocation.Builder invocationBuilder =  target.request(MediaType.APPLICATION_JSON_TYPE);
+    return invocationBuilder.get().readEntity(String.class);
+  }
+
+  public String put(String path, String requestBody) {
+    JerseyClient jerseyClient = JerseyClientBuilder.createClient();
+    HttpAuthenticationFeature authFeature = HttpAuthenticationFeature.basicBuilder()
+            .credentials("admin", "admin")
+            .build();
+    jerseyClient.register(authFeature);
+
+    String url = String.format("http://%s:%d%s", host, port, path);
+
+    LOG.info("Url: {}", url);
+
+    WebTarget target = jerseyClient.target(url);
+    Invocation.Builder invocationBuilder =  target.request(MediaType.APPLICATION_JSON_TYPE);
+    String response = invocationBuilder.put(Entity.entity(requestBody, MediaType.APPLICATION_JSON_TYPE)).readEntity(String.class);
+
+    LOG.info("Response: {}", response);
+
+    return response;
+  }
+
+}

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchApiSteps.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchApiSteps.java
@@ -18,24 +18,6 @@
  */
 package org.apache.ambari.logsearch.steps;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flipkart.zjsonpatch.JsonDiff;
-import com.google.common.io.Resources;
-import org.apache.ambari.logsearch.domain.StoryDataRegistry;
-import org.glassfish.jersey.client.JerseyClient;
-import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.jbehave.core.annotations.Named;
-import org.jbehave.core.annotations.Then;
-import org.jbehave.core.annotations.When;
-import org.junit.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -43,6 +25,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.ambari.logsearch.domain.StoryDataRegistry;
+import org.jbehave.core.annotations.Named;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.zjsonpatch.JsonDiff;
+import com.google.common.io.Resources;
 
 public class LogSearchApiSteps {
 
@@ -52,22 +47,7 @@ public class LogSearchApiSteps {
 
   @When("LogSearch api query sent: <apiQuery>")
   public void sendApiQuery(@Named("apiQuery") String apiQuery) {
-    JerseyClient jerseyClient = JerseyClientBuilder.createClient();
-    HttpAuthenticationFeature authFeature = HttpAuthenticationFeature.basicBuilder()
-      .credentials("admin", "admin")
-      .build();
-    jerseyClient.register(authFeature);
-
-    String logsearchUrl = String.format("http://%s:%d%s",
-      StoryDataRegistry.INSTANCE.getDockerHost(),
-      StoryDataRegistry.INSTANCE.getLogsearchPort(),
-      apiQuery);
-
-    LOG.info("Url: {}", logsearchUrl);
-
-    WebTarget target = jerseyClient.target(logsearchUrl);
-    Invocation.Builder invocationBuilder =  target.request(MediaType.APPLICATION_JSON_TYPE);
-    response = invocationBuilder.get().readEntity(String.class);
+    response = StoryDataRegistry.INSTANCE.logsearchClient().get(apiQuery);
   }
 
 

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchConfigApiSteps.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchConfigApiSteps.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.steps;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import org.apache.ambari.logsearch.config.api.model.inputconfig.InputConfig;
+import org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl.InputConfigGson;
+import org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl.InputConfigImpl;
+import org.apache.ambari.logsearch.domain.StoryDataRegistry;
+import org.hamcrest.Matchers;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+public class LogSearchConfigApiSteps {
+  private String response;
+  private InputConfig inputConfig;
+
+  @When("LogSearch api request sent: $url")
+  public String sendApiRequest(String url) {
+    response = StoryDataRegistry.INSTANCE.logsearchClient().get(url);
+    return response;
+  }
+
+  @Then("Result is an input.config of $inputConfigType with log file path $logFilePath")
+  public void checkInputConfig(String inputConfigType, String logFilePath) {
+    checkInputConfig(response, inputConfigType, logFilePath);
+  }
+
+  public void checkInputConfig(String result, String type, String path) {
+    inputConfig = InputConfigGson.gson.fromJson(response, InputConfigImpl.class);
+    assertThat(inputConfig.getInput(), is(not(Matchers.nullValue())));
+    assertThat(inputConfig.getInput(), hasSize(1));
+    assertThat(inputConfig.getInput().get(0).getType(), is(type));
+    assertThat(inputConfig.getInput().get(0).getPath(), is(path));
+  }
+
+  @When("Update input config of $inputConfigType path to $logFilePath at $url")
+  public void changeAndPut(String inputConfigType, String logFilePath, String url) {
+    String putRequest = response.replace(inputConfig.getInput().get(0).getPath(), logFilePath);
+    String putResponse = StoryDataRegistry.INSTANCE.logsearchClient().put(
+            url, putRequest);
+    assertThat(putResponse, is(""));
+
+    String getResponse = sendApiRequest(url);
+    checkInputConfig(getResponse, inputConfigType, logFilePath);
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/story/LogSearchBackendStories.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/story/LogSearchBackendStories.java
@@ -18,12 +18,12 @@
  */
 package org.apache.ambari.logsearch.story;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
+import java.util.List;
+
 import org.apache.ambari.logsearch.steps.LogSearchApiSteps;
-import org.apache.ambari.logsearch.steps.SolrSteps;
+import org.apache.ambari.logsearch.steps.LogSearchConfigApiSteps;
 import org.apache.ambari.logsearch.steps.LogSearchDockerSteps;
+import org.apache.ambari.logsearch.steps.SolrSteps;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.MostUsefulConfiguration;
 import org.jbehave.core.junit.JUnitStories;
@@ -33,7 +33,9 @@ import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
 import org.junit.Test;
 
-import java.util.List;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 
 public class LogSearchBackendStories extends JUnitStories {
 
@@ -53,7 +55,8 @@ public class LogSearchBackendStories extends JUnitStories {
     return new InstanceStepsFactory(configuration(),
       new LogSearchDockerSteps(),
       new SolrSteps(),
-      new LogSearchApiSteps());
+      new LogSearchApiSteps(),
+      new LogSearchConfigApiSteps());
   }
 
   @Test

--- a/ambari-logsearch/ambari-logsearch-it/src/test/resources/stories/backend/log_search_cofig_api_tests.story
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/resources/stories/backend/log_search_cofig_api_tests.story
@@ -1,0 +1,9 @@
+Scenario: scenario description
+
+Given logsearch docker container
+When LogSearch api request sent: /api/v1/shipper/input/cl1/services/ambari
+Then Result is an input.config of ambari_audit with log file path /root/test-logs/ambari-server/ambari-audit.log
+
+Given logsearch docker container
+When Update input config of ambari_audit path to /root/test-logs/ambari-server/ambari-audit.log.1 at /api/v1/shipper/input/cl1/services/ambari
+Then Result is an input.config of ambari_audit with log file path /root/test-logs/ambari-server/ambari-audit.log.1

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/alias_config.json
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/alias_config.json
@@ -25,13 +25,13 @@
     "map_date": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperDate"
     },
-    "map_fieldcopy": {
+    "map_field_copy": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperFieldCopy"
     },
-    "map_fieldname": {
+    "map_field_name": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperFieldName"
     },
-    "map_fieldvalue": {
+    "map_field_value": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperFieldValue"
     },
     "map_anonymize": {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/filters.config.json
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/filters.config.json
@@ -155,7 +155,7 @@
 					
 				},
 				"level":{
-					"map_fieldvalue":{
+					"map_field_value":{
 						"pre_value":"WARNING",
 						"post_value":"WARN"
 					}
@@ -509,55 +509,55 @@
 			"field_split":"\t",
 			"post_map_values":{
 				"src":{
-					"map_fieldname":{
-						"new_fieldname":"resource"
+					"map_field_name":{
+						"new_field_name":"resource"
 					}
 					
 				},
 				"ip":{
-					"map_fieldname":{
-						"new_fieldname":"cliIP"
+					"map_field_name":{
+						"new_field_name":"cliIP"
 					}
 					
 				},
 				"allowed":[
 					{
-						"map_fieldvalue":{
+						"map_field_value":{
 							"pre_value":"true",
 							"post_value":"1"
 						}
 						
 					},
 					{
-						"map_fieldvalue":{
+						"map_field_value":{
 							"pre_value":"false",
 							"post_value":"0"
 						}
 						
 					},
 					{
-						"map_fieldname":{
-							"new_fieldname":"result"
+						"map_field_name":{
+							"new_field_name":"result"
 						}
 						
 					}
 					
 				],
 				"cmd":{
-					"map_fieldname":{
-						"new_fieldname":"action"
+					"map_field_name":{
+						"new_field_name":"action"
 					}
 					
 				},
 				"proto":{
-					"map_fieldname":{
-						"new_fieldname":"cliType"
+					"map_field_name":{
+						"new_field_name":"cliType"
 					}
 					
 				},
 				"callerContext":{
-					"map_fieldname":{
-						"new_fieldname":"req_caller_id"
+					"map_field_name":{
+						"new_field_name":"req_caller_id"
 					}
 					
 				}
@@ -582,38 +582,38 @@
 			"message_pattern":"%{USERNAME:p_user}.+auth:%{USERNAME:p_authType}.+via %{USERNAME:k_user}.+auth:%{USERNAME:k_authType}|%{USERNAME:user}.+auth:%{USERNAME:authType}|%{USERNAME:x_user}",
 			"post_map_values":{
 				"user":{
-					"map_fieldname":{
-						"new_fieldname":"reqUser"
+					"map_field_name":{
+						"new_field_name":"reqUser"
 					}
 					
 				},
 				"x_user":{
-					"map_fieldname":{
-						"new_fieldname":"reqUser"
+					"map_field_name":{
+						"new_field_name":"reqUser"
 					}
 					
 				},
 				"p_user":{
-					"map_fieldname":{
-						"new_fieldname":"reqUser"
+					"map_field_name":{
+						"new_field_name":"reqUser"
 					}
 					
 				},
 				"k_user":{
-					"map_fieldname":{
-						"new_fieldname":"proxyUsers"
+					"map_field_name":{
+						"new_field_name":"proxyUsers"
 					}
 					
 				},
 				"p_authType":{
-					"map_fieldname":{
-						"new_fieldname":"authType"
+					"map_field_name":{
+						"new_field_name":"authType"
 					}
 					
 				},
 				"k_authType":{
-					"map_fieldname":{
-						"new_fieldname":"proxyAuthType"
+					"map_field_name":{
+						"new_field_name":"proxyAuthType"
 					}
 					
 				}

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/test/resources/samples/config/config_audit.json
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/test/resources/samples/config/config_audit.json
@@ -39,52 +39,52 @@
       "field_split": "\t",
       "post_map_values": {
         "src": {
-          "map_fieldname": {
-            "new_fieldname": "resource"
+          "map_field_name": {
+            "new_field_name": "resource"
           }
 
         },
         "ip": {
-          "map_fieldname": {
-            "new_fieldname": "cliIP"
+          "map_field_name": {
+            "new_field_name": "cliIP"
           }
 
         },
         "allowed": [{
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "true",
               "post_value": "1"
             }
 
           }, {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "false",
               "post_value": "0"
             }
 
           }, {
-            "map_fieldname": {
-              "new_fieldname": "result"
+            "map_field_name": {
+              "new_field_name": "result"
             }
 
           }
 
         ],
         "cmd": {
-          "map_fieldname": {
-            "new_fieldname": "action"
+          "map_field_name": {
+            "new_field_name": "action"
           }
 
         },
         "proto": {
-          "map_fieldname": {
-            "new_fieldname": "cliType"
+          "map_field_name": {
+            "new_field_name": "cliType"
           }
 
         },
         "callerContext": {
-          "map_fieldname": {
-            "new_fieldname": "req_caller_id"
+          "map_field_name": {
+            "new_field_name": "req_caller_id"
           }
 
         }
@@ -108,38 +108,38 @@
       "message_pattern": "%{USERNAME:p_user}.+auth:%{USERNAME:p_authType}.+via %{USERNAME:k_user}.+auth:%{USERNAME:k_authType}|%{USERNAME:user}.+auth:%{USERNAME:authType}|%{USERNAME:x_user}",
       "post_map_values": {
         "user": {
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
 
         },
         "x_user": {
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
 
         },
         "p_user": {
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
 
         },
         "k_user": {
-          "map_fieldname": {
-            "new_fieldname": "proxyUsers"
+          "map_field_name": {
+            "new_field_name": "proxyUsers"
           }
 
         },
         "p_authType": {
-          "map_fieldname": {
-            "new_fieldname": "authType"
+          "map_field_name": {
+            "new_field_name": "authType"
           }
 
         },
         "k_authType": {
-          "map_fieldname": {
-            "new_fieldname": "proxyAuthType"
+          "map_field_name": {
+            "new_field_name": "proxyAuthType"
           }
 
         }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldCopy.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldCopy.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModel;
 public class LSServerMapFieldCopy extends LSServerMapField {
   @Override
   public String getName() {
-    return "map_fieldcopy";
+    return "map_field_copy";
   }
 
   @NotNull

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldName.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldName.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModel;
 public class LSServerMapFieldName extends LSServerMapField {
   @Override
   public String getName() {
-    return "map_fieldname";
+    return "map_field_name";
   }
 
   @NotNull

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldValue.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldValue.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModel;
 public class LSServerMapFieldValue extends LSServerMapField {
   @Override
   public String getName() {
-    return "map_fieldvalue";
+    return "map_field_value";
   }
 
   @NotNull

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerPostMapValuesListDeserializer.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerPostMapValuesListDeserializer.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class LSServerPostMapValuesListDeserializer extends JsonDeserializer<LSServerPostMapValuesList> {
   @Override
   public LSServerPostMapValuesList deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws IOException {
     ObjectCodec oc = jp.getCodec();
     JsonNode node = oc.readTree(jp);
     
@@ -49,24 +49,24 @@ public class LSServerPostMapValuesListDeserializer extends JsonDeserializer<LSSe
         JsonNode mapperProperties = mapperData.getValue();
         switch (mapperType) {
           case "map_date" :
-            LSServerMapDate mapDate = oc.treeToValue((TreeNode)mapperProperties, LSServerMapDate.class);
+            LSServerMapDate mapDate = oc.treeToValue(mapperProperties, LSServerMapDate.class);
             mappers.add(mapDate);
             break;
-          case "map_fieldname" :
-            LSServerMapFieldName mapFieldName = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldName.class);
+          case "map_field_name" :
+            LSServerMapFieldName mapFieldName = oc.treeToValue(mapperProperties, LSServerMapFieldName.class);
             mappers.add(mapFieldName);
             break;
-          case "map_fieldvalue" :
-            LSServerMapFieldValue mapFieldValue = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldValue.class);
+          case "map_field_value" :
+            LSServerMapFieldValue mapFieldValue = oc.treeToValue(mapperProperties, LSServerMapFieldValue.class);
             mappers.add(mapFieldValue);
             break;
-          case "map_fieldcopy" :
-            LSServerMapFieldCopy mapFieldCopy = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldCopy.class);
+          case "map_field_copy" :
+            LSServerMapFieldCopy mapFieldCopy = oc.treeToValue(mapperProperties, LSServerMapFieldCopy.class);
             mappers.add(mapFieldCopy);
             break;
           case "map_anonymize" :
-            LSServerMapFieldAnonymize mapAnonyimize = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldAnonymize.class);
-            mappers.add(mapAnonyimize);
+            LSServerMapFieldAnonymize mapAnonymize = oc.treeToValue(mapperProperties, LSServerMapFieldAnonymize.class);
+            mappers.add(mapAnonymize);
             break;
         }
       }

--- a/ambari-logsearch/ambari-logsearch-web/src/mockdata/mock-data-get.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/mockdata/mock-data-get.ts
@@ -1954,54 +1954,54 @@ export const mockDataGet = {
         'post_map_values': {
           'callerContext': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'req_caller_id'
               }
             }
           ],
           'src': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'resource'
               }
             }
           ],
           'allowed': [
             {
-              'map_fieldvalue': {
+              'map_field_value': {
                 'pre_value': 'true',
                 'post_value': '1'
               }
             },
             {
-              'map_fieldvalue': {
+              'map_field_value': {
                 'pre_value': 'false',
                 'post_value': '0'
               }
             },
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'result'
               }
             }
           ],
           'ip': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'cliIP'
               }
             }
           ],
           'proto': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'cliType'
               }
             }
           ],
           'cmd': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'action'
               }
             }
@@ -2025,42 +2025,42 @@ export const mockDataGet = {
         'post_map_values': {
           'k_authType': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'proxyAuthType'
               }
             }
           ],
           'p_authType': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'authType'
               }
             }
           ],
           'x_user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'reqUser'
               }
             }
           ],
           'k_user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'proxyUsers'
               }
             }
           ],
           'p_user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'reqUser'
               }
             }
           ],
           'user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'reqUser'
               }
             }

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-ambari.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-ambari.json
@@ -49,324 +49,324 @@
       "value_borders": "()",
       "post_map_values": {
         "User": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
         },
         "Hostname": {
-          "map_fieldname": {
-            "new_fieldname": "host"
+          "map_field_name": {
+            "new_field_name": "host"
           }
         },
         "Host name": {
-          "map_fieldname": {
-            "new_fieldname": "host"
+          "map_field_name": {
+            "new_field_name": "host"
           }
         },
         "RemoteIp": {
-          "map_fieldname": {
-            "new_fieldname": "cliIP"
+          "map_field_name": {
+            "new_field_name": "cliIP"
           }
         },
         "RequestType": {
-          "map_fieldname": {
-            "new_fieldname": "cliType"
+          "map_field_name": {
+            "new_field_name": "cliType"
           }
         },
         "Operation": {
-          "map_fieldname": {
-            "new_fieldname": "action"
+          "map_field_name": {
+            "new_field_name": "action"
           }
         },
         "url": {
-          "map_fieldname": {
-            "new_fieldname": "resource"
+          "map_field_name": {
+            "new_field_name": "resource"
           }
         },
         "ResourcePath": {
-          "map_fieldname": {
-            "new_fieldname": "resource"
+          "map_field_name": {
+            "new_field_name": "resource"
           }
         },
         "Cluster name": {
-          "map_fieldname": {
-            "new_fieldname": "cluster"
+          "map_field_name": {
+            "new_field_name": "cluster"
           }
         },
         "Reason": {
-          "map_fieldname": {
-            "new_fieldname": "reason"
+          "map_field_name": {
+            "new_field_name": "reason"
           }
         },
         "Base URL": {
-          "map_fieldname": {
-            "new_fieldname": "ws_base_url"
+          "map_field_name": {
+            "new_field_name": "ws_base_url"
           }
         },
         "Command": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_command"
+          "map_field_name": {
+            "new_field_name": "ws_command"
           }
         },
         "Component": {
-          "map_fieldname": {
-            "new_fieldname": "ws_component"
+          "map_field_name": {
+            "new_field_name": "ws_component"
           }
         },
         "Details": {
-          "map_fieldname": {
-            "new_fieldname": "ws_details"
+          "map_field_name": {
+            "new_field_name": "ws_details"
           }
         },
         "Display name": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_display_name"
+          "map_field_name": {
+            "new_field_name": "ws_display_name"
           }
         },
         "OS": {
-          "map_fieldname": {
-            "new_fieldname": "ws_os"
+          "map_field_name": {
+            "new_field_name": "ws_os"
           }
         },
         "Repo id": {
-          "map_fieldname": {
-            "new_fieldname": "ws_repo_id"
+          "map_field_name": {
+            "new_field_name": "ws_repo_id"
           }
         },
         "Repo version": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_repo_version"
+          "map_field_name": {
+            "new_field_name": "ws_repo_version"
           }
         },
         "Repositories": {
-          "map_fieldname": {
-            "new_fieldname": "ws_repositories"
+          "map_field_name": {
+            "new_field_name": "ws_repositories"
           }
         },
         "RequestId": {
-          "map_fieldname": {
-            "new_fieldname": "ws_request_id"
+          "map_field_name": {
+            "new_field_name": "ws_request_id"
           }
         },
         "Roles": {
-          "map_fieldname": {
-            "new_fieldname": "ws_roles"
+          "map_field_name": {
+            "new_field_name": "ws_roles"
           }
         },
         "Stack": {
-          "map_fieldname": {
-            "new_fieldname": "ws_stack"
+          "map_field_name": {
+            "new_field_name": "ws_stack"
           }
         },
         "Stack version": {
-          "map_fieldname": {
-            "new_fieldname": "ws_stack_version"
+          "map_field_name": {
+            "new_field_name": "ws_stack_version"
           }
         },
         "TaskId": {
-          "map_fieldname": {
-            "new_fieldname": "ws_task_id"
+          "map_field_name": {
+            "new_field_name": "ws_task_id"
           }
         },
         "VersionNote": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_version_note"
+          "map_field_name": {
+            "new_field_name": "ws_version_note"
           }
         },
         "VersionNumber": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_version_number"
+          "map_field_name": {
+            "new_field_name": "ws_version_number"
           }
         },
         "Status": [
           {
-            "map_fieldcopy": {
+            "map_field_copy": {
               "copy_name": "ws_status"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Success",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Successfully queued",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "QUEUED",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "PENDING",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "COMPLETED",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "IN_PROGRESS",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Failed",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Failed to queue",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "HOLDING",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "HOLDING_FAILED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "HOLDING_TIMEDOUT",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "FAILED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "TIMEDOUT",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "ABORTED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "SKIPPED_FAILED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldname": {
-              "new_fieldname": "result"
+            "map_field_name": {
+              "new_field_name": "result"
             }
           }
         ],
         "ResultStatus": [
           {
-            "map_fieldcopy": {
+            "map_field_copy": {
               "copy_name": "ws_result_status"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "200 OK",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "201 Created",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "202 Accepted",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "400 Bad Request",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "401 Unauthorized",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "403 Forbidden",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "404 Not Found",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "409 Resource Conflict",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "500 Internal Server Error",
               "post_value": "0"
             }
           },
           {
-            "map_fieldname": {
-              "new_fieldname": "result"
+            "map_field_name": {
+              "new_field_name": "result"
             }
           }
         ]

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hdfs.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hdfs.json
@@ -56,55 +56,55 @@
       "field_split":"\t",
       "post_map_values":{
         "src":{
-          "map_fieldname":{
-            "new_fieldname":"resource"
+          "map_field_name":{
+            "new_field_name":"resource"
           }
 
         },
         "ip":{
-          "map_fieldname":{
-            "new_fieldname":"cliIP"
+          "map_field_name":{
+            "new_field_name":"cliIP"
           }
 
         },
         "allowed":[
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"true",
               "post_value":"1"
             }
 
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"false",
               "post_value":"0"
             }
 
           },
           {
-            "map_fieldname":{
-              "new_fieldname":"result"
+            "map_field_name":{
+              "new_field_name":"result"
             }
 
           }
 
         ],
         "cmd":{
-          "map_fieldname":{
-            "new_fieldname":"action"
+          "map_field_name":{
+            "new_field_name":"action"
           }
 
         },
         "proto":{
-          "map_fieldname":{
-            "new_fieldname":"cliType"
+          "map_field_name":{
+            "new_field_name":"cliType"
           }
 
         },
         "callerContext":{
-          "map_fieldname":{
-            "new_fieldname":"req_caller_id"
+          "map_field_name":{
+            "new_field_name":"req_caller_id"
           }
 
         }
@@ -129,38 +129,38 @@
       "message_pattern":"%{USERNAME:p_user}.+auth:%{USERNAME:p_authType}.+via %{USERNAME:k_user}.+auth:%{USERNAME:k_authType}|%{USERNAME:user}.+auth:%{USERNAME:authType}|%{USERNAME:x_user}",
       "post_map_values":{
         "user":{
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
 
         },
         "x_user":{
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
 
         },
         "p_user":{
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
 
         },
         "k_user":{
-          "map_fieldname":{
-            "new_fieldname":"proxyUsers"
+          "map_field_name":{
+            "new_field_name":"proxyUsers"
           }
 
         },
         "p_authType":{
-          "map_fieldname":{
-            "new_fieldname":"authType"
+          "map_field_name":{
+            "new_field_name":"authType"
           }
 
         },
         "k_authType":{
-          "map_fieldname":{
-            "new_fieldname":"proxyAuthType"
+          "map_field_name":{
+            "new_field_name":"proxyAuthType"
           }
 
         }

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hst.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hst.json
@@ -27,7 +27,7 @@
           }
         },
         "level": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "WARNING",
             "post_value": "WARN"
           }

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/input.config-hive.json.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/input.config-hive.json.j2
@@ -74,7 +74,7 @@
           }
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/input.config-ambari.json.j2
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/input.config-ambari.json.j2
@@ -87,7 +87,7 @@
 
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }
@@ -194,49 +194,49 @@
         },
         "level":[
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Severe",
               "post_value":"ERROR"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Warning",
               "post_value":"WARN"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Finer",
               "post_value":"WARN"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Info",
               "post_value":"INFO"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Config",
               "post_value":"INFO"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Fine",
               "post_value":"DEBUG"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Finest",
               "post_value":"TRACE"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"All",
               "post_value":"TRACE"
             }
@@ -311,540 +311,540 @@
       "value_borders":"()",
       "post_map_values":{
         "User":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
         },
         "Hostname":{
-          "map_fieldname":{
-            "new_fieldname":"host"
+          "map_field_name":{
+            "new_field_name":"host"
           }
         },
         "Host name":{
-          "map_fieldname":{
-            "new_fieldname":"host"
+          "map_field_name":{
+            "new_field_name":"host"
           }
         },
         "RemoteIp":{
-          "map_fieldname":{
-            "new_fieldname":"cliIP"
+          "map_field_name":{
+            "new_field_name":"cliIP"
           }
         },
         "RequestType":{
-          "map_fieldname":{
-            "new_fieldname":"cliType"
+          "map_field_name":{
+            "new_field_name":"cliType"
           }
         },
         "TaskId":{
-          "map_fieldname":{
-            "new_fieldname":"task_id"
+          "map_field_name":{
+            "new_field_name":"task_id"
           }
         },
         "Operation":{
-          "map_fieldname":{
-            "new_fieldname":"action"
+          "map_field_name":{
+            "new_field_name":"action"
           }
         },
         "Service":{
-          "map_fieldname":{
-            "new_fieldname":"ws_service"
+          "map_field_name":{
+            "new_field_name":"ws_service"
           }
         },
         "url":{
-          "map_fieldname":{
-            "new_fieldname":"resource"
+          "map_field_name":{
+            "new_field_name":"resource"
           }
         },
         "ResourcePath":{
-          "map_fieldname":{
-            "new_fieldname":"resource"
+          "map_field_name":{
+            "new_field_name":"resource"
           }
         },
         "Cluster name":{
-          "map_fieldname":{
-            "new_fieldname":"cluster"
+          "map_field_name":{
+            "new_field_name":"cluster"
           }
         },
         "Old name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_old_name"
+          "map_field_name":{
+            "new_field_name":"ws_old_name"
           }
         },
         "New name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_new_name"
+          "map_field_name":{
+            "new_field_name":"ws_new_name"
           }
         },
         "Reason":{
-          "map_fieldname":{
-            "new_fieldname":"reason"
+          "map_field_name":{
+            "new_field_name":"reason"
           }
         },
         "Base URL":{
-          "map_fieldname":{
-            "new_fieldname":"ws_base_url"
+          "map_field_name":{
+            "new_field_name":"ws_base_url"
           }
         },
         "Base url":{
-          "map_fieldname":{
-            "new_fieldname":"ws_base_url"
+          "map_field_name":{
+            "new_field_name":"ws_base_url"
           }
         },
         "Command":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_command"
+          "map_field_name":{
+            "new_field_name":"ws_command"
           }
         },
         "Component":{
-          "map_fieldname":{
-            "new_fieldname":"ws_component"
+          "map_field_name":{
+            "new_field_name":"ws_component"
           }
         },
         "Type":{
-          "map_fieldname":{
-            "new_fieldname":"ws_type"
+          "map_field_name":{
+            "new_field_name":"ws_type"
           }
         },
         "Consecutive failures": {
-          "map_fieldname":{
-            "new_fieldname":"ws_consecutive_failures"
+          "map_field_name":{
+            "new_field_name":"ws_consecutive_failures"
           }
         },
         "Created Username": {
-          "map_fieldname":{
-            "new_fieldname":"ws_username"
+          "map_field_name":{
+            "new_field_name":"ws_username"
           }
         },
         "Affected username": {
-          "map_fieldname":{
-            "new_fieldname":"ws_username"
+          "map_field_name":{
+            "new_field_name":"ws_username"
           }
         },
         "Deleted Username": {
-          "map_fieldname":{
-            "new_fieldname":"ws_username"
+          "map_field_name":{
+            "new_field_name":"ws_username"
           }
         },
         "Alert group name": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_group_name"
+          "map_field_name":{
+            "new_field_name":"ws_alert_group_name"
           }
         },
         "Alert group ID": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_group_id"
+          "map_field_name":{
+            "new_field_name":"ws_alert_group_id"
           }
         },
         "Definition IDs": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_definition_ids"
+          "map_field_name":{
+            "new_field_name":"std_alert_definition_ids"
           }
         },
         "Notification ID": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_notification_id"
+          "map_field_name":{
+            "new_field_name":"ws_alert_notification_id"
           }
         },
         "Notification IDs": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_notification_ids"
+          "map_field_name":{
+            "new_field_name":"std_alert_notification_ids"
           }
         },
         "Notification name": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_notification_name"
+          "map_field_name":{
+            "new_field_name":"ws_alert_notification_name"
           }
         },
         "Notification type": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_notification_type"
+          "map_field_name":{
+            "new_field_name":"ws_alert_notification_type"
           }
         },
         "Members": {
-          "map_fieldname":{
-            "new_fieldname":"std_members"
+          "map_field_name":{
+            "new_field_name":"std_members"
           }
         },
         "Description": {
-          "map_fieldname":{
-            "new_fieldname":"ws_description"
+          "map_field_name":{
+            "new_field_name":"ws_description"
           }
         },
         "Email from": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_email_from"
+          "map_field_name":{
+            "new_field_name":"ws_alert_email_from"
           }
         },
         "Email to": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_email_to"
+          "map_field_name":{
+            "new_field_name":"ws_alert_email_to"
           }
         },
         "Group": {
-          "map_fieldname":{
-            "new_fieldname":"ws_group"
+          "map_field_name":{
+            "new_field_name":"ws_group"
           }
         },
         "Group IDs": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_group_ids"
+          "map_field_name":{
+            "new_field_name":"std_alert_group_ids"
           }
         },
         "Alert states": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_states"
+          "map_field_name":{
+            "new_field_name":"std_alert_states"
           }
         },
         "Blueprint": {
-          "map_fieldname":{
-            "new_fieldname":"ws_blueprint"
+          "map_field_name":{
+            "new_field_name":"ws_blueprint"
           }
         },
         "Blueprint name": {
-          "map_fieldname":{
-            "new_fieldname":"ws_blueprint_name"
+          "map_field_name":{
+            "new_field_name":"ws_blueprint_name"
           }
         },
         "State": {
-          "map_fieldname":{
-            "new_fieldname":"ws_state"
+          "map_field_name":{
+            "new_field_name":"ws_state"
           }
         },
         "Principal": {
-          "map_fieldname":{
-            "new_fieldname":"ws_principal"
+          "map_field_name":{
+            "new_field_name":"ws_principal"
           }
         },
         "Alias": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alias"
+          "map_field_name":{
+            "new_field_name":"ws_alias"
           }
         },
         "Keytab file": {
-          "map_fieldname":{
-            "new_fieldname":"ws_keytab_file"
+          "map_field_name":{
+            "new_field_name":"ws_keytab_file"
           }
         },
         "Upgrade type":{
-          "map_fieldname":{
-            "new_fieldname":"ws_upgrade_type"
+          "map_field_name":{
+            "new_field_name":"ws_upgrade_type"
           }
         },
         "Details":{
-          "map_fieldname":{
-            "new_fieldname":"ws_details"
+          "map_field_name":{
+            "new_field_name":"ws_details"
           }
         },
         "Name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_name"
+          "map_field_name":{
+            "new_field_name":"ws_name"
           }
         },
         "Display name":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_display_name"
+          "map_field_name":{
+            "new_field_name":"ws_display_name"
           }
         },
         "OS":{
-          "map_fieldname":{
-            "new_fieldname":"ws_os"
+          "map_field_name":{
+            "new_field_name":"ws_os"
           }
         },
         "Repo id":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_id"
+          "map_field_name":{
+            "new_field_name":"ws_repo_id"
           }
         },
         "Repo version":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_version"
+          "map_field_name":{
+            "new_field_name":"ws_repo_version"
           }
         },
         "Repo version ID":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_version_id"
+          "map_field_name":{
+            "new_field_name":"ws_repo_version_id"
           }
         },
         "Repositories":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repositories"
+          "map_field_name":{
+            "new_field_name":"ws_repositories"
           }
         },
         "RequestId":{
-          "map_fieldname":{
-            "new_fieldname":"ws_request_id"
+          "map_field_name":{
+            "new_field_name":"ws_request_id"
           }
         },
         "Request id":{
-          "map_fieldname":{
-            "new_fieldname":"ws_request_id"
+          "map_field_name":{
+            "new_field_name":"ws_request_id"
           }
         },
         "Repository ID":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_id"
+          "map_field_name":{
+            "new_field_name":"ws_repo_id"
           }
         },
         "Repository name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_name"
+          "map_field_name":{
+            "new_field_name":"ws_repo_name"
           }
         },
         "Roles":{
-          "map_fieldname":{
-            "new_fieldname":"ws_roles"
+          "map_field_name":{
+            "new_field_name":"ws_roles"
           }
         },
         "Permissions":{
-          "map_fieldname":{
-            "new_fieldname":"std_permissions"
+          "map_field_name":{
+            "new_field_name":"std_permissions"
           }
         },
         "Stack":{
-          "map_fieldname":{
-            "new_fieldname":"ws_stack"
+          "map_field_name":{
+            "new_field_name":"ws_stack"
           }
         },
         "Stack version":{
-          "map_fieldname":{
-            "new_fieldname":"ws_stack_version"
+          "map_field_name":{
+            "new_field_name":"ws_stack_version"
           }
         },
         "Stage id":{
-          "map_fieldname":{
-            "new_fieldname":"ws_stage_id"
+          "map_field_name":{
+            "new_field_name":"ws_stage_id"
           }
         },
         "Administrator":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"yes",
             "post_value":"1"
           },
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"no",
             "post_value":"0"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_admin"
+          "map_field_name":{
+            "new_field_name":"ws_admin"
           }
         },
         "Active":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"y",
             "post_value":"1"
           },
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"n",
             "post_value":"0"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_active"
+          "map_field_name":{
+            "new_field_name":"ws_active"
           }
         },
         "Version":{
-          "map_fieldname":{
-            "new_fieldname":"ws_version"
+          "map_field_name":{
+            "new_field_name":"ws_version"
           }
         },
         "VersionNote":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_version_note"
+          "map_field_name":{
+            "new_field_name":"ws_version_note"
           }
         },
         "VersionNumber":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"Vnull",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_version_number"
+          "map_field_name":{
+            "new_field_name":"ws_version_number"
           }
         },
         "Status":[
           {
-            "map_fieldcopy":{
+            "map_field_copy":{
               "copy_name": "ws_status"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Success",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Successfully queued",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"QUEUED",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"PENDING",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"COMPLETED",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"IN_PROGRESS",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Failed",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Failed to queue",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"HOLDING",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"HOLDING_FAILED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"HOLDING_TIMEDOUT",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"FAILED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"TIMEDOUT",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"ABORTED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"SKIPPED_FAILED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldname":{
-              "new_fieldname":"result"
+            "map_field_name":{
+              "new_field_name":"result"
             }
           }
         ],
         "ResultStatus":[
           {
-            "map_fieldcopy":{
+            "map_field_copy":{
               "copy_name": "ws_result_status"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"200 OK",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"201 Created",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"202 Accepted",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"400 Bad Request",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"401 Unauthorized",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"403 Forbidden",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"404 Not Found",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"409 Resource Conflict",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"500 Internal Server Error",
               "post_value":"0"
             }
           },
           {
-            "map_fieldname":{
-              "new_fieldname":"result"
+            "map_field_name":{
+              "new_field_name":"result"
             }
           }
         ]

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/templates/input.config-spark.json.j2
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/templates/input.config-spark.json.j2
@@ -55,7 +55,7 @@
           }
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/templates/input.config-spark2.json.j2
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/templates/input.config-spark2.json.j2
@@ -55,7 +55,7 @@
           }
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }


### PR DESCRIPTION
…on Editor fails with 400 Error

## What changes were proposed in this pull request?

In the input configs, input config templates and the source code these names are not consistently spelled:
map_fieldname    map_field_name
new_fieldname    new_field_name
map_fieldvalue   map_field_value
map_fieldcopy    map_field_copy

Sometimes the first spelling is used and sometimes the second for the same object and the json parser can not parse the part of the input configs which are contains these names. It just omit their values.
Fix: Renamed all occurrences of these to the one in the 2nd column ones.

## How was this patch tested?

ambari-logsearch-it
mvn clean install -Dbackend-tests

Manually:
1. Login to Logsearch portal
2. Navigate to Configuration 
3. Select a service and update some configuration E.g Hdfs > update log file name
4. open chrome's inspect window and select "Network" tab
5. Click Save, configuration should be saved, but fails silently: check the entry in the inspect/network window.


Please review
@swagle @oleewere @miklosgergely @g-boros @adoroszlai 