### PR TITLE
[AMBARI-23112] Some libraries are not relocated in ambari-metrics-common jar

### DIFF
--- a/ambari-metrics/ambari-metrics-common/pom.xml
+++ b/ambari-metrics/ambari-metrics-common/pom.xml
@@ -82,6 +82,14 @@
                   <shadedPattern>org.apache.ambari.metrics.relocated.commons.lang</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.commons.math3</pattern>
+                  <shadedPattern>org.apache.ambari.metrics.relocated.commons.math3</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.codec</pattern>
+                  <shadedPattern>org.apache.ambari.metrics.relocated.commons.codec</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.apache.curator</pattern>
                   <shadedPattern>org.apache.ambari.metrics.sink.relocated.curator</shadedPattern>
                 </relocation>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some libraries are not relocated in ambari-metrics-common jar, that means some classes are exists in the jar, and those can be on the classpath as well (with different versions), which can cause issues.

## How was this patch tested?
mvn clean install
