### PR TITLE
Update incorrect instructions for updating alert groups with API

### DIFF
--- a/ambari-server/docs/api/v1/alert-dispatching.md
+++ b/ambari-server/docs/api/v1/alert-dispatching.md
@@ -68,7 +68,7 @@ Or it can be created with all valid properties. In this example, a group is bein
 
 
 ##### Update Request
-    POST api/v1/clusters/<cluster>/alert_groups/<group-id>
+    PUT api/v1/clusters/<cluster>/alert_groups/<group-id>
 
     {
       "AlertGroup": {


### PR DESCRIPTION
Submitting a `POST` request to `api/v1/clusters/CLUSTER/alert_groups/GROUP-ID` to update an alert returns a method not allowed error:

```
Status Code: 405 Method Not Allowed
Allow: HEAD,DELETE,GET,OPTIONS,PUT
```

## What changes were proposed in this pull request?

Update to API documentation.

## How was this patch tested?
Using POST:
![screen shot 2018-07-16 at 10 00 18](https://user-images.githubusercontent.com/2399721/42750441-1d3f31ca-88df-11e8-9a38-be34e14ad126.png)

Using PUT:
![screen shot 2018-07-16 at 10 01 30](https://user-images.githubusercontent.com/2399721/42750475-41c11bd0-88df-11e8-90bc-3fe4d996ec65.png)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.