### PR TITLE
AMBARI-24387 - Support YARN Application timeout feature in Ambari Capaacity Scheduler View

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/models/queue.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/models/queue.js
@@ -258,6 +258,8 @@ App.Queue = DS.Model.extend({
   priority: DS.attr('number', {defaultValue: 0}),
   maximum_allocation_mb:DS.attr('number'),
   maximum_allocation_vcores:DS.attr('number'),
+  maximum_application_lifetime:DS.attr('number'),
+  default_application_lifetime:DS.attr('number'),
 
   disable_preemption: DS.attr('string', {defaultValue: ''}),
   isPreemptionInherited: DS.attr('boolean', {defaultValue: true}),
@@ -340,5 +342,15 @@ App.Queue = DS.Model.extend({
 
   isLeafQ: function() {
     return this.get('queues') === null;
-  }.property('queues')
+  }.property('queues'),
+
+  /**
+   * To reset the maximum_application_lifetime and default_application_lifetime if current Q is no longer Leaf Queue 
+   */
+  watchChangeLeafQueue: function () {
+    if (this.get('isLeafQ') == false) {
+      this.set('maximum_application_lifetime', null);
+      this.set('default_application_lifetime', null);
+    }
+  }.observes('isLeafQ')
 });

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/serializers.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/serializers.js
@@ -109,7 +109,9 @@ App.SerializerMixin = Em.Mixin.create({
           disable_preemption:            props[base_path + '.disable_preemption'] || '',
           isPreemptionInherited:         (props[base_path + '.disable_preemption'] !== undefined)?false:true,
           maximum_allocation_mb:         props[base_path + '.maximum-allocation-mb'] || null,
-          maximum_allocation_vcores:     props[base_path + '.maximum-allocation-vcores'] || null
+          maximum_allocation_vcores:     props[base_path + '.maximum-allocation-vcores'] || null,
+          maximum_application_lifetime:     props[base_path + '.maximum-application-lifetime'] || null,
+          default_application_lifetime:     props[base_path + '.default-application-lifetime'] || null
         };
 
     //Converting capacity and max-capacity into two decimal point float numbers
@@ -233,6 +235,8 @@ App.QueueSerializer = DS.RESTSerializer.extend(App.SerializerMixin,{
     json[this.PREFIX + "." + record.get('path') + ".ordering-policy"] = record.get('ordering_policy')||null;
     json[this.PREFIX + "." + record.get('path') + ".maximum-allocation-mb"] = record.get('maximum_allocation_mb') || null;
     json[this.PREFIX + "." + record.get('path') + ".maximum-allocation-vcores"] = record.get('maximum_allocation_vcores') || null;
+    json[this.PREFIX + "." + record.get('path') + ".maximum-application-lifetime"] = record.get('maximum_application_lifetime') || null;
+    json[this.PREFIX + "." + record.get('path') + ".default-application-lifetime"] = record.get('default_application_lifetime') || null;
 
     if (record.get('ordering_policy') == 'fair') {
       json[this.PREFIX + "." + record.get('path') + ".ordering-policy.fair.enable-size-based-weight"] = record.get('enable_size_based_weight');

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/templates/queue.hbs
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/templates/queue.hbs
@@ -420,7 +420,7 @@
                 <div class="form-group">
                     {{tooltip-label
                             class="col-xs-6 control-label"
-                            label='Maximum lifetime '
+                            label='Maximum Application Lifetime '
                             message='Maximum lifetime of an application which is submitted to a queue in seconds.Any value less than or equal to zero will be considered as disabled.<br/> If positive value is configured then any application submitted to this queue will be killed after exceeds the configured lifetime'}}
                     {{#if isOperator}}
                         <div class="col-xs-6 control-value input-percent-wrap">
@@ -454,7 +454,7 @@
                   <div class="form-group">
                       {{tooltip-label
                               class="col-xs-6 control-label"
-                              label='Default lifetime '
+                              label='Default Application Lifetime '
                               message='Default lifetime of an application which is submitted to a queue in seconds. Any value less than or equal to zero will be considered as disabled.<br/>  If the user has not submitted application with lifetime value then this value will be taken.'}}
                       {{#if isOperator}}
                           <div class="col-xs-6 control-value input-percent-wrap">

--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/templates/queue.hbs
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/templates/queue.hbs
@@ -416,6 +416,74 @@
                 {{/if}}
               </div>
             {{/if}}
+            {{#if content.isLeafQ}}
+                <div class="form-group">
+                    {{tooltip-label
+                            class="col-xs-6 control-label"
+                            label='Maximum lifetime '
+                            message='Maximum lifetime of an application which is submitted to a queue in seconds.Any value less than or equal to zero will be considered as disabled.<br/> If positive value is configured then any application submitted to this queue will be killed after exceeds the configured lifetime'}}
+                    {{#if isOperator}}
+                        <div class="col-xs-6 control-value input-percent-wrap">
+                            <div>
+                                <div class="input-group input-percent">
+                                    {{int-input value=content.maximum_application_lifetime class="input-sm input-int"
+                                                placeholder="-1"}}
+                                    <span class="input-group-addon">sec</span>
+                                </div>
+                            </div>
+                            {{#if queueDirtyFilelds.maximum_application_lifetime}}
+                                <div class="btn-group btn-group-xs">
+                                    <a {{action 'rollbackProp' 'maximum_application_lifetime' content}} href="#"
+                                                                                                        class="btn btn-default btn-warning"><i
+                                            class="fa fa-undo"></i></a>
+                                </div>
+                            {{/if}}
+                        </div>
+                    {{else}}
+                        <div class="col-xs-6">
+                            {{#if content.maximum_application_lifetime}}
+                                <p class="form-control-static">{{content.maximum_application_lifetime}} sec</p>
+                            {{else}}
+                                <p class="form-control-static">-1</p>
+                            {{/if}}
+                        </div>
+                    {{/if}}
+                </div>
+            {{/if}}
+              {{#if content.isLeafQ}}
+                  <div class="form-group">
+                      {{tooltip-label
+                              class="col-xs-6 control-label"
+                              label='Default lifetime '
+                              message='Default lifetime of an application which is submitted to a queue in seconds. Any value less than or equal to zero will be considered as disabled.<br/>  If the user has not submitted application with lifetime value then this value will be taken.'}}
+                      {{#if isOperator}}
+                          <div class="col-xs-6 control-value input-percent-wrap">
+                              <div>
+                                  <div class="input-group input-percent">
+                                      {{int-input value=content.default_application_lifetime class="input-sm input-int"
+                                                  placeholder="-1"}}
+                                      <span class="input-group-addon">sec</span>
+                                  </div>
+                              </div>
+                              {{#if queueDirtyFilelds.default_application_lifetime}}
+                                  <div class="btn-group btn-group-xs">
+                                      <a {{action 'rollbackProp' 'default_application_lifetime' content}} href="#"
+                                                                                                          class="btn btn-default btn-warning"><i
+                                              class="fa fa-undo"></i></a>
+                                  </div>
+                              {{/if}}
+                          </div>
+                      {{else}}
+                          <div class="col-xs-6">
+                              {{#if content.default_application_lifetime}}
+                                  <p class="form-control-static">{{content.default_application_lifetime}} sec</p>
+                              {{else}}
+                                  <p class="form-control-static">-1</p>
+                              {{/if}}
+                          </div>
+                      {{/if}}
+                  </div>
+              {{/if}}
             {{#if isFairOP}}
               <div class="form-group">
                 {{tooltip-label


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-24387 - Support YARN Application timeout feature in Ambari Capacity Scheduler View
At high level, we need a mechanism to set timeout values for each leaf queue from Capacity Scheduler view. The sample configuration that should reflect in the backend is

yarn.scheduler.capacity.root.default.maximum-application-lifetime= values in seconds
yarn.scheduler.capacity.root.default.default-application-lifetime=values in seconds

## How was this patch tested?
Capacity Scheduler View to Support above two configurations related to application lifetime ( which is a feature of Hadoop-3.0 yarn feature).
Verified in UI

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:01 min
[INFO] Finished at: 2018-08-03T17:17:10+05:30
[INFO] Final Memory: 46M/349M
[INFO] ------------------------------------------------------------------------

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.