### PR TITLE
AMBARI-24296 [Yarn Queue Manager] Yarn Queue manager is allowing to Create a Child Queue for queue-mappings enabled Queue and Save it

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queues.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queues.js
@@ -407,14 +407,15 @@ App.QueuesController = Ember.ArrayController.extend({
       if(mapping.length!=3 || (mapping[0] != 'u'&& mapping[0] != 'g')) {
         hasInvalidMapping = true;
       }else{
-        hasInvalidMapping = queues.filter(function(queue){
+        //shouldn't allow if any of the leafqueue is having queue_mappings.
+        hasInvalidMapping = hasInvalidMapping || queues.filter(function(queue){
             return !queue.get("queues"); //get all leaf queues
           }).map(function(queue){
             return queue.get("name");
           }).indexOf(mapping[2]) == -1;
       }
 
-    })
+    });
 
     return hasInvalidMapping;
   }.property('scheduler.queue_mappings','content.length','content.@each.capacity'),


### PR DESCRIPTION
AMBARI-24296 - [Yarn Queue Manager] Yarn Queue manager is allowing to Create a Child Queue for queue-mappings enabled Queue and Save it

How was this patch tested?
Tested in UI
Tested the functionality works fine.
Saved the Created Child Queue and tried to restart resource manager it started successfully.

[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/contrib/views/capacity-scheduler/pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/contrib/views/capacity-scheduler/1.0.0.0-SNAPSHOT/capacity-scheduler-1.0.0.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 58.265 s
[INFO] Finished at: 2018-08-01T11:30:30+05:30
[INFO] Final Memory: 40M/229M
[INFO] ------------------------------------------------------------------------
Please review Ambari Contributing Guide before opening a pull request.