### PR TITLE
[AMBARI-24275] - Unable to Restart Hive When Using An Ambari-Managed MySQL Server

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -954,7 +954,7 @@ class Script(object):
     else:
       # To remain backward compatible with older stacks, only pass upgrade_type if available.
       # TODO, remove checking the argspec for "upgrade_type" once all of the services support that optional param.
-      if True:
+      if "upgrade_type" in inspect.getargspec(self.stop).args:
         self.stop(env, upgrade_type=upgrade_type)
       else:
         if is_stack_upgrade:

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
@@ -42,12 +42,12 @@ class MysqlServer(Script):
     env.set_params(params)
     mysql_configure()
 
-  def start(self, env, rolling_restart=False):
+  def start(self, env):
     import params
     env.set_params(params)
     mysql_service(action='start')
 
-  def stop(self, env, rolling_restart=False):
+  def stop(self, env):
     import params
     env.set_params(params)
     mysql_service(action='stop')


### PR DESCRIPTION
## What changes were proposed in this pull request?

During restart of Hive, the following is observed:
```
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py", line 63, in <module>
    MysqlServer().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 958, in restart
    self.stop(env, upgrade_type=upgrade_type)
TypeError: stop() got an unexpected keyword argument 'upgrade_type'
```
## How was this patch tested?
```
----------------------------------------------------------------------
Total run:1200
Total errors:0
Total failures:0
OK
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:04 min
[INFO] Finished at: 2018-07-10T15:32:05-04:00
[INFO] Final Memory: 20M/619M
[INFO] ------------------------------------------------------------------------
```