### PR TITLE
AMBARI-24263. Restart services just before stack upgrade fails due to AMS package incompatibility errors, causing EU not to be started. (mpapirkovskyy)

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/constants.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/constants.py
@@ -123,3 +123,4 @@ class StackFeature:
   KAFKA_EXTENDED_SASL_SUPPORT = "kafka_extended_sasl_support"
   OOZIE_EXTJS_INCLUDED = "oozie_extjs_included"
   MULTIPLE_ENV_SH_FILES_SUPPORT = "multiple_env_sh_files_support"
+  AMS_LEGACY_HADOOP_SINK = "ams_legacy_hadoop_sink"

--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -389,7 +389,10 @@
                   <defaultFilemode>644</defaultFilemode>
                   <defaultUsername>root</defaultUsername>
                   <defaultGroupname>root</defaultGroupname>
-
+                  <preinstallScriptlet>
+                    <scriptFile>${project.build.directory}/resources/rpm/sink/preinstall.sh</scriptFile>
+                    <fileEncoding>utf-8</fileEncoding>
+                  </preinstallScriptlet>
                   <postinstallScriptlet>
                     <scriptFile>${project.build.directory}/resources/rpm/sink/postinstall.sh</scriptFile>
                     <fileEncoding>utf-8</fileEncoding>

--- a/ambari-metrics/ambari-metrics-assembly/src/main/package/deb/control/preinst
+++ b/ambari-metrics/ambari-metrics-assembly/src/main/package/deb/control/preinst
@@ -16,26 +16,29 @@
 
 JAR_FILES_LEGACY_FOLDER="/usr/lib/ambari-metrics-sink-legacy"
 
-HADOOP_SINK_JAR="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-with-common-*jar"
+HADOOP_SINK_LINK="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar"
 
 HADOOP_LEGACY_LINK_NAME="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar"
 
-# should iterate only once since normally there's only 1 ambari-metrics-hadoop-sink-with-common-*jar
-for f in $HADOOP_SINK_JAR;
-do
-    if [ -f "$f" ]
+if [ -f ${HADOOP_SINK_LINK} ]
+then
+    old_jar=$(readlink -f ${HADOOP_SINK_LINK})
+    version_part=$(basename ${old_jar} | awk -F"-" '{print $7}')
+    IFS=. version=(${version_part})
+
+    if [[ ${version[0]} -le 2 && ${version[1]} -lt 7 ]] # backup only required on upgrade from version < 2.7
     then
         if [ ! -d "$JAR_FILES_LEGACY_FOLDER" ]
         then
             mkdir -p "$JAR_FILES_LEGACY_FOLDER"
         fi
-        echo "Backing up Ambari metrics hadoop sink jar $f -> $JAR_FILES_LEGACY_FOLDER/"
-        cp $f $JAR_FILES_LEGACY_FOLDER/
+        echo "Backing up Ambari metrics hadoop sink jar ${old_jar} -> $JAR_FILES_LEGACY_FOLDER/"
+        cp ${old_jar} ${JAR_FILES_LEGACY_FOLDER}/
 
-        HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename $f)"
+        HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename ${old_jar})"
         echo "Creating symlink for backup jar $HADOOP_LEGACY_LINK_NAME -> $HADOOP_SINK_LEGACY_JAR"
         rm -f ${HADOOP_LEGACY_LINK_NAME} ; ln -s ${HADOOP_SINK_LEGACY_JAR} ${HADOOP_LEGACY_LINK_NAME}
     fi
-done
+fi
 
 exit 0

--- a/ambari-metrics/ambari-metrics-assembly/src/main/package/deb/control/preinst
+++ b/ambari-metrics/ambari-metrics-assembly/src/main/package/deb/control/preinst
@@ -25,6 +25,7 @@ then
     old_jar=$(readlink -f ${HADOOP_SINK_LINK})
     version_part=$(basename ${old_jar} | awk -F"-" '{print $7}')
     IFS=. version=(${version_part})
+    unset IFS
 
     if [[ ${version[0]} -le 2 && ${version[1]} -lt 7 ]] # backup only required on upgrade from version < 2.7
     then
@@ -33,11 +34,11 @@ then
             mkdir -p "$JAR_FILES_LEGACY_FOLDER"
         fi
         echo "Backing up Ambari metrics hadoop sink jar ${old_jar} -> $JAR_FILES_LEGACY_FOLDER/"
-        cp ${old_jar} ${JAR_FILES_LEGACY_FOLDER}/
+        cp "${old_jar}" "${JAR_FILES_LEGACY_FOLDER}/"
 
         HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename ${old_jar})"
         echo "Creating symlink for backup jar $HADOOP_LEGACY_LINK_NAME -> $HADOOP_SINK_LEGACY_JAR"
-        rm -f ${HADOOP_LEGACY_LINK_NAME} ; ln -s ${HADOOP_SINK_LEGACY_JAR} ${HADOOP_LEGACY_LINK_NAME}
+        rm -f "${HADOOP_LEGACY_LINK_NAME}" ; ln -s "${HADOOP_SINK_LEGACY_JAR}" "${HADOOP_LEGACY_LINK_NAME}"
     fi
 fi
 

--- a/ambari-metrics/ambari-metrics-assembly/src/main/package/deb/control/preinst
+++ b/ambari-metrics/ambari-metrics-assembly/src/main/package/deb/control/preinst
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+JAR_FILES_LEGACY_FOLDER="/usr/lib/ambari-metrics-sink-legacy"
+
+HADOOP_SINK_JAR="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-with-common-*jar"
+
+HADOOP_LEGACY_LINK_NAME="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar"
+
+# should iterate only once since normally there's only 1 ambari-metrics-hadoop-sink-with-common-*jar
+for f in $HADOOP_SINK_JAR;
+do
+    if [ -f "$f" ]
+    then
+        if [ ! -d "$JAR_FILES_LEGACY_FOLDER" ]
+        then
+            mkdir -p "$JAR_FILES_LEGACY_FOLDER"
+        fi
+        echo "Backing up Ambari metrics hadoop sink jar $f -> $JAR_FILES_LEGACY_FOLDER/"
+        cp $f $JAR_FILES_LEGACY_FOLDER/
+
+        HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename $f)"
+        echo "Creating symlink for backup jar $HADOOP_LEGACY_LINK_NAME -> $HADOOP_SINK_LEGACY_JAR"
+        rm -f ${HADOOP_LEGACY_LINK_NAME} ; ln -s ${HADOOP_SINK_LEGACY_JAR} ${HADOOP_LEGACY_LINK_NAME}
+    fi
+done
+
+exit 0

--- a/ambari-metrics/ambari-metrics-assembly/src/main/package/rpm/sink/preinstall.sh
+++ b/ambari-metrics/ambari-metrics-assembly/src/main/package/rpm/sink/preinstall.sh
@@ -16,26 +16,29 @@
 
 JAR_FILES_LEGACY_FOLDER="/usr/lib/ambari-metrics-sink-legacy"
 
-HADOOP_SINK_JAR="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-with-common-*jar"
+HADOOP_SINK_LINK="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar"
 
 HADOOP_LEGACY_LINK_NAME="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar"
 
-# should iterate only once since normally there's only 1 ambari-metrics-hadoop-sink-with-common-*jar
-for f in $HADOOP_SINK_JAR;
-do
-    if [ -f "$f" ]
+if [ -f ${HADOOP_SINK_LINK} ]
+then
+    old_jar=$(readlink -f ${HADOOP_SINK_LINK})
+    version_part=$(basename ${old_jar} | awk -F"-" '{print $7}')
+    IFS=. version=(${version_part})
+
+    if [[ ${version[0]} -le 2 && ${version[1]} -lt 7 ]] # backup only required for versions < 2.7
     then
         if [ ! -d "$JAR_FILES_LEGACY_FOLDER" ]
         then
             mkdir -p "$JAR_FILES_LEGACY_FOLDER"
         fi
-        echo "Backing up Ambari metrics hadoop sink jar $f -> $JAR_FILES_LEGACY_FOLDER/"
-        cp $f $JAR_FILES_LEGACY_FOLDER/
+        echo "Backing up Ambari metrics hadoop sink jar ${old_jar} -> $JAR_FILES_LEGACY_FOLDER/"
+        cp ${old_jar} ${JAR_FILES_LEGACY_FOLDER}/
 
-        HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename $f)"
+        HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename ${old_jar})"
         echo "Creating symlink for backup jar $HADOOP_LEGACY_LINK_NAME -> $HADOOP_SINK_LEGACY_JAR"
         rm -f ${HADOOP_LEGACY_LINK_NAME} ; ln -s ${HADOOP_SINK_LEGACY_JAR} ${HADOOP_LEGACY_LINK_NAME}
     fi
-done
+fi
 
 exit 0

--- a/ambari-metrics/ambari-metrics-assembly/src/main/package/rpm/sink/preinstall.sh
+++ b/ambari-metrics/ambari-metrics-assembly/src/main/package/rpm/sink/preinstall.sh
@@ -25,19 +25,20 @@ then
     old_jar=$(readlink -f ${HADOOP_SINK_LINK})
     version_part=$(basename ${old_jar} | awk -F"-" '{print $7}')
     IFS=. version=(${version_part})
+    unset IFS
 
-    if [[ ${version[0]} -le 2 && ${version[1]} -lt 7 ]] # backup only required for versions < 2.7
+    if [[ ${version[0]} -le 2 && ${version[1]} -lt 7 ]] # backup only required on upgrade from version < 2.7
     then
         if [ ! -d "$JAR_FILES_LEGACY_FOLDER" ]
         then
             mkdir -p "$JAR_FILES_LEGACY_FOLDER"
         fi
         echo "Backing up Ambari metrics hadoop sink jar ${old_jar} -> $JAR_FILES_LEGACY_FOLDER/"
-        cp ${old_jar} ${JAR_FILES_LEGACY_FOLDER}/
+        cp "${old_jar}" "${JAR_FILES_LEGACY_FOLDER}/"
 
         HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename ${old_jar})"
         echo "Creating symlink for backup jar $HADOOP_LEGACY_LINK_NAME -> $HADOOP_SINK_LEGACY_JAR"
-        rm -f ${HADOOP_LEGACY_LINK_NAME} ; ln -s ${HADOOP_SINK_LEGACY_JAR} ${HADOOP_LEGACY_LINK_NAME}
+        rm -f "${HADOOP_LEGACY_LINK_NAME}" ; ln -s "${HADOOP_SINK_LEGACY_JAR}" "${HADOOP_LEGACY_LINK_NAME}"
     fi
 fi
 

--- a/ambari-metrics/ambari-metrics-assembly/src/main/package/rpm/sink/preinstall.sh
+++ b/ambari-metrics/ambari-metrics-assembly/src/main/package/rpm/sink/preinstall.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+JAR_FILES_LEGACY_FOLDER="/usr/lib/ambari-metrics-sink-legacy"
+
+HADOOP_SINK_JAR="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-with-common-*jar"
+
+HADOOP_LEGACY_LINK_NAME="/usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar"
+
+# should iterate only once since normally there's only 1 ambari-metrics-hadoop-sink-with-common-*jar
+for f in $HADOOP_SINK_JAR;
+do
+    if [ -f "$f" ]
+    then
+        if [ ! -d "$JAR_FILES_LEGACY_FOLDER" ]
+        then
+            mkdir -p "$JAR_FILES_LEGACY_FOLDER"
+        fi
+        echo "Backing up Ambari metrics hadoop sink jar $f -> $JAR_FILES_LEGACY_FOLDER/"
+        cp $f $JAR_FILES_LEGACY_FOLDER/
+
+        HADOOP_SINK_LEGACY_JAR="$JAR_FILES_LEGACY_FOLDER/$(basename $f)"
+        echo "Creating symlink for backup jar $HADOOP_LEGACY_LINK_NAME -> $HADOOP_SINK_LEGACY_JAR"
+        rm -f ${HADOOP_LEGACY_LINK_NAME} ; ln -s ${HADOOP_SINK_LEGACY_JAR} ${HADOOP_LEGACY_LINK_NAME}
+    fi
+done
+
+exit 0

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1056,6 +1056,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     updateSolrConfigurations();
     updateAmsConfigs();
     updateStormConfigs();
+    clearHadoopMetrics2Content();
   }
 
   protected void renameAmbariInfra() throws SQLException {
@@ -1886,6 +1887,32 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
               Map<String, String> updateProperty = Collections.singletonMap(stormSecurityClassKey, stormSecurityClassValue);
               updateConfigurationPropertiesForCluster(cluster, stormSite, updateProperty, removeProperties,
                 true, false);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  protected void clearHadoopMetrics2Content() throws AmbariException {
+    AmbariManagementController ambariManagementController = injector.getInstance(AmbariManagementController.class);
+    Clusters clusters = ambariManagementController.getClusters();
+    if (clusters != null) {
+      Map<String, Cluster> clusterMap = clusters.getClusters();
+
+      if (clusterMap != null && !clusterMap.isEmpty()) {
+        String hadoopMetrics2ContentProperty = "content";
+        String hadoopMetrics2ContentValue = "";
+        String hadoopMetrics2ConfigType = "hadoop-metrics2.properties";
+        for (final Cluster cluster : clusterMap.values()) {
+          Config config = cluster.getDesiredConfigByType(hadoopMetrics2ConfigType);
+          if (config != null) {
+            Map<String, String> hadoopMetrics2Configs = config.getProperties();
+            if (hadoopMetrics2Configs.containsKey(hadoopMetrics2ContentProperty)) {
+              LOG.info("Updating " + hadoopMetrics2ContentProperty);
+              Map<String, String> updateProperty = Collections.singletonMap(hadoopMetrics2ContentProperty, hadoopMetrics2ContentValue);
+              updateConfigurationPropertiesForCluster(cluster, hadoopMetrics2ConfigType, updateProperty, Collections.EMPTY_SET,
+                  true, false);
             }
           }
         }

--- a/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/scripts/params.py
@@ -150,6 +150,7 @@ if has_metric_collector:
   metric_truststore_path= default("/configurations/ams-ssl-client/ssl.client.truststore.location", "")
   metric_truststore_type= default("/configurations/ams-ssl-client/ssl.client.truststore.type", "")
   metric_truststore_password= default("/configurations/ams-ssl-client/ssl.client.truststore.password", "")
+  metric_legacy_hadoop_sink = check_stack_feature(StackFeature.AMS_LEGACY_HADOOP_SINK, stack_version_formatted)
   pass
 metrics_report_interval = default("/configurations/ams-site/timeline.metrics.sink.report.interval", 60)
 metrics_collection_period = default("/configurations/ams-site/timeline.metrics.sink.collection.period", 10)

--- a/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/templates/hadoop-metrics2-accumulo.properties.j2
+++ b/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/templates/hadoop-metrics2-accumulo.properties.j2
@@ -24,7 +24,7 @@
 
 {% if has_metric_collector %}
 
-{% if metric_legacy_hadoop_sink}
+{% if metric_legacy_hadoop_sink %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 {% else %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/templates/hadoop-metrics2-accumulo.properties.j2
+++ b/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/templates/hadoop-metrics2-accumulo.properties.j2
@@ -24,7 +24,11 @@
 
 {% if has_metric_collector %}
 
+{% if metric_legacy_hadoop_sink}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+{% else %}
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+{% endif %}
 *.sink.timeline.slave.host.name={{hostname}}
 accumulo.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 accumulo.period={{metrics_collection_period}}

--- a/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/templates/hadoop-metrics2-accumulo.properties.j2
+++ b/ambari-server/src/main/resources/common-services/ACCUMULO/1.6.1.2.2.0/package/templates/hadoop-metrics2-accumulo.properties.j2
@@ -24,7 +24,7 @@
 
 {% if has_metric_collector %}
 
-*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 *.sink.timeline.slave.host.name={{hostname}}
 accumulo.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 accumulo.period={{metrics_collection_period}}

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/hbase_service.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/hbase_service.py
@@ -20,7 +20,6 @@ limitations under the License.
 
 from resource_management.core.resources.system import Execute, File
 from resource_management.libraries.functions.format import format
-from ambari_commons.repo_manager.repo_manager_helper import check_installed_metrics_hadoop_sink_version
 
 def hbase_service(
   name,
@@ -34,8 +33,6 @@ def hbase_service(
     no_op_test = format("ls {pid_file} >/dev/null 2>&1 && ps `cat {pid_file}` >/dev/null 2>&1")
     
     if action == 'start':
-      # Check ambari-metrics-hadoop-sink version is less than 2.7.0.0
-      check_installed_metrics_hadoop_sink_version()
 
       daemon_cmd = format("{cmd} start {role}")
       

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
@@ -36,7 +36,7 @@ rpc.collector.hosts={{ams_collector_hosts}}
 rpc.port={{metric_collector_port}}
 rpc.protocol={{metric_collector_protocol}}
 
-{% if metric_legacy_hadoop_sink}
+{% if metric_legacy_hadoop_sink %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 {% else %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
@@ -36,11 +36,7 @@ rpc.collector.hosts={{ams_collector_hosts}}
 rpc.port={{metric_collector_port}}
 rpc.protocol={{metric_collector_protocol}}
 
-{% if metric_legacy_hadoop_sink %}
-*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
-{% else %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
-{% endif %}
 *.sink.timeline.slave.host.name={{hostname}}
 *.host_in_memory_aggregation = {{host_in_memory_aggregation}}
 *.host_in_memory_aggregation_port = {{host_in_memory_aggregation_port}}

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
@@ -36,7 +36,11 @@ rpc.collector.hosts={{ams_collector_hosts}}
 rpc.port={{metric_collector_port}}
 rpc.protocol={{metric_collector_protocol}}
 
+{% if metric_legacy_hadoop_sink}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+{% else %}
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+{% endif %}
 *.sink.timeline.slave.host.name={{hostname}}
 *.host_in_memory_aggregation = {{host_in_memory_aggregation}}
 *.host_in_memory_aggregation_port = {{host_in_memory_aggregation_port}}

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/templates/hadoop-metrics2-hbase.properties.j2
@@ -36,7 +36,7 @@ rpc.collector.hosts={{ams_collector_hosts}}
 rpc.port={{metric_collector_port}}
 rpc.protocol={{metric_collector_protocol}}
 
-*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 *.sink.timeline.slave.host.name={{hostname}}
 *.host_in_memory_aggregation = {{host_in_memory_aggregation}}
 *.host_in_memory_aggregation_port = {{host_in_memory_aggregation_port}}

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/hbase_service.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/hbase_service.py
@@ -22,7 +22,6 @@ from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.show_logs import show_logs
 from resource_management.core.shell import as_sudo
 from resource_management.core.resources.system import Execute, File
-from ambari_commons.repo_manager.repo_manager_helper import check_installed_metrics_hadoop_sink_version
 
 def hbase_service(
   name,
@@ -37,8 +36,6 @@ def hbase_service(
     no_op_test = as_sudo(["test", "-f", pid_file]) + format(" && ps -p `{pid_expression}` >/dev/null 2>&1")
     
     if action == 'start':
-      # Check ambari-metrics-hadoop-sink version is less than 2.7.0.0
-      check_installed_metrics_hadoop_sink_version()
 
       daemon_cmd = format("{cmd} start {role}")
       

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/params_linux.py
@@ -186,6 +186,7 @@ if has_metric_collector:
   metric_truststore_path= default("/configurations/ams-ssl-client/ssl.client.truststore.location", "")
   metric_truststore_type= default("/configurations/ams-ssl-client/ssl.client.truststore.type", "")
   metric_truststore_password= default("/configurations/ams-ssl-client/ssl.client.truststore.password", "")
+  metric_legacy_hadoop_sink = check_stack_feature(StackFeature.AMS_LEGACY_HADOOP_SINK, version_for_stack_feature_checks)
 
   pass
 metrics_report_interval = default("/configurations/ams-site/timeline.metrics.sink.report.interval", 60)

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-MASTER.j2
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-MASTER.j2
@@ -49,7 +49,11 @@ hbase.extendedperiod = 3600
 
 {% if has_metric_collector %}
 
+{% if metric_legacy_hadoop_sink}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+{% else %}
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+{% endif %}
 *.sink.timeline.slave.host.name={{hostname}}
 
 hbase.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-MASTER.j2
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-MASTER.j2
@@ -49,7 +49,7 @@ hbase.extendedperiod = 3600
 
 {% if has_metric_collector %}
 
-*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 *.sink.timeline.slave.host.name={{hostname}}
 
 hbase.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-MASTER.j2
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-MASTER.j2
@@ -49,7 +49,7 @@ hbase.extendedperiod = 3600
 
 {% if has_metric_collector %}
 
-{% if metric_legacy_hadoop_sink}
+{% if metric_legacy_hadoop_sink %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 {% else %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-RS.j2
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-RS.j2
@@ -48,7 +48,11 @@ hbase.extendedperiod = 3600
 
 {% if has_metric_collector %}
 
+{% if metric_legacy_hadoop_sink}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+{% else %}
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+{% endif %}
 *.sink.timeline.slave.host.name={{hostname}}
 hbase.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 hbase.period={{metrics_collection_period}}

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-RS.j2
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-RS.j2
@@ -48,7 +48,7 @@ hbase.extendedperiod = 3600
 
 {% if has_metric_collector %}
 
-{% if metric_legacy_hadoop_sink}
+{% if metric_legacy_hadoop_sink %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 {% else %}
 *.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-RS.j2
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/templates/hadoop-metrics2-hbase.properties-GANGLIA-RS.j2
@@ -48,7 +48,7 @@ hbase.extendedperiod = 3600
 
 {% if has_metric_collector %}
 
-*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+*.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 *.sink.timeline.slave.host.name={{hostname}}
 hbase.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 hbase.period={{metrics_collection_period}}

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/utils.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/utils.py
@@ -37,7 +37,6 @@ from resource_management.libraries.functions.curl_krb_request import curl_krb_re
 from resource_management.libraries.script.script import Script
 from resource_management.libraries.functions.namenode_ha_utils import get_namenode_states
 from resource_management.libraries.functions.show_logs import show_logs
-from ambari_commons.repo_manager.repo_manager_helper import check_installed_metrics_hadoop_sink_version
 from ambari_commons.inet_utils import ensure_ssl_using_protocol
 from zkfc_slave import ZkfcSlaveDefault
 
@@ -270,8 +269,6 @@ def service(action=None, name=None, user=None, options="", create_pid_dir=False,
     daemon_cmd = as_user(cmd, user)
      
   if action == "start":
-    # Check ambari-metrics-hadoop-sink version is less than 2.7.0.0
-    check_installed_metrics_hadoop_sink_version()
 
     # remove pid file from dead process
     File(pid_file, action="delete", not_if=process_id_exists_command)

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive_service.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive_service.py
@@ -36,7 +36,6 @@ from resource_management.libraries.functions.stack_features import check_stack_f
 
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
 from ambari_commons import OSConst
-from ambari_commons.repo_manager.repo_manager_helper import check_installed_metrics_hadoop_sink_version
 
 
 @OsFamilyFuncImpl(os_family=OSConst.WINSRV_FAMILY)
@@ -73,8 +72,6 @@ def hive_service(name, action='start', upgrade_type=None):
   process_id_exists_command = format("ls {pid_file} >/dev/null 2>&1 && ps -p {pid} >/dev/null 2>&1")
 
   if action == 'start':
-    # Check ambari-metrics-hadoop-sink version is less than 2.7.0.0
-    check_installed_metrics_hadoop_sink_version()
 
     if name == 'hiveserver2':
       check_fs_root(params.hive_server_conf_dir, params.execute_path)

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
@@ -574,6 +574,7 @@ if has_metric_collector:
   metric_truststore_path= default("/configurations/ams-ssl-client/ssl.client.truststore.location", "")
   metric_truststore_type= default("/configurations/ams-ssl-client/ssl.client.truststore.type", "")
   metric_truststore_password= default("/configurations/ams-ssl-client/ssl.client.truststore.password", "")
+  metric_legacy_hadoop_sink = check_stack_feature(StackFeature.AMS_LEGACY_HADOOP_SINK, version_for_stack_feature_checks)
 
 metrics_report_interval = default("/configurations/ams-site/timeline.metrics.sink.report.interval", 60)
 metrics_collection_period = default("/configurations/ams-site/timeline.metrics.sink.collection.period", 10)

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hivemetastore.properties.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hivemetastore.properties.j2
@@ -37,7 +37,11 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
+  {% if metric_legacy_hadoop_sink}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+  {% else %}
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  {% endif %}
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hivemetastore.properties.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hivemetastore.properties.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hivemetastore.properties.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hivemetastore.properties.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  {% if metric_legacy_hadoop_sink}
+  {% if metric_legacy_hadoop_sink %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   {% else %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hiveserver2.properties.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hiveserver2.properties.j2
@@ -37,7 +37,11 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
+  {% if metric_legacy_hadoop_sink}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+  {% else %}
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  {% endif %}
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hiveserver2.properties.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hiveserver2.properties.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hiveserver2.properties.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-hiveserver2.properties.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  {% if metric_legacy_hadoop_sink}
+  {% if metric_legacy_hadoop_sink %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   {% else %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llapdaemon.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llapdaemon.j2
@@ -37,7 +37,11 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
+  {% if metric_legacy_hadoop_sink}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+  {% else %}
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  {% endif %}
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llapdaemon.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llapdaemon.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llapdaemon.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llapdaemon.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  {% if metric_legacy_hadoop_sink}
+  {% if metric_legacy_hadoop_sink %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   {% else %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llaptaskscheduler.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llaptaskscheduler.j2
@@ -37,7 +37,11 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
+  {% if metric_legacy_hadoop_sink}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+  {% else %}
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  {% endif %}
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llaptaskscheduler.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llaptaskscheduler.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+  *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
   *.sink.timeline.period={{metrics_collection_period}}
   *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llaptaskscheduler.j2
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/templates/hadoop-metrics2-llaptaskscheduler.j2
@@ -37,7 +37,7 @@
 {% if has_metric_collector %}
 
   *.period={{metrics_collection_period}}
-  {% if metric_legacy_hadoop_sink}
+  {% if metric_legacy_hadoop_sink %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
   {% else %}
   *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/service.py
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/package/scripts/service.py
@@ -21,7 +21,6 @@ Ambari Agent
 
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
 from ambari_commons import OSConst
-from ambari_commons.repo_manager.repo_manager_helper import check_installed_metrics_hadoop_sink_version
 from resource_management.core.shell import as_user, as_sudo
 from resource_management.libraries.functions.show_logs import show_logs
 from resource_management.libraries.functions.format import format
@@ -65,8 +64,6 @@ def service(componentName, action='start', serviceName='yarn'):
   cmd = format("export HADOOP_LIBEXEC_DIR={hadoop_libexec_dir} && {daemon} --config {hadoop_conf_dir}")
 
   if action == 'start':
-    # Check ambari-metrics-hadoop-sink version is less than 2.7.0.0
-    check_installed_metrics_hadoop_sink_version()
 
     daemon_cmd = format("{ulimit_cmd} {cmd} start {componentName}")
     check_process = as_sudo(["test", "-f", pid_file]) + " && " + as_sudo(["pgrep", "-F", pid_file])

--- a/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/scripts/params.py
@@ -162,8 +162,10 @@ if has_metric_collector:
   metric_truststore_path= default("/configurations/ams-ssl-client/ssl.client.truststore.location", "")
   metric_truststore_type= default("/configurations/ams-ssl-client/ssl.client.truststore.type", "")
   metric_truststore_password= default("/configurations/ams-ssl-client/ssl.client.truststore.password", "")
+  metric_legacy_hadoop_sink = check_stack_feature(StackFeature.AMS_LEGACY_HADOOP_SINK, version_for_stack_feature_checks)
 
   pass
+
 metrics_report_interval = default("/configurations/ams-site/timeline.metrics.sink.report.interval", 60)
 metrics_collection_period = default("/configurations/ams-site/timeline.metrics.sink.collection.period", 10)
 

--- a/ambari-server/src/main/resources/stack-hooks/before-START/templates/hadoop-metrics2.properties.j2
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/templates/hadoop-metrics2.properties.j2
@@ -67,7 +67,11 @@ resourcemanager.sink.ganglia.tagsForPrefix.yarn=Queue
 {% if has_metric_collector %}
 
 *.period={{metrics_collection_period}}
+{% if metric_legacy_hadoop_sink}
 *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+{% else %}
+*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+{% endif %}
 *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 *.sink.timeline.period={{metrics_collection_period}}
 *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/stack-hooks/before-START/templates/hadoop-metrics2.properties.j2
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/templates/hadoop-metrics2.properties.j2
@@ -67,7 +67,7 @@ resourcemanager.sink.ganglia.tagsForPrefix.yarn=Queue
 {% if has_metric_collector %}
 
 *.period={{metrics_collection_period}}
-*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 *.sink.timeline.period={{metrics_collection_period}}
 *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/stack-hooks/before-START/templates/hadoop-metrics2.properties.j2
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/templates/hadoop-metrics2.properties.j2
@@ -67,7 +67,7 @@ resourcemanager.sink.ganglia.tagsForPrefix.yarn=Queue
 {% if has_metric_collector %}
 
 *.period={{metrics_collection_period}}
-{% if metric_legacy_hadoop_sink}
+{% if metric_legacy_hadoop_sink %}
 *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 {% else %}
 *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/properties/stack_features.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/properties/stack_features.json
@@ -458,6 +458,11 @@
         "description": "ExtJS is included in the repository and automatically installed by Ambari",
         "min_version": "2.2.0.0",
         "max_version": "2.6.0.0"
+      },
+      {
+        "name": "ams_legacy_hadoop_sink",
+        "description": "Legacy AMS hadoop sink should be used",
+        "max_version": "2.6.99.99"
       }
     ]
   }

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-metrics2.properties.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-metrics2.properties.xml
@@ -78,7 +78,11 @@ resourcemanager.sink.ganglia.tagsForPrefix.yarn=Queue
 {% if has_metric_collector %}
 
 *.period={{metrics_collection_period}}
+{% if metric_legacy_hadoop_sink %}
 *.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
+{% else %}
+*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+{% endif %}
 *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 *.sink.timeline.period={{metrics_collection_period}}
 *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-metrics2.properties.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-metrics2.properties.xml
@@ -124,6 +124,7 @@ namenode.sink.timeline.metric.rpc.healthcheck.port={{nn_rpc_healthcheck_port}}
     </value>
     <value-attributes>
       <type>content</type>
+      <empty-value-valid>true</empty-value-valid>
     </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-metrics2.properties.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HDFS/configuration/hadoop-metrics2.properties.xml
@@ -78,7 +78,7 @@ resourcemanager.sink.ganglia.tagsForPrefix.yarn=Queue
 {% if has_metric_collector %}
 
 *.period={{metrics_collection_period}}
-*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar
+*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink-legacy.jar
 *.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink
 *.sink.timeline.period={{metrics_collection_period}}
 *.sink.timeline.sendInterval={{metrics_report_interval}}000

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -330,6 +330,7 @@ public class UpgradeCatalog270Test {
     Method updateSolrConfigurations = UpgradeCatalog270.class.getDeclaredMethod("updateSolrConfigurations");
     Method updateAmsConfigurations = UpgradeCatalog270.class.getDeclaredMethod("updateAmsConfigs");
     Method updateStormConfigurations = UpgradeCatalog270.class.getDeclaredMethod("updateStormConfigs");
+    Method clearHadoopMetrics2Content = UpgradeCatalog270.class.getDeclaredMethod("clearHadoopMetrics2Content");
 
     UpgradeCatalog270 upgradeCatalog270 = createMockBuilder(UpgradeCatalog270.class)
         .addMockedMethod(showHcatDeletedUserMessage)
@@ -346,6 +347,7 @@ public class UpgradeCatalog270Test {
         .addMockedMethod(updateSolrConfigurations)
         .addMockedMethod(updateAmsConfigurations)
         .addMockedMethod(updateStormConfigurations)
+        .addMockedMethod(clearHadoopMetrics2Content)
         .createMock();
 
 
@@ -387,6 +389,9 @@ public class UpgradeCatalog270Test {
     expectLastCall().once();
 
     upgradeCatalog270.updateStormConfigs();
+    expectLastCall().once();
+
+    upgradeCatalog270.clearHadoopMetrics2Content();
     expectLastCall().once();
 
     replay(upgradeCatalog270);
@@ -1662,6 +1667,59 @@ public class UpgradeCatalog270Test {
 
     Map<String, String> updatedProperties = propertiesCapture.getValue();
     assertTrue(Maps.difference(newStormProperties, updatedProperties).areEqual());
+
+  }
+
+  @Test
+  public void testClearHadoopMetrics2Content() throws Exception {
+
+    Map<String, String> oldContentProperty = new HashMap<String, String>() {
+      {
+        put("content", "# Licensed to the Apache Software Foundation (ASF) under one or more...");
+      }
+    };
+    Map<String, String> newContentProperty = new HashMap<String, String>() {
+      {
+        put("content", "");
+      }
+    };
+
+    EasyMockSupport easyMockSupport = new EasyMockSupport();
+
+    Clusters clusters = easyMockSupport.createNiceMock(Clusters.class);
+    final Cluster cluster = easyMockSupport.createNiceMock(Cluster.class);
+    Config mockHadoopMetrics2Properties = easyMockSupport.createNiceMock(Config.class);
+
+    expect(clusters.getClusters()).andReturn(new HashMap<String, Cluster>() {{
+      put("normal", cluster);
+    }}).once();
+    expect(cluster.getDesiredConfigByType("hadoop-metrics2.properties")).andReturn(mockHadoopMetrics2Properties).atLeastOnce();
+    expect(mockHadoopMetrics2Properties.getProperties()).andReturn(oldContentProperty).anyTimes();
+
+    Injector injector = easyMockSupport.createNiceMock(Injector.class);
+
+    replay(injector, clusters, mockHadoopMetrics2Properties, cluster);
+
+    AmbariManagementControllerImpl controller = createMockBuilder(AmbariManagementControllerImpl.class)
+        .addMockedMethod("getClusters", new Class[] { })
+        .addMockedMethod("createConfig")
+        .withConstructor(createNiceMock(ActionManager.class), clusters, injector)
+        .createNiceMock();
+
+    Injector injector2 = easyMockSupport.createNiceMock(Injector.class);
+    Capture<Map> propertiesCapture = EasyMock.newCapture();
+
+    expect(injector2.getInstance(AmbariManagementController.class)).andReturn(controller).anyTimes();
+    expect(controller.getClusters()).andReturn(clusters).anyTimes();
+    expect(controller.createConfig(anyObject(Cluster.class), anyObject(StackId.class), anyString(), capture(propertiesCapture), anyString(),
+        anyObject(Map.class))).andReturn(createNiceMock(Config.class)).once();
+
+    replay(controller, injector2);
+    new UpgradeCatalog270(injector2).clearHadoopMetrics2Content();
+    easyMockSupport.verifyAll();
+
+    Map<String, String> updatedProperties = propertiesCapture.getValue();
+    assertTrue(Maps.difference(newContentProperty, updatedProperties).areEqual());
 
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Preserve old hadoop sink jar on AMS/Ambari upgrade and allow to use it for services from old stacks.

## How was this patch tested?

Basic manual testing, more in-depth testing in progress.