### PR TITLE
[AMBARI-24315] Clicking on password warnings doesn't update the service tab navigation

### DIFF
--- a/ambari-web/app/controllers/wizard/step7_controller.js
+++ b/ambari-web/app/controllers/wizard/step7_controller.js
@@ -1904,6 +1904,7 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
   },
 
   selectService: function (event) {
+    event.context.set('isActive', true);
     this.set('selectedService', event.context);
     var activeTabs = this.get('tabs').findProperty('isActive', true);
     if (activeTabs) {
@@ -2079,6 +2080,9 @@ App.WizardStep7Controller = Em.Controller.extend(App.ServerValidatorMixin, App.E
     Em.run.next(this, function () {
       this.set('filter', propertyName);
     });
+
+    this.get('stepConfigs').setEach('isActive', false);
+    stepConfig.set('isActive', true);
   },
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When choosing an insufficient password like 'admin' for services, we're seeing the critical warning for password strength which is what we want, but when you click on the property to navigate to it, the service tab navigation is not getting updated so it "looks" like you're always in the HDFS service.

## How was this patch tested?

  21828 passing (55s)
  48 pending