### PR TITLE
[AMBARI-24453] Ambari stack hook changes to create HDFS users and groups in workload cluster that has only HDFS client

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/hook.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/hook.py
@@ -29,7 +29,7 @@ class BeforeAnyHook(Hook):
     env.set_params(params)
 
     setup_users()
-    if params.has_namenode or params.dfs_type == 'HCFS':
+    if params.has_hdfs_clients or params.dfs_type == 'HCFS':
       setup_hadoop_env()
     setup_java()
 

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -177,7 +177,7 @@ zeppelin_group = config['configurations']['zeppelin-env']["zeppelin_group"]
 user_group = config['configurations']['cluster-env']['user_group']
 
 ganglia_server_hosts = default("/clusterHostInfo/ganglia_server_hosts", [])
-namenode_host = default("/clusterHostInfo/namenode_hosts", [])
+hdfs_client_hosts = default("/clusterHostInfo/hdfs_client_hosts", [])
 hbase_master_hosts = default("/clusterHostInfo/hbase_master_hosts", [])
 oozie_servers = default("/clusterHostInfo/oozie_server", [])
 falcon_server_hosts = default("/clusterHostInfo/falcon_server_hosts", [])
@@ -188,7 +188,7 @@ zeppelin_master_hosts = default("/clusterHostInfo/zeppelin_master_hosts", [])
 version_for_stack_feature_checks = get_stack_feature_version(config)
 
 
-has_namenode = not len(namenode_host) == 0
+has_hdfs_clients = not len(hdfs_client_hosts) == 0
 has_ganglia_server = not len(ganglia_server_hosts) == 0
 has_tez = 'tez-site' in config['configurations']
 has_hbase_masters = not len(hbase_master_hosts) == 0
@@ -242,7 +242,7 @@ for ns, dfs_ha_namenode_ids in dfs_ha_namenode_ids_all_ns.iteritems():
   if found:
     break
 
-if has_namenode or dfs_type == 'HCFS':
+if has_hdfs_clients or dfs_type == 'HCFS':
     hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
     hadoop_conf_secure_dir = os.path.join(hadoop_conf_dir, "secure")
 

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/shared_initialization.py
@@ -74,7 +74,7 @@ def setup_users():
       Logger.info('Skipping setting uid for hbase user as host is sys prepped')
 
   if should_create_users_and_groups:
-    if params.has_namenode:
+    if params.has_hdfs_clients:
       create_dfs_cluster_admins()
     if params.has_tez and params.stack_version_formatted != "" and compare_versions(params.stack_version_formatted, '2.3') >= 0:
       create_tez_am_view_acls()
@@ -180,7 +180,7 @@ def setup_hadoop_env():
   import params
   stackversion = params.stack_version_unformatted
   Logger.info("FS Type: {0}".format(params.dfs_type))
-  if params.has_namenode or stackversion.find('Gluster') >= 0 or params.dfs_type == 'HCFS':
+  if params.has_hdfs_clients or stackversion.find('Gluster') >= 0 or params.dfs_type == 'HCFS':
     if params.security_enabled:
       tc_owner = "root"
     else:

--- a/ambari-server/src/test/python/stacks/2.0.6/configs/default.json
+++ b/ambari-server/src/test/python/stacks/2.0.6/configs/default.json
@@ -1370,6 +1370,10 @@
         "namenode_hosts": [
             "c6401.ambari.apache.org"
         ],
+        "hdfs_client_hosts": [
+            "c6401.ambari.apache.org",
+            "c6402.ambari.apache.org"
+        ],
         "hbase_master_hosts": [
             "c6402.ambari.apache.org"
         ],

--- a/ambari-server/src/test/python/stacks/2.0.6/configs/default.json
+++ b/ambari-server/src/test/python/stacks/2.0.6/configs/default.json
@@ -1077,7 +1077,7 @@
             "timeline.metrics.daily.aggregator.minute.interval": "86400",
             "timeline.metrics.cluster.aggregator.minute.interval": "120",
             "timeline.metrics.host.aggregator.hourly.interval": "3600",
-            "timeline.metrics.initial.configured.master.components": "drpc_server,hive_server,resourcemanager,all,webhcat_server,snamenode,storm_ui_server,falcon_server,namenode,ganglia_server,logviewer_server,hive_metastore,nimbus,zookeeper_server,historyserver,hbase_master,oozie_server,metrics_collector,supervisor,ganglia_monitor,hive_mysql,ambari_server",
+            "timeline.metrics.initial.configured.master.components": "drpc_server,hive_server,resourcemanager,all,webhcat_server,snamenode,storm_ui_server,falcon_server,namenode,hdfs_client,logviewer_server,hive_metastore,nimbus,zookeeper_server,historyserver,hbase_master,ganglia_server,oozie_server,metrics_collector,supervisor,ganglia_monitor,hive_mysql,ambari_server",
             "timeline.metrics.initial.configured.slave.components": "hbase_regionserver,datanode,nodemanager",
             "hbase_total_heapsize": 536870912
         },


### PR DESCRIPTION
## What changes were proposed in this pull request?
Current logic is to create hdfs users and group on all hosts only when NameNode is installed on a cluster
Patch changes this to create hdfs users and group even when only HDFS client is being managed by ambari . 
In a cluster that has hdfs clients but no namenode, hdfs user is expected to be present by other service scripts while copying tarballs to hdfs, service check, setting ownership to hdfs user for some configuration files

## How was this patch tested?

Deploying a cluster with only HDFS client component in HDFS service and other services