### PR TITLE
AMBARI-24319. Regenerating keytabs for the given service(s) only

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -138,7 +138,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -1867,7 +1866,7 @@ public class KerberosHelperImpl implements KerberosHelper {
 
                   String uniqueKey = String.format("%s|%s", principal, (keytabFile == null) ? "" : keytabFile);
 
-                  if (!hostActiveIdentities.containsKey(uniqueKey)) {
+                  if (!hostActiveIdentities.containsKey(uniqueKey) || (StringUtils.isNotBlank(hostActiveIdentities.get(uniqueKey).getReference()) && StringUtils.isBlank(identity.getReference()))) {
                     KerberosPrincipalType principalType = principalDescriptor.getType();
 
                     // Assume the principal is a service principal if not specified
@@ -2468,8 +2467,7 @@ public class KerberosHelperImpl implements KerberosHelper {
       handler.createStages(cluster,
         clusterHostInfoJson, hostParamsJson, event, roleCommandOrder, kerberosDetails,
         dataDirectory, requestStageContainer, serviceComponentHostsToProcess,
-        Collections.singletonMap("KERBEROS", Lists.newArrayList("KERBEROS_CLIENT")),
-        null, Sets.newHashSet(principal), hostsWithValidKerberosClient);
+        null, null, Sets.newHashSet(principal), hostsWithValidKerberosClient);
 
 
       handler.addFinalizeOperationStage(cluster, clusterHostInfoJson, hostParamsJson, event,

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.serveraction.kerberos;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,6 +42,7 @@ import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerbero
 import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerberosPrincipal;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -176,12 +178,6 @@ public abstract class KerberosServerAction extends AbstractServerAction {
    */
   @Inject
   private KerberosOperationHandlerFactory kerberosOperationHandlerFactory;
-
-  /**
-   * The KerberosIdentityDataFileReaderFactory to use to obtain KerberosIdentityDataFileReader instances
-   */
-  @Inject
-  private KerberosIdentityDataFileReaderFactory kerberosIdentityDataFileReaderFactory;
 
   /**
    * KerberosHelper
@@ -455,13 +451,17 @@ public abstract class KerberosServerAction extends AbstractServerAction {
       }
 
       try {
-        for (ResolvedKerberosKeytab rkk : kerberosKeytabController.getFilteredKeytabs((Map<String, Collection<String>>) getServiceComponentFilter(), getHostFilter(), getIdentityFilter())) {
+        final Map<String, Collection<String>> serviceComponentFilter = (Map<String, Collection<String>>) getServiceComponentFilter();
+        final Collection<KerberosIdentityDescriptor> serviceIdentities = serviceComponentFilter == null ? null : calculateServiceIdentities(getClusterName(), serviceComponentFilter);
+        for (ResolvedKerberosKeytab rkk : kerberosKeytabController.getFilteredKeytabs(serviceComponentFilter, getHostFilter(), getIdentityFilter())) {
           for (ResolvedKerberosPrincipal principal : rkk.getPrincipals()) {
-            commandReport = processIdentity(principal, handler, kerberosConfiguration, requestSharedDataContext);
-            // If the principal processor returns a CommandReport, than it is time to stop since
-            // an error condition has probably occurred, else all is assumed to be well.
-            if (commandReport != null) {
-              break;
+            if (isRelevantIdentity(serviceIdentities, principal)) {
+              commandReport = processIdentity(principal, handler, kerberosConfiguration, requestSharedDataContext);
+              // If the principal processor returns a CommandReport, than it is time to stop
+              // since an error condition has probably occurred, else all is assumed to be well.
+              if (commandReport != null) {
+                break;
+              }
             }
           }
         }
@@ -485,6 +485,32 @@ public abstract class KerberosServerAction extends AbstractServerAction {
     return (commandReport == null)
         ? createCommandReport(0, HostRoleStatus.COMPLETED, "{}", actionLog.getStdOut(), actionLog.getStdErr())
         : commandReport;
+  }
+
+  private boolean isRelevantIdentity(Collection<KerberosIdentityDescriptor> serviceIdentities, ResolvedKerberosPrincipal principal) {
+    if (serviceIdentities != null) {
+      boolean hasValidIdentity = false;
+      for (KerberosIdentityDescriptor serviceIdentity : serviceIdentities) {
+        if (principal.getPrincipal().equals(serviceIdentity.getPrincipalDescriptor().getName()) && StringUtils.isBlank(serviceIdentity.getReference())) {
+          hasValidIdentity = true;
+          break;
+        }
+      }
+      return hasValidIdentity;
+    }
+
+    return true;
+  }
+
+  private Collection<KerberosIdentityDescriptor> calculateServiceIdentities(String clusterName, Map<String, Collection<String>> serviceComponentFilter)
+      throws AmbariException {
+    final Collection<KerberosIdentityDescriptor> serviceIdentities = new ArrayList<>();
+    for (String service : serviceComponentFilter.keySet()) {
+      for (Collection<KerberosIdentityDescriptor> activeIdentities : kerberosHelper.getActiveIdentities(clusterName, null, service, null, true).values()) {
+        serviceIdentities.addAll(activeIdentities);
+      }
+    }
+    return serviceIdentities;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When regenerating keytabs on service level (i.e. in Services / HDFS / Actions / Regenerating keytabs) Ambari regenerated shared keytabs too (i.e. SPNEGO keytabs that are referenced by other services too). This led several issues when tried to authenticate to other web based services.
The solution is to regenerate keytabs that belong to that  actual service only. 

## How was this patch tested?

Latest JUnit test results in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 46:32 min
[INFO] Finished at: 2018-07-21T10:37:09+02:00
[INFO] Final Memory: 171M/825M
[INFO] ------------------------------------------------------------------------
```

In addition to this I've tested this scenario in a test cluster. After my change I regenerated HDFS service's keytabs with this result:
```
[root@c7401 ~]# ls -tal /etc/security/keytabs/
total 32
-r--------. 1 hdfs      hadoop  433 Jul 21 08:48 nn.service.keytab
-r--------. 1 hdfs      hadoop  363 Jul 21 08:48 hdfs.headless.keytab
-r--r-----. 1 ambari-qa hadoop  388 Jul 21 07:35 smokeuser.headless.keytab
-rw-r-----. 1 ambari-qa hadoop  373 Jul 21 07:35 kerberos.service_check.072018.keytab
-r--r-----. 1 root      hadoop  443 Jul 21 07:35 spnego.service.keytab
-r--------. 1 root      root    408 Jul 21 07:35 ambari.server.keytab
drwxr-xr-x. 2 root      root    237 Jul 21 07:28 .
drwxr-xr-x. 7 root      root   4096 Jul 21 07:25 ..
-rw-r-----. 1 ambari-qa hadoop  373 Jul 21 07:25 kerberos.service_check.072118.keytab
```
