### PR TITLE
[AMBARI-24405] Components in hosts page should be sorted by display name

### DIFF
--- a/ambari-web/app/views/main/host/summary.js
+++ b/ambari-web/app/views/main/host/summary.js
@@ -171,23 +171,19 @@ App.MainHostSummaryView = Em.View.extend(App.HiveInteractiveCheck, App.TimeRange
    * Master components first, then slaves and clients
    */
   sortedComponentsFormatter: function() {
-    const updatebleProperties = Em.A(['workStatus', 'passiveState', 'staleConfigs', 'haStatus']);
     const hostComponentViewMap = this.get('hostComponentViewMap');
-    const masters = [], slaves = [], clients = [];
-
+    let sortedComponentsArray = [];
     this.get('content.hostComponents').forEach(function (component) {
       component.set('viewClass', hostComponentViewMap[component.get('componentName')] ? hostComponentViewMap[component.get('componentName')] : App.HostComponentView);
-      if (component.get('isMaster')) {
-        masters.push(component);
-      } else if (component.get('isSlave')) {
-        slaves.push(component);
-      } else if (component.get('isClient')) {
+      if (component.get('isClient')) {
         component.set('isLast', true);
         component.set('isInstallFailed', ['INSTALL_FAILED', 'INIT'].contains(component.get('workStatus')));
-        clients.pushObject(component);
-        }
-    }, this);
-    this.set('sortedComponents', masters.concat(slaves, clients));
+      }
+      sortedComponentsArray.push(component);
+    });
+
+    sortedComponentsArray = sortedComponentsArray.sort((a, b) => a.get('displayName').localeCompare(b.get('displayName')));
+    this.set('sortedComponents', sortedComponentsArray);
   },
 
   /**

--- a/ambari-web/test/views/main/host/summary_test.js
+++ b/ambari-web/test/views/main/host/summary_test.js
@@ -57,69 +57,14 @@ describe('App.MainHostSummaryView', function() {
       {
         content: Em.Object.create({
           hostComponents: Em.A([
-            Em.Object.create({isMaster: false, isSlave: true, componentName: 'B'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'A'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'C'}),
-            Em.Object.create({isMaster: false, isSlave: false, componentName: 'D'})
+            Em.Object.create({componentName: 'C', displayName: 'C'}),
+            Em.Object.create({componentName: 'A', displayName: 'A'}),
+            Em.Object.create({componentName: 'B', displayName: 'B'}),
+            Em.Object.create({componentName: 'D', displayName: 'D'})
           ])
         }),
-        m: 'List of masters, slaves and clients',
-        e: ['A', 'C', 'B']
-      },
-      {
-        content: Em.Object.create({
-          hostComponents: Em.A([
-            Em.Object.create({isMaster: false, isSlave: true, componentName: 'B'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'A'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'C'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'D'})
-          ])
-        }),
-        m: 'List of masters and slaves',
-        e: ['A', 'C', 'D', 'B']
-      },
-      {
-        content: Em.Object.create({
-          hostComponents: Em.A([
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'B'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'A'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'C'}),
-            Em.Object.create({isMaster: true, isSlave: false, componentName: 'D'})
-          ])
-        }),
-        m: 'List of masters',
-        e: ['B', 'A', 'C', 'D']
-      },
-      {
-        content: Em.Object.create({
-          hostComponents: Em.A([
-            Em.Object.create({isMaster: false, isSlave: true, componentName: 'B'}),
-            Em.Object.create({isMaster: false, isSlave: true, componentName: 'A'}),
-            Em.Object.create({isMaster: false, isSlave: true, componentName: 'C'}),
-            Em.Object.create({isMaster: false, isSlave: true, componentName: 'D'})
-          ])
-        }),
-        m: 'List of slaves',
-        e: ['B', 'A', 'C', 'D']
-      },
-      {
-        content: Em.Object.create({
-          hostComponents: Em.A([])
-        }),
-        m: 'Empty list',
-        e: []
-      },
-      {
-        content: Em.Object.create({
-          hostComponents: Em.A([
-            Em.Object.create({isClient: true, componentName: 'B'}),
-            Em.Object.create({isMaster: true, componentName: 'A'}),
-            Em.Object.create({isSlave: true, componentName: 'C'}),
-            Em.Object.create({isClient: true, componentName: 'D'})
-          ])
-        }),
-        m: 'List of clients',
-        e: ['A', 'C', 'B', 'D']
+        m: 'List of components',
+        e: ['A', 'B', 'C', 'D']
       }
     ]);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Components in hosts page seem to be sorted by component type (master, slave, client etc) and within them they are not sorted by "display names", "Timeline" comes before "History"

More importantly people when looking for a component don't look by their type but instead look by their name. So all the components should be alphabetically sorted by their display name irrespective of their type. Else it becomes painful to look for a component of interest. (and finally have to rely on browser's search capability)

## How was this patch tested?

  21736 passing (50s)
  48 pending