### PR TITLE
[AMBARI-24442] HIVESERVER2 JDBC URL doesn't fit inside block

### DIFF
--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -905,6 +905,7 @@ a:focus {
       display: inline-block;
       &.endpoint-value {
         padding-left: 30px;
+        word-break: break-word;
       }
       .clip-board{
         margin-left: 5px;


### PR DESCRIPTION
## What changes were proposed in this pull request?

On Hive Service Summary page text doesn't fit inside the appropriate block if HIVESERVER2 JDBC URL has much hosts in its value.

## How was this patch tested?

  21751 passing (33s)
  48 pending