### PR TITLE
AMBARI-24457. Hiveserver2 can't connect to metastore when using OneFS…

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -108,6 +108,7 @@ else:
   class ONEFSServiceAdvisor(service_advisor.ServiceAdvisor):
     def getServiceConfigurationRecommendations(self, configs, clusterData, services, hosts):
       try:
+        self.recommendHadoopProxyUsers(configs, services, hosts)
         putCoreSiteProperty = self.putProperty(configs, "core-site", services)
         putHdfsSiteProperty = self.putProperty(configs, "hdfs-site", services)
         onefs_host = Uri.onefs(services)


### PR DESCRIPTION
… (amagyar)

## What changes were proposed in this pull request?

Hadoop proxy users were not set which caused an authentication problem when Hiveserver2 wanted to connect hive metastore.

```text
2018-07-12T07:56:27,148 ERROR [pool-6-thread-3]: metastore.HiveMetaStore (HiveMetaStore.java:get_current_notificationEventId(7617)) - Not authorized to make the get_current_notificationEventId call. You can try to disable metastore.metastore.event.db.notification.api.auth
org.apache.hadoop.hive.metastore.api.MetaException: User hive is not allowed to perform this API call
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.authorizeProxyPrivilege(HiveMetaStore.java:7655) ~[hive-exec-3.1.0.3.0.0.0-1628.jar:3.1.0.3.0.0.0-1628]
        at 
```

## How was this patch tested?

* Installed onefs + hive
* Started hive service