### PR TITLE
AMBARI-24322. Log Search / Ambari upgrade: db config consistency chec…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1528,7 +1528,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
   }
 
   private void removeLogSearchPatternConfigs(DBAccessor dbAccessor) throws SQLException {
-    // remove config types with -logsearch-conf prefix
+    // remove config types with -logsearch-conf suffix
     String configSuffix = "-logsearch-conf";
     String serviceConfigMappingRemoveSQL = String.format(
       "DELETE FROM %s WHERE config_id IN (SELECT config_id from %s where type_name like '%%%s')",

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -1113,7 +1113,7 @@ public class UpgradeCatalog270Test {
     Capture<Map<String, String>> logFeederOutputConfCapture = EasyMock.newCapture();
     expect(controller.createConfig(anyObject(Cluster.class), anyObject(StackId.class), anyString(), capture(logFeederOutputConfCapture), anyString(),
         EasyMock.anyObject())).andReturn(config).once();
-    
+
     String serviceConfigMapping = "serviceconfigmapping";
     String clusterConfig = "clusterconfig";
     dbAccessor.executeQuery(startsWith("DELETE FROM "+ serviceConfigMapping));

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -1113,8 +1113,7 @@ public class UpgradeCatalog270Test {
     Capture<Map<String, String>> logFeederOutputConfCapture = EasyMock.newCapture();
     expect(controller.createConfig(anyObject(Cluster.class), anyObject(StackId.class), anyString(), capture(logFeederOutputConfCapture), anyString(),
         EasyMock.anyObject())).andReturn(config).once();
-
-    String logsearchConfPrefix = "-logsearch-conf";
+    
     String serviceConfigMapping = "serviceconfigmapping";
     String clusterConfig = "clusterconfig";
     dbAccessor.executeQuery(startsWith("DELETE FROM "+ serviceConfigMapping));


### PR DESCRIPTION
…k has warnings (*-logearch-conf configs).

## What changes were proposed in this pull request?
Seems like ConfigHelper.removeConfigType does not worked at all, even with evicting cache with entity manager, or create a transaction at the right place of the code removing and flushing the proper config entities, so i just run 2 queries with dbAccessor.


## How was this patch tested?
manually with updated jar + ambari-server upgrade command
(for some reason i still have 1 warning, there is an ams-site config in my db, although there was no ams installed at all...but that was there before upgrade as well)

Also i get dbAccessor through the injector if it does not exist, but it just useful for testing as it was a bit complicated to do with mocking (the filed mock from UpgradeCatalog270Test was not injected there for some reason)

Please review @g-boros @miklosgergely @rlevas @zeroflag 