### PR TITLE
AMBARI-24431. Infra Manager / Log Search: Fix Jetty CVE-2018-12536.

### DIFF
--- a/ambari-infra/ambari-infra-manager/pom.xml
+++ b/ambari-infra/ambari-infra-manager/pom.xml
@@ -34,7 +34,7 @@
     <spring.security.version>4.2.4.RELEASE</spring.security.version>
     <spring.ldap.version>2.2.0.RELEASE</spring.ldap.version>
     <jersey.version>2.25.1</jersey.version>
-    <jetty.version>9.4.8.v20171121</jetty.version>
+    <jetty.version>9.4.11.v20180605</jetty.version>
     <spring-batch.version>3.0.7.RELEASE</spring-batch.version>
     <sqlite.version>3.8.11.2</sqlite.version>
     <spring-data-solr.version>2.0.2.RELEASE</spring-data-solr.version>

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -31,7 +31,7 @@
     <spring.security.version>4.2.4.RELEASE</spring.security.version>
     <spring.ldap.version>2.2.0.RELEASE</spring.ldap.version>
     <jersey.version>2.25.1</jersey.version>
-    <jetty.version>9.4.8.v20171121</jetty.version>
+    <jetty.version>9.4.11.v20180605</jetty.version>
     <swagger.version>1.5.16</swagger.version>
     <spring-data-solr.version>2.0.2.RELEASE</spring-data-solr.version>
     <jjwt.version>0.6.0</jjwt.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix Jetty CVE-2018-12536

## How was this patch tested?
manually checked endpoints where static files are served

Please review @g-boros @zeroflag @rlevas @swagle 