### PR TITLE
AMBARI-24353. Log Feeder: generate solr id from specific fields.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/output/Output.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/output/Output.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +78,13 @@ public abstract class Output<PROP_TYPE extends LogFeederProperties, INPUT_MARKER
 
   public void setDestination(String destination) {
     this.destination = destination;
+  }
+
+  /**
+   * Get the list of fields that will be used for ID generation of log entries.
+   */
+  public List<String> getIdFields() {
+    return new ArrayList<>();
   }
 
   public boolean isClosed() {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/IdGeneratorHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/IdGeneratorHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.common;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Helper class to generete UUID (random or based on specific fields)
+ */
+public class IdGeneratorHelper {
+
+  private IdGeneratorHelper() {
+  }
+
+  /**
+   * Generate UUID based on fields (or just randomly)
+   * @param data object map which can contain the field key-value pairs
+   * @param idFields field names that used for generating uuid
+   * @return generated UUID string
+   */
+  public static String generateUUID(Map<String, Object> data, List<String> idFields) {
+    String uuid = null;
+    if (CollectionUtils.isNotEmpty(idFields)) {
+      final StringBuilder sb = new StringBuilder();
+      for (String idField : idFields) {
+        if (data.containsKey(idField)) {
+          sb.append(data.get(idField).toString());
+        }
+      }
+      String concatId = sb.toString();
+      if (StringUtils.isNotEmpty(concatId)) {
+        uuid = UUID.nameUUIDFromBytes(concatId.getBytes()).toString();
+      } else {
+        uuid = UUID.randomUUID().toString();
+      }
+    } else {
+      uuid = UUID.randomUUID().toString();
+    }
+    return uuid;
+  }
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputManagerImpl.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputManagerImpl.java
@@ -20,10 +20,10 @@ package org.apache.ambari.logfeeder.output;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
+import org.apache.ambari.logfeeder.common.IdGeneratorHelper;
 import org.apache.ambari.logfeeder.common.LogFeederConstants;
 import org.apache.ambari.logfeeder.conf.LogFeederProps;
 import org.apache.ambari.logfeeder.loglevelfilter.LogLevelFilterHandler;
-import org.apache.ambari.logfeeder.input.InputFile;
 import org.apache.ambari.logfeeder.plugin.common.MetricData;
 import org.apache.ambari.logfeeder.plugin.input.Input;
 import org.apache.ambari.logfeeder.plugin.input.InputMarker;
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class OutputManagerImpl extends OutputManager {
   private static final Logger LOG = Logger.getLogger(OutputManagerImpl.class);
@@ -127,9 +126,6 @@ public class OutputManagerImpl extends OutputManager {
     }
 
     jsonObj.put("seq_num", new Long(docCounter++));
-    if (jsonObj.get("id") == null) {
-      jsonObj.put("id", UUID.randomUUID().toString());
-    }
     if (jsonObj.get("event_count") == null) {
       jsonObj.put("event_count", new Integer(1));
     }
@@ -154,6 +150,9 @@ public class OutputManagerImpl extends OutputManager {
       List<? extends Output> outputList = input.getOutputList();
       for (Output output : outputList) {
         try {
+          if (jsonObj.get("id") == null) {
+            jsonObj.put("id", IdGeneratorHelper.generateUUID(jsonObj, output.getIdFields()));
+          }
           output.write(jsonObj, inputMarker);
         } catch (Exception e) {
           LOG.error("Error writing. to " + output.getShortDescription(), e);

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/test/java/org/apache/ambari/logfeeder/common/IdGeneratorHelperTest.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/test/java/org/apache/ambari/logfeeder/common/IdGeneratorHelperTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.common;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IdGeneratorHelperTest {
+
+  @Test
+  public void testGenerateRandomUUID() {
+    // GIVEN
+    Map<String, Object> fieldKeyMap = new HashMap<>();
+    List<String> fields = new ArrayList<>();
+    // WHEN
+    String uuid1 = IdGeneratorHelper.generateUUID(fieldKeyMap, fields);
+    String uuid2 = IdGeneratorHelper.generateUUID(fieldKeyMap, fields);
+    // THEN
+    assertFalse(uuid1.equals(uuid2));
+  }
+
+  @Test
+  public void testUUIDFromFields() {
+    // GIVEN
+    Map<String, Object> fieldKeyMap1 = new HashMap<>();
+    fieldKeyMap1.put("one-field", "1");
+    Map<String, Object> fieldKeyMap2 = new HashMap<>();
+    fieldKeyMap2.put("one-field", "1");
+    List<String> fields = new ArrayList<>();
+    fields.add("one-field");
+    // WHEN
+    String uuid1 = IdGeneratorHelper.generateUUID(fieldKeyMap1, fields);
+    String uuid2 = IdGeneratorHelper.generateUUID(fieldKeyMap2, fields);
+    // THEN
+    assertTrue(uuid1.equals(uuid2));
+  }
+
+  @Test
+  public void testUUIDFromFieldsWithMultipleFields() {
+    // GIVEN
+    Map<String, Object> fieldKeyMap1 = new HashMap<>();
+    fieldKeyMap1.put("one-field", "1");
+    fieldKeyMap1.put("two-field", "2");
+    Map<String, Object> fieldKeyMap2 = new HashMap<>();
+    fieldKeyMap2.put("one-field", "1");
+    fieldKeyMap2.put("two-field", "2");
+    List<String> fields = new ArrayList<>();
+    fields.add("one-field");
+    fields.add("two-field");
+    // WHEN
+    String uuid1 = IdGeneratorHelper.generateUUID(fieldKeyMap1, fields);
+    String uuid2 = IdGeneratorHelper.generateUUID(fieldKeyMap2, fields);
+    // THEN
+    assertTrue(uuid1.equals(uuid2));
+  }
+
+  @Test
+  public void testUUIDFromFieldsDifferentNumberOfFields() {
+    // GIVEN
+    Map<String, Object> fieldKeyMap1 = new HashMap<>();
+    fieldKeyMap1.put("one-field", "1");
+    Map<String, Object> fieldKeyMap2 = new HashMap<>();
+    fieldKeyMap2.put("one-field", "1");
+    fieldKeyMap2.put("two-field", "2");
+    List<String> fields = new ArrayList<>();
+    fields.add("one-field");
+    fields.add("two-field");
+    // WHEN
+    String uuid1 = IdGeneratorHelper.generateUUID(fieldKeyMap1, fields);
+    String uuid2 = IdGeneratorHelper.generateUUID(fieldKeyMap2, fields);
+    // THEN
+    assertFalse(uuid1.equals(uuid2));
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
new output config that you can use to set up how to generate ids for log entries. (that can solve more easily any duplication problems as well), by default its disabled.

usage (in output.json configs):
```json
{
  outputs: [
  "id_fields" : [
  "log_message", "logtime", "type", "path" 
  ]
]
```
## How was this patch tested?
UTs added and passed. FT: manually (if i had used only type as an id field it generated only that 7 doc - as there were only 7 different log type)

Please review @swagle @kasakrisz 