### PR TITLE
AMBARI-24349. Rescheduled and canceled tasks stay in progress forever

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -350,6 +350,7 @@ class ActionQueue(threading.Thread):
             if com['taskId'] == command['taskId']:
               logger.info('Command with taskId = {cid} was rescheduled by server. '
                           'Fail report on cancelled command won\'t be sent with heartbeat.'.format(cid=taskId))
+              self.commandStatuses.delete_command_data(command['taskId'])
               return
 
     # final result to stdout

--- a/ambari-agent/src/main/python/ambari_agent/CommandStatusDict.py
+++ b/ambari-agent/src/main/python/ambari_agent/CommandStatusDict.py
@@ -57,6 +57,11 @@ class CommandStatusDict():
     self.log_max_symbols_size = initializer_module.config.log_max_symbols_size
     self.reported_reports = set()
 
+  def delete_command_data(self, key):
+    # delete stale data about this command
+    with self.lock:
+      self.reported_reports.discard(key)
+      self.current_state.pop(key, None)
 
   def put_command_status(self, command, report):
     """
@@ -65,11 +70,8 @@ class CommandStatusDict():
     from ActionQueue import ActionQueue
 
     key = command['taskId']
-
     # delete stale data about this command
-    with self.lock:
-      self.reported_reports.discard(key)
-      self.current_state.pop(key, None)
+    self.delete_command_data(key)
 
     is_sent, correlation_id = self.force_update_to_server({command['clusterId']: [report]})
     updatable = report['status'] == ActionQueue.IN_PROGRESS_STATUS and self.command_update_output


### PR DESCRIPTION
1. Ambari-server reschedules task (timeout #1)
2. Task did yet got rescheduled (due to something else being in queue)
3. but, ambari-server cancels it (timeout #2)
4. The tasks keeps reprorting that's it's in progess forever, however being canceled

