### PR TITLE
AMBARI-24254. ADDENDUM: flag infra-solr instances to restart after upgrade

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1111,6 +1111,9 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
         hostComponentDesiredStateDAO.remove(hostComponentDesiredStateEntity);
         entityManager.detach(hostComponentDesiredStateEntity);
         hostComponentDesiredStateEntity.setServiceName(AMBARI_INFRA_NEW_NAME);
+        if ("INFRA_SOLR".equals(hostComponentDesiredStateEntity.getComponentName())) {
+          hostComponentDesiredStateEntity.setRestartRequired(true);
+        }
       }
 
       clusterServiceEntity.getServiceComponentDesiredStateEntities().clear();


### PR DESCRIPTION
## What changes were proposed in this pull request?
INFRA SOLR instances are not flagged with restart required after ambari server upgrade

## How was this patch tested?
manually, UTs are in progress

Please review @g-boros @fimugdha @adoroszlai @zeroflag 