### PR TITLE
AMBARI-24390. Filter services eligible for Ambari Single Sign-on Conf…

### DIFF
--- a/ambari-server/src/test/python/TestSetupSso.py
+++ b/ambari-server/src/test/python/TestSetupSso.py
@@ -518,14 +518,20 @@ class TestSetupSso(unittest.TestCase):
                   "href": "http://c7401:8080/api/v1/clusters/cluster1/services/HDFS",
                   "ServiceInfo": {
                       "cluster_name": "cluster1",
-                      "service_name": "HDFS"
+                      "service_name": "HDFS",
+                      "sso_integration_supported": true,
+                      "sso_integration_requires_kerberos": false,
+                      "kerberos_enabled": false
                   }
               },
               {
                   "href": "http://c7401:8080/api/v1/clusters/cluster1/services/ZOOKEPER",
                   "ServiceInfo": {
                       "cluster_name": "cluster1",
-                      "service_name": "ZOOKEPER"
+                      "service_name": "ZOOKEPER",
+                      "sso_integration_supported": true,
+                      "sso_integration_requires_kerberos": false,
+                      "kerberos_enabled": false
                   }
               }
             ]
@@ -538,14 +544,20 @@ class TestSetupSso(unittest.TestCase):
           "href": "http://c7401:8080/api/v1/clusters/cluster1/services/HDFS",
           "ServiceInfo": {
             "cluster_name": "cluster1",
-            "service_name": "HDFS"
+            "service_name": "HDFS",
+            "sso_integration_supported": True,
+            "sso_integration_requires_kerberos": False,
+            "kerberos_enabled": False
           }
         },
         {
           "href": "http://c7401:8080/api/v1/clusters/cluster1/services/ZOOKEPER",
           "ServiceInfo": {
             "cluster_name": "cluster1",
-            "service_name": "ZOOKEPER"
+            "service_name": "ZOOKEPER",
+            "sso_integration_supported": True,
+            "sso_integration_requires_kerberos": False,
+            "kerberos_enabled": False
           }
         }
       ]


### PR DESCRIPTION
…iguration if Kerberos is required but not enabled (amagyar)

## What changes were proposed in this pull request?

Some services require Kerberos to be enabled for SSO to work. For example, HDFS, Yarn, and Oozie. For this case, the metadata is enhanced allowing for the metadata to indicate whether Kerberos is required. These services should be filtered from Ambari CLI when setting up SSO if not eligible when Kerberos is not enabled.

## How was this patch tested?

Ran 

```bash
$ ambari-server setups-sso
```

and checked the eligible service list in different cases  

