### PR TITLE
[Ambari 24363] - Allow Ambari to Bypass Hashing of Stack Resources

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
@@ -302,7 +302,8 @@ public class AmbariMetaInfo {
     readServerVersion();
 
     stackManager = stackManagerFactory.create(resourcesRoot, stackRoot, commonServicesRoot, extensionsRoot,
-        osFamily, false /* validate = false */, true /* refreshArchives = true */);
+        osFamily, false /* validate = false */,
+        conf.isStackResourceHashAndArchiveGenerationEnabled());
 
     mpackManager = mpackManagerFactory.create(mpacksV2Staging, stackRoot);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -2601,6 +2601,16 @@ public class Configuration {
   public static final ConfigurationProperty<Integer> DEFAULT_MAX_DEGREE_OF_PARALLELISM_FOR_UPGRADES = new ConfigurationProperty<>(
     "stack.upgrade.default.parallelism", 100);
 
+  /**
+   * If enabled, Ambari will generate hash files for stack resource directories
+   * and generate compressed archives of those directories to send to agents.
+   * This should normally always be {@code true} except in a development
+   * environment.
+   */
+  @Markdown(description = "Enables whether Ambari should generate .hash files for stack resource directories. This should always be enabled unless working in a development environment.")
+  public static final ConfigurationProperty<Boolean> STACK_RESOURCE_HASH_ENABLED = new ConfigurationProperty<>(
+      "server.stack.resources.hash.enabled", true);
+
   private static final Logger LOG = LoggerFactory.getLogger(
     Configuration.class);
 
@@ -3015,7 +3025,7 @@ public class Configuration {
     writeConfigFile(existingProperties, false);
 
     // reloading properties
-    this.properties = readConfigFile();
+    properties = readConfigFile();
   }
 
   /**
@@ -6031,4 +6041,15 @@ public class Configuration {
   public int getAlertServiceCorePoolSize() {
     return Integer.parseInt(getProperty(SERVER_SIDE_ALERTS_CORE_POOL_SIZE));
   }
+
+  /**
+   * Gets whether Ambari should generate {@code .hash} and {@code archive.zip}
+   * files for stack resources.
+   *
+   * @return {@code true} to generate the files, {@code false} otherwise.
+   */
+  public boolean isStackResourceHashAndArchiveGenerationEnabled() {
+    return Boolean.parseBoolean(getProperty(STACK_RESOURCE_HASH_ENABLED));
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari will normally attempt to create {{.hash}} and {{archive.zip}} files of all stack resource directories in order to push new or updated resources to all agents. In a development environment, however, this might not be necessary, especially if Ambari is not installed and running as a Python process.

This change will introduce a configuration parameter, {{true}} by default, which will allow overriding this behavior for developers.

## How was this patch tested?

Manually tested in development environment.