### PR TITLE
AMBARI-24332 - PERF 1.0 package not installed in the cluster at deploy time

### DIFF
--- a/ambari-server/src/main/resources/stacks/PERF/1.0/hooks/before-INSTALL/scripts/distro-select.py
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/hooks/before-INSTALL/scripts/distro-select.py
@@ -17,8 +17,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys
 import os
+import sys
 
 AMBARI_AGENT_HOST_DIR = "AMBARI_AGENT_HOST_DIR"
 
@@ -125,6 +125,12 @@ def install_version(args):
       if args[1]:
         f.write(args[1] + "\n")
 
+def deploy_cluster(args):
+  dest = versions_file_destination()
+  with open(dest, 'w') as f:
+    if args[1]:
+      f.write(args[1] + "\n")
+
 def do_work(args):
   """
   Check that all required args are passed in. If so, perform required action.
@@ -138,6 +144,8 @@ def do_work(args):
     set_version(args)
   elif args[0] == "install":
     install_version(args)
+  elif args[0] == "deploy_cluster":
+    deploy_cluster(args)
 
 
 

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/hooks/before-INSTALL/scripts/hook.py
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/hooks/before-INSTALL/scripts/hook.py
@@ -17,9 +17,10 @@ limitations under the License.
 
 """
 import os
-
 from resource_management import ExecutionFailed
-from resource_management.core.resources.system import Directory, File, Execute
+from resource_management.core.resources.system import Execute
+from resource_management.core.shell import call
+from resource_management.libraries.functions.default import default
 from resource_management.libraries.script import Hook
 
 AMBARI_AGENT_CACHE_DIR = 'AMBARI_AGENT_CACHE_DIR'
@@ -56,6 +57,8 @@ class BeforeInstallHook(Hook):
     try:
       Execute("cp -n %s %s" % (dist_select, DISTRO_SELECT_DEST), user="root")
       Execute("chmod a+x %s" % (DISTRO_SELECT_DEST), user="root")
+      stack_version_unformatted = str(default("/clusterLevelParams/stack_version", ""))
+      call((DISTRO_SELECT_DEST, 'deploy_cluster', stack_version_unformatted))
     except ExecutionFailed:
       pass   # Due to concurrent execution, may produce error
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When deploying a PERF 1.0 or 2.0 cluster the versions are not installed on the hosts.
For PERF stacks the stack-select tool is implemented in a python program (distro-select.py)
 which manages the installed versions. It was not initialized with the version of the stack before cluster deployment.

## How was this patch tested?

Manually:
- Deploy ambari-server and agent to vm
- Copy PERF stack code to vm and activate in metainfo.xml
- Patch install_packages.py using install_packages.sed
- set stack.hooks.folder=stacks/PERF/1.0/hooks in ambari-server properties
- Patch PythonExecutor.py using PythonExecutor.sed
- Start Ambari Server and deploy a PERF 1.0 stack using the Cluster creation wizard
- Stop and Start all services
- Stack and Versions->Versions tab should show PERF-1.0 is the Current


Please review:
@aonishuk @swagle @dlysnichenko @zeroflag 