### PR TITLE
[AMBARI-24445] [Log Search UI] exclude mock data from production build

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/README.md
+++ b/ambari-logsearch/ambari-logsearch-web/README.md
@@ -7,7 +7,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 Run `npm start` or `yarn start` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ## Webpack Development Config
-In order to use Webpack Devserver proxy without changing the main config file and commit accidentally we can use a `webpack.config.dev.js` file for that. So you can set a service URL in order to test the UI against real data.
+In order to use the UI without changing the main webpack config file (and commit accidentally) we can use a `webpack.config.dev.js` file for that. So you can set a service URL proxy.
 
 The content of the `webpack.config.dev.js` can be:
 ```
@@ -18,13 +18,14 @@ module.exports = merge(baseConfig, {
   devServer: {
     historyApiFallback: true,
     proxy: {
-      '/': 'http://c7401.ambari.apache.org:61888'
+      '/api': 'http://c7401.ambari.apache.org:61888/', // proxying the api requests
+      '/login': 'http://c7401.ambari.apache.org:61888/', // proxying the login action
+      '/logout': 'http://c7401.ambari.apache.org:61888/' // proxying the the logout action
     }
   }
 });
 ```
-And you can start it that way: `NODE_ENV=production yarn start --config webpack.config.dev.js`
-You have to set the `NODE_ENV` to production in order to skip the mock data usage
+And you can start it that way: `yarn start --config webpack.config.dev.js`
 
 ## Code scaffolding
 

--- a/ambari-logsearch/ambari-logsearch-web/src/app/app.module.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/app.module.ts
@@ -38,7 +38,6 @@ import {ShipperModule} from '@modules/shipper/shipper.module';
 
 import {ServiceInjector} from '@app/classes/service-injector';
 
-import {MockApiDataService} from '@app/services/mock-api-data.service';
 import {HttpClientService} from '@app/services/http-client.service';
 import {UtilsService} from '@app/services/utils.service';
 import {LogsContainerService} from '@app/services/logs-container.service';
@@ -115,23 +114,6 @@ import {LogsBreadcrumbsResolverService} from '@app/services/logs-breadcrumbs-res
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {LoginScreenGuardService} from '@app/services/login-screen-guard.service';
-
-export function getXHRBackend(
-  injector: Injector, browser: BrowserXhr, xsrf: XSRFStrategy, options: ResponseOptions
-): XHRBackend | InMemoryBackendService {
-  if (environment.production) {
-    return new XHRBackend(browser, options, xsrf);
-  } else {
-    return new InMemoryBackendService(
-      injector,
-      new MockApiDataService(),
-      {
-        passThruUnknownUrl: true,
-        rootPath: ''
-      }
-    );
-  }
-}
 
 @NgModule({
   declarations: [
@@ -230,11 +212,6 @@ export function getXHRBackend(
     TabsService,
     TabGuard,
     LogsBreadcrumbsResolverService,
-    {
-      provide: XHRBackend,
-      useFactory: getXHRBackend,
-      deps: [Injector, BrowserXhr, XSRFStrategy, ResponseOptions]
-    },
     AuthService,
     AuthGuardService,
     HistoryManagerService,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removing the mock data from the application. So that from now in order to develop you'll need to have a Log Search server set up and set the Webpack Dev Server proxy. See README.md

## How was this patch tested?

It was tested manually and by running unit tests:
`PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (10.885 secs / 10.718 secs)`

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.