### PR TITLE
[AMBARI-24397] - Allow PATCH VDFs to Specify Services Which Are Not Installed in the Cluster

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterStackVersionResourceProvider.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.controller.internal;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.JDK_LOCATION;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -79,8 +78,6 @@ import org.apache.ambari.server.state.RepositoryVersionState;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.ServiceOsSpecific;
 import org.apache.ambari.server.state.StackId;
-import org.apache.ambari.server.state.StackInfo;
-import org.apache.ambari.server.state.repository.AvailableService;
 import org.apache.ambari.server.state.repository.ClusterVersionSummary;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.stack.upgrade.RepositoryVersionHelper;
@@ -521,8 +518,6 @@ public class ClusterStackVersionResourceProvider extends AbstractControllerResou
       }
     }
 
-    checkPatchVDFAvailableServices(cluster, repoVersionEntity, versionDefinitionXml);
-
     // the cluster will create/update all of the host versions to the correct state
     List<Host> hostsNeedingInstallCommands = cluster.transitionHostsToInstalling(
         repoVersionEntity, versionDefinitionXml, forceInstalled);
@@ -648,38 +643,6 @@ public class ClusterStackVersionResourceProvider extends AbstractControllerResou
     req.persist();
 
     return req;
-  }
-
-  /**
-   * Reject PATCH VDFs with Services that are not included in the Cluster
-   * @param cluster cluster instance
-   * @param repoVersionEnt repo version entity
-   * @param desiredVersionDefinition VDF
-   * @throws IllegalArgumentException thrown if VDF includes services that are not installed
-   * @throws AmbariException thrown if could not load stack for repo repoVersionEnt
-   */
-  protected void checkPatchVDFAvailableServices(Cluster cluster, RepositoryVersionEntity repoVersionEnt,
-                                              VersionDefinitionXml desiredVersionDefinition) throws SystemException, AmbariException {
-    if (repoVersionEnt.getType() == RepositoryType.PATCH) {
-
-      Collection<String> notPresentServices = new ArrayList<>();
-      Collection<String> presentServices = new ArrayList<>();
-
-      presentServices.addAll(cluster.getServices().keySet());
-      final StackInfo stack;
-      stack = metaInfo.get().getStack(repoVersionEnt.getStackName(), repoVersionEnt.getStackVersion());
-
-      for (AvailableService availableService : desiredVersionDefinition.getAvailableServices(stack)) {
-        String name = availableService.getName();
-        if (!presentServices.contains(name)) {
-          notPresentServices.add(name);
-        }
-      }
-      if (!notPresentServices.isEmpty()) {
-        throw new IllegalArgumentException(String.format("%s VDF includes services that are not installed: %s",
-            RepositoryType.PATCH, StringUtils.join(notPresentServices, ",")));
-      }
-    }
   }
 
   @Transactional

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -1603,12 +1603,12 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
 
         // depending on whether this is an upgrade or a downgrade, the history
         // will be different
-        if (upgradeContext.getDirection() == Direction.UPGRADE || upgradeContext.isPatchRevert()) {
+        if (upgradeContext.getDirection() == Direction.UPGRADE) {
           history.setFromRepositoryVersion(component.getDesiredRepositoryVersion());
           history.setTargetRepositoryVersion(upgradeContext.getRepositoryVersion());
         } else {
           // the target version on a downgrade is the original version that the
-          // service was on in the failed upgrade
+          // service was on in the upgrade
           RepositoryVersionEntity targetRepositoryVersion = upgradeContext.getTargetRepositoryVersion(
               serviceName);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryVersionEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RepositoryVersionEntity.java
@@ -54,6 +54,7 @@ import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.stack.upgrade.RepositoryVersionHelper;
 import org.apache.commons.lang.StringUtils;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -392,7 +393,7 @@ public class RepositoryVersionEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("id", id).add("stack", stack).add("version",
+    return MoreObjects.toStringHelper(this).add("id", id).add("stack", stack).add("version",
         version).add("type", type).add("hidden", isHidden == 1).toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FinalizeUpgradeAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FinalizeUpgradeAction.java
@@ -35,7 +35,6 @@ import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.events.StackUpgradeFinishEvent;
 import org.apache.ambari.server.events.publishers.VersionEventPublisher;
-import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
 import org.apache.ambari.server.orm.dao.HostComponentStateDAO;
 import org.apache.ambari.server.orm.dao.HostVersionDAO;
 import org.apache.ambari.server.orm.entities.HostComponentStateEntity;
@@ -50,8 +49,11 @@ import org.apache.ambari.server.state.Service;
 import org.apache.ambari.server.state.ServiceComponent;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.state.UpgradeContext;
 import org.apache.ambari.server.state.UpgradeState;
+import org.apache.ambari.server.state.repository.AvailableService;
+import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -94,9 +96,6 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
       return finalizeDowngrade(upgradeContext);
     }
   }
-
-  @Inject
-  private RoleCommandOrderProvider roleCommandOrderProvider;
 
   /**
    * Execution path for upgrade.
@@ -200,7 +199,7 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
 
       // move host versions from CURRENT to INSTALLED if their repos are no
       // longer used
-      finalizeHostVersionsNotDesired(cluster);
+      finalizeHostVersionsNotDesired(cluster, upgradeContext);
 
       if (upgradeContext.getOrchestrationType() == RepositoryType.STANDARD) {
         outSB.append(String.format("Finalizing the version for cluster %s.\n", cluster.getClusterName()));
@@ -280,7 +279,7 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
         throw new AmbariException(messageBuff.toString());
       }
 
-      finalizeHostVersionsNotDesired(cluster);
+      finalizeHostVersionsNotDesired(cluster, upgradeContext);
 
       // for every repository being downgraded to, ensure the host versions are correct
       Map<String, RepositoryVersionEntity> targetVersionsByService = upgradeContext.getTargetVersions();
@@ -400,11 +399,19 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
    * {@link RepositoryVersionState#INSTALLED} or
    * {@link RepositoryVersionState#NOT_REQUIRED} if their assocaited
    * repositories are no longer in use.
+   * <p/>
+   * If this is a patch reversion, then this method will also attempt to
+   * determine if the downgrade-from repository needs to be set to
+   * {@link RepositoryVersionState#OUT_OF_SYNC}. If a patch upgrade was
+   * completed and then a service added after that happens to be specified in
+   * the VDF, then we must mark the repository as OUT_OF_SYNC since those
+   * service's packages were never distributed.
    *
    * @param cluster
    * @throws AmbariException
    */
-  private void finalizeHostVersionsNotDesired(Cluster cluster) throws AmbariException {
+  private void finalizeHostVersionsNotDesired(Cluster cluster, UpgradeContext upgradeContext)
+      throws AmbariException {
     // create a set of all of the repos that the services are on
     Set<RepositoryVersionEntity> desiredRepoVersions = new HashSet<>();
     Set<String> serviceNames = cluster.getServices().keySet();
@@ -423,6 +430,47 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
       if (!desiredRepoVersions.contains(hostRepoVersion)) {
         hostVersion.setState(RepositoryVersionState.INSTALLED);
         hostVersion = hostVersionDAO.merge(hostVersion);
+      }
+    }
+
+    // reverting a patch requires us to check the repository state and
+    // possibly set it to OUT_OF_SYNC if services were added after this patch
+    // was originally distributed
+    if (upgradeContext.isPatchRevert()) {
+      RepositoryVersionEntity repositoryVersionEntity = upgradeContext.getRepositoryVersion();
+
+      final VersionDefinitionXml vdfXml;
+      try {
+        vdfXml = repositoryVersionEntity.getRepositoryXml();
+      } catch (Exception exception) {
+        throw new AmbariException("The VDF's XML could not be deserialized", exception);
+      }
+
+      StackInfo stack = ambariMetaInfo.getStack(repositoryVersionEntity.getStackId());
+
+      // grab the services in the VDF, the services which were part of the
+      // revert, and the services in the cluster to determine if a service was
+      // added to the cluster after the patch was originally applied
+      Collection<AvailableService> availableServices = vdfXml.getAvailableServices(stack);
+      Set<String> participatingServices = upgradeContext.getSupportedServices();
+      Set<String> clusterServices = cluster.getServices().keySet();
+
+      boolean resetRepoStateToOutOfSync = false;
+      for (AvailableService availableService : availableServices) {
+        if (clusterServices.contains(availableService.getName())
+            && !participatingServices.contains(availableService.getName())) {
+          resetRepoStateToOutOfSync = true;
+          break;
+        }
+      }
+
+      if (resetRepoStateToOutOfSync) {
+        List<HostVersionEntity> hostVersions = hostVersionDAO.findHostVersionByClusterAndRepository(
+            cluster.getClusterId(), repositoryVersionEntity);
+        for (HostVersionEntity hostVersion : hostVersions) {
+          hostVersion.setState(RepositoryVersionState.OUT_OF_SYNC);
+          hostVersion = hostVersionDAO.merge(hostVersion);
+        }
       }
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -387,7 +387,8 @@ public class UpgradeContext {
         throw new AmbariException(message);
       }
 
-      m_repositoryVersion = priors.iterator().next();
+      // the "associated" repository of the revert is the target of what's being reverted
+      m_repositoryVersion = revertUpgrade.getRepositoryVersion();
 
       // !!! the version is used later in validators
       upgradeRequestMap.put(UPGRADE_REPO_VERSION_ID, m_repositoryVersion.getId().toString());
@@ -1061,11 +1062,11 @@ public class UpgradeContext {
 
   /**
    * Gets the set of services which will participate in the upgrade. The
-   * services available in the repository are comapred against those installed
+   * services available in the repository are compared against those installed
    * in the cluster to arrive at the final subset.
    * <p/>
    * In some cases, such as with a {@link RepositoryType#MAINT} repository, the
-   * subset can be further trimmed by determing that an installed services is
+   * subset can be further trimmed by determing that an installed service is
    * already at a high enough version and doesn't need to be upgraded.
    * <p/>
    * This method will also populate the source ({@link #m_sourceRepositoryMap})

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/UpgradeActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/UpgradeActionTest.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -66,6 +69,7 @@ import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.ConfigFactory;
 import org.apache.ambari.server.state.Host;
+import org.apache.ambari.server.state.RepositoryType;
 import org.apache.ambari.server.state.RepositoryVersionState;
 import org.apache.ambari.server.state.Service;
 import org.apache.ambari.server.state.ServiceComponent;
@@ -77,8 +81,10 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.state.UpgradeState;
 import org.apache.ambari.server.state.stack.UpgradePack;
+import org.apache.ambari.server.state.stack.upgrade.Direction;
 import org.apache.ambari.server.state.stack.upgrade.UpgradeType;
 import org.apache.ambari.server.utils.EventBusSynchronizer;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -139,6 +145,9 @@ public class UpgradeActionTest {
   private FinalizeUpgradeAction finalizeUpgradeAction;
   @Inject
   private ConfigFactory configFactory;
+
+  @Inject
+  private RepositoryVersionDAO repositoryVersionDAO;
 
   @Inject
   private HostComponentStateDAO hostComponentStateDAO;
@@ -583,6 +592,110 @@ public class UpgradeActionTest {
     }
   }
 
+  /**
+   * Tests the case where a revert happens on a patch upgrade and a new service
+   * has been added which causes the repository to go OUT_OF_SYNC.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testHostVersionsOutOfSyncAfterRevert() throws Exception {
+    String hostName = "h1";
+    Cluster cluster = createUpgradeCluster(repositoryVersion2110, hostName);
+    createHostVersions(repositoryVersion2111, hostName);
+
+    // Install ZK with some components (HBase is installed later to test the
+    // logic of revert)
+    Service zk = installService(cluster, "ZOOKEEPER", repositoryVersion2110);
+    addServiceComponent(cluster, zk, "ZOOKEEPER_SERVER");
+    addServiceComponent(cluster, zk, "ZOOKEEPER_CLIENT");
+    createNewServiceComponentHost(cluster, "ZOOKEEPER", "ZOOKEEPER_SERVER", hostName);
+    createNewServiceComponentHost(cluster, "ZOOKEEPER", "ZOOKEEPER_CLIENT", hostName);
+
+    List<HostVersionEntity> hostVersions = hostVersionDAO.findAll();
+    assertEquals(2, hostVersions.size());
+
+    // repo 2110 - CURRENT
+    // repo 2111 - CURRENT (PATCH)
+    for (HostVersionEntity hostVersion : hostVersions) {
+      RepositoryVersionEntity hostRepoVersion = hostVersion.getRepositoryVersion();
+      if (repositoryVersion2110.equals(hostRepoVersion)) {
+        hostVersion.setState(RepositoryVersionState.CURRENT);
+      } else {
+        hostVersion.setState(RepositoryVersionState.CURRENT);
+      }
+
+      hostVersionDAO.merge(hostVersion);
+    }
+
+    // convert the repository into a PATCH repo (which should have ZK and HBase
+    // as available services)
+    repositoryVersion2111.setParent(repositoryVersion2110);
+    repositoryVersion2111.setType(RepositoryType.PATCH);
+    repositoryVersion2111.setVersionXml(hostName);
+    repositoryVersion2111.setVersionXsd("version_definition.xsd");
+
+    File patchVdfFile = new File("src/test/resources/hbase_version_test.xml");
+    repositoryVersion2111.setVersionXml(
+        IOUtils.toString(new FileInputStream(patchVdfFile), Charset.defaultCharset()));
+
+    repositoryVersion2111 = repositoryVersionDAO.merge(repositoryVersion2111);
+
+    // pretend like we patched
+    UpgradeEntity upgrade = createUpgrade(cluster, repositoryVersion2111);
+    upgrade.setOrchestration(RepositoryType.PATCH);
+    upgrade.setRevertAllowed(true);
+    upgrade = upgradeDAO.merge(upgrade);
+
+    // add a service on the parent repo to cause the OUT_OF_SYNC on revert
+    Service hbase = installService(cluster, "HBASE", repositoryVersion2110);
+    addServiceComponent(cluster, hbase, "HBASE_MASTER");
+    createNewServiceComponentHost(cluster, "HBASE", "HBASE_MASTER", hostName);
+
+    // revert the patch
+    UpgradeEntity revert = createRevert(cluster, upgrade);
+    assertEquals(RepositoryType.PATCH, revert.getOrchestration());
+
+    // push all services to the revert repo version for finalize
+    Map<String, Service> services = cluster.getServices();
+    assertTrue(services.size() > 0);
+    for (Service service : services.values()) {
+      service.setDesiredRepositoryVersion(repositoryVersion2110);
+    }
+
+    // push all components to the revert version
+    List<HostComponentStateEntity> hostComponentStates = hostComponentStateDAO.findByHost(hostName);
+    for (HostComponentStateEntity hostComponentState : hostComponentStates) {
+      hostComponentState.setVersion(repositoryVersion2110.getVersion());
+      hostComponentStateDAO.merge(hostComponentState);
+    }
+
+    Map<String, String> commandParams = new HashMap<>();
+    ExecutionCommand executionCommand = new ExecutionCommand();
+    executionCommand.setCommandParams(commandParams);
+    executionCommand.setClusterName(clusterName);
+
+    HostRoleCommand hostRoleCommand = hostRoleCommandFactory.create(null, null, null, null);
+    hostRoleCommand.setExecutionCommandWrapper(new ExecutionCommandWrapper(executionCommand));
+
+    finalizeUpgradeAction.setExecutionCommand(executionCommand);
+    finalizeUpgradeAction.setHostRoleCommand(hostRoleCommand);
+
+    // finalize
+    CommandReport report = finalizeUpgradeAction.execute(null);
+    assertNotNull(report);
+    assertEquals(HostRoleStatus.COMPLETED.name(), report.getStatus());
+
+    for (HostVersionEntity hostVersion : hostVersions) {
+      RepositoryVersionEntity hostRepoVersion = hostVersion.getRepositoryVersion();
+      if (repositoryVersion2110.equals(hostRepoVersion)) {
+        assertEquals(RepositoryVersionState.CURRENT, hostVersion.getState());
+      } else {
+        assertEquals(RepositoryVersionState.OUT_OF_SYNC, hostVersion.getState());
+      }
+    }
+  }
+
   private ServiceComponentHost createNewServiceComponentHost(Cluster cluster, String svc,
                                                              String svcComponent, String hostName) throws AmbariException {
     Assert.assertNotNull(cluster.getConfigGroups());
@@ -692,4 +805,46 @@ public class UpgradeActionTest {
     cluster.setUpgradeEntity(upgradeEntity);
     return upgradeEntity;
   }
+
+  /**
+   * Creates a revert based on an existing upgrade.
+   */
+  private UpgradeEntity createRevert(Cluster cluster, UpgradeEntity upgradeToRevert)
+      throws Exception {
+
+    // create some entities for the finalize action to work with for patch
+    // history
+    RequestEntity requestEntity = new RequestEntity();
+    requestEntity.setClusterId(cluster.getClusterId());
+    requestEntity.setRequestId(2L);
+    requestEntity.setStartTime(System.currentTimeMillis());
+    requestEntity.setCreateTime(System.currentTimeMillis());
+    requestDAO.create(requestEntity);
+
+    UpgradeEntity revert = new UpgradeEntity();
+    revert.setId(2L);
+    revert.setDirection(Direction.DOWNGRADE);
+    revert.setClusterId(cluster.getClusterId());
+    revert.setRequestEntity(requestEntity);
+    revert.setUpgradePackage("");
+    revert.setRepositoryVersion(upgradeToRevert.getRepositoryVersion());
+    revert.setUpgradeType(upgradeToRevert.getUpgradeType());
+    revert.setOrchestration(upgradeToRevert.getOrchestration());
+
+
+    for (UpgradeHistoryEntity historyToRevert : upgradeToRevert.getHistory()) {
+      UpgradeHistoryEntity history = new UpgradeHistoryEntity();
+      history.setUpgrade(revert);
+      history.setServiceName(historyToRevert.getServiceName());
+      history.setComponentName(historyToRevert.getComponentName());
+      history.setFromRepositoryVersion(upgradeToRevert.getRepositoryVersion());
+      history.setTargetRepositoryVersion(historyToRevert.getFromReposistoryVersion());
+      revert.addHistory(history);
+
+    }
+    upgradeDAO.create(revert);
+    cluster.setUpgradeEntity(revert);
+    return revert;
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-21832 limited the flexibility of a PATCH VDF by requiring that the list of `available-services` match what is installed in the cluster. For example, if a cluster contained ZooKeeper and Storm, a patch VDF which specified Storm and Accumulo could not be registered.

Ambari should allow registration of a VDF without restricting it to the services which are currently installed in the cluster. In the above mentioned case, one concern would be what would happen if Accumulo was added after the patch was applied. In this case, Ambari should add Accumulo from the parent `STANDARD` repo. 

When a patch is reverted, Ambari must now check to ensure that a service included in that patch wasn't added after the patch was applied. Consider this scenario:
- Install a ZK only cluster
- Register and patch using a VDF with ZK, STORM
- Add Storm
- Revert the patch
- Re-apply the patch

When the patch is re-applied, the hosts will not have the new storm packages installed since the patch repository was distributed before Storm was a part of the cluster.

## How was this patch tested?

Manually tested application and reversion of a patch.