### PR TITLE
[AMBARI-23811] TimelineMetricsFilterTest fails if dir name contains @

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/TimelineMetricsFilterTest.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/TimelineMetricsFilterTest.java
@@ -27,7 +27,6 @@ import org.easymock.EasyMock;
 import org.junit.Test;
 
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -91,9 +90,7 @@ public class TimelineMetricsFilterTest {
     expect(configuration.getMetricsConf()).andReturn(metricsConf).once();
     replay(configuration);
 
-    URL fileUrl = ClassLoader.getSystemResource("test_data/metric_blacklist.dat");
-
-    metricsConf.set("timeline.metrics.blacklist.file", fileUrl.getPath());
+    metricsConf.set("timeline.metrics.blacklist.file", getTestBlacklistFilePath());
     TimelineMetricsFilter.initializeMetricFilter(configuration);
 
     TimelineMetric timelineMetric = new TimelineMetric();
@@ -183,8 +180,7 @@ public class TimelineMetricsFilterTest {
     metricsConf.set("timeline.metrics.apps.whitelist", "namenode,nimbus");
     metricsConf.set("timeline.metrics.apps.blacklist", "datanode,kafka_broker");
     metricsConf.set("timeline.metrics.whitelist.file", getTestWhitelistFilePath());
-    URL fileUrl2 = ClassLoader.getSystemResource("test_data/metric_blacklist.dat");
-    metricsConf.set("timeline.metrics.blacklist.file", fileUrl2.getPath());
+    metricsConf.set("timeline.metrics.blacklist.file", getTestBlacklistFilePath());
     expect(configuration.getMetricsConf()).andReturn(metricsConf).once();
 
     Set<String> whitelist = new HashSet<>();
@@ -255,5 +251,9 @@ public class TimelineMetricsFilterTest {
 
   private static String getTestWhitelistFilePath() throws URISyntaxException {
     return ClassLoader.getSystemResource("test_data/metric_whitelist.dat").toURI().getPath();
+  }
+
+  private static String getTestBlacklistFilePath() throws URISyntaxException {
+    return ClassLoader.getSystemResource("test_data/metric_blacklist.dat").toURI().getPath();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unit test failure caused by running in directory with `@2` suffix was fixed in #1237, but #1503 introduced the problem again for the blacklist-file.

```
Tests run: 6, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.42 sec <<< FAILURE! - in org.apache.ambari.metrics.core.timeline.TimelineMetricsFilterTest
testMetricBlacklisting(org.apache.ambari.metrics.core.timeline.TimelineMetricsFilterTest)  Time elapsed: 0.014 sec  <<< FAILURE!
junit.framework.AssertionFailedError
	at org.apache.ambari.metrics.core.timeline.TimelineMetricsFilterTest.testMetricBlacklisting(TimelineMetricsFilterTest.java:105)

testHybridFilter(org.apache.ambari.metrics.core.timeline.TimelineMetricsFilterTest)  Time elapsed: 0.007 sec  <<< FAILURE!
junit.framework.AssertionFailedError
	at org.apache.ambari.metrics.core.timeline.TimelineMetricsFilterTest.testHybridFilter(TimelineMetricsFilterTest.java:208)


Results :

Failed tests:
  TimelineMetricsFilterTest.testHybridFilter:208 null
  TimelineMetricsFilterTest.testMetricBlacklisting:105 null
```

https://issues.apache.org/jira/browse/AMBARI-23811
https://issues.apache.org/jira/browse/AMBARI-24066

https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/3539/
https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/3537/
https://builds.apache.org/job/Ambari-Github-PullRequest-Builder/3521/

## How was this patch tested?

```
$ mv ambari Ambari-Github-PullRequest-Builder@2
$ cd Ambari-Github-PullRequest-Builder@2
$ mvn -am -pl ambari-metrics/ambari-metrics-timelineservice clean test
...
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.461 sec - in org.apache.ambari.metrics.core.timeline.TimelineMetricsFilterTest
...
[INFO] BUILD SUCCESS
```