### PR TITLE
[AMBARI-24262] - Hive Client Restart Fails When Using A Credential Store

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
@@ -70,7 +70,7 @@ def hive(name=None):
 
   params.hive_site_config = update_credential_provider_path(params.hive_site_config,
                                                      'hive-site',
-                                                     os.path.join(params.hive_conf_dir, 'hive-site.jceks'),
+                                                     os.path.join(params.hive_config_dir, 'hive-site.jceks'),
                                                      params.hive_user,
                                                      params.user_group
                                                      )


### PR DESCRIPTION
## What changes were proposed in this pull request?

`branch-2.7` cherry-pick of 

```
commit a9aafef9e0df6609e0c14c5c4b3f503c8386c929 (HEAD -> AMBARI-24262, origin/AMBARI-24262)
Author: Jonathan Hurley <jonathanhurley@apache.org>
Date:   Sat Jul 7 11:14:17 2018 -0400

    [AMBARI-24262] - Hive Client Restart Fails When Using A Credential Store (#1704)
```