### PR TITLE
AMBARI-24421 Revise a description same as HiveConf.java

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/hive-interactive-site.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/hive-interactive-site.xml
@@ -83,7 +83,7 @@ limitations under the License.
   <property>
     <name>hive.server2.tez.sessions.custom.queue.allowed</name>
     <value>ignore</value>
-    <description>Whether to allow the users of this HS2 to specify custom queues - yes, no (fail if specified), ignore (use the default queues even if a custom one is specified)</description>
+    <description>Whether Tez session pool should allow submitting queries to custom queues - true, false (error out), ignore (accept the query but ignore the queue setting)</description>
     <display-name>Allow custom queues</display-name>
     <on-ambari-upgrade add="true"/>
   </property>


### PR DESCRIPTION

## What changes were proposed in this pull request?
Revise a description of hive.server2.tez.sessions.custom.queue.allowed at hive-interactive-site.xml to be same as HiveConf.java of Hive code
- yes, no => true, false

## How was this patch tested?
It only needs xml syntax correctness.
