### PR TITLE
[AMBARI-24161] Cannot distinguish components on Host Details page due to shortened display name (Ambari should show full component name on mouse over)

### DIFF
--- a/ambari-web/app/templates/main/host/details/host_component.hbs
+++ b/ambari-web/app/templates/main/host/details/host_component.hbs
@@ -47,9 +47,9 @@
 <td class="component-name-block">
   <span>
     {{#if component.displayNameAdvanced}}
-      <span {{bindAttr title="component.displayNameAdvanced"}}>{{component.getDisplayNameAdvanced}}&nbsp;/</span>
+      <span rel="componentNameTooltip" {{bindAttr data-original-title="component.displayNameAdvanced"}}>{{component.getDisplayNameAdvanced}}&nbsp;/</span>
     {{else}}
-      <span {{bindAttr title="component.displayName"}}>{{component.getDisplayName}}&nbsp;/</span>
+      <span rel="componentNameTooltip" {{bindAttr data-original-title="component.displayName"}}>{{component.getDisplayName}}&nbsp;/</span>
     {{/if}}
     <span class="hidden-lg"><br/></span>
     <a href="#" {{action routeToService component.service}} {{bindAttr title="component.service.displayName"}}>

--- a/ambari-web/app/views/main/host/details/host_component_view.js
+++ b/ambari-web/app/views/main/host/details/host_component_view.js
@@ -274,6 +274,7 @@ App.HostComponentView = Em.View.extend({
   didInsertElement: function () {
     App.tooltip($('[rel=componentHealthTooltip]'));
     App.tooltip($('[rel=passiveTooltip]'));
+    App.tooltip($('[rel=componentNameTooltip]'));
     if (this.get('isInProgress')) {
       this.doBlinking();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Yarn has 2 version of  timeline service .
1) TIMELINE SERVICE V1.5
2) TIMELINE SERVICE V2.0 READER

When both of these services are installed on one host, go to Component page . Component Page only shows first few chars "Timeline Service... ".
Ambari UI shows "Timeline Service.." for both Timeline service 1.5 and 2.0 . Thus, user can not identify which is Timeline service 1.5 or 2.0 

ambari should show the full component name when user brings mouse pointer on the component name. 

## How was this patch tested?

UI unit tests:
  21825 passing (26s)
  48 pending
