### PR TITLE
[AMBARI-24362] Fixes for modal with config validations and dependent properties

### DIFF
--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -1521,8 +1521,8 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
       primary: popupPrimary,
       primaryClass: 'btn-danger',
       disablePrimary: Em.computed.alias('controller.isRecommendationInProgress'),
-      classNameBindings: ['controller.changedProperties.length:common-modal-wrapper', 'controller.changedProperties.length:modal-full-width'],
-      modalDialogClasses: Em.computed.ifThenElse('controller.changedProperties.length', ['modal-lg'], []),
+      classNameBindings: ['controller.changedProperties.length:common-modal-wrapper'],
+      modalDialogClasses: Em.computed.ifThenElse('controller.changedProperties.length', ['modal-xlg'], []),
       bodyClass: Em.View.extend({
         templateName: require('templates/main/service/info/delete_service_warning_popup'),
         warningMessage: new Em.Handlebars.SafeString(warningMessage)

--- a/ambari-web/app/mixins/common/configs/config_recommendations.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendations.js
@@ -96,20 +96,24 @@ App.ConfigRecommendations = Em.Mixin.create({
    */
   addRecommendation: function (name, fileName, configGroupName, recommendedValue, initialValue, parentPropertyIds, isEditable) {
     Em.assert('name and fileName should be defined', name && fileName);
-    var site = App.config.getConfigTagFromFileName(fileName);
-    var service = App.config.get('serviceByConfigTypeMap')[site];
+    const site = App.config.getConfigTagFromFileName(fileName);
+    const service = App.config.get('serviceByConfigTypeMap')[site];
+    const configObject = App.configsCollection.getConfigByName(name, fileName);
+    const displayName = configObject && configObject.displayName;
 
-    var recommendation = {
+    const recommendation = {
       saveRecommended: true,
       saveRecommendedDefault: true,
       propertyFileName: site,
       propertyName: name,
+      propertyTitle: configObject && Em.I18n.t('installer.controls.serviceConfigPopover.title').format(displayName, displayName === name ? '' : name),
+      propertyDescription: configObject && configObject.description,
 
       isDeleted: Em.isNone(recommendedValue),
       notDefined: Em.isNone(initialValue),
 
       configGroup: configGroupName || "Default",
-      initialValue: initialValue,
+      initialValue,
       parentConfigs: parentPropertyIds || [],
       serviceName: service.get('serviceName'),
       allowChangeGroup: false,//TODO groupName!= "Default" && (service.get('serviceName') != this.get('selectedService.serviceName'))

--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -20,7 +20,7 @@
 
 body {
   overflow-y: scroll;
-  line-height: 1.3em;
+  line-height: @default-line-height;
 }
 
 html, body {
@@ -2171,6 +2171,26 @@ input[type="radio"].align-checkbox, input[type="checkbox"].align-checkbox {
 
 .config-validation-warnings {
   table {
+    table-layout: fixed;
+    td, th {
+      &.issue-type-cell {
+        width: 5%;
+      }
+      &.service-name-cell {
+        width: 15%;
+      }
+      &.property-name-cell {
+        width: 15%;
+      }
+      &.property-value-cell {
+        width: 25%;
+        overflow: hidden;
+        overflow-wrap: break-word;
+      }
+      &.property-description-cell {
+        width: 40%;
+      }
+    }
     tbody{
       tr {
         &.warning {
@@ -2221,13 +2241,18 @@ input[type="radio"].align-checkbox, input[type="checkbox"].align-checkbox {
 #config-dependencies {
   max-height: 500px;
   overflow-y: visible;
-  td {
-    min-width: 120px;
-    word-break: break-all;
+  td, th {
     &.check-box-col {
       min-width: 5px;
       width: 5px;
+      .checkbox {
+        display: inline-block;
+      }
     }
+  }
+  td {
+    min-width: 120px;
+    word-break: break-all;
     &.config-dependency-name {
       min-width: @config-dependency-t-name-width;
     }

--- a/ambari-web/app/styles/bootstrap_overrides.less
+++ b/ambari-web/app/styles/bootstrap_overrides.less
@@ -432,7 +432,7 @@ select.form-control {
 
 .btn-group.open .dropdown-menu input[type="checkbox"] + label,
 .dropdown.open .dropdown-menu input[type="checkbox"] + label {
-  line-height: 1.3em;
+  line-height: @default-line-height;
 }
 
 .navigation-bar-container.collapsed ul.nav.side-nav-menu li ul.sub-menu,

--- a/ambari-web/app/styles/common.less
+++ b/ambari-web/app/styles/common.less
@@ -188,6 +188,7 @@
 @default-font-size: 14px;
 @smaller-font-size: 12px;
 @default-button-height: 34px;
+@default-line-height: 1.3em;
 
 /************************************************************************
 * Modal popup properties
@@ -198,6 +199,10 @@
 @modal-header-height: 57px;
 // modal footer height
 @modal-footer-height: 75px;
+// default modal top margin
+@modal-dialog-margin-top-default: 10px;
+// modal top margin for wide screen
+@modal-dialog-margin-top-wide-screen: 30px;
 
 .ellipsis-overflow {
   overflow: hidden;
@@ -210,3 +215,11 @@
 }
 
 @dashboard-widget-height: 157px;
+
+/************************************************************************
+* Top navbar styles
+***********************************************************************/
+@navbar-header-vertical-padding: 19px;
+@navbar-header-padding-right: 15px;
+@navbar-header-padding-left: 0;
+@navbar-header-font-size: 20px;

--- a/ambari-web/app/styles/modal_popups.less
+++ b/ambari-web/app/styles/modal_popups.less
@@ -17,6 +17,8 @@
  */
 @import 'common.less';
 
+@modal-top-calculated-without-margin: @navbar-header-vertical-padding + (@navbar-header-font-size * unit(@default-line-height));
+
 #modal {
   outline: none;
 }
@@ -25,7 +27,7 @@
   margin-left: 20px;
   margin-right: 20px;
   text-indent: -20px;
-  line-height: 1.3em;
+  line-height: @default-line-height;
 
   a:not(.disabled) {
       cursor: pointer;
@@ -97,7 +99,7 @@
 }
 
 .modal {
-  top: 5%;
+  top: @modal-top-calculated-without-margin - @modal-dialog-margin-top-default;
   .modal-body {
     .top-wrap {
       &.top-wrap-header {
@@ -107,6 +109,13 @@
     }
   }
 }
+
+@media (min-width: 768px) {
+  .modal {
+    top: @modal-top-calculated-without-margin - @modal-dialog-margin-top-wide-screen;
+  }
+}
+
 .modal-body {
   max-height: 600px;
   overflow-y: auto;

--- a/ambari-web/app/styles/top-nav.less
+++ b/ambari-web/app/styles/top-nav.less
@@ -26,9 +26,9 @@
     margin-bottom: 10px;
 
     .navbar-header {
-      padding: 19px 15px 19px 0;
+      padding: @navbar-header-vertical-padding @navbar-header-padding-right @navbar-header-vertical-padding @navbar-header-padding-left;
       margin-top: -5px;
-      font-size: 20px;
+      font-size: @navbar-header-font-size;
       width: ~"calc(100% - 400px)";
       a {
         color: #313D54;

--- a/ambari-web/app/templates/common/configs/services_config.hbs
+++ b/ambari-web/app/templates/common/configs/services_config.hbs
@@ -72,7 +72,9 @@
       <div id="notifications-dropdown" class="dropdown-menu row">
         <div class="popover-content">
           <div class="popup-arrow-up"></div>
-          {{view App.DependentConfigsListView recommendationsBinding="controller.recommendations" requiredChangesBinding="controller.requiredChanges"}}
+          {{view App.DependentConfigsListView recommendationsBinding="controller.recommendations"
+            requiredChangesBinding="controller.requiredChanges" isRecommendationsClickable=true
+            showRecommendationsPopovers=false}}
         </div>
       </div>
     </div>

--- a/ambari-web/app/templates/common/modal_popups/config_recommendation_popup.hbs
+++ b/ambari-web/app/templates/common/modal_popups/config_recommendation_popup.hbs
@@ -25,29 +25,29 @@
     <table class="table table-hover">
       <thead>
       <tr>
-        <th>{{t common.type}}</th>
-        <th>{{t common.service}}</th>
-        <th>{{t common.property}}</th>
-        <th>{{t common.value}}</th>
-        <th>{{t common.description}}</th>
+        <th class="issue-type-cell">{{t common.type}}</th>
+        <th class="service-name-cell">{{t common.service}}</th>
+        <th class="property-name-cell">{{t common.property}}</th>
+        <th class="property-value-cell">{{t common.value}}</th>
+        <th class="property-description-cell">{{t common.description}}</th>
       </tr>
       </thead>
       <tbody>
       {{#each error in view.configErrors.criticalIssues}}
         <tr {{bindAttr class="error.cssClass"}}>
-          <td>
+          <td class="issue-type-cell">
             {{t common.critical}}
           </td>
-          <td>{{error.serviceName}}</td>
-          <td>
+          <td class="service-name-cell">{{error.serviceName}}</td>
+          <td class="property-name-cell">
             {{#if controller.isInstallWizard}}
               <a href="#" {{action "showConfigProperty" error target="controller"}}>{{error.propertyName}}</a>
             {{else}}
               {{error.propertyName}}
             {{/if}}
           </td>
-          <td>{{error.value}}</td>
-          <td>
+          <td class="property-value-cell">{{error.value}}</td>
+          <td class="property-description-cell">
             {{#each message in error.messages}}
               <div class="property-message">{{message}}</div>
             {{/each}}
@@ -71,17 +71,17 @@
     <table class="table table-hover">
       <thead>
       <tr>
-        <th>{{t common.type}}</th>
-        <th>{{t common.service}}</th>
-        <th>{{t common.property}}</th>
-        <th>{{t installer.step7.popup.currentValue}}</th>
-        <th>{{t common.description}}</th>
+        <th class="issue-type-cell">{{t common.type}}</th>
+        <th class="service-name-cell">{{t common.service}}</th>
+        <th class="property-name-cell">{{t common.property}}</th>
+        <th class="property-value-cell">{{t installer.step7.popup.currentValue}}</th>
+        <th class="property-description-cell">{{t common.description}}</th>
       </tr>
       </thead>
       <tbody>
       {{#each error in view.configErrors.issues}}
         <tr {{bindAttr class="error.cssClass"}}>
-          <td>
+          <td class="issue-type-cell">
             {{#if error.isError}}
               {{t common.error}}
             {{else}}
@@ -94,16 +94,16 @@
               <td colspan="4">{{error.message}}</td>
             {{/each}}
           {{else}}
-            <td>{{error.serviceName}}</td>
-            <td>
+            <td class="service-name-cell">{{error.serviceName}}</td>
+            <td class="property-name-cell">
               {{#if controller.isInstallWizard}}
                 <a href="#" {{action "showConfigProperty" error target="controller"}}>{{error.propertyName}}</a>
               {{else}}
                 {{error.propertyName}}
               {{/if}}
             </td>
-            <td>{{error.value}}</td>
-            <td>
+            <td class="property-value-cell">{{error.value}}</td>
+            <td class="property-description-cell">
               {{#each message in error.messages}}
                 <div class="property-message">{{message}}</div>
               {{/each}}

--- a/ambari-web/app/templates/common/modal_popups/dependent_configs_list.hbs
+++ b/ambari-web/app/templates/common/modal_popups/dependent_configs_list.hbs
@@ -63,9 +63,11 @@
 {{/if}}
 <span id="config-dependencies" class="limited-height-2">
   {{#if view.recommendations.length}}
-    {{view App.DependentConfigsTableView recommendationsBinding="view.recommendations" checkboxesFirstBinding="controller.isInstallWizard" isClickable=true}}
+    {{view App.DependentConfigsTableView recommendationsBinding="view.recommendations"
+      isClickableBinding="view.isRecommendationsClickable" showPopoversBinding="view.showRecommendationsPopovers"}}
   {{/if}}
   {{#if view.requiredChanges.length}}
-    {{view App.DependentConfigsTableView recommendationsBinding="view.requiredChanges" isEditable=false checkboxesFirstBinding="controller.isInstallWizard" isClickable=true}}
+    {{view App.DependentConfigsTableView recommendationsBinding="view.requiredChanges" isEditable=false
+      isClickableBinding="view.isRecommendationsClickable" showPopoversBinding="view.showRecommendationsPopovers"}}
   {{/if}}
 </span>

--- a/ambari-web/app/templates/common/modal_popups/dependent_configs_table.hbs
+++ b/ambari-web/app/templates/common/modal_popups/dependent_configs_table.hbs
@@ -22,10 +22,8 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      {{#if view.checkboxesFirst}}
-        {{#if view.isEditable}}
-          <th class="check-box-col">{{view view.parentView.toggleAll}}<label {{bindAttr for="view.parentView.toggleAllId"}}></label></th>
-        {{/if}}
+      {{#if view.isEditable}}
+        <th class="check-box-col">{{view view.parentView.toggleAll}}<label {{bindAttr for="view.parentView.toggleAllId"}}></label></th>
       {{/if}}
       <th>{{t common.property}}</th>
       <th>{{t common.service}}</th>
@@ -45,22 +43,15 @@
           </div>
         </div>
       </th>
-      {{#unless view.checkboxesFirst}}
-        {{#if view.isEditable}}
-          <th class="check-box-col">{{view view.parentView.toggleAll}}<label {{bindAttr for="view.parentView.toggleAllId"}}></label></th>
-        {{/if}}
-      {{/unless}}
     </tr>
   </thead>
   <tbody>
   {{#each recommendation in view.recommendations}}
     <tr {{bindAttr class="recommendation.saveRecommended:active"}}>
-      {{#if view.checkboxesFirst}}
-        {{#if view.isEditable}}
-          <td class="check-box-col">{{view App.CheckboxView checkedBinding="recommendation.saveRecommended"}}</td>
-        {{/if}}
+      {{#if view.isEditable}}
+        <td class="check-box-col">{{view App.CheckboxView checkedBinding="recommendation.saveRecommended"}}</td>
       {{/if}}
-      <td class="config-dependency-name">
+      <td class="config-dependency-name" {{bindAttr data-original-title="recommendation.propertyTitle" data-content="recommendation.propertyDescription"}}>
         {{#if view.isClickable}}
           <a href="#" {{action "showConfigProperty" recommendation target="controller"}}>{{recommendation.propertyName}}</a>
         {{else}}
@@ -82,11 +73,6 @@
           {{view App.ConfigDiffView configBinding="recommendation"}}
         </div>
       </td>
-      {{#unless view.checkboxesFirst}}
-        {{#if view.isEditable}}
-          <td class="check-box-col">{{view App.CheckboxView checkedBinding="recommendation.saveRecommended"}}</td>
-        {{/if}}
-      {{/unless}}
     </tr>
   {{/each}}
   </tbody>

--- a/ambari-web/app/views/common/modal_popup.js
+++ b/ambari-web/app/views/common/modal_popup.js
@@ -162,12 +162,19 @@ App.ModalPopup = Ember.View.extend({
 
   fitHeight: function () {
     if (this.get('state') === 'destroyed') return;
-    var popup = this.$().find('#modal'),
+    const popup = this.$().find('#modal'),
       wrapper = $(popup).find('.modal-dialog'),
       block = $(popup).find('.modal-body'),
       wh = $(window).height(),
-      top = wh * 0.05,
-      newMaxHeight = wh - top * 2 - (wrapper.height() - block.height());
+      ww = $(window).width(),
+      topNavPaddingTop = 19, // from ambari-web/app/styles/common.less
+      topNavFontSize = 20, // from ambari-web/app/styles/common.less
+      topNavLineHeight = 1.3, // from ambari-web/app/styles/common.less
+      modalMarginTopDefault = 10, // from ambari-web/app/styles/common.less
+      modalMarginTopWide = 30, // from ambari-web/app/styles/common.less
+      modalMarginTop = ww < 768 ? modalMarginTopDefault : modalMarginTopWide, // from ambari-web/vendor/styles/bootstrap.css
+      top = topNavPaddingTop + topNavFontSize * topNavLineHeight - modalMarginTop;
+    let newMaxHeight = wh - top * 2 - (wrapper.height() - block.height());
 
     popup.css({
       'top': top + 'px',

--- a/ambari-web/app/views/common/modal_popups/config_validation/config_validation_popup.js
+++ b/ambari-web/app/views/common/modal_popups/config_validation/config_validation_popup.js
@@ -26,8 +26,8 @@ var App = require('app');
 App.showConfigValidationPopup = function (configErrors, primary, secondary, controller) {
   return App.ModalPopup.show({
     header: Em.I18n.t('installer.step7.popup.validation.warning.header'),
-    classNames: ['common-modal-wrapper','modal-full-width'],
-    modalDialogClasses: ['modal-lg'],
+    classNames: ['common-modal-wrapper'],
+    modalDialogClasses: ['modal-xlg'],
     primary: Em.I18n.t('common.proceedAnyway'),
     primaryClass: 'btn-danger',
     marginBottom: 200,

--- a/ambari-web/app/views/common/modal_popups/dependent_configs_list_popup.js
+++ b/ambari-web/app/views/common/modal_popups/dependent_configs_list_popup.js
@@ -21,8 +21,11 @@ var App = require('app');
 App.DependentConfigsTableView = Em.View.extend({
   templateName: require('templates/common/modal_popups/dependent_configs_table'),
   recommendations: [],
-  checkboxesFirst: false,
   isClickable: false,
+  showPopovers: true,
+  elementsWithPopover: function () {
+    return this.$('td.config-dependency-name');
+  }.property(),
   hideMessage: function () {
     return this.get('controller.isInstallWizard');
   }.property('controller.isInstallWizard'),
@@ -47,12 +50,28 @@ App.DependentConfigsTableView = Em.View.extend({
       message += Em.I18n.t('popup.dependent.configs.title.required');
     }
     return message;
-  }.property('isEditable')
+  }.property('isEditable'),
+  didInsertElement: function () {
+    if (this.get('showPopovers')) {
+      App.popover(this.get('elementsWithPopover'), {
+        placement: 'auto right',
+        trigger: 'hover',
+        html: true
+      });
+    }
+  },
+  willDestroyElement: function () {
+    if (this.get('showPopovers')) {
+      this.get('elementsWithPopover').popover('destroy');
+    }
+  }
 });
 
 App.DependentConfigsListView = Em.View.extend({
   templateName: require('templates/common/modal_popups/dependent_configs_list'),
   isAfterRecommendation: true,
+  isRecommendationsClickable: false,
+  showRecommendationsPopovers: true,
   recommendations: [],
   requiredChanges: [],
   allConfigsWithErrors: [],
@@ -96,32 +115,36 @@ App.DependentConfigsListView = Em.View.extend({
 
 /**
  * Show confirmation popup
- * @param {[Object]} recommendedChanges
+ * @param {[Object]} recommendations
  * @param {[Object]} requiredChanges
  * @param {function} [primary=null]
  * @param {function} [secondary=null]
+ * @param {boolean} [isRecommendationsClickable=false]
+ * @param {boolean} [isRecommendationsClickable=true]
  * we use this parameter to defer saving configs before we make some decisions.
  * @return {App.ModalPopup}
  */
-App.showDependentConfigsPopup = function (recommendedChanges, requiredChanges, primary, secondary, controller) {
+App.showDependentConfigsPopup = function (recommendations, requiredChanges, primary, secondary, controller, isRecommendationsClickable = false, showRecommendationsPopovers = true) {
   return App.ModalPopup.show({
     encodeBody: false,
     header: Em.I18n.t('popup.dependent.configs.header'),
-    classNames: ['common-modal-wrapper','modal-full-width'],
-    modalDialogClasses: ['modal-lg'],
+    classNames: ['common-modal-wrapper'],
+    modalDialogClasses: ['modal-xlg'],
     secondaryClass: 'cancel-button',
     bodyClass: App.DependentConfigsListView.extend({
-      recommendations: recommendedChanges,
-      requiredChanges: requiredChanges,
-      controller: controller
+      recommendations,
+      requiredChanges,
+      controller,
+      isRecommendationsClickable,
+      showRecommendationsPopovers
     }),
     saveChanges: function() {
-      recommendedChanges.forEach(function (c) {
+      recommendations.forEach(function (c) {
         Em.set(c, 'saveRecommendedDefault', Em.get(c, 'saveRecommended'));
       });
     },
     discardChanges: function() {
-      recommendedChanges.forEach(function(c) {
+      recommendations.forEach(function(c) {
         Em.set(c, 'saveRecommended', Em.get(c, 'saveRecommendedDefault'));
       });
     },

--- a/ambari-web/app/views/common/modal_popups/log_file_search_popup.js
+++ b/ambari-web/app/views/common/modal_popups/log_file_search_popup.js
@@ -20,7 +20,7 @@ var App = require('app');
 
 App.LogFileSearchPopup = function(header) {
   return App.ModalPopup.show({
-    classNames: ['modal-full-width', 'common-modal-wrapper', 'log-file-search-popup'],
+    classNames: ['common-modal-wrapper', 'log-file-search-popup'],
     modalDialogClasses: ['modal-lg'],
     header: header,
     bodyView: null,

--- a/ambari-web/test/mixins/common/configs/config_recommendations_test.js
+++ b/ambari-web/test/mixins/common/configs/config_recommendations_test.js
@@ -32,12 +32,17 @@ describe('App.ConfigRecommendations', function() {
       sinon.stub(App.config, 'get').withArgs('serviceByConfigTypeMap').returns({
         'pFile': Em.Object.create({serviceName: 'sName', displayName: 'sDisplayName'})
       });
-    sinon.stub(Handlebars, 'SafeString');
+      sinon.stub(App.configsCollection, 'getConfigByName').withArgs('pName', 'pFile').returns({
+        displayName: 'pDisplayName',
+        description: 'pDescription'
+      });
+      sinon.stub(Handlebars, 'SafeString');
     });
     afterEach(function() {
       instanceObject.formatParentProperties.restore();
       App.config.get.restore();
-    Handlebars.SafeString.restore();
+      App.configsCollection.getConfigByName.restore();
+      Handlebars.SafeString.restore();
     });
 
     it('adds new recommendation', function() {
@@ -47,6 +52,8 @@ describe('App.ConfigRecommendations', function() {
         saveRecommendedDefault: true,
         propertyFileName: 'pFile',
         propertyName: 'pName',
+        propertyTitle: 'pDisplayName<br><small>pName</small>',
+        propertyDescription: 'pDescription',
         isDeleted: false,
         notDefined: false,
         configGroup: 'pGroup',
@@ -123,6 +130,8 @@ describe('App.ConfigRecommendations', function() {
           saveRecommendedDefault: true,
           propertyFileName: 'pFile',
           propertyName: 'pName',
+          propertyTitle: 'pDisplayName<br><small>pName</small>',
+          propertyDescription: 'pDescription',
           isDeleted: false,
           notDefined: false,
           configGroup: 'pGroup',
@@ -144,6 +153,8 @@ describe('App.ConfigRecommendations', function() {
           saveRecommendedDefault: true,
           propertyFileName: 'pFile',
           propertyName: 'pName',
+          propertyTitle: 'pDisplayName<br><small>pName</small>',
+          propertyDescription: 'pDescription',
           isDeleted: false,
           notDefined: false,
           configGroup: 'pGroup',
@@ -165,6 +176,8 @@ describe('App.ConfigRecommendations', function() {
           saveRecommendedDefault: true,
           propertyFileName: 'pFile',
           propertyName: 'pName',
+          propertyTitle: 'pDisplayName<br><small>pName</small>',
+          propertyDescription: 'pDescription',
           isDeleted: true,
           notDefined: true,
           configGroup: 'Default',
@@ -187,12 +200,17 @@ describe('App.ConfigRecommendations', function() {
             'pFile': c.service
           });
           sinon.stub(Handlebars, 'SafeString');
+          sinon.stub(App.configsCollection, 'getConfigByName').withArgs('pName', 'pFile.xml').returns({
+            displayName: 'pDisplayName',
+            description: 'pDescription'
+          });
           recommendation = instanceObject.addRecommendation(c.name, c.file, c.group, c.recommended, c.initial, c.parent, c.isEditable);
         });
 
         afterEach(function() {
           App.config.get.restore();
           Handlebars.SafeString.restore();
+          App.configsCollection.getConfigByName.restore();
         });
 
         it(c.title, function() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dependent configs table:
- Checkboxes should be located on the left side
- Properties names hyperlinks are broken; remove the links and add the tooltip with property description on hover instead
- Make modal wider
- Move modal closer to the top

Config validations results table:
- Limit the width and wrap the contents of 'Current Value' column
- Make modal wider

## How was this patch tested?

UI unit tests:
  21810 passing (27s)
  48 pending