### PR TITLE
Fix to ensure appropriate case for Topic

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/service_check.py
@@ -61,7 +61,7 @@ class ServiceCheck(Script):
     if under_rep_cmd_code > 0:
       raise Fail("Error encountered when attempting find under replicated partitions: {0}".format(under_rep_cmd_out))
     elif len(under_rep_cmd_out) > 0 and "Topic" in under_rep_cmd_out:
-      raise Fail("Under replicated partitions found: {0}".format(under_rep_cmd_out))
+      Logger.warning("Under replicated partitions found: {0}".format(under_rep_cmd_out))
 
   def read_kafka_config(self):
     import params


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of throwing error, it raises warning for under replicated partitions after running service check for kafka.

## How was this patch tested?

It was tested manually with creating under replicated partition and running service_check. It will raise error as below which will now be shown as warning while running service_check for kafka.

```
\".format(under_rep_cmd_out))\nresource_management.core.exceptions.Fail: Under replicated partitions found: \tTopic: __consumer_offsets\tPartition: 0\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 3\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 6\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 9\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 12\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 15\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 18\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 21\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 24\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 27\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 30\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 33\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 36\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 39\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 42\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 45\tLeader: 1003\tReplicas: 1003,1001,1002\tIsr: 1003\n\tTopic: __consumer_offsets\tPartition: 48\tLeader: 1003\tReplicas: 1003,1002,1001\tIsr: 1003", 
"request_id": 28, 
"attempt_cnt": 1, 
"role": "KAFKA_SERVICE_CHECK", 
"ops_display_name": null, 
"id": 238, 
```
