### PR TITLE
[AMBARI-24461] Python 2/3 compatible topology_script.py

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-START/files/topology_script.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-START/files/topology_script.py
@@ -18,9 +18,14 @@ limitations under the License.
 '''
 
 import sys, os
-from string import join
-import ConfigParser
-
+try:
+  # Python 2
+  from string import join
+  import ConfigParser
+except ImportError:
+  # Python 3
+  join = ' '.join
+  import configparser as ConfigParser
 
 DEFAULT_RACK = "/default-rack"
 DATA_FILE_NAME =  os.path.dirname(os.path.abspath(__file__)) + "/topology_mappings.data"
@@ -60,7 +65,7 @@ class TopologyScript():
   def execute(self, args):
     rack_map = self.load_rack_map()
     rack = self.get_racks(rack_map, args)
-    print rack
+    print(rack)
 
 if __name__ == "__main__":
   TopologyScript().execute(sys.argv)

--- a/contrib/management-packs/hdf-ambari-mpack/src/main/resources/stacks/HDF/2.0/hooks/before-START/files/topology_script.py
+++ b/contrib/management-packs/hdf-ambari-mpack/src/main/resources/stacks/HDF/2.0/hooks/before-START/files/topology_script.py
@@ -18,9 +18,14 @@ limitations under the License.
 '''
 
 import sys, os
-from string import join
-import ConfigParser
-
+try:
+  # Python 2
+  from string import join
+  import ConfigParser
+except ImportError:
+  # Python 3
+  join = ' '.join
+  import configparser as ConfigParser
 
 DEFAULT_RACK = "/default-rack"
 DATA_FILE_NAME =  os.path.dirname(os.path.abspath(__file__)) + "/topology_mappings.data"
@@ -60,7 +65,7 @@ class TopologyScript():
   def execute(self, args):
     rack_map = self.load_rack_map()
     rack = self.get_racks(rack_map, args)
-    print rack
+    print(rack)
 
 if __name__ == "__main__":
   TopologyScript().execute(sys.argv)

--- a/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/hooks/before-START/files/topology_script.py
+++ b/contrib/management-packs/odpi-ambari-mpack/src/main/resources/stacks/ODPi/2.0/hooks/before-START/files/topology_script.py
@@ -18,9 +18,14 @@ limitations under the License.
 '''
 
 import sys, os
-from string import join
-import ConfigParser
-
+try:
+  # Python 2
+  from string import join
+  import ConfigParser
+except ImportError:
+  # Python 3
+  join = ' '.join
+  import configparser as ConfigParser
 
 DEFAULT_RACK = "/default-rack"
 DATA_FILE_NAME =  os.path.dirname(os.path.abspath(__file__)) + "/topology_mappings.data"
@@ -60,7 +65,7 @@ class TopologyScript():
   def execute(self, args):
     rack_map = self.load_rack_map()
     rack = self.get_racks(rack_map, args)
-    print rack
+    print(rack)
 
 if __name__ == "__main__":
   TopologyScript().execute(sys.argv)


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/AMBARI-24461:

The topology_script.py included with ambari is not Python 3 compatible. With support for Python 2 ending in just over 1 year (https://pythonclock.org/) and many commonly used Python projects moving to Python 3-only before then (http://python3statement.org/), it would be good to have a script compatible with both versions included in Ambari.