### PR TITLE
[AMBARI-24375] Adding services when Kerberos is enabled incorrectly changes unrelated service configurations

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -752,25 +752,6 @@ public class KerberosHelperImpl implements KerberosHelper {
           continue;
         }
 
-        for (Map.Entry<String, Map<String, Map<String, String>>> config : requestConfigurations.entrySet()) {
-          for (Map<String, String> properties : config.getValue().values()) {
-            for (Map.Entry<String, String> property : properties.entrySet()) {
-              String oldValue = property.getValue();
-              String updatedValue = variableReplacementHelper.replaceVariables(property.getValue(), existingConfigurations);
-              if (!StringUtils.equals(oldValue, updatedValue) && !config.getKey().isEmpty()) {
-                property.setValue(updatedValue);
-                if (kerberosConfigurations.containsKey(config.getKey())) {
-                  kerberosConfigurations.get(config.getKey()).put(property.getKey(), updatedValue);
-                } else {
-                  Map kerberosConfigProperties = new HashMap<>();
-                  kerberosConfigProperties.put(property.getKey(), updatedValue);
-                  kerberosConfigurations.put(config.getKey(), kerberosConfigProperties);
-                }
-              }
-            }
-          }
-        }
-
         StackAdvisorRequest request = StackAdvisorRequest.StackAdvisorRequestBuilder
           .forStack(stackId.getStackName(), stackId.getStackVersion())
           .forServices(services)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding services when Kerberos is enabled incorrectly changes unrelated service configurations.  For example, `kerberos-env/service_check_principal_name` is changed from "`$\{cluster_name|toLower()\}-$\{short_date\}`" to a concrete value like "`c1-072818`".

This is a regression created with the resolution of [AMBARI-23292](https://issues.apache.org/jira/browse/AMBARI-23292)

The solution is to remove some of the code added as a result of the patch for AMBARI-23292.  The actual solution AMBARI-23292 is a fix in the service's service advisor code.  The removed codes does not change the _correct_ data being set, it just prevents the incorrect data from being set. 

This was cherry-picked from #1965 

## How was this patch tested?

Manually tested using different scenarios.

```
mvn clean test package -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25:53 min
[INFO] Finished at: 2018-08-05T17:57:15-04:00
[INFO] Final Memory: 102M/1164M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.