### PR TITLE
[AMBARI-24463]Heatmaps:Calculation for Host Memory Used and Host CPU Wait IO is not correct

### DIFF
--- a/ambari-server/src/main/resources/widgets.json
+++ b/ambari-server/src/main/resources/widgets.json
@@ -48,17 +48,12 @@
               "name": "mem_free",
               "metric_path": "metrics/memory/mem_free",
               "service_name": "STACK"
-            },
-            {
-              "name": "mem_cached",
-              "metric_path": "metrics/memory/mem_cached",
-              "service_name": "STACK"
             }
           ],
           "values": [
             {
               "name": "Host Memory Used %",
-              "value": "${((mem_total - mem_free - mem_cached)/mem_total)*100}"
+              "value": "${((mem_total - mem_free)/mem_total)*100}"
             }
           ],
           "properties": {
@@ -81,7 +76,7 @@
           "values": [
             {
               "name": "Host Memory Used %",
-              "value": "${cpu_wio*100}"
+              "value": "${cpu_wio}"
             }
           ],
           "properties": {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1.Host Memory Used calculation method : ((mem_total - mem_free - mem_cached)/mem_total)*100 
The value of mem_free was collected by psutil.virtual_memory() method in host_info.py file and it correspond to 'available' in results returned by psutil.virtual_memory() .Actually,the available = free + buffers + cached.So,the Host Memory Used calculation method should be ((mem_total - mem_free)/mem_total)*100.

2.Host CPU Wait IO was collected by psutil.cpu_times_percent() method in host_info.py.It has been converted to percentage.So,we should use ${cpu_wio} instead of ${cpu_wio*100} as its value in widgets.json.

## How was this patch tested?
Manually Tested.