### PR TITLE
[AMBARI-24303] [Log Search UI] Move the dev environment information from .gitignore to README.md

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/.gitignore
+++ b/ambari-logsearch/ambari-logsearch-web/.gitignore
@@ -42,22 +42,4 @@ testem.log
 Thumbs.db
 
 # Development Test Files
-#
-# Webpack Development Config
-# In order to use Webpack Devserver proxy without changing the main config file
-# and commit accidentally we can use a webpack.config.dev.js file for that
-# Eg.:
-# const merge = require('webpack-merge');
-# const baseConfig = require('./webpack.config.js');
-#
-# module.exports = merge(baseConfig, {
-#   devServer: {
-#     historyApiFallback: true,
-#     proxy: {
-#       '/': 'http://c7401.ambari.apache.org:61888'
-#     }
-#   }
-# });
-# And you can start it that way: NODE_ENV=production yarn start --config webpack.config.dev.js
-# You have to set the NODE_ENV to production in order to skip the mock data usage
 webpack.config.dev.js

--- a/ambari-logsearch/ambari-logsearch-web/README.md
+++ b/ambari-logsearch/ambari-logsearch-web/README.md
@@ -6,6 +6,26 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `npm start` or `yarn start` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
+## Webpack Development Config
+In order to use Webpack Devserver proxy without changing the main config file and commit accidentally we can use a `webpack.config.dev.js` file for that. So you can set a service URL in order to test the UI against real data.
+
+The content of the `webpack.config.dev.js` can be:
+```
+const merge = require('webpack-merge');
+const baseConfig = require('./webpack.config.js');
+
+module.exports = merge(baseConfig, {
+  devServer: {
+    historyApiFallback: true,
+    proxy: {
+      '/': 'http://c7401.ambari.apache.org:61888'
+    }
+  }
+});
+```
+And you can start it that way: `NODE_ENV=production yarn start --config webpack.config.dev.js`
+You have to set the `NODE_ENV` to production in order to skip the mock data usage
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive/pipe/service/class/module`.


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change the webpack develompent configuration information has been moved from `.gitignore` to `README.md` file.

## How was this patch tested?

No need testing, but the unit test are all successful.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.