### PR TITLE
AMBARI-24454. WebHdfs calls being made from yarn/docker container to NameNode hosted on bare metal host fails.

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
@@ -249,6 +249,8 @@ class WebHDFSUtil:
 
       if file_to_put:
         cmd += ["--data-binary", "@"+file_to_put, "-H", "Content-Type: application/octet-stream"]
+      else:
+        cmd += ["-d", "", "-H", "Content-Length: 0"]
 
     if self.security_enabled:
       cmd += ["--negotiate", "-u", ":"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Explicitly set data to be empty and content length to be 0 when webhdfs put call is made without any data like 'setpermission' 

## How was this patch tested?
Verified the patch manually