### PR TITLE
[AMBARI-24229] Prevent Configuration Changes During Keytab Regeneration in an Upgrade

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/sideNav.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/sideNav.html
@@ -34,7 +34,7 @@
     </ul>
     <ul class="nav side-nav-menu nav-pills nav-stacked">
       <li class="mainmenu-li active" ng-show="cluster.Clusters.provisioning_state === 'INSTALLED'">
-        <a title="{{'common.dashboard' | translate}}" rel="tooltip" data-placement="right" href="{{fromSiteRoot('/#/dashboard')}}" class="gotodashboard">
+        <a title="{{'common.dashboard' | translate}}" rel="tooltip" data-placement="right" href="{{fromSiteRoot('/#/main/dashboard')}}" class="gotodashboard">
           <i class="navigation-icon fa fa-tachometer" aria-hidden="true"></i>
           <span class="navigation-menu-item">{{'common.dashboard' | translate}}</span>
         </a>

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputConfigGson.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputConfigGson.java
@@ -27,7 +27,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 /**
- * Helper class to convert betweeb json string and InputConfig class.
+ * Helper class to convert between json string and InputConfig class.
  */
 public class InputConfigGson {
   public static Gson gson;

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldCopyDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldCopyDescriptorImpl.java
@@ -33,7 +33,7 @@ import com.google.gson.annotations.SerializedName;
 public class MapFieldCopyDescriptorImpl extends MapFieldDescriptorImpl implements MapFieldCopyDescriptor {
   @Override
   public String getJsonName() {
-    return "map_fieldcopy";
+    return "map_field_copy";
   }
 
   @ShipperConfigElementDescription(

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldNameDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldNameDescriptorImpl.java
@@ -28,22 +28,22 @@ import com.google.gson.annotations.SerializedName;
 
 @ShipperConfigTypeDescription(
     name = "Map Field Name",
-    description = "The name of the mapping element should be map_fieldname. The value json element should contain the following parameter:"
+    description = "The name of the mapping element should be map_field_name. The value json element should contain the following parameter:"
 )
 public class MapFieldNameDescriptorImpl extends MapFieldDescriptorImpl implements MapFieldNameDescriptor {
   @Override
   public String getJsonName() {
-    return "map_fieldname";
+    return "map_field_name";
   }
 
   @ShipperConfigElementDescription(
-    path = "/filter/[]/post_map_values/{field_name}/[]/map_fieldname/new_field_name",
+    path = "/filter/[]/post_map_values/{field_name}/[]/map_field_name/new_field_name",
     type = "string",
     description = "The name of the renamed field",
     examples = {"new_name"}
   )
   @Expose
-  @SerializedName("new_fieldname")
+  @SerializedName("new_field_name")
   private String newFieldName;
 
   @Override

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldValueDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/MapFieldValueDescriptorImpl.java
@@ -28,16 +28,16 @@ import com.google.gson.annotations.SerializedName;
 
 @ShipperConfigTypeDescription(
     name = "Map Field Value",
-    description = "The name of the mapping element should be map_fieldvalue. The value json element should contain the following parameter:"
+    description = "The name of the mapping element should be map_field_value. The value json element should contain the following parameter:"
 )
 public class MapFieldValueDescriptorImpl extends MapFieldDescriptorImpl implements MapFieldValueDescriptor {
   @Override
   public String getJsonName() {
-    return "map_fieldvalue";
+    return "map_field_value";
   }
 
   @ShipperConfigElementDescription(
-    path = "/filter/[]/post_map_values/{field_name}/[]/map_fieldvalue/pre_value",
+    path = "/filter/[]/post_map_values/{field_name}/[]/map_field_value/pre_value",
     type = "string",
     description = "The value that the field must match (ignoring case) to be mapped",
     examples = {"old_value"}
@@ -47,7 +47,7 @@ public class MapFieldValueDescriptorImpl extends MapFieldDescriptorImpl implemen
   private String preValue;
 
   @ShipperConfigElementDescription(
-      path = "/filter/[]/post_map_values/{field_name}/[]/map_fieldvalue/post_value",
+      path = "/filter/[]/post_map_values/{field_name}/[]/map_field_value/post_value",
       type = "string",
       description = "The value to which the field is modified to",
       examples = {"new_value"}

--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/PostMapValuesAdapter.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/PostMapValuesAdapter.java
@@ -57,13 +57,13 @@ public class PostMapValuesAdapter implements JsonDeserializer<List<PostMapValues
         case "map_date":
           mappers.add(context.deserialize(m.getValue(), MapDateDescriptorImpl.class));
           break;
-        case "map_fieldcopy":
+        case "map_field_copy":
           mappers.add(context.deserialize(m.getValue(), MapFieldCopyDescriptorImpl.class));
           break;
-        case "map_fieldname":
+        case "map_field_name":
           mappers.add(context.deserialize(m.getValue(), MapFieldNameDescriptorImpl.class));
           break;
-        case "map_fieldvalue":
+        case "map_field_value":
           mappers.add(context.deserialize(m.getValue(), MapFieldValueDescriptorImpl.class));
           break;
         case "map_anonymize":
@@ -97,7 +97,7 @@ public class PostMapValuesAdapter implements JsonDeserializer<List<PostMapValues
   private JsonElement createMapperObject(PostMapValuesImpl postMapValues, JsonSerializationContext context) {
     JsonObject jsonObject = new JsonObject();
     for (MapFieldDescriptor m : postMapValues.getMappers()) {
-      jsonObject.add(((MapFieldDescriptorImpl)m).getJsonName(), context.serialize(m));
+      jsonObject.add(m.getJsonName(), context.serialize(m));
     }
     return jsonObject;
   }

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/StoryDataRegistry.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/StoryDataRegistry.java
@@ -18,11 +18,28 @@
  */
 package org.apache.ambari.logsearch.domain;
 
+import org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl.InputAdapter;
 import org.apache.solr.client.solrj.SolrClient;
 import org.jbehave.web.selenium.WebDriverProvider;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
 public class StoryDataRegistry {
   public static final StoryDataRegistry INSTANCE = new StoryDataRegistry();
+
+  public static final String CLUSTER = "cl1";
+  public static final String LOGSEARCH_GLOBAL_CONFIG = "[\n" +
+          "    {\n" +
+          "      \"add_fields\": {\n" +
+          "        \"cluster\": \""+ CLUSTER +"\"\n" +
+          "      },\n" +
+          "      \"source\": \"file\",\n" +
+          "      \"tail\": \"true\",\n" +
+          "      \"gen_event_md5\": \"true\"\n" +
+          "    }\n" +
+          "]";
+
 
   private SolrClient solrClient;
   private boolean logsearchContainerStarted = false;
@@ -38,6 +55,9 @@ public class StoryDataRegistry {
   private WebDriverProvider webDriverProvider;
 
   private StoryDataRegistry() {
+    JsonParser jsonParser = new JsonParser();
+    JsonElement globalConfigJsonElement = jsonParser.parse(LOGSEARCH_GLOBAL_CONFIG);
+    InputAdapter.setGlobalConfigs(globalConfigJsonElement.getAsJsonArray());
   }
 
   public String getDockerHost() {
@@ -114,5 +134,9 @@ public class StoryDataRegistry {
 
   public void setShellScriptFolder(String shellScriptFolder) {
     this.shellScriptFolder = shellScriptFolder;
+  }
+
+  public WebClient logsearchClient() {
+    return new WebClient(dockerHost, logsearchPort);
   }
 }

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/WebClient.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/domain/WebClient.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.domain;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebClient {
+  private static Logger LOG = LoggerFactory.getLogger(WebClient.class);
+
+  private final String host;
+  private final int port;
+
+  public WebClient(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  public String get(String path) {
+    JerseyClient jerseyClient = JerseyClientBuilder.createClient();
+    HttpAuthenticationFeature authFeature = HttpAuthenticationFeature.basicBuilder()
+            .credentials("admin", "admin")
+            .build();
+    jerseyClient.register(authFeature);
+
+    String url = String.format("http://%s:%d%s", host, port, path);
+
+    LOG.info("Url: {}", url);
+
+    WebTarget target = jerseyClient.target(url);
+    Invocation.Builder invocationBuilder =  target.request(MediaType.APPLICATION_JSON_TYPE);
+    return invocationBuilder.get().readEntity(String.class);
+  }
+
+  public String put(String path, String requestBody) {
+    JerseyClient jerseyClient = JerseyClientBuilder.createClient();
+    HttpAuthenticationFeature authFeature = HttpAuthenticationFeature.basicBuilder()
+            .credentials("admin", "admin")
+            .build();
+    jerseyClient.register(authFeature);
+
+    String url = String.format("http://%s:%d%s", host, port, path);
+
+    LOG.info("Url: {}", url);
+
+    WebTarget target = jerseyClient.target(url);
+    Invocation.Builder invocationBuilder =  target.request(MediaType.APPLICATION_JSON_TYPE);
+    String response = invocationBuilder.put(Entity.entity(requestBody, MediaType.APPLICATION_JSON_TYPE)).readEntity(String.class);
+
+    LOG.info("Response: {}", response);
+
+    return response;
+  }
+
+}

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchApiSteps.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchApiSteps.java
@@ -18,24 +18,6 @@
  */
 package org.apache.ambari.logsearch.steps;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flipkart.zjsonpatch.JsonDiff;
-import com.google.common.io.Resources;
-import org.apache.ambari.logsearch.domain.StoryDataRegistry;
-import org.glassfish.jersey.client.JerseyClient;
-import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.jbehave.core.annotations.Named;
-import org.jbehave.core.annotations.Then;
-import org.jbehave.core.annotations.When;
-import org.junit.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -43,6 +25,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.ambari.logsearch.domain.StoryDataRegistry;
+import org.jbehave.core.annotations.Named;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.zjsonpatch.JsonDiff;
+import com.google.common.io.Resources;
 
 public class LogSearchApiSteps {
 
@@ -52,22 +47,7 @@ public class LogSearchApiSteps {
 
   @When("LogSearch api query sent: <apiQuery>")
   public void sendApiQuery(@Named("apiQuery") String apiQuery) {
-    JerseyClient jerseyClient = JerseyClientBuilder.createClient();
-    HttpAuthenticationFeature authFeature = HttpAuthenticationFeature.basicBuilder()
-      .credentials("admin", "admin")
-      .build();
-    jerseyClient.register(authFeature);
-
-    String logsearchUrl = String.format("http://%s:%d%s",
-      StoryDataRegistry.INSTANCE.getDockerHost(),
-      StoryDataRegistry.INSTANCE.getLogsearchPort(),
-      apiQuery);
-
-    LOG.info("Url: {}", logsearchUrl);
-
-    WebTarget target = jerseyClient.target(logsearchUrl);
-    Invocation.Builder invocationBuilder =  target.request(MediaType.APPLICATION_JSON_TYPE);
-    response = invocationBuilder.get().readEntity(String.class);
+    response = StoryDataRegistry.INSTANCE.logsearchClient().get(apiQuery);
   }
 
 

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchConfigApiSteps.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/steps/LogSearchConfigApiSteps.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logsearch.steps;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import org.apache.ambari.logsearch.config.api.model.inputconfig.InputConfig;
+import org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl.InputConfigGson;
+import org.apache.ambari.logsearch.config.zookeeper.model.inputconfig.impl.InputConfigImpl;
+import org.apache.ambari.logsearch.domain.StoryDataRegistry;
+import org.hamcrest.Matchers;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+public class LogSearchConfigApiSteps {
+  private String response;
+  private InputConfig inputConfig;
+
+  @When("LogSearch api request sent: $url")
+  public String sendApiRequest(String url) {
+    response = StoryDataRegistry.INSTANCE.logsearchClient().get(url);
+    return response;
+  }
+
+  @Then("Result is an input.config of $inputConfigType with log file path $logFilePath")
+  public void checkInputConfig(String inputConfigType, String logFilePath) {
+    checkInputConfig(response, inputConfigType, logFilePath);
+  }
+
+  public void checkInputConfig(String result, String type, String path) {
+    inputConfig = InputConfigGson.gson.fromJson(response, InputConfigImpl.class);
+    assertThat(inputConfig.getInput(), is(not(Matchers.nullValue())));
+    assertThat(inputConfig.getInput(), hasSize(1));
+    assertThat(inputConfig.getInput().get(0).getType(), is(type));
+    assertThat(inputConfig.getInput().get(0).getPath(), is(path));
+  }
+
+  @When("Update input config of $inputConfigType path to $logFilePath at $url")
+  public void changeAndPut(String inputConfigType, String logFilePath, String url) {
+    String putRequest = response.replace(inputConfig.getInput().get(0).getPath(), logFilePath);
+    String putResponse = StoryDataRegistry.INSTANCE.logsearchClient().put(
+            url, putRequest);
+    assertThat(putResponse, is(""));
+
+    String getResponse = sendApiRequest(url);
+    checkInputConfig(getResponse, inputConfigType, logFilePath);
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/story/LogSearchBackendStories.java
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/java/org/apache/ambari/logsearch/story/LogSearchBackendStories.java
@@ -18,12 +18,12 @@
  */
 package org.apache.ambari.logsearch.story;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
+import java.util.List;
+
 import org.apache.ambari.logsearch.steps.LogSearchApiSteps;
-import org.apache.ambari.logsearch.steps.SolrSteps;
+import org.apache.ambari.logsearch.steps.LogSearchConfigApiSteps;
 import org.apache.ambari.logsearch.steps.LogSearchDockerSteps;
+import org.apache.ambari.logsearch.steps.SolrSteps;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.MostUsefulConfiguration;
 import org.jbehave.core.junit.JUnitStories;
@@ -33,7 +33,9 @@ import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.InstanceStepsFactory;
 import org.junit.Test;
 
-import java.util.List;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 
 public class LogSearchBackendStories extends JUnitStories {
 
@@ -53,7 +55,8 @@ public class LogSearchBackendStories extends JUnitStories {
     return new InstanceStepsFactory(configuration(),
       new LogSearchDockerSteps(),
       new SolrSteps(),
-      new LogSearchApiSteps());
+      new LogSearchApiSteps(),
+      new LogSearchConfigApiSteps());
   }
 
   @Test

--- a/ambari-logsearch/ambari-logsearch-it/src/test/resources/stories/backend/log_search_cofig_api_tests.story
+++ b/ambari-logsearch/ambari-logsearch-it/src/test/resources/stories/backend/log_search_cofig_api_tests.story
@@ -1,0 +1,9 @@
+Scenario: scenario description
+
+Given logsearch docker container
+When LogSearch api request sent: /api/v1/shipper/input/cl1/services/ambari
+Then Result is an input.config of ambari_audit with log file path /root/test-logs/ambari-server/ambari-audit.log
+
+Given logsearch docker container
+When Update input config of ambari_audit path to /root/test-logs/ambari-server/ambari-audit.log.1 at /api/v1/shipper/input/cl1/services/ambari
+Then Result is an input.config of ambari_audit with log file path /root/test-logs/ambari-server/ambari-audit.log.1

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/alias_config.json
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/alias_config.json
@@ -25,13 +25,13 @@
     "map_date": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperDate"
     },
-    "map_fieldcopy": {
+    "map_field_copy": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperFieldCopy"
     },
-    "map_fieldname": {
+    "map_field_name": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperFieldName"
     },
-    "map_fieldvalue": {
+    "map_field_value": {
       "klass": "org.apache.ambari.logfeeder.mapper.MapperFieldValue"
     },
     "map_anonymize": {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/filters.config.json
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/resources/filters.config.json
@@ -155,7 +155,7 @@
 					
 				},
 				"level":{
-					"map_fieldvalue":{
+					"map_field_value":{
 						"pre_value":"WARNING",
 						"post_value":"WARN"
 					}
@@ -509,55 +509,55 @@
 			"field_split":"\t",
 			"post_map_values":{
 				"src":{
-					"map_fieldname":{
-						"new_fieldname":"resource"
+					"map_field_name":{
+						"new_field_name":"resource"
 					}
 					
 				},
 				"ip":{
-					"map_fieldname":{
-						"new_fieldname":"cliIP"
+					"map_field_name":{
+						"new_field_name":"cliIP"
 					}
 					
 				},
 				"allowed":[
 					{
-						"map_fieldvalue":{
+						"map_field_value":{
 							"pre_value":"true",
 							"post_value":"1"
 						}
 						
 					},
 					{
-						"map_fieldvalue":{
+						"map_field_value":{
 							"pre_value":"false",
 							"post_value":"0"
 						}
 						
 					},
 					{
-						"map_fieldname":{
-							"new_fieldname":"result"
+						"map_field_name":{
+							"new_field_name":"result"
 						}
 						
 					}
 					
 				],
 				"cmd":{
-					"map_fieldname":{
-						"new_fieldname":"action"
+					"map_field_name":{
+						"new_field_name":"action"
 					}
 					
 				},
 				"proto":{
-					"map_fieldname":{
-						"new_fieldname":"cliType"
+					"map_field_name":{
+						"new_field_name":"cliType"
 					}
 					
 				},
 				"callerContext":{
-					"map_fieldname":{
-						"new_fieldname":"req_caller_id"
+					"map_field_name":{
+						"new_field_name":"req_caller_id"
 					}
 					
 				}
@@ -582,38 +582,38 @@
 			"message_pattern":"%{USERNAME:p_user}.+auth:%{USERNAME:p_authType}.+via %{USERNAME:k_user}.+auth:%{USERNAME:k_authType}|%{USERNAME:user}.+auth:%{USERNAME:authType}|%{USERNAME:x_user}",
 			"post_map_values":{
 				"user":{
-					"map_fieldname":{
-						"new_fieldname":"reqUser"
+					"map_field_name":{
+						"new_field_name":"reqUser"
 					}
 					
 				},
 				"x_user":{
-					"map_fieldname":{
-						"new_fieldname":"reqUser"
+					"map_field_name":{
+						"new_field_name":"reqUser"
 					}
 					
 				},
 				"p_user":{
-					"map_fieldname":{
-						"new_fieldname":"reqUser"
+					"map_field_name":{
+						"new_field_name":"reqUser"
 					}
 					
 				},
 				"k_user":{
-					"map_fieldname":{
-						"new_fieldname":"proxyUsers"
+					"map_field_name":{
+						"new_field_name":"proxyUsers"
 					}
 					
 				},
 				"p_authType":{
-					"map_fieldname":{
-						"new_fieldname":"authType"
+					"map_field_name":{
+						"new_field_name":"authType"
 					}
 					
 				},
 				"k_authType":{
-					"map_fieldname":{
-						"new_fieldname":"proxyAuthType"
+					"map_field_name":{
+						"new_field_name":"proxyAuthType"
 					}
 					
 				}

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/test/resources/samples/config/config_audit.json
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/test/resources/samples/config/config_audit.json
@@ -39,52 +39,52 @@
       "field_split": "\t",
       "post_map_values": {
         "src": {
-          "map_fieldname": {
-            "new_fieldname": "resource"
+          "map_field_name": {
+            "new_field_name": "resource"
           }
 
         },
         "ip": {
-          "map_fieldname": {
-            "new_fieldname": "cliIP"
+          "map_field_name": {
+            "new_field_name": "cliIP"
           }
 
         },
         "allowed": [{
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "true",
               "post_value": "1"
             }
 
           }, {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "false",
               "post_value": "0"
             }
 
           }, {
-            "map_fieldname": {
-              "new_fieldname": "result"
+            "map_field_name": {
+              "new_field_name": "result"
             }
 
           }
 
         ],
         "cmd": {
-          "map_fieldname": {
-            "new_fieldname": "action"
+          "map_field_name": {
+            "new_field_name": "action"
           }
 
         },
         "proto": {
-          "map_fieldname": {
-            "new_fieldname": "cliType"
+          "map_field_name": {
+            "new_field_name": "cliType"
           }
 
         },
         "callerContext": {
-          "map_fieldname": {
-            "new_fieldname": "req_caller_id"
+          "map_field_name": {
+            "new_field_name": "req_caller_id"
           }
 
         }
@@ -108,38 +108,38 @@
       "message_pattern": "%{USERNAME:p_user}.+auth:%{USERNAME:p_authType}.+via %{USERNAME:k_user}.+auth:%{USERNAME:k_authType}|%{USERNAME:user}.+auth:%{USERNAME:authType}|%{USERNAME:x_user}",
       "post_map_values": {
         "user": {
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
 
         },
         "x_user": {
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
 
         },
         "p_user": {
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
 
         },
         "k_user": {
-          "map_fieldname": {
-            "new_fieldname": "proxyUsers"
+          "map_field_name": {
+            "new_field_name": "proxyUsers"
           }
 
         },
         "p_authType": {
-          "map_fieldname": {
-            "new_fieldname": "authType"
+          "map_field_name": {
+            "new_field_name": "authType"
           }
 
         },
         "k_authType": {
-          "map_fieldname": {
-            "new_fieldname": "proxyAuthType"
+          "map_field_name": {
+            "new_field_name": "proxyAuthType"
           }
 
         }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldCopy.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldCopy.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModel;
 public class LSServerMapFieldCopy extends LSServerMapField {
   @Override
   public String getName() {
-    return "map_fieldcopy";
+    return "map_field_copy";
   }
 
   @NotNull

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldName.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldName.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModel;
 public class LSServerMapFieldName extends LSServerMapField {
   @Override
   public String getName() {
-    return "map_fieldname";
+    return "map_field_name";
   }
 
   @NotNull

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldValue.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerMapFieldValue.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModel;
 public class LSServerMapFieldValue extends LSServerMapField {
   @Override
   public String getName() {
-    return "map_fieldvalue";
+    return "map_field_value";
   }
 
   @NotNull

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerPostMapValuesListDeserializer.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerPostMapValuesListDeserializer.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class LSServerPostMapValuesListDeserializer extends JsonDeserializer<LSServerPostMapValuesList> {
   @Override
   public LSServerPostMapValuesList deserialize(JsonParser jp, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws IOException {
     ObjectCodec oc = jp.getCodec();
     JsonNode node = oc.readTree(jp);
     
@@ -49,24 +49,24 @@ public class LSServerPostMapValuesListDeserializer extends JsonDeserializer<LSSe
         JsonNode mapperProperties = mapperData.getValue();
         switch (mapperType) {
           case "map_date" :
-            LSServerMapDate mapDate = oc.treeToValue((TreeNode)mapperProperties, LSServerMapDate.class);
+            LSServerMapDate mapDate = oc.treeToValue(mapperProperties, LSServerMapDate.class);
             mappers.add(mapDate);
             break;
-          case "map_fieldname" :
-            LSServerMapFieldName mapFieldName = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldName.class);
+          case "map_field_name" :
+            LSServerMapFieldName mapFieldName = oc.treeToValue(mapperProperties, LSServerMapFieldName.class);
             mappers.add(mapFieldName);
             break;
-          case "map_fieldvalue" :
-            LSServerMapFieldValue mapFieldValue = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldValue.class);
+          case "map_field_value" :
+            LSServerMapFieldValue mapFieldValue = oc.treeToValue(mapperProperties, LSServerMapFieldValue.class);
             mappers.add(mapFieldValue);
             break;
-          case "map_fieldcopy" :
-            LSServerMapFieldCopy mapFieldCopy = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldCopy.class);
+          case "map_field_copy" :
+            LSServerMapFieldCopy mapFieldCopy = oc.treeToValue(mapperProperties, LSServerMapFieldCopy.class);
             mappers.add(mapFieldCopy);
             break;
           case "map_anonymize" :
-            LSServerMapFieldAnonymize mapAnonyimize = oc.treeToValue((TreeNode)mapperProperties, LSServerMapFieldAnonymize.class);
-            mappers.add(mapAnonyimize);
+            LSServerMapFieldAnonymize mapAnonymize = oc.treeToValue(mapperProperties, LSServerMapFieldAnonymize.class);
+            mappers.add(mapAnonymize);
             break;
         }
       }

--- a/ambari-logsearch/ambari-logsearch-web/src/mockdata/mock-data-get.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/mockdata/mock-data-get.ts
@@ -1954,54 +1954,54 @@ export const mockDataGet = {
         'post_map_values': {
           'callerContext': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'req_caller_id'
               }
             }
           ],
           'src': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'resource'
               }
             }
           ],
           'allowed': [
             {
-              'map_fieldvalue': {
+              'map_field_value': {
                 'pre_value': 'true',
                 'post_value': '1'
               }
             },
             {
-              'map_fieldvalue': {
+              'map_field_value': {
                 'pre_value': 'false',
                 'post_value': '0'
               }
             },
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'result'
               }
             }
           ],
           'ip': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'cliIP'
               }
             }
           ],
           'proto': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'cliType'
               }
             }
           ],
           'cmd': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'action'
               }
             }
@@ -2025,42 +2025,42 @@ export const mockDataGet = {
         'post_map_values': {
           'k_authType': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'proxyAuthType'
               }
             }
           ],
           'p_authType': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'authType'
               }
             }
           ],
           'x_user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'reqUser'
               }
             }
           ],
           'k_user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'proxyUsers'
               }
             }
           ],
           'p_user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'reqUser'
               }
             }
           ],
           'user': [
             {
-              'map_fieldname': {
+              'map_field_name': {
                 'new_field_name': 'reqUser'
               }
             }

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-ambari.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-ambari.json
@@ -49,324 +49,324 @@
       "value_borders": "()",
       "post_map_values": {
         "User": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "reqUser"
+          "map_field_name": {
+            "new_field_name": "reqUser"
           }
         },
         "Hostname": {
-          "map_fieldname": {
-            "new_fieldname": "host"
+          "map_field_name": {
+            "new_field_name": "host"
           }
         },
         "Host name": {
-          "map_fieldname": {
-            "new_fieldname": "host"
+          "map_field_name": {
+            "new_field_name": "host"
           }
         },
         "RemoteIp": {
-          "map_fieldname": {
-            "new_fieldname": "cliIP"
+          "map_field_name": {
+            "new_field_name": "cliIP"
           }
         },
         "RequestType": {
-          "map_fieldname": {
-            "new_fieldname": "cliType"
+          "map_field_name": {
+            "new_field_name": "cliType"
           }
         },
         "Operation": {
-          "map_fieldname": {
-            "new_fieldname": "action"
+          "map_field_name": {
+            "new_field_name": "action"
           }
         },
         "url": {
-          "map_fieldname": {
-            "new_fieldname": "resource"
+          "map_field_name": {
+            "new_field_name": "resource"
           }
         },
         "ResourcePath": {
-          "map_fieldname": {
-            "new_fieldname": "resource"
+          "map_field_name": {
+            "new_field_name": "resource"
           }
         },
         "Cluster name": {
-          "map_fieldname": {
-            "new_fieldname": "cluster"
+          "map_field_name": {
+            "new_field_name": "cluster"
           }
         },
         "Reason": {
-          "map_fieldname": {
-            "new_fieldname": "reason"
+          "map_field_name": {
+            "new_field_name": "reason"
           }
         },
         "Base URL": {
-          "map_fieldname": {
-            "new_fieldname": "ws_base_url"
+          "map_field_name": {
+            "new_field_name": "ws_base_url"
           }
         },
         "Command": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_command"
+          "map_field_name": {
+            "new_field_name": "ws_command"
           }
         },
         "Component": {
-          "map_fieldname": {
-            "new_fieldname": "ws_component"
+          "map_field_name": {
+            "new_field_name": "ws_component"
           }
         },
         "Details": {
-          "map_fieldname": {
-            "new_fieldname": "ws_details"
+          "map_field_name": {
+            "new_field_name": "ws_details"
           }
         },
         "Display name": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_display_name"
+          "map_field_name": {
+            "new_field_name": "ws_display_name"
           }
         },
         "OS": {
-          "map_fieldname": {
-            "new_fieldname": "ws_os"
+          "map_field_name": {
+            "new_field_name": "ws_os"
           }
         },
         "Repo id": {
-          "map_fieldname": {
-            "new_fieldname": "ws_repo_id"
+          "map_field_name": {
+            "new_field_name": "ws_repo_id"
           }
         },
         "Repo version": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_repo_version"
+          "map_field_name": {
+            "new_field_name": "ws_repo_version"
           }
         },
         "Repositories": {
-          "map_fieldname": {
-            "new_fieldname": "ws_repositories"
+          "map_field_name": {
+            "new_field_name": "ws_repositories"
           }
         },
         "RequestId": {
-          "map_fieldname": {
-            "new_fieldname": "ws_request_id"
+          "map_field_name": {
+            "new_field_name": "ws_request_id"
           }
         },
         "Roles": {
-          "map_fieldname": {
-            "new_fieldname": "ws_roles"
+          "map_field_name": {
+            "new_field_name": "ws_roles"
           }
         },
         "Stack": {
-          "map_fieldname": {
-            "new_fieldname": "ws_stack"
+          "map_field_name": {
+            "new_field_name": "ws_stack"
           }
         },
         "Stack version": {
-          "map_fieldname": {
-            "new_fieldname": "ws_stack_version"
+          "map_field_name": {
+            "new_field_name": "ws_stack_version"
           }
         },
         "TaskId": {
-          "map_fieldname": {
-            "new_fieldname": "ws_task_id"
+          "map_field_name": {
+            "new_field_name": "ws_task_id"
           }
         },
         "VersionNote": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_version_note"
+          "map_field_name": {
+            "new_field_name": "ws_version_note"
           }
         },
         "VersionNumber": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "null",
             "post_value": "unknown"
           },
-          "map_fieldname": {
-            "new_fieldname": "ws_version_number"
+          "map_field_name": {
+            "new_field_name": "ws_version_number"
           }
         },
         "Status": [
           {
-            "map_fieldcopy": {
+            "map_field_copy": {
               "copy_name": "ws_status"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Success",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Successfully queued",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "QUEUED",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "PENDING",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "COMPLETED",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "IN_PROGRESS",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Failed",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "Failed to queue",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "HOLDING",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "HOLDING_FAILED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "HOLDING_TIMEDOUT",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "FAILED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "TIMEDOUT",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "ABORTED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "SKIPPED_FAILED",
               "post_value": "0"
             }
           },
           {
-            "map_fieldname": {
-              "new_fieldname": "result"
+            "map_field_name": {
+              "new_field_name": "result"
             }
           }
         ],
         "ResultStatus": [
           {
-            "map_fieldcopy": {
+            "map_field_copy": {
               "copy_name": "ws_result_status"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "200 OK",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "201 Created",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "202 Accepted",
               "post_value": "1"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "400 Bad Request",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "401 Unauthorized",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "403 Forbidden",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "404 Not Found",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "409 Resource Conflict",
               "post_value": "0"
             }
           },
           {
-            "map_fieldvalue": {
+            "map_field_value": {
               "pre_value": "500 Internal Server Error",
               "post_value": "0"
             }
           },
           {
-            "map_fieldname": {
-              "new_fieldname": "result"
+            "map_field_name": {
+              "new_field_name": "result"
             }
           }
         ]

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hdfs.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hdfs.json
@@ -56,55 +56,55 @@
       "field_split":"\t",
       "post_map_values":{
         "src":{
-          "map_fieldname":{
-            "new_fieldname":"resource"
+          "map_field_name":{
+            "new_field_name":"resource"
           }
 
         },
         "ip":{
-          "map_fieldname":{
-            "new_fieldname":"cliIP"
+          "map_field_name":{
+            "new_field_name":"cliIP"
           }
 
         },
         "allowed":[
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"true",
               "post_value":"1"
             }
 
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"false",
               "post_value":"0"
             }
 
           },
           {
-            "map_fieldname":{
-              "new_fieldname":"result"
+            "map_field_name":{
+              "new_field_name":"result"
             }
 
           }
 
         ],
         "cmd":{
-          "map_fieldname":{
-            "new_fieldname":"action"
+          "map_field_name":{
+            "new_field_name":"action"
           }
 
         },
         "proto":{
-          "map_fieldname":{
-            "new_fieldname":"cliType"
+          "map_field_name":{
+            "new_field_name":"cliType"
           }
 
         },
         "callerContext":{
-          "map_fieldname":{
-            "new_fieldname":"req_caller_id"
+          "map_field_name":{
+            "new_field_name":"req_caller_id"
           }
 
         }
@@ -129,38 +129,38 @@
       "message_pattern":"%{USERNAME:p_user}.+auth:%{USERNAME:p_authType}.+via %{USERNAME:k_user}.+auth:%{USERNAME:k_authType}|%{USERNAME:user}.+auth:%{USERNAME:authType}|%{USERNAME:x_user}",
       "post_map_values":{
         "user":{
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
 
         },
         "x_user":{
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
 
         },
         "p_user":{
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
 
         },
         "k_user":{
-          "map_fieldname":{
-            "new_fieldname":"proxyUsers"
+          "map_field_name":{
+            "new_field_name":"proxyUsers"
           }
 
         },
         "p_authType":{
-          "map_fieldname":{
-            "new_fieldname":"authType"
+          "map_field_name":{
+            "new_field_name":"authType"
           }
 
         },
         "k_authType":{
-          "map_fieldname":{
-            "new_fieldname":"proxyAuthType"
+          "map_field_name":{
+            "new_field_name":"proxyAuthType"
           }
 
         }

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hst.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-hst.json
@@ -27,7 +27,7 @@
           }
         },
         "level": {
-          "map_fieldvalue": {
+          "map_field_value": {
             "pre_value": "WARNING",
             "post_value": "WARN"
           }

--- a/ambari-server/src/main/java/org/apache/ambari/server/AmbariRuntimeException.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/AmbariRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,33 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ambari.server.agent.stomp.dto;
 
+package org.apache.ambari.server;
 
-import org.apache.ambari.server.agent.RecoveryConfig;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class HostLevelParamsCluster {
-
-  @JsonProperty("hostRepositories")
-  private HostRepositories hostRepositories;
-
-  @JsonProperty("recoveryConfig")
-  private RecoveryConfig recoveryConfig;
-
-  public HostLevelParamsCluster(HostRepositories hostRepositories, RecoveryConfig recoveryConfig) {
-    this.hostRepositories = hostRepositories;
-    this.recoveryConfig = recoveryConfig;
-  }
-
-  public HostRepositories getHostRepositories() {
-    return hostRepositories;
-  }
-
-  public RecoveryConfig getRecoveryConfig() {
-    return recoveryConfig;
+/**
+ * Ambari unchecked exception.
+ */
+public class AmbariRuntimeException extends RuntimeException {
+  public AmbariRuntimeException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentConfigsHolder.java
@@ -58,9 +58,9 @@ public class AgentConfigsHolder extends AgentHostDataHolder<AgentConfigsUpdateEv
     return configHelper.getHostActualConfigsExcludeCluster(hostId, clusterId);
   }
 
-  protected boolean handleUpdate(AgentConfigsUpdateEvent update) throws AmbariException {
-    setData(update, update.getHostId());
-    return true;
+  @Override
+  protected AgentConfigsUpdateEvent handleUpdate(AgentConfigsUpdateEvent current, AgentConfigsUpdateEvent update) throws AmbariException {
+    return update;
   }
 
   public void updateData(Long clusterId, List<Long> hostIds) throws AmbariException {
@@ -75,7 +75,6 @@ public class AgentConfigsHolder extends AgentHostDataHolder<AgentConfigsUpdateEv
 
     for (Long hostId : hostIds) {
       AgentConfigsUpdateEvent agentConfigsUpdateEvent = configHelper.getHostActualConfigs(hostId);
-      agentConfigsUpdateEvent.setHostId(hostId);
       updateData(agentConfigsUpdateEvent);
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/AgentHostDataHolder.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.AmbariRuntimeException;
 import org.apache.ambari.server.agent.stomp.dto.Hashable;
 import org.apache.ambari.server.events.STOMPEvent;
 import org.apache.ambari.server.events.STOMPHostEvent;
@@ -42,10 +43,10 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
   @Inject
   private STOMPUpdatePublisher STOMPUpdatePublisher;
 
-  private final Map<Long, T> data = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Long, T> data = new ConcurrentHashMap<>();
 
   protected abstract T getCurrentData(Long hostId) throws AmbariException;
-  protected abstract boolean handleUpdate(T update) throws AmbariException;
+  protected abstract T handleUpdate(T current, T update) throws AmbariException;
 
   public T getUpdateIfChanged(String agentHash, Long hostId) throws AmbariException {
     T hostData = initializeDataIfNeeded(hostId, true);
@@ -53,23 +54,25 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
   }
 
   public T initializeDataIfNeeded(Long hostId, boolean regenerateHash) throws AmbariException {
-    updateLock.lock();
     try {
-      T hostData = data.get(hostId);
-      if (hostData == null) {
-        hostData = data.get(hostId);
-        if (hostData == null) {
-          hostData = getCurrentData(hostId);
-          if (regenerateHash) {
-            regenerateDataIdentifiers(hostData);
-          }
-          data.put(hostId, hostData);
-        }
-      }
-      return hostData;
-    } finally {
-      updateLock.unlock();
+      return data.computeIfAbsent(hostId, id -> initializeData(hostId, regenerateHash));
+    } catch (AmbariRuntimeException e) {
+      throw new AmbariException(e.getMessage(), e);
     }
+  }
+
+  private T initializeData(Long hostId, boolean regenerateHash) {
+    T hostData;
+    try {
+      hostData = getCurrentData(hostId);
+    } catch (AmbariException e) {
+      LOG.error("Error during retrieving initial value for host: {} and class {}", hostId, getClass().getName(), e);
+      throw new AmbariRuntimeException("Error during retrieving initial value for host: " + hostId + " and class: " + getClass().getName(), e);
+    }
+    if (regenerateHash) {
+      regenerateDataIdentifiers(hostData);
+    }
+    return hostData;
   }
 
   /**
@@ -77,21 +80,34 @@ public abstract class AgentHostDataHolder<T extends STOMPHostEvent & Hashable> e
    * event to listeners.
    */
   public void updateData(T update) throws AmbariException {
-    //TODO need optimization for perf cluster
-    updateLock.lock();
     try {
-      initializeDataIfNeeded(update.getHostId(), true);
-      if (handleUpdate(update)) {
-        T hostData = getData(update.getHostId());
-        regenerateDataIdentifiers(hostData);
-        setIdentifiersToEventUpdate(update, hostData);
-        if (update.getType().equals(STOMPEvent.Type.AGENT_CONFIGS)) {
-          LOG.info("Configs update with hash {} will be sent to host {}", update.getHash(), hostData.getHostId());
+      data.compute(update.getHostId(), (id, current) -> {
+        if (current == null) {
+          current = initializeData(id, true);
         }
-        STOMPUpdatePublisher.publish(update);
+        T updated;
+        try {
+          updated = handleUpdate(current, update);
+        } catch (AmbariException e) {
+          LOG.error("Error during handling update for host: {} and class {}", id, getClass().getName(), e);
+          throw new AmbariRuntimeException("Error during handling update for host: " + id + " and class: " + getClass().getName(), e);
+        }
+        if (updated == null) {
+          return current;
+        } else {
+          regenerateDataIdentifiers(updated);
+          setIdentifiersToEventUpdate(update, updated);
+          return updated;
+        }
+      });
+    } catch(AmbariRuntimeException e) {
+      throw new AmbariException(e.getMessage(), e);
+    }
+    if (isIdentifierValid(update)) {
+      if (update.getType().equals(STOMPEvent.Type.AGENT_CONFIGS)) {
+        LOG.info("Configs update with hash {} will be sent to host {}", update.getHash(), update.getHostId());
       }
-    } finally {
-      updateLock.unlock();
+      STOMPUpdatePublisher.publish(update);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolder.java
@@ -17,12 +17,17 @@
  */
 package org.apache.ambari.server.agent.stomp;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.agent.CommandRepository;
+import org.apache.ambari.server.agent.RecoveryConfig;
 import org.apache.ambari.server.agent.RecoveryConfigHelper;
 import org.apache.ambari.server.agent.stomp.dto.HostLevelParamsCluster;
+import org.apache.ambari.server.agent.stomp.dto.HostRepositories;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.events.ClusterComponentsRepoChangedEvent;
 import org.apache.ambari.server.events.HostLevelParamsUpdateEvent;
@@ -76,42 +81,72 @@ public class HostLevelParamsHolder extends AgentHostDataHolder<HostLevelParamsUp
       hostLevelParamsClusters.put(Long.toString(cl.getClusterId()),
           hostLevelParamsCluster);
     }
-    HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent = new HostLevelParamsUpdateEvent(hostLevelParamsClusters);
-    hostLevelParamsUpdateEvent.setHostId(hostId);
+    HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent = new HostLevelParamsUpdateEvent(hostId, hostLevelParamsClusters);
     return hostLevelParamsUpdateEvent;
   }
 
-  protected boolean handleUpdate(HostLevelParamsUpdateEvent update) {
+  @Override
+  protected HostLevelParamsUpdateEvent handleUpdate(HostLevelParamsUpdateEvent current, HostLevelParamsUpdateEvent update) {
+    HostLevelParamsUpdateEvent result = null;
     boolean changed = false;
+    Map<String, HostLevelParamsCluster> mergedClusters = new HashMap<>();
     if (MapUtils.isNotEmpty(update.getHostLevelParamsClusters())) {
-      Long hostId = update.getHostId();
-      for (Map.Entry<String, HostLevelParamsCluster> hostLevelParamsClusterEntry : update.getHostLevelParamsClusters().entrySet()) {
-        HostLevelParamsCluster updatedCluster = hostLevelParamsClusterEntry.getValue();
+      // put from current all clusters absent in update
+      for (Map.Entry<String, HostLevelParamsCluster> hostLevelParamsClusterEntry : current.getHostLevelParamsClusters().entrySet()) {
         String clusterId = hostLevelParamsClusterEntry.getKey();
-        Map<String, HostLevelParamsCluster> clusters = getData().get(hostId).getHostLevelParamsClusters();
-        if (clusters.containsKey(clusterId)) {
-          HostLevelParamsCluster cluster = clusters.get(clusterId);
-          if (!cluster.getRecoveryConfig().equals(updatedCluster.getRecoveryConfig())) {
-            cluster.setRecoveryConfig(updatedCluster.getRecoveryConfig());
-            changed = true;
+        if (!update.getHostLevelParamsClusters().containsKey(clusterId)) {
+          mergedClusters.put(clusterId, hostLevelParamsClusterEntry.getValue());
+        }
+      }
+      // process clusters from update
+      for (Map.Entry<String, HostLevelParamsCluster> hostLevelParamsClusterEntry : update.getHostLevelParamsClusters().entrySet()) {
+        String clusterId = hostLevelParamsClusterEntry.getKey();
+        if (current.getHostLevelParamsClusters().containsKey(clusterId)) {
+          boolean clusterChanged = false;
+          HostLevelParamsCluster updatedCluster = hostLevelParamsClusterEntry.getValue();
+          HostLevelParamsCluster currentCluster = current.getHostLevelParamsClusters().get(clusterId);
+          RecoveryConfig mergedRecoveryConfig;
+          SortedMap<Long, CommandRepository> mergedRepositories;
+          SortedMap<String, Long> mergedComponentRepos;
+          if (!currentCluster.getRecoveryConfig().equals(updatedCluster.getRecoveryConfig())) {
+            mergedRecoveryConfig = updatedCluster.getRecoveryConfig();
+            clusterChanged = true;
+          } else {
+            mergedRecoveryConfig = currentCluster.getRecoveryConfig();
           }
-          if (!cluster.getHostRepositories().getRepositories()
+          if (!currentCluster.getHostRepositories().getRepositories()
               .equals(updatedCluster.getHostRepositories().getRepositories())) {
-            cluster.getHostRepositories().setRepositories(updatedCluster.getHostRepositories().getRepositories());
-            changed = true;
+            mergedRepositories = updatedCluster.getHostRepositories().getRepositories();
+            clusterChanged = true;
+          } else {
+            mergedRepositories = currentCluster.getHostRepositories().getRepositories();
           }
-          if (!cluster.getHostRepositories().getComponentRepos()
+          if (!currentCluster.getHostRepositories().getComponentRepos()
               .equals(updatedCluster.getHostRepositories().getComponentRepos())) {
-            cluster.getHostRepositories().setComponentRepos(updatedCluster.getHostRepositories().getComponentRepos());
+            mergedComponentRepos = updatedCluster.getHostRepositories().getComponentRepos();
+            clusterChanged = true;
+          } else {
+            mergedComponentRepos = currentCluster.getHostRepositories().getComponentRepos();
+          }
+          if (clusterChanged) {
+            HostLevelParamsCluster mergedCluster = new HostLevelParamsCluster(
+                new HostRepositories(mergedRepositories, mergedComponentRepos),
+                mergedRecoveryConfig);
+            mergedClusters.put(clusterId, mergedCluster);
             changed = true;
+          } else {
+            mergedClusters.put(clusterId, hostLevelParamsClusterEntry.getValue());
           }
         } else {
-          clusters.put(clusterId, updatedCluster);
+          mergedClusters.put(clusterId, hostLevelParamsClusterEntry.getValue());
           changed = true;
         }
       }
     }
-    return changed;
+    if (changed) {
+      result = new HostLevelParamsUpdateEvent(current.getHostId(), mergedClusters);
+    }
+    return result;
   }
 
   @Override
@@ -137,11 +172,11 @@ public class HostLevelParamsHolder extends AgentHostDataHolder<HostLevelParamsUp
   }
 
   private void updateDataOfHost(long clusterId, Cluster cluster, Host host) throws AmbariException {
-    HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent = new HostLevelParamsUpdateEvent(Long.toString(clusterId),
+    HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent = new HostLevelParamsUpdateEvent(host.getHostId(),
+        Long.toString(clusterId),
             new HostLevelParamsCluster(
                     m_ambariManagementController.get().retrieveHostRepositories(cluster, host),
                     recoveryConfigHelper.getRecoveryConfig(cluster.getClusterName(), host.getHostName())));
-    hostLevelParamsUpdateEvent.setHostId(host.getHostId());
     updateData(hostLevelParamsUpdateEvent);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/AlertCluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/AlertCluster.java
@@ -79,41 +79,58 @@ public class AlertCluster {
     return hostName;
   }
 
-  public boolean handleUpdate(AlertDefinitionEventType eventType, AlertCluster update) {
+  public AlertCluster handleUpdate(AlertDefinitionEventType eventType, AlertCluster update) {
     boolean changed = false;
 
+    AlertCluster mergedCluster = null;
+    Map<Long, AlertDefinition> mergedDefinitions = new HashMap<>();
+    Integer mergedStaleIntervalMultiplier = null;
     switch (eventType) {
       case CREATE:
         // FIXME should clear map first?
       case UPDATE:
-        changed = !alertDefinitions.keySet().containsAll(update.alertDefinitions.keySet());
-        if (changed) {
-          alertDefinitions.putAll(update.alertDefinitions);
-        } else {
-          for (Map.Entry<Long, AlertDefinition> e : update.alertDefinitions.entrySet()) {
-            Long definitionId = e.getKey();
-            AlertDefinition newDefinition = e.getValue();
-            AlertDefinition oldDefinition = alertDefinitions.put(definitionId, newDefinition);
-            changed = changed || !oldDefinition.deeplyEquals(newDefinition);
+        for (Map.Entry<Long, AlertDefinition> alertDefinitionEntry : alertDefinitions.entrySet()) {
+          Long definitionId = alertDefinitionEntry.getKey();
+          if (!update.alertDefinitions.containsKey(definitionId)) {
+            mergedDefinitions.put(definitionId, alertDefinitionEntry.getValue());
+          } else {
+            AlertDefinition newDefinition = update.alertDefinitions.get(definitionId);
+            AlertDefinition oldDefinition = alertDefinitionEntry.getValue();
+            if (!oldDefinition.deeplyEquals(newDefinition)) {
+              changed = true;
+            }
+            mergedDefinitions.put(definitionId, oldDefinition);
           }
         }
         if (update.getStaleIntervalMultiplier() != null
             && !update.getStaleIntervalMultiplier().equals(staleIntervalMultiplier)) {
-          staleIntervalMultiplier = update.getStaleIntervalMultiplier();
+          mergedStaleIntervalMultiplier = update.getStaleIntervalMultiplier();
           changed = true;
+        } else {
+          mergedStaleIntervalMultiplier = staleIntervalMultiplier;
         }
         LOG.debug("Handled {} of {} alerts, changed = {}", eventType, update.alertDefinitions.size(), changed);
         break;
       case DELETE:
-        changed = alertDefinitions.keySet().removeAll(update.alertDefinitions.keySet());
+        for (Map.Entry<Long, AlertDefinition> alertDefinitionEntry : alertDefinitions.entrySet()) {
+          Long definitionId = alertDefinitionEntry.getKey();
+          if (!update.alertDefinitions.containsKey(definitionId)) {
+            mergedDefinitions.put(definitionId, alertDefinitionEntry.getValue());
+          } else {
+            changed = true;
+          }
+        }
+        mergedStaleIntervalMultiplier = staleIntervalMultiplier;
         LOG.debug("Handled {} of {} alerts", eventType, update.alertDefinitions.size());
         break;
       default:
         LOG.warn("Unhandled event type {}", eventType);
         break;
     }
-
-    return changed;
+    if (changed) {
+      mergedCluster = new AlertCluster(mergedDefinitions, hostName, mergedStaleIntervalMultiplier);
+    }
+    return mergedCluster;
   }
 
   public static AlertCluster emptyAlertCluster() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/ClusterConfigs.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/ClusterConfigs.java
@@ -36,16 +36,9 @@ public class ClusterConfigs {
     return configurations;
   }
 
-  public void setConfigurations(SortedMap<String, SortedMap<String, String>> configurations) {
-    this.configurations = configurations;
-  }
 
   public SortedMap<String, SortedMap<String, SortedMap<String, String>>> getConfigurationAttributes() {
     return configurationAttributes;
-  }
-
-  public void setConfigurationAttributes(SortedMap<String, SortedMap<String, SortedMap<String, String>>> configurationAttributes) {
-    this.configurationAttributes = configurationAttributes;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/HostRepositories.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/stomp/dto/HostRepositories.java
@@ -44,15 +44,7 @@ public class HostRepositories {
     return repositories;
   }
 
-  public void setRepositories(SortedMap<Long, CommandRepository> repositories) {
-    this.repositories = repositories;
-  }
-
   public SortedMap<String, Long> getComponentRepos() {
     return componentRepos;
-  }
-
-  public void setComponentRepos(SortedMap<String, Long> componentRepos) {
-    this.componentRepos = componentRepos;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ClusterResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/ClusterResourceDefinition.java
@@ -88,6 +88,7 @@ public class ClusterResourceDefinition extends BaseResourceDefinition {
     directives.add(KerberosHelper.DIRECTIVE_HOSTS);
     directives.add(KerberosHelper.DIRECTIVE_COMPONENTS);
     directives.add(KerberosHelper.DIRECTIVE_IGNORE_CONFIGS);
+    directives.add(KerberosHelper.DIRECTIVE_CONFIG_UPDATE_POLICY);
     return directives;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
@@ -61,9 +61,25 @@ public interface KerberosHelper {
    */
   String DIRECTIVE_COMPONENTS = "regenerate_components";
   /**
-   * directive used to pass host list to regenerate keytabs on
+   * directive used to indicate configurations are not to be updated (if set to "true") when regenerating
+   * keytab files
+   * @deprecated use {@link #DIRECTIVE_CONFIG_UPDATE_POLICY}
    */
   String DIRECTIVE_IGNORE_CONFIGS = "ignore_config_updates";
+  /**
+   * directive used to indicate how to handle configuration updates when regenerating keytab files
+   *
+   * expected values:
+   * <ul>
+   * <li>none</li>
+   * <li>identities_only</li>
+   * <li>new_and_identities</li>
+   * <li>all</li>
+   * </ul>
+   *
+   * @see UpdateConfigurationPolicy
+   */
+  String DIRECTIVE_CONFIG_UPDATE_POLICY = "config_update_policy";
   /**
    * directive used to indicate that the enable Kerberos operation should proceed even if the
    * cluster's security type is not changing

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -279,36 +279,49 @@ public class KerberosHelperImpl implements KerberosHelper {
                 throw new AmbariException(String.format("Custom operation %s can only be requested with the security type cluster property: %s", operation.name(), SecurityType.KERBEROS.name()));
               }
 
+              KerberosServerAction.OperationType operationType;
+              if ("true".equalsIgnoreCase(value) || "all".equalsIgnoreCase(value)) {
+                operationType = KerberosServerAction.OperationType.RECREATE_ALL;
+              } else if ("missing".equalsIgnoreCase(value)) {
+                operationType = KerberosServerAction.OperationType.CREATE_MISSING;
+              } else {
+                throw new AmbariException(String.format("Unexpected directive value: %s", value));
+              }
+
               boolean retryAllowed = false;
               if (requestProperties.containsKey(ALLOW_RETRY)) {
                 String allowRetryString = requestProperties.get(ALLOW_RETRY);
                 retryAllowed = Boolean.parseBoolean(allowRetryString);
               }
 
-              CreatePrincipalsAndKeytabsHandler handler = null;
-
               Set<String> hostFilter = parseHostFilter(requestProperties);
               Map<String, Set<String>> serviceComponentFilter = parseComponentFilter(requestProperties);
 
-              boolean updateConfigurations = !requestProperties.containsKey(DIRECTIVE_IGNORE_CONFIGS)
-                || !"true".equalsIgnoreCase(requestProperties.get(DIRECTIVE_IGNORE_CONFIGS));
+              UpdateConfigurationPolicy updateConfigurationsPolicy = UpdateConfigurationPolicy.ALL;
+              if(requestProperties.containsKey(DIRECTIVE_CONFIG_UPDATE_POLICY)) {
+                String policyValue = requestProperties.get(DIRECTIVE_CONFIG_UPDATE_POLICY);
+                updateConfigurationsPolicy = UpdateConfigurationPolicy.translate(policyValue);
+
+                if(updateConfigurationsPolicy== null) {
+                  throw new AmbariException(String.format("Unexpected comfiguration policy value: %s", policyValue));
+                }
+              }
+              else if(requestProperties.containsKey(DIRECTIVE_IGNORE_CONFIGS)) {
+                if("true".equalsIgnoreCase(requestProperties.get(DIRECTIVE_IGNORE_CONFIGS))) {
+                  // This really means to no update existing properties. However, we need to ensure
+                  // that Kerberos identity specific configurations are updated or added to make
+                  // sure all is consistent.
+                  updateConfigurationsPolicy = UpdateConfigurationPolicy.NEW_AND_IDENTITIES;
+                }
+              }
 
               boolean forceAllHosts = (hostFilter == null) || (hostFilter.contains("*"));
 
-              if ("true".equalsIgnoreCase(value) || "all".equalsIgnoreCase(value)) {
-                handler = new CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType.RECREATE_ALL, updateConfigurations, forceAllHosts, true);
-              } else if ("missing".equalsIgnoreCase(value)) {
-                handler = new CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType.CREATE_MISSING, updateConfigurations, forceAllHosts, true);
-              }
+              CreatePrincipalsAndKeytabsHandler handler = new CreatePrincipalsAndKeytabsHandler(operationType, updateConfigurationsPolicy, forceAllHosts, true);
+              handler.setRetryAllowed(retryAllowed);
 
-              if (handler != null) {
-                handler.setRetryAllowed(retryAllowed);
-
-                requestStageContainer = handle(cluster, getKerberosDetails(cluster, manageIdentities),
+              requestStageContainer = handle(cluster, getKerberosDetails(cluster, manageIdentities),
                   serviceComponentFilter, hostFilter, null, null, requestStageContainer, handler);
-              } else {
-                throw new AmbariException(String.format("Unexpected directive value: %s", value));
-              }
 
               break;
 
@@ -368,9 +381,17 @@ public class KerberosHelperImpl implements KerberosHelper {
                                                 Set<String> hostFilter, Collection<String> identityFilter, Set<String> hostsToForceKerberosOperations,
                                                 RequestStageContainer requestStageContainer, Boolean manageIdentities)
     throws AmbariException, KerberosOperationException {
-    return handle(cluster, getKerberosDetails(cluster, manageIdentities), serviceComponentFilter, hostFilter, identityFilter,
-      hostsToForceKerberosOperations, requestStageContainer, new CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType.DEFAULT, false, false,
-        false));
+    return handle(cluster,
+        getKerberosDetails(cluster, manageIdentities),
+        serviceComponentFilter,
+        hostFilter,
+        identityFilter,
+        hostsToForceKerberosOperations,
+        requestStageContainer,
+        new CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType.DEFAULT,
+            UpdateConfigurationPolicy.NONE,
+            false,
+            false));
   }
 
   @Override
@@ -1112,8 +1133,14 @@ public class KerberosHelperImpl implements KerberosHelper {
   public RequestStageContainer createTestIdentity(Cluster cluster, Map<String, String> commandParamsStage,
                                                   RequestStageContainer requestStageContainer)
     throws KerberosOperationException, AmbariException {
-    return handleTestIdentity(cluster, getKerberosDetails(cluster, null), commandParamsStage, requestStageContainer,
-      new CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType.DEFAULT, false, false, false));
+    return handleTestIdentity(cluster,
+        getKerberosDetails(cluster, null),
+        commandParamsStage,
+        requestStageContainer,
+        new CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType.DEFAULT,
+            UpdateConfigurationPolicy.NONE,
+            false,
+            false));
   }
 
   @Override
@@ -3891,7 +3918,7 @@ public class KerberosHelperImpl implements KerberosHelper {
       Map<String, String> commandParameters = new HashMap<>();
       commandParameters.put(KerberosServerAction.AUTHENTICATED_USER_NAME, ambariManagementController.getAuthName());
       commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_NOTE, "Enabling Kerberos");
-      commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATIONS, "true");
+      commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_POLICY, UpdateConfigurationPolicy.ALL.name());
       commandParameters.put(KerberosServerAction.DEFAULT_REALM, kerberosDetails.getDefaultRealm());
       commandParameters.put(KerberosServerAction.INCLUDE_AMBARI_IDENTITY, (kerberosDetails.createAmbariPrincipal()) ? "true" : "false");
       commandParameters.put(KerberosServerAction.PRECONFIGURE_SERVICES, kerberosDetails.getPreconfigureServices());
@@ -3987,7 +4014,7 @@ public class KerberosHelperImpl implements KerberosHelper {
       Map<String, String> commandParameters = new HashMap<>();
       commandParameters.put(KerberosServerAction.AUTHENTICATED_USER_NAME, ambariManagementController.getAuthName());
       commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_NOTE, "Disabling Kerberos");
-      commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATIONS, "true");
+      commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_POLICY, UpdateConfigurationPolicy.ALL.name());
       commandParameters.put(KerberosServerAction.DEFAULT_REALM, kerberosDetails.getDefaultRealm());
       if (dataDirectory != null) {
         commandParameters.put(KerberosServerAction.DATA_DIRECTORY, dataDirectory.getAbsolutePath());
@@ -4084,10 +4111,9 @@ public class KerberosHelperImpl implements KerberosHelper {
     private KerberosServerAction.OperationType operationType;
 
     /**
-     * A boolean value indicating whether to update service configurations (<code>true</code>)
-     * or ignore any potential configuration changes (<code>false</code>).
+     * A UpdateConfigurationPolicy indicating how to handle configuration changes.
      */
-    private boolean updateConfigurations;
+    private UpdateConfigurationPolicy updateConfigurationPolicy;
 
     /**
      * A boolean value indicating whether to include all hosts (<code>true</code>) when setting up
@@ -4107,19 +4133,20 @@ public class KerberosHelperImpl implements KerberosHelper {
      * CreatePrincipalsAndKeytabsHandler constructor to set whether this instance should be used to
      * regenerate all keytabs or just the ones that have not been distributed
      *
-     * @param operationType         The type of Kerberos operation being performed
-     * @param updateConfigurations  A boolean value indicating whether to update service configurations
-     *                              (<code>true</code>) or ignore any potential configuration changes
-     * @param forceAllHosts         A boolean value indicating whether to include all hosts (<code>true</code>)
-     *                              when setting up agent-side tasks or to select only the hosts found to be
-     *                              relevant (<code>false</code>)
-     * @param includeAmbariIdentity A boolean value indicating whether to include Ambari server
-     *                              identity (<code>true</code>) or ignore it (<code>false</code>)
+     * @param operationType             The type of Kerberos operation being performed
+     * @param updateConfigurationPolicy The policy to use when updating configurations
+     *                                  (<code>true</code>) or ignore any potential configuration changes
+     * @param forceAllHosts             A boolean value indicating whether to include all hosts (<code>true</code>)
+     *                                  when setting up agent-side tasks or to select only the hosts found to be
+     *                                  relevant (<code>false</code>)
+     * @param includeAmbariIdentity     A boolean value indicating whether to include Ambari server
+     *                                  identity (<code>true</code>) or ignore it (<code>false</code>)
      */
-    CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType operationType, boolean updateConfigurations,
+    CreatePrincipalsAndKeytabsHandler(KerberosServerAction.OperationType operationType,
+                                      UpdateConfigurationPolicy updateConfigurationPolicy,
                                       boolean forceAllHosts, boolean includeAmbariIdentity) {
       this.operationType = operationType;
-      this.updateConfigurations = updateConfigurations;
+      this.updateConfigurationPolicy = updateConfigurationPolicy;
       this.forceAllHosts = forceAllHosts;
       this.includeAmbariIdentity = includeAmbariIdentity;
     }
@@ -4176,9 +4203,9 @@ public class KerberosHelperImpl implements KerberosHelper {
       commandParameters.put(KerberosServerAction.OPERATION_TYPE, (operationType == null) ? KerberosServerAction.OperationType.DEFAULT.name() : operationType.name());
       commandParameters.put(KerberosServerAction.INCLUDE_AMBARI_IDENTITY, (processAmbariIdentity) ? "true" : "false");
 
-      if (updateConfigurations) {
+      if (updateConfigurationPolicy != UpdateConfigurationPolicy.NONE) {
         commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_NOTE, "Updated Kerberos-related configurations");
-        commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATIONS, "true");
+        commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_POLICY, updateConfigurationPolicy.name());
       }
 
       List<String> hostsToInclude = calculateHosts(cluster, serviceComponentHosts, hostsWithValidKerberosClient, forceAllHosts);
@@ -4219,7 +4246,7 @@ public class KerberosHelperImpl implements KerberosHelper {
           roleCommandOrder, requestStageContainer, hostsToInclude);
       }
 
-      if (updateConfigurations) {
+      if (updateConfigurationPolicy != UpdateConfigurationPolicy.NONE) {
         // *****************************************************************
         // Create stage to update configurations of services
         addUpdateConfigurationsStage(cluster, clusterHostInfoJson, hostParamsJson, event, commandParameters,
@@ -4353,6 +4380,7 @@ public class KerberosHelperImpl implements KerberosHelper {
         }
 
         commandParameters.put(KerberosServerAction.KDC_TYPE, kerberosDetails.getKdcType().name());
+        commandParameters.put(KerberosServerAction.UPDATE_CONFIGURATION_POLICY, UpdateConfigurationPolicy.ALL.name());
 
         // *****************************************************************
         // Create stage to create principals

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -2747,6 +2747,9 @@ public class KerberosHelperImpl implements KerberosHelper {
 
             if (allowedStates.contains(host.getState())) {
               hostNames.add(hostname);
+            } else {
+              LOG.warn("Host {} was excluded due {} state is not allowed. Allowed states: {}", hostname, host.getState(),
+                  allowedStates);
             }
           }
 
@@ -4277,6 +4280,8 @@ public class KerberosHelperImpl implements KerberosHelper {
         for (Host host : clusterHosts) {
           if (host.getState() == HostState.HEALTHY) {
             hosts.add(host.getHostName());
+          } else {
+            LOG.warn("Host {} was excluded due {} state", host.getHostName(), host.getState());
           }
         }
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/UpdateConfigurationPolicy.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/UpdateConfigurationPolicy.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.controller;
+
+/**
+ * The update configuration policies
+ * <ul>
+ * <li>NONE - No configurations will be updated</li>
+ * <li>IDENTITIES_ONLY - New and updated configurations related to Kerberos identity information - principal, keytab file, and auth-to-local rule properties</li>
+ * <li>NEW_AND_IDENTITIES - Only new configurations declared by the Kerberos descriptor and stack advisor as well as the identity-related changes</li>
+ * <li>ALL - All configuration changes (default)</li>
+ * </ul>
+ */
+public enum UpdateConfigurationPolicy {
+  /**
+   * No configurations will be updated
+   */
+  NONE(false, false, false, false),
+
+  /**
+   * New and updated configurations related to Kerberos identity information - principal, keytab
+   * file, and auth-to-local rule properties
+   */
+  IDENTITIES_ONLY(false, true, false, false),
+
+  /**
+   * Only new configurations declared by the Kerberos descriptor and stack advisor as well as the
+   * identity-related changes
+   */
+  NEW_AND_IDENTITIES(true, true, true, false),
+
+  /**
+   * All configuration changes (default)
+   */
+  ALL(true, true, true, true);
+
+  private final boolean invokeStackAdvisor;
+  private final boolean applyIdentityChanges;
+  private final boolean applyAdditions;
+  private final boolean applyOtherChanges;
+
+  UpdateConfigurationPolicy(boolean invokeStackAdvisor, boolean applyIdentityChanges, boolean applyAdditions, boolean applyOtherChanges) {
+    this.invokeStackAdvisor = invokeStackAdvisor;
+    this.applyIdentityChanges = applyIdentityChanges;
+    this.applyAdditions = applyAdditions;
+    this.applyOtherChanges = applyOtherChanges;
+  }
+
+  public boolean invokeStackAdvisor() {
+    return invokeStackAdvisor;
+  }
+
+  public boolean applyIdentityChanges() {
+    return applyIdentityChanges;
+  }
+
+  public boolean applyAdditions() {
+    return applyAdditions;
+  }
+
+  public boolean applyOtherChanges() {
+    return applyOtherChanges;
+  }
+
+  /**
+   * Safely translates a {@link UpdateConfigurationPolicy} value to a {@link String} of all
+   * lowercase characters.
+   *
+   * @param value the value to translate
+   * @return <code>null</code> if the input is <code>null</code>; otherwise the String value of
+   * the policy enum converted to lowercase characters.
+   */
+  public static String translate(UpdateConfigurationPolicy value) {
+    return (value == null) ? null : value.name().toLowerCase();
+  }
+
+  /**
+   * Safely translates a {@link String} value to an {@link UpdateConfigurationPolicy}.
+   * <p>
+   * The input value will be trimmed and converted to all uppercase characters.  If "-"'s are used
+   * instead of "_"'s, they will be converted.
+   *
+   * @param stringValue the String to translate
+   * @return The translated {@link UpdateConfigurationPolicy} value; or <code>null</code> if a translation cannot be made
+   */
+  public static UpdateConfigurationPolicy translate(String stringValue) {
+    if (stringValue != null) {
+      stringValue = stringValue.trim().toUpperCase();
+
+      if (!stringValue.isEmpty()) {
+        try {
+          return valueOf(stringValue.replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+          // ignore this and return null later...
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -565,12 +565,13 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
             addedHost.getHostName(),
             addedHost.getRackInfo(),
             addedHost.getIPv4()));
-        HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent = new HostLevelParamsUpdateEvent(clusterId, new HostLevelParamsCluster(
+        HostLevelParamsUpdateEvent hostLevelParamsUpdateEvent = new HostLevelParamsUpdateEvent(addedHost.getHostId(),
+            clusterId,
+            new HostLevelParamsCluster(
             getManagementController().retrieveHostRepositories(cl, addedHost),
             recoveryConfigHelper.getRecoveryConfig(cl.getClusterName(),
                 addedHost.getHostName())
         ));
-        hostLevelParamsUpdateEvent.setHostId(addedHost.getHostId());
         hostLevelParamsUpdateEvents.add(hostLevelParamsUpdateEvent);
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -52,6 +52,7 @@ import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ExecuteCommandJson;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.KerberosHelperImpl.SupportedCustomOperation;
+import org.apache.ambari.server.controller.UpdateConfigurationPolicy;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.NoSuchResourceException;
 import org.apache.ambari.server.controller.spi.Predicate;
@@ -857,6 +858,7 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
               Map<String, String> requestProperties = new HashMap<>();
               requestProperties.put(SupportedCustomOperation.REGENERATE_KEYTABS.name().toLowerCase(), "missing");
               requestProperties.put(KerberosHelper.ALLOW_RETRY, Boolean.TRUE.toString().toLowerCase());
+              requestProperties.put(KerberosHelper.DIRECTIVE_CONFIG_UPDATE_POLICY, UpdateConfigurationPolicy.NEW_AND_IDENTITIES.name());
 
               // add stages to the upgrade which will regenerate missing keytabs only
               req = s_kerberosHelper.get().executeCustomOperations(cluster, requestProperties, req, null);

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AgentActionEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AgentActionEvent.java
@@ -29,7 +29,7 @@ public class AgentActionEvent extends STOMPHostEvent {
   /**
    * Host id with agent action commands will be send to.
    */
-  private Long hostId;
+  private final Long hostId;
 
   @JsonProperty("actionName")
   private AgentAction agentAction;
@@ -37,10 +37,6 @@ public class AgentActionEvent extends STOMPHostEvent {
   public AgentActionEvent(AgentAction agentAction, Long hostId) {
     super(Type.AGENT_ACTIONS);
     this.agentAction = agentAction;
-    this.hostId = hostId;
-  }
-
-  public void setHostId(Long hostId) {
     this.hostId = hostId;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AgentConfigsUpdateEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AgentConfigsUpdateEvent.java
@@ -44,7 +44,7 @@ public class AgentConfigsUpdateEvent extends STOMPHostEvent implements Hashable 
   /**
    * Host identifier.
    */
-  private Long hostId;
+  private final Long hostId;
 
   /**
    * Configs grouped by cluster id as keys.
@@ -52,8 +52,9 @@ public class AgentConfigsUpdateEvent extends STOMPHostEvent implements Hashable 
   @JsonProperty("clusters")
   private final SortedMap<String, ClusterConfigs> clustersConfigs;
 
-  public AgentConfigsUpdateEvent(SortedMap<String, ClusterConfigs> clustersConfigs) {
+  public AgentConfigsUpdateEvent(Long hostId, SortedMap<String, ClusterConfigs> clustersConfigs) {
     super(Type.AGENT_CONFIGS);
+    this.hostId = hostId;
     this.clustersConfigs = clustersConfigs;
     this.timestamp = System.currentTimeMillis();
   }
@@ -75,10 +76,6 @@ public class AgentConfigsUpdateEvent extends STOMPHostEvent implements Hashable 
     this.timestamp = timestamp;
   }
 
-  public void setHostId(Long hostId) {
-    this.hostId = hostId;
-  }
-
   @Override
   public Long getHostId() {
     return hostId;
@@ -89,7 +86,7 @@ public class AgentConfigsUpdateEvent extends STOMPHostEvent implements Hashable 
   }
 
   public static AgentConfigsUpdateEvent emptyUpdate() {
-    return new AgentConfigsUpdateEvent(null);
+    return new AgentConfigsUpdateEvent(null, null);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/ExecutionCommandEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/ExecutionCommandEvent.java
@@ -33,7 +33,7 @@ public class ExecutionCommandEvent extends STOMPHostEvent {
   /**
    * Host id with agent execution commands will be send to.
    */
-  private Long hostId;
+  private final Long hostId;
 
   /**
    *
@@ -47,17 +47,16 @@ public class ExecutionCommandEvent extends STOMPHostEvent {
   @JsonProperty("clusters")
   private TreeMap<String, ExecutionCommandsCluster> clusters;
 
-  public ExecutionCommandEvent(TreeMap<String, ExecutionCommandsCluster> clusters) {
+  public ExecutionCommandEvent(Long hostId, Long requiredConfigTimestamp,
+                               TreeMap<String, ExecutionCommandsCluster> clusters) {
     super(Type.COMMAND);
+    this.hostId = hostId;
+    this.requiredConfigTimestamp = requiredConfigTimestamp;
     this.clusters = clusters;
   }
 
   public TreeMap<String, ExecutionCommandsCluster> getClusters() {
     return clusters;
-  }
-
-  public void setClusters(TreeMap<String, ExecutionCommandsCluster> clusters) {
-    this.clusters = clusters;
   }
 
   @Override
@@ -78,10 +77,6 @@ public class ExecutionCommandEvent extends STOMPHostEvent {
     return result;
   }
 
-  public void setHostId(Long hostId) {
-    this.hostId = hostId;
-  }
-
   @Override
   public Long getHostId() {
     return hostId;
@@ -89,9 +84,5 @@ public class ExecutionCommandEvent extends STOMPHostEvent {
 
   public Long getRequiredConfigTimestamp() {
     return requiredConfigTimestamp;
-  }
-
-  public void setRequiredConfigTimestamp(Long requiredConfigTimestamp) {
-    this.requiredConfigTimestamp = requiredConfigTimestamp;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/HostLevelParamsUpdateEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/HostLevelParamsUpdateEvent.java
@@ -42,7 +42,7 @@ public class HostLevelParamsUpdateEvent extends STOMPHostEvent implements Hashab
   /**
    * Host identifier.
    */
-  private Long hostId;
+  private final Long hostId;
 
   /**
    * Host level parameters by clusters.
@@ -50,13 +50,14 @@ public class HostLevelParamsUpdateEvent extends STOMPHostEvent implements Hashab
   @JsonProperty("clusters")
   private final Map<String, HostLevelParamsCluster> hostLevelParamsClusters;
 
-  public HostLevelParamsUpdateEvent(Map<String, HostLevelParamsCluster> hostLevelParamsClusters) {
+  public HostLevelParamsUpdateEvent(Long hostId, Map<String, HostLevelParamsCluster> hostLevelParamsClusters) {
     super(Type.HOSTLEVELPARAMS);
+    this.hostId = hostId;
     this.hostLevelParamsClusters = hostLevelParamsClusters;
   }
 
-  public HostLevelParamsUpdateEvent(String clusterId, HostLevelParamsCluster hostLevelParamsCluster) {
-    this(Collections.singletonMap(clusterId, hostLevelParamsCluster));
+  public HostLevelParamsUpdateEvent(Long hostId, String clusterId, HostLevelParamsCluster hostLevelParamsCluster) {
+    this(hostId, Collections.singletonMap(clusterId, hostLevelParamsCluster));
   }
 
   @Override
@@ -70,11 +71,7 @@ public class HostLevelParamsUpdateEvent extends STOMPHostEvent implements Hashab
   }
 
   public static HostLevelParamsUpdateEvent emptyUpdate() {
-    return new HostLevelParamsUpdateEvent(null);
-  }
-
-  public void setHostId(Long hostId) {
-    this.hostId = hostId;
+    return new HostLevelParamsUpdateEvent(null, null);
   }
 
   @Override
@@ -83,7 +80,7 @@ public class HostLevelParamsUpdateEvent extends STOMPHostEvent implements Hashab
   }
 
   public Map<String, HostLevelParamsCluster> getHostLevelParamsClusters() {
-    return hostLevelParamsClusters;
+    return hostLevelParamsClusters == null ? null : Collections.unmodifiableMap(hostLevelParamsClusters);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerAction.java
@@ -34,15 +34,19 @@ import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.RootService;
+import org.apache.ambari.server.controller.UpdateConfigurationPolicy;
 import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerberosKeytab;
 import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerberosPrincipal;
 import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.kerberos.AbstractKerberosDescriptorContainer;
 import org.apache.ambari.server.state.kerberos.KerberosComponentDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosServiceDescriptor;
 import org.apache.ambari.server.utils.StageUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +68,9 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
   @Inject
   private KerberosConfigDataFileWriterFactory kerberosConfigDataFileWriterFactory;
 
+  @Inject
+  private ConfigHelper configHelper;
+
   @Override
   protected CommandReport processIdentity(ResolvedKerberosPrincipal resolvedPrincipal, KerberosOperationHandler operationHandler, Map<String, String> kerberosConfiguration, Map<String, Object> requestSharedDataContext) throws AmbariException {
     throw new UnsupportedOperationException();
@@ -74,12 +81,12 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
   }
 
   public void processServiceComponentHosts(Cluster cluster, KerberosDescriptor kerberosDescriptor,
-                                    List<ServiceComponentHost> schToProcess,
-                                    Collection<String> identityFilter, String dataDirectory,
-                                    Map<String, Map<String, String>> currentConfigurations,
-                                    Map<String, Map<String, String>> kerberosConfigurations,
-                                    boolean includeAmbariIdentity,
-                                    Map<String, Set<String>> propertiesToBeIgnored) throws AmbariException {
+                                           List<ServiceComponentHost> schToProcess,
+                                           Collection<String> identityFilter, String dataDirectory,
+                                           Map<String, Map<String, String>> currentConfigurations,
+                                           Map<String, Map<String, String>> kerberosConfigurations,
+                                           boolean includeAmbariIdentity,
+                                           Map<String, Set<String>> propertiesToBeIgnored) throws AmbariException {
     List<Component> components = new ArrayList<>();
     for (ServiceComponentHost each : schToProcess) {
       components.add(Component.fromServiceComponentHost(each));
@@ -266,15 +273,19 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
    * If work is to be done, a data file containing the details is created so it they changes may be
    * processed in the appropriate stage.
    *
-   * @param dataDirectory          the directory in which to write the configuration changes data file
-   * @param kerberosConfigurations the Kerberos-specific configuration map
-   * @param propertiesToBeRemoved  a map of properties to be removed from the current configuration,
-   *                               grouped by configuration type.
+   * @param dataDirectory             the directory in which to write the configuration changes data file
+   * @param kerberosConfigurations    the Kerberos-specific configuration map
+   * @param propertiesToBeRemoved     a map of properties to be removed from the current configuration,
+   *                                  grouped by configuration type.
+   * @param kerberosDescriptor        the Kerberos descriptor
+   * @param updateConfigurationPolicy the policy used to determine which configurations to update
    * @throws AmbariException
    */
   protected void processConfigurationChanges(String dataDirectory,
                                              Map<String, Map<String, String>> kerberosConfigurations,
-                                             Map<String, Set<String>> propertiesToBeRemoved)
+                                             Map<String, Set<String>> propertiesToBeRemoved,
+                                             KerberosDescriptor kerberosDescriptor,
+                                             UpdateConfigurationPolicy updateConfigurationPolicy)
       throws AmbariException {
     actionLog.writeStdOut("Determining configuration changes");
 
@@ -286,6 +297,12 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
         LOG.error(message);
         throw new AmbariException(message);
       }
+
+      // Determine what the relevant Kerberos identity-related properties are...
+      Map<String, Set<String>> kerberosIdentityProperties = getIdentityProperties(kerberosDescriptor, null);
+
+      // Determine what the existing properties are...
+      Map<String, Map<String, String>> existingProperties = configHelper.getEffectiveConfigProperties(getClusterName(), null);
 
       File configFile = new File(dataDirectory, KerberosConfigDataFileWriter.DATA_FILE_NAME);
       KerberosConfigDataFileWriter kerberosConfDataFileWriter = null;
@@ -300,10 +317,15 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
 
           if (properties != null) {
             for (Map.Entry<String, String> configTypeEntry : properties.entrySet()) {
-              kerberosConfDataFileWriter.addRecord(type,
-                  configTypeEntry.getKey(),
-                  configTypeEntry.getValue(),
-                  KerberosConfigDataFileWriter.OPERATION_TYPE_SET);
+
+              // Determine if this configuration should be written or not...
+              String propertyName = configTypeEntry.getKey();
+              if (includeConfiguration(type, propertyName, updateConfigurationPolicy, existingProperties, kerberosIdentityProperties)) {
+                kerberosConfDataFileWriter.addRecord(type,
+                    propertyName,
+                    configTypeEntry.getValue(),
+                    KerberosConfigDataFileWriter.OPERATION_TYPE_SET);
+              }
             }
           }
         }
@@ -342,5 +364,121 @@ public abstract class AbstractPrepareKerberosServerAction extends KerberosServer
         }
       }
     }
+  }
+
+  /**
+   * Determine of the configuration should be included in the set of configurations to update.
+   *
+   * @param configType
+   * @param propertyName
+   * @param updateConfigurationPolicy
+   * @param existingProperties
+   * @param kerberosIdentityProperties
+   * @return
+   */
+  private boolean includeConfiguration(String configType, String propertyName,
+                                       UpdateConfigurationPolicy updateConfigurationPolicy,
+                                       Map<String, Map<String, String>> existingProperties,
+                                       Map<String, Set<String>> kerberosIdentityProperties) {
+
+    // Determine if the property represents a Kerberos identity-related property
+    boolean isIdentity;
+    if (kerberosIdentityProperties == null) {
+      isIdentity = false;
+    } else {
+      Set<String> propertyNames = kerberosIdentityProperties.get(configType);
+      isIdentity = !CollectionUtils.isEmpty(propertyNames) && propertyNames.contains(propertyName);
+    }
+
+    if (isIdentity) {
+      return updateConfigurationPolicy.applyIdentityChanges();
+    }
+
+    // Determine if the property is a new property
+    boolean isNew;
+    if (existingProperties == null) {
+      isNew = true;
+    } else {
+      Map<String, String> propertyNames = existingProperties.get(configType);
+      isNew = (propertyNames == null) || !propertyNames.containsKey(propertyName);
+    }
+
+    if (isNew) {
+      return updateConfigurationPolicy.applyAdditions();
+    }
+
+    // All other properties...
+    return updateConfigurationPolicy.applyOtherChanges();
+  }
+
+  /**
+   * Recursively processes a Kerberos descriptor container and it children to find the
+   * Kerberos identity-related properties.
+   * <p>
+   * Kerberos identity-related properties are those that contain the following information:
+   * <ul>
+   * <li>principal names</li>
+   * <li>keytab file paths</li>
+   * <li>auth-to-local rules</li>
+   * </ul>
+   *
+   * @param container          the AbstractKerberosDescriptorContainer to process
+   * @param identityProperties a map of config-types to sets of property names to append data
+   * @return a map of config-types to sets of property names
+   */
+  private Map<String, Set<String>> getIdentityProperties(AbstractKerberosDescriptorContainer container, Map<String, Set<String>> identityProperties) {
+    if (container != null) {
+      if (identityProperties == null) {
+        identityProperties = new HashMap<>();
+      }
+
+      // Process the Kerberos identities - principal and keytab file properties.
+      List<KerberosIdentityDescriptor> identityDescriptors;
+      try {
+        // There is no need to resolve references since we just need to get the set of configurations that can be changed.
+        identityDescriptors = container.getIdentities(false, null);
+      } catch (AmbariException e) {
+        LOG.error("An exception occurred getting the Kerberos identity descriptors.  No configurations will be identified.", e);
+        identityDescriptors = null;
+      }
+
+      if (identityDescriptors != null) {
+        Map<String, Map<String, String>> identityConfigurations = kerberosHelper.getIdentityConfigurations(identityDescriptors);
+
+        if (identityConfigurations != null) {
+          for (Map.Entry<String, Map<String, String>> entry : identityConfigurations.entrySet()) {
+            Map<String, String> properties = entry.getValue();
+            if (properties != null) {
+              Set<String> configProperties = identityProperties.computeIfAbsent(entry.getKey(), k -> new HashSet<>());
+              configProperties.addAll(properties.keySet());
+            }
+          }
+        }
+      }
+
+      // Process any auth-to-local rule properties
+      Map<String, Set<String>> authToLocalProperties = kerberosHelper.translateConfigurationSpecifications(container.getAuthToLocalProperties());
+      if (authToLocalProperties != null) {
+        for (Map.Entry<String, Set<String>> entry : authToLocalProperties.entrySet()) {
+          String configType = entry.getKey();
+          Set<String> propertyNames = entry.getValue();
+
+          if (propertyNames != null) {
+            Set<String> configProperties = identityProperties.computeIfAbsent(configType, k -> new HashSet<>());
+            configProperties.addAll(propertyNames);
+          }
+        }
+      }
+
+      // Process the children...
+      Collection<? extends AbstractKerberosDescriptorContainer> childContainers = container.getChildContainers();
+      if (childContainers != null) {
+        for (AbstractKerberosDescriptorContainer childContainer : childContainers) {
+          getIdentityProperties(childContainer, identityProperties);
+        }
+      }
+    }
+
+    return identityProperties;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreateKeytabFilesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreateKeytabFilesServerAction.java
@@ -214,7 +214,7 @@ public class CreateKeytabFilesServerAction extends KerberosServerAction {
                     // There is nothing to do for this since it must already exist and we don't want to
                     // regenerate the keytab
                     message = String.format("Skipping keytab file for %s, missing password indicates nothing to do", resolvedPrincipal.getPrincipal());
-                    LOG.debug(message);
+                    LOG.info(message);
                   } else {
                     if (cachedKeytabPath == null) {
                       message = String.format("Failed to create keytab for %s, missing cached file", resolvedPrincipal.getPrincipal());
@@ -241,7 +241,7 @@ public class CreateKeytabFilesServerAction extends KerberosServerAction {
                         ensureAmbariOnlyAccess(destinationKeytabFile);
 
                         message = String.format("Successfully created keytab file for %s at %s", resolvedPrincipal.getPrincipal(), destinationKeytabFile.getAbsolutePath());
-                        LOG.debug(message);
+                        LOG.info(message);
                         auditEventBuilder.withPrincipal(resolvedPrincipal.getPrincipal()).withHostName(hostName).withKeyTabFilePath(destinationKeytabFile.getAbsolutePath());
                       } else {
                         message = String.format("Failed to create keytab file for %s at %s", resolvedPrincipal.getPrincipal(), destinationKeytabFile.getAbsolutePath());

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
@@ -31,6 +31,7 @@ import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.controller.KerberosHelper;
+import org.apache.ambari.server.controller.UpdateConfigurationPolicy;
 import org.apache.ambari.server.orm.dao.HostDAO;
 import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.security.credential.PrincipalKeyCredential;
@@ -100,10 +101,20 @@ public abstract class KerberosServerAction extends AbstractServerAction {
   public static final String KDC_TYPE = "kdc_type";
 
   /**
-   * A (command parameter) property name used to hold a boolean value indicating whether configurations
-   * should be process to see if they need to be updated
+   * A (command parameter) property name used to hold the value indicating how to process
+   * configurations updates. One of the of the following values is expected:
+   * <dl>
+   * <dt>none</dt>
+   * <dd>No configurations will be updated</dd>
+   * <dt>identities_only</dt>
+   * <dd>New and updated configurations related to Kerberos identity information - principal, keytab file, and auth-to-local rule properties</dd>
+   * <dt>new_and_identities</dt>
+   * <dd>Only new configurations declared by the Kerberos descriptor and stack advisor as well as the identity-related changes</dd>
+   * <dt>all</dt>
+   * <dd>All configuration changes (default)</dd>
+   * </dl>
    */
-  public static final String UPDATE_CONFIGURATIONS = "update_configurations";
+  public static final String UPDATE_CONFIGURATION_POLICY = "update_configuration_policy";
 
   /**
    * A (command parameter) property name used to hold the note to set when applying any
@@ -194,6 +205,20 @@ public abstract class KerberosServerAction extends AbstractServerAction {
    */
   protected static String getCommandParameterValue(Map<String, String> commandParameters, String propertyName) {
     return ((commandParameters == null) || (propertyName == null)) ? null : commandParameters.get(propertyName);
+  }
+
+  /**
+   * Given a (command parameter) Map, attempts to safely retrieve the "update_configuration_policy" property.
+   *
+   * @param commandParameters a Map containing the dictionary of data to interrogate
+   * @return a UpdateConfigurationPolicy
+   */
+  protected static UpdateConfigurationPolicy getUpdateConfigurationPolicy(Map<String, String> commandParameters) {
+    String stringValue = getCommandParameterValue(commandParameters, UPDATE_CONFIGURATION_POLICY);
+    UpdateConfigurationPolicy value = UpdateConfigurationPolicy.translate(stringValue);
+
+    // Return UpdateConfigurationPolicy.ALL as a default value
+    return (value == null) ? UpdateConfigurationPolicy.ALL : value;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareDisableKerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareDisableKerberosServerAction.java
@@ -203,7 +203,7 @@ public class PrepareDisableKerberosServerAction extends AbstractPrepareKerberosS
       kerberosHelper.applyStackAdvisorUpdates(cluster, services, configurations, kerberosConfigurations,
           propertiesToIgnore, configurationsToRemove, false);
 
-      processConfigurationChanges(dataDirectory, kerberosConfigurations, configurationsToRemove);
+      processConfigurationChanges(dataDirectory, kerberosConfigurations, configurationsToRemove, kerberosDescriptor, getUpdateConfigurationPolicy(commandParameters));
     }
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", actionLog.getStdOut(), actionLog.getStdErr());

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareEnableKerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/PrepareEnableKerberosServerAction.java
@@ -128,7 +128,7 @@ public class PrepareEnableKerberosServerAction extends PrepareKerberosIdentities
     }
     clusterEnvProperties.put(KerberosHelper.SECURITY_ENABLED_PROPERTY_NAME, "true");
 
-    processConfigurationChanges(dataDirectory, kerberosConfigurations, propertiesToRemove);
+    processConfigurationChanges(dataDirectory, kerberosConfigurations, propertiesToRemove, kerberosDescriptor, getUpdateConfigurationPolicy(commandParameters));
 
     return createCommandReport(0, HostRoleStatus.COMPLETED, "{}", actionLog.getStdOut(), actionLog.getStdErr());
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.state;
 
+import static java.util.stream.Collectors.toSet;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -131,6 +133,7 @@ public interface Cluster {
    * @return collection of hosts that are associated with this cluster
    */
   Collection<Host> getHosts();
+  default Set<String> getHostNames() { return getHosts().stream().map(Host::getHostName).collect(toSet()); }
 
   /**
    * Get all of the hosts running the provided service and component.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
@@ -185,10 +185,8 @@ public interface Clusters {
    * Gets all the hosts associated with the cluster
    * @param clusterName The name of the cluster
    * @return <code>Map</code> containing host name and <code>Host</code>
-   * @throws AmbariException
    */
-  Map<String, Host> getHostsForCluster(String clusterName)
-      throws AmbariException;
+  Map<String, Host> getHostsForCluster(String clusterName);
 
   /**
    * Gets all the host Ids associated with the cluster

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -2067,8 +2067,7 @@ public class ConfigHelper {
           new ClusterConfigs(configurationsTreeMap, configurationAttributesTreeMap));
     }
 
-    AgentConfigsUpdateEvent agentConfigsUpdateEvent = new AgentConfigsUpdateEvent(clustersConfigs);
-    agentConfigsUpdateEvent.setHostId(hostId);
+    AgentConfigsUpdateEvent agentConfigsUpdateEvent = new AgentConfigsUpdateEvent(hostId, clustersConfigs);
     return agentConfigsUpdateEvent;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertDefinitionHash.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertDefinitionHash.java
@@ -361,18 +361,9 @@ public class AlertDefinitionHash {
       return Collections.emptySet();
     }
 
-    Map<String, Host> hosts = null;
     String clusterName = cluster.getClusterName();
+    Map<String, Host> hosts = m_clusters.get().getHostsForCluster(clusterName);
     Set<String> affectedHosts = new HashSet<>();
-
-    try {
-      hosts = m_clusters.get().getHostsForCluster(clusterName);
-    } catch (AmbariException ambariException) {
-      LOG.error("Unable to lookup hosts for cluster named {}", clusterName,
-          ambariException);
-
-      return affectedHosts;
-    }
 
     String ambariServiceName = RootService.AMBARI.name();
     String agentComponentName = RootComponent.AMBARI_AGENT.name();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -2246,18 +2246,7 @@ public class ClusterImpl implements Cluster {
 
   @Override
   public Collection<Host> getHosts() {
-    Map<String, Host> hosts;
-
-    try {
-      //todo: why the hell does this method throw AmbariException???
-      //todo: this is ridiculous that I need to get hosts for this cluster from Clusters!!!
-      //todo: should I getHosts using the same logic as the other getHosts call?  At least that doesn't throw AmbariException.
-      hosts =  clusters.getHostsForCluster(clusterName);
-    } catch (AmbariException e) {
-      //todo: in what conditions is AmbariException thrown?
-      throw new RuntimeException("Unable to get hosts for cluster: " + clusterName, e);
-    }
-    return hosts == null ? Collections.emptyList() : hosts.values();
+    return clusters.getHostsForCluster(clusterName).values();
   }
 
   private ClusterHealthReport getClusterHealthReport(

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -706,9 +706,7 @@ public class ClustersImpl implements Clusters {
   }
 
   @Override
-  public Map<String, Host> getHostsForCluster(String clusterName)
-      throws AmbariException {
-
+  public Map<String, Host> getHostsForCluster(String clusterName) {
     Map<String, Host> hosts = new HashMap<>();
     for (Host h : getClusterHostsMap().get(clusterName)) {
       hosts.put(h.getHostName(), h);

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/input.config-hive.json.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/input.config-hive.json.j2
@@ -74,7 +74,7 @@
           }
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/input.config-ambari.json.j2
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/input.config-ambari.json.j2
@@ -87,7 +87,7 @@
 
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }
@@ -194,49 +194,49 @@
         },
         "level":[
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Severe",
               "post_value":"ERROR"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Warning",
               "post_value":"WARN"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Finer",
               "post_value":"WARN"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Info",
               "post_value":"INFO"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Config",
               "post_value":"INFO"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Fine",
               "post_value":"DEBUG"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Finest",
               "post_value":"TRACE"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"All",
               "post_value":"TRACE"
             }
@@ -311,540 +311,540 @@
       "value_borders":"()",
       "post_map_values":{
         "User":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"reqUser"
+          "map_field_name":{
+            "new_field_name":"reqUser"
           }
         },
         "Hostname":{
-          "map_fieldname":{
-            "new_fieldname":"host"
+          "map_field_name":{
+            "new_field_name":"host"
           }
         },
         "Host name":{
-          "map_fieldname":{
-            "new_fieldname":"host"
+          "map_field_name":{
+            "new_field_name":"host"
           }
         },
         "RemoteIp":{
-          "map_fieldname":{
-            "new_fieldname":"cliIP"
+          "map_field_name":{
+            "new_field_name":"cliIP"
           }
         },
         "RequestType":{
-          "map_fieldname":{
-            "new_fieldname":"cliType"
+          "map_field_name":{
+            "new_field_name":"cliType"
           }
         },
         "TaskId":{
-          "map_fieldname":{
-            "new_fieldname":"task_id"
+          "map_field_name":{
+            "new_field_name":"task_id"
           }
         },
         "Operation":{
-          "map_fieldname":{
-            "new_fieldname":"action"
+          "map_field_name":{
+            "new_field_name":"action"
           }
         },
         "Service":{
-          "map_fieldname":{
-            "new_fieldname":"ws_service"
+          "map_field_name":{
+            "new_field_name":"ws_service"
           }
         },
         "url":{
-          "map_fieldname":{
-            "new_fieldname":"resource"
+          "map_field_name":{
+            "new_field_name":"resource"
           }
         },
         "ResourcePath":{
-          "map_fieldname":{
-            "new_fieldname":"resource"
+          "map_field_name":{
+            "new_field_name":"resource"
           }
         },
         "Cluster name":{
-          "map_fieldname":{
-            "new_fieldname":"cluster"
+          "map_field_name":{
+            "new_field_name":"cluster"
           }
         },
         "Old name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_old_name"
+          "map_field_name":{
+            "new_field_name":"ws_old_name"
           }
         },
         "New name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_new_name"
+          "map_field_name":{
+            "new_field_name":"ws_new_name"
           }
         },
         "Reason":{
-          "map_fieldname":{
-            "new_fieldname":"reason"
+          "map_field_name":{
+            "new_field_name":"reason"
           }
         },
         "Base URL":{
-          "map_fieldname":{
-            "new_fieldname":"ws_base_url"
+          "map_field_name":{
+            "new_field_name":"ws_base_url"
           }
         },
         "Base url":{
-          "map_fieldname":{
-            "new_fieldname":"ws_base_url"
+          "map_field_name":{
+            "new_field_name":"ws_base_url"
           }
         },
         "Command":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_command"
+          "map_field_name":{
+            "new_field_name":"ws_command"
           }
         },
         "Component":{
-          "map_fieldname":{
-            "new_fieldname":"ws_component"
+          "map_field_name":{
+            "new_field_name":"ws_component"
           }
         },
         "Type":{
-          "map_fieldname":{
-            "new_fieldname":"ws_type"
+          "map_field_name":{
+            "new_field_name":"ws_type"
           }
         },
         "Consecutive failures": {
-          "map_fieldname":{
-            "new_fieldname":"ws_consecutive_failures"
+          "map_field_name":{
+            "new_field_name":"ws_consecutive_failures"
           }
         },
         "Created Username": {
-          "map_fieldname":{
-            "new_fieldname":"ws_username"
+          "map_field_name":{
+            "new_field_name":"ws_username"
           }
         },
         "Affected username": {
-          "map_fieldname":{
-            "new_fieldname":"ws_username"
+          "map_field_name":{
+            "new_field_name":"ws_username"
           }
         },
         "Deleted Username": {
-          "map_fieldname":{
-            "new_fieldname":"ws_username"
+          "map_field_name":{
+            "new_field_name":"ws_username"
           }
         },
         "Alert group name": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_group_name"
+          "map_field_name":{
+            "new_field_name":"ws_alert_group_name"
           }
         },
         "Alert group ID": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_group_id"
+          "map_field_name":{
+            "new_field_name":"ws_alert_group_id"
           }
         },
         "Definition IDs": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_definition_ids"
+          "map_field_name":{
+            "new_field_name":"std_alert_definition_ids"
           }
         },
         "Notification ID": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_notification_id"
+          "map_field_name":{
+            "new_field_name":"ws_alert_notification_id"
           }
         },
         "Notification IDs": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_notification_ids"
+          "map_field_name":{
+            "new_field_name":"std_alert_notification_ids"
           }
         },
         "Notification name": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_notification_name"
+          "map_field_name":{
+            "new_field_name":"ws_alert_notification_name"
           }
         },
         "Notification type": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_notification_type"
+          "map_field_name":{
+            "new_field_name":"ws_alert_notification_type"
           }
         },
         "Members": {
-          "map_fieldname":{
-            "new_fieldname":"std_members"
+          "map_field_name":{
+            "new_field_name":"std_members"
           }
         },
         "Description": {
-          "map_fieldname":{
-            "new_fieldname":"ws_description"
+          "map_field_name":{
+            "new_field_name":"ws_description"
           }
         },
         "Email from": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_email_from"
+          "map_field_name":{
+            "new_field_name":"ws_alert_email_from"
           }
         },
         "Email to": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alert_email_to"
+          "map_field_name":{
+            "new_field_name":"ws_alert_email_to"
           }
         },
         "Group": {
-          "map_fieldname":{
-            "new_fieldname":"ws_group"
+          "map_field_name":{
+            "new_field_name":"ws_group"
           }
         },
         "Group IDs": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_group_ids"
+          "map_field_name":{
+            "new_field_name":"std_alert_group_ids"
           }
         },
         "Alert states": {
-          "map_fieldname":{
-            "new_fieldname":"std_alert_states"
+          "map_field_name":{
+            "new_field_name":"std_alert_states"
           }
         },
         "Blueprint": {
-          "map_fieldname":{
-            "new_fieldname":"ws_blueprint"
+          "map_field_name":{
+            "new_field_name":"ws_blueprint"
           }
         },
         "Blueprint name": {
-          "map_fieldname":{
-            "new_fieldname":"ws_blueprint_name"
+          "map_field_name":{
+            "new_field_name":"ws_blueprint_name"
           }
         },
         "State": {
-          "map_fieldname":{
-            "new_fieldname":"ws_state"
+          "map_field_name":{
+            "new_field_name":"ws_state"
           }
         },
         "Principal": {
-          "map_fieldname":{
-            "new_fieldname":"ws_principal"
+          "map_field_name":{
+            "new_field_name":"ws_principal"
           }
         },
         "Alias": {
-          "map_fieldname":{
-            "new_fieldname":"ws_alias"
+          "map_field_name":{
+            "new_field_name":"ws_alias"
           }
         },
         "Keytab file": {
-          "map_fieldname":{
-            "new_fieldname":"ws_keytab_file"
+          "map_field_name":{
+            "new_field_name":"ws_keytab_file"
           }
         },
         "Upgrade type":{
-          "map_fieldname":{
-            "new_fieldname":"ws_upgrade_type"
+          "map_field_name":{
+            "new_field_name":"ws_upgrade_type"
           }
         },
         "Details":{
-          "map_fieldname":{
-            "new_fieldname":"ws_details"
+          "map_field_name":{
+            "new_field_name":"ws_details"
           }
         },
         "Name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_name"
+          "map_field_name":{
+            "new_field_name":"ws_name"
           }
         },
         "Display name":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_display_name"
+          "map_field_name":{
+            "new_field_name":"ws_display_name"
           }
         },
         "OS":{
-          "map_fieldname":{
-            "new_fieldname":"ws_os"
+          "map_field_name":{
+            "new_field_name":"ws_os"
           }
         },
         "Repo id":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_id"
+          "map_field_name":{
+            "new_field_name":"ws_repo_id"
           }
         },
         "Repo version":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_version"
+          "map_field_name":{
+            "new_field_name":"ws_repo_version"
           }
         },
         "Repo version ID":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_version_id"
+          "map_field_name":{
+            "new_field_name":"ws_repo_version_id"
           }
         },
         "Repositories":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repositories"
+          "map_field_name":{
+            "new_field_name":"ws_repositories"
           }
         },
         "RequestId":{
-          "map_fieldname":{
-            "new_fieldname":"ws_request_id"
+          "map_field_name":{
+            "new_field_name":"ws_request_id"
           }
         },
         "Request id":{
-          "map_fieldname":{
-            "new_fieldname":"ws_request_id"
+          "map_field_name":{
+            "new_field_name":"ws_request_id"
           }
         },
         "Repository ID":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_id"
+          "map_field_name":{
+            "new_field_name":"ws_repo_id"
           }
         },
         "Repository name":{
-          "map_fieldname":{
-            "new_fieldname":"ws_repo_name"
+          "map_field_name":{
+            "new_field_name":"ws_repo_name"
           }
         },
         "Roles":{
-          "map_fieldname":{
-            "new_fieldname":"ws_roles"
+          "map_field_name":{
+            "new_field_name":"ws_roles"
           }
         },
         "Permissions":{
-          "map_fieldname":{
-            "new_fieldname":"std_permissions"
+          "map_field_name":{
+            "new_field_name":"std_permissions"
           }
         },
         "Stack":{
-          "map_fieldname":{
-            "new_fieldname":"ws_stack"
+          "map_field_name":{
+            "new_field_name":"ws_stack"
           }
         },
         "Stack version":{
-          "map_fieldname":{
-            "new_fieldname":"ws_stack_version"
+          "map_field_name":{
+            "new_field_name":"ws_stack_version"
           }
         },
         "Stage id":{
-          "map_fieldname":{
-            "new_fieldname":"ws_stage_id"
+          "map_field_name":{
+            "new_field_name":"ws_stage_id"
           }
         },
         "Administrator":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"yes",
             "post_value":"1"
           },
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"no",
             "post_value":"0"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_admin"
+          "map_field_name":{
+            "new_field_name":"ws_admin"
           }
         },
         "Active":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"y",
             "post_value":"1"
           },
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"n",
             "post_value":"0"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_active"
+          "map_field_name":{
+            "new_field_name":"ws_active"
           }
         },
         "Version":{
-          "map_fieldname":{
-            "new_fieldname":"ws_version"
+          "map_field_name":{
+            "new_field_name":"ws_version"
           }
         },
         "VersionNote":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"null",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_version_note"
+          "map_field_name":{
+            "new_field_name":"ws_version_note"
           }
         },
         "VersionNumber":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"Vnull",
             "post_value":"unknown"
           },
-          "map_fieldname":{
-            "new_fieldname":"ws_version_number"
+          "map_field_name":{
+            "new_field_name":"ws_version_number"
           }
         },
         "Status":[
           {
-            "map_fieldcopy":{
+            "map_field_copy":{
               "copy_name": "ws_status"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Success",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Successfully queued",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"QUEUED",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"PENDING",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"COMPLETED",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"IN_PROGRESS",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Failed",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"Failed to queue",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"HOLDING",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"HOLDING_FAILED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"HOLDING_TIMEDOUT",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"FAILED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"TIMEDOUT",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"ABORTED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"SKIPPED_FAILED",
               "post_value":"0"
             }
           },
           {
-            "map_fieldname":{
-              "new_fieldname":"result"
+            "map_field_name":{
+              "new_field_name":"result"
             }
           }
         ],
         "ResultStatus":[
           {
-            "map_fieldcopy":{
+            "map_field_copy":{
               "copy_name": "ws_result_status"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"200 OK",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"201 Created",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"202 Accepted",
               "post_value":"1"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"400 Bad Request",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"401 Unauthorized",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"403 Forbidden",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"404 Not Found",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"409 Resource Conflict",
               "post_value":"0"
             }
           },
           {
-            "map_fieldvalue":{
+            "map_field_value":{
               "pre_value":"500 Internal Server Error",
               "post_value":"0"
             }
           },
           {
-            "map_fieldname":{
-              "new_fieldname":"result"
+            "map_field_name":{
+              "new_field_name":"result"
             }
           }
         ]

--- a/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/templates/input.config-spark.json.j2
+++ b/ambari-server/src/main/resources/common-services/SPARK/1.2.1/package/templates/input.config-spark.json.j2
@@ -55,7 +55,7 @@
           }
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/templates/input.config-spark2.json.j2
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/templates/input.config-spark2.json.j2
@@ -55,7 +55,7 @@
           }
         },
         "level":{
-          "map_fieldvalue":{
+          "map_field_value":{
             "pre_value":"WARNING",
             "post_value":"WARN"
           }

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatTestHelper.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/HeartbeatTestHelper.java
@@ -44,6 +44,7 @@ import org.apache.ambari.server.actionmanager.Request;
 import org.apache.ambari.server.actionmanager.Stage;
 import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.events.publishers.STOMPUpdatePublisher;
 import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
 import org.apache.ambari.server.orm.OrmTestHelper;
 import org.apache.ambari.server.orm.dao.ClusterDAO;
@@ -65,6 +66,7 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.cluster.ClustersImpl;
 import org.apache.ambari.server.state.fsm.InvalidStateTransitionException;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStartEvent;
+import org.easymock.EasyMock;
 
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -117,6 +119,7 @@ public class HeartbeatTestHelper {
       @Override
       protected void configure() {
         super.configure();
+        binder().bind(STOMPUpdatePublisher.class).toInstance(EasyMock.createNiceMock(STOMPUpdatePublisher.class));
       }
     };
   }
@@ -184,7 +187,7 @@ public class HeartbeatTestHelper {
     // forcefully will refresh the internal state so that any tests which
     // incorrect use Clusters after calling this won't be affected
     Clusters clusters = injector.getInstance(Clusters.class);
-    Method method = ClustersImpl.class.getDeclaredMethod("loadClustersAndHosts");
+    Method method = ClustersImpl.class.getDeclaredMethod("safelyLoadClustersAndHosts");
     method.setAccessible(true);
     method.invoke(clusters);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/AgentDataHolderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/AgentDataHolderTest.java
@@ -35,31 +35,31 @@ public class AgentDataHolderTest {
     AmbariEventPublisher ambariEventPublisher = createNiceMock(AmbariEventPublisher.class);
     AgentConfigsHolder agentConfigsHolder = new AgentConfigsHolder(ambariEventPublisher);
 
-    AgentConfigsUpdateEvent event1 = new AgentConfigsUpdateEvent(null);
+    AgentConfigsUpdateEvent event1 = new AgentConfigsUpdateEvent(null, null);
     event1.setHash("01");
     event1.setTimestamp(1L);
     String eventHash1 = agentConfigsHolder.getHash(event1);
 
     // difference in hash only
-    AgentConfigsUpdateEvent event2 = new AgentConfigsUpdateEvent(null);
+    AgentConfigsUpdateEvent event2 = new AgentConfigsUpdateEvent(null, null);
     event2.setHash("02");
     event2.setTimestamp(1L);
     String eventHash2 = agentConfigsHolder.getHash(event2);
 
     // difference in timestamp only
-    AgentConfigsUpdateEvent event3 = new AgentConfigsUpdateEvent(null);
+    AgentConfigsUpdateEvent event3 = new AgentConfigsUpdateEvent(null, null);
     event3.setHash("01");
     event3.setTimestamp(2L);
     String eventHash3 = agentConfigsHolder.getHash(event3);
 
     // difference in both hash and timestamp
-    AgentConfigsUpdateEvent event4 = new AgentConfigsUpdateEvent(null);
+    AgentConfigsUpdateEvent event4 = new AgentConfigsUpdateEvent(null, null);
     event4.setHash("02");
     event4.setTimestamp(2L);
     String eventHash4 = agentConfigsHolder.getHash(event4);
 
     // hash and timestamp are the same, changes in body
-    AgentConfigsUpdateEvent event5 = new AgentConfigsUpdateEvent(MapUtils.EMPTY_SORTED_MAP);
+    AgentConfigsUpdateEvent event5 = new AgentConfigsUpdateEvent(null, MapUtils.EMPTY_SORTED_MAP);
     event5.setHash("01");
     event5.setTimestamp(1L);
     String eventHash5 = agentConfigsHolder.getHash(event5);

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/AlertDefinitionsHolderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/AlertDefinitionsHolderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.agent.stomp;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.agent.stomp.dto.AlertCluster;
+import org.apache.ambari.server.events.AlertDefinitionEventType;
+import org.apache.ambari.server.events.AlertDefinitionsAgentUpdateEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.junit.Test;
+
+public class AlertDefinitionsHolderTest {
+  private final Long HOST_ID = 1L;
+
+  @Test
+  public void testHandleUpdateEmptyCurrent() throws AmbariException {
+    AlertDefinitionsAgentUpdateEvent current = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.CREATE,
+        Collections.emptyMap(), "host1", HOST_ID);
+    Map<Long, AlertCluster> clusters = new HashMap<>();
+    AlertCluster cluster = AlertCluster.emptyAlertCluster();
+    clusters.put(1L, cluster);
+    AlertDefinitionsAgentUpdateEvent update = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.UPDATE,
+        clusters, "host1", HOST_ID);
+
+    AlertDefinitionsHolder alertDefinitionsHolder = new AlertDefinitionsHolder(createNiceMock(AmbariEventPublisher.class));
+    AlertDefinitionsAgentUpdateEvent result = alertDefinitionsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(AlertDefinitionEventType.CREATE, result.getEventType());
+    assertEquals(result.getClusters(), update.getClusters());
+  }
+
+  @Test
+  public void testHandleUpdateEmptyUpdate() throws AmbariException {
+    Map<Long, AlertCluster> clusters = new HashMap<>();
+    AlertCluster cluster = AlertCluster.emptyAlertCluster();
+    clusters.put(1L, cluster);
+    AlertDefinitionsAgentUpdateEvent current = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.CREATE,
+        clusters, "host1", HOST_ID);
+    AlertDefinitionsAgentUpdateEvent update = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.UPDATE,
+        Collections.emptyMap(), "host1", HOST_ID);
+
+    AlertDefinitionsHolder alertDefinitionsHolder = new AlertDefinitionsHolder(createNiceMock(AmbariEventPublisher.class));
+    AlertDefinitionsAgentUpdateEvent result = alertDefinitionsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(result, null);
+  }
+
+  @Test
+  public void testHandleUpdateNoChanges() throws AmbariException {
+    Map<Long, AlertCluster> currentClusters = new HashMap<>();
+    AlertCluster currentCluster = new AlertCluster(Collections.emptyMap(), "host1");
+    currentClusters.put(1L, currentCluster);
+    AlertDefinitionsAgentUpdateEvent current = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.CREATE,
+        currentClusters, "host1", HOST_ID);
+
+    Map<Long, AlertCluster> updateClusters = new HashMap<>();
+    AlertCluster updateCluster = new AlertCluster(Collections.emptyMap(), "host1");
+    updateClusters.put(1L, updateCluster);
+    AlertDefinitionsAgentUpdateEvent update = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.UPDATE,
+        updateClusters, "host1", HOST_ID);
+
+    AlertDefinitionsHolder alertDefinitionsHolder = new AlertDefinitionsHolder(createNiceMock(AmbariEventPublisher.class));
+    AlertDefinitionsAgentUpdateEvent result = alertDefinitionsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(result, null);
+  }
+
+  @Test
+  public void testHandleUpdateOnChanges() throws AmbariException {
+    Map<Long, AlertCluster> currentClusters = new HashMap<>();
+    AlertCluster currentCluster = new AlertCluster(Collections.emptyMap(), "host1");
+    currentClusters.put(1L, currentCluster);
+    AlertDefinitionsAgentUpdateEvent current = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.CREATE,
+        currentClusters, "host1", HOST_ID);
+
+    Map<Long, AlertCluster> updateClusters = new HashMap<>();
+    AlertCluster updateCluster = new AlertCluster(Collections.emptyMap(), "host1");
+    updateClusters.put(2L, updateCluster);
+    AlertDefinitionsAgentUpdateEvent update = new AlertDefinitionsAgentUpdateEvent(AlertDefinitionEventType.UPDATE,
+        updateClusters, "host1", HOST_ID);
+
+    AlertDefinitionsHolder alertDefinitionsHolder = new AlertDefinitionsHolder(createNiceMock(AmbariEventPublisher.class));
+    AlertDefinitionsAgentUpdateEvent result = alertDefinitionsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(2, result.getClusters().size());
+    assertTrue(result.getClusters().containsKey(1L));
+    assertTrue(result.getClusters().containsKey(2L));
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/stomp/HostLevelParamsHolderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.agent.stomp;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ambari.server.agent.RecoveryConfig;
+import org.apache.ambari.server.agent.stomp.dto.HostLevelParamsCluster;
+import org.apache.ambari.server.agent.stomp.dto.HostRepositories;
+import org.apache.ambari.server.events.HostLevelParamsUpdateEvent;
+import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
+import org.junit.Test;
+
+public class HostLevelParamsHolderTest {
+  private final Long HOST_ID = 1L;
+
+  @Test
+  public void testHandleUpdateEmptyCurrent() {
+    HostLevelParamsUpdateEvent current = new HostLevelParamsUpdateEvent(HOST_ID, Collections.emptyMap());
+    Map<String, HostLevelParamsCluster> clusters = new HashMap<>();
+    HostRepositories hostRepositories = new HostRepositories(Collections.emptySortedMap(), Collections.emptySortedMap());
+    HostLevelParamsCluster cluster = new HostLevelParamsCluster(hostRepositories, new RecoveryConfig(null));
+    clusters.put("1", cluster);
+    HostLevelParamsUpdateEvent update = new HostLevelParamsUpdateEvent(HOST_ID, clusters);
+
+    HostLevelParamsHolder levelParamsHolder = new HostLevelParamsHolder(createNiceMock(AmbariEventPublisher.class));
+    HostLevelParamsUpdateEvent result = levelParamsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(result, update);
+  }
+
+  @Test
+  public void testHandleUpdateEmptyUpdate() {
+    Map<String, HostLevelParamsCluster> clusters = new HashMap<>();
+    HostRepositories hostRepositories = new HostRepositories(Collections.emptySortedMap(), Collections.emptySortedMap());
+    HostLevelParamsCluster cluster = new HostLevelParamsCluster(hostRepositories, new RecoveryConfig(null));
+    clusters.put("1", cluster);
+    HostLevelParamsUpdateEvent current = new HostLevelParamsUpdateEvent(HOST_ID, clusters);
+    HostLevelParamsUpdateEvent update = new HostLevelParamsUpdateEvent(HOST_ID, Collections.emptyMap());
+
+    HostLevelParamsHolder levelParamsHolder = new HostLevelParamsHolder(createNiceMock(AmbariEventPublisher.class));
+    HostLevelParamsUpdateEvent result = levelParamsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(result, null);
+  }
+
+  @Test
+  public void testHandleUpdateNoChanges() {
+    Map<String, HostLevelParamsCluster> currentClusters = new HashMap<>();
+    HostRepositories currentHostRepositories = new HostRepositories(Collections.emptySortedMap(), Collections.emptySortedMap());
+    HostLevelParamsCluster currentCluster = new HostLevelParamsCluster(currentHostRepositories, new RecoveryConfig(null));
+    currentClusters.put("1", currentCluster);
+    HostLevelParamsUpdateEvent current = new HostLevelParamsUpdateEvent(HOST_ID, currentClusters);
+
+    Map<String, HostLevelParamsCluster> updateClusters = new HashMap<>();
+    HostRepositories updateHostRepositories = new HostRepositories(Collections.emptySortedMap(), Collections.emptySortedMap());
+    HostLevelParamsCluster updateCluster = new HostLevelParamsCluster(updateHostRepositories, new RecoveryConfig(null));
+    updateClusters.put("1", updateCluster);
+    HostLevelParamsUpdateEvent update = new HostLevelParamsUpdateEvent(HOST_ID, updateClusters);
+
+    HostLevelParamsHolder levelParamsHolder = new HostLevelParamsHolder(createNiceMock(AmbariEventPublisher.class));
+    HostLevelParamsUpdateEvent result = levelParamsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(result, null);
+  }
+
+  @Test
+  public void testHandleUpdateOnChanges() {
+    Map<String, HostLevelParamsCluster> currentClusters = new HashMap<>();
+    HostRepositories currentHostRepositories = new HostRepositories(Collections.emptySortedMap(), Collections.emptySortedMap());
+    HostLevelParamsCluster currentCluster = new HostLevelParamsCluster(currentHostRepositories, new RecoveryConfig(null));
+    currentClusters.put("1", currentCluster);
+    HostLevelParamsUpdateEvent current = new HostLevelParamsUpdateEvent(HOST_ID, currentClusters);
+
+    Map<String, HostLevelParamsCluster> updateClusters = new HashMap<>();
+    HostRepositories updateHostRepositories = new HostRepositories(Collections.emptySortedMap(), Collections.emptySortedMap());
+    HostLevelParamsCluster updateCluster = new HostLevelParamsCluster(updateHostRepositories, new RecoveryConfig(null));
+    updateClusters.put("2", updateCluster);
+    HostLevelParamsUpdateEvent update = new HostLevelParamsUpdateEvent(HOST_ID, updateClusters);
+
+    HostLevelParamsHolder levelParamsHolder = new HostLevelParamsHolder(createNiceMock(AmbariEventPublisher.class));
+    HostLevelParamsUpdateEvent result = levelParamsHolder.handleUpdate(current, update);
+
+    assertFalse(result == update);
+    assertFalse(result == current);
+    assertEquals(2, result.getHostLevelParamsClusters().size());
+    assertTrue(result.getHostLevelParamsClusters().containsKey("1"));
+    assertTrue(result.getHostLevelParamsClusters().containsKey("2"));
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -147,7 +147,7 @@ public class AmbariCustomCommandExecutionHelperTest {
         EasyMock.anyObject(Map.class))).andReturn(Collections.EMPTY_SET);
 
     EasyMock.expect(configHelper.getHostActualConfigs(EasyMock.anyLong())).andReturn(
-        new AgentConfigsUpdateEvent(new TreeMap<>())).anyTimes();
+        new AgentConfigsUpdateEvent(null, new TreeMap<>())).anyTimes();
 
     EasyMock.replay(configHelper);
 
@@ -544,7 +544,7 @@ public class AmbariCustomCommandExecutionHelperTest {
     AmbariCustomCommandExecutionHelper helper = injector.getInstance(AmbariCustomCommandExecutionHelper.class);
 
     EasyMock.expect(configHelper.getHostActualConfigs(EasyMock.anyLong())).andReturn(
-        new AgentConfigsUpdateEvent(new TreeMap<>())).anyTimes();
+        new AgentConfigsUpdateEvent(null, new TreeMap<>())).anyTimes();
 
     EasyMock.replay(configHelper);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UpgradeResourceProviderTest.java
@@ -58,7 +58,9 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.KerberosHelper;
+import org.apache.ambari.server.controller.KerberosHelperImpl;
 import org.apache.ambari.server.controller.ResourceProviderFactory;
+import org.apache.ambari.server.controller.UpdateConfigurationPolicy;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.RequestStatus;
@@ -120,6 +122,7 @@ import org.apache.ambari.server.view.ViewRegistry;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
@@ -188,7 +191,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     expect(
         configHelper.getDefaultProperties(EasyMock.anyObject(StackId.class),
             EasyMock.anyString())).andReturn(
-      new HashMap<>()).anyTimes();
+        new HashMap<>()).anyTimes();
 
     expect(
         configHelper.getChangedConfigTypes(EasyMock.anyObject(Cluster.class), EasyMock.anyObject(ServiceConfigEntity.class),
@@ -322,10 +325,11 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
 
   /**
    * Obtain request id from the {@code RequestStatus}
+   *
    * @param requestStatus reqult of the {@code createResources}
    * @return id of the request
    */
-  private long getRequestId(RequestStatus requestStatus){
+  private long getRequestId(RequestStatus requestStatus) {
     assertEquals(1, requestStatus.getAssociatedResources().size());
     Resource r = requestStatus.getAssociatedResources().iterator().next();
     String id = r.getPropertyValue("Upgrade/request_id").toString();
@@ -507,9 +511,9 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     propertyIds.add("Upgrade");
 
     Predicate predicate = new PredicateBuilder()
-      .property(UpgradeResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
-      .property(UpgradeResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
-      .toPredicate();
+        .property(UpgradeResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
+        .property(UpgradeResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
+        .toPredicate();
     Request request = PropertyHelper.getReadRequest(propertyIds);
 
     ResourceProvider upgradeResourceProvider = createProvider(amc);
@@ -529,9 +533,9 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     propertyIds.add("UpgradeGroup");
 
     predicate = new PredicateBuilder()
-      .property(UpgradeGroupResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
-      .property(UpgradeGroupResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
-      .toPredicate();
+        .property(UpgradeGroupResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
+        .property(UpgradeGroupResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
+        .toPredicate();
     request = PropertyHelper.getReadRequest(propertyIds);
 
     ResourceProvider upgradeGroupResourceProvider = new UpgradeGroupResourceProvider(amc);
@@ -550,10 +554,10 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     propertyIds.add("UpgradeItem");
 
     predicate = new PredicateBuilder()
-      .property(UpgradeItemResourceProvider.UPGRADE_GROUP_ID).equals("1").and()
-      .property(UpgradeItemResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
-      .property(UpgradeItemResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
-      .toPredicate();
+        .property(UpgradeItemResourceProvider.UPGRADE_GROUP_ID).equals("1").and()
+        .property(UpgradeItemResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
+        .property(UpgradeItemResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
+        .toPredicate();
     request = PropertyHelper.getReadRequest(propertyIds);
 
     ResourceProvider upgradeItemResourceProvider = new UpgradeItemResourceProvider(amc);
@@ -569,10 +573,10 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     propertyIds.add("UpgradeItem");
 
     predicate = new PredicateBuilder()
-      .property(UpgradeItemResourceProvider.UPGRADE_GROUP_ID).equals("3").and()
-      .property(UpgradeItemResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
-      .property(UpgradeItemResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
-      .toPredicate();
+        .property(UpgradeItemResourceProvider.UPGRADE_GROUP_ID).equals("3").and()
+        .property(UpgradeItemResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
+        .property(UpgradeItemResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
+        .toPredicate();
     request = PropertyHelper.getReadRequest(propertyIds);
 
     upgradeItemResourceProvider = new UpgradeItemResourceProvider(amc);
@@ -622,9 +626,9 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     propertyIds.add("Upgrade");
 
     Predicate predicate = new PredicateBuilder()
-      .property(UpgradeResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
-      .property(UpgradeResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
-      .toPredicate();
+        .property(UpgradeResourceProvider.UPGRADE_REQUEST_ID).equals("1").and()
+        .property(UpgradeResourceProvider.UPGRADE_CLUSTER_NAME).equals("c1")
+        .toPredicate();
 
     request = PropertyHelper.getReadRequest(propertyIds);
     Set<Resource> resources = upgradeResourceProvider.getResources(request, predicate);
@@ -812,7 +816,6 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
   }
 
 
-
   /**
    * Test Downgrade from the partially completed upgrade
    */
@@ -851,10 +854,10 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     boolean isZKGroupFound = false;
 
     // look only for testing groups
-    for (UpgradeGroupEntity group: groups) {
+    for (UpgradeGroupEntity group : groups) {
       if (group.getName().equalsIgnoreCase("hive")) {
         isHiveGroupFound = true;
-      } else if (group.getName().equalsIgnoreCase("zookeeper")){
+      } else if (group.getName().equalsIgnoreCase("zookeeper")) {
         isZKGroupFound = true;
       }
     }
@@ -883,10 +886,10 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     RequestStatus status = upgradeResourceProvider.createResources(request);
     UpgradeEntity upgradeEntity = upgradeDao.findUpgradeByRequestId(getRequestId(status));
 
-    for (UpgradeGroupEntity group: upgradeEntity.getUpgradeGroups()) {
+    for (UpgradeGroupEntity group : upgradeEntity.getUpgradeGroups()) {
       if (group.getName().equalsIgnoreCase("hive")) {
         isHiveGroupFound = true;
-      } else if (group.getName().equalsIgnoreCase("zookeeper")){
+      } else if (group.getName().equalsIgnoreCase("zookeeper")) {
         isZKGroupFound = true;
       }
     }
@@ -1141,7 +1144,6 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
   }
 
 
-
   @Test
   public void testPercents() throws Exception {
     RequestStatus status = testCreateResources();
@@ -1291,11 +1293,11 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     List<StageEntity> stageEntities = stageDAO.findByRequestId(entity.getRequestId());
     Gson gson = new Gson();
     for (StageEntity se : stageEntities) {
-      Map<String, String> map = gson.<Map<String, String>> fromJson(se.getCommandParamsStage(),Map.class);
+      Map<String, String> map = gson.<Map<String, String>>fromJson(se.getCommandParamsStage(), Map.class);
       assertTrue(map.containsKey("upgrade_direction"));
       assertEquals("upgrade", map.get("upgrade_direction"));
 
-      if(map.containsKey("upgrade_type")){
+      if (map.containsKey("upgrade_type")) {
         assertEquals("rolling_upgrade", map.get("upgrade_type"));
       }
     }
@@ -1541,7 +1543,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     try {
       upgradeResourceProvider.createResources(request);
       Assert.fail("The request should have failed due to the missing Upgrade/host_order property");
-    } catch( SystemException systemException ){
+    } catch (SystemException systemException) {
       // expected
     }
 
@@ -1679,7 +1681,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     requestProps.put(UpgradeResourceProvider.UPGRADE_REPO_VERSION_ID, String.valueOf(repoVersionEntity2200.getId()));
     requestProps.put(UpgradeResourceProvider.UPGRADE_PACK, "upgrade_test_host_ordered");
     requestProps.put(UpgradeResourceProvider.UPGRADE_TYPE, UpgradeType.HOST_ORDERED.toString());
-    requestProps.put(UpgradeResourceProvider.UPGRADE_SKIP_PREREQUISITE_CHECKS,Boolean.TRUE.toString());
+    requestProps.put(UpgradeResourceProvider.UPGRADE_SKIP_PREREQUISITE_CHECKS, Boolean.TRUE.toString());
     requestProps.put(UpgradeResourceProvider.UPGRADE_DIRECTION, Direction.UPGRADE.name());
     requestProps.put(UpgradeResourceProvider.UPGRADE_HOST_ORDERED_HOSTS, hostsOrder);
 
@@ -1726,8 +1728,8 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     List<UpgradeHistoryEntity> histories = upgrade.getHistory();
     assertEquals(2, histories.size());
 
-    for( UpgradeHistoryEntity history : histories){
-      assertEquals( "ZOOKEEPER", history.getServiceName() );
+    for (UpgradeHistoryEntity history : histories) {
+      assertEquals("ZOOKEEPER", history.getServiceName());
       assertEquals(repoVersionEntity2110, history.getFromReposistoryVersion());
       assertEquals(repoVersionEntity2200, history.getTargetRepositoryVersion());
     }
@@ -1830,7 +1832,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
       @Override
       public String apply(UpgradeHistoryEntity input) {
         return input.getServiceName() + "/" + input.getComponentName();
-      };
+      }
     };
 
     for (UpgradeEntity upgrade : upgrades) {
@@ -1874,7 +1876,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
 
     Map<String, Object> requestProps = new HashMap<>();
     requestProps.put(UpgradeResourceProvider.UPGRADE_CLUSTER_NAME, "c1");
-    requestProps.put(UpgradeResourceProvider.UPGRADE_REPO_VERSION_ID,String.valueOf(repoVersionEntity2112.getId()));
+    requestProps.put(UpgradeResourceProvider.UPGRADE_REPO_VERSION_ID, String.valueOf(repoVersionEntity2112.getId()));
     requestProps.put(UpgradeResourceProvider.UPGRADE_PACK, "upgrade_test");
     requestProps.put(UpgradeResourceProvider.UPGRADE_SKIP_PREREQUISITE_CHECKS, "true");
     requestProps.put(UpgradeResourceProvider.UPGRADE_DIRECTION, Direction.UPGRADE.name());
@@ -1984,7 +1986,6 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     assertTrue(foundConfigTask);
 
 
-
     // !!! test that a regular upgrade will pick up the config change
     cluster.setUpgradeEntity(null);
     repoVersionEntity2112.setType(RepositoryType.STANDARD);
@@ -2017,8 +2018,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
   }
 
 
-
-  private String parseSingleMessage(String msgStr){
+  private String parseSingleMessage(String msgStr) {
     JsonParser parser = new JsonParser();
     JsonArray msgArray = (JsonArray) parser.parse(msgStr);
     JsonObject msg = (JsonObject) msgArray.get(0);
@@ -2110,7 +2110,7 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
       if (command.getRole().equals(Role.ZOOKEEPER_SERVER) && command.getRoleCommand().equals(RoleCommand.CUSTOM_COMMAND)) {
         Map<String, String> commandParams = wrapper.getExecutionCommand().getCommandParams();
         assertTrue(commandParams.containsKey(KeyNames.COMMAND_TIMEOUT));
-        assertEquals("824",commandParams.get(KeyNames.COMMAND_TIMEOUT));
+        assertEquals("824", commandParams.get(KeyNames.COMMAND_TIMEOUT));
         found = true;
       }
     }
@@ -2178,6 +2178,8 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
    */
   @Test
   public void testCreateRegenerateKeytabStages() throws Exception {
+    Capture<Map<String, String>> requestPropertyMapCapture = EasyMock.newCapture();
+
     Map<String, Object> requestProps = new HashMap<>();
     requestProps.put(UpgradeResourceProvider.UPGRADE_CLUSTER_NAME, "c1");
     requestProps.put(UpgradeResourceProvider.UPGRADE_REPO_VERSION_ID, String.valueOf(repoVersionEntity2200.getId()));
@@ -2190,9 +2192,9 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     RequestStageContainer requestStageContainer = createNiceMock(RequestStageContainer.class);
     expect(requestStageContainer.getStages()).andReturn(Lists.newArrayList()).once();
 
-    expect(kerberosHelperMock.executeCustomOperations(eq(cluster), EasyMock.anyObject(),
+    expect(kerberosHelperMock.executeCustomOperations(eq(cluster), EasyMock.capture(requestPropertyMapCapture),
         EasyMock.anyObject(RequestStageContainer.class), eq(null))).andReturn(
-            requestStageContainer).once();
+        requestStageContainer).once();
 
     replayAll();
 
@@ -2207,6 +2209,11 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
     }
 
     verifyAll();
+
+    Map<String, String> requestPropertyMap = requestPropertyMapCapture.getValue();
+    assertEquals("true", requestPropertyMap.get(KerberosHelper.ALLOW_RETRY));
+    assertEquals("missing", requestPropertyMap.get(KerberosHelperImpl.SupportedCustomOperation.REGENERATE_KEYTABS.name().toLowerCase()));
+    assertEquals(UpdateConfigurationPolicy.NEW_AND_IDENTITIES.name(), requestPropertyMap.get(KerberosHelper.DIRECTIVE_CONFIG_UPDATE_POLICY.toLowerCase()));
   }
 
   /**
@@ -2214,8 +2221,8 @@ public class UpgradeResourceProviderTest extends EasyMockSupport {
    */
   private class MockModule implements Module {
     /**
-   *
-   */
+     *
+     */
     @Override
     public void configure(Binder binder) {
       binder.bind(ConfigHelper.class).toInstance(configHelper);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
@@ -20,14 +20,17 @@ package org.apache.ambari.server.serveraction.kerberos;
 
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,78 +39,215 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.persistence.EntityManager;
 
-import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.actionmanager.ActionDBAccessor;
+import org.apache.ambari.server.actionmanager.ActionManager;
+import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
+import org.apache.ambari.server.actionmanager.RequestFactory;
+import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.agent.CommandReport;
+import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.audit.AuditLogger;
+import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
+import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
+import org.apache.ambari.server.controller.KerberosHelperImpl;
+import org.apache.ambari.server.controller.UpdateConfigurationPolicy;
+import org.apache.ambari.server.hooks.HookContextFactory;
+import org.apache.ambari.server.hooks.HookService;
+import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
+import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
+import org.apache.ambari.server.scheduler.ExecutionScheduler;
+import org.apache.ambari.server.security.encryption.CredentialStoreService;
+import org.apache.ambari.server.stack.StackManagerFactory;
+import org.apache.ambari.server.stageplanner.RoleGraphFactory;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.ConfigFactory;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.Service;
+import org.apache.ambari.server.state.ServiceComponentFactory;
 import org.apache.ambari.server.state.ServiceComponentHost;
+import org.apache.ambari.server.state.ServiceComponentHostFactory;
+import org.apache.ambari.server.state.configgroup.ConfigGroupFactory;
 import org.apache.ambari.server.state.kerberos.KerberosComponentDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptorFactory;
 import org.apache.ambari.server.state.kerberos.KerberosServiceDescriptor;
-import org.easymock.EasyMock;
+import org.apache.ambari.server.state.scheduler.RequestExecutionFactory;
+import org.apache.ambari.server.state.stack.OsFamily;
+import org.apache.ambari.server.topology.PersistedState;
+import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
 
-public class AbstractPrepareKerberosServerActionTest {
-  private class PrepareKerberosServerAction extends AbstractPrepareKerberosServerAction{
+public class AbstractPrepareKerberosServerActionTest extends EasyMockSupport {
+  private static final String KERBEROS_DESCRIPTOR_JSON = "" +
+      "{" +
+      "  \"identities\": [" +
+      "    {" +
+      "      \"keytab\": {" +
+      "        \"file\": \"${keytab_dir}/spnego.service.keytab\"," +
+      "        \"group\": {" +
+      "          \"access\": \"r\"," +
+      "          \"name\": \"${cluster-env/user_group}\"" +
+      "        }," +
+      "        \"owner\": {" +
+      "          \"access\": \"r\"," +
+      "          \"name\": \"root\"" +
+      "        }" +
+      "      }," +
+      "      \"name\": \"spnego\"," +
+      "      \"principal\": {" +
+      "        \"configuration\": null," +
+      "        \"local_username\": null," +
+      "        \"type\": \"service\"," +
+      "        \"value\": \"HTTP/_HOST@${realm}\"" +
+      "      }" +
+      "    }" +
+      "  ]," +
+      "  \"services\": [" +
+      "    {" +
+      "      \"components\": [" +
+      "        {" +
+      "          \"identities\": [" +
+      "            {" +
+      "              \"name\": \"service_master_spnego_identity\"," +
+      "              \"reference\": \"/spnego\"" +
+      "            }" +
+      "          ]," +
+      "          \"name\": \"SERVICE_MASTER\"" +
+      "        }" +
+      "      ]," +
+      "      \"configurations\": [" +
+      "        {" +
+      "          \"service-site\": {" +
+      "            \"property1\": \"property1_updated_value\"," +
+      "            \"property2\": \"property2_updated_value\"" +
+      "          }" +
+      "        }" +
+      "      ]," +
+      "      \"identities\": [" +
+      "        {" +
+      "          \"name\": \"service_identity\"," +
+      "          \"keytab\": {" +
+      "            \"configuration\": \"service-site/keytab_file_path\"," +
+      "            \"file\": \"${keytab_dir}/service.service.keytab\"," +
+      "            \"group\": {" +
+      "              \"access\": \"r\"," +
+      "              \"name\": \"${cluster-env/user_group}\"" +
+      "            }," +
+      "            \"owner\": {" +
+      "              \"access\": \"r\"," +
+      "              \"name\": \"${service-env/service_user}\"" +
+      "            }" +
+      "          }," +
+      "          \"principal\": {" +
+      "            \"configuration\": \"service-site/principal_name\"," +
+      "            \"local_username\": \"${service-env/service_user}\"," +
+      "            \"type\": \"service\"," +
+      "            \"value\": \"${service-env/service_user}/_HOST@${realm}\"" +
+      "          }" +
+      "        }" +
+      "      ]," +
+      "      \"name\": \"SERVICE\"" +
+      "    }" +
+      "  ]," +
+      "  \"properties\": {" +
+      "    \"additional_realms\": \"\"," +
+      "    \"keytab_dir\": \"/etc/security/keytabs\"," +
+      "    \"principal_suffix\": \"-${cluster_name|toLower()}\"," +
+      "    \"realm\": \"${kerberos-env/realm}\"" +
+      "  }" +
+      "}";
+
+  private class TestKerberosServerAction extends AbstractPrepareKerberosServerAction {
 
     @Override
-    public CommandReport execute(ConcurrentMap<String, Object> requestSharedDataContext) throws AmbariException, InterruptedException {
+    protected String getClusterName() {
+      return "c1";
+    }
+
+    @Override
+    public CommandReport execute(ConcurrentMap<String, Object> requestSharedDataContext) {
       return null;
     }
   }
 
   private Injector injector;
-  private final PrepareKerberosServerAction prepareKerberosServerAction = new PrepareKerberosServerAction();
-
-  private final AuditLogger auditLogger = EasyMock.createNiceMock(AuditLogger.class);
-  private final Clusters clusters = EasyMock.createNiceMock(Clusters.class);
-  private final KerberosHelper kerberosHelper = EasyMock.createNiceMock(KerberosHelper.class);
-  private final KerberosIdentityDataFileWriterFactory kerberosIdentityDataFileWriterFactory = EasyMock.createNiceMock(KerberosIdentityDataFileWriterFactory.class);
+  private final AbstractPrepareKerberosServerAction testKerberosServerAction = new TestKerberosServerAction();
 
   @Before
   public void setUp() throws Exception {
     injector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
-        bind(KerberosHelper.class).toInstance(kerberosHelper);
-        bind(KerberosIdentityDataFileWriterFactory.class).toInstance(kerberosIdentityDataFileWriterFactory);
-        bind(Clusters.class).toInstance(clusters);
-        bind(AuditLogger.class).toInstance(auditLogger);
-        Provider<EntityManager> entityManagerProvider =  EasyMock.createNiceMock(Provider.class);
+        bind(AmbariMetaInfo.class).toInstance(createNiceMock(AmbariMetaInfo.class));
+        bind(KerberosHelper.class).to(KerberosHelperImpl.class);
+        bind(KerberosIdentityDataFileWriterFactory.class).toInstance(createNiceMock(KerberosIdentityDataFileWriterFactory.class));
+        bind(KerberosConfigDataFileWriterFactory.class).toInstance(createNiceMock(KerberosConfigDataFileWriterFactory.class));
+        bind(Clusters.class).toInstance(createNiceMock(Clusters.class));
+        bind(AuditLogger.class).toInstance(createNiceMock(AuditLogger.class));
+        bind(ConfigHelper.class).toInstance(createNiceMock(ConfigHelper.class));
+        bind(HostRoleCommandDAO.class).toInstance(createNiceMock(HostRoleCommandDAO.class));
+        bind(ActionManager.class).toInstance(createNiceMock(ActionManager.class));
+        bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));
+        bind(ExecutionScheduler.class).toInstance(createNiceMock(ExecutionScheduler.class));
+        bind(AmbariManagementController.class).toInstance(createNiceMock(AmbariManagementController.class));
+        bind(ActionDBAccessor.class).toInstance(createNiceMock(ActionDBAccessor.class));
+        bind(StackManagerFactory.class).toInstance(createNiceMock(StackManagerFactory.class));
+        bind(ConfigFactory.class).toInstance(createNiceMock(ConfigFactory.class));
+        bind(ConfigGroupFactory.class).toInstance(createNiceMock(ConfigGroupFactory.class));
+        bind(CredentialStoreService.class).toInstance(createNiceMock(CredentialStoreService.class));
+        bind(RequestExecutionFactory.class).toInstance(createNiceMock(RequestExecutionFactory.class));
+        bind(RequestFactory.class).toInstance(createNiceMock(RequestFactory.class));
+        bind(RoleCommandOrderProvider.class).toInstance(createNiceMock(RoleCommandOrderProvider.class));
+        bind(RoleGraphFactory.class).toInstance(createNiceMock(RoleGraphFactory.class));
+        bind(AbstractRootServiceResponseFactory.class).toInstance(createNiceMock(AbstractRootServiceResponseFactory.class));
+        bind(ServiceComponentFactory.class).toInstance(createNiceMock(ServiceComponentFactory.class));
+        bind(ServiceComponentHostFactory.class).toInstance(createNiceMock(ServiceComponentHostFactory.class));
+        bind(StageFactory.class).toInstance(createNiceMock(StageFactory.class));
+        bind(HostRoleCommandFactory.class).toInstance(createNiceMock(HostRoleCommandFactory.class));
+        bind(HookContextFactory.class).toInstance(createNiceMock(HookContextFactory.class));
+        bind(HookService.class).toInstance(createNiceMock(HookService.class));
+        bind(PasswordEncoder.class).toInstance(createNiceMock(PasswordEncoder.class));
+        bind(PersistedState.class).toInstance(createNiceMock(PersistedState.class));
+        bind(ConfigureClusterTaskFactory.class).toInstance(createNiceMock(ConfigureClusterTaskFactory.class));
+        Provider<EntityManager> entityManagerProvider = createNiceMock(Provider.class);
         bind(EntityManager.class).toProvider(entityManagerProvider);
       }
     });
 
-    injector.injectMembers(prepareKerberosServerAction);
+    injector.injectMembers(testKerberosServerAction);
   }
 
   /**
    * Test checks that {@code KerberosHelper.applyStackAdvisorUpdates} would be called with
    * full list of the services and not only list of services with KerberosDescriptior.
    * In this test HDFS service will have KerberosDescriptor, while Zookeeper not.
+   *
    * @throws Exception
    */
   @Test
   @SuppressWarnings("unchecked")
   public void testProcessServiceComponentHosts() throws Exception {
-    final Cluster cluster =  EasyMock.createNiceMock(Cluster.class);
-    final KerberosIdentityDataFileWriter kerberosIdentityDataFileWriter = EasyMock.createNiceMock(KerberosIdentityDataFileWriter.class);
-    final KerberosDescriptor kerberosDescriptor = EasyMock.createNiceMock(KerberosDescriptor.class);
-    final ServiceComponentHost serviceComponentHostHDFS = EasyMock.createNiceMock(ServiceComponentHost.class);
-    final ServiceComponentHost serviceComponentHostZK = EasyMock.createNiceMock(ServiceComponentHost.class);
-    final KerberosServiceDescriptor serviceDescriptor = EasyMock.createNiceMock(KerberosServiceDescriptor.class);
-    final KerberosComponentDescriptor componentDescriptor = EasyMock.createNiceMock(KerberosComponentDescriptor.class);
+    final Cluster cluster = createNiceMock(Cluster.class);
+    final KerberosIdentityDataFileWriter kerberosIdentityDataFileWriter = createNiceMock(KerberosIdentityDataFileWriter.class);
+    final KerberosDescriptor kerberosDescriptor = createNiceMock(KerberosDescriptor.class);
+    final ServiceComponentHost serviceComponentHostHDFS = createNiceMock(ServiceComponentHost.class);
+    final ServiceComponentHost serviceComponentHostZK = createNiceMock(ServiceComponentHost.class);
+    final KerberosServiceDescriptor serviceDescriptor = createNiceMock(KerberosServiceDescriptor.class);
+    final KerberosComponentDescriptor componentDescriptor = createNiceMock(KerberosComponentDescriptor.class);
 
     final String hdfsService = "HDFS";
     final String zookeeperService = "ZOOKEEPER";
@@ -118,20 +258,20 @@ public class AbstractPrepareKerberosServerActionTest {
     Collection<String> identityFilter = new ArrayList<>();
     Map<String, Map<String, String>> kerberosConfigurations = new HashMap<>();
     Map<String, Set<String>> propertiesToIgnore = new HashMap<>();
-    Map<String, String> descriptorProperties = new HashMap<>();
     Map<String, Map<String, String>> configurations = new HashMap<>();
 
     List<ServiceComponentHost> serviceComponentHosts = new ArrayList<ServiceComponentHost>() {{
       add(serviceComponentHostHDFS);
       add(serviceComponentHostZK);
     }};
-    Map<String, Service> clusterServices = new HashMap<String, Service>(){{
+    Map<String, Service> clusterServices = new HashMap<String, Service>() {{
       put(hdfsService, null);
       put(zookeeperService, null);
     }};
 
-    expect(kerberosDescriptor.getProperties()).andReturn(descriptorProperties).atLeastOnce();
-    expect(kerberosIdentityDataFileWriterFactory.createKerberosIdentityDataFileWriter((File)anyObject())).andReturn(kerberosIdentityDataFileWriter);
+    KerberosIdentityDataFileWriterFactory kerberosIdentityDataFileWriterFactory = injector.getInstance(KerberosIdentityDataFileWriterFactory.class);
+    expect(kerberosIdentityDataFileWriterFactory.createKerberosIdentityDataFileWriter(anyObject(File.class))).andReturn(kerberosIdentityDataFileWriter);
+
     // it's important to pass a copy of clusterServices
     expect(cluster.getServices()).andReturn(new HashMap<>(clusterServices)).atLeastOnce();
 
@@ -150,22 +290,201 @@ public class AbstractPrepareKerberosServerActionTest {
     expect(serviceDescriptor.getComponent(hdfsComponent)).andReturn(componentDescriptor).once();
     expect(componentDescriptor.getConfigurations(anyBoolean())).andReturn(null);
 
-    replay(kerberosDescriptor, kerberosHelper, kerberosIdentityDataFileWriterFactory,
-      cluster, serviceComponentHostHDFS, serviceComponentHostZK, serviceDescriptor, componentDescriptor);
+    replayAll();
 
-    prepareKerberosServerAction.processServiceComponentHosts(cluster,
-      kerberosDescriptor,
-      serviceComponentHosts,
-      identityFilter,
-      "",
+    injector.getInstance(AmbariMetaInfo.class).init();
+
+    testKerberosServerAction.processServiceComponentHosts(cluster,
+        kerberosDescriptor,
+        serviceComponentHosts,
+        identityFilter,
+        "",
         configurations, kerberosConfigurations,
         false, propertiesToIgnore);
 
-    verify(kerberosHelper);
+    verifyAll();
 
     // Ensure the host and hostname values were set in the configuration context
     Assert.assertEquals("host1", configurations.get("").get("host"));
     Assert.assertEquals("host1", configurations.get("").get("hostname"));
   }
 
+  @Test
+  public void testProcessConfigurationChanges() throws Exception {
+    // Existing property map....
+    Map<String, String> serviceSiteProperties = new HashMap<>();
+    serviceSiteProperties.put("property1", "property1_value");
+    serviceSiteProperties.put("principal_name", "principal_name_value");
+    serviceSiteProperties.put("keytab_file_path", "keytab_file_path_value");
+
+    Map<String, Map<String, String>> effectiveProperties = new HashMap<>();
+    effectiveProperties.put("service-site", serviceSiteProperties);
+
+    // Updated property map....
+    Map<String, String> updatedServiceSiteProperties = new HashMap<>();
+    updatedServiceSiteProperties.put("property1", "property1_updated_value");
+    updatedServiceSiteProperties.put("property2", "property2_updated_value");
+    updatedServiceSiteProperties.put("principal_name", "principal_name_updated_value");
+    updatedServiceSiteProperties.put("keytab_file_path", "keytab_file_path_updated_value");
+
+    Map<String, Map<String, String>> kerberosConfigurations = new HashMap<>();
+    kerberosConfigurations.put("service-site", updatedServiceSiteProperties);
+
+    KerberosDescriptor kerberosDescriptor = new KerberosDescriptorFactory().createInstance(KERBEROS_DESCRIPTOR_JSON);
+
+    ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
+    expect(configHelper.getEffectiveConfigProperties(eq("c1"), eq(null)))
+        .andReturn(effectiveProperties).anyTimes();
+
+    KerberosConfigDataFileWriterFactory factory = injector.getInstance(KerberosConfigDataFileWriterFactory.class);
+
+    ConfigWriterData dataCaptureAll = setupConfigWriter(factory);
+    ConfigWriterData dataCaptureIdentitiesOnly = setupConfigWriter(factory);
+    ConfigWriterData dataCaptureNewAndIdentities = setupConfigWriter(factory);
+    ConfigWriterData dataCaptureNone = setupConfigWriter(factory);
+
+    replayAll();
+
+    injector.getInstance(AmbariMetaInfo.class).init();
+
+    Map<String, String> expectedProperties;
+
+    // Update all configurations
+    testKerberosServerAction.processConfigurationChanges("test_directory",
+        kerberosConfigurations, Collections.emptyMap(), kerberosDescriptor, UpdateConfigurationPolicy.ALL);
+
+    expectedProperties = new HashMap<>();
+    expectedProperties.put("property1", "property1_updated_value");
+    expectedProperties.put("property2", "property2_updated_value");
+    expectedProperties.put("principal_name", "principal_name_updated_value");
+    expectedProperties.put("keytab_file_path", "keytab_file_path_updated_value");
+
+    verifyDataCapture(dataCaptureAll, Collections.singletonMap("service-site", expectedProperties));
+
+    // Update only identity configurations
+    testKerberosServerAction.processConfigurationChanges("test_directory",
+        kerberosConfigurations, Collections.emptyMap(), kerberosDescriptor, UpdateConfigurationPolicy.IDENTITIES_ONLY);
+
+    expectedProperties = new HashMap<>();
+    expectedProperties.put("principal_name", "principal_name_updated_value");
+    expectedProperties.put("keytab_file_path", "keytab_file_path_updated_value");
+
+    verifyDataCapture(dataCaptureIdentitiesOnly, Collections.singletonMap("service-site", expectedProperties));
+
+    // Update new and identity configurations
+    testKerberosServerAction.processConfigurationChanges("test_directory",
+        kerberosConfigurations, Collections.emptyMap(), kerberosDescriptor, UpdateConfigurationPolicy.NEW_AND_IDENTITIES);
+
+    expectedProperties = new HashMap<>();
+    expectedProperties.put("property2", "property2_updated_value");
+    expectedProperties.put("principal_name", "principal_name_updated_value");
+    expectedProperties.put("keytab_file_path", "keytab_file_path_updated_value");
+
+    verifyDataCapture(dataCaptureNewAndIdentities, Collections.singletonMap("service-site", expectedProperties));
+
+    // Update no configurations
+    testKerberosServerAction.processConfigurationChanges("test_directory",
+        kerberosConfigurations, Collections.emptyMap(), kerberosDescriptor, UpdateConfigurationPolicy.NONE);
+
+    verifyDataCapture(dataCaptureNone, Collections.emptyMap());
+
+    verifyAll();
+
+  }
+
+  private void verifyDataCapture(ConfigWriterData configWriterData, Map<String, Map<String, String>> expectedConfigurations) {
+
+    int expectedCaptures = 0;
+    Collection<Map<String, String>> expectedValuesCollection = expectedConfigurations.values();
+    for (Map<String, String> expectedValues : expectedValuesCollection) {
+      expectedCaptures += expectedValues.size();
+    }
+
+    Capture<String> captureConfigType = configWriterData.getCaptureConfigType();
+    if (expectedCaptures > 0) {
+      Assert.assertTrue(captureConfigType.hasCaptured());
+      List<String> valuesConfigType = captureConfigType.getValues();
+      Assert.assertEquals(expectedCaptures, valuesConfigType.size());
+    } else {
+      Assert.assertFalse(captureConfigType.hasCaptured());
+    }
+
+    Capture<String> capturePropertyName = configWriterData.getCapturePropertyName();
+    if (expectedCaptures > 0) {
+      Assert.assertTrue(capturePropertyName.hasCaptured());
+      List<String> valuesPropertyName = capturePropertyName.getValues();
+      Assert.assertEquals(expectedCaptures, valuesPropertyName.size());
+    } else {
+      Assert.assertFalse(capturePropertyName.hasCaptured());
+    }
+
+    Capture<String> capturePropertyValue = configWriterData.getCapturePropertyValue();
+    if (expectedCaptures > 0) {
+      Assert.assertTrue(capturePropertyValue.hasCaptured());
+      List<String> valuesPropertyValue = capturePropertyValue.getValues();
+      Assert.assertEquals(expectedCaptures, valuesPropertyValue.size());
+    } else {
+      Assert.assertFalse(capturePropertyValue.hasCaptured());
+    }
+
+    if (expectedCaptures > 0) {
+      int i = 0;
+      List<String> valuesConfigType = captureConfigType.getValues();
+      List<String> valuesPropertyName = capturePropertyName.getValues();
+      List<String> valuesPropertyValue = capturePropertyValue.getValues();
+
+      for (Map.Entry<String, Map<String, String>> entry : expectedConfigurations.entrySet()) {
+        String configType = entry.getKey();
+        Map<String, String> properties = entry.getValue();
+
+        for(Map.Entry<String, String> property:properties.entrySet()) {
+          Assert.assertEquals(configType, valuesConfigType.get(i));
+          Assert.assertEquals(property.getKey(), valuesPropertyName.get(i));
+          Assert.assertEquals(property.getValue(), valuesPropertyValue.get(i));
+          i++;
+        }
+      }
+    }
+
+  }
+
+  private ConfigWriterData setupConfigWriter(KerberosConfigDataFileWriterFactory factory) throws IOException {
+    Capture<String> captureConfigType = newCapture(CaptureType.ALL);
+    Capture<String> capturePropertyName = newCapture(CaptureType.ALL);
+    Capture<String> capturePropertyValue = newCapture(CaptureType.ALL);
+
+    KerberosConfigDataFileWriter mockWriter = createMock(KerberosConfigDataFileWriter.class);
+    mockWriter.addRecord(capture(captureConfigType), capture(capturePropertyName), capture(capturePropertyValue), eq(KerberosConfigDataFileWriter.OPERATION_TYPE_SET));
+    expectLastCall().anyTimes();
+    mockWriter.close();
+    expectLastCall().anyTimes();
+
+    expect(factory.createKerberosConfigDataFileWriter(anyObject(File.class))).andReturn(mockWriter).once();
+
+    return new ConfigWriterData(captureConfigType, capturePropertyName, capturePropertyValue);
+  }
+
+  private class ConfigWriterData {
+    private final Capture<String> captureConfigType;
+    private final Capture<String> capturePropertyName;
+    private final Capture<String> capturePropertyValue;
+
+    private ConfigWriterData(Capture<String> captureConfigType, Capture<String> capturePropertyName, Capture<String> capturePropertyValue) {
+      this.captureConfigType = captureConfigType;
+      this.capturePropertyName = capturePropertyName;
+      this.capturePropertyValue = capturePropertyValue;
+    }
+
+    Capture<String> getCaptureConfigType() {
+      return captureConfigType;
+    }
+
+    Capture<String> getCapturePropertyName() {
+      return capturePropertyName;
+    }
+
+    Capture<String> getCapturePropertyValue() {
+      return capturePropertyValue;
+    }
+  }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -156,7 +156,7 @@ public class UpgradeHelperTest extends EasyMockSupport {
     expect(m_configHelper.getEffectiveDesiredTags(
         EasyMock.anyObject(Cluster.class), EasyMock.anyObject(String.class))).andReturn(new HashMap<>()).anyTimes();
     expect(m_configHelper.getHostActualConfigs(
-        EasyMock.anyLong())).andReturn(new AgentConfigsUpdateEvent(Collections.emptySortedMap())).anyTimes();
+        EasyMock.anyLong())).andReturn(new AgentConfigsUpdateEvent(null, Collections.emptySortedMap())).anyTimes();
     expect(m_configHelper.getChangedConfigTypes(anyObject(Cluster.class), anyObject(ServiceConfigEntity.class),
         anyLong(), anyLong(), anyString())).andReturn(Collections.emptyMap()).anyTimes();
   }

--- a/ambari-web/app/mixins/wizard/assign_master_components.js
+++ b/ambari-web/app/mixins/wizard/assign_master_components.js
@@ -1185,11 +1185,11 @@ App.AssignMasterComponents = Em.Mixin.create(App.HostComponentValidationMixin, A
     this.getRecommendedHosts({
       hosts: hostNames,
       components: this.getCurrentComponentHostMap()
-    }).then(function() {
+    }).done(function() {
       self.validateSelectedHostComponents({
         hosts: hostNames,
         blueprint: self.get('recommendations')
-      }).then(function() {
+      }).always(function() {
         if (callback) {
           callback();
         }
@@ -1199,7 +1199,7 @@ App.AssignMasterComponents = Em.Mixin.create(App.HostComponentValidationMixin, A
           self.recommendAndValidate(callback);
         }
       });
-    }, true);
+    });
   },
 
   getCurrentComponentHostMap: function() {

--- a/ambari-web/app/models/host.js
+++ b/ambari-web/app/models/host.js
@@ -61,6 +61,8 @@ App.Host = DS.Model.extend({
    */
   selected:DS.attr('boolean'),
 
+  isActive: Em.computed.equal('passiveState', 'OFF'),
+
   criticalWarningAlertsCount: function() {
     const alertsSummary = this.get('alertsSummary');
     return alertsSummary ? (alertsSummary.CRITICAL || 0) + (alertsSummary.WARNING || 0) : 0;

--- a/ambari-web/app/routes/main.js
+++ b/ambari-web/app/routes/main.js
@@ -232,7 +232,17 @@ module.exports = Em.Route.extend(App.RouterRedirections, {
     hostDetails: Em.Route.extend({
 
       breadcrumbs: {
-        labelBindingPath: 'App.router.mainHostDetailsController.content.hostName'
+        itemView: Em.View.extend({
+          tagName: "a",
+          contentBinding: 'App.router.mainHostDetailsController.content',
+          isActive: Em.computed.equal('content.passiveState', 'OFF'),
+          click: function() {
+            App.router.transitionTo('hosts.hostDetails.summary', this.get('content'));
+          },
+          template: Em.Handlebars.compile('<span class="host-breadcrumb">{{view.content.hostName}}</span>' +
+            '<span rel="HealthTooltip" {{bindAttr class="view.content.healthClass view.content.healthIconClass :icon"}} ' +
+            'data-placement="bottom" {{bindAttr data-original-title="view.content.healthToolTip" }}></span>')
+        })
       },
 
       route: '/:host_id',

--- a/ambari-web/app/styles/hosts.less
+++ b/ambari-web/app/styles/hosts.less
@@ -462,6 +462,15 @@
   }
 }
 
+.host-breadcrumb {
+  max-width: 50%;
+  display: inline-block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  vertical-align: bottom;
+}
+
 #host-alerts {
   padding: 0 10px;
   background-color: #ffffff;

--- a/ambari-web/app/styles/top-nav.less
+++ b/ambari-web/app/styles/top-nav.less
@@ -26,9 +26,10 @@
     margin-bottom: 10px;
 
     .navbar-header {
-      padding: 19px 15px 19px 0px;
+      padding: 19px 15px 19px 0;
       margin-top: -5px;
       font-size: 20px;
+      width: ~"calc(100% - 400px)";
       a {
         color: #313D54;
         cursor: pointer;
@@ -36,6 +37,11 @@
       a.disabled {
         cursor: default;
         color: #999;
+      }
+      .icon {
+        font-size: @default-font-size;
+        margin: 0 4px;
+        vertical-align: baseline;
       }
     }
 

--- a/ambari-web/app/templates/main/host/details.hbs
+++ b/ambari-web/app/templates/main/host/details.hbs
@@ -18,18 +18,7 @@
 
 {{#if view.isLoaded}}
   <div id="host-details">
-    <div class="host-details-header">
-      <div class="status-info mbm">
-        <h2 class='table-title display-inline'>
-          <a class="disabled">{{t common.host}}</a><span>:&nbsp;{{unbound view.content.hostName}}</span>
-        </h2>
-        <span rel="HealthTooltip" {{bindAttr class="view.content.healthClass view.content.healthIconClass"}} data-placement="bottom" {{bindAttr data-original-title="view.content.healthToolTip" }}></span>
-        {{#unless view.isActive}}
-          <span class="host-maintenance-notice pull-right"><span class="icon-medkit"></span> {{t hosts.host.passive.mode}}</span>
-        {{/unless}}
-      </div>
-    </div>
-    <div class="content">
+       <div class="content">
       {{view App.MainHostMenuView hostBinding="view.content"}}
         <div class="service-button">
           <div class="btn-group display-inline-block">

--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -938,15 +938,18 @@ App.config = Em.Object.create({
    */
   textareaIntoFileConfigs: function (configs, filename) {
     var configsTextarea = configs.findProperty('name', 'capacity-scheduler');
+    var stackConfigs = App.configsCollection.getAll();
     if (configsTextarea && !App.get('testMode')) {
       var properties = configsTextarea.get('value').split('\n');
 
       properties.forEach(function (_property) {
-        var name, value;
+        var name, value, isUserProperty;
         if (_property) {
           _property = _property.split(/=(.+)/);
           name = _property[0];
           value = (_property[1]) ? _property[1] : "";
+          isUserProperty = !stackConfigs.filterProperty('filename', 'capacity-scheduler.xml').findProperty('name', name);
+
           configs.push(Em.Object.create({
             name: name,
             value: value,
@@ -956,6 +959,7 @@ App.config = Em.Object.create({
             isFinal: configsTextarea.get('isFinal'),
             isNotDefaultValue: configsTextarea.get('isNotDefaultValue'),
             isRequiredByAgent: configsTextarea.get('isRequiredByAgent'),
+            isUserProperty: isUserProperty,
             group: null
           }));
         }

--- a/ambari-web/app/views/main/host/details.js
+++ b/ambari-web/app/views/main/host/details.js
@@ -38,10 +38,8 @@ App.MainHostDetailsView = Em.View.extend({
 
   hasManyClientsWithConfigs: Em.computed.gt('clientsWithConfigs.length', 1),
 
-  isActive: Em.computed.equal('controller.content.passiveState', 'OFF'),
-
   maintenance: function () {
-    var onOff = this.get('isActive') ? "On" : "Off";
+    var onOff = this.get('controller.content.isActive') ? "On" : "Off";
     var result = [];
     if (App.isAuthorized("SERVICE.START_STOP")) {
       result = result.concat([

--- a/ambari-web/test/utils/config_test.js
+++ b/ambari-web/test/utils/config_test.js
@@ -574,6 +574,18 @@ describe('App.config', function() {
   describe('#textareaIntoFileConfigs', function () {
     var res, cs;
     beforeEach(function () {
+      var stackConfigs = [
+        Em.Object.create({
+          name: 'n1',
+          value: 'v1',
+          savedValue: 'v1',
+          serviceName: 'YARN',
+          filename: 'capacity-scheduler.xml',
+          isFinal: true,
+          group: null
+        })
+      ];
+      sinon.stub(App.configsCollection, 'getAll').returns(stackConfigs);
       res = [
         Em.Object.create({
           name: 'n1',
@@ -582,6 +594,7 @@ describe('App.config', function() {
           serviceName: 'YARN',
           filename: 'capacity-scheduler.xml',
           isFinal: true,
+          isUserProperty: false,
           group: null
         }),
         Em.Object.create({
@@ -591,6 +604,7 @@ describe('App.config', function() {
           serviceName: 'YARN',
           filename: 'capacity-scheduler.xml',
           isFinal: true,
+          isUserProperty: true,
           group: null
         })
       ];
@@ -609,6 +623,10 @@ describe('App.config', function() {
         'description': 'Capacity Scheduler properties',
         'displayType': 'capacityScheduler'
       });
+    });
+
+    afterEach(function () {
+      App.configsCollection.getAll.restore();
     });
 
     it('generate capacity scheduler', function () {

--- a/ambari-web/test/views/main/host/details_test.js
+++ b/ambari-web/test/views/main/host/details_test.js
@@ -72,25 +72,13 @@ describe('App.MainHostDetailsView', function () {
     });
   });
 
-  describe('#isActive', function () {
-    activeCases.forEach(function (item) {
-      it('should be ' + item.isActive, function () {
-        view.set('controller', {
-          content: {
-            passiveState: item.passiveState
-          }
-        });
-        expect(view.get('isActive')).to.equal(item.isActive);
-      });
-    });
-  });
-
   describe('#maintenance', function () {
     activeCases.forEach(function (item) {
       it('passive state label should contain ' + item.label, function () {
         view.set('controller', {
           content: {
-            passiveState: item.passiveState
+            passiveState: item.passiveState,
+            isActive: item.isActive
           }
         });
         expect(view.get('maintenance').findProperty('action', 'onOffPassiveModeForHost').label).to.contain(item.label);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Certain configuration changes should be avoided when regenerating keytab files during different scenarios.  

For example, existing non-Kerberos configurations should not be changed during the regenerate keytabs operation performed during an upgrade. However it is necessary for Kerberos identity-related configurations (such as keytab file paths and principal names) to be added and updated; as well as allow for new Kerberos-related configurations to be added. 

To allow for this, a new _update configuration policy_ value has been added to the set of directives (**_config_update_policy_**) allowed when issuing a call to regenerate keytab files. This directive replaces the less flexible **_ignore_config_updates_** directive which only allows a user to enable or disable the ability for the operation to change configurations. The values allowed for **_config_update_policy_** are as follows:
* `none` - No configurations will be updated
* `identities_only` - New and updated configurations related to Kerberos identity information - principal, keytab file, and auth-to-local rule properties
* `new_and_identities` - Only new configurations declared by the Kerberos descriptor and stack advisor as well as the identity-related changes
* `all` - All configuration changes

During an upgrade, the _update configuration policy_ is set to `new_and_identities`.

## How was this patch tested?

Manually testing in several upgrade and non-upgrade scenarios.

Updated unit tests, all tests passed. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.