### PR TITLE
[AMBARI-24404] Button label appears incorrect during service deletion

### DIFF
--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -1497,7 +1497,7 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
     var self = this,
       displayName = App.format.role(serviceName, true),
       popupHeader = Em.I18n.t('services.service.delete.popup.header'),
-      popupPrimary = Em.I18n.t('common.delete'),
+      popupPrimary = Em.I18n.t('common.proceed'),
       warningMessage = Em.I18n.t('services.service.delete.popup.warning').format(displayName) +
         (interDependentServices.length ? Em.I18n.t('services.service.delete.popup.warning.dependent').format(dependentServicesToDeleteFmt) : ''),
       callback = this.loadConfigRecommendations.bind(this, null, function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Try to delete Ranger service from a cluster, upon deletion stack advisor recommends changes to configs.

This is fine, however the button at the bottom of the dialog says 'DELETE'
It should instead say something like 'Proceed' and once user clicks Proceed, the delete pop-up should appear.

## How was this patch tested?

  21736 passing (50s)
  48 pending