### PR TITLE
AMBARI-24365: Add livy-client.conf setting to Ambari spark stack

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/setup_livy2.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/setup_livy2.py
@@ -66,6 +66,14 @@ def setup_livy(env, type, upgrade_type = None, action = None):
                 group=params.livy2_group,
   )
 
+  # create livy-client.conf in etc/conf dir
+  PropertiesFile(format("{livy2_conf}/livy-client.conf"),
+                properties = params.config['configurations']['livy2-client-conf'],
+                key_value_delimiter = " ",
+                owner=params.livy2_user,
+                group=params.livy2_group,
+   )
+
   # create log4j.properties in etc/conf dir
   File(os.path.join(params.livy2_conf, 'log4j.properties'),
        owner=params.livy2_user,

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/livy2-client-conf.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/livy2-client-conf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration supports_final="true">
+    <property>
+        <name>livy.rsc.launcher.address</name>
+        <value> </value>
+        <description>
+            Address for the RSC driver to connect back with it's connection info.
+        </description>
+        <on-ambari-upgrade add="false"/>
+    </property>
+</configuration>
+

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/metainfo.xml
@@ -82,6 +82,7 @@
         <config-type>spark2-hive-site-override</config-type>
         <config-type>spark2-thrift-fairscheduler</config-type>
         <config-type>livy2-conf</config-type>
+        <config-type>livy2-client-conf</config-type>
         <config-type>livy2-env</config-type>
         <config-type>livy2-log4j-properties</config-type>
         <config-type>livy2-spark-blacklist</config-type>

--- a/ambari-server/src/test/python/stacks/2.6/SPARK2/test_spark_livy2.py
+++ b/ambari-server/src/test/python/stacks/2.6/SPARK2/test_spark_livy2.py
@@ -130,6 +130,12 @@ class TestSparkClient(RMFTestCase):
                                   group = 'livy',
                                   properties = self.getConfig()['configurations']['livy2-conf'],
                                   )
+        self.assertResourceCalled('PropertiesFile', '/usr/hdp/current/livy2-server/conf/livy-client.conf',
+                                  owner = 'livy',
+                                  key_value_delimiter = ' ',
+                                  group = 'livy',
+                                  properties = self.getConfig()['configurations']['livy2-client-conf'],
+                                  )
         self.assertResourceCalled('File', '/usr/hdp/current/livy2-server/conf/log4j.properties',
                                   content = '\n            # Set everything to be logged to the console\n            log4j.rootCategory=INFO, console\n            log4j.appender.console=org.apache.log4j.ConsoleAppender\n            log4j.appender.console.target=System.err\n            log4j.appender.console.layout=org.apache.log4j.PatternLayout\n            log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n\n\n            log4j.logger.org.eclipse.jetty=WARN',
                                   owner = 'livy',

--- a/ambari-server/src/test/python/stacks/2.6/configs/default.json
+++ b/ambari-server/src/test/python/stacks/2.6/configs/default.json
@@ -373,6 +373,9 @@
       "livy.impersonation.enabled": "true",
       "livy.server.session.timeout": "3600000"
     },
+    "livy2-client-conf": {
+      "livy.rsc.launcher.address": ""
+    },
     "livy-spark-blacklist": {
       "content": "\n            #\n            # Configuration override / blacklist. Defines a list of properties that users are not allowed\n            # to override when starting Spark sessions.\n            #\n            # This file takes a list of property names (one per line). Empty lines and lines starting with \"#\"\n            # are ignored.\n            #"
     },


### PR DESCRIPTION
## What changes were proposed in this pull request?
We have run into a need to add livy-client.conf to Ambari's stack. For example we were trying to configure "livy.rsc.launcher.address" in this setting file. So this change is adding that configuration capability.

## How was this patch tested?
This has been tested manually in a HDP cluster.