### PR TITLE
[AMBARI-24262] - Hive Client Restart Fails When Using A Credential Store

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
@@ -70,7 +70,7 @@ def hive(name=None):
 
   params.hive_site_config = update_credential_provider_path(params.hive_site_config,
                                                      'hive-site',
-                                                     os.path.join(params.hive_conf_dir, 'hive-site.jceks'),
+                                                     os.path.join(params.hive_config_dir, 'hive-site.jceks'),
                                                      params.hive_user,
                                                      params.user_group
                                                      )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive clients cannot restart when a credential store is enabled. This is because the credential store uses the wrong config directory variable.

```
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/hive_client.py", line 63, in 
    HiveClient().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 953, in restart
    self.install(env)
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/hive_client.py", line 35, in install
    self.configure(env)
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/hive_client.py", line 43, in configure
    hive(name='client')
  File "/usr/lib/ambari-agent/lib/ambari_commons/os_family_impl.py", line 89, in thunk
    return fn(*args, **kwargs)
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py", line 75, in hive
    params.user_group
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/security_commons.py", line 55, in update_credential_provider_path
    content = StaticFile(src_provider_path)
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/system.py", line 120, in action_create
    raise Fail("Applying %s failed, parent directory %s doesn't exist" % (self.resource, dirname))
resource_management.core.exceptions.Fail: Applying File['/usr/hdp/current/hive-client/conf/conf.server/hive-site.jceks'] failed, parent directory /usr/hdp/current/hive-client/conf/conf.server doesn't exist
```

## How was this patch tested?

Manually tested in an environment where the credential store is enabled.