### PR TITLE
AMBARI-24403 grafana is not showing any datapoints if the queue name contains special characters

### DIFF
--- a/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
+++ b/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
@@ -284,7 +284,7 @@ define([
             var metricAggregator = target.aggregator === "none" ? '' : '._' + target.aggregator;
             var metricTransform = !target.transform || target.transform === "none" ? '' : '._' + target.transform;
             var seriesAggregator = !target.seriesAggregator || target.seriesAggregator === "none" ? '' : '&seriesAggregateFunction=' + target.seriesAggregator;
-            return self.doAmbariRequest({ url: '/ws/v1/timeline/metrics?metricNames=' + target.queue + metricTransform
+            return self.doAmbariRequest({ url: '/ws/v1/timeline/metrics?metricNames=' + encodeURIComponent(target.queue) + metricTransform
               + metricAggregator + '&appId=resourcemanager' + instanceId + '&startTime=' + from +
               '&endTime=' + to + precision + seriesAggregator }).then(
               getMetricsData(target)


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-24403 grafana is not showing any datapoints if the queue name contains special characters

I have a queue named 'A&B' , in Yarn queues dashboard if I select this queue name I am getting empty data showing no data points.

The issue is reproducible
## How was this patch tested?

tested in UI works fine

[INFO] --- maven-install-plugin:2.4:install (default-install) @ ambari-metrics-grafana ---
[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/ambari-metrics/ambari-metrics-grafana/pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/ambari-metrics-grafana/2.1.0.0.0/ambari-metrics-grafana-2.1.0.0.0.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.186 s
[INFO] Finished at: 2018-08-03T15:34:28+05:30
[INFO] Final Memory: 15M/210M
[INFO] ------------------------------------------------------------------------

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.