### PR TITLE
[AMBARI-24237] UI Install: Custom Yarn Capacity Scheduler property set is missing after deploy

### DIFF
--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -938,15 +938,18 @@ App.config = Em.Object.create({
    */
   textareaIntoFileConfigs: function (configs, filename) {
     var configsTextarea = configs.findProperty('name', 'capacity-scheduler');
+    var stackConfigs = App.configsCollection.getAll();
     if (configsTextarea && !App.get('testMode')) {
       var properties = configsTextarea.get('value').split('\n');
 
       properties.forEach(function (_property) {
-        var name, value;
+        var name, value, isUserProperty;
         if (_property) {
           _property = _property.split(/=(.+)/);
           name = _property[0];
           value = (_property[1]) ? _property[1] : "";
+          isUserProperty = !stackConfigs.filterProperty('filename', 'capacity-scheduler.xml').findProperty('name', name);
+
           configs.push(Em.Object.create({
             name: name,
             value: value,
@@ -956,6 +959,7 @@ App.config = Em.Object.create({
             isFinal: configsTextarea.get('isFinal'),
             isNotDefaultValue: configsTextarea.get('isNotDefaultValue'),
             isRequiredByAgent: configsTextarea.get('isRequiredByAgent'),
+            isUserProperty: isUserProperty,
             group: null
           }));
         }

--- a/ambari-web/test/utils/config_test.js
+++ b/ambari-web/test/utils/config_test.js
@@ -574,6 +574,18 @@ describe('App.config', function() {
   describe('#textareaIntoFileConfigs', function () {
     var res, cs;
     beforeEach(function () {
+      var stackConfigs = [
+        Em.Object.create({
+          name: 'n1',
+          value: 'v1',
+          savedValue: 'v1',
+          serviceName: 'YARN',
+          filename: 'capacity-scheduler.xml',
+          isFinal: true,
+          group: null
+        })
+      ];
+      sinon.stub(App.configsCollection, 'getAll').returns(stackConfigs);
       res = [
         Em.Object.create({
           name: 'n1',
@@ -582,6 +594,7 @@ describe('App.config', function() {
           serviceName: 'YARN',
           filename: 'capacity-scheduler.xml',
           isFinal: true,
+          isUserProperty: false,
           group: null
         }),
         Em.Object.create({
@@ -591,6 +604,7 @@ describe('App.config', function() {
           serviceName: 'YARN',
           filename: 'capacity-scheduler.xml',
           isFinal: true,
+          isUserProperty: true,
           group: null
         })
       ];
@@ -609,6 +623,10 @@ describe('App.config', function() {
         'description': 'Capacity Scheduler properties',
         'displayType': 'capacityScheduler'
       });
+    });
+
+    afterEach(function () {
+      App.configsCollection.getAll.restore();
     });
 
     it('generate capacity scheduler', function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?
New properties added in capacity-scheduler should be marked as user added property and should not be discarded

## How was this patch tested?
Manually tested on a cluster. 
  21797 passing (24s)
  48 pending