### PR TITLE
AMBARI-24281. Infra Solr migration: migrationConfigGenerator script failed with custom service user

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/src/main/python/migrationConfigGenerator.py
+++ b/ambari-infra/ambari-infra-solr-client/src/main/python/migrationConfigGenerator.py
@@ -305,7 +305,12 @@ def generate_ambari_solr_migration_ini_file(options, accessor, protocol):
 
   infra_solr_user = infra_solr_env_props['infra_solr_user'] if 'infra_solr_user' in infra_solr_env_props else 'infra-solr'
   infra_solr_kerberos_keytab = infra_solr_env_props['infra_solr_kerberos_keytab'] if 'infra_solr_kerberos_keytab' in infra_solr_env_props else '/etc/security/keytabs/ambari-infra-solr.service.keytab'
-  infra_solr_kerberos_principal = infra_solr_user + "/" + host
+  infra_solr_kerberos_principal_config = infra_solr_env_props['infra_solr_kerberos_principal'] if 'infra_solr_kerberos_principal' in infra_solr_env_props else 'infra-solr'
+  infra_solr_kerberos_principal = "infra-solr/" + host
+  if '/' in infra_solr_kerberos_principal_config:
+    infra_solr_kerberos_principal = infra_solr_kerberos_principal_config.replace('_HOST',host)
+  else:
+    infra_solr_kerberos_principal = infra_solr_kerberos_principal_config + "/" + host
   infra_solr_port = infra_solr_env_props['infra_solr_port'] if 'infra_solr_port' in infra_solr_env_props else '8886'
 
   config.add_section('local')

--- a/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
+++ b/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
@@ -157,6 +157,9 @@ def get_keytab_and_principal(config):
 
 def create_solr_api_request_command(request_url, config, output=None):
   user='infra-solr'
+  if config.has_section('infra_solr'):
+    if config.has_option('infra_solr', 'user'):
+      user=config.get('infra_solr', 'user')
   kerberos_enabled='false'
   if config.has_section('cluster') and config.has_option('cluster', 'kerberos_enabled'):
     kerberos_enabled=config.get('cluster', 'kerberos_enabled')


### PR DESCRIPTION
## What changes were proposed in this pull request?
migrationConfigGenerator and migrationHelper does not work anymore with custom infra solr user (after some refactor) fixing this.
## How was this patch tested?
manually

Please review @swagle 