### PR TITLE
[AMBARI-24447] No subject alternative DNS name exception encountered when Enabling Kerberos against an Active Directory even when SSL verification is off

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/security/InternalSSLSocketFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/InternalSSLSocketFactory.java
@@ -26,8 +26,10 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -94,9 +96,9 @@ public class InternalSSLSocketFactory extends SSLSocketFactory {
 
   /**
    * LenientTrustManager is a TrustManager that accepts all certificates without validating the
-   * chain of trust.
+   * chain of trust or hostname.
    */
-  public static class LenientTrustManager implements X509TrustManager {
+  public static class LenientTrustManager extends X509ExtendedTrustManager implements X509TrustManager {
     public void checkClientTrusted(X509Certificate[] xcs, String string) throws CertificateException {
       // do nothing
     }
@@ -107,6 +109,26 @@ public class InternalSSLSocketFactory extends SSLSocketFactory {
 
     public X509Certificate[] getAcceptedIssuers() {
       return new X509Certificate[0];
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+      // do nothing
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+      // do nothing
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+      // do nothing
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+      // do nothing
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

No subject alternative DNS name exception encountered when Enabling Kerberos against an Active Directory even when SSL verification is off.

```
2018-08-09 14:48:28,275  WARN [ambari-client-thread-35] ADKerberosOperationHandler:471 - Failed to communicate with the Active Directory at ldaps://adserver.example.com:636: adserver.example.com:636
javax.naming.CommunicationException: adserver.example.com:636 [Root exception is javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative DNS name matching adserver.example.com found.]
        at com.sun.jndi.ldap.Connection.<init>(Connection.java:238)
        at com.sun.jndi.ldap.LdapClient.<init>(LdapClient.java:137)
...
Caused by: javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative DNS name matching adserver.example.com found.
        at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)
        at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1964)
...
Caused by: java.security.cert.CertificateException: No subject alternative DNS name matching adserver.example.com found.
        at sun.security.util.HostnameChecker.matchDNS(HostnameChecker.java:214)
        at sun.security.util.HostnameChecker.match(HostnameChecker.java:96)
        at sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:459)
        at sun.security.ssl.AbstractTrustManagerWrapper.checkAdditionalTrust(SSLContextImpl.java:1026)
        at sun.security.ssl.AbstractTrustManagerWrapper.checkServerTrusted(SSLContextImpl.java:993)
        at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1596)
```

Note: This occurs when the hostname embedded in the SSL certificate does not match the hostname of the Active Directory host and Open JDK 1.8.181-b13 is used.  This is not seen when Oracle JDK is used. 

Observed with this version of JDK:
```
openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-b13)
OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)
```

Not observed with this version of JDK
```
java version "1.8.0_112"
Java(TM) SE Runtime Environment (build 1.8.0_112-b15)
Java HotSpot(TM) 64-Bit Server VM (build 25.112-b15, mixed mode)
```

**Solution**
The `org.apache.ambari.server.security.InternalSSLSocketFactory.LenientTrustManager` class needs to extend `javax.net.ssl.X509ExtendedTrustManager` and do nothing in the additional overridden methods. 

This was cherry-picked from #2012 

## How was this patch tested?

Manually tested. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.