### PR TITLE
AMBARI-24462. ambari-server upgrade stuck with NPE (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -1614,14 +1614,14 @@ public class KerberosHelperImpl implements KerberosHelper {
               // validating owner and group
               boolean differentOwners = false;
               String warnTemplate = "Keytab '{}' on host '{}' has different {}, originally set to '{}' and '{}:{}' has '{}', using '{}'";
-              if (!resolvedKeytab.getOwnerName().equals(sameKeytab.getOwnerName())) {
+              if (!StringUtils.equals(resolvedKeytab.getOwnerName(), sameKeytab.getOwnerName())) {
                 LOG.warn(warnTemplate,
                   keytabFilePath, hostname, "owners", sameKeytab.getOwnerName(),
                   serviceName, componentName, resolvedKeytab.getOwnerName(),
                   sameKeytab.getOwnerName());
                 differentOwners = true;
               }
-              if (!resolvedKeytab.getOwnerAccess().equals(sameKeytab.getOwnerAccess())) {
+              if (!StringUtils.equals(resolvedKeytab.getOwnerAccess(), sameKeytab.getOwnerAccess())) {
                 LOG.warn(warnTemplate,
                   keytabFilePath, hostname, "owner access", sameKeytab.getOwnerAccess(),
                   serviceName, componentName, resolvedKeytab.getOwnerAccess(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

NPE occurred when upgrading ambari 2.6 -> 2.7, which was originated from a string comparison in KerberosHelperImp.  

## How was this patch tested?

manual upgrade