### PR TITLE
[AMBARI-24288] Remove org.apache.directory.api:api-ldap-model from Am…

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1817,6 +1817,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.directory.api</groupId>
+          <artifactId>api-ldap-model</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `org.apache.directory.api:api-ldap-model` from Ambari server's dependencies due to security concerns regarding the following CVE:

* CVE-2018-1337: Plaintext Password Disclosure in Secured Channel

See https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-1337

Though Ambari server includes `api-ldap-model-1.0.0.jar` in `/usr/lib/ambari-server`, the library is not used.  Therefore, the vulnerability is not exposed and the library may be excluded from Ambari's package. 

This is the same patch as #1762 

## How was this patch tested?

Manually tested Kerberos and LDAP operations in a cluster.

```
mvn clean test package -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 28:31 min
[INFO] Finished at: 2018-07-18T15:17:46-04:00
[INFO] Final Memory: 105M/1355M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.