### PR TITLE
[AMBARI-24248] [LogSearch UI] There is no user notification on Log Feeder configuration saving

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/app-routing.module.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/app-routing.module.ts
@@ -37,7 +37,8 @@ const appRoutes: Routes = [{
     component: LogsContainerComponent,
     data: {
       breadcrumbs: 'logs.title',
-      multiClusterFilter: true
+      multiClusterFilter: true,
+      clusterParamKey: 'clusters'
     },
     resolve: {
       breadcrumbs: LogsBreadcrumbsResolverService

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.ts
@@ -35,12 +35,13 @@ export class AppComponent {
     .map((dataSetState: DataAvailability) => dataSetState === DataAvailabilityValues.AVAILABLE);
 
   private notificationServiceOptions: Options = {
-    timeOut: 5000,
+    timeOut: 2000,
     showProgressBar: true,
     pauseOnHover: true,
     preventLastDuplicates: 'visible',
     theClass: 'app-notification',
-    icons: notificationIcons
+    icons: notificationIcons,
+    position: ['top', 'left']
   };
 
   constructor(

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/notifications.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/notifications.less
@@ -23,19 +23,19 @@
   border-radius: 2px;
   box-shadow: 0 5px 15px rgba(0,0,0,.5);
   &.success {
-    border-left: 3px solid @form-success-color;
+    border: 1px solid @form-success-color;
     .fa {
       color: @form-success-color;
     }
   }
   &.info {
-    border-left: 3px solid @form-info-color;
+    border: 1px solid @form-info-color;
     .fa {
       color: @form-info-color;
     }
   }
   &.error {
-    border-left: 3px solid @form-error-color;
+    border: 1px solid @form-error-color;
     .fa {
       color: @form-error-color;
     }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/variables.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/variables.less
@@ -88,6 +88,6 @@
 
 // Notifications
 @notification-color: @base-font-color;
-@notification-title-font-size: 16px;
+@notification-title-font-size: 14px;
 @notification-content-font-size: 12px;
 @notification-background-color: #FFF;

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.html
@@ -41,6 +41,7 @@
               [configuration]="configuration$ | async"
               [existingServiceNames]="serviceNamesList$"
               [validationResponse]="validationResponse"
+              [disabled]="requestInProgress$ | async"
               (configurationSubmit)="onConfigurationFormSubmit($event)"
               (validationSubmit)="onValidationFormSubmit($event)"
             ></shipper-configuration-form>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.ts
@@ -129,9 +129,9 @@ export class ShipperConfigurationComponent implements CanComponentDeactivate, On
   getResponseHandler(cmd: string, type: string, msgVariables?: {[key: string]: any}) {
     return (response: Response) => {
       const result = response.json();
-      // @ToDo change the backend response status to some error code if the configuration is not valid and don't use the .errorMessage prop
-      const resultType = response ? (response.ok && !result.errorMessage ? NotificationType.SUCCESS : NotificationType.ERROR) : type;
-      const translateParams = {errorMessage: '', ...msgVariables, ...result};
+      // @ToDo change the backend response status to some error code if the configuration is not valid and don't use the .message prop
+      const resultType = response ? (response.ok && !result.message ? NotificationType.SUCCESS : NotificationType.ERROR) : type;
+      const translateParams = {errorMessage: (result && result.message) || '', ...msgVariables, ...result};
       const title = this.translate.instant(`shipperConfiguration.action.${cmd}.title`, translateParams);
       const message = this.translate.instant(`shipperConfiguration.action.${cmd}.${resultType}.message`, translateParams);
       this.notificationService.addNotification({type: resultType, title, message});

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.ts
@@ -32,10 +32,10 @@ import {
   ShipperServiceConfigurationFormComponent
 } from '@modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component';
 import {TranslateService} from '@ngx-translate/core';
-import {ClustersService} from '@app/services/storage/clusters.service';
-import {ShipperClusterServiceValidationModel} from '@modules/shipper/models/shipper-cluster-service-validation.model';
 import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
 import {Subscription} from 'rxjs/Subscription';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'shipper-configuration',
@@ -52,6 +52,8 @@ export class ShipperConfigurationComponent implements CanComponentDeactivate, On
   @ViewChild(ShipperServiceConfigurationFormComponent)
   configurationFormRef: ShipperServiceConfigurationFormComponent;
 
+  private requestInProgress$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+
   private clusterName$: Observable<ShipperClusterService> = this.activatedRoute.params.map(params => params.cluster);
   private serviceName$: Observable<ShipperClusterService> = this.activatedRoute.params.map(params => params.service);
 
@@ -59,8 +61,10 @@ export class ShipperConfigurationComponent implements CanComponentDeactivate, On
     return cluster ? this.shipperClusterServiceListService.getServicesForCluster(cluster) : Observable.of(undefined);
   });
 
-  private configuration$: Observable<{[key: string]: any}> = Observable.combineLatest(this.clusterName$, this.serviceName$)
-    .switchMap(([clusterName, serviceName]: [ShipperCluster, ShipperClusterService]) => {
+  private configuration$: Observable<{[key: string]: any}> = Observable.combineLatest(
+      this.clusterName$,
+      this.serviceName$
+    ).switchMap(([clusterName, serviceName]: [ShipperCluster, ShipperClusterService]) => {
       return clusterName && serviceName ?
         this.shipperConfigurationService.loadConfiguration(clusterName, serviceName) : Observable.of(undefined);
     });
@@ -76,8 +80,6 @@ export class ShipperConfigurationComponent implements CanComponentDeactivate, On
     private shipperConfigurationService: ShipperConfigurationService,
     private notificationService: NotificationService,
     private translate: TranslateService,
-
-    private clustersStoreService: ClustersService,
     private clusterSelectionStoreService: ClusterSelectionService
   ) { }
 
@@ -116,38 +118,39 @@ export class ShipperConfigurationComponent implements CanComponentDeactivate, On
     }
   }
 
-  private onShipperClusterServiceSelected(serviceName: ShipperClusterService) {
-    this.clusterName$.first().subscribe((clusterName: ShipperCluster) => this.router.navigate(
-      [...this.routerPath, clusterName, serviceName]
-    ));
-  }
-
   private getRouterLink(path: string | string[]): string[] {
     return [...this.routerPath, ...(Array.isArray(path) ? path : [path])];
   }
 
-  getResponseHandler(cmd: string, type: string, msgVariables?: {[key: string]: any}) {
+  getResponseHandler(cmd: string, type: string, form?: FormGroup) {
+    const msgVariables = form.getRawValue();
     return (response: Response) => {
       const result = response.json();
       // @ToDo change the backend response status to some error code if the configuration is not valid and don't use the .message prop
-      const resultType = response ? (response.ok && !result.message ? NotificationType.SUCCESS : NotificationType.ERROR) : type;
+      const resultType = response ? (response.ok && !result.errorMessage ? NotificationType.SUCCESS : NotificationType.ERROR) : type;
       const translateParams = {errorMessage: (result && result.message) || '', ...msgVariables, ...result};
       const title = this.translate.instant(`shipperConfiguration.action.${cmd}.title`, translateParams);
       const message = this.translate.instant(`shipperConfiguration.action.${cmd}.${resultType}.message`, translateParams);
       this.notificationService.addNotification({type: resultType, title, message});
+      if (resultType !== NotificationType.ERROR) {
+        form.markAsPristine();
+      }
+      this.requestInProgress$.next(false);
     };
   }
 
-  onConfigurationFormSubmit(rawValue: any): void {
+  onConfigurationFormSubmit(configurationForm: FormGroup): void {
+    const rawValue = configurationForm.getRawValue();
     this.serviceNamesList$.first().subscribe((services: ShipperClusterService[]) => {
-      const cmd: string = services.indexOf(rawValue.service) > -1 ? 'update' : 'add';
+      const cmd: string = services.indexOf(rawValue.serviceName) > -1 ? 'update' : 'add';
+      this.requestInProgress$.next(true);
       this.shipperConfigurationService[`${cmd}Configuration`]({
-        cluster: rawValue.cluster,
-        service: rawValue.service,
-        configuration: rawValue.configuration
+        cluster: rawValue.clusterName,
+        service: rawValue.serviceName,
+        configuration: JSON.parse(rawValue.configuration)
       }).subscribe(
-        this.getResponseHandler(cmd, NotificationType.SUCCESS, rawValue),
-        this.getResponseHandler(cmd, NotificationType.ERROR, rawValue)
+        this.getResponseHandler(cmd, NotificationType.SUCCESS, configurationForm),
+        this.getResponseHandler(cmd, NotificationType.ERROR, configurationForm)
       );
     });
   }
@@ -156,12 +159,13 @@ export class ShipperConfigurationComponent implements CanComponentDeactivate, On
     this.validationResponse = result;
   }
 
-  onValidationFormSubmit(rawValue: ShipperClusterServiceValidationModel): void {
+  onValidationFormSubmit(validationForm: FormGroup): void {
     this.validationResponse = null;
+    const rawValue = validationForm.getRawValue();
     const request$: Observable<Response> = this.shipperConfigurationService.testConfiguration(rawValue);
     request$.subscribe(
-      this.getResponseHandler('validate', NotificationType.SUCCESS, rawValue),
-      this.getResponseHandler('validate', NotificationType.ERROR, rawValue)
+      this.getResponseHandler('validate', NotificationType.SUCCESS, validationForm),
+      this.getResponseHandler('validate', NotificationType.ERROR, validationForm)
     );
     request$
       .filter((response: Response): boolean => response.ok)

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.html
@@ -21,45 +21,47 @@
   <div class="row">
     <div class="shipper-form-configuration col-md-6">
       <form [formGroup]="configurationForm" (ngSubmit)="onConfigurationSubmit($event)">
-        <h2>{{(serviceName ? 'shipperConfiguration.form.titleEdit' : 'shipperConfiguration.form.titleAdd') | translate}}</h2>
-        <div [ngClass]="{'has-error': serviceNameField.invalid, 'form-group': true}">
-          <label>
-            {{'shipperConfiguration.form.serviceLabel' | translate}}
-            <span *ngIf="serviceNameField.errors && serviceNameField.errors.serviceNameExists"
-                  class="help-block validation-block pull-right">
-              {{'shipperConfiguration.form.errors.serviceName.exists' | translate}}
-            </span>
-            <span *ngIf="serviceNameField.errors && serviceNameField.errors.required"
-                  class="help-block validation-block pull-right">
-              {{'common.form.errors.required' | translate}}
-            </span>
-          </label>
-          <input *ngIf="!serviceName" formControlName="serviceName" class="form-control">
-          <ng-container *ngIf="serviceName">
-            <div class="shipper-configuration-service-name">{{serviceName}}</div>
-            <input type="hidden" name="serviceName" formControlName="serviceName">
-          </ng-container>
-        </div>
-        <input type="hidden" name="clusterName" formControlName="clusterName">
-        <div [ngClass]="{'has-error': configurationField.invalid, 'form-group': true}">
-          <label>
-            {{'shipperConfiguration.form.configurationJSONLabel' | translate}}
-            <span *ngIf="configurationField.errors && configurationField.errors.invalidJSON"
-                  class="help-block validation-block pull-right">
-              {{'shipperConfiguration.form.errors.configuration.invalidJSON' | translate}}
-            </span>
-            <span *ngIf="configurationField.errors && configurationField.errors.required"
-                  class="help-block validation-block pull-right">
-              {{'common.form.errors.required' | translate}}
-            </span>
-          </label>
-          <textarea class="form-control configuration" name="configuration"
-            formControlName="configuration"></textarea>
-        </div>
-        <button class="btn btn-primary pull-right" type="submit"
-                [disabled]="(!configurationForm.valid || configurationForm.pristine)">
-          {{'shipperConfiguration.form.saveBtn.label' | translate}}
-        </button>
+        <fieldset [disabled]="disabled">
+          <h2>{{(serviceName ? 'shipperConfiguration.form.titleEdit' : 'shipperConfiguration.form.titleAdd') | translate}}</h2>
+          <div [ngClass]="{'has-error': serviceNameField.invalid, 'form-group': true}">
+            <label>
+              {{'shipperConfiguration.form.serviceLabel' | translate}}
+              <span *ngIf="serviceNameField.errors && serviceNameField.errors.serviceNameExists"
+                    class="help-block validation-block pull-right">
+                {{'shipperConfiguration.form.errors.serviceName.exists' | translate}}
+              </span>
+              <span *ngIf="serviceNameField.errors && serviceNameField.errors.required"
+                    class="help-block validation-block pull-right">
+                {{'common.form.errors.required' | translate}}
+              </span>
+            </label>
+            <input *ngIf="!serviceName" formControlName="serviceName" class="form-control">
+            <ng-container *ngIf="serviceName">
+              <div class="shipper-configuration-service-name">{{serviceName}}</div>
+              <input type="hidden" name="serviceName" formControlName="serviceName">
+            </ng-container>
+          </div>
+          <input type="hidden" name="clusterName" formControlName="clusterName">
+          <div [ngClass]="{'has-error': configurationField.invalid, 'form-group': true}">
+            <label>
+              {{'shipperConfiguration.form.configurationJSONLabel' | translate}}
+              <span *ngIf="configurationField.errors && configurationField.errors.invalidJSON"
+                    class="help-block validation-block pull-right">
+                {{'shipperConfiguration.form.errors.configuration.invalidJSON' | translate}}
+              </span>
+              <span *ngIf="configurationField.errors && configurationField.errors.required"
+                    class="help-block validation-block pull-right">
+                {{'common.form.errors.required' | translate}}
+              </span>
+            </label>
+            <textarea class="form-control configuration" name="configuration"
+              formControlName="configuration"></textarea>
+          </div>
+          <button class="btn btn-primary pull-right" type="submit"
+                  [disabled]="(!configurationForm.valid || configurationForm.pristine)">
+            {{'shipperConfiguration.form.saveBtn.label' | translate}}
+          </button>
+        </fieldset>
       </form>
     </div>
     <div class="shipper-form-validator col-md-6">

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/services/shipper-configuration.service.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shipper/services/shipper-configuration.service.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import {Response} from '@angular/http';
+import {Response, ResponseOptions, ResponseType} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
 
@@ -31,7 +31,20 @@ export class ShipperConfigurationService {
     private httpClientService: HttpClientService
   ) { }
 
-  addConfiguration(configuration: ShipperClusterServiceConfigurationModel): Observable<ShipperClusterServiceConfigurationModel | Error> {
+  createResponseWithConfigBody(configuration: ShipperClusterServiceConfigurationModel, originalResponse?: Response): Response {
+    return new Response(
+      new ResponseOptions({
+        body: configuration,
+        status: originalResponse ? originalResponse.status : null,
+        statusText: originalResponse ? originalResponse.statusText : null,
+        headers: originalResponse ? originalResponse.headers : null,
+        type: originalResponse ? originalResponse.type : ResponseType.Basic,
+        url: originalResponse ? originalResponse.url : ''
+      })
+    );
+  }
+
+  addConfiguration(configuration: ShipperClusterServiceConfigurationModel): Observable<Response | Error> {
     return this.httpClientService.post(
       'shipperClusterServiceConfiguration',
       configuration.configuration,
@@ -40,15 +53,13 @@ export class ShipperConfigurationService {
         cluster: configuration.cluster,
         service: configuration.service
       })
-      .map((response: Response): ShipperClusterServiceConfigurationModel => {
-        return configuration;
-      })
-      .catch((error: Response): Observable<Error> => {
-        return Observable.of(new Error(error.json().message || ''));
+      .map((response: Response): Response => this.createResponseWithConfigBody(configuration, response))
+      .catch((error: Response): Observable<Response> => {
+        return Observable.of(error);
       });
   }
 
-  updateConfiguration(configuration: ShipperClusterServiceConfigurationModel): Observable<ShipperClusterServiceConfigurationModel | Error> {
+  updateConfiguration(configuration: ShipperClusterServiceConfigurationModel): Observable<Response> {
     return this.httpClientService.put(
       'shipperClusterServiceConfiguration',
       configuration.configuration,
@@ -57,11 +68,9 @@ export class ShipperConfigurationService {
         cluster: configuration.cluster,
         service: configuration.service
       })
-      .map((response: Response): ShipperClusterServiceConfigurationModel => {
-        return configuration;
-      })
-      .catch((error: Response): Observable<Error> => {
-        return Observable.of(new Error(error.json().message || ''));
+      .map((response: Response): Response => this.createResponseWithConfigBody(configuration, response))
+      .catch((error: Response): Observable<Response> => {
+        return Observable.of(error);
       });
   }
 

--- a/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
@@ -255,13 +255,13 @@
 
   "shipperConfiguration.action.add.title": "New Configuration",
   "shipperConfiguration.action.add.success.message": "New configuration has been added successfully.",
-  "shipperConfiguration.action.add.error.message": "Error at adding new configuration.<div class='cluster-name'>Cluster: {{clusterName}}</div><div class='service-name'>Service: {{componentName}}</div>",
+  "shipperConfiguration.action.add.error.message": "Error at adding new configuration.<div class='cluster-name'>Cluster: {{cluster}}</div><div class='service-name'>Service: {{service}}</div>",
   "shipperConfiguration.action.update.title": "Update Configuration",
-  "shipperConfiguration.action.update.success.message": "The configuration has been updated successfully.<div class='cluster-name'>Cluster: {{clusterName}}</div><div class='service-name'>Service: {{componentName}}</div>",
-  "shipperConfiguration.action.update.error.message": "Error at updating the configuration.<div class='cluster-name'>Cluster: {{clusterName}}</div><div class='service-name'>Service: {{componentName}}</div>",
+  "shipperConfiguration.action.update.success.message": "The configuration has been updated successfully.<div class='cluster-name'>Cluster: {{cluster}}</div><div class='service-name'>Service: {{service}}</div>",
+  "shipperConfiguration.action.update.error.message": "Error at updating the configuration.<div class='cluster-name'>Cluster: {{cluster}}</div><div class='service-name'>Service: {{service}}</div>",
   "shipperConfiguration.action.validate.title": "Validate Configuration",
   "shipperConfiguration.action.validate.success.message": "The configuration is valid.",
-  "shipperConfiguration.action.validate.error.message": "The configuration is not valid.<div class='cluster-name'>Cluster: {{clusterName}}</div><div class='service-name'>Service: {{componentName}}</div><div class='error-message'>{{errorMessage}}</div>",
+  "shipperConfiguration.action.validate.error.message": "The configuration is not valid.<div class='cluster-name'>Cluster: {{cluster}}</div><div class='service-name'>Service: {{service}}</div><div class='error-message'>{{errorMessage}}</div>",
 
   "dataAvaibilityState.clustersDataState.label": "Loading clusters",
   "dataAvaibilityState.hostsDataState.label": "Loading hosts",

--- a/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
@@ -261,7 +261,7 @@
   "shipperConfiguration.action.update.error.message": "Error at updating the configuration.<div class='cluster-name'>Cluster: {{cluster}}</div><div class='service-name'>Service: {{service}}</div>",
   "shipperConfiguration.action.validate.title": "Validate Configuration",
   "shipperConfiguration.action.validate.success.message": "The configuration is valid.",
-  "shipperConfiguration.action.validate.error.message": "The configuration is not valid.<div class='cluster-name'>Cluster: {{cluster}}</div><div class='service-name'>Service: {{service}}</div><div class='error-message'>{{errorMessage}}</div>",
+  "shipperConfiguration.action.validate.error.message": "The configuration is not valid.<div class='cluster-name'>Cluster: {{clusterName}}</div><div class='service-name'>Service: {{componentName}}</div><div class='error-message'>{{errorMessage}}</div>",
 
   "dataAvaibilityState.clustersDataState.label": "Loading clusters",
   "dataAvaibilityState.hostsDataState.label": "Loading hosts",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Three issue has been targeted here which are connected:

- There is no notification for the user when the configuration successfully updated: since the backend does not send back the saved configuration we added it to the response (createResponseWithConfigBody)
- False 'form is not saved' when the user wants to leave the page after a successfully save action: the form submission event now emit the submitting form itself and not the raw value, so that we can mark it as pristine after a successful save action
- The cluster selection does not work: changing the way, how the cluster-filter component get the cluster information from the url params

+1: updated styling for the notifications

## How was this patch tested?

It was tested manually and by the existing unit tests.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.