### PR TITLE
[AMBARI-24354] [Log Search UI] wrong filter label on open log tab

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-filtering-utils.service.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-filtering-utils.service.ts
@@ -435,9 +435,13 @@ export class LogsFilteringUtilsService {
                 });
               } else {
                 Object.assign(timeRangeParams, {
-                  timeRangeInterval: timeRangeValue.interval,
                   timeRangeUnit: timeRangeValue.unit
                 });
+                if (timeRangeValue.interval !== undefined) {
+                  Object.assign(timeRangeParams, {
+                    timeRangeInterval: timeRangeValue.interval
+                  });
+                }
               }
               Object.assign(newParams, timeRangeParams);
             }
@@ -493,7 +497,7 @@ export class LogsFilteringUtilsService {
           break;
         case 'timeRangeType':
           const type = params.timeRangeType || 'LAST';
-          const interval = parseInt(params.timeRangeInterval, 0);
+          const interval = params.timeRangeInterval && parseInt(params.timeRangeInterval, 0);
           const unit = params.timeRangeUnit;
           const timeRangeFilterValue: {[key: string]: any} = {type, unit, interval};
           let timeRangeFilterLabel = 'filter.timeRange.';


### PR DESCRIPTION
(cherry picked from commit 6917b7146437f66f00a2d52ff7d0da8c213da3df)

## What changes were proposed in this pull request?

The time range interval value for the PAST and the CURRENT time range type is not applicable (it is always 1) so it has been removed from the params when we use those time range params. The params to filter sync has been modified to reflect this change.

## How was this patch tested?

It was tested manually and by the unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (7.53 secs / 7.455 secs)
✨  Done in 35.53s.
```

Identical with: https://github.com/apache/ambari/pull/1879

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.