### PR TITLE
[AMBARI-24434] Cannot deploy HBase without HDFS

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -2905,7 +2905,7 @@ public class BlueprintConfigurationProcessor {
     hdfsSiteMap.put("dfs.namenode.https-address", new SingleHostTopologyUpdater("NAMENODE"));
     hdfsSiteMap.put("dfs.namenode.rpc-address", new SingleHostTopologyUpdater("NAMENODE"));
     coreSiteMap.put("fs.defaultFS", new SingleHostTopologyUpdater("NAMENODE"));
-    hbaseSiteMap.put("hbase.rootdir", new SingleHostTopologyUpdater("NAMENODE"));
+    hbaseSiteMap.put("hbase.rootdir", new OptionalSingleHostTopologyUpdater("NAMENODE"));
     accumuloSiteMap.put("instance.volumes", new SingleHostTopologyUpdater("NAMENODE"));
     // HDFS shared.edits JournalNode Quorum URL uses semi-colons as separators
     multiHdfsSiteMap.put("dfs.namenode.shared.edits.dir", new MultipleHostTopologyUpdater("JOURNALNODE", ';', false, false, true));

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/hbase.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/hbase.py
@@ -208,7 +208,7 @@ def hbase(name=None):
       group=params.user_group,
       owner=params.hbase_user
     )
-  if name == "master":
+  if name == "master" and params.default_fs:
     if not params.hbase_hdfs_root_dir_protocol or params.hbase_hdfs_root_dir_protocol == urlparse(params.default_fs).scheme:
       params.HdfsResource(params.hbase_hdfs_root_dir,
                            type="directory",
@@ -229,6 +229,14 @@ def hbase(name=None):
                           mode=0755
       )
     params.HdfsResource(None, action="execute")
+
+  if name in ('master', 'regionserver') and not params.default_fs:
+    Directory(params.hbase_staging_dir,
+      owner = params.hbase_user,
+      create_parents = True,
+      cd_access = "a",
+      mode = 0711,
+    )
 
   if params.phoenix_enabled:
     Package(params.phoenix_package,

--- a/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HBASE/0.96.0.2.0/package/scripts/params_linux.py
@@ -260,7 +260,7 @@ hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
 hdfs_principal_name = config['configurations']['hadoop-env']['hdfs_principal_name']
 
 hdfs_site = config['configurations']['hdfs-site']
-default_fs = config['configurations']['core-site']['fs.defaultFS']
+default_fs = default('configurations/core-site/fs.defaultFS', None)
 
 dfs_type = default("/clusterLevelParams/dfs_type", "")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow deployment of HBase without HDFS:

1. do not require NameNode for `hbase.rootdir`
2. do not try to create HDFS directories if HDFS or compatible filesystem is not available (checking `fs.defaultFS`)
3. create staging directory on local FS

The dependency specified in service metainfo is not removed, so topology validation needs to be disabled.  This can be relaxed later, if needed.

## How was this patch tested?

Tested blueprint deployment with HDFS and with local filesystem (setting `hbase.rootdir` to `file:///...`).  Ran HBase service check after deployment.