### PR TITLE
[AMBARI-24260] Ambari shows success when HBase Decommission/Recommission operations fail

### DIFF
--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -988,6 +988,9 @@ var urls = {
     'real': '/clusters/{clusterName}/host_components?HostRoles/component_name=NAMENODE&HostRoles/host_name.in({hostNames})&fields=metrics/dfs/namenode',
     'mock': '/data/hosts/HDP2/decommission_state.json'
   },
+  'host.host_component.decommission_status_regionserver': {
+    'real': '/clusters/{clusterName}/host_components?HostRoles/component_name=HBASE_MASTER&HostRoles/host_name={hostName}&fields=metrics/hbase/master/liveRegionServersHosts,metrics/hbase/master/deadRegionServersHosts&minimal_response=true'
+  },
   'host.region_servers.in_inservice': {
     'real': '/clusters/{clusterName}/host_components?HostRoles/component_name=HBASE_REGIONSERVER&HostRoles/desired_admin_state=INSERVICE&fields=HostRoles/host_name&minimal_response=true',
     'mock': ''

--- a/ambari-web/test/views/main/host/details/host_component_views/regionserver_view_test.js
+++ b/ambari-web/test/views/main/host/details/host_component_views/regionserver_view_test.js
@@ -22,7 +22,7 @@ require('views/main/host/details/host_component_views/regionserver_view');
 describe('App.RegionServerComponentView', function () {
   var view = App.RegionServerComponentView.create();
 
-  describe("#setDesiredAdminState()", function () {
+  describe("#setDesiredAdminStateDefault()", function () {
     beforeEach(function () {
       sinon.stub(view, 'setStatusAs', Em.K);
     });
@@ -30,11 +30,11 @@ describe('App.RegionServerComponentView', function () {
       view.setStatusAs.restore();
     });
     it("INSERVICE state)", function () {
-      view.setDesiredAdminState('INSERVICE');
+      view.setDesiredAdminStateDefault('INSERVICE');
       expect(view.setStatusAs.calledWith('INSERVICE')).to.be.true;
     });
     it("DECOMMISSIONED state)", function () {
-      view.setDesiredAdminState('DECOMMISSIONED');
+      view.setDesiredAdminStateDefault('DECOMMISSIONED');
       expect(view.setStatusAs.calledWith('RS_DECOMMISSIONED')).to.be.true;
     });
   });

--- a/ambari-web/test/views/main/host/details/host_component_views/regionserver_view_test.js
+++ b/ambari-web/test/views/main/host/details/host_component_views/regionserver_view_test.js
@@ -20,22 +20,228 @@ var App = require('app');
 require('views/main/host/details/host_component_views/regionserver_view');
 
 describe('App.RegionServerComponentView', function () {
-  var view = App.RegionServerComponentView.create();
+  var view;
 
-  describe("#setDesiredAdminStateDefault()", function () {
+  beforeEach(function () {
+    view = App.RegionServerComponentView.create();
+  });
+
+  describe('#setDesiredAdminStateDefault()', function () {
     beforeEach(function () {
       sinon.stub(view, 'setStatusAs', Em.K);
     });
     afterEach(function () {
       view.setStatusAs.restore();
     });
-    it("INSERVICE state)", function () {
+    it('INSERVICE state', function () {
       view.setDesiredAdminStateDefault('INSERVICE');
       expect(view.setStatusAs.calledWith('INSERVICE')).to.be.true;
     });
-    it("DECOMMISSIONED state)", function () {
+    it('DECOMMISSIONED state', function () {
       view.setDesiredAdminStateDefault('DECOMMISSIONED');
       expect(view.setStatusAs.calledWith('RS_DECOMMISSIONED')).to.be.true;
+    });
+  });
+
+  describe('#parseRegionServersHosts()', function () {
+    var cases = [
+      {
+        input: undefined,
+        result: [],
+        title: 'undefined input'
+      },
+      {
+        input: '',
+        result: [],
+        title: 'empty string'
+      },
+      {
+        input: 'host,1,2',
+        result: ['host'],
+        title: 'single host string'
+      },
+      {
+        input: 'host1,1,2;host2,3,4',
+        result: ['host1', 'host2'],
+        title: 'multiple hosts string'
+      }
+    ];
+
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        expect(view.parseRegionServersHosts(test.input)).to.eql(test.result);
+      });
+    });
+  });
+
+  describe('#getRSDecommissionStatusSuccessCallback()', function () {
+    var cases = [
+      {
+        data: null,
+        desiredAdminState: 'INSERVICE',
+        resultingState: 'INSERVICE',
+        title: 'no data, INSERVICE desired state'
+      },
+      {
+        data: null,
+        desiredAdminState: 'DECOMMISSIONED',
+        resultingState: 'RS_DECOMMISSIONED',
+        title: 'no data, DECOMMISSIONED desired state'
+      },
+      {
+        data: {},
+        desiredAdminState: 'INSERVICE',
+        resultingState: 'INSERVICE',
+        title: 'empty data, INSERVICE desired state'
+      },
+      {
+        data: {},
+        desiredAdminState: 'DECOMMISSIONED',
+        resultingState: 'RS_DECOMMISSIONED',
+        title: 'empty data, DECOMMISSIONED desired state'
+      },
+      {
+        data: {
+          items: []
+        },
+        desiredAdminState: 'INSERVICE',
+        resultingState: 'INSERVICE',
+        title: 'empty items array, INSERVICE desired state'
+      },
+      {
+        data: {
+          items: []
+        },
+        desiredAdminState: 'DECOMMISSIONED',
+        resultingState: 'RS_DECOMMISSIONED',
+        title: 'empty items array, DECOMMISSIONED desired state'
+      },
+      {
+        data: {
+          items: [
+            {
+              metrics: {
+                hbase: {
+                  master: {}
+                }
+              }
+            }
+          ]
+        },
+        desiredAdminState: 'INSERVICE',
+        resultingState: 'INSERVICE',
+        title: 'no live and dead RS hosts provided, INSERVICE desired state'
+      },
+      {
+        data: {
+          items: [
+            {
+              metrics: {
+                hbase: {
+                  master: {}
+                }
+              }
+            }
+          ]
+        },
+        desiredAdminState: 'DECOMMISSIONED',
+        resultingState: 'RS_DECOMMISSIONED',
+        title: 'no live and dead RS hosts provided, DECOMMISSIONED desired state'
+      },
+      {
+        data: {
+          items: [
+            {
+              metrics: {
+                hbase: {
+                  master: {
+                    liveRegionServersHosts: 'h0,1,2;h1,3,4'
+                  }
+                }
+              }
+            }
+          ]
+        },
+        desiredAdminState: 'INSERVICE',
+        resultingState: 'INSERVICE',
+        title: 'RS is live, INSERVICE desired state'
+      },
+      {
+        data: {
+          items: [
+            {
+              metrics: {
+                hbase: {
+                  master: {
+                    liveRegionServersHosts: 'h0,1,2;h1,3,4'
+                  }
+                }
+              }
+            }
+          ]
+        },
+        desiredAdminState: 'DECOMMISSIONED',
+        resultingState: 'INSERVICE',
+        title: 'RS is live, DECOMMISSIONED desired state'
+      },
+      {
+        data: {
+          items: [
+            {
+              metrics: {
+                hbase: {
+                  master: {
+                    deadRegionServersHosts: 'h0,1,2;h1,3,4'
+                  }
+                }
+              }
+            }
+          ]
+        },
+        desiredAdminState: 'INSERVICE',
+        resultingState: 'RS_DECOMMISSIONED',
+        title: 'RS is dead, INSERVICE desired state'
+      },
+      {
+        data: {
+          items: [
+            {
+              metrics: {
+                hbase: {
+                  master: {
+                    deadRegionServersHosts: 'h0,1,2;h1,3,4'
+                  }
+                }
+              }
+            }
+          ]
+        },
+        desiredAdminState: 'DECOMMISSIONED',
+        resultingState: 'RS_DECOMMISSIONED',
+        title: 'RS is dead, DECOMMISSIONED desired state'
+      }
+    ];
+
+    beforeEach(function () {
+      sinon.stub(view, 'setStatusAs', Em.K);
+      sinon.stub(view, 'startBlinking', Em.K);
+      view.set('content', {
+        hostName: 'h0'
+      });
+    });
+
+    afterEach(function () {
+      view.setStatusAs.restore();
+      view.startBlinking.restore();
+    });
+
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        view.getRSDecommissionStatusSuccessCallback(test.data, null, {
+          desiredAdminState: test.desiredAdminState
+        });
+        expect(view.setStatusAs.calledWith(test.resultingState)).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

If HBase Decommission/Recommission operation fails with non zero exit code, that component still gets decommissioned/recommissioned. We need to handle this failure and not transition the state to Decommissioned/Recommissioned when the respective operation fails

## How was this patch tested?

UI unit tests:
  21810 passing (24s)
  48 pending

