### PR TITLE
[AMBARI-22994] Completely Remove Upgrade Pack Target Information

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/UpgradePack.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.xml.bind.Unmarshaller;
@@ -66,12 +65,6 @@ public class UpgradePack {
    * Name of the file without the extension, such as upgrade-2.2
    */
   private String name;
-
-  @XmlElement(name="target")
-  private String target;
-
-  @XmlElement(name="target-stack")
-  private String targetStack;
 
   @XmlElement(name="lifecycle")
   public List<Lifecycle> lifecycles;
@@ -126,12 +119,6 @@ public class UpgradePack {
   public void setName(String name) {
     this.name = name;
   }
-  /**
-   * @return the target version for the upgrade pack
-   */
-  public String getTarget() {
-    return target;
-  }
 
   /**
    * @return the type of upgrade, e.g., "ROLLING" or "NON_ROLLING"
@@ -172,13 +159,6 @@ public class UpgradePack {
 
     // new processing has been created, so rebuild the mappings
     initializeProcessingComponentMappings();
-  }
-
-  /**
-   * @return the target stack, or {@code null} if the upgrade is within the same stack
-   */
-  public String getTargetStack() {
-    return targetStack;
   }
 
   /**
@@ -243,15 +223,6 @@ public class UpgradePack {
    */
   public boolean isDowngradeAllowed(){
     return downgradeAllowed;
-  }
-
-  public boolean canBeApplied(String targetVersion){
-    // check that upgrade pack can be applied to selected stack
-    // converting 2.2.*.* -> 2\.2(\.\d+)?(\.\d+)?(-\d+)?
-    String regexPattern = getTarget().replaceAll("\\.", "\\\\."); // . -> \.
-    regexPattern = regexPattern.replaceAll("\\\\\\.\\*", "(\\\\\\.\\\\d+)?"); // \.* -> (\.\d+)?
-    regexPattern = regexPattern.concat("(-\\d+)?");
-    return Pattern.matches(regexPattern, targetVersion);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/RepositoryVersionHelper.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.state.stack.upgrade;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.ambari.annotations.Experimental;
@@ -42,9 +41,6 @@ import org.apache.ambari.server.state.Mpack;
 import org.apache.ambari.server.state.RepositoryInfo;
 import org.apache.ambari.server.state.ServiceComponent;
 import org.apache.ambari.server.state.ServiceGroup;
-import org.apache.ambari.server.state.stack.OsFamily;
-import org.apache.ambari.server.state.stack.UpgradePack;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,13 +64,7 @@ public class RepositoryVersionHelper {
   private Gson gson;
 
   @Inject
-  private Provider<AmbariMetaInfo> ami;
-
-  @Inject
   private Provider<Configuration> configuration;
-
-  @Inject
-  private Provider<OsFamily> os_family;
 
   @Inject Provider<Clusters> clusters;
 
@@ -110,38 +100,6 @@ public class RepositoryVersionHelper {
       repoOsEntities.add(operatingSystemEntity);
     }
     return repoOsEntities;
-  }
-
-  /**
-   * Scans the given stack for upgrade packages which can be applied to update the cluster to given repository version.
-   *
-   * @param stackName stack name
-   * @param stackVersion stack version
-   * @param repositoryVersion target repository version
-   * @param upgradeType if not {@code null} null, will only return upgrade packs whose type matches.
-   * @return upgrade pack name
-   * @throws AmbariException if no upgrade packs suit the requirements
-   */
-  public String getUpgradePackageName(String stackName, String stackVersion, String repositoryVersion, UpgradeType upgradeType) throws AmbariException {
-    final Map<String, UpgradePack> upgradePacks = ami.get().getUpgradePacks(stackName, stackVersion);
-    for (UpgradePack upgradePack : upgradePacks.values()) {
-      final String upgradePackName = upgradePack.getName();
-
-      if (null != upgradeType && upgradePack.getType() != upgradeType) {
-        continue;
-      }
-
-      // check that upgrade pack has <target> node
-      if (StringUtils.isBlank(upgradePack.getTarget())) {
-        LOG.error("Upgrade pack " + upgradePackName + " is corrupted, it should contain <target> node");
-        continue;
-      }
-      if (upgradePack.canBeApplied(repositoryVersion)) {
-        return upgradePackName;
-      }
-    }
-    throw new AmbariException("There were no suitable upgrade packs for stack " + stackName + " " + stackVersion +
-        ((null != upgradeType) ? " and upgrade type " + upgradeType : ""));
   }
 
   /**

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -404,8 +404,6 @@
     
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="target" type="xs:string" />
-        <xs:element name="target-stack" type="xs:string" />
         <xs:element name="downgrade-allowed" minOccurs="0" type="xs:boolean" />
         <xs:element name="type" type="upgrade-kind-type" />
         <xs:element name="prerequisite-checks" type="prerequisite-check-type" minOccurs="0" />

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
@@ -35,7 +35,6 @@ import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.UpgradeCheckResult;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.upgrade.RepositoryVersionHelper;
-import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -114,7 +113,6 @@ public class HostsMasterMaintenanceCheckTest {
     Mockito.when(cluster.getClusterId()).thenReturn(1L);
     Mockito.when(clusters.getCluster("cluster")).thenReturn(cluster);
     Mockito.when(cluster.getDesiredStackVersion()).thenReturn(new StackId("HDP", "1.0"));
-    Mockito.when(repositoryVersionHelper.getUpgradePackageName(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), (UpgradeType) Mockito.anyObject())).thenReturn(null);
 
     UpgradePlanEntity upgradePlan = Mockito.mock(UpgradePlanEntity.class);
     PrereqCheckRequest checkRequest = new PrereqCheckRequest(upgradePlan);
@@ -122,7 +120,6 @@ public class HostsMasterMaintenanceCheckTest {
     UpgradeCheckResult result = hostsMasterMaintenanceCheck.perform(checkRequest);
     Assert.assertEquals(PrereqCheckStatus.FAIL, result.getStatus());
 
-    Mockito.when(repositoryVersionHelper.getUpgradePackageName(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), (UpgradeType) Mockito.anyObject())).thenReturn(upgradePackName);
     Mockito.when(ambariMetaInfo.getUpgradePacks(Mockito.anyString(), Mockito.anyString())).thenReturn(new HashMap<>());
 
     checkRequest = new PrereqCheckRequest(upgradePlan);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -63,7 +63,6 @@ import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.PrereqCheckType;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.UpgradePack.PrerequisiteCheckConfig;
-import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -122,14 +121,11 @@ public class PreUpgradeCheckResourceProviderTest {
     expect(targetStackId.getStackName()).andReturn("Stack100").anyTimes();
     expect(targetStackId.getStackVersion()).andReturn("1.1").anyTimes();
 
-    expect(upgradeHelper.suggestUpgradePack("Cluster100", currentStackId, targetStackId, Direction.UPGRADE, UpgradeType.EXPRESS, "upgrade_pack11")).andReturn(upgradePack);
-
     List<ClusterCheck> upgradeChecksToRun = new LinkedList<>();
     List<String> prerequisiteChecks = new LinkedList<>();
     prerequisiteChecks.add("org.apache.ambari.server.sample.checks.SampleServiceCheck");
     expect(upgradePack.getPrerequisiteCheckConfig()).andReturn(config);
     expect(upgradePack.getPrerequisiteChecks()).andReturn(prerequisiteChecks).anyTimes();
-    expect(upgradePack.getTarget()).andReturn("1.1.*.*").anyTimes();
 
     expect(ambariMetaInfo.getServices("Stack100", "1.0")).andReturn(allServiceInfoMap).anyTimes();
     String checks = ClassLoader.getSystemClassLoader().getResource("checks").getPath();

--- a/ambari-server/src/test/resources/mpacks-v2/upgrade-packs/upgrade-basic.xml
+++ b/ambari-server/src/test/resources/mpacks-v2/upgrade-packs/upgrade-basic.xml
@@ -17,8 +17,6 @@
 -->
 
 <upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
-  <target>2.6.*.*</target>
-  <target-stack>HDP-2.6</target-stack>
   <type>rolling</type>
   
   <prerequisite-checks>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The target for an upgrade pack is deprecated

## How was this patch tested?

Unit tests:  no new tests are failed:
```
[ERROR] Tests run: 4814, Failures: 10, Errors: 57, Skipped: 97
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 28:11 min
[INFO] Finished at: 2018-07-05T12:14:46-04:00
[INFO] Final Memory: 105M/1804M
[INFO] ------------------------------------------------------------------------
```