### PR TITLE
[AMBARI-24364] - Mpack Instance Manager Not Listing Versions Correctly

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/execution_command.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/execution_command.py
@@ -96,7 +96,8 @@ class ExecutionCommand(object):
     Retrieve service name from command.json, eg. 'zk1'
     :return: service name
     """
-    if '_CLIENTS' in self.get_module_name(): # FIXME temporary hack
+    module_name = self.get_module_name()
+    if module_name and '_CLIENTS' in module_name: # FIXME temporary hack
       return 'default'
     return self.__get_value("serviceName") # multi-service, but not multi-component per service
 
@@ -279,14 +280,20 @@ class ExecutionCommand(object):
     Retrieve a list of user groups from command.json, i.e "group_list": "[\"hadoop\"]"
     :return: a list of groups
     """
-    return self.__get_value("stackSettings/group_list")
+    group_list = self.__get_value("stackSettings/group_list")
+    if not group_list:
+      group_list = "[]"
+    return group_list
 
   def get_user_list(self):
     """
     Retrieve a list of users from command.json, i.e "user_list": "[\"zookeeper\",\"ambari-qa\"]"
     :return: a list of users
     """
-    return self.__get_value("stackSettings/user_list")
+    user_list = self.__get_value("stackSettings/user_list")
+    if not user_list:
+      user_list = "[]"
+    return user_list
 
   """
   Agent related variable section

--- a/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/get_not_managed_resources.py
@@ -34,7 +34,9 @@ def get_not_managed_resources():
   except config values from cluster-env/managed_hdfs_resource_property_names
   """
   config = Script.get_config()
-  not_managed_hdfs_path_list = json.loads(config['stackSettings']['not_managed_hdfs_path_list'])[:]
+  not_managed_hdfs_path_list = []
+  if 'not_managed_hdfs_path_list' in config['stackSettings']:
+    not_managed_hdfs_path_list = json.loads(config['stackSettings']['not_managed_hdfs_path_list'])[:]
   if get_cluster_setting_value('managed_hdfs_resource_property_names') is not None:
     managed_hdfs_resource_property_names = get_cluster_setting_value('managed_hdfs_resource_property_names')
     managed_hdfs_resource_property_list = filter(None, [property.strip() for property in managed_hdfs_resource_property_names.split(',')])

--- a/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
@@ -78,9 +78,9 @@ def get_component_target_path(mpack_name, instance_name, module_name, components
   instances_json = list_instances(mpack_name, instance_name, subgroup_name, module_name,
                                   {components_instance_type: [component_instance_name]})
   walk_mpack_dict(instances_json, PATH_KEY_NAME, dirs)
-  return [dir for dir in dirs if
+  target_path_list =  [dir for dir in dirs if
           (mpack_name == None or mpack_name.lower() in dir) and (instance_name == None or instance_name.lower() in dir)]
-
+  return "" if len(target_path_list) == 0 else target_path_list[0]
 
 def get_versions(mpack_name, instance_name, module_name, components_instance_type,
                               subgroup_name='default', component_instance_name='default'):
@@ -108,12 +108,12 @@ def get_component_home_path(mpack_name, instance_name, module_name, components_i
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
 
-  component_paths = get_component_target_path(mpack_name=mpack_name, instance_name=instance_name,
+  component_path = get_component_target_path(mpack_name=mpack_name, instance_name=instance_name,
                                              subgroup_name=subgroup_name,
                                              module_name=module_name, components_instance_type=components_instance_type,
                                              component_instance_name=component_instance_name)
 
-  return os.readlink(component_paths[0])
+  return os.readlink(component_path)
 
 
 def create_component_instance(mpack_name, mpack_version, instance_name, module_name, components_instance_type,

--- a/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/mpack_manager_helper.py
@@ -34,7 +34,8 @@ MODULE_VERSION_KEY_NAME = 'module_version'
 def get_component_conf_path(mpack_name, instance_name, module_name, components_instance_type,
                             subgroup_name='default', component_instance_name='default'):
   """
-  :returns the single string that contains the path to the configuration folder of given component instance
+  :returns a list contains the path to the configuration folder of given component instance,
+           this may include multiple mpack instances cases
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
 
@@ -45,7 +46,8 @@ def get_component_conf_path(mpack_name, instance_name, module_name, components_i
 def get_component_log_path(mpack_name, instance_name, module_name, components_instance_type,
                             subgroup_name='default', component_instance_name='default'):
   """
-  :returns the single string that contains the path to the log folder of given component instance
+  :returns a list contains the path to the log folder of given component instance,
+           this may include multiple mpack instances cases
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
 
@@ -56,7 +58,8 @@ def get_component_log_path(mpack_name, instance_name, module_name, components_in
 def get_component_rundir_path(mpack_name, instance_name, module_name, components_instance_type,
                             subgroup_name='default', component_instance_name='default'):
   """
-  :returns the single string that contains the path to the rundir folder of given component instance
+  :returns a list contains the paths to the rundir folder of given component instance,
+           this may include multiple mpack instances cases
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
 
@@ -67,7 +70,8 @@ def get_component_rundir_path(mpack_name, instance_name, module_name, components
 def get_component_target_path(mpack_name, instance_name, module_name, components_instance_type,
                               subgroup_name='default', component_instance_name='default'):
   """
-  :returns the single string that contains the path to the mpack component folder of given component instance
+  :returns a list contains the paths to the mpack component folder of given component instance,
+           this may include multiple mpack instances cases
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
   dirs = set()
@@ -81,18 +85,18 @@ def get_component_target_path(mpack_name, instance_name, module_name, components
 def get_versions(mpack_name, instance_name, module_name, components_instance_type,
                               subgroup_name='default', component_instance_name='default'):
   """
-  :returns a tuple representing the mpack version and the module version
+  :returns a tuple representing the mpack version and the module version, module_name should not be None
   :raises ValueError if the parameters doesn't match the mpack or instances structure
   """
 
   instances_json = list_instances(mpack_name, instance_name, subgroup_name, module_name,
                                   {components_instance_type: [component_instance_name]})
-
-  mpack_version = instances_json[COMPONENTS_PLURAL_KEY_NAME][components_instance_type.lower()][
-    COMPONENT_INSTANCES_PLURAL_KEY_NAME][component_instance_name][MPACK_VERSION_KEY_NAME]
-
-  module_version = instances_json[COMPONENTS_PLURAL_KEY_NAME][components_instance_type.lower()][
-    COMPONENT_INSTANCES_PLURAL_KEY_NAME][component_instance_name][MODULE_VERSION_KEY_NAME]
+  dirs = set()
+  walk_mpack_dict(instances_json, MPACK_VERSION_KEY_NAME, dirs)
+  mpack_version = next(iter(dirs))
+  dirs.clear()
+  walk_mpack_dict(instances_json, MODULE_VERSION_KEY_NAME, dirs)
+  module_version = next(iter(dirs))
 
   return mpack_version, module_version
 

--- a/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/stack_features.py
@@ -108,7 +108,8 @@ def get_stack_feature_version(config):
     raise Fail("Unable to determine the correct version since stackSettings and commandParams were not present in the configuration dictionary")
 
   # should always be there
-  stack_version = config['stackSettings']['stack_version']
+  # Actually not always, i.e if we restart zookeeper service and no stack_version is included in command.json
+  stack_version = default("/stackSettings/stack_version", None)
 
   # something like 2.4.0.0-1234; represents the version for the command
   # (or None if this is a cluster install and it hasn't been calculated yet)

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -216,10 +216,11 @@ class Script(object):
     mpack_instance_name = execution_command.get_servicegroup_name()
     module_name = execution_command.get_module_name()
     component_type = execution_command.get_component_type()
+    component_name = execution_command.get_component_instance_name()
 
     try:
       mpack_version, component_version = mpack_manager_helper.get_versions(mpack_name,
-        mpack_instance_name, module_name, component_type )
+        mpack_instance_name, module_name, component_type, "default", component_name )
 
       mpack_version_dictionary = {
         "mpackVersion": mpack_version,

--- a/mpack-instance-manager/src/main/python/instance_manager/instance_manager.py
+++ b/mpack-instance-manager/src/main/python/instance_manager/instance_manager.py
@@ -22,8 +22,6 @@ __all__ = ["create_mpack", "set_mpack_instance", "get_conf_dir", "get_log_dir", 
 import sys
 import os
 import json
-sys.path.append("/usr/lib/ambari-agent/lib")
-from resource_management.core import sudo
 
 MPACK_JSON_FILE_NAME = 'mpack.json'
 CURRENT_SOFTLINK_NAME = 'current'

--- a/mpack-instance-manager/src/main/python/instance_manager/instance_manager.py
+++ b/mpack-instance-manager/src/main/python/instance_manager/instance_manager.py
@@ -115,12 +115,15 @@ def get_conf_dir(mpack=None, mpack_instance=None, subgroup_name=DEFAULT_SUBGROUP
   zookeeper_server: /usr/hwx/instances/hdpcore/default/default/zookeeper/zookeeper_server/ZOOKEEPER/conf/
   """
   dirs, is_client = get_conf_log_run_dir_helper(mpack, mpack_instance, subgroup_name, module_name, components_map, output_conf_dir = True, output_log_dir = False, output_run_dir = False)
+  path = ""
   if not is_client:
-    return [dir for dir in dirs if
+    pathlist =  [dir for dir in dirs if
             (mpack == None or mpack in dir) and (mpack_instance == None or mpack_instance in dir) and (
             module_name == None or module_name in dir)]
-  return [dir for dir in dirs if
+  else:
+    pathlist = [dir for dir in dirs if
             (mpack == None or mpack in dir) and (mpack_instance == None or mpack_instance in dir)]
+  return path if len(pathlist) == 0 else pathlist[0]
 
 def get_log_dir(mpack=None, mpack_instance=None, subgroup_name=DEFAULT_SUBGROUP_NAME, module_name=None,
                  components_map=None):
@@ -140,12 +143,15 @@ def get_log_dir(mpack=None, mpack_instance=None, subgroup_name=DEFAULT_SUBGROUP_
   names' OR empty map for all component instances present
   """
   dirs, is_client = get_conf_log_run_dir_helper(mpack, mpack_instance, subgroup_name, module_name, components_map, output_conf_dir = False, output_log_dir = True, output_run_dir = False)
+  path = ""
   if not is_client:
-    return [dir for dir in dirs if
+    pathlist = [dir for dir in dirs if
             (mpack == None or mpack in dir) and (mpack_instance == None or mpack_instance in dir) and (
             module_name == None or module_name in dir)]
-  return [dir for dir in dirs if
+  else:
+    pathlist = [dir for dir in dirs if
             (mpack == None or mpack in dir) and (mpack_instance == None or mpack_instance in dir)]
+  return path if len(pathlist) == 0 else pathlist[0]
 
 
 def get_run_dir(mpack=None, mpack_instance=None, subgroup_name=DEFAULT_SUBGROUP_NAME, module_name=None,
@@ -166,12 +172,15 @@ def get_run_dir(mpack=None, mpack_instance=None, subgroup_name=DEFAULT_SUBGROUP_
   names' OR empty map for all component instances present
   """
   dirs, is_client = get_conf_log_run_dir_helper(mpack, mpack_instance, subgroup_name, module_name, components_map, output_conf_dir = False, output_log_dir = False, output_run_dir = True)
+  path = ""
   if not is_client:
-    return [dir for dir in dirs if
+    pathlist = [dir for dir in dirs if
             (mpack == None or mpack in dir) and (mpack_instance == None or mpack_instance in dir) and (
             module_name == None or module_name in dir)]
-  return [dir for dir in dirs if
+  else:
+    pathlist = [dir for dir in dirs if
             (mpack == None or mpack in dir) and (mpack_instance == None or mpack_instance in dir)]
+  return path if len(pathlist) == 0 else pathlist[0]
 
 
 def walk_mpack_dict(mpack_dict, filter, dirs):

--- a/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
+++ b/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
@@ -329,6 +329,29 @@ class TestInstanceManager(TestCase):
     expected_run_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/run", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/run"]
     self.assertEqual(run_dir_list, expected_run_dir_list)
 
+  def test_get_mpack_module_versions(self):
+    MPACK_VERSION_KEY_NAME = 'mpack_version'
+    MODULE_VERSION_KEY_NAME = 'module_version'
+
+    create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME.upper())
+    create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
+                               components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
+
+    instances_json = instance_manager.list_instances(module_name=CLIENT_MODULE_NAME)
+    dirs = set()
+    instance_manager.walk_mpack_dict(instances_json, MPACK_VERSION_KEY_NAME, dirs)
+    self.assertEqual(next(iter(dirs)), "1.0.0-b1")
+    dirs.clear()
+    instance_manager.walk_mpack_dict(instances_json, MODULE_VERSION_KEY_NAME, dirs)
+    self.assertEqual(next(iter(dirs)), "3.1.0.0-b1")
+    instances_json = instance_manager.list_instances(module_name=SERVER_MODULE_NAME)
+    dirs.clear()
+    instance_manager.walk_mpack_dict(instances_json, MPACK_VERSION_KEY_NAME, dirs)
+    self.assertEqual(next(iter(dirs)), "1.0.0-b1")
+    dirs.clear()
+    instance_manager.walk_mpack_dict(instances_json, MODULE_VERSION_KEY_NAME, dirs)
+    self.assertEqual(next(iter(dirs)), "3.1.0.0-b1")
+
   def test_list_instances_all(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME.upper())
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,

--- a/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
+++ b/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
@@ -164,8 +164,9 @@ class TestInstanceManager(TestCase):
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    conf_dir_json = instance_manager.get_conf_dir()
-
+    conf_dir_list = instance_manager.get_conf_dir()
+    """
+    This is the conf_dir_json
     expected_json = {
       "mpacks": {
         "hdpcore": {
@@ -211,15 +212,17 @@ class TestInstanceManager(TestCase):
         }
       }
     }
-    self.assertEqual(conf_dir_json, expected_json)
+    """
+    expected_conf_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/conf", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/conf"]
+    self.assertEqual(conf_dir_list, expected_conf_dir_list)
 
   def test_get_log_dir_all(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME.upper())
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    log_dir_json = instance_manager.get_log_dir()
-
+    log_dir_list = instance_manager.get_log_dir()
+    """
     expected_json = {
       "mpacks": {
         "hdpcore": {
@@ -265,15 +268,18 @@ class TestInstanceManager(TestCase):
         }
       }
     }
-    self.assertEqual(log_dir_json, expected_json)
+    """
+    expected_log_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/log", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/log"]
+    self.assertEqual(log_dir_list, expected_log_dir_list)
+
 
   def test_get_run_dir_all(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME.upper())
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    run_dir_json = instance_manager.get_run_dir()
-
+    run_dir_list = instance_manager.get_run_dir()
+    """
     expected_json = {
       "mpacks": {
         "hdpcore": {
@@ -319,14 +325,16 @@ class TestInstanceManager(TestCase):
         }
       }
     }
-    self.assertEqual(run_dir_json, expected_json)
+    """
+    expected_run_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/run", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/run"]
+    self.assertEqual(run_dir_list, expected_run_dir_list)
 
   def test_list_instances_all(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME.upper())
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    conf_dir_json = instance_manager.list_instances()
+    instance_json = instance_manager.list_instances()
 
     expected_json = {
       "mpacks": {
@@ -387,43 +395,52 @@ class TestInstanceManager(TestCase):
         }
       }
     }
-    self.assertDictEqual(conf_dir_json, expected_json)
+
+    self.assertDictEqual(instance_json, expected_json)
 
   def test_granularity(self):
     create_mpack_with_defaults()
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME)
 
-    full_conf_dir_json = instance_manager.get_conf_dir()
-    self.assertTrue('mpacks' in full_conf_dir_json)
+    full_conf_dir_list = instance_manager.get_conf_dir()
+    self.assertEquals(len(full_conf_dir_list), 2)
+    self.assertTrue('/hdfs_server/default/conf' in full_conf_dir_list[0])
 
-    mpack_conf_dir_json = instance_manager.get_conf_dir(mpack=MPACK_NAME)
-    self.assertTrue('mpack-instances' in mpack_conf_dir_json)
+    mpack_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME)
+    self.assertEquals(len(mpack_conf_dir_list), 2)
+    self.assertTrue('/hdfs_client/conf' in mpack_conf_dir_list[1])
 
-    instance_conf_dir_json = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    instance_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                            subgroup_name=None)
-    self.assertTrue('subgroups' in instance_conf_dir_json)
+    self.assertEquals(len(instance_conf_dir_list), 2)
+    self.assertTrue('/hdfs_server/default/conf' in instance_conf_dir_list[0])
 
-    subgroup_conf_dir_json = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    subgroup_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                            subgroup_name=SUBGROUP_NAME)
-    self.assertTrue('modules' in subgroup_conf_dir_json)
+    self.assertEquals(len(subgroup_conf_dir_list), 2)
+    self.assertTrue('/hdfs_client/conf' in subgroup_conf_dir_list[1])
 
-    module_conf_dir_json = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    module_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                          subgroup_name=SUBGROUP_NAME, module_name=SERVER_MODULE_NAME)
-    self.assertTrue('components' in module_conf_dir_json)
+    self.assertEquals(len(module_conf_dir_list), 1)
+    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir_list[0])
 
-    module_conf_dir_json = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    module_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                          subgroup_name=SUBGROUP_NAME, module_name=CLIENT_MODULE_NAME)
-    self.assertTrue('components' in module_conf_dir_json)
+    self.assertEquals(len(module_conf_dir_list), 1)
+    self.assertTrue('/hdfs_client/conf' in module_conf_dir_list[0])
 
     # The mpack level filter not specified
-    full_conf_dir_json = instance_manager.get_conf_dir(mpack_instance=INSTANCE_NAME_1, subgroup_name=SUBGROUP_NAME,
+    module_conf_dir_list = instance_manager.get_conf_dir(mpack_instance=INSTANCE_NAME_1, subgroup_name=SUBGROUP_NAME,
                                                        module_name=SERVER_MODULE_NAME)
-    self.assertTrue('mpacks' in full_conf_dir_json)
+    self.assertEquals(len(module_conf_dir_list), 1)
+    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir_list[0])
 
     # The instance level filter not specified
-    mpack_conf_dir_json = instance_manager.get_conf_dir(mpack=MPACK_NAME, subgroup_name=SUBGROUP_NAME,
+    module_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, subgroup_name=SUBGROUP_NAME,
                                                         module_name=SERVER_MODULE_NAME)
-    self.assertTrue('mpack-instances' in mpack_conf_dir_json)
+    self.assertEquals(len(module_conf_dir_list), 1)
+    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir_list[0])
 
   def test_filtering(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME)

--- a/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
+++ b/mpack-instance-manager/src/test/python/instance_manager/test_instance_manager.py
@@ -164,7 +164,8 @@ class TestInstanceManager(TestCase):
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    conf_dir_list = instance_manager.get_conf_dir()
+    conf_server_dir = instance_manager.get_conf_dir(components_map={"hdfs_server": ["server1"]}, module_name="hdfs")
+    conf_client_dir = instance_manager.get_conf_dir(components_map={"hdfs_client": [""]}, module_name="hdfs-clients")
     """
     This is the conf_dir_json
     expected_json = {
@@ -213,15 +214,18 @@ class TestInstanceManager(TestCase):
       }
     }
     """
-    expected_conf_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/conf", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/conf"]
-    self.assertEqual(conf_dir_list, expected_conf_dir_list)
+    expected_conf_server_dir = "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/conf"
+    expected_conf_client_dir = "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/conf"
+    self.assertEqual(conf_server_dir, expected_conf_server_dir)
+    self.assertEqual(conf_client_dir, expected_conf_client_dir)
 
   def test_get_log_dir_all(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME.upper())
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    log_dir_list = instance_manager.get_log_dir()
+    log_server_dir = instance_manager.get_log_dir(components_map={"hdfs_server": ["server1"]}, module_name="hdfs")
+    log_client_dir = instance_manager.get_log_dir(components_map={"hdfs_client": [""]}, module_name="hdfs-clients")
     """
     expected_json = {
       "mpacks": {
@@ -269,8 +273,10 @@ class TestInstanceManager(TestCase):
       }
     }
     """
-    expected_log_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/log", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/log"]
-    self.assertEqual(log_dir_list, expected_log_dir_list)
+    expected_log_server_dir = "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/log"
+    expected_log_client_dir = "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/log"
+    self.assertEqual(log_server_dir, expected_log_server_dir)
+    self.assertEqual(log_client_dir, expected_log_client_dir)
 
 
   def test_get_run_dir_all(self):
@@ -278,7 +284,8 @@ class TestInstanceManager(TestCase):
     create_mpack_with_defaults(module_name=SERVER_MODULE_NAME.upper(), components=None,
                                components_map={SERVER_COMPONENT_NAME.upper(): ['server1']})
 
-    run_dir_list = instance_manager.get_run_dir()
+    run_server_dir = instance_manager.get_run_dir(components_map={"hdfs_server": ["server1"]}, module_name="hdfs")
+    run_client_dir = instance_manager.get_run_dir(components_map={"hdfs_client": [""]}, module_name="hdfs-clients")
     """
     expected_json = {
       "mpacks": {
@@ -326,8 +333,10 @@ class TestInstanceManager(TestCase):
       }
     }
     """
-    expected_run_dir_list = ["/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/run", "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/run"]
-    self.assertEqual(run_dir_list, expected_run_dir_list)
+    expected_run_server_dir = "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs/hdfs_server/server1/run"
+    expected_run_client_dir = "/tmp/instance_manager_test/instances/hdpcore/Production/default/hdfs_client/run"
+    self.assertEqual(run_server_dir, expected_run_server_dir)
+    self.assertEqual(run_client_dir, expected_run_client_dir)
 
   def test_get_mpack_module_versions(self):
     MPACK_VERSION_KEY_NAME = 'mpack_version'
@@ -425,45 +434,37 @@ class TestInstanceManager(TestCase):
     create_mpack_with_defaults()
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME)
 
-    full_conf_dir_list = instance_manager.get_conf_dir()
-    self.assertEquals(len(full_conf_dir_list), 2)
-    self.assertTrue('/hdfs_server/default/conf' in full_conf_dir_list[0])
+    conf_dir = instance_manager.get_conf_dir()
+    self.assertTrue('/hdfs_server/default/conf' in conf_dir)
 
-    mpack_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME)
-    self.assertEquals(len(mpack_conf_dir_list), 2)
-    self.assertTrue('/hdfs_client/conf' in mpack_conf_dir_list[1])
+    conf_dir = instance_manager.get_conf_dir(mpack=MPACK_NAME, module_name=SERVER_MODULE_NAME)
+    self.assertTrue('/hdfs_server/default/conf' in conf_dir)
 
-    instance_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    instance_conf_dir = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                            subgroup_name=None)
-    self.assertEquals(len(instance_conf_dir_list), 2)
-    self.assertTrue('/hdfs_server/default/conf' in instance_conf_dir_list[0])
+    self.assertTrue('/hdfs_server/default/conf' in instance_conf_dir)
 
-    subgroup_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    subgroup_conf_dir = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                            subgroup_name=SUBGROUP_NAME)
-    self.assertEquals(len(subgroup_conf_dir_list), 2)
-    self.assertTrue('/hdfs_client/conf' in subgroup_conf_dir_list[1])
+    self.assertTrue('/hdfs_server/default/conf' in subgroup_conf_dir)
 
-    module_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    module_conf_dir = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                          subgroup_name=SUBGROUP_NAME, module_name=SERVER_MODULE_NAME)
-    self.assertEquals(len(module_conf_dir_list), 1)
-    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir_list[0])
+    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir)
 
-    module_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
+    module_conf_dir = instance_manager.get_conf_dir(mpack=MPACK_NAME, mpack_instance=INSTANCE_NAME_1,
                                                          subgroup_name=SUBGROUP_NAME, module_name=CLIENT_MODULE_NAME)
-    self.assertEquals(len(module_conf_dir_list), 1)
-    self.assertTrue('/hdfs_client/conf' in module_conf_dir_list[0])
+    self.assertTrue('/hdfs_client/conf' in module_conf_dir)
 
     # The mpack level filter not specified
-    module_conf_dir_list = instance_manager.get_conf_dir(mpack_instance=INSTANCE_NAME_1, subgroup_name=SUBGROUP_NAME,
+    module_conf_dir = instance_manager.get_conf_dir(mpack_instance=INSTANCE_NAME_1, subgroup_name=SUBGROUP_NAME,
                                                        module_name=SERVER_MODULE_NAME)
-    self.assertEquals(len(module_conf_dir_list), 1)
-    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir_list[0])
+    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir)
 
     # The instance level filter not specified
-    module_conf_dir_list = instance_manager.get_conf_dir(mpack=MPACK_NAME, subgroup_name=SUBGROUP_NAME,
+    module_conf_dir = instance_manager.get_conf_dir(mpack=MPACK_NAME, subgroup_name=SUBGROUP_NAME,
                                                         module_name=SERVER_MODULE_NAME)
-    self.assertEquals(len(module_conf_dir_list), 1)
-    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir_list[0])
+    self.assertTrue('/hdfs_server/default/conf' in module_conf_dir)
 
   def test_filtering(self):
     create_mpack_with_defaults(module_name=CLIENT_MODULE_NAME)


### PR DESCRIPTION
## What changes were proposed in this pull request?
After merge, mpack_manager, execution_command and some other python module codes are broken

## How was this patch tested?

1. UT test
2. Manually e2e test