### PR TITLE
[AMBARI-24424] [Log Search UI] Align the time histogram chart axis

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
@@ -109,7 +109,7 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
   }
 
   protected setXScaleDomain(data: GraphScaleItem[]): void {
-    this.xScale.domain(d3.extent(data, item => item.tick)).nice();
+    this.xScale.domain(d3.extent(data, item => item.tick)).nice().domain();
   }
 
   /**

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/time-histogram/time-histogram.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/time-histogram/time-histogram.component.ts
@@ -73,7 +73,7 @@ export class TimeHistogramComponent extends TimeGraphComponent {
     const columnWidth = this.columnWidth[this.chartTimeGap.unit] || this.columnWidth.base;
 
     // drawing the axis
-    this.drawXAxis(null, (columnWidth / 2) + 2);
+    this.drawXAxis();
     this.drawYAxis();
 
     // populate the data and drawing the bars


### PR DESCRIPTION
## What changes were proposed in this pull request?

Call the missing domain after the nice method and remove the offset in the populate method.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (11.09 secs / 10.934 secs)
✨  Done in 52.39s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.