### PR TITLE
AMBARI-24278. Infra Solr: /etc/security/limits.d folder does not exist on Suse

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/setup_infra_solr.py
@@ -91,13 +91,13 @@ def setup_infra_solr(name = None):
            owner=params.infra_solr_user,
            group=params.user_group,
            mode=0640)
-
-    File(os.path.join(params.limits_conf_dir, 'infra-solr.conf'),
-         owner='root',
-         group='root',
-         mode=0644,
-         content=Template("infra-solr.conf.j2")
-         )
+    if os.path.exists(params.limits_conf_dir):
+      File(os.path.join(params.limits_conf_dir, 'infra-solr.conf'),
+           owner='root',
+           group='root',
+           mode=0644,
+           content=Template("infra-solr.conf.j2")
+      )
 
   elif name == 'client':
     solr_cloud_util.setup_solr_client(params.config)


### PR DESCRIPTION
## What changes were proposed in this pull request?
check agains /etc/security/limits.d file before creating infra solr conf
## How was this patch tested?
UTs passed

please review @adoroszlai @zeroflag 