### PR TITLE
[AMBARI-14714] Fix test issues introduced during recent merge

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -82,9 +82,7 @@ import org.apache.ambari.server.actionmanager.StageHelper;
 import org.apache.ambari.server.agent.CommandRepository;
 import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.agent.rest.AgentResource;
-import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.agent.stomp.HostLevelParamsHolder;
-import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.agent.stomp.TopologyHolder;
 import org.apache.ambari.server.agent.stomp.dto.HostRepositories;
 import org.apache.ambari.server.agent.stomp.dto.TopologyCluster;
@@ -350,10 +348,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
   @Inject
   private Provider<TopologyHolder> m_topologyHolder;
-
-  private Provider<MetadataHolder> m_metadataHolder;
-
-  private Provider<AgentConfigsHolder> m_agentConfigsHolder;
 
   @Inject
   private Provider<HostLevelParamsHolder> m_hostLevelParamsHolder;
@@ -5542,9 +5536,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
           }
         }
       }
-
-      m_metadataHolder.get().updateData(metadataGenerator.getClusterMetadataOnConfigsUpdate(cluster));
-      m_agentConfigsHolder.get().updateData(cluster.getClusterId(), null);
 
       if (request.getVersion() != null) {
         if (!AuthorizationHelper.isAuthorized(ResourceType.CLUSTER, cluster.getResourceId(), EnumSet.of(RoleAuthorization.SERVICE_MODIFY_CONFIGS))) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ComponentResourceProvider.java
@@ -141,7 +141,7 @@ public class ComponentResourceProvider extends AbstractControllerResourceProvide
 
   private static Set<String> pkPropertyIds = Sets.newHashSet(
           CLUSTER_NAME,
-          SERVICE_GROUP_NAME_PROPERTY_ID,
+          SERVICE_GROUP_NAME,
           SERVICE_NAME,
           COMPONENT_ID,
           COMPONENT_NAME,

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
@@ -29,14 +29,9 @@ import javax.persistence.EntityManager;
 import org.apache.ambari.server.actionmanager.ActionDBAccessor;
 import org.apache.ambari.server.actionmanager.ActionDBAccessorImpl;
 import org.apache.ambari.server.actionmanager.ActionManager;
-import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
-import org.apache.ambari.server.actionmanager.HostRoleCommandFactoryImpl;
-import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
-import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariCustomCommandExecutionHelper;
-import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.PrereqCheckRequest;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
@@ -48,8 +43,6 @@ import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.dao.ArtifactDAO;
 import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
 import org.apache.ambari.server.orm.entities.UpgradePlanEntity;
-import org.apache.ambari.server.scheduler.ExecutionScheduler;
-import org.apache.ambari.server.scheduler.ExecutionSchedulerImpl;
 import org.apache.ambari.server.security.SecurityHelper;
 import org.apache.ambari.server.security.credential.Credential;
 import org.apache.ambari.server.security.encryption.CredentialStoreService;
@@ -61,22 +54,18 @@ import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.DesiredConfig;
 import org.apache.ambari.server.state.SecurityType;
-import org.apache.ambari.server.state.ServiceComponentHostFactory;
 import org.apache.ambari.server.state.UpgradeHelper;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.apache.ambari.server.state.stack.PrereqCheckStatus;
 import org.apache.ambari.server.state.stack.UpgradeCheckResult;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.testutils.PartialNiceMockBinder;
-import org.apache.ambari.server.topology.PersistedState;
-import org.apache.ambari.server.topology.PersistedStateImpl;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -215,37 +204,29 @@ public class KerberosAdminPersistedCredentialCheckTest extends EasyMockSupport {
 
       @Override
       protected void configure() {
-        PartialNiceMockBinder.newBuilder().addActionDBAccessorConfigsBindings().addFactoriesInstallBinding()
-            .build().configure(binder());
+        PartialNiceMockBinder.newBuilder(KerberosAdminPersistedCredentialCheckTest.this)
+          .addAmbariMetaInfoBinding()
+          .addActionDBAccessorConfigsBindings()
+          .addFactoriesInstallBinding()
+          .build().configure(binder());
 
-        bind(ExecutionScheduler.class).toInstance(createNiceMock(ExecutionSchedulerImpl.class));
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
         bind(DBAccessor.class).toInstance(createNiceMock(DBAccessor.class));
         bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));
         bind(HostRoleCommandDAO.class).toInstance(createNiceMock(HostRoleCommandDAO.class));
-        bind(HostRoleCommandFactory.class).toInstance(createNiceMock(HostRoleCommandFactoryImpl.class));
         bind(ActionDBAccessor.class).to(ActionDBAccessorImpl.class);
         bind(AbstractRootServiceResponseFactory.class).to(RootServiceResponseFactory.class);
-        bind(ServiceComponentHostFactory.class).toInstance(createNiceMock(ServiceComponentHostFactory.class));
-        bind(PasswordEncoder.class).toInstance(createNiceMock(PasswordEncoder.class));
         bind(HookService.class).to(UserHookService.class);
-        bind(PersistedState.class).to(PersistedStateImpl.class);
         bind(SecurityHelper.class).toInstance(createNiceMock(SecurityHelper.class));
         bind(AmbariCustomCommandExecutionHelper.class).toInstance(createNiceMock(AmbariCustomCommandExecutionHelper.class));
-        bind(AmbariManagementController.class).toInstance(createNiceMock(AmbariManagementController.class));
         bind(AmbariMetaInfo.class).toInstance(createNiceMock(AmbariMetaInfo.class));
         bind(ActionManager.class).toInstance(createNiceMock(ActionManager.class));
-        bind(StageFactory.class).toInstance(createNiceMock(StageFactory.class));
         bind(Clusters.class).toInstance(createNiceMock(Clusters.class));
         bind(ConfigHelper.class).toInstance(createNiceMock(ConfigHelper.class));
         bind(StackManagerFactory.class).toInstance(createNiceMock(StackManagerFactory.class));
-        bind(AuditLogger.class).toInstance(createNiceMock(AuditLogger.class));
         bind(ArtifactDAO.class).toInstance(createNiceMock(ArtifactDAO.class));
         bind(RoleCommandOrderProvider.class).to(CachedRoleCommandOrderProvider.class);
         bind(UpgradeHelper.class).toInstance(upgradeHelper);
-        bind(KerberosHelper.class).toInstance(createNiceMock(KerberosHelper.class));
-
-        bind(CredentialStoreService.class).toInstance(createMock(CredentialStoreService.class));
       }
     });
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerImplTest.java
@@ -329,18 +329,8 @@ public class AmbariManagementControllerImplTest {
     configRequests.add(configurationRequest);
 
     KerberosHelper kerberosHelper = createStrictMock(KerberosHelper.class);
-    MetadataHolder metadataHolder = createMock(MetadataHolder.class);
-    AgentConfigsHolder agentConfigsHolder = createMockBuilder(AgentConfigsHolder.class)
-        .addMockedMethod("updateData").createMock();
     // expectations
-    constructorInit(injector, controllerCapture, null, null,
-        kerberosHelper, metadataHolder, agentConfigsHolder
-    );
-
-    expect(metadataHolder.updateData(anyObject())).andReturn(true).anyTimes();
-
-    agentConfigsHolder.updateData(anyLong(), anyObject(List.class));
-    expectLastCall().anyTimes();
+    constructorInit(injector, controllerCapture, null, null, kerberosHelper);
 
     expect(clusterRequest.getClusterName()).andReturn("clusterNew").times(3);
     expect(clusterRequest.getClusterId()).andReturn(1L).times(4);
@@ -360,7 +350,7 @@ public class AmbariManagementControllerImplTest {
 
     // replay mocks
     replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, configurationRequest,
-            hostComponentStateDAO, serviceComponentDesiredStateDAO, metadataHolder, agentConfigsHolder);
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
 
     // test
@@ -370,8 +360,7 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
     verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, configurationRequest,
-            hostComponentStateDAO, serviceComponentDesiredStateDAO,
-        metadataHolder, agentConfigsHolder);
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -461,9 +450,7 @@ public class AmbariManagementControllerImplTest {
     AgentConfigsHolder agentConfigsHolder = createMockBuilder(AgentConfigsHolder.class)
         .addMockedMethod("updateData").createMock();
     // expectations
-    constructorInit(injector, controllerCapture, null, null,
-        kerberosHelper, metadataHolder, agentConfigsHolder
-    );
+    constructorInit(injector, controllerCapture, null, null, kerberosHelper);
 
     expect(metadataHolder.updateData(anyObject())).andReturn(true).anyTimes();
 
@@ -511,18 +498,8 @@ public class AmbariManagementControllerImplTest {
     Set<ClusterRequest> setRequests = Collections.singleton(clusterRequest);
 
     KerberosHelper kerberosHelper = createStrictMock(KerberosHelper.class);
-    MetadataHolder metadataHolder = createMock(MetadataHolder.class);
-    AgentConfigsHolder agentConfigsHolder = createMockBuilder(AgentConfigsHolder.class)
-        .addMockedMethod("updateData").createMock();
     // expectations
-    constructorInit(injector, controllerCapture, null, null,
-        kerberosHelper, metadataHolder, agentConfigsHolder
-    );
-
-    expect(metadataHolder.updateData(anyObject())).andReturn(true).anyTimes();
-
-    agentConfigsHolder.updateData(anyLong(), anyObject(List.class));
-    expectLastCall().anyTimes();
+    constructorInit(injector, controllerCapture, null, null, kerberosHelper);
 
     expect(clusterRequest.getClusterId()).andReturn(1L).times(4);
     expect(clusterRequest.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
@@ -543,8 +520,7 @@ public class AmbariManagementControllerImplTest {
 
     // replay mocks
     replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
-            hostComponentStateDAO, serviceComponentDesiredStateDAO,
-        metadataHolder, agentConfigsHolder);
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, metadataGenerator, injector);
@@ -553,8 +529,7 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
     verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
-            hostComponentStateDAO, serviceComponentDesiredStateDAO,
-        metadataHolder, agentConfigsHolder);
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
   /**
    * Ensure that when the cluster security type updated from NONE to KERBEROS, KerberosHandler.toggleKerberos
@@ -577,9 +552,7 @@ public class AmbariManagementControllerImplTest {
     AgentConfigsHolder agentConfigsHolder = createMockBuilder(AgentConfigsHolder.class)
         .addMockedMethod("updateData").createMock();
     // expectations
-    constructorInit(injector, controllerCapture, null, null,
-        kerberosHelper, metadataHolder, agentConfigsHolder
-    );
+    constructorInit(injector, controllerCapture, null, null, kerberosHelper);
 
     expect(metadataHolder.updateData(anyObject())).andReturn(true).anyTimes();
 
@@ -672,18 +645,8 @@ public class AmbariManagementControllerImplTest {
     Capture<Boolean> manageIdentitiesCapture = EasyMock.newCapture();
 
     KerberosHelper kerberosHelper = createStrictMock(KerberosHelper.class);
-    MetadataHolder metadataHolder = createMock(MetadataHolder.class);
-    AgentConfigsHolder agentConfigsHolder = createMockBuilder(AgentConfigsHolder.class)
-        .addMockedMethod("updateData").createMock();
     // expectations
-    constructorInit(injector, controllerCapture, null, null,
-        kerberosHelper, metadataHolder, agentConfigsHolder
-    );
-
-    expect(metadataHolder.updateData(anyObject())).andReturn(true).anyTimes();
-
-    agentConfigsHolder.updateData(anyLong(), anyObject(List.class));
-    expectLastCall().anyTimes();
+    constructorInit(injector, controllerCapture, null, null, kerberosHelper);
 
     expect(clusterRequest.getClusterId()).andReturn(1L).times(4);
     expect(clusterRequest.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
@@ -708,8 +671,7 @@ public class AmbariManagementControllerImplTest {
         .once();
 
     // replay mocks
-    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
-        metadataHolder, agentConfigsHolder);
+    replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, metadataGenerator, injector);
@@ -718,8 +680,7 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
     assertEquals(manageIdentities, manageIdentitiesCapture.getValue());
-    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
-        metadataHolder, agentConfigsHolder);
+    verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper);
   }
 
   /**
@@ -739,18 +700,8 @@ public class AmbariManagementControllerImplTest {
     Set<ClusterRequest> setRequests = Collections.singleton(clusterRequest);
 
     KerberosHelper kerberosHelper = createStrictMock(KerberosHelper.class);
-    MetadataHolder metadataHolder = createMock(MetadataHolder.class);
-    AgentConfigsHolder agentConfigsHolder = createMockBuilder(AgentConfigsHolder.class)
-        .addMockedMethod("updateData").createMock();
     // expectations
-    constructorInit(injector, controllerCapture, null, null,
-        kerberosHelper, metadataHolder, agentConfigsHolder
-    );
-
-    expect(metadataHolder.updateData(anyObject())).andReturn(true);
-
-    agentConfigsHolder.updateData(anyLong(), anyObject(List.class));
-    expectLastCall();
+    constructorInit(injector, controllerCapture, null, null, kerberosHelper);
 
     expect(clusterRequest.getClusterId()).andReturn(1L).times(4);
     expect(clusterRequest.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
@@ -785,8 +736,7 @@ public class AmbariManagementControllerImplTest {
 
     // replay mocks
     replay(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
-            hostComponentStateDAO, serviceComponentDesiredStateDAO,
-      agentConfigsHolder, metadataHolder);
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
 
     // test
     AmbariManagementController controller = new AmbariManagementControllerImpl(actionManager, clusters, metadataGenerator, injector);
@@ -801,8 +751,7 @@ public class AmbariManagementControllerImplTest {
     // assert and verify
     assertSame(controller, controllerCapture.getValue());
     verify(actionManager, cluster, clusters, injector, clusterRequest, sessionManager, kerberosHelper,
-            hostComponentStateDAO, serviceComponentDesiredStateDAO,
-      agentConfigsHolder, metadataHolder);
+            hostComponentStateDAO, serviceComponentDesiredStateDAO);
   }
 
   /**
@@ -877,9 +826,7 @@ public class AmbariManagementControllerImplTest {
     setRequests.add(request1);
 
     // expectations
-    constructorInit(injector, controllerCapture, null, maintHelper,
-        createNiceMock(KerberosHelper.class), null, null
-    );
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
     expect(hostComponentStateDAO.findById(1L)).andReturn(hostComponentStateEntity).anyTimes();
@@ -963,7 +910,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class), null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
@@ -1043,8 +990,7 @@ public class AmbariManagementControllerImplTest {
     setRequests.add(request1);
 
     // expectations
-    constructorInit(injector, controllerCapture, null, maintHelper,
-        createNiceMock(KerberosHelper.class), null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     expect(maintHelper.getEffectiveState(
         anyObject(ServiceComponentHost.class),
@@ -1125,8 +1071,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     expect(maintHelper.getEffectiveState(
         anyObject(ServiceComponentHost.class),
@@ -1221,8 +1166,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, stateHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, stateHelper, createNiceMock(KerberosHelper.class));
 
 
     // getHostComponent
@@ -1357,8 +1301,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster).times(3);
@@ -1494,8 +1437,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster).times(3);
@@ -1639,8 +1581,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster).times(3);
@@ -1761,8 +1702,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
     expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
@@ -1817,8 +1757,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andThrow(new ClusterNotFoundException("cluster1"));
@@ -1880,8 +1819,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
@@ -1969,8 +1907,7 @@ public class AmbariManagementControllerImplTest {
 
     // expectations
     // constructor init
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     // getHostComponent
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
@@ -2064,8 +2001,7 @@ public class AmbariManagementControllerImplTest {
     expect(serviceInfo.getOsSpecifics()).andReturn(osSpecificsService);
     expect(stackInfo.getOsSpecifics()).andReturn(osSpecificsStack);
 
-    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class),
-        null, null);
+    constructorInit(injector, controllerCapture, null, maintHelper, createNiceMock(KerberosHelper.class));
 
     expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
     expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();
@@ -2285,15 +2221,12 @@ public class AmbariManagementControllerImplTest {
   }
 
   public static void constructorInit(Injector injector, Capture<AmbariManagementController> controllerCapture, Gson gson,
-    MaintenanceStateHelper maintenanceStateHelper, KerberosHelper kerberosHelper,
-    MetadataHolder metadataHolder, AgentConfigsHolder agentConfigsHolder
+    MaintenanceStateHelper maintenanceStateHelper, KerberosHelper kerberosHelper
   ) {
     injector.injectMembers(capture(controllerCapture));
     expect(injector.getInstance(Gson.class)).andReturn(gson);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(maintenanceStateHelper);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(kerberosHelper);
-    expect(injector.getProvider(MetadataHolder.class)).andReturn(() -> metadataHolder);
-    expect(injector.getProvider(AgentConfigsHolder.class)).andReturn(() -> agentConfigsHolder);
   }
 
   public static void constructorInit(Injector injector, Capture<AmbariManagementController> controllerCapture,
@@ -2302,7 +2235,5 @@ public class AmbariManagementControllerImplTest {
     expect(injector.getInstance(Gson.class)).andReturn(null);
     expect(injector.getInstance(MaintenanceStateHelper.class)).andReturn(null);
     expect(injector.getInstance(KerberosHelper.class)).andReturn(kerberosHelper);
-    expect(injector.getProvider(MetadataHolder.class)).andReturn(() -> null);
-    expect(injector.getProvider(AgentConfigsHolder.class)).andReturn(() -> null);
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -8565,7 +8565,8 @@ public class AmbariManagementControllerTest {
     // expectations
     // constructor init
     AmbariManagementControllerImplTest.constructorInit(injector, controllerCapture, null, maintHelper,
-        createStrictMock(KerberosHelper.class), null, null);
+        createStrictMock(KerberosHelper.class)
+    );
 
     // getServices
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
@@ -8615,7 +8616,8 @@ public class AmbariManagementControllerTest {
     // expectations
     // constructor init
     AmbariManagementControllerImplTest.constructorInit(injector, controllerCapture, null, maintHelper,
-        createStrictMock(KerberosHelper.class), null, null);
+        createStrictMock(KerberosHelper.class)
+    );
 
     // getServices
     expect(clusters.getCluster("cluster1")).andReturn(cluster);
@@ -8679,7 +8681,8 @@ public class AmbariManagementControllerTest {
     // expectations
     // constructor init
     AmbariManagementControllerImplTest.constructorInit(injector, controllerCapture, null, maintHelper,
-        createStrictMock(KerberosHelper.class), null, null);
+        createStrictMock(KerberosHelper.class)
+    );
 
     // getServices
     expect(clusters.getCluster("cluster1")).andReturn(cluster).times(4);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ComponentResourceProviderTest.java
@@ -988,7 +988,8 @@ public class ComponentResourceProviderTest {
     // expectations
     // constructor init
     AmbariManagementControllerImplTest.constructorInit(injector, controllerCapture, null, maintHelper,
-        createNiceMock(KerberosHelper.class), null, null);
+        createNiceMock(KerberosHelper.class)
+    );
 
     expect(injector.getInstance(HostComponentStateDAO.class)).andReturn(hostComponentStateDAO).anyTimes();
     expect(injector.getInstance(ServiceComponentDesiredStateDAO.class)).andReturn(serviceComponentDesiredStateDAO).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
@@ -63,7 +63,6 @@ import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.HostRequest;
 import org.apache.ambari.server.controller.HostResponse;
-import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.MaintenanceStateHelper;
 import org.apache.ambari.server.controller.ResourceProviderFactory;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
@@ -1414,7 +1413,6 @@ public class HostResourceProviderTest extends EasyMockSupport {
         bind(AmbariMetaInfo.class).toInstance(createNiceMock(AmbariMetaInfo.class));
         bind(Gson.class).toInstance(new Gson());
         bind(MaintenanceStateHelper.class).toInstance(createNiceMock(MaintenanceStateHelper.class));
-        bind(KerberosHelper.class).toInstance(createNiceMock(KerberosHelper.class));
         bind(HostRoleCommandFactory.class).to(HostRoleCommandFactoryImpl.class);
         bind(RoleCommandOrderProvider.class).to(CachedRoleCommandOrderProvider.class);
         bind(HookService.class).to(UserHookService.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
@@ -39,52 +39,30 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.persistence.EntityManager;
 
-import org.apache.ambari.server.actionmanager.ActionDBAccessor;
 import org.apache.ambari.server.actionmanager.ActionManager;
-import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
-import org.apache.ambari.server.actionmanager.RequestFactory;
-import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
-import org.apache.ambari.server.audit.AuditLogger;
-import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
-import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.KerberosHelper;
-import org.apache.ambari.server.controller.KerberosHelperImpl;
 import org.apache.ambari.server.controller.UpdateConfigurationPolicy;
-import org.apache.ambari.server.hooks.HookContextFactory;
-import org.apache.ambari.server.hooks.HookService;
-import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
 import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
-import org.apache.ambari.server.scheduler.ExecutionScheduler;
-import org.apache.ambari.server.security.encryption.CredentialStoreService;
 import org.apache.ambari.server.stack.StackManagerFactory;
-import org.apache.ambari.server.stageplanner.RoleGraphFactory;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
-import org.apache.ambari.server.state.ConfigFactory;
 import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.Service;
-import org.apache.ambari.server.state.ServiceComponentFactory;
 import org.apache.ambari.server.state.ServiceComponentHost;
-import org.apache.ambari.server.state.ServiceComponentHostFactory;
-import org.apache.ambari.server.state.configgroup.ConfigGroupFactory;
 import org.apache.ambari.server.state.kerberos.KerberosComponentDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosDescriptorFactory;
 import org.apache.ambari.server.state.kerberos.KerberosServiceDescriptor;
-import org.apache.ambari.server.state.scheduler.RequestExecutionFactory;
 import org.apache.ambari.server.state.stack.OsFamily;
-import org.apache.ambari.server.topology.PersistedState;
-import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
+import org.apache.ambari.server.testutils.PartialNiceMockBinder;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -192,37 +170,20 @@ public class AbstractPrepareKerberosServerActionTest extends EasyMockSupport {
     injector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
+        PartialNiceMockBinder.newBuilder(AbstractPrepareKerberosServerActionTest.this)
+          .addAmbariMetaInfoBinding()
+          .addActionDBAccessorConfigsBindings()
+          .build().configure(binder());
+
         bind(AmbariMetaInfo.class).toInstance(createNiceMock(AmbariMetaInfo.class));
-        bind(KerberosHelper.class).to(KerberosHelperImpl.class);
         bind(KerberosIdentityDataFileWriterFactory.class).toInstance(createNiceMock(KerberosIdentityDataFileWriterFactory.class));
         bind(KerberosConfigDataFileWriterFactory.class).toInstance(createNiceMock(KerberosConfigDataFileWriterFactory.class));
         bind(Clusters.class).toInstance(createNiceMock(Clusters.class));
-        bind(AuditLogger.class).toInstance(createNiceMock(AuditLogger.class));
         bind(ConfigHelper.class).toInstance(createNiceMock(ConfigHelper.class));
         bind(HostRoleCommandDAO.class).toInstance(createNiceMock(HostRoleCommandDAO.class));
         bind(ActionManager.class).toInstance(createNiceMock(ActionManager.class));
         bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));
-        bind(ExecutionScheduler.class).toInstance(createNiceMock(ExecutionScheduler.class));
-        bind(AmbariManagementController.class).toInstance(createNiceMock(AmbariManagementController.class));
-        bind(ActionDBAccessor.class).toInstance(createNiceMock(ActionDBAccessor.class));
         bind(StackManagerFactory.class).toInstance(createNiceMock(StackManagerFactory.class));
-        bind(ConfigFactory.class).toInstance(createNiceMock(ConfigFactory.class));
-        bind(ConfigGroupFactory.class).toInstance(createNiceMock(ConfigGroupFactory.class));
-        bind(CredentialStoreService.class).toInstance(createNiceMock(CredentialStoreService.class));
-        bind(RequestExecutionFactory.class).toInstance(createNiceMock(RequestExecutionFactory.class));
-        bind(RequestFactory.class).toInstance(createNiceMock(RequestFactory.class));
-        bind(RoleCommandOrderProvider.class).toInstance(createNiceMock(RoleCommandOrderProvider.class));
-        bind(RoleGraphFactory.class).toInstance(createNiceMock(RoleGraphFactory.class));
-        bind(AbstractRootServiceResponseFactory.class).toInstance(createNiceMock(AbstractRootServiceResponseFactory.class));
-        bind(ServiceComponentFactory.class).toInstance(createNiceMock(ServiceComponentFactory.class));
-        bind(ServiceComponentHostFactory.class).toInstance(createNiceMock(ServiceComponentHostFactory.class));
-        bind(StageFactory.class).toInstance(createNiceMock(StageFactory.class));
-        bind(HostRoleCommandFactory.class).toInstance(createNiceMock(HostRoleCommandFactory.class));
-        bind(HookContextFactory.class).toInstance(createNiceMock(HookContextFactory.class));
-        bind(HookService.class).toInstance(createNiceMock(HookService.class));
-        bind(PasswordEncoder.class).toInstance(createNiceMock(PasswordEncoder.class));
-        bind(PersistedState.class).toInstance(createNiceMock(PersistedState.class));
-        bind(ConfigureClusterTaskFactory.class).toInstance(createNiceMock(ConfigureClusterTaskFactory.class));
         Provider<EntityManager> entityManagerProvider = createNiceMock(Provider.class);
         bind(EntityManager.class).toProvider(entityManagerProvider);
       }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
@@ -65,8 +65,6 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariCustomCommandExecutionHelper;
 import org.apache.ambari.server.controller.AmbariManagementController;
-import org.apache.ambari.server.controller.KerberosHelper;
-import org.apache.ambari.server.controller.KerberosHelperImpl;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
 import org.apache.ambari.server.events.AmbariEvent;
 import org.apache.ambari.server.hooks.AmbariEventFactory;
@@ -616,7 +614,6 @@ public class PreconfigureKerberosActionTest extends EasyMockSupport {
         bind(HookService.class).to(UserHookService.class);
         bind(AbstractRootServiceResponseFactory.class).to(RootServiceResponseFactory.class);
 
-        bind(KerberosHelper.class).to(KerberosHelperImpl.class);
         bind(Clusters.class).toInstance(createMock(Clusters.class));
         bind(StackAdvisorHelper.class).toInstance(createMock(StackAdvisorHelper.class));
         bind(ConfigHelper.class).toInstance(createMock(ConfigHelper.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -193,7 +193,6 @@ import org.apache.ambari.server.controller.KerberosHelperImpl;
 import org.apache.ambari.server.controller.MaintenanceStateHelper;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
 import org.apache.ambari.server.controller.ServiceConfigVersionResponse;
-import org.apache.ambari.server.events.MetadataUpdateEvent;
 import org.apache.ambari.server.hooks.HookService;
 import org.apache.ambari.server.hooks.users.UserHookService;
 import org.apache.ambari.server.metadata.CachedRoleCommandOrderProvider;
@@ -1261,16 +1260,13 @@ public class UpgradeCatalog270Test {
         .createMock();
     expect(controller.getClusters()).andReturn(clusters).anyTimes();
     expect(controller.createConfig(eq(cluster1), eq(stackId), eq("kerberos-env"), capture(capturedProperties), anyString(), anyObject(Map.class), isNull())).andReturn(newConfig).once();
-    final ClusterMetadataGenerator metadataGenerator = createMock(ClusterMetadataGenerator.class);
-    expect(metadataGenerator.getClusterMetadataOnConfigsUpdate(eq(cluster1))).andReturn(createNiceMock(MetadataUpdateEvent.class)).once();
-
 
 
     Injector injector = createNiceMock(Injector.class);
     ConfigHelper configHelper = createStrictMock(ConfigHelper.class);
     expect(injector.getInstance(AmbariManagementController.class)).andReturn(controller).anyTimes();
     expect(injector.getInstance(MetadataHolder.class)).andReturn(createNiceMock(MetadataHolder.class)).anyTimes();
-    expect(injector.getInstance(ClusterMetadataGenerator.class)).andReturn(metadataGenerator).anyTimes();
+    expect(injector.getInstance(ClusterMetadataGenerator.class)).andReturn(createMock(ClusterMetadataGenerator.class)).anyTimes();
     expect(injector.getInstance(AgentConfigsHolder.class)).andReturn(createNiceMock(AgentConfigsHolder.class)).anyTimes();
     expect(injector.getInstance(AmbariServer.class)).andReturn(createNiceMock(AmbariServer.class)).anyTimes();
     expect(injector.getInstance(ConfigHelper.class)).andReturn(configHelper).anyTimes();
@@ -1281,7 +1277,7 @@ public class UpgradeCatalog270Test {
     configHelper.updateAgentConfigs(anyObject(Set.class));
     expectLastCall();
 
-    replay(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, kerberosHelperMock, metadataGenerator, configHelper);
+    replay(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, kerberosHelperMock, configHelper);
 
     Field field = AbstractUpgradeCatalog.class.getDeclaredField("configuration");
 
@@ -1297,7 +1293,7 @@ public class UpgradeCatalog270Test {
     field.set(upgradeCatalog270, createNiceMock(Configuration.class));
     upgradeCatalog270.updateKerberosConfigurations();
 
-    verify(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, upgradeCatalog270, metadataGenerator, configHelper);
+    verify(controller, clusters, cluster1, cluster2, configWithGroup, configWithoutGroup, newConfig, response, injector, upgradeCatalog270, configHelper);
 
 
     Assert.assertEquals(1, capturedProperties.getValues().size());
@@ -1514,7 +1510,7 @@ public class UpgradeCatalog270Test {
       .addMockedMethod("createConfiguration")
       .addMockedMethod("getClusters", new Class[] { })
       .addMockedMethod("createConfig")
-      .withConstructor(createNiceMock(ActionManager.class), clusters, injector)
+      .withConstructor(createNiceMock(ActionManager.class), clusters, createNiceMock(ClusterMetadataGenerator.class), injector)
       .createNiceMock();
 
     Injector injector2 = easyMockSupport.createNiceMock(Injector.class);
@@ -1576,7 +1572,7 @@ public class UpgradeCatalog270Test {
       .addMockedMethod("createConfiguration")
       .addMockedMethod("getClusters", new Class[] { })
       .addMockedMethod("createConfig")
-      .withConstructor(createNiceMock(ActionManager.class), clusters, injector)
+      .withConstructor(createNiceMock(ActionManager.class), clusters, createNiceMock(ClusterMetadataGenerator.class), injector)
       .createNiceMock();
 
     Injector injector2 = easyMockSupport.createNiceMock(Injector.class);
@@ -1633,7 +1629,7 @@ public class UpgradeCatalog270Test {
     AmbariManagementControllerImpl controller = createMockBuilder(AmbariManagementControllerImpl.class)
       .addMockedMethod("getClusters", new Class[] { })
       .addMockedMethod("createConfig")
-      .withConstructor(createNiceMock(ActionManager.class), clusters, injector)
+      .withConstructor(createNiceMock(ActionManager.class), clusters, createNiceMock(ClusterMetadataGenerator.class), injector)
       .createNiceMock();
 
     Injector injector2 = easyMockSupport.createNiceMock(Injector.class);
@@ -1691,7 +1687,7 @@ public class UpgradeCatalog270Test {
     AmbariManagementControllerImpl controller = createMockBuilder(AmbariManagementControllerImpl.class)
       .addMockedMethod("getClusters", new Class[] { })
       .addMockedMethod("createConfig")
-      .withConstructor(createNiceMock(ActionManager.class), clusters, injector)
+      .withConstructor(createNiceMock(ActionManager.class), clusters, createNiceMock(ClusterMetadataGenerator.class), injector)
       .createNiceMock();
 
     Injector injector2 = easyMockSupport.createNiceMock(Injector.class);
@@ -1744,7 +1740,7 @@ public class UpgradeCatalog270Test {
     AmbariManagementControllerImpl controller = createMockBuilder(AmbariManagementControllerImpl.class)
         .addMockedMethod("getClusters", new Class[] { })
         .addMockedMethod("createConfig")
-        .withConstructor(createNiceMock(ActionManager.class), clusters, injector)
+        .withConstructor(createNiceMock(ActionManager.class), clusters, createNiceMock(ClusterMetadataGenerator.class), injector)
         .createNiceMock();
 
     Injector injector2 = easyMockSupport.createNiceMock(Injector.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed several test issues after the latest merges from `trunk`.  Notable changes:

 * Need to use "qualified" property name as key (for `service_group_name`) in `ComponentResourceProvider`
 * `m_metadataHolder` and `m_agentConfigsHolder` are no longer present in `AmbariManagementControllerImpl`, removed leftover usage
 * restore deleted test case `testDeleteResources_clusterAlreadyProvisioned` in `BlueprintResourceProviderTest`

## How was this patch tested?

Unit tests, pass rate improved.