### PR TITLE
Ambari 24246. Ambari does not pick the existing hive database from the jdbc url set

### DIFF
--- a/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
@@ -169,7 +169,7 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
           allowConfigUpdate = false;
         }
       }
-      if (prevRecommeneded !== config.get('value')) {
+      if (prevRecommeneded !== value) {
         allowConfigUpdate = false;
       }
       if (allowConfigUpdate) {

--- a/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
@@ -159,7 +159,6 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
         value = Em.get(config, 'value'),
         prevRecommeneded = config.get('recommendedValue');
     Em.set(config, 'recommendedValue', recommendedValue);
-    console.log('test123', config, recommendedValue)
     if (this.allowUpdateProperty(parentProperties, name, fileName, group, value)) {
       var allowConfigUpdate = true;
       // workaround for capacity-scheduler

--- a/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
@@ -157,7 +157,7 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
         fileName = Em.get(config, 'filename'),
         group = Em.get(config, 'group.name'),
         value = Em.get(config, 'value'),
-        prevRecommeneded = config.get('recommendedValue');
+        prevRecommeneded = Em.get(config, 'recommendedValue');
     Em.set(config, 'recommendedValue', recommendedValue);
     if (this.allowUpdateProperty(parentProperties, name, fileName, group, value)) {
       var allowConfigUpdate = true;

--- a/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
@@ -55,7 +55,6 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
     App.assertFunction(updateCallback);
     App.assertFunction(removeCallback);
     App.assertFunction(updateBoundariesCallback);
-
     var propertiesToDelete = [];
     configs.forEach(function (config) {
       var name = Em.get(config, 'name'),
@@ -157,9 +156,10 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
     var name = Em.get(config, 'name'),
         fileName = Em.get(config, 'filename'),
         group = Em.get(config, 'group.name'),
-        value = Em.get(config, 'value');
-
+        value = Em.get(config, 'value'),
+        prevRecommeneded = config.get('recommendedValue');
     Em.set(config, 'recommendedValue', recommendedValue);
+    console.log('test123', config, recommendedValue)
     if (this.allowUpdateProperty(parentProperties, name, fileName, group, value)) {
       var allowConfigUpdate = true;
       // workaround for capacity-scheduler
@@ -168,6 +168,9 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
         if (App.config.configId(name, fileName) === cId) {
           allowConfigUpdate = false;
         }
+      }
+      if (prevRecommeneded !== config.get('value')) {
+        allowConfigUpdate = false;
       }
       if (allowConfigUpdate) {
         Em.setProperties(config, {

--- a/ambari-web/app/mixins/common/configs/config_recommendations.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendations.js
@@ -204,7 +204,12 @@ App.ConfigRecommendations = Em.Mixin.create({
    */
   cleanUpRecommendations: function () {
     var cleanDependentList = this.get('recommendations').filter(function (d) {
-      return !((Em.isNone(d.initialValue) && Em.isNone(d.recommendedValue)) || d.initialValue == d.recommendedValue);
+      var service = this.get('stepConfigs').findProperty('serviceName', d.serviceName);
+      var serviceConfigs = service && service.get('configs') || [];
+      var configId = App.config.configId(d.propertyName, d.propertyFileName);
+      var config = serviceConfigs.findProperty('id', configId);
+      return !((Em.isNone(d.initialValue) && Em.isNone(d.recommendedValue)) || d.initialValue == d.recommendedValue) &&
+        (!config || Em.get(config, 'isNotDefaultValue'));
     }, this);
     this.set('recommendations', cleanDependentList);
   },

--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -113,14 +113,6 @@ App.SupportsDependentConfigs = Ember.Mixin.create({
          }]);
       }
     }
-
-    //Fix required by QA (Ambari does not pick the existing hive database from the jdbc url set)
-    if (['oozie.service.JPAService.jdbc.url__oozie-site', 'javax.jdo.option.ConnectionURL__hive-site'].contains(config.get('id'))) {
-      controller.set('recommendationsInProgress', true);
-      controller.runServerSideValidation().done(function () {
-        controller.set('recommendationsInProgress', false)
-      });
-    }
     return $.Deferred().resolve().promise();
   },
 

--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -114,6 +114,13 @@ App.SupportsDependentConfigs = Ember.Mixin.create({
       }
     }
 
+    //Fix required by QA (Ambari does not pick the existing hive database from the jdbc url set)
+    if (['oozie.service.JPAService.jdbc.url__oozie-site', 'javax.jdo.option.ConnectionURL__hive-site'].contains(config.get('id'))) {
+      controller.set('recommendationsInProgress', true);
+      controller.runServerSideValidation().done(function () {
+        controller.set('recommendationsInProgress', false)
+      });
+    }
     return $.Deferred().resolve().promise();
   },
 

--- a/ambari-web/test/mixins/common/configs/config_recommendations_test.js
+++ b/ambari-web/test/mixins/common/configs/config_recommendations_test.js
@@ -359,31 +359,31 @@ describe('App.ConfigRecommendations', function() {
       {
         title: 'remove recommendations with same init and recommended values',
         recommendations: [{
-          initialValue: 'v1', recommendedValue: 'v1'
+          initialValue: 'v1', recommendedValue: 'v1', serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }, {
-            initialValue: 'v1', recommendedValue: 'v2'
+            initialValue: 'v1', recommendedValue: 'v2', serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }],
         cleanUpRecommendations: [{
-          initialValue: 'v1', recommendedValue: 'v2'
+          initialValue: 'v1', recommendedValue: 'v2', serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }]
       },
       {
         title: 'remove recommendations with null init and recommended values',
         recommendations: [{
-          initialValue: null, recommendedValue: null
+          initialValue: null, recommendedValue: null, serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }, {
-          recommendedValue: null
+          recommendedValue: null, serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }, {
           initialValue: null
         },{
-          initialValue: null, recommendedValue: 'v1'
+          initialValue: null, recommendedValue: 'v1', serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }, {
-          initialValue: 'v1', recommendedValue: null
+          initialValue: 'v1', recommendedValue: null, serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }],
         cleanUpRecommendations: [{
-          initialValue: null, recommendedValue: 'v1'
+          initialValue: null, recommendedValue: 'v1', serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }, {
-          initialValue: 'v1', recommendedValue: null
+          initialValue: 'v1', recommendedValue: null, serviceName: 'test', propertyName: 'test', propertyFileName: 'test'
         }
         ]
       }
@@ -393,7 +393,13 @@ describe('App.ConfigRecommendations', function() {
       describe(c.title, function() {
         beforeEach(function() {
           instanceObject.set('recommendations', c.recommendations);
-          instanceObject.cleanUpRecommendations()
+          instanceObject.set('stepConfigs', [Em.Object.create({serviceName: 'test',  configs: []})]);
+          sinon.stub(App.config, 'configId').returns('test__test');
+          instanceObject.cleanUpRecommendations();
+
+        });
+        afterEach(function(){
+          App.config.configId.restore();
         });
         it('do clean up', function() {
           expect(instanceObject.get('recommendations')).to.eql(c.cleanUpRecommendations);


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Ambari does not pick the existing hive database from the jdbc url set

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.