### PR TITLE
AMBARI-24261. logfeeder fail to start due to missing conf file post l…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/logfeeder/postinst
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/logfeeder/postinst
@@ -22,16 +22,3 @@ LOGFEEDER_CONF_SOURCE="/usr/lib/ambari-logsearch-logfeeder/conf"
 
 ln -s $LOGFEEDER_SCRIPT_SOURCE $LOGFEEDER_SCRIPT_LINK_NAME
 #ln -s $LOGFEEDER_CONF_SOURCE $LOGFEEDER_CONF_LINK
-
-# handle old checkpoint & keys folder
-
-LOGFEEDER_CONF_BACKUP="/usr/lib/ambari-logsearch-logfeeder/conf-old"
-
-if [ -d "$LOGFEEDER_CONF_BACKUP" ]; then
-  if [ -d "$LOGFEEDER_CONF_BACKUP/keys" ]; then
-    cp -r $LOGFEEDER_CONF_BACKUP/keys $LOGFEEDER_CONF_SOURCE
-  fi
-  if [ -d "$LOGFEEDER_CONF_BACKUP/checkpoints" ]; then
-    cp -r $LOGFEEDER_CONF_BACKUP/checkpoints $LOGFEEDER_CONF_SOURCE
-  fi
-fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/logfeeder/preinst
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/logfeeder/preinst
@@ -24,5 +24,4 @@ fi
 if [ -d $LOGFEEDER_CONF ]; then
   mkdir -p $LOGFEEDER_CONF_BACKUP
   cp -r $LOGFEEDER_CONF/* $LOGFEEDER_CONF_BACKUP
-  rm -rf $LOGFEEDER_CONF
 fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/portal/postinst
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/portal/postinst
@@ -22,13 +22,3 @@ LOGSEARCH_CONF_SOURCE="/usr/lib/ambari-logsearch-portal/conf"
 
 ln -s $LOGSEARCH_SCRIPT_SOURCE $LOGSEARCH_SCRIPT_LINK_NAME
 #ln -s $LOGSEARCH_CONF_SOURCE $LOGSEARCH_CONF_LINK
-
-# handle old keys folder
-
-LOGSEARCH_CONF_BACKUP="/usr/lib/ambari-logsearch-portal/conf-old"
-
-if [ -d "$LOGSEARCH_CONF_BACKUP" ]; then
-  if [ -d "$LOGSEARCH_CONF_BACKUP/keys" ]; then
-    cp -r $LOGSEARCH_CONF_BACKUP/keys $LOGSEARCH_CONF_SOURCE
-  fi
-fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/portal/preinst
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/deb/portal/preinst
@@ -24,5 +24,4 @@ fi
 if [ -d $LOGSEARCH_CONF ]; then
   mkdir -p $LOGSEARCH_CONF_BACKUP
   cp -r $LOGSEARCH_CONF/* $LOGSEARCH_CONF_BACKUP
-  rm -rf $LOGSEARCH_CONF
 fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/postinstall.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/postinstall.sh
@@ -25,16 +25,3 @@ mkdir -p $LOGFEEDER_ETC_FOLDER
 
 ln -s $LOGFEEDER_SCRIPT_SOURCE $LOGFEEDER_SCRIPT_LINK_NAME
 #ln -s $LOGFEEDER_CONF_SOURCE $LOGFEEDER_CONF_LINK
-
-# handle old checkpoint & keys folder
-
-LOGFEEDER_CONF_BACKUP="/usr/lib/ambari-logsearch-logfeeder/conf-old"
-
-if [ -d "$LOGFEEDER_CONF_BACKUP" ]; then
-  if [ -d "$LOGFEEDER_CONF_BACKUP/keys" ]; then
-    cp -r $LOGFEEDER_CONF_BACKUP/keys $LOGFEEDER_CONF_SOURCE
-  fi
-  if [ -d "$LOGFEEDER_CONF_BACKUP/checkpoints" ]; then
-    cp -r $LOGFEEDER_CONF_BACKUP/checkpoints $LOGFEEDER_CONF_SOURCE
-  fi
-fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/preinstall.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/logfeeder/preinstall.sh
@@ -24,5 +24,4 @@ fi
 if [ -d $LOGFEEDER_CONF ]; then
   mkdir -p $LOGFEEDER_CONF_BACKUP
   cp -r $LOGFEEDER_CONF/* $LOGFEEDER_CONF_BACKUP
-  rm -rf $LOGFEEDER_CONF
 fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/postinstall.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/postinstall.sh
@@ -25,13 +25,3 @@ mkdir -p $LOGSEARCH_ETC_FOLDER
 
 ln -s $LOGSEARCH_SCRIPT_SOURCE $LOGSEARCH_SCRIPT_LINK_NAME
 #ln -s $LOGSEARCH_CONF_SOURCE $LOGSEARCH_CONF_LINK
-
-# handle old keys folder
-
-LOGSEARCH_CONF_BACKUP="/usr/lib/ambari-logsearch-portal/conf-old"
-
-if [ -d "$LOGSEARCH_CONF_BACKUP" ]; then
-  if [ -d "$LOGSEARCH_CONF_BACKUP/keys" ]; then
-    cp -r $LOGSEARCH_CONF_BACKUP/keys $LOGSEARCH_CONF_SOURCE
-  fi
-fi

--- a/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/preinstall.sh
+++ b/ambari-logsearch/ambari-logsearch-assembly/src/main/package/rpm/portal/preinstall.sh
@@ -24,5 +24,4 @@ fi
 if [ -d $LOGSEARCH_CONF ]; then
   mkdir -p $LOGSEARCH_CONF_BACKUP
   cp -r $LOGSEARCH_CONF/* $LOGSEARCH_CONF_BACKUP
-  rm -rf $LOGSEARCH_CONF
 fi


### PR DESCRIPTION
Upgraded above cluster from Ambari 2.6.2 to Ambari 2.7.0 and logsearch also from 2.6.2 to 2.7.0.0

In ambari 2.6.2 we had created file "kafka-output.json" under "/usr/lib/ambari-logsearch-logfeeder/conf" so that logsearch data is pushed to kafka topic.

Looks like Ambari upgrade renames the conf dir to "conf-old" as below and due to which kafka-output.json file in missing from the new config dir.