### PR TITLE
AMBARI-24340 : AMS Migration tools should auto-detect whitelist file.

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
@@ -105,12 +105,9 @@ public class MetricsDataMigrationLauncher {
 
     if (whitelistedFilePath != null) {
       this.metricNames = readMetricWhitelistFromFile(whitelistedFilePath);
-    } else if (timelineMetricConfiguration.isWhitelistingEnabled()) {
+    } else {
       String whitelistFile = timelineMetricConfiguration.getMetricsConf().get(TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_FILE, TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_FILE_LOCATION_DEFAULT);
       metricNames = readMetricWhitelistFromFile(whitelistFile);
-    } else {
-      LOG.error("No whitelisted metrics specified. Exiting...");
-      throw new Exception("List of whitelisted metrics must be provided");
     }
 
     readProcessedMetricsMap();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Whitelist file should not be a mandatory parameter for AMS data migration. The default file should be used.

## How was this patch tested?
Manually tested.