### PR TITLE
AMBARI-24422. Log Feeder: upgrade guava version (because of CVE-2018-10237)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>25.0-jre</version>
     </dependency>
   </dependencies>
 

--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>25.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -291,7 +291,7 @@
     <dependency>
         <artifactId>guava</artifactId>
         <groupId>com.google.guava</groupId>
-        <version>20.0</version>
+        <version>25.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Security fix for logfeeder plugin api + logsearch

## How was this patch tested?
manually, i tried out most of the rest call to make sure everything work as expected (as i had to upgrade 5 or 7 major version for guava)

Please review @g-boros @zeroflag @swagle @rlevas 