### PR TITLE
AMBARI-24298 - fix preupload for zeppelin dependecies

### DIFF
--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -281,7 +281,7 @@ with Environment() as env:
   def copy_zeppelin_dependencies_to_hdfs(file_pattern):
     spark_deps_full_path = glob.glob(file_pattern)
     if spark_deps_full_path and os.path.exists(spark_deps_full_path[0]):
-      copy_tarballs_to_hdfs(spark_deps_full_path[0], hdfs_path_prefix+'/apps/zeppelin/', 'hadoop-mapreduce-historyserver', params.hdfs_user, 'zeppelin', 'zeppelin')
+      copy_tarballs_to_hdfs(spark_deps_full_path[0], hdfs_path_prefix+'/apps/zeppelin/', params.hdfs_user, 'zeppelin', 'zeppelin')
     else:
       Logger.info('zeppelin-spark-dependencies not found at %s.' % file_pattern)
 


### PR DESCRIPTION
Change-Id: Ic85e6237563d10f53e311248fb458c13c2480790

## What changes were proposed in this pull request?

Fix invocation of `copy_tarballs_to_hdfs` function which has been changed in previous commits. This is a missing piece for previous Ambaripreupload changes required for 2.7.

## How was this patch tested?

manually

Please review @oleewere , @zeroflag 