### PR TITLE
[AMBARI-24183] Log Feeder: read and ship docker container logs.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputFileDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-zookeeper/src/main/java/org/apache/ambari/logsearch/config/zookeeper/model/inputconfig/impl/InputFileDescriptorImpl.java
@@ -70,6 +70,17 @@ public class InputFileDescriptorImpl extends InputFileBaseDescriptorImpl impleme
   @SerializedName("max_age_min")
   private Integer maxAgeMin;
 
+  @ShipperConfigElementDescription(
+    path = "/input/[]/docker",
+    type = "boolean",
+    description = "Input comes from a docker container.",
+    examples = {"true", "false"},
+    defaultValue = "false"
+  )
+  @Expose
+  @SerializedName("docker")
+  private Boolean dockerEnabled;
+
   @Override
   public Integer getDetachIntervalMin() {
     return this.detachIntervalMin;
@@ -90,6 +101,11 @@ public class InputFileDescriptorImpl extends InputFileBaseDescriptorImpl impleme
     return this.maxAgeMin;
   }
 
+  @Override
+  public Boolean getDockerEnabled() {
+    return dockerEnabled;
+  }
+
   public void setDetachIntervalMin(Integer detachIntervalMin) {
     this.detachIntervalMin = detachIntervalMin;
   }
@@ -104,5 +120,9 @@ public class InputFileDescriptorImpl extends InputFileBaseDescriptorImpl impleme
 
   public void setMaxAgeMin(Integer maxAgeMin) {
     this.maxAgeMin = maxAgeMin;
+  }
+
+  public void setDockerEnabled(Boolean dockerEnabled) {
+    this.dockerEnabled = dockerEnabled;
   }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>ambari-logsearch</artifactId>
+    <groupId>org.apache.ambari</groupId>
+    <version>2.0.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <artifactId>ambari-logsearch-logfeeder-container-registry</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.9.4</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/log4j.properties</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/ContainerMetadata.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/ContainerMetadata.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,17 +16,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.ambari.logfeeder;
 
-package org.apache.ambari.logsearch.config.api.model.inputconfig;
+/**
+ * Holds container related metadata
+ **/
+public interface ContainerMetadata {
 
-public interface InputFileDescriptor extends InputFileBaseDescriptor {
-  Integer getDetachIntervalMin();
+  /**
+   * Id of the container, used for getting the right log path
+   * @return container id
+   */
+  String getId();
 
-  Integer getDetachTimeMin();
+  /**
+   * Name of the container
+   * @return container name
+   */
+  String getName();
 
-  Integer getPathUpdateIntervalMin();
+  /**
+   * Hostname of the container, can be container host itself or the actual hostname
+   * @return container host name
+   */
+  String getHostName();
 
-  Integer getMaxAgeMin();
+  /**
+   * Log label
+   * @return log type label
+   */
+  String getLogTypeLabel();
 
-  Boolean getDockerEnabled();
+  /**
+   * Log path of the container (should be json file)
+   * @return log path
+   */
+  String getLogPath();
+
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/ContainerRegistry.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/ContainerRegistry.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,17 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.ambari.logfeeder;
 
-package org.apache.ambari.logsearch.config.api.model.inputconfig;
+import java.util.Map;
 
-public interface InputFileDescriptor extends InputFileBaseDescriptor {
-  Integer getDetachIntervalMin();
+/**
+ * Responsible of register or drop new / existing containers.
+ * @param <METADATA_TYPE> type of metadata - could be docker or other container implementation
+ */
+public interface ContainerRegistry<METADATA_TYPE extends ContainerMetadata> {
 
-  Integer getDetachTimeMin();
+  /**
+   * Register process of running containers
+   */
+  void register();
 
-  Integer getPathUpdateIntervalMin();
+  /**
+   * Holds container metadata per log component type and container id.
+   * @return container metadata
+   */
+  Map<String, Map<String, METADATA_TYPE>> getContainerMetadataMap();
 
-  Integer getMaxAgeMin();
-
-  Boolean getDockerEnabled();
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/DockerContainerRegistry.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/DockerContainerRegistry.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.docker;
+
+import org.apache.ambari.logfeeder.ContainerRegistry;
+import org.apache.ambari.logfeeder.docker.command.DockerInspectContainerCommand;
+import org.apache.ambari.logfeeder.docker.command.DockerListContainerCommand;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Register docker metadata from docker containers on the host (with listing containers and inspecting them)
+ */
+public final class DockerContainerRegistry implements ContainerRegistry<DockerMetadata> {
+
+  private static final String LOGFEEDER_CONTAINER_REGISTRY_DOCKER_INTERVAL = "logfeeder.container.registry.docker.interval";
+  private static final Logger logger = LoggerFactory.getLogger(DockerContainerRegistry.class);
+
+  private static DockerContainerRegistry INSTANCE = null;
+  private final Properties configs;
+  private Map<String, Map<String, DockerMetadata>> dockerMetadataMap = new ConcurrentHashMap<>();
+  private int waitIntervalMin = 5;
+
+  private DockerContainerRegistry(Properties configs) {
+    this.configs = configs;
+    init(configs);
+  }
+
+  @Override
+  public synchronized void register() {
+    Map<String, Map<String, DockerMetadata>> actualDockerMetadataMap = renewMetadata();
+    if (!actualDockerMetadataMap.isEmpty()) {
+      dockerMetadataMap.putAll(actualDockerMetadataMap);
+      dockerMetadataMap = dockerMetadataMap
+        .entrySet()
+        .stream()
+        .filter(e -> actualDockerMetadataMap.keySet().contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      for (Map.Entry<String, Map<String, DockerMetadata>> entry : dockerMetadataMap.entrySet()) {
+        for (Map.Entry<String, DockerMetadata> metadataEntry : entry.getValue().entrySet()) {
+          logger.debug("Found container metadata: {}", entry.getValue().toString());
+        }
+      }
+    }
+  }
+
+  private Map<String, Map<String, DockerMetadata>> renewMetadata() {
+    final Map<String, Map<String, DockerMetadata>> actualDockerMetadataMap = new HashMap<>();
+    final List<String> containerIds = new DockerListContainerCommand().execute(null);
+    final Map<String, String> params = new HashMap<>();
+
+    params.put("containerIds", StringUtils.join(containerIds, ","));
+    List<Map<String, Object>> containerDataList = new DockerInspectContainerCommand().execute(params);
+
+    for (Map<String, Object> containerDataMap : containerDataList) {
+      String id = containerDataMap.get("Id").toString();
+      String name = containerDataMap.get("Name").toString();
+      String logPath = containerDataMap.get("LogPath").toString();
+      Map<String, Object> dockerConfigMap = (HashMap<String, Object>) containerDataMap.get("Config");
+      String hostname = dockerConfigMap.get("Hostname").toString();
+      Map<String, String> labels = (Map<String, String>) dockerConfigMap.get("Labels");
+      Map<String, Object> stateMap = (HashMap<String, Object>) containerDataMap.get("State");
+      String componentType = labels.get("logfeeder.log.type");
+      boolean running = (Boolean) stateMap.get("Running");
+      long timestamp = running ? convertDateStrToLong((String)stateMap.get("StartedAt")) : convertDateStrToLong((String)stateMap.get("FinishedAt"));
+
+      if (componentType != null) {
+        if (actualDockerMetadataMap.containsKey(componentType)) {
+          Map<String, DockerMetadata> componentMetadataMap = actualDockerMetadataMap.get(componentType);
+          componentMetadataMap.put(id, new DockerMetadata(id, name, hostname, componentType, logPath, running, timestamp));
+          actualDockerMetadataMap.put(componentType, componentMetadataMap);
+        } else {
+          Map<String, DockerMetadata> componentMetadataMap = new HashMap<>();
+          componentMetadataMap.put(id, new DockerMetadata(id, name, hostname, componentType, logPath, running, timestamp));
+          actualDockerMetadataMap.put(componentType, componentMetadataMap);
+        }
+      } else {
+        logger.debug("Ignoring docker metadata from registry as container (id: {}, name: {}) as it has no 'logfeeder.log.type' label", id, name);
+      }
+    }
+
+    return actualDockerMetadataMap;
+  }
+
+  @Override
+  public synchronized Map<String, Map<String, DockerMetadata>> getContainerMetadataMap() {
+    return dockerMetadataMap;
+  }
+
+  public void init(Properties configs) {
+    // init docker related data
+    String waitStr = configs.getProperty(LOGFEEDER_CONTAINER_REGISTRY_DOCKER_INTERVAL, "5");
+    setWaitIntervalMin(Integer.parseInt(waitStr));
+    // TODO: add docker authentication settings through this
+  }
+
+  public static synchronized DockerContainerRegistry getInstance(Properties dockerConfig) {
+    if (INSTANCE == null) {
+      return new DockerContainerRegistry(dockerConfig);
+    } else {
+      return INSTANCE;
+    }
+  }
+
+  public int getWaitIntervalMin() {
+    return waitIntervalMin;
+  }
+
+  public void setWaitIntervalMin(int waitIntervalMin) {
+    this.waitIntervalMin = waitIntervalMin;
+  }
+
+  private long convertDateStrToLong(String timestampStr) {
+    LocalDateTime localDateTime = LocalDateTime.parse(timestampStr, DateTimeFormatter.ISO_DATE_TIME);
+    return localDateTime.toInstant(ZoneOffset.ofTotalSeconds(0)).toEpochMilli();
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/DockerContainerRegistryMonitor.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/DockerContainerRegistryMonitor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.docker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically re-register docker container metadata for {@link org.apache.ambari.logfeeder.docker.DockerContainerRegistry}
+ * based on a time interval in seconds (property: logfeeder.container.registry.docker.interval, default: 5)
+ */
+public class DockerContainerRegistryMonitor implements Runnable {
+
+  private static final Logger logger = LoggerFactory.getLogger(DockerContainerRegistryMonitor.class);
+
+  private final DockerContainerRegistry registry;
+
+  public DockerContainerRegistryMonitor(DockerContainerRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public void run() {
+    while (!Thread.currentThread().isInterrupted()) {
+      try {
+        logger.debug("Gather docker containers metadata ...");
+        registry.register();
+        Thread.sleep(1000 * registry.getWaitIntervalMin());
+      } catch (Exception e) {
+        logger.error("Error during gather docker containers metadata.", e);
+      }
+    }
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/DockerMetadata.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/DockerMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.docker;
+
+import org.apache.ambari.logfeeder.ContainerMetadata;
+
+public class DockerMetadata implements ContainerMetadata {
+
+  private final String id;
+  private final String name;
+  private final String logTypeLabel;
+  private final String logPath;
+  private final String hostName;
+  private final boolean running;
+  private final long timestamp;
+
+  public DockerMetadata(String id, String name, String hostName, String logTypeLabel, String logPath, boolean running, long timestamp) {
+    this.id = id;
+    this.name = name;
+    this.hostName = hostName;
+    this.logTypeLabel = logTypeLabel;
+    this.logPath = logPath;
+    this.running = running;
+    this.timestamp = timestamp;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getHostName() {
+    return hostName;
+  }
+
+  public String getLogTypeLabel() {
+    return logTypeLabel;
+  }
+
+  public String getLogPath() {
+    return logPath;
+  }
+
+  public boolean isRunning() {
+    return running;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public String toString() {
+    return "DockerMetadata{" +
+      "id='" + id + '\'' +
+      ", name='" + name + '\'' +
+      ", logTypeLabel='" + logTypeLabel + '\'' +
+      ", logPath='" + logPath + '\'' +
+      ", hostName='" + hostName + '\'' +
+      '}';
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/CommandExecutionHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/CommandExecutionHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.docker.command;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CommandExecutionHelper {
+
+  public static CommandResponse executeCommand(List<String> commands, Map<String, String> envMap) throws Exception {
+    ProcessBuilder processBuilder = new ProcessBuilder(commands);
+    Map<String, String> env = processBuilder.environment();
+    if (envMap != null) {
+      env.putAll(envMap);
+    }
+    Process shell = processBuilder.start();
+
+    BufferedReader stdInput = new BufferedReader(new InputStreamReader(shell.getInputStream()));
+    BufferedReader stdError = new BufferedReader(new InputStreamReader(shell.getErrorStream()));
+    List<String> stdOutLines = new ArrayList<>();
+    StringBuilder errOut = new StringBuilder();
+    String s = null;
+    while ((s = stdInput.readLine()) != null) {
+      stdOutLines.add(s);
+    }
+    while ((s = stdError.readLine()) != null) {
+      errOut.append(s);
+    }
+    int exitCode = shell.waitFor();
+
+    return new CommandResponse(exitCode, stdOutLines, errOut.toString());
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/CommandResponse.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/CommandResponse.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,17 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.ambari.logfeeder.docker.command;
 
-package org.apache.ambari.logsearch.config.api.model.inputconfig;
+import java.util.List;
 
-public interface InputFileDescriptor extends InputFileBaseDescriptor {
-  Integer getDetachIntervalMin();
+/**
+ * Represent a bash command response (stdout as string list, stderr in string and an exit code)
+ */
+public class CommandResponse {
+  private final int exitCode;
+  private final List<String> stdOut;
+  private final String stdErr;
 
-  Integer getDetachTimeMin();
+  CommandResponse(int exitCode, List<String> stdOut, String stdErr) {
+    this.exitCode = exitCode;
+    this.stdOut = stdOut;
+    this.stdErr = stdErr;
+  }
 
-  Integer getPathUpdateIntervalMin();
+  public int getExitCode() {
+    return exitCode;
+  }
 
-  Integer getMaxAgeMin();
+  public List<String> getStdOut() {
+    return stdOut;
+  }
 
-  Boolean getDockerEnabled();
+  public String getStdErr() {
+    return stdErr;
+  }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/ContainerCommand.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/ContainerCommand.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,17 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.ambari.logfeeder.docker.command;
 
-package org.apache.ambari.logsearch.config.api.model.inputconfig;
+import java.util.Map;
 
-public interface InputFileDescriptor extends InputFileBaseDescriptor {
-  Integer getDetachIntervalMin();
+/**
+ * Responsible of execute container commands. (like listing or inspecting containers)
+ * @param <RESPONSE_TYPE>
+ */
+public interface ContainerCommand<RESPONSE_TYPE> {
 
-  Integer getDetachTimeMin();
-
-  Integer getPathUpdateIntervalMin();
-
-  Integer getMaxAgeMin();
-
-  Boolean getDockerEnabled();
+  /**
+   * Execute a container command
+   * @param params extra parameters for the command
+   * @return return type of the execution - can be anything
+   */
+  RESPONSE_TYPE execute(Map<String, String> params);
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/DockerInspectContainerCommand.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/DockerInspectContainerCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.docker.command;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Run 'docker inspect' on container ids - and read response and convert it from json response to a map object
+ */
+public class DockerInspectContainerCommand implements ContainerCommand<List<Map<String, Object>>> {
+
+  private static final Logger logger = LoggerFactory.getLogger(DockerInspectContainerCommand.class);
+
+  @Override
+  public List<Map<String, Object>> execute(Map<String, String> params) {
+    List<String> containerIds = Arrays.asList(params.get("containerIds").split(","));
+    CommandResponse commandResponse = null;
+    List<Map<String, Object>> listResponse = new ArrayList<>();
+    List<String> commandList = new ArrayList<>();
+    commandList.add("/usr/local/bin/docker");
+    commandList.add("inspect");
+    commandList.addAll(containerIds);
+    try {
+      commandResponse = CommandExecutionHelper.executeCommand(commandList, null);
+      if (commandResponse.getExitCode() != 0) {
+        logger.error("Error during inspect containers request: {} (exit code: {})", commandResponse.getStdErr(), commandResponse.getExitCode());
+      } else {
+        String jsonResponse = StringUtils.join(commandResponse.getStdOut(), "");
+        ObjectMapper mapper = new ObjectMapper();
+        listResponse = mapper.readValue(jsonResponse, List.class);
+      }
+    } catch (Exception e) {
+      logger.error("Error during inspect containers request", e);
+    }
+    return listResponse;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/DockerListContainerCommand.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/java/org/apache/ambari/logfeeder/docker/command/DockerListContainerCommand.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.docker.command;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Run 'docker ps -a -q' (+ logfeeder type filter) and save the response in a string list (container ids)
+ */
+public class DockerListContainerCommand implements ContainerCommand<List<String>> {
+
+  private static final Logger logger = LoggerFactory.getLogger(DockerListContainerCommand.class);
+
+  @Override
+  public List<String> execute(Map<String, String> params) {
+    CommandResponse commandResponse = null;
+    List<String> commandList = new ArrayList<>();
+    commandList.add("/usr/local/bin/docker");
+    commandList.add("ps");
+    commandList.add("-a");
+    commandList.add("-q");
+    // TODO: add --filter="label=logfeeder.log.type"
+    try {
+      commandResponse = CommandExecutionHelper.executeCommand(commandList, null);
+      if (commandResponse.getExitCode() != 0) {
+        logger.error("Error during inspect containers request: {} (exit code: {})", commandResponse.getStdErr(), commandResponse.getExitCode());
+      }
+    } catch (Exception e) {
+      logger.error("Error during inspect containers request", e);
+    }
+    return commandResponse != null ? commandResponse.getStdOut() : null;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/resources/log4j.properties
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/src/main/resources/log4j.properties
@@ -12,22 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-cluster.name=CL1
-logfeeder.checkpoint.folder=/root/checkpoints
-logfeeder.metrics.collector.hosts=
-logfeeder.config.dir=/root/config/logfeeder/shipper-conf/
-logfeeder.config.files=shipper-conf/global.config.json,\
-  shipper-conf/output.config.json
-logfeeder.log.filter.enable=true
-logfeeder.solr.config.interval=5
-logfeeder.solr.core.config.name=history
-logfeeder.solr.zk_connect_string=localhost:9983
-logfeeder.cache.enabled=true
-logfeeder.cache.size=100
-logfeeder.cache.key.field=log_message
-logfeeder.cache.dedup.interval=1000
-logfeeder.cache.last.dedup.enabled=true
-logsearch.config.zk_connect_string=localhost:9983
-logfeeder.include.default.level=FATAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
-logfeeder.docker.registry.enabled=true
+log4j.rootLogger=DEBUG, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5p [%t] - %m%n

--- a/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/input/Input.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/input/Input.java
@@ -51,6 +51,7 @@ public abstract class Input<PROP_TYPE extends LogFeederProperties, INPUT_MARKER 
   private Filter<PROP_TYPE> firstFilter;
   private boolean isClosed;
   private String type;
+  private String logType;
   private boolean useEventMD5 = false;
   private boolean genEventMD5 = true;
   private Thread thread;
@@ -236,6 +237,14 @@ public abstract class Input<PROP_TYPE extends LogFeederProperties, INPUT_MARKER 
 
   public void setType(String type) {
     this.type = type;
+  }
+
+  public String getLogType() {
+    return logType;
+  }
+
+  public void setLogType(String logType) {
+    this.logType = logType;
   }
 
   public boolean isUseEventMD5() {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -54,6 +54,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.ambari</groupId>
+      <artifactId>ambari-logsearch-logfeeder-container-registry</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.3.1</version>

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/ConfigHandler.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/ConfigHandler.java
@@ -297,6 +297,7 @@ public class ConfigHandler implements InputConfigMonitor {
         continue;
       }
       input.setType(source);
+      input.setLogType(inputDescriptor.getType());
       input.loadConfig(inputDescriptor);
 
       if (input.isEnabled()) {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
@@ -89,4 +89,7 @@ public class LogFeederConstants {
   public static final String CHECKPOINT_EXTENSION_PROPERTY = "logfeeder.checkpoint.extension";
   public static final String DEFAULT_CHECKPOINT_EXTENSION = ".cp";
 
+  public static final String DOCKER_CONTAINER_REGISTRY_ENABLED_PROPERTY = "logfeeder.docker.registry.enabled";
+  public static final boolean DOCKER_CONTAINER_REGISTRY_ENABLED_DEFAULT = false;
+
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/ApplicationConfig.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/ApplicationConfig.java
@@ -19,7 +19,10 @@
 package org.apache.ambari.logfeeder.conf;
 
 import com.google.common.collect.Maps;
+import org.apache.ambari.logfeeder.ContainerRegistry;
+import org.apache.ambari.logfeeder.docker.DockerContainerRegistry;
 import org.apache.ambari.logfeeder.common.LogFeederConstants;
+import org.apache.ambari.logfeeder.docker.DockerContainerRegistryMonitor;
 import org.apache.ambari.logfeeder.input.InputConfigUploader;
 import org.apache.ambari.logfeeder.input.InputManagerImpl;
 import org.apache.ambari.logfeeder.loglevelfilter.LogLevelFilterHandler;
@@ -39,6 +42,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
 import javax.inject.Inject;
+import java.util.Properties;
 
 @Configuration
 @PropertySource(value = {
@@ -99,6 +103,7 @@ public class ApplicationConfig {
 
 
   @Bean
+  @DependsOn("containerRegistry")
   public InputManager inputManager() {
     return new InputManagerImpl();
   }
@@ -106,5 +111,14 @@ public class ApplicationConfig {
   @Bean
   public OutputManager outputManager() {
     return new OutputManagerImpl();
+  }
+
+  @Bean
+  public DockerContainerRegistry containerRegistry() {
+    if (logFeederProps.isDockerContainerRegistryEnabled()) {
+      return DockerContainerRegistry.getInstance(logFeederProps.getProperties());
+    } else {
+      return null;
+    }
   }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
@@ -130,6 +130,16 @@ public class LogFeederProps implements LogFeederProperties {
   @Value("${" + LogFeederConstants.CHECKPOINT_FOLDER_PROPERTY + ":/usr/lib/ambari-logsearch-logfeeder/conf/checkpoints}")
   public String checkpointFolder;
 
+  @LogSearchPropertyDescription(
+    name = LogFeederConstants.DOCKER_CONTAINER_REGISTRY_ENABLED_PROPERTY,
+    description = "",
+    examples = {"true"},
+    defaultValue = LogFeederConstants.DOCKER_CONTAINER_REGISTRY_ENABLED_DEFAULT + "",
+    sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}
+  )
+  @Value("${" + LogFeederConstants.DOCKER_CONTAINER_REGISTRY_ENABLED_PROPERTY + ":false}")
+  public boolean dockerContainerRegistryEnabled;
+
   @Inject
   private LogEntryCacheConfig logEntryCacheConfig;
 
@@ -225,6 +235,14 @@ public class LogFeederProps implements LogFeederProperties {
 
   public void setSolrImplicitRouting(boolean solrImplicitRouting) {
     this.solrImplicitRouting = solrImplicitRouting;
+  }
+
+  public boolean isDockerContainerRegistryEnabled() {
+    return dockerContainerRegistryEnabled;
+  }
+
+  public void setDockerContainerRegistryEnabled(boolean dockerContainerRegistryEnabled) {
+    this.dockerContainerRegistryEnabled = dockerContainerRegistryEnabled;
   }
 
   @PostConstruct

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/filter/DockerLogFilter.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/filter/DockerLogFilter.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,17 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.ambari.logfeeder.filter;
 
-package org.apache.ambari.logsearch.config.api.model.inputconfig;
+import org.apache.ambari.logfeeder.util.LogFeederUtil;
 
-public interface InputFileDescriptor extends InputFileBaseDescriptor {
-  Integer getDetachIntervalMin();
+import java.util.Map;
 
-  Integer getDetachTimeMin();
+public class DockerLogFilter {
 
-  Integer getPathUpdateIntervalMin();
+  private DockerLogFilter() {
+  }
 
-  Integer getMaxAgeMin();
-
-  Boolean getDockerEnabled();
+  public static String getLogFromDockerJson(String jsonInput) {
+    Map<String, Object> jsonMap = LogFeederUtil.toJSONObject(jsonInput);
+    return jsonMap.get("log").toString();
+  }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/monitor/DockerLogFileUpdateMonitor.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/monitor/DockerLogFileUpdateMonitor.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.input.monitor;
+
+import org.apache.ambari.logfeeder.docker.DockerContainerRegistry;
+import org.apache.ambari.logfeeder.docker.DockerMetadata;
+import org.apache.ambari.logfeeder.input.InputFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Periodically check docker containers metadata registry, stop monitoring container log files if those do not exist or stopped too long time ago.
+ * If it finds a new container log for the specific type, it will start to monitoring it.
+ * <br/>
+ * Use cases:<br/>
+ * - input has not monitored yet - found new container -> start monitoring it <br/>
+ * - input has not monitored yet - found new stopped container -> start monitoring it <br/>
+ * - input has not monitored yet - found new stopped container but log is too old -> do not monitoring it <br/>
+ * - input has monitored already - container stopped - if it's stopped for too long time -> remove it from the monitoed list<br/>
+ * - input has monitored already - container stopped - log is not too old -> keep in the monitored list <br/>
+ * - input has monitored already - container does not exist - remove it from the monitoed list (and all other input with the same log type) <br/>
+ */
+public class DockerLogFileUpdateMonitor extends AbstractLogFileMonitor {
+
+  private Logger LOG = LoggerFactory.getLogger(DockerLogFileUpdateMonitor.class);
+
+  public DockerLogFileUpdateMonitor(InputFile inputFile, int waitInterval, int detachTime) {
+    super(inputFile, waitInterval, detachTime);
+  }
+
+  @Override
+  protected String getStartLog() {
+    return "Start docker component type log files monitor thread for " + getInputFile().getLogType();
+  }
+
+  @Override
+  protected void monitorAndUpdate() throws Exception {
+    DockerContainerRegistry dockerContainerRegistry = getInputFile().getDockerContainerRegistry();
+    Map<String, Map<String, DockerMetadata>> dockerMetadataMapByType = dockerContainerRegistry.getContainerMetadataMap();
+    String logType = getInputFile().getLogType();
+    Map<String, InputFile> copiedChildMap = new HashMap<>(getInputFile().getInputChildMap());
+
+    if (dockerMetadataMapByType.containsKey(logType)) {
+      Map<String, DockerMetadata> dockerMetadataMap = dockerMetadataMapByType.get(logType);
+      for (Map.Entry<String, DockerMetadata> containerEntry : dockerMetadataMap.entrySet()) {
+        String logPath = containerEntry.getValue().getLogPath();
+        String containerId = containerEntry.getValue().getId();
+        long timestamp = containerEntry.getValue().getTimestamp();
+        boolean running = containerEntry.getValue().isRunning();
+        LOG.debug("Found log path: {} (container id: {})", logPath, containerId);
+        if (!copiedChildMap.containsKey(logPath)) {
+          if (!running && isItTooOld(timestamp, new Date().getTime(), getDetachTime())) {
+            LOG.debug("Container with id {} is stopped, won't monitor as it stopped for long time.", containerId);
+          } else {
+            LOG.info("Found new container (id: {}) with new log path: {}", logPath, containerId);
+            getInputFile().startNewChildDockerInputFileThread(containerEntry.getValue());
+          }
+        } else {
+          if (!running && isItTooOld(timestamp, new Date().getTime(), getDetachTime())) {
+            LOG.info("Removing: {}", logPath);
+            getInputFile().stopChildDockerInputFileThread(containerEntry.getKey());
+          }
+        }
+      }
+    } else {
+      if (!copiedChildMap.isEmpty()) {
+        LOG.info("Removing all inputs with type: {}", logType);
+        for (Map.Entry<String, InputFile> inputFileEntry : copiedChildMap.entrySet()) {
+          LOG.info("Removing: {}", inputFileEntry.getKey());
+          getInputFile().stopChildDockerInputFileThread(inputFileEntry.getKey());
+        }
+      }
+    }
+  }
+
+  private boolean isItTooOld(long timestamp, long actualTimestamp, long maxDiffMinutes) {
+    long diff = actualTimestamp - timestamp;
+    long maxDiffMins = maxDiffMinutes * 1000 * 60;
+    return diff > maxDiffMins;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerInputFile.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerInputFile.java
@@ -40,6 +40,9 @@ public class LSServerInputFile extends LSServerInputFileBase {
   @JsonProperty("max_age_min")
   private Integer maxAgeMin;
 
+  @JsonProperty("docker")
+  private Boolean dockerEnabled;
+
   public LSServerInputFile() {}
 
   public LSServerInputFile(InputDescriptor inputDescriptor) {
@@ -49,6 +52,7 @@ public class LSServerInputFile extends LSServerInputFileBase {
     this.detachTimeMin = inputFileDescriptor.getDetachTimeMin();
     this.pathUpdateIntervalMin = inputFileDescriptor.getPathUpdateIntervalMin();
     this.maxAgeMin = inputFileDescriptor.getMaxAgeMin();
+    this.dockerEnabled = inputFileDescriptor.getDockerEnabled();
   }
 
   public Integer getDetachIntervalMin() {
@@ -81,5 +85,13 @@ public class LSServerInputFile extends LSServerInputFileBase {
 
   public void setMaxAgeMin(Integer maxAgeMin) {
     this.maxAgeMin = maxAgeMin;
+  }
+
+  public Boolean getDockerEnabled() {
+    return dockerEnabled;
+  }
+
+  public void setDockerEnabled(Boolean dockerEnabled) {
+    this.dockerEnabled = dockerEnabled;
   }
 }

--- a/ambari-logsearch/docker/docker-compose.yml
+++ b/ambari-logsearch/docker/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     image: ambari-logsearch:v1.0
     restart: always
     hostname: logsearch.apache.org
+    labels:
+      logfeeder.log.type: "logsearch_server"
     networks:
       - logsearch-network
     env_file:
@@ -68,6 +70,9 @@ services:
     image: ambari-logsearch:v1.0
     restart: always
     hostname: logfeeder.apache.org
+    privileged: true
+    labels:
+      logfeeder.log.type: "logfeeder"
     networks:
       - logsearch-network
     env_file:
@@ -82,6 +87,9 @@ services:
       - $AMBARI_LOCATION:/root/ambari
       - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
       - $AMBARI_LOCATION/ambari-logsearch/docker/test-config:/root/test-config
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/local/bin/docker:/usr/local/bin/docker
+      - /var/lib/docker:/var/lib/docker
 networks:
    logsearch-network:
       driver: bridge

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-logsearch-docker.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-logsearch-docker.json
@@ -1,0 +1,31 @@
+{
+  "input": [
+    {
+      "type": "logsearch_server",
+      "rowtype": "service",
+      "docker": "true"
+    }
+  ],
+  "filter": [
+    {
+      "filter": "grok",
+      "conditions": {
+        "fields": {
+          "type": [
+            "logsearch_server"
+          ]
+        }
+      },
+      "log4j_format": "",
+      "multiline_pattern": "^(%{DATESTAMP:logtime})",
+      "message_pattern": "(?m)^%{DATESTAMP:logtime}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}%{LOGLEVEL:level}%{SPACE}%{JAVACLASS}%{SPACE}\\(%{JAVAFILE:file}:%{INT:line_number}\\)%{SPACE}-%{SPACE}%{GREEDYDATA:log_message}",
+      "post_map_values": {
+        "logtime": {
+          "map_date": {
+            "target_date_pattern":"yyyy-MM-dd HH:mm:ss,SSS"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -33,6 +33,7 @@
     <module>ambari-logsearch-config-zookeeper</module>
     <module>ambari-logsearch-it</module>
     <module>ambari-logsearch-logfeeder-plugin-api</module>
+    <module>ambari-logsearch-logfeeder-container-registry</module>
   </modules>
   <properties>
     <jdk.version>1.8</jdk.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Based on a flag (`logfeeder.docker.registry.enabled`) docker support can be turned on for logfeeders. Idea is to use docker logs as input sources. as those are simple files on the filesystem, for docker environments we can share the docker binary with a logfeeder (which probably also runs in a container)
As the log file paths are in the docker metadata, we need a registry to get those informations. Also sometimes containers are killed or multiple containers with the same type can run on a host, so periodically we need to update those informations. Based on these logfeeders need to stop or start monitoring specific files:
- for every log type we will have a thread group
- for every log type we will have "n" input file monitor thread if the number of containers with the same type is "n"
- for every log type there will be a log updater thread (then it can stop/start a thread in the thread group)
- also we will have the global updater for docker container registry

To enable the docker input usages (instead of using path), the configuration can look like this
```json
"inputs" : [
{
  ...
 "docker" : "true"
}
```

TODO: use specific hostname from the containers (do not use the hostname from the logfeeder container)

I think it can be done on trunk as this feature is off by default.

## How was this patch tested?
UTs passed.
New UTs have not done yet, as it will require some refactor to make it more testable (because of thread stuff)

Please review @g-boros @swagle @kasakrisz 