### PR TITLE
AMBARI-24349. Rescheduled and canceled tasks stay in progress forever

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -327,6 +327,7 @@ class ActionQueue(threading.Thread):
             if com['taskId'] == command['taskId']:
               logger.info("Command with taskId = {cid} was rescheduled by server. "
                           "Fail report on cancelled command won't be sent with heartbeat.".format(cid=taskId))
+              self.commandStatuses.delete_command_data(command['taskId'])
               return
 
     # final result to stdout


### PR DESCRIPTION
Ambari-server reschedules task (timeout #1)
Task did yet got rescheduled (due to something else being in queue)
but, ambari-server cancels it (timeout #2)
The tasks keeps reprorting that's it's in progess forever, however being canceled