### PR TITLE
AMBARI-24283 - DB consistency warning due to config group without service name

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -1379,15 +1379,21 @@ public class DatabaseConsistencyCheckHelper {
       for (Map.Entry<Long, ConfigGroup> configGroupEntry : configGroupMap.entrySet()) {
         Long id = configGroupEntry.getKey();
         ConfigGroup configGroup = configGroupEntry.getValue();
-        LOG.info("Deleting config group {} with id {} for deleted service {}",
-          configGroup.getName(), id, configGroup.getServiceName());
-        try {
-          Cluster cluster = clusters.getCluster(configGroup.getClusterName());
-          cluster.deleteConfigGroup(id);
-        } catch (AuthorizationException e) {
-          // This call does not thrown Authorization Exception
-        } catch (AmbariException e) {
-          // Ignore if cluster not found
+        if (!StringUtils.isEmpty(configGroup.getServiceName())) {
+          LOG.info("Deleting config group {} with id {} for deleted service {}",
+                  configGroup.getName(), id, configGroup.getServiceName());
+          try {
+            Cluster cluster = clusters.getCluster(configGroup.getClusterName());
+            cluster.deleteConfigGroup(id);
+          } catch (AuthorizationException e) {
+            // This call does not thrown Authorization Exception
+          } catch (AmbariException e) {
+            // Ignore if cluster not found
+          }
+        }
+        else {
+          warning("The config group {} with id {} can not be fixed automatically because service name is missing.",
+                  configGroup.getName(), id);
         }
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -1229,7 +1229,7 @@ public class DatabaseConsistencyCheckHelper {
     output.replace(output.lastIndexOf(","), output.length(), "]");
     warning("You have config groups present in the database with no " +
             " service name, {}. Run --auto-fix-database to fix " +
-            "this automatically.", output.toString());
+            "this automatically. Please backup ambari database before running --auto-fix-database.", output.toString());
   }
 
   @Transactional
@@ -1310,7 +1310,7 @@ public class DatabaseConsistencyCheckHelper {
       warning("You have config group host mappings with hosts that are no " +
         "longer associated with the cluster, {}. Run --auto-fix-database to " +
         "fix this automatically. Alternatively, you can remove this mapping " +
-        "from the UI.", output.toString());
+        "from the UI. Please backup ambari database before running --auto-fix-database.", output.toString());
     }
 
     return nonMappedHostIds;
@@ -1346,7 +1346,7 @@ public class DatabaseConsistencyCheckHelper {
       output.replace(output.lastIndexOf(","), output.length(), "]");
       warning("You have config groups present in the database with no " +
         "corresponding service found, {}. Run --auto-fix-database to fix " +
-          "this automatically.", output.toString());
+          "this automatically. Please backup ambari database before running --auto-fix-database.", output.toString());
     }
 
     return configGroupMap;

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -1355,7 +1355,7 @@ public class DatabaseConsistencyCheckHelper {
       output.replace(output.lastIndexOf(","), output.length(), "]");
       warning("You have config groups present in the database with no " +
         "corresponding service found, {}. Run --auto-fix-database to fix " +
-          "this automatically. Please Ambari Server database before running --auto-fix-database.", output.toString());
+          "this automatically. Please backup Ambari Server database before running --auto-fix-database.", output.toString());
     }
 
     return configGroupMap;

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -1253,7 +1253,8 @@ public class DatabaseConsistencyCheckHelper {
       ConfigGroup configGroup = configGroupEntry.getValue();
       try {
         Cluster cluster = clusters.getCluster(configGroup.getClusterName());
-        if (cluster.getService(configGroup.getTag()) != null) {
+        Map<String, Service> serviceMap = cluster.getServices();
+        if (serviceMap.containsKey(configGroup.getTag())) {
           LOG.info("Setting service name of config group {} with id {} to {}",
                   configGroup.getName(), configGroupEntry.getKey(), configGroup.getTag());
           configGroup.setServiceName(configGroup.getTag());

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -1189,6 +1189,9 @@ public class DatabaseConsistencyCheckHelper {
 
   }
 
+  /**
+   * This method collects the ConfigGroups with empty or null service name field
+   */
   static Map<Long, ConfigGroup> collectConfigGroupsWithoutServiceName() {
     Map<Long, ConfigGroup> configGroupMap = new HashMap<>();
     Clusters clusters = injector.getInstance(Clusters.class);
@@ -1213,14 +1216,17 @@ public class DatabaseConsistencyCheckHelper {
     return configGroupMap;
   }
 
+  /**
+   * This method checks if there are any ConfigGroup with empty or null service name field
+   */
   static void checkConfigGroupsHasServiceName() {
     Map<Long, ConfigGroup> configGroupMap = collectConfigGroupsWithoutServiceName();
     if (MapUtils.isEmpty(configGroupMap))
       return;
+
     StringBuilder output = new StringBuilder("[(ConfigGroup) => ");
 
     for (ConfigGroup configGroup : configGroupMap.values()) {
-      configGroupMap.put(configGroup.getId(), configGroup);
       output.append("( ");
       output.append(configGroup.getName());
       output.append(" ), ");
@@ -1229,9 +1235,12 @@ public class DatabaseConsistencyCheckHelper {
     output.replace(output.lastIndexOf(","), output.length(), "]");
     warning("You have config groups present in the database with no " +
             " service name, {}. Run --auto-fix-database to fix " +
-            "this automatically. Please backup ambari database before running --auto-fix-database.", output.toString());
+            "this automatically. Please backup Ambari Server database before running --auto-fix-database.", output.toString());
   }
 
+  /**
+   * Fix inconsistencies found by @collectConfigGroupsWithoutServiceName
+   */
   @Transactional
   static void fixConfigGroupServiceNames() {
     Map<Long, ConfigGroup> configGroupMap = collectConfigGroupsWithoutServiceName();
@@ -1310,7 +1319,7 @@ public class DatabaseConsistencyCheckHelper {
       warning("You have config group host mappings with hosts that are no " +
         "longer associated with the cluster, {}. Run --auto-fix-database to " +
         "fix this automatically. Alternatively, you can remove this mapping " +
-        "from the UI. Please backup ambari database before running --auto-fix-database.", output.toString());
+        "from the UI. Please backup Ambari Server database before running --auto-fix-database.", output.toString());
     }
 
     return nonMappedHostIds;
@@ -1346,7 +1355,7 @@ public class DatabaseConsistencyCheckHelper {
       output.replace(output.lastIndexOf(","), output.length(), "]");
       warning("You have config groups present in the database with no " +
         "corresponding service found, {}. Run --auto-fix-database to fix " +
-          "this automatically. Please backup ambari database before running --auto-fix-database.", output.toString());
+          "this automatically. Please Ambari Server database before running --auto-fix-database.", output.toString());
     }
 
     return configGroupMap;

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelperTest.java
@@ -778,8 +778,6 @@ public class DatabaseConsistencyCheckHelperTest {
 
     Map<String, Cluster> clusters = new HashMap<>();
     Cluster cluster1 = easyMockSupport.createNiceMock(Cluster.class);
-    Service yarnService = easyMockSupport.createNiceMock(Service.class);
-    expect(cluster1.getService("YARN")).andReturn(yarnService).anyTimes();
     clusters.put("c1", cluster1);
     Cluster cluster2 = easyMockSupport.createNiceMock(Cluster.class);
     clusters.put("c2", cluster2);
@@ -810,9 +808,11 @@ public class DatabaseConsistencyCheckHelperTest {
     expect(cgForNonExistentService.getServiceName()).andReturn(null).anyTimes();
     expect(cgForNonExistentService.getTag()).andReturn("NOT_EXISTS").anyTimes();
 
-    Service service = easyMockSupport.createNiceMock(Service.class);
+    Service hdfsService = easyMockSupport.createNiceMock(Service.class);
+    Service yarnService = easyMockSupport.createNiceMock(Service.class);
     Map<String, Service> services = new HashMap<>();
-    services.put("HDFS", service);
+    services.put("HDFS", hdfsService);
+    services.put("YARN", yarnService);
     expect(cluster1.getServices()).andReturn(services).anyTimes();
 
     DatabaseConsistencyCheckHelper.setInjector(mockInjector);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a configuration group to any services in Ambari 2.5 do not populate the service name in the configuration group record.
In Ambari 2.6 DB consistency check warns these configuration groups and indicates that they are not related to any of the services in the cluster. Auto-fix-db also deletes them however they can be used by customer.
Fix.: configuration group records stores the related service name in the tag field.  Auto-fix-db copies tag field values to service name fields before checking for configuration group of deleted services.


## How was this patch tested?

ambari-server
mvn clean install

manually:
1. Deploy ZooKeeper with Ambari 2.5.2
2. Create config group on UI
3. Upgrade to Ambari 2.6.2
4. Start ambari-server -> warning in the ambari-server-check-database.log: WARN - You have config groups present in the database with no corresponding service found
5. Stop ambari-server
6. Run --auto-fix-database
7. Start ambari-server -> no warnings in the ambari-server-check-database.log and the configuration group remained
