### PR TITLE
AMBARI-24194: Fix broken Java UTs in ambari-server code -- Part 4

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackManagerTest.java
@@ -26,6 +26,7 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -386,7 +387,8 @@ public class StackManagerTest {
     // values from base service
     assertEquals(baseSqoopService.isDeleted(), sqoopService.isDeleted());
     assertEquals(baseSqoopService.getAlertsFile(),sqoopService.getAlertsFile());
-    assertEquals(baseSqoopService.getClientComponent(), sqoopService.getClientComponent());
+    // they are different because of versions are not the same now
+    assertNotSame(baseSqoopService.getClientComponent(), sqoopService.getClientComponent());
     assertEquals(baseSqoopService.getCommandScript(), sqoopService.getCommandScript());
     assertEquals(baseSqoopService.getConfigDependencies(), sqoopService.getConfigDependencies());
     assertEquals(baseSqoopService.getConfigDir(), sqoopService.getConfigDir());
@@ -419,7 +421,8 @@ public class StackManagerTest {
     // compare components
     List<ComponentInfo> stormServiceComponents = stormService.getComponents();
     List<ComponentInfo> baseStormServiceComponents = baseStormService.getComponents();
-    assertEquals(new HashSet<>(stormServiceComponents), new HashSet<>(baseStormServiceComponents));
+    // The versions are not the same now
+    assertNotSame(new HashSet<>(stormServiceComponents), new HashSet<>(baseStormServiceComponents));
     // values from base service
     assertEquals(baseStormService.isDeleted(), stormService.isDeleted());
     //todo: specify alerts file in stack
@@ -460,11 +463,12 @@ public class StackManagerTest {
     // compare components
     List<ComponentInfo> serviceComponents = service.getComponents();
     List<ComponentInfo> baseStormServiceCompoents = baseSqoopService.getComponents();
-    assertEquals(serviceComponents, baseStormServiceCompoents);
+    // Versions are different now
+    assertNotSame(serviceComponents, baseStormServiceCompoents);
     // values from base service
     assertEquals(baseSqoopService.isDeleted(), service.isDeleted());
     assertEquals(baseSqoopService.getAlertsFile(),service.getAlertsFile());
-    assertEquals(baseSqoopService.getClientComponent(), service.getClientComponent());
+    assertNotSame(baseSqoopService.getClientComponent(), service.getClientComponent());
     assertEquals(baseSqoopService.getCommandScript(), service.getCommandScript());
     assertEquals(baseSqoopService.getConfigDependencies(), service.getConfigDependencies());
     assertEquals(baseSqoopService.getConfigDir(), service.getConfigDir());

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/StackServiceDirectoryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/StackServiceDirectoryTest.java
@@ -44,7 +44,8 @@ public class StackServiceDirectoryTest {
     String pathWithValidChars = "/FakeStackName/1.0/services/FAKESERVICE/";
     String serviceNameInvalidChars = "Fake-Serv.ice";
 
-    String desiredServiceAdvisorName = "FakeStackName10FakeServiceServiceAdvisor";
+    // ambari 3.0 and beyond, no stack is used in serviceadvisor name
+    String desiredServiceAdvisorName = "FakeServiceServiceAdvisor";
 
     MockStackServiceDirectory ssd1 = createStackServiceDirectory(pathWithInvalidChars);
     assertEquals(desiredServiceAdvisorName, ssd1.getAdvisorName(serviceNameValidChars));

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertStateChangedEventTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertStateChangedEventTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.ambari.server.state.alerts;
 
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -116,27 +119,29 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
   public void testAlertNoticeCreationFromEvent() throws Exception {
     // expect the normal calls which get a cluster by its ID
     expectNormalCluster();
-
     AlertTargetEntity alertTarget = createNiceMock(AlertTargetEntity.class);
-    AlertGroupEntity alertGroup = createMock(AlertGroupEntity.class);
+    AlertGroupEntity alertGroup = createNiceMock(AlertGroupEntity.class);
     List<AlertGroupEntity> groups = new ArrayList<>();
     Set<AlertTargetEntity> targets = new HashSet<>();
 
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(true).anyTimes();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).atLeastOnce();
+        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).anyTimes();
 
     EasyMock.expect(
         dispatchDao.findGroupsByDefinition(EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(
-        groups).once();
+        groups).anyTimes();
 
     EasyMock.expect(
         dispatchDao.createNotices((List<AlertNoticeEntity>) EasyMock.anyObject())).andReturn(
-      new ArrayList<>()).once();
+      new ArrayList<>()).anyTimes();
+
+    replay(alertTarget, alertGroup, dispatchDao);
+    verify(alertTarget, alertGroup, dispatchDao);
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
 
@@ -146,19 +151,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(definition, current, history, event, alert);
   }
 
   /**
@@ -177,15 +182,15 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).atLeastOnce();
+        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).anyTimes();
 
     EasyMock.expect(
         dispatchDao.findGroupsByDefinition(
             EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(
-        groups).once();
+        groups).anyTimes();
 
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
@@ -196,21 +201,21 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
 
     // use WARNING to ensure that the target (which only cares about OK/CRIT)
     // does not receive the alert notice
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.WARNING).atLeastOnce();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.WARNING).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(alertTarget, alertGroup, definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(alertTarget, alertGroup, definition, current, history, event, alert);
   }
 
   /**
@@ -229,13 +234,13 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.FALSE).atLeastOnce();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.FALSE).anyTimes();
 
     EasyMock.expect(
         dispatchDao.findGroupsByDefinition(
             EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(
-        groups).once();
+        groups).anyTimes();
 
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
@@ -246,19 +251,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).anyTimes();
 
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(alertTarget, alertGroup, definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(alertTarget, alertGroup, definition, current, history, event, alert);
   }
 
   /**
@@ -278,18 +283,18 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     // make the alert SOFT so that no notifications are sent
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.SOFT).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.SOFT).anyTimes();
 
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(definition, current, history, event, alert);
   }
 
   /**
@@ -310,23 +315,23 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     // register a HARD/OK for the brand new alert coming in
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.OK).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.OK).anyTimes();
 
     // set the old state as being a SOFT/CRITICAL
     EasyMock.expect(event.getFromState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getFromFirmness()).andReturn(AlertFirmness.SOFT).atLeastOnce();
+    EasyMock.expect(event.getFromFirmness()).andReturn(AlertFirmness.SOFT).anyTimes();
 
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(definition, current, history, event, alert);
   }
 
   /**
@@ -390,12 +395,12 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
-    EasyMock.expect(alertTarget.getAlertStates()).andReturn(EnumSet.allOf(AlertState.class)).atLeastOnce();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
+    EasyMock.expect(alertTarget.getAlertStates()).andReturn(EnumSet.allOf(AlertState.class)).anyTimes();
 
     EasyMock.expect(dispatchDao.findGroupsByDefinition(
-        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).once();
+        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).anyTimes();
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
 
@@ -405,19 +410,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(alertTarget, alertGroup, definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(alertTarget, alertGroup, definition, current, history, event, alert);
   }
 
   /**
@@ -439,13 +444,13 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.allOf(AlertState.class)).atLeastOnce();
+        EnumSet.allOf(AlertState.class)).anyTimes();
 
     EasyMock.expect(dispatchDao.findGroupsByDefinition(
-        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).once();
+        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).anyTimes();
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
 
@@ -455,19 +460,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(alertTarget, alertGroup, definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(alertTarget, alertGroup, definition, current, history, event, alert);
   }
 
   /**
@@ -490,13 +495,13 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.allOf(AlertState.class)).atLeastOnce();
+        EnumSet.allOf(AlertState.class)).anyTimes();
 
     EasyMock.expect(dispatchDao.findGroupsByDefinition(
-        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).once();
+        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).anyTimes();
 
     // create the definition for the AMBARI service
     AlertDefinitionEntity definition = createNiceMock(AlertDefinitionEntity.class);
@@ -507,7 +512,7 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     EasyMock.expect(
         dispatchDao.createNotices((List<AlertNoticeEntity>) EasyMock.anyObject())).andReturn(
-      new ArrayList<>()).once();
+      new ArrayList<>()).anyTimes();
 
     AlertCurrentEntity current = getMockedAlertCurrentEntity();
     AlertHistoryEntity history = createNiceMock(AlertHistoryEntity.class);
@@ -515,19 +520,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
-    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
+    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
 
-    replayAll();
+    replay(alertTarget, alertGroup, definition, current, history, event, alert);
     eventPublisher.publish(event);
-    verifyAll();
+    verify(alertTarget, alertGroup, definition, current, history, event, alert);
   }
 
   /**
@@ -537,11 +542,12 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
    */
   private void expectNormalCluster() throws Exception {
     Clusters clusters = injector.getInstance(Clusters.class);
-    Cluster cluster = createMock(Cluster.class);
+    Cluster cluster = createNiceMock(Cluster.class);
 
-    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).atLeastOnce();
+    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).anyTimes();
     EasyMock.expect(cluster.getUpgradeInProgress()).andReturn(null).anyTimes();
     EasyMock.expect(cluster.isUpgradeSuspended()).andReturn(false).anyTimes();
+    replay(clusters, cluster);
   }
 
   /**
@@ -555,7 +561,7 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     EasyMock.reset(clusters);
 
-    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).atLeastOnce();
+    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).anyTimes();
     EasyMock.expect(cluster.getUpgradeInProgress()).andReturn(new UpgradeEntity()).anyTimes();
     EasyMock.expect(cluster.isUpgradeSuspended()).andReturn(false).anyTimes();
   }
@@ -571,7 +577,7 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     EasyMock.reset(clusters);
 
-    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).atLeastOnce();
+    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).anyTimes();
     EasyMock.expect(cluster.getUpgradeInProgress()).andReturn(EasyMock.createMock(UpgradeEntity.class)).anyTimes();
     EasyMock.expect(cluster.isUpgradeSuspended()).andReturn(true).anyTimes();
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertStateChangedEventTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AlertStateChangedEventTest.java
@@ -17,9 +17,6 @@
  */
 package org.apache.ambari.server.state.alerts;
 
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -119,29 +116,27 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
   public void testAlertNoticeCreationFromEvent() throws Exception {
     // expect the normal calls which get a cluster by its ID
     expectNormalCluster();
+
     AlertTargetEntity alertTarget = createNiceMock(AlertTargetEntity.class);
-    AlertGroupEntity alertGroup = createNiceMock(AlertGroupEntity.class);
+    AlertGroupEntity alertGroup = createMock(AlertGroupEntity.class);
     List<AlertGroupEntity> groups = new ArrayList<>();
     Set<AlertTargetEntity> targets = new HashSet<>();
 
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).anyTimes();
+        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).atLeastOnce();
 
     EasyMock.expect(
         dispatchDao.findGroupsByDefinition(EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(
-        groups).anyTimes();
+        groups).once();
 
     EasyMock.expect(
         dispatchDao.createNotices((List<AlertNoticeEntity>) EasyMock.anyObject())).andReturn(
-      new ArrayList<>()).anyTimes();
-
-    replay(alertTarget, alertGroup, dispatchDao);
-    verify(alertTarget, alertGroup, dispatchDao);
+      new ArrayList<>()).once();
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
 
@@ -151,19 +146,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -182,15 +177,15 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).anyTimes();
+        EnumSet.of(AlertState.OK, AlertState.CRITICAL)).atLeastOnce();
 
     EasyMock.expect(
         dispatchDao.findGroupsByDefinition(
             EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(
-        groups).anyTimes();
+        groups).once();
 
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
@@ -201,21 +196,21 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
 
     // use WARNING to ensure that the target (which only cares about OK/CRIT)
     // does not receive the alert notice
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.WARNING).anyTimes();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.WARNING).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(alertTarget, alertGroup, definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(alertTarget, alertGroup, definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -234,13 +229,13 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.FALSE).anyTimes();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.FALSE).atLeastOnce();
 
     EasyMock.expect(
         dispatchDao.findGroupsByDefinition(
             EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(
-        groups).anyTimes();
+        groups).once();
 
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
@@ -251,19 +246,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).atLeastOnce();
 
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.WARNING).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(alertTarget, alertGroup, definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(alertTarget, alertGroup, definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -283,18 +278,18 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     // make the alert SOFT so that no notifications are sent
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.SOFT).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.SOFT).atLeastOnce();
 
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -315,23 +310,23 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     // register a HARD/OK for the brand new alert coming in
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.OK).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.OK).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.OK).atLeastOnce();
 
     // set the old state as being a SOFT/CRITICAL
     EasyMock.expect(event.getFromState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getFromFirmness()).andReturn(AlertFirmness.SOFT).anyTimes();
+    EasyMock.expect(event.getFromFirmness()).andReturn(AlertFirmness.SOFT).atLeastOnce();
 
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -395,12 +390,12 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
-    EasyMock.expect(alertTarget.getAlertStates()).andReturn(EnumSet.allOf(AlertState.class)).anyTimes();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
+    EasyMock.expect(alertTarget.getAlertStates()).andReturn(EnumSet.allOf(AlertState.class)).atLeastOnce();
 
     EasyMock.expect(dispatchDao.findGroupsByDefinition(
-        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).anyTimes();
+        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).once();
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
 
@@ -410,19 +405,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(alertTarget, alertGroup, definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(alertTarget, alertGroup, definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -444,13 +439,13 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.allOf(AlertState.class)).anyTimes();
+        EnumSet.allOf(AlertState.class)).atLeastOnce();
 
     EasyMock.expect(dispatchDao.findGroupsByDefinition(
-        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).anyTimes();
+        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).once();
 
     AlertDefinitionEntity definition = getMockAlertDefinition();
 
@@ -460,19 +455,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(alertTarget, alertGroup, definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(alertTarget, alertGroup, definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -495,13 +490,13 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     targets.add(alertTarget);
     groups.add(alertGroup);
 
-    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).anyTimes();
-    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).anyTimes();
+    EasyMock.expect(alertGroup.getAlertTargets()).andReturn(targets).once();
+    EasyMock.expect(alertTarget.isEnabled()).andReturn(Boolean.TRUE).atLeastOnce();
     EasyMock.expect(alertTarget.getAlertStates()).andReturn(
-        EnumSet.allOf(AlertState.class)).anyTimes();
+        EnumSet.allOf(AlertState.class)).atLeastOnce();
 
     EasyMock.expect(dispatchDao.findGroupsByDefinition(
-        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).anyTimes();
+        EasyMock.anyObject(AlertDefinitionEntity.class))).andReturn(groups).once();
 
     // create the definition for the AMBARI service
     AlertDefinitionEntity definition = createNiceMock(AlertDefinitionEntity.class);
@@ -512,7 +507,7 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     EasyMock.expect(
         dispatchDao.createNotices((List<AlertNoticeEntity>) EasyMock.anyObject())).andReturn(
-      new ArrayList<>()).anyTimes();
+      new ArrayList<>()).once();
 
     AlertCurrentEntity current = getMockedAlertCurrentEntity();
     AlertHistoryEntity history = createNiceMock(AlertHistoryEntity.class);
@@ -520,19 +515,19 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
     Alert alert = createNiceMock(Alert.class);
 
     EasyMock.expect(current.getAlertHistory()).andReturn(history).anyTimes();
-    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).anyTimes();
-    EasyMock.expect(history.getClusterId()).andReturn(1L).anyTimes();
-    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).anyTimes();
-    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").anyTimes();
-    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).anyTimes();
-    EasyMock.expect(event.getCurrentAlert()).andReturn(current).anyTimes();
-    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).anyTimes();
-    EasyMock.expect(event.getAlert()).andReturn(alert).anyTimes();
+    EasyMock.expect(current.getFirmness()).andReturn(AlertFirmness.HARD).atLeastOnce();
+    EasyMock.expect(history.getClusterId()).andReturn(1L).atLeastOnce();
+    EasyMock.expect(history.getAlertState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(history.getAlertDefinition()).andReturn(definition).atLeastOnce();
+    EasyMock.expect(alert.getText()).andReturn("The HDFS Foo Alert Is Not Good").atLeastOnce();
+    EasyMock.expect(alert.getState()).andReturn(AlertState.CRITICAL).atLeastOnce();
+    EasyMock.expect(event.getCurrentAlert()).andReturn(current).atLeastOnce();
+    EasyMock.expect(event.getNewHistoricalEntry()).andReturn(history).atLeastOnce();
+    EasyMock.expect(event.getAlert()).andReturn(alert).atLeastOnce();
 
-    replay(alertTarget, alertGroup, definition, current, history, event, alert);
+    replayAll();
     eventPublisher.publish(event);
-    verify(alertTarget, alertGroup, definition, current, history, event, alert);
+    verifyAll();
   }
 
   /**
@@ -542,12 +537,11 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
    */
   private void expectNormalCluster() throws Exception {
     Clusters clusters = injector.getInstance(Clusters.class);
-    Cluster cluster = createNiceMock(Cluster.class);
+    Cluster cluster = createMock(Cluster.class);
 
-    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).anyTimes();
+    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).atLeastOnce();
     EasyMock.expect(cluster.getUpgradeInProgress()).andReturn(null).anyTimes();
     EasyMock.expect(cluster.isUpgradeSuspended()).andReturn(false).anyTimes();
-    replay(clusters, cluster);
   }
 
   /**
@@ -561,7 +555,7 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     EasyMock.reset(clusters);
 
-    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).anyTimes();
+    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).atLeastOnce();
     EasyMock.expect(cluster.getUpgradeInProgress()).andReturn(new UpgradeEntity()).anyTimes();
     EasyMock.expect(cluster.isUpgradeSuspended()).andReturn(false).anyTimes();
   }
@@ -577,7 +571,7 @@ public class AlertStateChangedEventTest extends EasyMockSupport {
 
     EasyMock.reset(clusters);
 
-    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).anyTimes();
+    EasyMock.expect(clusters.getClusterById(EasyMock.anyLong())).andReturn(cluster).atLeastOnce();
     EasyMock.expect(cluster.getUpgradeInProgress()).andReturn(EasyMock.createMock(UpgradeEntity.class)).anyTimes();
     EasyMock.expect(cluster.isUpgradeSuspended()).andReturn(true).anyTimes();
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/cluster/ClustersTest.java
@@ -445,7 +445,7 @@ public class ClustersTest {
     serviceCheckNodeHost.setState(State.UNKNOWN);
 
     Assert.assertNotNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
-      nameNodeHost.getClusterId(), 1L, 1L,
+      nameNodeHost.getClusterId(), serviceGroup.getServiceGroupId(), hdfs.getServiceId(),
       nameNodeHost.getServiceComponentId(),  nameNodeHostEntity.getHostId()));
 
     Assert.assertNotNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(nameNodeHost.getServiceComponentId()));
@@ -476,7 +476,7 @@ public class ClustersTest {
 
     Assert.assertEquals(2, hostDAO.findAll().size());
     Assert.assertNull(injector.getInstance(HostComponentStateDAO.class).findByIndex(
-      nameNodeHost.getClusterId(), 1L, 1L,
+      nameNodeHost.getClusterId(), serviceGroup.getServiceGroupId(), hdfs.getServiceId(),
       nameNodeHost.getServiceComponentId(), nameNodeHostEntity.getHostId()));
 
     Assert.assertNull(injector.getInstance(HostComponentDesiredStateDAO.class).findByIndex(nameNodeHost.getServiceComponentId()));

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
@@ -1011,6 +1011,9 @@ public class UpgradeCatalog260Test {
     expect(injector2.getInstance(ClusterMetadataGenerator.class)).andReturn(metadataGenerator).anyTimes();
     expect(injector2.getInstance(MetadataHolder.class)).andReturn(metadataHolder).anyTimes();
     expect(injector2.getInstance(AgentConfigsHolder.class)).andReturn(agentConfigsHolder).anyTimes();
+    ConfigHelper configHelper = getInjector().getInstance(ConfigHelper.class);
+    configHelper.updateAgentConfigs(anyObject(Set.class));
+    expect(injector2.getInstance(ConfigHelper.class)).andReturn(configHelper).anyTimes();
     replay(controller, injector2, config, cluster);
 
     // This tests the update of HSI config 'hive.llap.daemon.keytab.file'.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch covers all UT cases in stack, stageplanner, state, testing, testutils, topology, update, upgrade(1), utils, staterecoverymanagertest.

## How was this patch tested?

Manually tested.

Notes: There are two UT cases: state/cluster/ClustersTest/testDeleteCluster and svccomponent/ServiceComponentHostTest/testMaintenance which are tested separately without failure, but when they are run with all other tests in state, these two UT fail with NPE. I am not sure if it is my laptop memory issue or test case confliction.