### PR TITLE
AMBARI-24324. install tasks sometimes fail

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/shell.py
+++ b/ambari-common/src/main/python/ambari_commons/shell.py
@@ -487,6 +487,7 @@ def process_executor(command, timeout=__TIMEOUT_SECONDS, error_callback=None, st
 
   buff_queue = None
   kill_timer = None
+  kill_timer_started = False
 
   try:
     cmd = launch_subprocess(command, env=env)
@@ -497,6 +498,7 @@ def process_executor(command, timeout=__TIMEOUT_SECONDS, error_callback=None, st
     kill_timer.daemon = True
     if timeout > -1:
       kill_timer.start()
+      kill_timer_started = True
 
     if strategy == ReaderStrategy.BufferedQueue:
       buff_queue = BufferedQueue()
@@ -521,7 +523,7 @@ def process_executor(command, timeout=__TIMEOUT_SECONDS, error_callback=None, st
   finally:
     if buff_queue:
       buff_queue.notify_end()
-    if kill_timer:
+    if kill_timer and kill_timer_started:
       kill_timer.cancel()
       kill_timer.join()
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/ZOOKEEPER/package/scripts/zookeeper_client.py", line 81, in <module>
    ZookeeperClient().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 353, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/ZOOKEEPER/package/scripts/zookeeper_client.py", line 61, in install
    self.install_packages(env)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 836, in install_packages
    retry_count=agent_stack_retry_count)
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/packaging.py", line 30, in action_install
    self._pkg_manager.install_package(package_name, self.__create_context())
  File "/usr/lib/ambari-agent/lib/ambari_commons/repo_manager/yum_manager.py", line 219, in install_package
    shell.repository_manager_executor(cmd, self.properties, context)
  File "/usr/lib/ambari-agent/lib/ambari_commons/shell.py", line 742, in repository_manager_executor
    call_result = subprocess_executor(cmd, timeout=-1, env=env)
  File "/usr/lib/ambari-agent/lib/ambari_commons/shell.py", line 446, in subprocess_executor
    lines = [line for line in output]
  File "/usr/lib64/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/usr/lib/ambari-agent/lib/ambari_commons/shell.py", line 528, in process_executor
    kill_timer.join()
  File "/usr/lib64/python2.7/threading.py", line 940, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started