### PR TITLE
[AMBARI-24283] DB consistency warning due to config group without service name

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -51,7 +51,6 @@ import org.apache.ambari.server.orm.dao.HostComponentDesiredStateDAO;
 import org.apache.ambari.server.orm.dao.HostComponentStateDAO;
 import org.apache.ambari.server.orm.dao.MetainfoDAO;
 import org.apache.ambari.server.orm.entities.ClusterConfigEntity;
-import org.apache.ambari.server.orm.entities.ConfigGroupConfigMappingEntity;
 import org.apache.ambari.server.orm.entities.HostComponentDesiredStateEntity;
 import org.apache.ambari.server.orm.entities.HostComponentStateEntity;
 import org.apache.ambari.server.orm.entities.MetainfoEntity;
@@ -60,8 +59,6 @@ import org.apache.ambari.server.state.ClientConfigFileDefinition;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ComponentInfo;
-import org.apache.ambari.server.state.Config;
-import org.apache.ambari.server.state.DesiredConfig;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.SecurityState;
 import org.apache.ambari.server.state.Service;
@@ -77,6 +74,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -1272,7 +1270,7 @@ public class DatabaseConsistencyCheckHelper {
 
         if (!MapUtils.isEmpty(configGroups)) {
           for (ConfigGroup configGroup : configGroups.values()) {
-            if (!services.containsKey(configGroup.getServiceName())) {
+            if (!Strings.isNullOrEmpty(configGroup.getServiceName()) && !services.containsKey(configGroup.getServiceName())) {
               configGroupMap.put(configGroup.getId(), configGroup);
               output.append("( ");
               output.append(configGroup.getName());


### PR DESCRIPTION
## What changes were proposed in this pull request?

DB consistency check was added in [AMBARI-21784](https://issues.apache.org/jira/browse/AMBARI-21784) for config groups that reference non-existent services.  It produces false positive warning for config groups that reference no service at all (`service_name` is optional).

```
WARN - You have config groups present in the database with no corresponding service found, [(ConfigGroup, Service) => ( asdf, null )]. Run --auto-fix-database to fix this automatically.
```

## How was this patch tested?

Tested DB check after Ambari upgrade from 2.5.2 to 2.6.2.

No warning with empty service name:

```
DB configs consistency check: no errors and warnings were found.
Ambari Server 'start' completed successfully.
```

Warning as expected with non-existent service name:

```
WARN - You have config groups present in the database with no corresponding service found, [(ConfigGroup, Service) => ( asdf, NO_SUCH_SERVICE )]. Run --auto-fix-database to fix this automatically.
```

Only config group for non-existent service is removed with `--auto-fix-database`:

```
INFO - Deleting config group invalid with id 4 for deleted service NO_SUCH_SERVICE
```