### PR TITLE
[AMBARI-24391] Properties filter in Customize Services Page brings up LOGDIRS and PIDDIRS even if they dont qualify

### DIFF
--- a/ambari-web/app/templates/wizard/step7/directories_theme_layout.hbs
+++ b/ambari-web/app/templates/wizard/step7/directories_theme_layout.hbs
@@ -23,33 +23,35 @@
         <div class="panel panel-default">
           {{#each row in view.content.sectionRows}}
             {{#each section in row}}
-              {{#view App.DirectoriesLayoutCategoryView}}
-                <div class="panel-heading" {{action "toggleCollapsed" target="view"}}>
-                  <h3 class="panel-title">
-                    <i {{bindAttr class=":pull-right :panel-toggle view.isCollapsed:icon-angle-down:icon-angle-up"}}></i>
-                    <a class="panel-toggle category-header" {{QAAttr "category-header"}}>
-                      <span class="category-name" {{QAAttr "category-name"}}>{{section.displayName}}</span>
-                    </a>
-                  </h3>
-                </div>
-                <div class="panel-body collapse in" {{QAAttr "panel-body"}}>
-                  <div class="service-config-section">
-                    {{#each subRow in section.subsectionRows}}
-                      {{#each subsection in subRow}}
-                        {{#each config in subsection.configs}}
-                          {{#if config.widget}}
-                            {{#if config.isVisible}}
-                              {{#unless config.isHiddenByFilter}}
-                                {{view config.widget configBinding="config" canEditBinding="view.parentView.canEdit" sectionBinding="section" subSectionBinding="subsection" tabBinding="view.parentView.content" inlineControls=true}}
-                              {{/unless}}
+              {{#unless section.isHiddenByFilter}}
+                {{#view App.DirectoriesLayoutCategoryView}}
+                  <div class="panel-heading" {{action "toggleCollapsed" target="view"}}>
+                    <h3 class="panel-title">
+                      <i {{bindAttr class=":pull-right :panel-toggle view.isCollapsed:icon-angle-down:icon-angle-up"}}></i>
+                      <a class="panel-toggle category-header" {{QAAttr "category-header"}}>
+                        <span class="category-name" {{QAAttr "category-name"}}>{{section.displayName}}</span>
+                      </a>
+                    </h3>
+                  </div>
+                  <div class="panel-body collapse in" {{QAAttr "panel-body"}}>
+                    <div class="service-config-section">
+                      {{#each subRow in section.subsectionRows}}
+                        {{#each subsection in subRow}}
+                          {{#each config in subsection.configs}}
+                            {{#if config.widget}}
+                              {{#if config.isVisible}}
+                                {{#unless config.isHiddenByFilter}}
+                                  {{view config.widget configBinding="config" canEditBinding="view.parentView.canEdit" sectionBinding="section" subSectionBinding="subsection" tabBinding="view.parentView.content" inlineControls=true}}
+                                {{/unless}}
+                              {{/if}}
                             {{/if}}
-                          {{/if}}
+                          {{/each}}
                         {{/each}}
                       {{/each}}
-                    {{/each}}
+                    </div>
                   </div>
-                </div>
-              {{/view}}
+                {{/view}}
+              {{/unless}}
             {{/each}}
           {{/each}}
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

At customize services page - Directories tab - use properties filter to show 'Property issues' and 'Final properties'. In both cases LOGDIR and PIDDIR shows up as show in screenshot. There is no property in that panel but they do show up

## How was this patch tested?

  21823 passing (34s)
  48 pending