### PR TITLE
AMBARI-24386 - [Log Search] Input config validator unable to parse any log entry

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogEntryParseTester.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogEntryParseTester.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ambari.logfeeder.conf.LogEntryCacheConfig;
 import org.apache.ambari.logfeeder.conf.LogFeederProps;
 import org.apache.ambari.logfeeder.input.InputFileMarker;
 import org.apache.ambari.logfeeder.input.InputManagerImpl;
@@ -82,13 +83,20 @@ public class LogEntryParseTester {
     ConfigHandler configHandler = new ConfigHandler(null);
     configHandler.setInputManager(new InputManagerImpl());
     OutputManagerImpl outputManager = new OutputManagerImpl();
+    LogFeederProps logFeederProps = new LogFeederProps();
+    LogEntryCacheConfig logEntryCacheConfig = new LogEntryCacheConfig();
+    logEntryCacheConfig.setCacheEnabled(false);
+    logEntryCacheConfig.setCacheSize(0);
+    logFeederProps.setLogEntryCacheConfig(logEntryCacheConfig);
+    outputManager.setLogFeederProps(logFeederProps);
     LogLevelFilterHandler logLevelFilterHandler = new LogLevelFilterHandler(null);
-    logLevelFilterHandler.setLogFeederProps(new LogFeederProps());
+    logLevelFilterHandler.setLogFeederProps(logFeederProps);
     outputManager.setLogLevelFilterHandler(logLevelFilterHandler);
     configHandler.setOutputManager(outputManager);
     Input input = configHandler.getTestInput(inputConfig, logId);
+    input.init(logFeederProps);
     final Map<String, Object> result = new HashMap<>();
-    input.getFirstFilter().init(new LogFeederProps());
+    input.getFirstFilter().init(logFeederProps);
     input.addOutput(new Output<LogFeederProps, InputFileMarker>() {
       @Override
       public void init(LogFeederProps logFeederProperties) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

On LogSearch UI on the "Configuration Editor" page the input config validator could not parse any log entries because of an NPE. The LogEntryParseTester.parse method creates its own instance of OutputManagerImpl which depends on LogFeederProps. LogFeederProps was not set.

## How was this patch tested?

Manually:
* Deploy a cluster including zookeeper, infra-solr and logsearch.
* Login to Logsearch portal
* Select "Configuration Editor" from the right upper corner menu
* Select an input config from "All Configuration" (ambari)
* Enter a "Component Name" on the "Validator" section (ambari_agent)
* Enter a log entry to the "Sample Data" text area

    `INFO 2018-07-31 06:14:06,550 security.py:67 - SSL connection established. Two-way SSL authentication is turned off on the server.`

* Click "Test"
* The UI indicates that the "Configuration is valid." 