### PR TITLE
[AMBARI-24351] Using Predicate based evaluation when determining if SSO is enabled for a service

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -653,8 +653,15 @@ public class ServiceInfo implements Validable {
     return (singleSignOnInfo != null) && singleSignOnInfo.isSupported();
   }
 
+  /**
+   * @deprecated Use {@link #getSingleSignOnEnabledTest()} instead
+   */
   public String getSingleSignOnEnabledConfiguration() {
     return singleSignOnInfo != null ? singleSignOnInfo.getEnabledConfiguration() : null;
+  }
+
+  public String getSingleSignOnEnabledTest() {
+    return singleSignOnInfo != null ? singleSignOnInfo.getSsoEnabledTest() : null;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/SingleSignOnInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/SingleSignOnInfo.java
@@ -41,7 +41,7 @@ import com.google.common.base.MoreObjects;
  *             "true"
  *           ]
  *         }
- *     &lt;/enabledConfiguration&gt;
+ *     &lt;/ssoEnabledTest&gt;
  *   &lt;/sso&gt;
  * </pre>
  */

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/SingleSignOnInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/SingleSignOnInfo.java
@@ -22,6 +22,8 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 
+import org.apache.ambari.server.collections.PredicateUtils;
+
 import com.google.common.base.MoreObjects;
 
 /**
@@ -32,7 +34,13 @@ import com.google.common.base.MoreObjects;
  * <pre>
  *   &lt;sso&gt;
  *     &lt;supported&gt;true&lt;/supported&gt;
- *     &lt;enabledConfiguration&gt;config-type/sso.enabled.property_name&lt;/enabledConfiguration&gt;
+ *     &lt;enabledConfiguration&gt;{
+ *           "equals": [
+ *             "service-properties/sso.knox.enabled",
+ *             "true"
+ *           ]
+ *         }
+ *     &lt;/enabledConfiguration&gt;
  *   &lt;/sso&gt;
  * </pre>
  */
@@ -48,7 +56,7 @@ public class SingleSignOnInfo {
   /**
    * The configuration that can be used to determine if SSO integration has been enabled.
    * <p>
-   * It is expected that this value is in the form of <code>configuration-type/property_name</code>
+   * It is expected that this value is in the form of a valid JSON predicate ({@link PredicateUtils#fromJSON(String)}
    */
   @XmlElement(name = "enabledConfiguration")
   private String enabledConfiguration = null;
@@ -111,7 +119,7 @@ public class SingleSignOnInfo {
   /**
    * Gets the configuration specification that can be used to determine if SSO has been enabled or not.
    *
-   * @return a configuration specification (config-type/property_name)
+   * @return a configuration specification (JSON predicate)
    */
   public String getEnabledConfiguration() {
     return enabledConfiguration;
@@ -120,7 +128,7 @@ public class SingleSignOnInfo {
   /**
    * Sets the configuration specification that can be used to determine if SSO has been enabled or not.
    *
-   * @param enabledConfiguration a configuration specification (config-type/property_name)
+   * @param enabledConfiguration a configuration specification (JSON predicate)
    */
   public void setEnabledConfiguration(String enabledConfiguration) {
     this.enabledConfiguration = enabledConfiguration;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/SingleSignOnInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/SingleSignOnInfo.java
@@ -34,9 +34,10 @@ import com.google.common.base.MoreObjects;
  * <pre>
  *   &lt;sso&gt;
  *     &lt;supported&gt;true&lt;/supported&gt;
- *     &lt;enabledConfiguration&gt;{
+ *     &lt;ssoEnabledTest&gt;
+ *         {
  *           "equals": [
- *             "service-properties/sso.knox.enabled",
+ *             "config-type/sso.enabled.property_name",
  *             "true"
  *           ]
  *         }
@@ -56,10 +57,20 @@ public class SingleSignOnInfo {
   /**
    * The configuration that can be used to determine if SSO integration has been enabled.
    * <p>
-   * It is expected that this value is in the form of a valid JSON predicate ({@link PredicateUtils#fromJSON(String)}
+   * It is expected that this value is in the form of <code>configuration-type/property_name</code>
+   *
+   * @deprecated Use {@link #ssoEnabledTest} instead
    */
   @XmlElement(name = "enabledConfiguration")
   private String enabledConfiguration = null;
+
+  /**
+   * The configuration that can be used to determine if SSO integration has been enabled.
+   * <p>
+   * It is expected that this value is in the form of a valid JSON predicate ({@link PredicateUtils#fromJSON(String)}
+   */
+  @XmlElement(name = "ssoEnabledTest")
+  private String ssoEnabledTest = null;
 
   /**
    * Indicates if Kerberos is required for SSO integration (<code>true</code>) or not (<code>false</code>)
@@ -117,21 +128,46 @@ public class SingleSignOnInfo {
   }
 
   /**
+   * @deprecated USe {@link #getSsoEnabledTest()} instead
+   * <p>
    * Gets the configuration specification that can be used to determine if SSO has been enabled or not.
    *
-   * @return a configuration specification (JSON predicate)
+   * @return a configuration specification (config-type/property_name)
    */
   public String getEnabledConfiguration() {
     return enabledConfiguration;
   }
 
   /**
+   * @deprecated Use {@link #setSsoEnabledTest(String)} instead
+   * <p>
    * Sets the configuration specification that can be used to determine if SSO has been enabled or not.
    *
-   * @param enabledConfiguration a configuration specification (JSON predicate)
+   * @param enabledConfiguration a configuration specification (config-type/property_name)
    */
   public void setEnabledConfiguration(String enabledConfiguration) {
     this.enabledConfiguration = enabledConfiguration;
+  }
+
+  /**
+   * Gets the configuration specification that can be used to determine if SSO has
+   * been enabled or not.
+   *
+   * @return a configuration specification (a valid JSON predicate)
+   */
+  public String getSsoEnabledTest() {
+    return ssoEnabledTest;
+  }
+
+  /**
+   * Sets the configuration specification that can be used to determine if SSO has
+   * been enabled or not.
+   *
+   * @param enabledConfiguration
+   *          a configuration specification (a valid JSON predicate)
+   */
+  public void setSsoEnabledTest(String ssoEnabledTest) {
+    this.ssoEnabledTest = ssoEnabledTest;
   }
 
   /**
@@ -158,6 +194,7 @@ public class SingleSignOnInfo {
     return MoreObjects.toStringHelper(this)
         .add("supported", supported)
         .add("enabledConfiguration", enabledConfiguration)
+        .add("ssoEnabledTest", ssoEnabledTest)
         .add("kerberosRequired", kerberosRequired)
         .toString();
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -3537,7 +3537,7 @@ public class KerberosHelperTest extends EasyMockSupport {
           .once();
 
       final ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
-      expect(configHelper.getEffectiveConfigProperties(anyObject(Cluster.class), EasyMock.anyObject()))
+      expect(configHelper.calculateExistingConfigurations(eq(ambariManagementController), anyObject(Cluster.class), EasyMock.anyObject()))
           .andReturn(new HashMap<String, Map<String, String>>() {
             {
               put("cluster-env", new HashMap<String, String>() {{
@@ -3710,7 +3710,7 @@ public class KerberosHelperTest extends EasyMockSupport {
         .once();
 
     final ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
-    expect(configHelper.getEffectiveConfigProperties(anyObject(Cluster.class), EasyMock.anyObject()))
+    expect(configHelper.calculateExistingConfigurations(eq(ambariManagementController), anyObject(Cluster.class), EasyMock.anyObject()))
         .andReturn(new HashMap<String, Map<String, String>>() {
           {
             put("cluster-env", new HashMap<String, String>() {
@@ -3927,7 +3927,7 @@ public class KerberosHelperTest extends EasyMockSupport {
         .anyTimes();
 
     final ConfigHelper configHelper = injector.getInstance(ConfigHelper.class);
-    expect(configHelper.getEffectiveConfigProperties(anyObject(Cluster.class), EasyMock.anyObject()))
+    expect(configHelper.calculateExistingConfigurations(eq(ambariManagementController), anyObject(Cluster.class), EasyMock.anyObject()))
         .andReturn(new HashMap<String, Map<String, String>>() {
           {
             put("cluster-env", new HashMap<String, String>() {{


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of using a single boolean flag to decide if SSO is enabled or not we use a predicate based approach (see detailed explanation in the [JIRA](https://issues.apache.org/jira/browse/AMBARI-24351)).

## How was this patch tested?

In addition to uni testing I executed several manual tests in a local cluster using various types of predicates: `and`, `or`, `equals`, `contains`