### PR TITLE
[AMBARI-24413] - Unable to Revert a Patch When There Are Multiple Patches

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -359,13 +359,10 @@ public class UpgradeContext {
       m_type = calculateUpgradeType(upgradeRequestMap, revertUpgrade);
 
       // !!! build all service-specific reversions
-      Set<RepositoryVersionEntity> priors = new HashSet<>();
       Map<String, Service> clusterServices = cluster.getServices();
       for (UpgradeHistoryEntity history : revertUpgrade.getHistory()) {
         String serviceName = history.getServiceName();
         String componentName = history.getComponentName();
-
-        priors.add(history.getFromReposistoryVersion());
 
         // if the service is no longer installed, do nothing
         if (!clusterServices.containsKey(serviceName)) {
@@ -378,13 +375,6 @@ public class UpgradeContext {
         m_services.add(serviceName);
         m_sourceRepositoryMap.put(serviceName, history.getTargetRepositoryVersion());
         m_targetRepositoryMap.put(serviceName, history.getFromReposistoryVersion());
-      }
-
-      if (priors.size() != 1) {
-        String message = String.format("Upgrade from %s could not be reverted as there is no single "
-            + " repository across services.", revertUpgrade.getRepositoryVersion().getVersion());
-
-        throw new AmbariException(message);
       }
 
       // the "associated" repository of the revert is the target of what's being reverted


### PR DESCRIPTION
## What changes were proposed in this pull request?

When multiple patch upgrades are performed, reverting the latest patch might throw the following exception:

```
018-08-07 11:26:57,703 ERROR [ambari-client-thread-6474] CreateHandler:74 - Caught a system exception while attempting to create a resource: An internal system exception occurred: Upgrade from 3.0.1.1-10 could not be reverted as there is no single  repository across services.
org.apache.ambari.server.controller.spi.SystemException: An internal system exception occurred: Upgrade from 3.0.1.1-10 could not be reverted as there is no single  repository across services.
	at org.apache.ambari.server.controller.internal.AbstractResourceProvider.createResources(AbstractResourceProvider.java:297)
	at org.apache.ambari.server.controller.internal.UpgradeResourceProvider.createResources(UpgradeResourceProvider.java:350)
	at 
```

STR:
- Install ZK and Storm on 3.0.0.0-1
- Patch Upgrade ZK to 3.0.0.0-2
- Patch Upgrade ZK and Storm to 3.0.0.0-3

You are now not able to revert the latest patch b/c Storm would go to 3.0.0.0-1 while ZK goes to 3.0.0.0-2.  This should be allowed.

## How was this patch tested?

Manually tested on an environment with 3 intersecting patches. 