### PR TITLE
AMBARI-24457. Hiveserver2 can't connect to metastore when using OneFS…

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -108,6 +108,7 @@ else:
   class ONEFSServiceAdvisor(service_advisor.ServiceAdvisor):
     def getServiceConfigurationRecommendations(self, configs, clusterData, services, hosts):
       try:
+        self.recommendHadoopProxyUsers(configs, services, hosts)
         putCoreSiteProperty = self.putProperty(configs, "core-site", services)
         putHdfsSiteProperty = self.putProperty(configs, "hdfs-site", services)
         onefs_host = Uri.onefs(services)


### PR DESCRIPTION
clone of #2024