### PR TITLE
[AMBARI-24429] Remove dependencies with CVE issues from Ambari Agent

### DIFF
--- a/contrib/views/utils/pom.xml
+++ b/contrib/views/utils/pom.xml
@@ -131,11 +131,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.0</version>
-    </dependency>
-    <dependency>
       <groupId>
         org.glassfish.jersey.test-framework.providers
       </groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependencies with CVE issues from Ambari Agent

* org.apache.commons:commons-collections4:jar before version 4.0-alpha1-RC1
  * CVE-2015-6420 - https://nvd.nist.gov/vuln/detail/CVE-2015-6420

```
[INFO] org.apache.ambari.contrib.views:ambari-views-utils:jar:2.0.0.0-SNAPSHOT
[INFO] \- org.apache.commons:commons-collections4:jar:4.0:compile
```

Note: org.apache.commons:commons-collections4:jar:4.0 was apparently not being used by any view.

This was cherry-picked from #1999 

## How was this patch tested?

'''
mvn clean test package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:30 min
[INFO] Finished at: 2018-08-08T14:06:29-04:00
[INFO] Final Memory: 43M/830M
[INFO] ------------------------------------------------------------------------
'''

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.