### PR TITLE
[AMBARI-24207] Python unit test failure on 2.7.6

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverUtils.py
+++ b/ambari-server/src/main/python/ambari_server/serverUtils.py
@@ -245,7 +245,7 @@ def get_ssl_context(properties, requested_protocol=None):
   :return: a permissive SSLContext or None
   """
 
-  if not is_api_ssl_enabled(properties):
+  if not is_api_ssl_enabled(properties) or not hasattr(ssl, 'SSLContext'):
     return None
 
   if requested_protocol:

--- a/ambari-server/src/test/python/TestServerUtils.py
+++ b/ambari-server/src/test/python/TestServerUtils.py
@@ -122,11 +122,19 @@ class TestServerUtils(TestCase):
       SSL_API: "true"
     })
     context = get_ssl_context(properties)
-    self.assertIsNotNone(context)
+    if hasattr(ssl, 'SSLContext'):
+      self.assertIsNotNone(context)
+    else:
+      self.assertIsNone(context)
 
     context = get_ssl_context(properties, ssl.PROTOCOL_TLSv1)
-    self.assertIsNotNone(context)
-    self.assertEqual(ssl.PROTOCOL_TLSv1, context.protocol)
+    if hasattr(ssl, 'SSLContext'):
+      self.assertIsNotNone(context)
+      self.assertEqual(ssl.PROTOCOL_TLSv1, context.protocol)
+    else:
+      self.assertIsNone(context)
+
+
 
     properties = FakeProperties({
       SSL_API: "false"


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the event SSLContext is not available in the Python's `ssl` module, do not attempt to create a new SSLContext to pass into the `urllib2.urlopen` calls - use `None` instead.  

This is the same patch as #1745. 

## How was this patch tested?

```
mvn -pl ambari-server -DskipSurefireTests test
...
PENDING
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.