### PR TITLE
AMBARI-24300. Error in Tez Service Advisor for HDP 3.0 (amagyar)

### DIFF
--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -1311,7 +1311,7 @@ class DefaultStackAdvisor(StackAdvisor):
     self.logger.info("Containers per node - cluster[containers]: " + str(cluster["containers"]))
 
     if cluster["containers"] * cluster["minContainerSize"] > cluster["totalAvailableRam"]:
-      cluster["containers"] = ceil(cluster["totalAvailableRam"] / cluster["minContainerSize"])
+      cluster["containers"] = int(ceil(cluster["totalAvailableRam"] / cluster["minContainerSize"]))
       self.logger.info("Modified number of containers based on provided value for yarn.scheduler.minimum-allocation-mb")
       pass
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following stack advisor error comes from tez under some circumstances.

```text
Traceback (most recent call last):
  File "/var/lib/ambari-server/resources/scripts/stack_advisor.py", line 178, in <module>
    main(sys.argv)
  File "/var/lib/ambari-server/resources/scripts/stack_advisor.py", line 120, in main
    result = stackAdvisor.recommendConfigurations(services, hosts)
  File "/var/lib/ambari-server/resources/scripts/../stacks/stack_advisor.py", line 1625, in recommendConfigurations
    serviceAdvisor.getServiceConfigurationRecommendations(configurations, clusterSummary, services, hosts)
  File "/var/lib/ambari-server/resources/stacks/HDP/3.0/services/TEZ/service_advisor.py", line 127, in getServiceConfigurationRecommendations
    recommender.recommendTezConfigurationsFromHDP23(configurations, clusterData, services, hosts)
  File "/var/lib/ambari-server/resources/stacks/HDP/3.0/services/TEZ/service_advisor.py", line 239, in recommendTezConfigurationsFromHDP23
    taskResourceMemory = int(configurations["tez-site"]["properties"]["tez.task.resource.memory.mb"])
ValueError: invalid literal for int() with base 10: '341.0'
```

## How was this patch tested?

- rerun stackadvisor and checked that there was no error