### PR TITLE
AMBARI-24320. Using the proper command name when creating a pre-initialized ActionExecuteContent instead of the hard coded SET_KEYTAB value

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -3866,7 +3866,7 @@ public class KerberosHelperImpl implements KerberosHelper {
         String commandName, List<RequestResourceFilter> resourceFilters,
         Map<String, String> parameters, boolean retryAllowed) {
 
-      ActionExecutionContext actionExecContext = new ActionExecutionContext(clusterName, SET_KEYTAB,
+      ActionExecutionContext actionExecContext = new ActionExecutionContext(clusterName, commandName,
           resourceFilters, parameters);
 
       actionExecContext.setRetryAllowed(retryAllowed);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When enabling Kerberos or regenerating keytabs on Kerberos page with `Only regenerate keytabs for missing hosts and components `enabled there were two SET_KEYTAB commands sent to the agent instead of a CHECK_KEYTABS and a SET_KEYTAB commands.

## How was this patch tested?

Executed unit tests and manually tested on a cluster; after I deployed the new version of my code and regenerated keytabs for missing hosts and components only I found the proper records in the database:

<img width="1444" alt="screen shot 2018-07-20 at 10 51 19 am" src="https://user-images.githubusercontent.com/34065904/42993145-e5750740-8c0a-11e8-93e2-e09e7379cca9.png">

I also checked Ambari's UI:

<img width="1603" alt="screen shot 2018-07-20 at 10 47 09 am" src="https://user-images.githubusercontent.com/34065904/42992983-818c2060-8c0a-11e8-8dbc-8a8e24f81942.png">
