### PR TITLE
[AMBARI-24232] Alert definitions have not updated after stack upgrade (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
@@ -1075,9 +1075,7 @@ public class AmbariMetaInfo {
    * @param updateScriptPaths whether existing script-based alerts should be updated
    *        with possibly new paths from the stack definition
    */
-  public void reconcileAlertDefinitions(Clusters clusters, boolean updateScriptPaths)
-      throws AmbariException {
-
+  public void reconcileAlertDefinitions(Clusters clusters, boolean updateScriptPaths)  throws AmbariException {
     Map<String, Cluster> clusterMap = clusters.getClusters();
     if (null == clusterMap || clusterMap.size() == 0) {
       return;
@@ -1085,6 +1083,29 @@ public class AmbariMetaInfo {
 
     // for every cluster
     for (Cluster cluster : clusterMap.values()) {
+       reconcileAlertDefinitions(cluster, updateScriptPaths);
+    }
+
+  }
+
+  /**
+   * Compares the alert definitions defined on the stack with those in the
+   * database and merges any new or updated definitions. This method will first
+   * determine the services that are installed on each cluster to prevent alert
+   * definitions from undeployed services from being shown.
+   * <p/>
+   * This method will also detect "agent" alert definitions, which are
+   * definitions that should be run on agent hosts but are not associated with a
+   * service.
+   *
+   * @param cluster cluster
+   * @param updateScriptPaths whether existing script-based alerts should be updated
+   *        with possibly new paths from the stack definition
+   */
+  public void reconcileAlertDefinitions(Cluster cluster, boolean updateScriptPaths) throws AmbariException {
+      if (null == cluster) {
+        return;
+      }
 
       long clusterId = cluster.getClusterId();
       Map<String, ServiceInfo> stackServiceMap = new HashMap<>();
@@ -1137,11 +1158,6 @@ public class AmbariMetaInfo {
         // use the REST APIs to modify them instead
         AlertDefinition databaseDefinition = alertDefinitionFactory.coerce(entity);
         if (!stackDefinition.deeplyEquals(databaseDefinition)) {
-
-          LOG.debug(
-              "The alert named {} has been modified from the stack definition and will not be merged",
-              stackDefinition.getName());
-
           if (updateScriptPaths) {
             Source databaseSource = databaseDefinition.getSource();
             Source stackSource = stackDefinition.getSource();
@@ -1160,6 +1176,9 @@ public class AmbariMetaInfo {
                 );
               }
             }
+          } else {
+            LOG.debug("The alert named {} has been modified from the stack definition and will not be merged",
+              stackDefinition.getName());
           }
         }
       }
@@ -1179,9 +1198,7 @@ public class AmbariMetaInfo {
       // all definition resolved; publish their registration
       for (AlertDefinitionEntity def : alertDefinitionDao.findAll(cluster.getClusterId())) {
         AlertDefinition realDef = alertDefinitionFactory.coerce(def);
-
-        AlertDefinitionRegistrationEvent event = new AlertDefinitionRegistrationEvent(
-            cluster.getClusterId(), realDef);
+        AlertDefinitionRegistrationEvent event = new AlertDefinitionRegistrationEvent(cluster.getClusterId(), realDef);
 
         eventPublisher.publish(event);
       }
@@ -1223,13 +1240,8 @@ public class AmbariMetaInfo {
       for (AlertDefinitionEntity definition : definitionsToDisable) {
         definition.setEnabled(false);
         alertDefinitionDao.merge(definition);
-
-        AlertDefinitionDisabledEvent event = new AlertDefinitionDisabledEvent(
-            clusterId, definition.getDefinitionId());
-
-        eventPublisher.publish(event);
+        eventPublisher.publish(new AlertDefinitionDisabledEvent(clusterId, definition.getDefinitionId()));
       }
-    }
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/StackUpgradeFinishListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/StackUpgradeFinishListener.java
@@ -93,6 +93,13 @@ public class StackUpgradeFinishListener {
         CachedRoleCommandOrderProvider cachedRcoProvider = (CachedRoleCommandOrderProvider) roleCommandOrderProvider.get();
         cachedRcoProvider.clearRoleCommandOrderCache();
       }
+
+      try {
+        ambariMetaInfo.get().reconcileAlertDefinitions(cluster, true);
+      } catch (AmbariException e){
+        LOG.error("Caught AmbariException when update alert definitions", e);
+      }
+
     }
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stack definitions need to be updated on Upgrade finalization, as alert script patch may change after upgrade from one stack to another.

## How was this patch tested?
Live cluster + UT