### PR TITLE
[AMBARI-24333] Raising an error when user is trying to create a view URL with an existing short URL prefix

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ViewURLResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ViewURLResourceProvider.java
@@ -55,7 +55,6 @@ import com.google.inject.Inject;
 /**
  * Resource provider for view URLs.
  */
-@SuppressWarnings("Duplicates")
 @StaticallyInject
 public class ViewURLResourceProvider extends AbstractAuthorizedResourceProvider {
 
@@ -273,6 +272,11 @@ public class ViewURLResourceProvider extends AbstractAuthorizedResourceProvider 
 
         if(savedUrl.isPresent()){
           throw new AmbariException("This view URL name exists, URL names should be unique");
+        }
+
+        savedUrl = viewURLDAO.findBySuffix(urlEntity.getUrlSuffix());
+        if (savedUrl.isPresent()) {
+          throw new AmbariException("This view URL suffix has already been recorded, URL suffixes should be unique");
         }
 
         if(viewUrl != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ViewURLResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ViewURLResourceProvider.java
@@ -267,20 +267,16 @@ public class ViewURLResourceProvider extends AbstractAuthorizedResourceProvider 
           throw new IllegalStateException("The view " + viewName + " is not loaded.");
         }
 
-        ViewURLEntity viewUrl = viewInstanceEntity.getViewUrl();
-        Optional<ViewURLEntity> savedUrl = viewURLDAO.findByName(urlEntity.getUrlName());
+        if(viewInstanceEntity.getViewUrl() != null) {
+          throw new AmbariException("The view instance selected already has a linked URL");
+        }
 
-        if(savedUrl.isPresent()){
+        if(viewURLDAO.findByName(urlEntity.getUrlName()).isPresent()){
           throw new AmbariException("This view URL name exists, URL names should be unique");
         }
 
-        savedUrl = viewURLDAO.findBySuffix(urlEntity.getUrlSuffix());
-        if (savedUrl.isPresent()) {
+        if (viewURLDAO.findBySuffix(urlEntity.getUrlSuffix()).isPresent()) {
           throw new AmbariException("This view URL suffix has already been recorded, URL suffixes should be unique");
-        }
-
-        if(viewUrl != null) {
-          throw new AmbariException("The view instance selected already has a linked URL");
         }
 
         viewURLDAO.save(urlEntity);

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ViewURLDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ViewURLDAO.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.orm.dao;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 
 import org.apache.ambari.server.orm.RequiresSession;
@@ -88,7 +89,7 @@ public class ViewURLDAO {
     query.setParameter("urlSuffix", urlSuffix);
     try {
       return Optional.of(query.getSingleResult());
-    } catch (Exception e) {
+    } catch (NoResultException e) {
       return Optional.absent();
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ViewURLDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ViewURLDAO.java
@@ -42,9 +42,6 @@ public class ViewURLDAO {
    */
   @Inject
   private Provider<EntityManager> entityManagerProvider;
-  @Inject
-  private DaoUtils daoUtils;
-
 
   /**
    * Find all view instances.
@@ -72,6 +69,26 @@ public class ViewURLDAO {
     try {
       return Optional.of(query.getSingleResult());
     } catch (Exception e){
+      return Optional.absent();
+    }
+  }
+
+  /**
+   * Find URL by suffix
+   *
+   * @param urlSuffix
+   *          the suffix to get the URL by
+   * @return <code>Optional.absent()</code> if no view URL with the given suffix;
+   *         otherwise an appropriate <code>Optional</code> instance holding the
+   *         fetched view URL
+   */
+  @RequiresSession
+  public Optional<ViewURLEntity> findBySuffix(String urlSuffix) {
+    TypedQuery<ViewURLEntity> query = entityManagerProvider.get().createNamedQuery("viewUrlBySuffix", ViewURLEntity.class);
+    query.setParameter("urlSuffix", urlSuffix);
+    try {
+      return Optional.of(query.getSingleResult());
+    } catch (Exception e) {
       return Optional.absent();
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ViewURLEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ViewURLEntity.java
@@ -41,13 +41,9 @@ import javax.persistence.TableGenerator;
 )
 
 @NamedQueries({
-        @NamedQuery(name = "allViewUrls",
-                query = "SELECT viewUrl FROM ViewURLEntity viewUrl"),
-        @NamedQuery(name = "viewUrlByName", query =
-                "SELECT viewUrlEntity " +
-                        "FROM ViewURLEntity viewUrlEntity " +
-                        "WHERE viewUrlEntity.urlName=:urlName")})
-
+        @NamedQuery(name = "allViewUrls", query = "SELECT viewUrl FROM ViewURLEntity viewUrl"),
+        @NamedQuery(name = "viewUrlByName", query ="SELECT viewUrlEntity FROM ViewURLEntity viewUrlEntity WHERE viewUrlEntity.urlName=:urlName"),
+        @NamedQuery(name = "viewUrlBySuffix", query ="SELECT viewUrlEntity FROM ViewURLEntity viewUrlEntity WHERE viewUrlEntity.urlSuffix=:urlSuffix")})
 
 @Entity
 public class ViewURLEntity {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewURLResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewURLResourceProviderTest.java
@@ -140,6 +140,7 @@ public class ViewURLResourceProviderTest {
     expect(viewInstanceEntity.getName()).andReturn("test").once();
     expect(viewInstanceEntity.getViewUrl()).andReturn(null).once();
     expect(viewURLDAO.findByName("test")).andReturn(Optional.absent());
+    expect(viewURLDAO.findBySuffix("suffix")).andReturn(Optional.absent());
     Capture<ViewURLEntity> urlEntityCapture = newCapture();
     viewURLDAO.save(capture(urlEntityCapture));
     viewregistry.updateViewInstance(viewInstanceEntity);
@@ -160,7 +161,7 @@ public class ViewURLResourceProviderTest {
   }
 
   @Test(expected = org.apache.ambari.server.controller.spi.SystemException.class)
-  public void testCreateResources_existingUrl() throws Exception {
+  public void testCreateResources_existingUrlName() throws Exception {
     ViewInstanceEntity viewInstanceEntity = createNiceMock(ViewInstanceEntity.class);
     ViewEntity viewEntity = createNiceMock(ViewEntity.class);
     ViewURLResourceProvider provider = new ViewURLResourceProvider();
@@ -189,6 +190,38 @@ public class ViewURLResourceProviderTest {
     SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
     provider.createResources(PropertyHelper.getCreateRequest(properties, null));
 
+  }
+
+  @Test(expected = org.apache.ambari.server.controller.spi.SystemException.class)
+  public void testCreateResources_existingUrlSuffix() throws Exception {
+    ViewInstanceEntity viewInstanceEntity = createNiceMock(ViewInstanceEntity.class);
+    ViewEntity viewEntity = createNiceMock(ViewEntity.class);
+    ViewURLResourceProvider provider = new ViewURLResourceProvider();
+
+    ViewURLDAO viewURLDAO = createNiceMock(ViewURLDAO.class);
+    setDao(ViewURLResourceProvider.class.getDeclaredField("viewURLDAO"), viewURLDAO);
+    Set<Map<String, Object>> properties = new HashSet<>();
+    Map<String, Object> propertyMap = new HashMap<>();
+    propertyMap.put(ViewURLResourceProvider.URL_NAME,"test");
+    propertyMap.put(ViewURLResourceProvider.URL_SUFFIX,"suffix");
+    propertyMap.put(ViewURLResourceProvider.VIEW_INSTANCE_COMMON_NAME,"FILES");
+    propertyMap.put(ViewURLResourceProvider.VIEW_INSTANCE_NAME,"test");
+    propertyMap.put(ViewURLResourceProvider.VIEW_INSTANCE_VERSION,"1.0.0");
+
+    expect(viewregistry.getInstanceDefinition("FILES","1.0.0","test")).andReturn(viewInstanceEntity);
+    expect(viewregistry.getDefinition("FILES","1.0.0")).andReturn(viewEntity);
+    expect(viewInstanceEntity.getViewEntity()).andReturn(viewEntity).once();
+    expect(viewEntity.getCommonName()).andReturn("FILES").once();
+    expect(viewEntity.isDeployed()).andReturn(true).once();
+    expect(viewEntity.getVersion()).andReturn("1.0.0").once();
+    expect(viewInstanceEntity.getName()).andReturn("test").once();
+    expect(viewInstanceEntity.getViewUrl()).andReturn(null).once();
+    expect(viewURLDAO.findByName("test")).andReturn(Optional.absent());
+    expect(viewURLDAO.findBySuffix("suffix")).andReturn(Optional.of(new ViewURLEntity()));
+    replay(viewregistry,viewEntity,viewInstanceEntity,viewURLDAO);
+    properties.add(propertyMap);
+    SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
+    provider.createResources(PropertyHelper.getCreateRequest(properties, null));
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case the user created a view URL with an already exiting name we have thrown an error; this was not the case when the user created a view URL with an already existing suffix. As a result one of the URLs became unreachable.
So that we only allow unique URL suffixes.

## How was this patch tested?

In addition to unit testing I've tested view URL addition/edition manually in a test cluster.