### PR TITLE
[AMBARI-24308] 'Changed properties' filter for configs is displayed even in non-compare mode

### DIFF
--- a/ambari-web/app/controllers/main/service/info/configs.js
+++ b/ambari-web/app/controllers/main/service/info/configs.js
@@ -230,7 +230,7 @@ App.MainServiceInfoConfigsController = Em.Controller.extend(App.AddSecurityConfi
     var filterColumns = [];
 
     this.get('propertyFilters').forEach(function(filter) {
-      if (this.get('canBeExcluded') && !(Em.isNone(filter.dependentOn) || this.get(filter.dependentOn))) {
+      if (filter.canBeExcluded && !(Em.isNone(filter.dependentOn) || this.get(filter.dependentOn))) {
         return; // exclude column
       }
       filterColumns.push(Ember.Object.create({


### PR DESCRIPTION
## What changes were proposed in this pull request?

Filtering configs by changed properties should be available in versions comparison mode only, but as of now it's displayed always, not filtering out anything in regular mode.

## How was this patch tested?

UI unit tests:
  21825 passing (26s)
  48 pending
