### PR TITLE
[AMBARI-24312] [LogSearch UI] Audit screen sub tab changes clear the Summary charts.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/graph.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/graph.component.ts
@@ -209,6 +209,7 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
     this.graphContainer = this.graphContainerRef.nativeElement;
     this.tooltip = this.tooltipRef.nativeElement;
     this.host = d3.select(this.graphContainer);
+    this.createGraph();
   }
 
   ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The graph creation process now is triggered from `afterViewInit` too, since we have to be sure that the chart has been created event if the `afterViewInit` runs later then `ngOnChanges` (so that the `host` property will be available later.

## How was this patch tested?

It was tested manually and by running unit tests (`Executed 268 of 268 SUCCESS (8.955 secs / 8.837 secs)`)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.