### PR TITLE
[AMBARI-22832] Add flexible environment handling and environment depended API Url config

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/.gitignore
+++ b/ambari-logsearch/ambari-logsearch-web/.gitignore
@@ -40,3 +40,24 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Development Test Files
+#
+# Webpack Development Config
+# In order to use Webpack Devserver proxy without changing the main config file
+# and commit accidentally we can use a webpack.config.dev.js file for that
+# Eg.:
+# const merge = require('webpack-merge');
+# const baseConfig = require('./webpack.config.js');
+#
+# module.exports = merge(baseConfig, {
+#   devServer: {
+#     historyApiFallback: true,
+#     proxy: {
+#       '/': 'http://c7401.ambari.apache.org:61888'
+#     }
+#   }
+# });
+# And you can start it that way: NODE_ENV=production yarn start --config webpack.config.dev.js
+# You have to set the NODE_ENV to production in order to skip the mock data usage
+webpack.config.dev.js


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is just a helper change to avoid committing a dev test Webpack config file.
Writing a custom webpack config with a dev server proxy is an easy way to test the client with real backend data, so that we can check our changes against a real backend.
The PR itself just about to help the developers to not to commit this custom config file.

Example webpack.config.dev.js file content:
```
const merge = require('webpack-merge');
const baseConfig = require('./webpack.config.js');

 module.exports = merge(baseConfig, {
  devServer: {
    historyApiFallback: true,
    proxy: {
       '/': 'http://c7401.ambari.apache.org:61888'
     }
  }
});
```

And you can run like this:
```
NODE_ENV=production yarn start --config webpack.config.dev.js
```
(Note that you have to set the NODE_ENV to production in order to skip the mock data!)

## How was this patch tested?

No need testing (but I ran the unit tests :) )

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.