### PR TITLE
[AMBARI-24417] HDFS Service page Datanode does not show count.

### DIFF
--- a/ambari-web/app/controllers/global/update_controller.js
+++ b/ambari-web/app/controllers/global/update_controller.js
@@ -196,6 +196,7 @@ App.UpdateController = Em.Controller.extend({
     if (this.get('isWorking') && !App.get('isOnlyViewUser')) {
       App.updater.run(this, 'updateHostsMetrics', 'isWorking', App.contentUpdateInterval, '\/main\/(hosts).*');
       App.updater.run(this, 'updateServiceMetric', 'isWorking', App.componentsUpdateInterval, '\/main\/(dashboard|services).*');
+      App.updater.run(this, 'updateComponentsState', 'isWorking', App.componentsUpdateInterval);
       App.updater.run(this, 'graphsUpdate', 'isWorking');
 
       if (!App.get('router.mainAlertInstancesController.isUpdating')) {

--- a/ambari-web/app/templates/main/service/info/summary/hdfs/slaves.hbs
+++ b/ambari-web/app/templates/main/service/info/summary/hdfs/slaves.hbs
@@ -29,7 +29,7 @@
         <div class="summary-value main-info">
           {{#if App.router.clusterController.isServiceContentFullyLoaded}}
             <span>
-              {{#view App.ComponentLiveTextView liveComponentsBinding="view.service.dataNodesStarted" totalComponentsBinding="view.service.dataNodesTotal"}}
+              {{#view App.ComponentLiveTextView liveComponentsBinding="view.dataNodesStarted" totalComponentsBinding="view.dataNodesTotal"}}
                 {{view.liveComponents}}/{{view.totalComponents}}
               {{/view}}
             </span>

--- a/ambari-web/app/views/main/service/info/summary/hdfs/slaves.js
+++ b/ambari-web/app/views/main/service/info/summary/hdfs/slaves.js
@@ -52,6 +52,24 @@ App.HDFSSlaveComponentsView = Em.View.extend({
 
   journalNodesTotal: Em.computed.alias('service.journalNodes.length'),
 
+  dataNodesStarted: function () {
+    var startedNum = this.get('service.dataNodesStarted');
+    if (!startedNum) {
+      let dataNodeComponent = App.SlaveComponent.find().findProperty('componentName', 'DATANODE');
+      startedNum = dataNodeComponent ? dataNodeComponent.get('startedCount') : 0;
+    }
+    return startedNum;
+  }.property('service.dataNodesStarted'),
+
+  dataNodesTotal: function () {
+    var totalNum = this.get('service.dataNodesTotal');
+    if (totalNum == null) {
+      let dataNodeComponent = App.SlaveComponent.find().findProperty('componentName', 'DATANODE');
+      totalNum = dataNodeComponent ? dataNodeComponent.get('totalCount') : 0;
+    }
+    return totalNum;
+  }.property('service.dataNodesTotal'),
+
   /**
    * Define if NFS_GATEWAY is present in the installed stack
    * @type {Boolean}

--- a/ambari-web/app/views/main/service/info/summary/hdfs/slaves.js
+++ b/ambari-web/app/views/main/service/info/summary/hdfs/slaves.js
@@ -63,7 +63,7 @@ App.HDFSSlaveComponentsView = Em.View.extend({
 
   dataNodesTotal: function () {
     var totalNum = this.get('service.dataNodesTotal');
-    if (totalNum == null) {
+    if (!totalNum) {
       let dataNodeComponent = App.SlaveComponent.find().findProperty('componentName', 'DATANODE');
       totalNum = dataNodeComponent ? dataNodeComponent.get('totalCount') : 0;
     }

--- a/ambari-web/test/controllers/global/update_controller_test.js
+++ b/ambari-web/test/controllers/global/update_controller_test.js
@@ -65,7 +65,7 @@ describe('App.UpdateController', function () {
 
     it('isWorking = true', function () {
       controller.set('isWorking', true);
-      expect(App.updater.run.callCount).to.equal(6);
+      expect(App.updater.run.callCount).to.equal(7);
     });
   });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update component states after initial load. Incase of null get the values from other SlaveComponent model.

## How was this patch tested?
  21102 passing (17s)
  50 pending