### PR TITLE
[AMBARI-24310] UI sends host check request for custom jdk with invalid hosts

### DIFF
--- a/ambari-web/app/controllers/wizard/step3_controller.js
+++ b/ambari-web/app/controllers/wizard/step3_controller.js
@@ -725,9 +725,9 @@ App.WizardStep3Controller = Em.Controller.extend(App.ReloadPopupMixin, App.Check
   },
 
   doCheckJDK: function () {
-    var hostsNames = (!this.get('content.installOptions.manualInstall')) ? this.get('bootHosts').filterProperty('bootStatus', 'REGISTERED').getEach('name').join(",") : this.get('bootHosts').getEach('name').join(",");
-    var javaHome = this.get('javaHome');
-    var jdkLocation = this.get('jdkLocation');
+    const hostsNames = this.get('bootHosts').filterProperty('bootStatus', 'REGISTERED').getEach('name').join(','),
+      javaHome = this.get('javaHome'),
+      jdkLocation = this.get('jdkLocation');
     App.ajax.send({
       name: 'wizard.step3.jdk_check',
       sender: this,


### PR DESCRIPTION
## What changes were proposed in this pull request?

UI sends "java_home_check" host check with all populated hosts instead hosts with passed registration only. This can cause 500 server exception due HostNotFoundException.
```
2018-07-05 14:10:30,930 ERROR [ambari-client-thread-573] AbstractResourceProvider:295 - Caught AmbariException when creating a resource
org.apache.ambari.server.HostNotFoundException: Host not found, hostname=test-0000
        at org.apache.ambari.server.state.cluster.ClustersImpl.getHost(ClustersImpl.java:456)
        at org.apache.ambari.server.state.ConfigHelper.getEffectiveDesiredTags(ConfigHelper.java:189)
        at org.apache.ambari.server.state.ConfigHelper.getEffectiveDesiredTags(ConfigHelper.java:173)
        at org.apache.ambari.server.controller.AmbariManagementControllerImpl.findConfigurationTagsWithOverrides(AmbariManagementControllerImpl.java:2353)
```
```
POST http://host:8080/api/v1/requests 500 (Internal Server Error)
send @ vendor.js:8630
jQuery.extend.ajax @ vendor.js:8082
send @ app.js:192735
doCheckJDK @ app.js:41241
(anonymous function) @ app.js:41318
fire @ vendor.js:1141
self.fireWith @ vendor.js:1252
done @ vendor.js:8178
callback @ vendor.js:8702
```
Body of request:
```
{"RequestInfo":{"context":"Check hosts","action":"check_host","parameters":{"threshold":"60","java_home":"/tmp/jdk1.8.0_171/","jdk_location":"http://host:8080/resources","check_execute_list":"java_home_check"}},"Requests/resource_filters":[{"hosts":"test-0000,test-0001,test-0002,...
```

## How was this patch tested?

UI unit tests:
  21825 passing (26s)
  48 pending
