### PR TITLE
AMBARI-24456. Ambari server can not start on latest Amazon Linux 2

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/os_check.py
+++ b/ambari-common/src/main/python/ambari_commons/os_check.py
@@ -78,7 +78,7 @@ VER_NT_SERVER = 3
 _IS_ORACLE_LINUX = os.path.exists('/etc/oracle-release')
 _IS_REDHAT_LINUX = os.path.exists('/etc/redhat-release')
 
-SYSTEM_RELEASE_FILE = "/etc/system-release"
+OS_RELEASE_FILE = "/etc/os-release"
 
 def _is_oracle_linux():
   return _IS_ORACLE_LINUX
@@ -91,13 +91,16 @@ def _is_powerpc():
 
 def advanced_check(distribution):
   distribution = list(distribution)
-  if os.path.exists(SYSTEM_RELEASE_FILE):
-    with open(SYSTEM_RELEASE_FILE, "rb") as fp:
-      issue_content = fp.read()
+  if os.path.exists(OS_RELEASE_FILE):
+    with open(OS_RELEASE_FILE, "rb") as fp:
+      file_content = fp.read()
   
-    if "Amazon" in issue_content:
+    search_groups = re.search('NAME="(.+)"', file_content)
+    name = search_groups.group(1) if search_groups else ''
+
+    if "amazon" in name.lower():
       distribution[0] = "amazonlinux"
-      search_groups = re.search(' release (\d+)', issue_content)
+      search_groups = re.search('VERSION_ID="(\d+)"', file_content)
       
       if search_groups:
         distribution[1] = search_groups.group(1)


### PR DESCRIPTION
On latest Amazon Linux 2 ambari-server cannot start with error message:

[root@ip-10-0-222-155 cloudbreak]# ambari-server start
Using python  /usr/bin/python
Starting ambari-server
Traceback (most recent call last):
  File "/usr/sbin/ambari-server.py", line 37, in <module>
    from ambari_server.dbConfiguration import DATABASE_NAMES, LINUX_DBMS_KEYS_LIST
  File "/usr/lib/ambari-server/lib/ambari_server/dbConfiguration.py", line 30, in <module>
    from ambari_server.serverConfiguration import decrypt_password_for_alias, get_ambari_properties, get_is_secure, \
  File "/usr/lib/ambari-server/lib/ambari_server/serverConfiguration.py", line 46, in <module>
    OS_VERSION = OSCheck().get_os_major_version()
  File "/usr/lib/ambari-server/lib/ambari_commons/os_check.py", line 322, in get_os_major_version
    return OSCheck.get_os_version().split('.')[0]
  File "/usr/lib/ambari-server/lib/ambari_commons/os_check.py", line 301, in get_os_version
    return OSCheck.get_alias(OSCheck._get_os_type(), OSCheck._get_os_version())[1]
  File "/usr/lib/ambari-server/lib/ambari_commons/os_check.py", line 313, in _get_os_version
    raise Exception("Cannot detect os version. Exiting...")
Exception: Cannot detect os version. Exiting...
Additional infos from the machine:

[root@ip-10-0-222-155 cloudbreak]# cat /etc/system-release
Amazon Linux 2
[root@ip-10-0-222-155 cloudbreak]# cat /etc/*release
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
Amazon Linux 2
[root@ip-10-0-222-155 cloudbreak]#