### PR TITLE
AMBARI-24366: Honor zeppelin.livy.url setting as an interpreter setti…

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
@@ -609,7 +609,10 @@ class Master(Script):
           del interpreter_settings[setting_key]
 
       elif interpreter['group'] == 'livy' and interpreter['name'] == 'livy2':
-        if params.livy2_livyserver_host:
+        # Honor this Zeppelin setting if it exists
+        if 'zeppelin.livy.url' in params.config['configurations']['zeppelin-config']:
+          interpreter['properties']['zeppelin.livy.url'] = params.config['configurations']['zeppelin-config']['zeppelin.livy.url']
+        elif params.livy2_livyserver_host:
           interpreter['properties']['zeppelin.livy.url'] = params.livy2_livyserver_protocol + \
                                                            "://" + params.livy2_livyserver_host + \
                                                            ":" + params.livy2_livyserver_port


### PR DESCRIPTION
## What changes were proposed in this pull request?

The resolved value for this settings from Ambari auto update is not good enough in certain scenarios. It just uses the first host where Livy server is running. We want to have the flexibility to honor an explicit configuration for this setting.

## How was this patch tested?

This is been manually tested in a HDP cluster and we verified that the Ambari setting for zeppelin took effect.