### PR TITLE
AMBARI-24286. Enabling Hive Server Interactive doesn't work with ONEF…

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -2977,7 +2977,9 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
         break;
     }
     var component = App.StackServiceComponent.find(componentName);
-    return component.missingDependencies(installedComponents, opt);
+    return component.missingDependencies(installedComponents, opt).map(function(componentDependency) {
+      return componentDependency.chooseCompatible();
+    });
   },
 
   /**

--- a/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
+++ b/ambari-web/app/controllers/wizard/step7/assign_master_controller.js
@@ -354,12 +354,14 @@ App.AssignMasterOnStep7Controller = Em.Controller.extend(App.BlueprintMixin, App
   getAllMissingDependentServices: function () {
     var configActionComponentName = this.get('configActionComponent').componentName;
     var componentStackService = App.StackServiceComponent.find(configActionComponentName).get('stackService');
-    var dependentServices = componentStackService.get('requiredServices');
+    var missing = [];
+    componentStackService.collectMissingDependencies(this.installedStackServices(), App.StackService.find(), missing);
+    return missing.mapProperty('displayName');
+  },
 
-    return dependentServices.filter(function (item) {
-      return !App.Service.find().findProperty('serviceName', item);
-    }).map(function (item) {
-      return App.StackService.find(item).get('displayName');
+  installedStackServices: function() {
+    return App.Service.find().map(function(each) {
+      return App.StackService.find(each.get('serviceName'));
     });
   },
 

--- a/ambari-web/app/mixins/main/service/configs/component_actions_by_configs.js
+++ b/ambari-web/app/mixins/main/service/configs/component_actions_by_configs.js
@@ -315,9 +315,11 @@ App.ComponentActionsByConfigs = Em.Mixin.create({
     var dependentComponents = [];
 
     componentsToAdd.forEach(function (_component) {
-      var dependencies = App.StackServiceComponent.find(_component.componentName).get('dependencies').filterProperty('scope', 'host').map(function (_dependency) {
+      var componentToAdd = App.StackServiceComponent.find(_component.componentName);
+      var installedComponents = App.HostComponent.find().filterProperty('hostName', _component.hostName).mapProperty('componentName').uniq();
+      var dependencies = componentToAdd.missingDependencies(installedComponents, {'scope': 'host'}).map(function (_dependency) {
         return {
-          componentName: _dependency.componentName,
+          componentName: _dependency.chooseCompatible(),
           hostName: _component.hostName,
           isClient: App.StackServiceComponent.find(_dependency.componentName).get('isClient')
         }

--- a/ambari-web/test/controllers/main/host/details_test.js
+++ b/ambari-web/test/controllers/main/host/details_test.js
@@ -3711,6 +3711,11 @@ describe('App.MainHostDetailsController', function () {
     });
     it("dependecies should be added", function () {
       var opt = {scope: '*', installedComponents: ['C2']};
+      this.mock.returns([
+        App.StackServiceComponent.createRecord({componentName: 'C1'}),
+        App.StackServiceComponent.createRecord({componentName: 'C2'}),
+        App.StackServiceComponent.createRecord({componentName: 'C3'})
+      ]);
       this.mock.withArgs('C1').returns(App.StackServiceComponent.createRecord({
         dependencies: [{componentName: 'C3'}]
       }));
@@ -3729,6 +3734,11 @@ describe('App.MainHostDetailsController', function () {
     });
     it("scope is host", function () {
       var opt = {scope: 'host', hostName: 'host1'};
+      this.mock.returns([
+        App.StackServiceComponent.createRecord({componentName: 'C1'}),
+        App.StackServiceComponent.createRecord({componentName: 'C2'}),
+        App.StackServiceComponent.createRecord({componentName: 'C3'})
+      ]);
       this.mock.withArgs('C1').returns(App.StackServiceComponent.createRecord({
         dependencies: [{componentName: 'C3', scope: 'host'}]
       }));

--- a/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
+++ b/ambari-web/test/controllers/wizard/step7/assign_master_controller_test.js
@@ -299,15 +299,20 @@ describe('App.AssignMasterOnStep7Controller', function () {
 
     beforeEach(function() {
       sinon.stub(App.StackServiceComponent, 'find').returns(Em.Object.create({
-        stackService: Em.Object.create({
+        stackService: App.StackService.createRecord({
           requiredServices: ['S1', 'S2']
         })
       }));
       sinon.stub(App.Service, 'find').returns([
-        {serviceName: 'S1'}
+        App.Service.createRecord({serviceName: 'S1'})
       ]);
       sinon.stub(App.StackService, 'find', function(input) {
-        return Em.Object.create({displayName: input});
+        return input
+          ? Em.Object.create({displayName: input, serviceName: input})
+          : [
+              App.StackService.createRecord({serviceName: 'S1', displayName: 'S1'}),
+              App.StackService.createRecord({serviceName: 'S2', displayName: 'S2'})
+            ]
       });
     });
 

--- a/ambari-web/test/mixins/main/service/configs/component_actions_by_configs_test.js
+++ b/ambari-web/test/mixins/main/service/configs/component_actions_by_configs_test.js
@@ -298,13 +298,19 @@ describe('App.ComponentActionsByConfigs', function () {
   describe("#getDependentComponents()", function () {
 
     beforeEach(function() {
-      sinon.stub(App.StackServiceComponent, 'find').returns(Em.Object.create({
-        dependencies: [{
-          scope: 'host',
-          componentName: 'C2'
-        }],
-        isClient: false
-      }));
+      var mock = sinon.stub(App.StackServiceComponent, 'find');
+      mock.returns([
+        App.StackServiceComponent.createRecord({componentName: 'C1'}),
+        App.StackServiceComponent.createRecord({componentName: 'C2'})
+      ]);
+      mock.withArgs('C1').returns(
+        App.StackServiceComponent.createRecord({
+          componentName: 'C1',
+          dependencies: [{ scope: 'host', componentName: 'C2' }],
+          isClient: false
+        })
+      );
+      mock.withArgs('C2').returns(App.StackServiceComponent.createRecord({componentName: 'C2'}));
       sinon.stub(App.HostComponent, 'find').returns([]);
     });
 


### PR DESCRIPTION
…S (amagyar)

## What changes were proposed in this pull request?

The following problems were observed when trying to enable HSI on a cluster that uses ONEFS instead of HDFS

1. Ambari UI does not allow Interactive Query to be enabled with ONEFS_CLIENT
2. Automatic installation and start of HSI fails, after enable and saving via Hive configuration. 
3. Manually adding HSI is prevented by a popup saying HSI needs HDFS_CLIENT (ONEFS is not recognized as an HDFS compatible client)

## How was this patch tested?

1. enabled HSI on the UI
2. added a second HSI instance manually