### PR TITLE
[AMBARI-24406] Fix validate single sign-in support information to look for ssoEnabledTest

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -1299,9 +1299,9 @@ public class ServiceInfo implements Validable {
     // validate single sign-in support information
     if (singleSignOnInfo != null) {
       if (singleSignOnInfo.isSupported()) {
-        if (StringUtils.isEmpty(singleSignOnInfo.getEnabledConfiguration())) {
+        if (StringUtils.isEmpty(singleSignOnInfo.getSsoEnabledTest()) && StringUtils.isEmpty(singleSignOnInfo.getEnabledConfiguration())) {
           setValid(false);
-          addError("Single Sign-on support is indicated for service " + getName() + " but no test configuration has been set (enabledConfiguration).");
+          addError("Single Sign-on support is indicated for service " + getName() + " but no test configuration has been set (enabledConfiguration or ssoEnabledTest).");
         }
       }
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
@@ -1093,6 +1093,7 @@ public class ServiceModuleTest {
     assertEquals(singleSignOnInfoChild.isSupported(), serviceInfo.getSingleSignOnInfo().isSupported());
     assertEquals(singleSignOnInfoChild.getSupported(), serviceInfo.getSingleSignOnInfo().getSupported());
     assertEquals(singleSignOnInfoChild.getEnabledConfiguration(), serviceInfo.getSingleSignOnInfo().getEnabledConfiguration());
+    assertEquals(singleSignOnInfoChild.getSsoEnabledTest(), serviceInfo.getSingleSignOnInfo().getSsoEnabledTest());
     assertEquals(singleSignOnInfoChild.isKerberosRequired(), serviceInfo.isKerberosRequiredForSingleSignOnIntegration());
     assertEquals(singleSignOnInfoChild.isKerberosRequired(), serviceInfo.getSingleSignOnInfo().isKerberosRequired());
 
@@ -1105,6 +1106,7 @@ public class ServiceModuleTest {
     assertEquals(singleSignOnInfoParent.isSupported(), serviceInfo.getSingleSignOnInfo().isSupported());
     assertEquals(singleSignOnInfoParent.getSupported(), serviceInfo.getSingleSignOnInfo().getSupported());
     assertEquals(singleSignOnInfoParent.getEnabledConfiguration(), serviceInfo.getSingleSignOnInfo().getEnabledConfiguration());
+    assertEquals(singleSignOnInfoParent.getSsoEnabledTest(), serviceInfo.getSingleSignOnInfo().getSsoEnabledTest());
     assertEquals(singleSignOnInfoParent.isKerberosRequired(), serviceInfo.isKerberosRequiredForSingleSignOnIntegration());
     assertEquals(singleSignOnInfoParent.isKerberosRequired(), serviceInfo.getSingleSignOnInfo().isKerberosRequired());
 
@@ -1117,6 +1119,7 @@ public class ServiceModuleTest {
     assertEquals(singleSignOnInfoChild.isSupported(), serviceInfo.getSingleSignOnInfo().isSupported());
     assertEquals(singleSignOnInfoChild.getSupported(), serviceInfo.getSingleSignOnInfo().getSupported());
     assertEquals(singleSignOnInfoChild.getEnabledConfiguration(), serviceInfo.getSingleSignOnInfo().getEnabledConfiguration());
+    assertEquals(singleSignOnInfoChild.getSsoEnabledTest(), serviceInfo.getSingleSignOnInfo().getSsoEnabledTest());
     assertEquals(singleSignOnInfoChild.isKerberosRequired(), serviceInfo.isKerberosRequiredForSingleSignOnIntegration());
     assertEquals(singleSignOnInfoChild.isKerberosRequired(), serviceInfo.getSingleSignOnInfo().isKerberosRequired());
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceInfoTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceInfoTest.java
@@ -788,6 +788,7 @@ public class ServiceInfoTest {
     assertTrue(singleSignOnInfo.isSupported());
     assertEquals(Boolean.TRUE, singleSignOnInfo.getSupported());
     assertNull(singleSignOnInfo.getEnabledConfiguration());
+    assertNull(singleSignOnInfo.getSsoEnabledTest());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix validate single sign-in support information to look for `ssoEnabledTest`.

The current test looks for the old `enabledConfiguration` value only. However `ssoEnabledTest` is the new way, leaving `enabledConfiguration` for backward compatibility.

This was cherry-picked from #1963.

## How was this patch tested?

Manually tested

```
mvn clean test package -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 30:02 min
[INFO] Finished at: 2018-08-03T12:02:10-04:00
[INFO] Final Memory: 102M/1323M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.