### PR TITLE
AMBARI-24329. Log Feeder define default log levels per component.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/InputDescriptor.java
+++ b/ambari-logsearch/ambari-logsearch-config-api/src/main/java/org/apache/ambari/logsearch/config/api/model/inputconfig/InputDescriptor.java
@@ -19,6 +19,7 @@
 
 package org.apache.ambari.logsearch.config.api.model.inputconfig;
 
+import java.util.List;
 import java.util.Map;
 
 public interface InputDescriptor {
@@ -53,4 +54,6 @@ public interface InputDescriptor {
   String getGroup();
 
   Boolean isInitDefaultFields();
+
+  List<String> getDefaultLogLevels();
 }

--- a/ambari-logsearch/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputDescriptorImpl.java
+++ b/ambari-logsearch/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputDescriptorImpl.java
@@ -19,6 +19,7 @@
 
 package org.apache.ambari.logsearch.config.json.model.inputconfig.impl;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
@@ -200,6 +201,16 @@ public abstract class InputDescriptorImpl implements InputDescriptor {
   @SerializedName("init_default_fields")
   private Boolean initDefaultFields;
 
+  @ShipperConfigElementDescription(
+    path = "/input/[]/default_log_levels",
+    type = "list of strings",
+    description = "Use these as default log levels for the input - overrides the global default log levels.",
+    examples = {"default_log_levels: [\"INFO\", \"WARN\"]"}
+  )
+  @Expose
+  @SerializedName("default_log_levels")
+  private List<String> defaultLogLevels;
+
   public String getType() {
     return type;
   }
@@ -328,5 +339,14 @@ public abstract class InputDescriptorImpl implements InputDescriptor {
 
   public void setInitDefaultFields(Boolean initDefaultFields) {
     this.initDefaultFields = initDefaultFields;
+  }
+
+  @Override
+  public List<String> getDefaultLogLevels() {
+    return defaultLogLevels;
+  }
+
+  public void setDefaultLogLevels(List<String> defaultLogLevels) {
+    this.defaultLogLevels = defaultLogLevels;
   }
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/test/java/org/apache/ambari/logfeeder/output/OutputManagerTest.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/test/java/org/apache/ambari/logfeeder/output/OutputManagerTest.java
@@ -110,7 +110,7 @@ public class OutputManagerTest {
     expect(mockInput.isUseEventMD5()).andReturn(false).anyTimes();
     expect(mockInput.isGenEventMD5()).andReturn(false).anyTimes();
     expect(mockInput.getInputDescriptor()).andReturn(inputDescriptor).anyTimes();
-    expect(mockFilter.isAllowed(jsonObj, inputMarker)).andReturn(true).anyTimes();
+    expect(mockFilter.isAllowed(jsonObj, inputMarker, null)).andReturn(true).anyTimes();
     expect(mockInput.getCache()).andReturn(null);
     expect(mockInput.getOutputList()).andReturn(Arrays.asList(output1, output2, output3));
 
@@ -121,6 +121,7 @@ public class OutputManagerTest {
     replay(output1, output2, output3, mockFilter, mockInput);
     
     OutputManagerImpl manager = new OutputManagerImpl();
+    manager.setLogFeederProps(new LogFeederProps());
     manager.setLogLevelFilterHandler(mockFilter);
     manager.add(output1);
     manager.add(output2);
@@ -146,7 +147,7 @@ public class OutputManagerTest {
     LogLevelFilterHandler mockFilter = strictMock(LogLevelFilterHandler.class);
     
     expect(mockInput.getInputDescriptor()).andReturn(inputDescriptor).anyTimes();
-    expect(mockFilter.isAllowed(jsonString, inputMarker)).andReturn(true).anyTimes();
+    expect(mockFilter.isAllowed(jsonString, inputMarker, null)).andReturn(true).anyTimes();
     expect(mockInput.getOutputList()).andReturn(Arrays.asList(output1, output2, output3));
     
     output1.write(jsonString, inputMarker); expectLastCall();
@@ -157,6 +158,7 @@ public class OutputManagerTest {
 
     OutputManagerImpl manager = new OutputManagerImpl();
     manager.setLogLevelFilterHandler(mockFilter);
+    manager.setLogFeederProps(new LogFeederProps());
     manager.add(output1);
     manager.add(output2);
     manager.add(output3);

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerInput.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/model/common/LSServerInput.java
@@ -19,6 +19,7 @@
 
 package org.apache.ambari.logsearch.model.common;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.validation.constraints.NotNull;
@@ -73,6 +74,9 @@ public abstract class LSServerInput {
 
   @JsonProperty("init_default_fields")
   private Boolean initDefaultFields;
+
+  @JsonProperty("default_log_levels")
+  private List<String> defaultLogLevels;
   
   public LSServerInput() {}
   
@@ -92,6 +96,7 @@ public abstract class LSServerInput {
     this.cacheDedupInterval = inputDescriptor.getCacheDedupInterval();
     this.isEnabled = inputDescriptor.isEnabled();
     this.initDefaultFields = inputDescriptor.isInitDefaultFields();
+    this.defaultLogLevels = inputDescriptor.getDefaultLogLevels();
   }
 
   public String getType() {
@@ -152,5 +157,9 @@ public abstract class LSServerInput {
 
   public Boolean getInitDefaultFields() {
     return initDefaultFields;
+  }
+
+  public List<String> getDefaultLogLevels() {
+    return defaultLogLevels;
   }
 }

--- a/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-logsearch-docker.json
+++ b/ambari-logsearch/docker/test-config/logfeeder/shipper-conf/input.config-logsearch-docker.json
@@ -3,7 +3,10 @@
     {
       "type": "logsearch_server",
       "rowtype": "service",
-      "docker": "true"
+      "docker": "true",
+      "default_log_levels" : [
+       "FATAL", "ERROR", "WARN", "INFO", "DEBUG"
+      ]
     }
   ],
   "filter": [


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support to have specific default filters per components, that can be useful if someone want to predefine log level filters by default (in order to not go to the UI and change specific ones)

## How was this patch tested?
UTs passed.

Please review @kasakrisz @swagle 