### PR TITLE
AMBARI-24259. Let custom TrustStore settings saved in ambari.properties when configuring LDAP just like we did it in 2.6

### DIFF
--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -687,10 +687,6 @@ def update_ldap_configuration(options, properties, ldap_property_value_map):
   request_data['Configuration']['properties'] = ldap_property_value_map
   perform_changes_via_rest_api(properties, admin_login, admin_password, SETUP_LDAP_CONFIG_URL, 'PUT', request_data)
 
-LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY = "ambari.ldap.connectivity.trust_store.type"
-LDAP_SSL_TRUSTSTORE_PATH_PROPERTY = "ambari.ldap.connectivity.trust_store.path"
-LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY = "ambari.ldap.connectivity.trust_store.password"
-
 def setup_ldap(options):
   logger.info("Setup LDAP.")
 
@@ -727,18 +723,19 @@ def setup_ldap(options):
 
   ldap_property_list_opt = [LDAP_MGR_USERNAME_PROPERTY,
                             LDAP_MGR_PASSWORD_PROPERTY,
-                            LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY,
-                            LDAP_SSL_TRUSTSTORE_PATH_PROPERTY,
-                            LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY]
+                            SSL_TRUSTSTORE_TYPE_PROPERTY,
+                            SSL_TRUSTSTORE_PATH_PROPERTY,
+                            SSL_TRUSTSTORE_PASSWORD_PROPERTY]
 
-  ldap_property_list_passwords=[LDAP_MGR_PASSWORD_PROPERTY, LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY]
+  ldap_property_list_passwords=[LDAP_MGR_PASSWORD_PROPERTY, SSL_TRUSTSTORE_PASSWORD_PROPERTY]
 
   LDAP_MGR_DN_DEFAULT = None
 
-  SSL_TRUSTSTORE_TYPE_DEFAULT = get_value_from_properties(properties, LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY, "jks")
-  SSL_TRUSTSTORE_PATH_DEFAULT = get_value_from_properties(properties, LDAP_SSL_TRUSTSTORE_PATH_PROPERTY)
+  SSL_TRUSTSTORE_TYPE_DEFAULT = get_value_from_properties(properties, SSL_TRUSTSTORE_TYPE_PROPERTY, "jks")
+  SSL_TRUSTSTORE_PATH_DEFAULT = get_value_from_properties(properties, SSL_TRUSTSTORE_PATH_PROPERTY)
 
   ldap_property_value_map = {}
+  ldap_property_values_in_ambari_properties = {}
   for ldap_prop in ldap_property_list_reqd:
     input = get_validated_string_input(ldap_prop.ldap_prop_val_prompt, ldap_prop.ldap_prop_name, ldap_prop.prompt_regex,
                                        "Invalid characters in the input!", False, ldap_prop.allow_empty_prompt,
@@ -788,19 +785,19 @@ def setup_ldap(options):
 
       ts_password = read_password("", ".*", "Password for TrustStore:", "Invalid characters in password", options.trust_store_password)
 
-      ldap_property_value_map[LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY] = ts_type
-      ldap_property_value_map[LDAP_SSL_TRUSTSTORE_PATH_PROPERTY] = ts_path
-      ldap_property_value_map[LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY] = ts_password
+      ldap_property_values_in_ambari_properties[SSL_TRUSTSTORE_TYPE_PROPERTY] = ts_type
+      ldap_property_values_in_ambari_properties[SSL_TRUSTSTORE_PATH_PROPERTY] = ts_path
+      ldap_property_values_in_ambari_properties[SSL_TRUSTSTORE_PASSWORD_PROPERTY] = ts_password
       pass
-    elif properties.get_property(LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY):
+    elif properties.get_property(SSL_TRUSTSTORE_TYPE_PROPERTY):
       print 'The TrustStore is already configured: '
-      print '  ' + LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY + ' = ' + properties.get_property(LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY)
-      print '  ' + LDAP_SSL_TRUSTSTORE_PATH_PROPERTY + ' = ' + properties.get_property(LDAP_SSL_TRUSTSTORE_PATH_PROPERTY)
-      print '  ' + LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY + ' = ' + properties.get_property(LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY)
+      print '  ' + SSL_TRUSTSTORE_TYPE_PROPERTY + ' = ' + properties.get_property(SSL_TRUSTSTORE_TYPE_PROPERTY)
+      print '  ' + SSL_TRUSTSTORE_PATH_PROPERTY + ' = ' + properties.get_property(SSL_TRUSTSTORE_PATH_PROPERTY)
+      print '  ' + SSL_TRUSTSTORE_PASSWORD_PROPERTY + ' = ' + properties.get_property(SSL_TRUSTSTORE_PASSWORD_PROPERTY)
       if get_YN_input("Do you want to remove these properties [y/n] (y)? ", True, options.trust_store_reconfigure):
-        properties.removeOldProp(LDAP_SSL_TRUSTSTORE_TYPE_PROPERTY)
-        properties.removeOldProp(LDAP_SSL_TRUSTSTORE_PATH_PROPERTY)
-        properties.removeOldProp(LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY)
+        properties.removeOldProp(SSL_TRUSTSTORE_TYPE_PROPERTY)
+        properties.removeOldProp(SSL_TRUSTSTORE_PATH_PROPERTY)
+        properties.removeOldProp(SSL_TRUSTSTORE_PASSWORD_PROPERTY)
     pass
   pass
 
@@ -818,6 +815,13 @@ def setup_ldap(options):
       else:
         print("%s: %s" % (property, BLIND_PASSWORD))
 
+  for property in ldap_property_list_opt:
+    if ldap_property_values_in_ambari_properties.has_key(property):
+      if property not in ldap_property_list_passwords:
+        print("%s: %s" % (property, ldap_property_values_in_ambari_properties[property]))
+      else:
+        print("%s: %s" % (property, BLIND_PASSWORD))
+
   save_settings = True if options.ldap_save_settings is not None else get_YN_input("Save settings [y/n] (y)? ", True)
 
   if save_settings:
@@ -830,7 +834,7 @@ def setup_ldap(options):
       if ts_password:
         encrypted_passwd = encrypt_password(SSL_TRUSTSTORE_PASSWORD_ALIAS, ts_password, options)
         if ts_password != encrypted_passwd:
-          ldap_property_value_map[LDAP_SSL_TRUSTSTORE_PASSWORD_PROPERTY] = encrypted_passwd
+          ldap_property_values_in_ambari_properties[SSL_TRUSTSTORE_PASSWORD_PROPERTY] = encrypted_passwd
       pass
     pass
 
@@ -844,10 +848,9 @@ def setup_ldap(options):
     #Saving LDAP configuration in Ambari DB using the REST API
     update_ldap_configuration(options, properties, ldap_property_value_map)
 
-    #The only property we want to write out in Ambari.properties is the client.security type being LDAP
-    ldap_property_value_map.clear()
-    ldap_property_value_map[CLIENT_SECURITY] = 'ldap'
-    update_properties_2(properties, ldap_property_value_map)
+    #The only properties we want to write out in Ambari.properties are the client.security type being LDAP and the custom Truststore related properties (if any)
+    ldap_property_values_in_ambari_properties[CLIENT_SECURITY] = 'ldap'
+    update_properties_2(properties, ldap_property_values_in_ambari_properties)
 
     print 'Saving LDAP properties finished'
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to our changes in 2.7 we kept the reference of two different trust stores within Ambari:
the trust store created just after HTTPS was enabled
the optional custom trust store that the user could setup while configuring LDAP

In Ambari 2.6 we used the same properties in `ambari.properties` when setting any of the above; the related properties became overwritten. Whereas in 2.7 we saved the LDAP data in the DB which led to different security issues (such as Ambari's TS could not be open because of password mismatch, errors while syncing LDAP users/groups, etc...)
To avoid this issue we decided to follow the same pattern we had before and save LDAP TS related properties in `ambari.properties` in 2.7 too. Therefore the functionality does not change and end users can configure their environment as usual.

## How was this patch tested?

Manually testing ldap-configuration and ldap-sync:

Setup custom LDAP TS, restarted the server and synced test users/groups:
```
root@ctr-e138-1518143905142-391100-01-000006 ~]# ambari-server setup-ldap --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
...
====================
Review Settings
====================
Primary URL Host* :  XXX
Primary URL Port* :  636
Use SSL* [true/false] (false):  true
User object class* (person):  user
User name attribute* (uid):  XXX
Group object class* (posixGroup):  group
Group name attribute* (cn):  cn
Group member attribute* (memberUid):  member
Distinguished name attribute* (dn):  distinguishedName
Base DN* (dc=ambari,dc=apache,dc=org):  XXX
Referral method [follow/ignore] :  follow
Bind anonymously* [true/false] (false):  false
Handling behavior for username collisions [convert/skip] for LDAP sync* (convert):  convert
Force lower-case user names [true/false] : false
Results from LDAP are paginated when requested [true/false] : false
ambari.ldap.connectivity.bind_dn: XXX
ambari.ldap.connectivity.bind_password: *****
ssl.trustStore.type: jks
ssl.trustStore.path: /tmp/ambari-server-truststore
ssl.trustStore.password: *****
Save settings [y/n] (y)? y
Saving LDAP properties...
Saving LDAP properties finished
Ambari Server 'setup-ldap' completed successfully.

[root@ctr-e138-1518143905142-391100-01-000006 ~]# grep ssl.trustStore /etc/ambari-server/conf/ambari.properties 
ssl.trustStore.password=${alias=ambari.ssl.trustStore.password}
ssl.trustStore.path=/tmp/ambari-server-truststore
ssl.trustStore.type=jks

[root@ctr-e138-1518143905142-391100-01-000006 ~]# ambari-server restart
...
Server started listening on 8443

DB configs consistency check: no errors and warnings were found.

[root@ctr-e138-1518143905142-391100-01-000006 ~]# ambari-server sync-ldap --user /tmp/users.txt --groups /tmp/groups.txt --ldap-sync-admin-name admin --ldap-sync-admin-password admin
Using python  /usr/bin/python
Syncing with LDAP...

Fetching LDAP configuration from DB.
Syncing specified users and groups....

Completed LDAP Sync.
Summary:
  memberships:
    removed = 0
    created = 3
  users:
    skipped = 0
    removed = 0
    updated = 0
    created = 20
  groups:
    updated = 0
    removed = 0
    created = 2

Ambari Server 'sync-ldap' completed successfully.
```

Removed custom LDAP TS:
```
[root@ctr-e138-1518143905142-391100-01-000006 ~]# ambari-server setup-ldap --ambari-admin-username=admin --ambari-admin-password=admin
Using python  /usr/bin/python
...
Do you want to provide custom TrustStore for Ambari [y/n] (y)?n
The TrustStore is already configured: 
  ssl.trustStore.type = jks
  ssl.trustStore.path = /tmp/ambari-server-truststore
  ssl.trustStore.password = ${alias=ambari.ssl.trustStore.password}
Do you want to remove these properties [y/n] (y)? y
====================
Review Settings
====================
...
Save settings [y/n] (y)? y
Saving LDAP properties...
Saving LDAP properties finished
Ambari Server 'setup-ldap' completed successfully.

[root@ctr-e138-1518143905142-391100-01-000006 ~]# grep ssl.trustStore /etc/ambari-server/conf/ambari.properties 
[root@ctr-e138-1518143905142-391100-01-000006 ~]#
```