### PR TITLE
AMBARI-24268 Ambaripreupload.py fixes - addendum

### DIFF
--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -206,6 +206,7 @@ with Environment() as env:
                     owner=file_owner,
                     group=group_owner,
                     source=source,
+                    dfs_type=params.dfs_type
       )
    
    
@@ -248,34 +249,34 @@ with Environment() as env:
   
   def createHdfsResources():
     print "Creating hdfs directories..."
-    params.HdfsResource(format('{hdfs_path_prefix}/atshistory'), user='hdfs', change_permissions_for_parents=True, owner='yarn', group='hadoop', type='directory', action= ['create_on_execute'], mode=0755)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/hcat'), owner='hcat', type='directory', action=['create_on_execute'], mode=0755)
-    params.HdfsResource(format('{hdfs_path_prefix}/hive/warehouse'), owner='hive', type='directory', action=['create_on_execute'], mode=0777)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/hive'), owner='hive', type='directory', action=['create_on_execute'], mode=0755)
-    params.HdfsResource(format('{hdfs_path_prefix}/tmp'), mode=0777, action=['create_on_execute'], type='directory', owner='hdfs')
-    params.HdfsResource(format('{hdfs_path_prefix}/user/ambari-qa'), type='directory', action=['create_on_execute'], mode=0770)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/oozie'), owner='oozie', type='directory', action=['create_on_execute'], mode=0775)
-    params.HdfsResource(format('{hdfs_path_prefix}/app-logs'), recursive_chmod=True, owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
-    params.HdfsResource(format('{hdfs_path_prefix}/tmp/entity-file-history/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'])
-    params.HdfsResource(format('{hdfs_path_prefix}/mapred'), owner='mapred', type='directory', action=['create_on_execute'])
-    params.HdfsResource(format('{hdfs_path_prefix}/mapred/system'), owner='hdfs', type='directory', action=['create_on_execute'])
-    params.HdfsResource(format('{hdfs_path_prefix}/mr-history/done'), change_permissions_for_parents=True, owner='mapred', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
-    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/done'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0700)
-    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=01777)
-    params.HdfsResource(format('{hdfs_path_prefix}/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775)
-    params.HdfsResource(format('{hdfs_path_prefix}/amshbase/staging'), owner='ams', type='directory', action=['create_on_execute'], mode=0711)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775)
-    params.HdfsResource(format('{hdfs_path_prefix}/hdp'), owner='hdfs', type='directory', action=['create_on_execute'], mode=0755)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/spark'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0775)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/livy'), owner='livy', group='hadoop', type='directory', action=['create_on_execute'], mode=0775)
-    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
-    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark2-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
-    params.HdfsResource(format('{hdfs_path_prefix}/hbase'), owner='hbase', type='directory', action=['create_on_execute'])
-    params.HdfsResource(format('{hdfs_path_prefix}/apps/hbase/staging'), owner='hbase', type='directory', action=['create_on_execute'], mode=0711)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/hbase'), owner='hbase', type='directory', action=['create_on_execute'], mode=0755)
-    params.HdfsResource(format('{hdfs_path_prefix}/apps/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'])
-    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'])
-    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin/test'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/atshistory'), user='hdfs', change_permissions_for_parents=True, owner='yarn', group='hadoop', type='directory', action= ['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/hcat'), owner='hcat', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/hive/warehouse'), owner='hive', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/hive'), owner='hive', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/tmp'), mode=0777, action=['create_on_execute'], type='directory', owner='hdfs', dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/ambari-qa'), type='directory', action=['create_on_execute'], mode=0770, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/oozie'), owner='oozie', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/app-logs'), recursive_chmod=True, owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/tmp/entity-file-history/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/mapred'), owner='mapred', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/mapred/system'), owner='hdfs', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/mr-history/done'), change_permissions_for_parents=True, owner='mapred', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/done'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0700, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=01777, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/amshbase/staging'), owner='ams', type='directory', action=['create_on_execute'], mode=0711, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/hdp'), owner='hdfs', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/spark'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/livy'), owner='livy', group='hadoop', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark2-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/hbase'), owner='hbase', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/apps/hbase/staging'), owner='hbase', type='directory', action=['create_on_execute'], mode=0711, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/hbase'), owner='hbase', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/apps/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin/test'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
 
   def copy_zeppelin_dependencies_to_hdfs(file_pattern):
     spark_deps_full_path = glob.glob(file_pattern)
@@ -301,7 +302,8 @@ with Environment() as env:
       
   def putSQLDriverToOozieShared():
     params.HdfsResource(hdfs_path_prefix + '/user/oozie/share/lib/sqoop/{0}'.format(os.path.basename(SQL_DRIVER_PATH)),
-                        owner='hdfs', type='file', action=['create_on_execute'], mode=0644, source=SQL_DRIVER_PATH)
+                        owner='hdfs', type='file', action=['create_on_execute'], mode=0644, source=SQL_DRIVER_PATH,
+                        dfs_type=params.dfs_type)
 
   def create_yarn_service_tarball():
     """
@@ -360,7 +362,8 @@ with Environment() as env:
   else:
     params.HdfsResource(format("{oozie_hdfs_user_dir}/share/"),
       action="delete_on_execute",
-      type = 'directory'
+      type = 'directory',
+      dfs_type = params.dfs_type
     )
 
     spark_client_dir = format("/usr/hdp/{stack_version}/spark")
@@ -418,21 +421,22 @@ with Environment() as env:
       recursive_chmod = True,
       owner=oozie_user,
       source = oozie_shared_lib,
+      dfs_type = params.dfs_type
     )
 
   print "Copying tarballs..."
   # TODO, these shouldn't hardcode the stack root or destination stack name.
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop/mapreduce.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/mapreduce/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/tez/lib/tez.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/tez/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hive/hive.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/hive/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop/mapreduce.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/mapreduce/", params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/tez/lib/tez.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/tez/", params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hive/hive.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/hive/", params.mapred_user, params.hdfs_user, params.user_group)
 
   # Needed by Hive Interactive
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/tez_hive2/lib/tez.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/tez_hive2/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/tez_hive2/lib/tez.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/tez_hive2/", params.mapred_user, params.hdfs_user, params.user_group)
 
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/pig/pig.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/pig/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-mapreduce/hadoop-streaming.jar"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/mapreduce/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/sqoop/sqoop.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/sqoop/", 'hadoop-mapreduce-historyserver', params.mapred_user, params.hdfs_user, params.user_group)
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-yarn/lib/service-dep.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/yarn/", 'hadoop-mapreduce-historyserver', params.hdfs_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/pig/pig.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/pig/", params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-mapreduce/hadoop-streaming.jar"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/mapreduce/", params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/sqoop/sqoop.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/sqoop/", params.mapred_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-yarn/lib/service-dep.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/yarn/", params.hdfs_user, params.hdfs_user, params.user_group)
   
   createHdfsResources()
   copy_zeppelin_dependencies_to_hdfs(format("/usr/hdp/{stack_version}/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies*.jar"))
@@ -449,7 +453,8 @@ with Environment() as env:
   try:
     params.HdfsResource(None, 
                  logoutput=True,
-                 action="execute"
+                 action="execute",
+                 dfs_type=params.dfs_type
     )
   except:
     os.remove("/var/lib/ambari-agent/data/.hdfs_resource_ignore")

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -184,6 +184,7 @@ with Environment() as env:
       hdfs_site = hdfs_site,
       default_fs = fs_default,
       hdfs_resource_ignore_file = "/var/lib/ambari-agent/data/.hdfs_resource_ignore",
+      dfs_type = dfs_type
     )
    
   def _copy_files(source_and_dest_pairs, file_owner, group_owner, kinit_if_needed):
@@ -205,11 +206,10 @@ with Environment() as env:
                     mode=0444,
                     owner=file_owner,
                     group=group_owner,
-                    source=source,
-                    dfs_type=params.dfs_type
+                    source=source
       )
-   
-   
+
+
   def copy_tarballs_to_hdfs(source, dest, component_user, file_owner, group_owner):
     """
     :param source: source on host FS
@@ -218,65 +218,65 @@ with Environment() as env:
     :param file_owner: Owner of the files copied to HDFS (typically hdfs account)
     :param group_owner: Group owner of the files copied to HDFS (typically hadoop group)
     :return: Returns 0 on success, 1 if no files were copied, and in some cases may raise an exception.
-   
+
     In order to call this function, params.py must have all of the following,
     stack_version_formatted, kinit_path_local, security_enabled, hdfs_user, hdfs_principal_name, hdfs_user_keytab,
     hadoop_bin_dir, hadoop_conf_dir, and HdfsDirectory as a partial function.
     """
-   
+
     component_tar_source_file, component_tar_destination_folder = source, dest
-   
+
     if not os.path.exists(component_tar_source_file):
       Logger.warning("Could not find file: %s" % str(component_tar_source_file))
       return 1
-   
+
     file_name = os.path.basename(component_tar_source_file)
     destination_file = os.path.join(component_tar_destination_folder, file_name)
     destination_file = destination_file.replace("{{ stack_version_formatted }}", stack_version)
-  
+
     kinit_if_needed = ""
     if params.security_enabled:
       kinit_if_needed = format("{kinit_path_local} -kt {hdfs_user_keytab} {hdfs_principal_name};")
-   
+
     if kinit_if_needed:
       Execute(kinit_if_needed,
               user=component_user,
               path='/bin'
       )
-   
+
     source_and_dest_pairs = [(component_tar_source_file, destination_file), ]
     return _copy_files(source_and_dest_pairs, file_owner, group_owner, kinit_if_needed)
-  
+
   def createHdfsResources():
     print "Creating hdfs directories..."
-    params.HdfsResource(format('{hdfs_path_prefix}/atshistory'), user='hdfs', change_permissions_for_parents=True, owner='yarn', group='hadoop', type='directory', action= ['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/hcat'), owner='hcat', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/hive/warehouse'), owner='hive', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/hive'), owner='hive', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/tmp'), mode=0777, action=['create_on_execute'], type='directory', owner='hdfs', dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/ambari-qa'), type='directory', action=['create_on_execute'], mode=0770, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/oozie'), owner='oozie', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/app-logs'), recursive_chmod=True, owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/tmp/entity-file-history/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/mapred'), owner='mapred', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/mapred/system'), owner='hdfs', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/mr-history/done'), change_permissions_for_parents=True, owner='mapred', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/done'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0700, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=01777, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/amshbase/staging'), owner='ams', type='directory', action=['create_on_execute'], mode=0711, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/hdp'), owner='hdfs', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/spark'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/livy'), owner='livy', group='hadoop', type='directory', action=['create_on_execute'], mode=0775, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark2-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/hbase'), owner='hbase', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/apps/hbase/staging'), owner='hbase', type='directory', action=['create_on_execute'], mode=0711, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/hbase'), owner='hbase', type='directory', action=['create_on_execute'], mode=0755, dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/apps/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
-    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin/test'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'], dfs_type=params.dfs_type)
+    params.HdfsResource(format('{hdfs_path_prefix}/atshistory'), user='hdfs', change_permissions_for_parents=True, owner='yarn', group='hadoop', type='directory', action= ['create_on_execute'], mode=0755)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/hcat'), owner='hcat', type='directory', action=['create_on_execute'], mode=0755)
+    params.HdfsResource(format('{hdfs_path_prefix}/hive/warehouse'), owner='hive', type='directory', action=['create_on_execute'], mode=0777)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/hive'), owner='hive', type='directory', action=['create_on_execute'], mode=0755)
+    params.HdfsResource(format('{hdfs_path_prefix}/tmp'), mode=0777, action=['create_on_execute'], type='directory', owner='hdfs')
+    params.HdfsResource(format('{hdfs_path_prefix}/user/ambari-qa'), type='directory', action=['create_on_execute'], mode=0770)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/oozie'), owner='oozie', type='directory', action=['create_on_execute'], mode=0775)
+    params.HdfsResource(format('{hdfs_path_prefix}/app-logs'), recursive_chmod=True, owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
+    params.HdfsResource(format('{hdfs_path_prefix}/tmp/entity-file-history/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/mapred'), owner='mapred', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/mapred/system'), owner='hdfs', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/mr-history/done'), change_permissions_for_parents=True, owner='mapred', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
+    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/done'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=0700)
+    params.HdfsResource(format('{hdfs_path_prefix}/atshistory/active'), owner='yarn', group='hadoop', type='directory', action=['create_on_execute'], mode=01777)
+    params.HdfsResource(format('{hdfs_path_prefix}/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775)
+    params.HdfsResource(format('{hdfs_path_prefix}/amshbase/staging'), owner='ams', type='directory', action=['create_on_execute'], mode=0711)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/ams/hbase'), owner='ams', type='directory', action=['create_on_execute'], mode=0775)
+    params.HdfsResource(format('{hdfs_path_prefix}/hdp'), owner='hdfs', type='directory', action=['create_on_execute'], mode=0755)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/spark'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0775)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/livy'), owner='livy', group='hadoop', type='directory', action=['create_on_execute'], mode=0775)
+    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
+    params.HdfsResource(format('{hdfs_path_prefix}/hdp/spark2-events'), owner='spark', group='hadoop', type='directory', action=['create_on_execute'], mode=0777)
+    params.HdfsResource(format('{hdfs_path_prefix}/hbase'), owner='hbase', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/apps/hbase/staging'), owner='hbase', type='directory', action=['create_on_execute'], mode=0711)
+    params.HdfsResource(format('{hdfs_path_prefix}/user/hbase'), owner='hbase', type='directory', action=['create_on_execute'], mode=0755)
+    params.HdfsResource(format('{hdfs_path_prefix}/apps/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'])
+    params.HdfsResource(format('{hdfs_path_prefix}/user/zeppelin/test'), owner='zeppelin', group='hadoop', type='directory', action=['create_on_execute'])
 
   def copy_zeppelin_dependencies_to_hdfs(file_pattern):
     spark_deps_full_path = glob.glob(file_pattern)
@@ -289,21 +289,20 @@ with Environment() as env:
     if not 'hdfs_files' in env.config:
       Logger.info("Not creating .hdfs_resource_ignore as no resources to use.")
       return
-    
+
     file_content = ""
     for file in env.config['hdfs_files']:
       if not file['target'].startswith(hdfs_path_prefix):
         raise Exception("Something created outside hdfs_path_prefix!")
       file_content += file['target'][len(hdfs_path_prefix):]
       file_content += "\n"
-      
+
     with open("/var/lib/ambari-agent/data/.hdfs_resource_ignore", "a+") as fp:
       fp.write(file_content)
-      
+
   def putSQLDriverToOozieShared():
     params.HdfsResource(hdfs_path_prefix + '/user/oozie/share/lib/sqoop/{0}'.format(os.path.basename(SQL_DRIVER_PATH)),
-                        owner='hdfs', type='file', action=['create_on_execute'], mode=0644, source=SQL_DRIVER_PATH,
-                        dfs_type=params.dfs_type)
+                        owner='hdfs', type='file', action=['create_on_execute'], mode=0644, source=SQL_DRIVER_PATH)
 
   def create_yarn_service_tarball():
     """
@@ -317,10 +316,10 @@ with Environment() as env:
       for folder in folders:
         for filepath in glob.glob(format("{folder}/*.jar")):
           tar.add(os.path.realpath(filepath), arcname=os.path.basename(filepath))
-      
+
   env.set_params(params)
   hadoop_conf_dir = params.hadoop_conf_dir
-   
+
   oozie_libext_dir = params.oozie_libext_dir
   sql_driver_filename = os.path.basename(SQL_DRIVER_PATH)
   oozie_home=params.oozie_home
@@ -328,7 +327,7 @@ with Environment() as env:
   configure_cmds.append(('tar','-xvf', oozie_home + '/oozie-sharelib.tar.gz','-C', oozie_home))
   configure_cmds.append(('cp', "/usr/share/HDP-oozie/ext-2.2.zip", SQL_DRIVER_PATH, oozie_libext_dir))
   configure_cmds.append(('chown', 'oozie:hadoop', oozie_libext_dir + "/ext-2.2.zip", oozie_libext_dir + "/" + sql_driver_filename))
-   
+
   no_op_test = "ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1"
 
   File("/etc/oozie/conf/oozie-env.sh",
@@ -340,14 +339,14 @@ with Environment() as env:
   skip_recreate_sharelib = format("test -f {hashcode_file} && test -d {oozie_home}/share")
 
   Execute( configure_cmds,
-           not_if  = format("{no_op_test} || {skip_recreate_sharelib}"), 
+           not_if  = format("{no_op_test} || {skip_recreate_sharelib}"),
            sudo = True,
            )
-  
+
   File(hashcode_file,
        mode = 0644,
   )
-  
+
   prepare_war(params)
 
   oozie_shared_lib = format("/usr/hdp/{stack_version}/oozie/share")
@@ -362,8 +361,7 @@ with Environment() as env:
   else:
     params.HdfsResource(format("{oozie_hdfs_user_dir}/share/"),
       action="delete_on_execute",
-      type = 'directory',
-      dfs_type = params.dfs_type
+      type = 'directory'
     )
 
     spark_client_dir = format("/usr/hdp/{stack_version}/spark")
@@ -420,8 +418,7 @@ with Environment() as env:
       mode=0755,
       recursive_chmod = True,
       owner=oozie_user,
-      source = oozie_shared_lib,
-      dfs_type = params.dfs_type
+      source = oozie_shared_lib
     )
 
   print "Copying tarballs..."
@@ -437,7 +434,7 @@ with Environment() as env:
   copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-mapreduce/hadoop-streaming.jar"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/mapreduce/", params.mapred_user, params.hdfs_user, params.user_group)
   copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/sqoop/sqoop.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/sqoop/", params.mapred_user, params.hdfs_user, params.user_group)
   copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-yarn/lib/service-dep.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/yarn/", params.hdfs_user, params.hdfs_user, params.user_group)
-  
+
   createHdfsResources()
   copy_zeppelin_dependencies_to_hdfs(format("/usr/hdp/{stack_version}/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies*.jar"))
   putSQLDriverToOozieShared()
@@ -451,10 +448,9 @@ with Environment() as env:
   # Create everything in one jar call (this is fast).
   # (! Before everything should be executed with action="create_on_execute/delete_on_execute" for this time-optimization to work)
   try:
-    params.HdfsResource(None, 
+    params.HdfsResource(None,
                  logoutput=True,
-                 action="execute",
-                 dfs_type=params.dfs_type
+                 action="execute"
     )
   except:
     os.remove("/var/lib/ambari-agent/data/.hdfs_resource_ignore")


### PR DESCRIPTION
## What changes were proposed in this pull request?

previous commit contained bad file, this change contains all required fixes to get it running. 

## How was this patch tested?

install cluster having HDFS, YARN, Oozie, Hive, Tez and running preupload script: 

```
[root@gboros-preupload-1 ~]# sed -i -e 's@wasb://@hdfs://@g' /var/lib/ambari-server/resources/scripts/Ambaripreupload.py
[root@gboros-preupload-1 ~]# /var/lib/ambari-server/resources/scripts/Ambaripreupload.py
2018-07-10 09:18:20,618 - call['/usr/bin/hdp-select status hadoop-mapreduce-historyserver > /tmp/tmpuOVBFc'] {}
2018-07-10 09:18:20,647 - call returned (0, '')
Returning fs.defaultFS -> hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020
2018-07-10 09:18:20,715 - File['/etc/oozie/conf/oozie-env.sh'] {'content': '\n  #!/bin/bash\n  \n  export OOZIE_CONFIG=${OOZIE_CONFIG:-/usr/hdp/3.0.0.0-1625/oozie/conf}\n  export OOZIE_DATA=${OOZIE_DATA:-/var/lib/oozie/data}\n  export OOZIE_LOG=${OOZIE_LOG:-/var/log/oozie}\n  export CATALINA_BASE=${CATALINA_BASE:-/usr/hdp/3.0.0.0-1625/oozie/oozie-server}\n  export CATALINA_TMPDIR=${CATALINA_TMPDIR:-/var/tmp/oozie}\n  export CATALINA_PID=${CATALINA_PID:-/var/run/oozie/oozie.pid}\n  export OOZIE_CATALINA_HOME=/usr/lib/bigtop-tomcat\n  ', 'owner': 'oozie'}
2018-07-10 09:18:20,752 - Writing File['/etc/oozie/conf/oozie-env.sh'] because contents don't match
2018-07-10 09:18:20,753 - Execute[('tar', '-xvf', '/usr/hdp/3.0.0.0-1625/oozie/oozie-sharelib.tar.gz', '-C', '/usr/hdp/3.0.0.0-1625/oozie')] {'not_if': 'ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1 || test -f /usr/hdp/3.0.0.0-1625/oozie/.hashcode && test -d /usr/hdp/3.0.0.0-1625/oozie/share', 'sudo': True}
2018-07-10 09:18:20,787 - Skipping Execute[('tar', '-xvf', '/usr/hdp/3.0.0.0-1625/oozie/oozie-sharelib.tar.gz', '-C', '/usr/hdp/3.0.0.0-1625/oozie')] due to not_if
2018-07-10 09:18:20,787 - Execute[('cp', '/usr/share/HDP-oozie/ext-2.2.zip', '/var/lib/ambari-server/resources/sqljdbc41.jar', '/usr/hdp/3.0.0.0-1625/oozie/libext')] {'not_if': 'ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1 || test -f /usr/hdp/3.0.0.0-1625/oozie/.hashcode && test -d /usr/hdp/3.0.0.0-1625/oozie/share', 'sudo': True}
2018-07-10 09:18:20,802 - Skipping Execute[('cp', '/usr/share/HDP-oozie/ext-2.2.zip', '/var/lib/ambari-server/resources/sqljdbc41.jar', '/usr/hdp/3.0.0.0-1625/oozie/libext')] due to not_if
2018-07-10 09:18:20,802 - Execute[('chown', 'oozie:hadoop', '/usr/hdp/3.0.0.0-1625/oozie/libext/ext-2.2.zip', '/usr/hdp/3.0.0.0-1625/oozie/libext/sqljdbc41.jar')] {'not_if': 'ls /var/run/oozie/oozie.pid >/dev/null 2>&1 && ps -p `cat /var/run/oozie/oozie.pid` >/dev/null 2>&1 || test -f /usr/hdp/3.0.0.0-1625/oozie/.hashcode && test -d /usr/hdp/3.0.0.0-1625/oozie/share', 'sudo': True}
2018-07-10 09:18:20,816 - Skipping Execute[('chown', 'oozie:hadoop', '/usr/hdp/3.0.0.0-1625/oozie/libext/ext-2.2.zip', '/usr/hdp/3.0.0.0-1625/oozie/libext/sqljdbc41.jar')] due to not_if
2018-07-10 09:18:20,816 - File['/usr/hdp/3.0.0.0-1625/oozie/.hashcode'] {'mode': 0644}
2018-07-10 09:18:20,818 - call['ambari-sudo.sh su oozie -l -s /bin/bash -c 'ls -l /usr/hdp/3.0.0.0-1625/oozie/libext | awk '"'"'{print $9, $5}'"'"' | awk '"'"'NF > 0'"'"' 1>/tmp/tmpYLjvQS 2>/tmp/tmp9hYBwy''] {'quiet': False}
2018-07-10 09:18:20,940 - call returned (0, '')
2018-07-10 09:18:20,940 - get_user_call_output returned (0, u'', u'')
2018-07-10 09:18:20,941 - No need to run prepare-war since marker file /usr/hdp/3.0.0.0-1625/oozie/.prepare_war_cmd already exists.
2018-07-10 09:18:20,941 - Creating /usr/hdp/3.0.0.0-1625/hadoop-yarn/lib/service-dep.tar.gz
2018-07-10 09:18:27,750 - HdfsResource['/user/oozie/share/'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'action': ['delete_on_execute'], 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory'}
2018-07-10 09:18:28,057 - Skipping 'HdfsResource['/user/oozie/share/']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,058 - HdfsResource['/user/oozie/share'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/usr/hdp/3.0.0.0-1625/oozie/share', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'user': 'hdfs', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'recursive_chmod': True, 'owner': 'oozie', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0755}
2018-07-10 09:18:28,059 - Skipping 'HdfsResource['/user/oozie/share']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
Copying tarballs...
2018-07-10 09:18:28,059 - HdfsResource['/hdp/apps/3.0.0.0-1625/mapreduce/mapreduce.tar.gz'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/usr/hdp/3.0.0.0-1625/hadoop/mapreduce.tar.gz', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'file', 'action': ['create_on_execute'], 'mode': 0444}
2018-07-10 09:18:28,060 - Skipping 'HdfsResource['/hdp/apps/3.0.0.0-1625/mapreduce/mapreduce.tar.gz']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,060 - HdfsResource['/hdp/apps/3.0.0.0-1625/tez/tez.tar.gz'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/usr/hdp/3.0.0.0-1625/tez/lib/tez.tar.gz', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'file', 'action': ['create_on_execute'], 'mode': 0444}
2018-07-10 09:18:28,061 - HdfsResource['/hdp/apps/3.0.0.0-1625/hive/hive.tar.gz'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/usr/hdp/3.0.0.0-1625/hive/hive.tar.gz', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'file', 'action': ['create_on_execute'], 'mode': 0444}
2018-07-10 09:18:28,062 - Could not find file: /usr/hdp/3.0.0.0-1625/tez_hive2/lib/tez.tar.gz
2018-07-10 09:18:28,062 - Could not find file: /usr/hdp/3.0.0.0-1625/pig/pig.tar.gz
2018-07-10 09:18:28,063 - HdfsResource['/hdp/apps/3.0.0.0-1625/mapreduce/hadoop-streaming.jar'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/usr/hdp/3.0.0.0-1625/hadoop-mapreduce/hadoop-streaming.jar', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'file', 'action': ['create_on_execute'], 'mode': 0444}
2018-07-10 09:18:28,063 - Skipping 'HdfsResource['/hdp/apps/3.0.0.0-1625/mapreduce/hadoop-streaming.jar']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,064 - Could not find file: /usr/hdp/3.0.0.0-1625/sqoop/sqoop.tar.gz
2018-07-10 09:18:28,064 - HdfsResource['/hdp/apps/3.0.0.0-1625/yarn/service-dep.tar.gz'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/usr/hdp/3.0.0.0-1625/hadoop-yarn/lib/service-dep.tar.gz', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'file', 'action': ['create_on_execute'], 'mode': 0444}
2018-07-10 09:18:28,065 - Skipping 'HdfsResource['/hdp/apps/3.0.0.0-1625/yarn/service-dep.tar.gz']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
Creating hdfs directories...
2018-07-10 09:18:28,065 - HdfsResource['/atshistory'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'change_permissions_for_parents': True, 'owner': 'yarn', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0755}
2018-07-10 09:18:28,066 - Skipping 'HdfsResource['/atshistory']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,066 - HdfsResource['/user/hcat'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hcat', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0755}
2018-07-10 09:18:28,067 - Skipping 'HdfsResource['/user/hcat']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,067 - HdfsResource['/hive/warehouse'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hive', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0777}
2018-07-10 09:18:28,068 - Skipping 'HdfsResource['/hive/warehouse']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,068 - HdfsResource['/user/hive'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hive', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0755}
2018-07-10 09:18:28,069 - Skipping 'HdfsResource['/user/hive']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,069 - HdfsResource['/tmp'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0777}
2018-07-10 09:18:28,070 - Skipping 'HdfsResource['/tmp']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,070 - HdfsResource['/user/ambari-qa'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'action': ['create_on_execute'], 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'mode': 0770}
2018-07-10 09:18:28,071 - Skipping 'HdfsResource['/user/ambari-qa']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,071 - HdfsResource['/user/oozie'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'oozie', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0775}
2018-07-10 09:18:28,072 - Skipping 'HdfsResource['/user/oozie']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,072 - HdfsResource['/app-logs'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'user': 'hdfs', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'mode': 0777, 'owner': 'yarn', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'recursive_chmod': True}
2018-07-10 09:18:28,073 - Skipping 'HdfsResource['/app-logs']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,073 - HdfsResource['/tmp/entity-file-history/active'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'yarn', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,074 - Skipping 'HdfsResource['/tmp/entity-file-history/active']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,074 - HdfsResource['/mapred'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'mapred', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,075 - Skipping 'HdfsResource['/mapred']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,075 - HdfsResource['/mapred/system'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,076 - Skipping 'HdfsResource['/mapred/system']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,076 - HdfsResource['/mr-history/done'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'change_permissions_for_parents': True, 'owner': 'mapred', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0777}
2018-07-10 09:18:28,077 - Skipping 'HdfsResource['/mr-history/done']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,077 - HdfsResource['/atshistory/done'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'yarn', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0700}
2018-07-10 09:18:28,078 - Skipping 'HdfsResource['/atshistory/done']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,078 - HdfsResource['/atshistory/active'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'yarn', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 01777}
2018-07-10 09:18:28,079 - Skipping 'HdfsResource['/atshistory/active']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,079 - HdfsResource['/ams/hbase'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'ams', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0775}
2018-07-10 09:18:28,080 - Skipping 'HdfsResource['/ams/hbase']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,080 - HdfsResource['/amshbase/staging'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'ams', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0711}
2018-07-10 09:18:28,081 - Skipping 'HdfsResource['/amshbase/staging']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,081 - HdfsResource['/user/ams/hbase'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'ams', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0775}
2018-07-10 09:18:28,082 - Skipping 'HdfsResource['/user/ams/hbase']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,082 - HdfsResource['/hdp'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0755}
2018-07-10 09:18:28,083 - Skipping 'HdfsResource['/hdp']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,083 - HdfsResource['/user/spark'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'spark', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0775}
2018-07-10 09:18:28,084 - Skipping 'HdfsResource['/user/spark']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,084 - HdfsResource['/user/livy'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'livy', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0775}
2018-07-10 09:18:28,085 - Skipping 'HdfsResource['/user/livy']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,085 - HdfsResource['/hdp/spark-events'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'spark', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0777}
2018-07-10 09:18:28,086 - Skipping 'HdfsResource['/hdp/spark-events']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,086 - HdfsResource['/hdp/spark2-events'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'spark', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0777}
2018-07-10 09:18:28,087 - Skipping 'HdfsResource['/hdp/spark2-events']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,087 - HdfsResource['/hbase'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hbase', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,088 - Skipping 'HdfsResource['/hbase']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,088 - HdfsResource['/apps/hbase/staging'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hbase', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0711}
2018-07-10 09:18:28,089 - Skipping 'HdfsResource['/apps/hbase/staging']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,089 - HdfsResource['/user/hbase'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hbase', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute'], 'mode': 0755}
2018-07-10 09:18:28,090 - Skipping 'HdfsResource['/user/hbase']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,090 - HdfsResource['/apps/zeppelin'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'zeppelin', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,091 - Skipping 'HdfsResource['/apps/zeppelin']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,091 - HdfsResource['/user/zeppelin'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'zeppelin', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,092 - Skipping 'HdfsResource['/user/zeppelin']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,092 - HdfsResource['/user/zeppelin/test'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'zeppelin', 'group': 'hadoop', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'directory', 'action': ['create_on_execute']}
2018-07-10 09:18:28,093 - Skipping 'HdfsResource['/user/zeppelin/test']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,093 - zeppelin-spark-dependencies not found at /usr/hdp/3.0.0.0-1625/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies*.jar.
2018-07-10 09:18:28,093 - HdfsResource['/user/oozie/share/lib/sqoop/sqljdbc41.jar'] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'source': '/var/lib/ambari-server/resources/sqljdbc41.jar', 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'owner': 'hdfs', 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'type': 'file', 'action': ['create_on_execute'], 'mode': 0644}
2018-07-10 09:18:28,094 - Skipping 'HdfsResource['/user/oozie/share/lib/sqoop/sqljdbc41.jar']' because it is in ignore file /var/lib/ambari-agent/data/.hdfs_resource_ignore.
2018-07-10 09:18:28,095 - File['/var/lib/ambari-agent/lib/fast-hdfs-resource.jar'] {'content': StaticFile('/var/lib/ambari-agent/cache/stack-hooks/before-START/files/fast-hdfs-resource.jar'), 'mode': 0644}
2018-07-10 09:18:28,306 - HdfsResource[None] {'security_enabled': False, 'hadoop_conf_dir': '/etc/hadoop/conf', 'keytab': None, 'dfs_type': 'WASB', 'default_fs': 'hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020', 'hdfs_resource_ignore_file': '/var/lib/ambari-agent/data/.hdfs_resource_ignore', 'hdfs_site': {'dfs.webhdfs.enabled': False}, 'kinit_path_local': None, 'principal_name': None, 'user': 'hdfs', 'action': ['execute'], 'hadoop_bin_dir': '/usr/hdp/3.0.0.0-1625/hadoop/bin', 'logoutput': True}
2018-07-10 09:18:28,307 - File['/var/lib/ambari-agent/tmp/hdfs_resources_1531214308.31.json'] {'content': ..., 'owner': 'hdfs'}
2018-07-10 09:18:28,308 - Writing File['/var/lib/ambari-agent/tmp/hdfs_resources_1531214308.31.json'] because it doesn't exist
2018-07-10 09:18:28,308 - Changing owner for /var/lib/ambari-agent/tmp/hdfs_resources_1531214308.31.json from 0 to hdfs
2018-07-10 09:18:28,308 - Execute['hadoop --config /etc/hadoop/conf jar /var/lib/ambari-agent/lib/fast-hdfs-resource.jar /var/lib/ambari-agent/tmp/hdfs_resources_1531214308.31.json'] {'logoutput': True, 'path': ['/usr/hdp/3.0.0.0-1625/hadoop/bin'], 'user': 'hdfs'}
Initializing filesystem uri: hdfs://gboros-preupload-1.c.pramod-thangali.internal:8020
Creating: Resource [source=/usr/hdp/3.0.0.0-1625/tez/lib/tez.tar.gz, target=/hdp/apps/3.0.0.0-1625/tez/tez.tar.gz, type=file, action=create, owner=hdfs, group=hadoop, mode=444, recursiveChown=false, recursiveChmod=false, changePermissionforParents=false, manageIfExists=true] in default filesystem
Creating: Resource [source=/usr/hdp/3.0.0.0-1625/hive/hive.tar.gz, target=/hdp/apps/3.0.0.0-1625/hive/hive.tar.gz, type=file, action=create, owner=hdfs, group=hadoop, mode=444, recursiveChown=false, recursiveChmod=false, changePermissionforParents=false, manageIfExists=true] in default filesystem
All resources created.
Completed tarball copy.
Executing stack-selector-tool for stack 3.0.0.0-1625 ...
2018-07-10 09:18:46,695 - Execute[('/usr/bin/hdp-select', 'set', 'all', '3.0.0.0-1625')] {'sudo': True}
Ambari preupload script completed.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.

sorry for the dup work, please review again @adoroszlai @oleewere @aonishuk 