### PR TITLE
[AMBARI-24325] [Log Search UI] Unaccessible query filter type ahead element in small window

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.less
@@ -101,6 +101,8 @@
 
     /deep/ typeahead-container .dropdown-menu {
       .dropdown-list-default;
+      max-height: 80vh;
+      overflow-y: auto;
 
       > li {
         .dropdown-item-default;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a quick fix for the long dropdown for query filter bar.

## How was this patch tested?

It was tested manually.
Unit tests: `Executed 268 of 268 SUCCESS (7.76 secs / 7.655 secs)`

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.