### PR TITLE
[AMBARI-24443] Slider type widget displays erroneously before first touch

### DIFF
--- a/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
@@ -419,6 +419,13 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
      */
     var correctConfigValue = this.get('config.value');
 
+    // workaround for cases when slider input is hidden in DOM
+    try {
+      $(this.get('element')).find('.ui-slider-wrapper').removeClass('hide');
+    } catch (e) {
+      console.error('Error when trying to show slider input');
+    }
+
     var slider = new Slider(this.$('input.slider-input')[0], {
       value: this.get('mirrorValue'),
       ticks: ticks,


### PR DESCRIPTION
## What changes were proposed in this pull request?

On Hive Service Summary page text doesn't fit inside the appropriate block if HIVESERVER2 JDBC URL has much hosts in its value.

## How was this patch tested?

  21751 passing (33s)
  48 pending