### PR TITLE
AMBARI-24367 : Fix integration test regressions in AMS collector due to scale changes

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/TimelineMetricClusterAggregator.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/TimelineMetricClusterAggregator.java
@@ -83,7 +83,7 @@ public class TimelineMetricClusterAggregator extends AbstractTimelineAggregator 
   protected void aggregate(ResultSet rs, long startTime, long endTime) throws IOException, SQLException {
     Map<TimelineClusterMetric, MetricHostAggregate> hostAggregateMap = aggregateMetricsFromResultSet(rs, endTime);
 
-    LOG.info("Saving " + hostAggregateMap.size() + " metric aggregates.");
+    LOG.info("Saving " + hostAggregateMap.size() + " metric aggregates to " + outputTableName);
     hBaseAccessor.saveClusterAggregateRecordsSecond(hostAggregateMap, outputTableName);
   }
 
@@ -136,7 +136,7 @@ public class TimelineMetricClusterAggregator extends AbstractTimelineAggregator 
     }
 
     if (existingMetric != null) {
-      hostAggregate.setSum(hostAggregate.getSum() / perMetricCount);
+      hostAggregate.setSum(hostAggregate.getSum() / (perMetricCount - 1));
       hostAggregate.setNumberOfSamples(Math.round((float)hostAggregate.getNumberOfSamples() / (float)perMetricCount));
     }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/TimelineMetricClusterAggregator.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/TimelineMetricClusterAggregator.java
@@ -83,7 +83,7 @@ public class TimelineMetricClusterAggregator extends AbstractTimelineAggregator 
   protected void aggregate(ResultSet rs, long startTime, long endTime) throws IOException, SQLException {
     Map<TimelineClusterMetric, MetricHostAggregate> hostAggregateMap = aggregateMetricsFromResultSet(rs, endTime);
 
-    LOG.info("Saving " + hostAggregateMap.size() + " metric aggregates to " + outputTableName);
+    LOG.info("Saving " + hostAggregateMap.size() + " metric aggregates.");
     hBaseAccessor.saveClusterAggregateRecordsSecond(hostAggregateMap, outputTableName);
   }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -185,13 +185,13 @@ public class TimelineMetricMetadataManager {
       }
     }
 
-      metricMetadataSync = new TimelineMetricMetadataSync(this);
+    metricMetadataSync = new TimelineMetricMetadataSync(this);
     // Schedule the executor to sync to store
     if (scheduleMetadateSync) {
       executorService.scheduleWithFixedDelay(metricMetadataSync,
-          metricsConf.getInt(METRICS_METADATA_SYNC_INIT_DELAY, 120), // 2 minutes
-          metricsConf.getInt(METRICS_METADATA_SYNC_SCHEDULE_DELAY, 300), // 5 minutes
-          TimeUnit.SECONDS);
+        metricsConf.getInt(METRICS_METADATA_SYNC_INIT_DELAY, 120), // 2 minutes
+        metricsConf.getInt(METRICS_METADATA_SYNC_SCHEDULE_DELAY, 300), // 5 minutes
+        TimeUnit.SECONDS);
     }
     // Read from store and initialize map
     try {
@@ -592,7 +592,11 @@ public class TimelineMetricMetadataManager {
       timelineMetric.setInstanceId(key.instanceId);
 
       byte[] hostUuid = ArrayUtils.subarray(uuid, TIMELINE_METRIC_UUID_LENGTH, HOSTNAME_UUID_LENGTH + TIMELINE_METRIC_UUID_LENGTH);
-      timelineMetric.setHostName(uuidHostMap.get(new TimelineMetricUuid(hostUuid)));
+      String hostname = uuidHostMap.get(new TimelineMetricUuid(hostUuid));
+      if (hostname == null) {
+        return null;
+      }
+      timelineMetric.setHostName(hostname);
       return timelineMetric;
     }
   }
@@ -736,7 +740,7 @@ public class TimelineMetricMetadataManager {
    * @throws IOException
    */
   public Map<String, List<TimelineMetricMetadata>> getTimelineMetricMetadataByAppId(String appId, String metricPattern,
-                                                                             boolean includeBlacklistedMetrics) throws SQLException, IOException {
+                                                                                    boolean includeBlacklistedMetrics) throws SQLException, IOException {
 
     Map<TimelineMetricMetadataKey, TimelineMetricMetadata> metadata = getMetadataCache();
 
@@ -839,8 +843,8 @@ public class TimelineMetricMetadataManager {
           cacheValue.setType(oldValue.getType());
           cacheValue.setIsWhitelisted(oldValue.isWhitelisted());
         } else if (oldValue.getSeriesStartTime() < cacheValue.getSeriesStartTime() &&
-                   cacheValue.getSeriesStartTime() != 0L &&
-                   cacheValue.isWhitelisted())
+          cacheValue.getSeriesStartTime() != 0L &&
+          cacheValue.isWhitelisted())
         {
           LOG.info(String.format("Updating startTime for %s", key));
           cacheValue.setSeriesStartTime(oldValue.getSeriesStartTime());

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/ITPhoenixHBaseAccessor.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/ITPhoenixHBaseAccessor.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.TableDescriptor;
-import org.apache.hadoop.metrics2.lib.MetricsTestHelper;
 import org.apache.hadoop.metrics2.sink.timeline.ContainerMetric;
 import org.apache.hadoop.metrics2.sink.timeline.MetricClusterAggregate;
 import org.apache.hadoop.metrics2.sink.timeline.MetricHostAggregate;
@@ -71,8 +70,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
 import junit.framework.Assert;
-
-
 
 public class ITPhoenixHBaseAccessor extends AbstractMiniHBaseClusterTest {
 
@@ -226,14 +223,14 @@ public class ITPhoenixHBaseAccessor extends AbstractMiniHBaseClusterTest {
     long startTime = System.currentTimeMillis();
     long ctime = startTime + 1;
     long minute = 60 * 1000;
-    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local1",
+    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local_c1",
       "disk_free", 1), true);
-    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local2",
+    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local_c2",
       "disk_free", 2), true);
     ctime += minute;
-    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local1",
+    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local_c1",
       "disk_free", 2), true);
-    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local2",
+    hdb.insertMetricRecords(MetricTestHelper.prepareSingleTimelineMetric(ctime, "local_c2",
       "disk_free", 1), true);
 
     long endTime = ctime + minute + 1;
@@ -443,7 +440,7 @@ public class ITPhoenixHBaseAccessor extends AbstractMiniHBaseClusterTest {
           .filter(t -> tableName.equals(t.getNameAsString())).findFirst();
 
         TableDescriptor tableDescriptor = hBaseAdmin.getTableDescriptor(tableNameOptional.get());
-        
+
         normalizerEnabled = tableDescriptor.isNormalizationEnabled();
         if (tableName.equals(METRICS_RECORD_TABLE_NAME)) {
           precisionTableCompactionPolicy = tableDescriptor.getValue(HSTORE_COMPACTION_CLASS_KEY);

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/MetricTestHelper.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/MetricTestHelper.java
@@ -38,20 +38,20 @@ public class MetricTestHelper {
   }
 
   public static TimelineMetrics prepareSingleTimelineMetric(long startTime,
-                                                        String host,
-                                                        String metricName,
-                                                        double val) {
+                                                            String host,
+                                                            String metricName,
+                                                            double val) {
     return prepareSingleTimelineMetric(startTime, host, null, metricName, val);
   }
 
   public static TimelineMetrics prepareSingleTimelineMetric(long startTime,
-                                                        String host,
-                                                        String instanceId,
-                                                        String metricName,
-                                                        double val) {
+                                                            String host,
+                                                            String instanceId,
+                                                            String metricName,
+                                                            double val) {
     TimelineMetrics m = new TimelineMetrics();
     m.setMetrics(Arrays.asList(
-        createTimelineMetric(startTime, metricName, host, null, instanceId, val)));
+      createTimelineMetric(startTime, metricName, host, null, instanceId, val)));
 
     return m;
   }
@@ -71,11 +71,11 @@ public class MetricTestHelper {
 
 
   public static TimelineMetric createTimelineMetric(long startTime,
-                                                String metricName,
-                                                String host,
-                                                String appId,
-                                                String instanceId,
-                                                double val) {
+                                                    String metricName,
+                                                    String host,
+                                                    String appId,
+                                                    String instanceId,
+                                                    double val) {
     TimelineMetric m = new TimelineMetric();
     m.setHostName(host);
     m.setAppId(appId != null ? appId : "host");
@@ -104,16 +104,27 @@ public class MetricTestHelper {
     return metric;
   }
 
-  public static TimelineClusterMetric createEmptyTimelineClusterMetric(
-      String name, long startTime) {
-    TimelineClusterMetric metric = new TimelineClusterMetric(name,
-        "test_app", "instance_id", startTime);
+  public static TimelineMetric createEmptyTimelineMetric(String metricName, long startTime) {
+    TimelineMetric metric = new TimelineMetric();
+    metric.setMetricName(metricName);
+    metric.setAppId("test_app");
+    metric.setInstanceId("test_instance");
+    metric.setHostName("test_host");
+    metric.setStartTime(startTime);
 
     return metric;
   }
 
   public static TimelineClusterMetric createEmptyTimelineClusterMetric(
-      long startTime) {
+    String name, long startTime) {
+    TimelineClusterMetric metric = new TimelineClusterMetric(name,
+      "test_app", "instance_id", startTime);
+
+    return metric;
+  }
+
+  public static TimelineClusterMetric createEmptyTimelineClusterMetric(
+    long startTime) {
     return createEmptyTimelineClusterMetric("disk_used", startTime);
   }
 }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/StandaloneHBaseTestingUtility.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/StandaloneHBaseTestingUtility.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.metrics.core.timeline;
+
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+
+public class StandaloneHBaseTestingUtility extends HBaseTestingUtility {
+
+  public StandaloneHBaseTestingUtility(Configuration configuration) {
+    super(configuration);
+  }
+
+  public MiniHBaseCluster startStandaloneHBaseCluster() throws Exception {
+    if (this.getZkCluster() == null) {
+      this.startMiniZKCluster();
+    }
+    return this.startMiniHBaseCluster(1, 1, (List) null, null, null, true, true);
+  }
+
+}


### PR DESCRIPTION
Extend HBaseTestingUtility to spin up standalone HBase cluster for integraton testing instead of distributed mode instance with HDFS.
Fix integration test regressions from 2.7.0.

## What changes were proposed in this pull request?
mvn clean install