### PR TITLE
[AMBARI-24250] Create Checkpoint page stuck while Enabling HA on Namenode

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
@@ -133,17 +133,23 @@ public class KerberosKeytabController {
       Set<String> serviceSet = new HashSet<>();
       Set<String> componentSet = new HashSet<>();
       Set<String> serviceOnlySet = new HashSet<>();
-      serviceSet.addAll(serviceComponentFilter.keySet());
-      for (String serviceName : serviceSet) {
-        Collection<String> serviceComponents = serviceComponentFilter.get(serviceName);
-        if (serviceComponents.contains("*")) { // star means that this is filtered by whole SERVICE
+
+      // Split the filter into a service/component filter or a service-only filter.
+      for(Map.Entry<String, Collection<String>> entry: serviceComponentFilter.entrySet()) {
+        String serviceName = entry.getKey();
+        Collection<String> serviceComponents = entry.getValue();
+
+        if((serviceComponents == null) || serviceComponents.contains("*")) {
           serviceOnlySet.add(serviceName);
-          serviceSet.remove(serviceName); // remove service from regular
-        } else {
+        }
+        else {
+          serviceSet.add(serviceName);
           componentSet.addAll(serviceComponents);
         }
       }
+
       List<KerberosKeytabPrincipalDAO.KerberosKeytabPrincipalFilter> result = new ArrayList<>();
+      // Handle the service/component filter
       if (serviceSet.size() > 0) {
         result.add(new KerberosKeytabPrincipalDAO.KerberosKeytabPrincipalFilter(
           null,
@@ -152,6 +158,7 @@ public class KerberosKeytabController {
           null
         ));
       }
+      // Handler the service/* filter
       if (serviceOnlySet.size() > 0) {
         result.add(new KerberosKeytabPrincipalDAO.KerberosKeytabPrincipalFilter(
           null,

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
@@ -1412,6 +1412,12 @@ public class TestHeartbeatHandler {
     List<Map<String, String>> kcp;
     Map<String, String> properties;
 
+    Cluster cluster = heartbeatTestHelper.getDummyCluster();
+    Service hdfs = addService(cluster, HDFS);
+    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+
     kcp = testInjectKeytabSetKeytab("c6403.ambari.apache.org");
     Assert.assertNotNull(kcp);
     Assert.assertEquals(1, kcp.size());
@@ -1448,6 +1454,12 @@ public class TestHeartbeatHandler {
 
   @Test
   public void testInjectKeytabNotApplicableHost() throws Exception {
+    Cluster cluster = heartbeatTestHelper.getDummyCluster();
+    Service hdfs = addService(cluster, HDFS);
+    hdfs.addServiceComponent(DATANODE);
+    hdfs.addServiceComponent(NAMENODE);
+    hdfs.addServiceComponent(SECONDARY_NAMENODE);
+
     List<Map<String, String>> kcp;
     kcp = testInjectKeytabSetKeytab("c6401.ambari.apache.org");
     Assert.assertNotNull(kcp);
@@ -1469,6 +1481,7 @@ public class TestHeartbeatHandler {
     Map<String, String> commandparams = new HashMap<>();
     commandparams.put(KerberosServerAction.AUTHENTICATED_USER_NAME, "admin");
     executionCommand.setCommandParams(commandparams);
+    executionCommand.setClusterName(DummyCluster);
 
     final HostRoleCommand command = hostRoleCommandFactory.create(DummyHostname1,
         Role.DATANODE, null, null);
@@ -1501,6 +1514,7 @@ public class TestHeartbeatHandler {
     Map<String, String> commandparams = new HashMap<>();
     commandparams.put(KerberosServerAction.AUTHENTICATED_USER_NAME, "admin");
     executionCommand.setCommandParams(commandparams);
+    executionCommand.setClusterName(DummyCluster);
 
     final HostRoleCommand command = hostRoleCommandFactory.create(DummyHostname1,
         Role.DATANODE, null, null);
@@ -1524,7 +1538,9 @@ public class TestHeartbeatHandler {
 
   private File createTestKeytabData(AgentCommandsPublisher agentCommandsPublisher) throws Exception {
     KerberosKeytabController kerberosKeytabControllerMock = createMock(KerberosKeytabController.class);
-    expect(kerberosKeytabControllerMock.getFilteredKeytabs(null,null,null)).andReturn(
+    Map<String, Collection<String>> filter = new HashMap<>();
+    filter.put("HDFS", Collections.singletonList("*"));
+    expect(kerberosKeytabControllerMock.getFilteredKeytabs(filter,null,null)).andReturn(
       Sets.newHashSet(
         new ResolvedKerberosKeytab(
           "/etc/security/keytabs/dn.service.keytab",


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Ambari sever's Kerberos keytab file's ACL was being set so that only the Ambari agent (or root) could read it. If Ambari server was running as non-root it failed to read the keytab file and therefore has no Kerberos identity token to supply to a JMX interface that requires Kerberos authentication.  This resulted in the inability for Ambari to detect details about the Namenode, causing the UI to appear to be suck while in the Enable HA wizard. 

The reason the Ambari server's keytab file was being set for only access by the Ambari agent is because details about the keytab file were sent via the SET_KEYTAB operation.  This should not happen and was happening due to an invalid filter used to get the list of keytab entries to process.   The filter needed to include on Ambari installed services; but not Ambari itself. 

After fixing the filter, the Ambari agent no longer changed the ACL on the Ambari sever's keytab file, leaving the ACL set by the Ambari server. 
 
## How was this patch tested?

Manually tested.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.