### PR TITLE
AMBARI-24273. hadoop-env is not regenerated when OneFS is used as a F…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -5771,13 +5771,13 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         PropertyType.NOT_MANAGED_HDFS_PATH, cluster, desiredConfigs);
     String notManagedHdfsPathList = gson.toJson(notManagedHdfsPathSet);
     clusterLevelParams.put(NOT_MANAGED_HDFS_PATH_LIST, notManagedHdfsPathList);
-
-    Map<String, ServiceInfo> serviceInfos = ambariMetaInfo.getServices(stackId.getStackName(), stackId.getStackVersion());
-    for (ServiceInfo serviceInfoInstance : serviceInfos.values()) {
-      if (serviceInfoInstance.getServiceType() != null) {
+    
+    for (Service service : cluster.getServices().values()) {
+      ServiceInfo serviceInfoInstance = ambariMetaInfo.getService(service);
+      String serviceType = serviceInfoInstance.getServiceType();
+      if (serviceType != null) {
         LOG.debug("Adding {} to command parameters for {}", serviceInfoInstance.getServiceType(),
-            serviceInfoInstance.getName());
-
+          serviceInfoInstance.getName());
         clusterLevelParams.put(DFS_TYPE, serviceInfoInstance.getServiceType());
         break;
       }


### PR DESCRIPTION
…ileSystem (amagyar)

## What changes were proposed in this pull request?

dfs_type is incorrectly set by ambari-server when there are multiple services in the stack with a service_type. The service_type should come from cluster services and not from the stack.

## How was this patch tested?

Installed onefs and checked that the hadoop-env was regenerated correctly after every change.