### PR TITLE
AMBARI-24411. Infra Solr: gc logs are not rotated by default.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/configuration/infra-solr-env.xml
@@ -305,7 +305,7 @@
 
   <property>
     <name>infra_solr_gc_log_opts</name>
-    <value>-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime</value>
+    <value>-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=15 -XX:GCLogFileSize=200M</value>
     <display-name>Infra Solr GC log options</display-name>
     <description>Infra Solr GC log options</description>
     <on-ambari-upgrade add="true"/>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/properties/infra-solr-env.sh.j2
@@ -24,7 +24,7 @@ SOLR_JAVA_MEM="-Xms{{infra_solr_min_mem}}m -Xmx{{infra_solr_max_mem}}m"
 
 SOLR_JAVA_STACK_SIZE="-Xss{{infra_solr_java_stack_size}}m"
 
-GC_LOG_OPTS="{{infra_solr_gc_log_opts}}"
+GC_LOG_OPTS="{{infra_solr_gc_log_opts}} -Xloggc:{{infra_solr_log_dir}}/solr_gc.log"
 
 GC_TUNE="{{infra_solr_gc_tune}}"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
same as #1978
## How was this patch tested?
same as #1978