### PR TITLE
ambari: Add jdeb support

### DIFF
--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -24,6 +24,27 @@
   <description>Ambari Functional Tests</description>
   <build>
     <plugins>
+       <plugin>
+         <groupId>org.vafer</groupId>
+         <artifactId>jdeb</artifactId>
+         <version>1.0.1</version>
+         <executions>
+           <execution>
+             <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+             <id>stub-execution</id>
+             <phase>none</phase>
+             <goals>
+               <goal>jdeb</goal>
+             </goals>
+           </execution>
+         </executions>
+         <configuration>
+           <skip>true</skip>
+           <attach>false</attach>
+           <submodules>false</submodules>
+           <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+         </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -99,6 +99,27 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.vafer</groupId>
+          <artifactId>jdeb</artifactId>
+          <version>1.4</version>
+          <executions>
+            <execution>
+              <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+              <id>stub-execution</id>
+              <phase>none</phase>
+              <goals>
+                <goal>jdeb</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <skip>true</skip>
+            <attach>false</attach>
+            <submodules>false</submodules>
+            <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+          </configuration>
+       </plugin>
        <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>rpm-maven-plugin</artifactId>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -154,6 +154,27 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.vafer</groupId>
+        <artifactId>jdeb</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+            <id>stub-execution</id>
+            <phase>none</phase>
+            <goals>
+              <goal>jdeb</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+          <attach>false</attach>
+          <submodules>false</submodules>
+          <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+        </configuration>
+      </plugin>
+      <plugin>
         <inherited>false</inherited>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/ambari-metrics/ambari-metrics-grafana/pom.xml
+++ b/ambari-metrics/ambari-metrics-grafana/pom.xml
@@ -34,6 +34,27 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.vafer</groupId>
+        <artifactId>jdeb</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+            <id>stub-execution</id>
+            <phase>none</phase>
+            <goals>
+              <goal>jdeb</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+          <attach>false</attach>
+          <submodules>false</submodules>
+          <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>1.8</version>

--- a/ambari-metrics/ambari-metrics-host-aggregator/pom.xml
+++ b/ambari-metrics/ambari-metrics-host-aggregator/pom.xml
@@ -115,6 +115,27 @@
 
     <build>
         <plugins>
+        <plugin>
+          <groupId>org.vafer</groupId>
+          <artifactId>jdeb</artifactId>
+          <version>1.0.1</version>
+          <executions>
+            <execution>
+              <!--Stub execution on direct plugin call - workaround for ambari deb build process-->
+              <id>stub-execution</id>
+              <phase>none</phase>
+              <goals>
+                <goal>jdeb</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <skip>true</skip>
+            <attach>false</attach>
+            <submodules>false</submodules>
+            <controlDir>${project.basedir}/../src/main/package/deb/control</controlDir>
+          </configuration>
+        </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
This patch add jdeb (debian) package creation support for the following
packages.
-ambari-funtest
-ambari-logsearch
-ambari-metrics-grafana
-ambari-metrics-host-aggregator

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>

## What changes were proposed in this pull request?

jdeb support for branch 2.7

## How was this patch tested?

I did a build on AArch64 machine with Debian 9 stretch

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.