### PR TITLE
AMBARI-24299 [Yarn Queue Manager] Yarn Queue manager View is resetting value some properties that are not defined UI (asnaik)

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/models/queue.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/models/queue.js
@@ -256,6 +256,8 @@ App.Queue = DS.Model.extend({
   maximum_applications: DS.attr('number', { defaultValue: null }),
   maximum_am_resource_percent: DS.attr('number', { defaultValue: null }),
   priority: DS.attr('number', {defaultValue: 0}),
+  maximum_allocation_mb:DS.attr('number'),
+  maximum_allocation_vcores:DS.attr('number'),
 
   disable_preemption: DS.attr('string', {defaultValue: ''}),
   isPreemptionInherited: DS.attr('boolean', {defaultValue: true}),

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/serializers.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/serializers.js
@@ -107,7 +107,9 @@ App.SerializerMixin = Em.Mixin.create({
           priority:                      (props[base_path + ".priority"])? +props[base_path + ".priority"] : 0,
           labelsEnabled:                 props.hasOwnProperty(labelsPath),
           disable_preemption:            props[base_path + '.disable_preemption'] || '',
-          isPreemptionInherited:         (props[base_path + '.disable_preemption'] !== undefined)?false:true
+          isPreemptionInherited:         (props[base_path + '.disable_preemption'] !== undefined)?false:true,
+          maximum_allocation_mb:         props[base_path + '.maximum-allocation-mb'] || null,
+          maximum_allocation_vcores:     props[base_path + '.maximum-allocation-vcores'] || null
         };
 
     //Converting capacity and max-capacity into two decimal point float numbers
@@ -229,6 +231,8 @@ App.QueueSerializer = DS.RESTSerializer.extend(App.SerializerMixin,{
     json[this.PREFIX + "." + record.get('path') + ".queues"] = record.get('queues')||null;
     json[this.PREFIX + "." + record.get('path') + ".default-node-label-expression"] = record.get('default_node_label_expression')||null;
     json[this.PREFIX + "." + record.get('path') + ".ordering-policy"] = record.get('ordering_policy')||null;
+    json[this.PREFIX + "." + record.get('path') + ".maximum-allocation-mb"] = record.get('maximum_allocation_mb') || null;
+    json[this.PREFIX + "." + record.get('path') + ".maximum-allocation-vcores"] = record.get('maximum_allocation_vcores') || null;
 
     if (record.get('ordering_policy') == 'fair') {
       json[this.PREFIX + "." + record.get('path') + ".ordering-policy.fair.enable-size-based-weight"] = record.get('enable_size_based_weight');

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/templates/queue.hbs
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/templates/queue.hbs
@@ -456,6 +456,64 @@
                   {{/if}}
               </div>
             {{/if}}
+              <div class="form-group">
+                  {{tooltip-label
+                          class="col-xs-6 control-label"
+                          label='Maximum Allocation Vcores'
+                          message='The per queue maximum limit of virtual cores to allocate to each container request at the Resource Manager.'
+                  }}
+                  {{#if isOperator}}
+                      <div class="col-xs-6 control-value">
+                          {{int-input value=content.maximum_allocation_vcores class="input-sm input-int" placeholder="Inherited"}}
+                          {{#if queueDirtyFilelds.maximum_allocation_vcores}}
+                              <div class="btn-group btn-group-xs" >
+                                  <a {{action 'rollbackProp' 'maximum_allocation_vcores' content}} href="#" class="btn btn-default btn-warning"><i class="fa fa-undo"></i></a>
+                              </div>
+                          {{/if}}
+                      </div>
+                  {{else}}
+                      <div class="col-xs-6">
+                          {{#if content.maximum_allocation_vcores}}
+                              <p class="form-control-static">{{content.maximum_allocation_vcores}}</p>
+                          {{else}}
+                              <p class="form-control-static">Inherited</p>
+                          {{/if}}
+                      </div>
+                  {{/if}}
+              </div>
+              <div class="form-group">
+                  {{tooltip-label
+                          class="col-xs-6 control-label"
+                          label='Maximum Allocation Mb'
+                          message='The per queue maximum limit of memory to allocate to each container request at the Resource Manager.'
+                  }}
+                  {{#if isOperator}}
+                      <div class="col-xs-6 control-value input-percent-wrap">
+                          <div>
+                              <div class="input-group input-percent">
+                                  {{int-input value=content.maximum_allocation_mb class="input-sm input-int"
+                                              placeholder="Inherited"}}
+                                  <span class="input-group-addon">MB</span>
+                              </div>
+                          </div>
+                          {{#if queueDirtyFilelds.maximum_allocation_mb}}
+                              <div class="btn-group btn-group-xs">
+                                  <a {{action 'rollbackProp' 'maximum_allocation_mb' content}} href="#"
+                                                                                               class="btn btn-default btn-warning"><i
+                                          class="fa fa-undo"></i></a>
+                              </div>
+                          {{/if}}
+                      </div>
+                  {{else}}
+                      <div class="col-xs-6">
+                          {{#if content.maximum_allocation_mb}}
+                              <p class="form-control-static">{{content.maximum_allocation_mb}} MB</p>
+                          {{else}}
+                              <p class="form-control-static">Inherited</p>
+                          {{/if}}
+                      </div>
+                  {{/if}}
+              </div>
           </form>
         </div>
       </div>


### PR DESCRIPTION

## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/AMBARI-24299
[Yarn Queue Manager] Yarn Queue manager View is resetting value some properties that are not defined UI
## How was this patch tested?
Tested the functionality in UI,
Tested the Functionality as Cluster User in UI

[INFO] Ambari Contrib Views ............................... SUCCESS [ 14.992 s]
[INFO] Ambari View Utils .................................. SUCCESS [  3.066 s]
[INFO] Ambari View Commons ................................ SUCCESS [  0.559 s]
[INFO] Files .............................................. SUCCESS [ 42.333 s]
[INFO] Pig ................................................ SUCCESS [ 35.204 s]
[INFO] Capacity Scheduler ................................. SUCCESS [ 55.801 s]
[INFO] WF Manager View .................................... SUCCESS [01:55 min]
[INFO] Ambari Views Package ............................... SUCCESS [  0.025 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:27 min
[INFO] Finished at: 2018-07-31T23:31:49+05:30
[INFO] Final Memory: 57M/447M
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.