### PR TITLE
AMBARI-24383. A NPE occurs if a Kerberos identity descriptor is missi…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -1597,9 +1597,11 @@ public class KerberosHelperImpl implements KerberosHelper {
               keytabFileGroupName = variableReplacementHelper.replaceVariables(keytabDescriptor.getGroupName(), configurations);
               keytabFileGroupAccess = variableReplacementHelper.replaceVariables(keytabDescriptor.getGroupAccess(), configurations);
               keytabFileConfiguration = variableReplacementHelper.replaceVariables(keytabDescriptor.getConfiguration(), configurations);
-            }
-            if (keytabFileOwnerName == null || keytabFileGroupName == null) {
-              LOG.warn("Missing owner ({}) or group name ({}) of kerberos descriptor {}", keytabFileOwnerName, keytabFileGroupName, keytabDescriptor.getName());
+              if (keytabFileOwnerName == null || keytabFileGroupName == null) {
+                LOG.warn("Missing owner ({}) or group name ({}) of kerberos descriptor {}", keytabFileOwnerName, keytabFileGroupName, keytabDescriptor.getName());
+              }
+            } else {
+              throw new AmbariException("Missing keytab descriptor for " + identity.getName());
             }
 
             // Evaluate the principal "pattern" found in the record to generate the "evaluated principal"


### PR DESCRIPTION
…ng a Keytab specification (amagyar)

## What changes were proposed in this pull request?

Ambari fails with an NPE when it encounters a kerberos descriptor with no keytab.

## How was this patch tested?

- removed keytab field from kerberos.json of zookeeper
- enabled kerberos in ambari
- checked that kerberos operation failed with the expected error