### PR TITLE
AMBARI-24422. Log Feeder: upgrade guava version (because of CVE-2018-10237)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>25.0-jre</version>
     </dependency>
   </dependencies>
 

--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>25.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -291,7 +291,7 @@
     <dependency>
         <artifactId>guava</artifactId>
         <groupId>com.google.guava</groupId>
-        <version>20.0</version>
+        <version>25.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
same as #1992
## How was this patch tested?
same as #1992