### PR TITLE
AMBARI-24246. Ambari does not pick the existing hive database from th…

### DIFF
--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -114,6 +114,13 @@ App.SupportsDependentConfigs = Ember.Mixin.create({
       }
     }
 
+    //Fix required by QA (Ambari does not pick the existing hive database from the jdbc url set)
+    if (['oozie.service.JPAService.jdbc.url__oozie-site', 'javax.jdo.option.ConnectionURL__hive-site'].contains(config.get('id'))) {
+      controller.set('recommendationsInProgress', true);
+      controller.runServerSideValidation().done(function () {
+        controller.set('recommendationsInProgress', false)
+      });
+    }
     return $.Deferred().resolve().promise();
   },
 


### PR DESCRIPTION
…e jdbc url set

## What changes were proposed in this pull request?
Ambari does not pick the existing hive database from the jdbc url set

## How was this patch tested?
manually, unit

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.