### PR TITLE
AMBARI-24276 include derby jars for Hive convert table step (ashutosh)

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
@@ -21,7 +21,7 @@ limitations under the License.
 import os
 import shutil
 import traceback
-
+import glob
 
 # Ambari Commons & Resource Management Imports
 from resource_management.core.exceptions import Fail
@@ -100,6 +100,10 @@ class HivePreUpgrade(Script):
       Execute(hive_kinit_cmd, user = params.hive_user)
     
     classpath = format("{source_dir}/hive2/lib/*:{source_dir}/hadoop/*:{source_dir}/hadoop/lib/*:{source_dir}/hadoop-mapreduce/*:{source_dir}/hadoop-mapreduce/lib/*:{source_dir}/hadoop-hdfs/*:{source_dir}/hadoop-hdfs/lib/*:{source_dir}/hadoop/etc/hadoop/:{target_dir}/hive/lib/hive-pre-upgrade.jar:{source_dir}/hive/conf/conf.server")
+    # hack to avoid derby cp issue we want derby-10.10.2.0.jar to appear first in cp, if its available, note other derby jars are derbyclient-10.11.1.1.jar  derbynet-10.11.1.1.jar
+    derby_jars = glob.glob(source_dir+"/hive2/lib/*derby-*.jar")
+    if len(derby_jars) == 1:
+      classpath = derby_jars[0] + ":" + classpath
     cmd = format("{java64_home}/bin/java -Djavax.security.auth.useSubjectCredsOnly=false -cp {classpath} org.apache.hadoop.hive.upgrade.acid.PreUpgradeTool -execute")
     Execute(cmd, user = params.hive_user)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Derby jars are included in the classpath of the Hive convert table upgrade step

## How was this patch tested?

Tested on the test cluster that provided the problem.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.