### PR TITLE
[AMBARI-24465] Warnings during ambari-agent, ambari-server upgrade (dgrinenko)

### DIFF
--- a/ambari-agent/conf/unix/install-helper.sh
+++ b/ambari-agent/conf/unix/install-helper.sh
@@ -18,18 +18,28 @@
 #                      AGENT INSTALL HELPER                      #
 ##################################################################
 
-INSTALL_HELPER_SERVER="/var/lib/ambari-server/install-helper.sh"
-COMMON_DIR="/usr/lib/ambari-agent/lib/ambari_commons"
-RESOURCE_MANAGEMENT_DIR="/usr/lib/ambari-agent/lib/resource_management"
-JINJA_DIR="/usr/lib/ambari-agent/lib/ambari_jinja2"
-SIMPLEJSON_DIR="/usr/lib/ambari-agent/lib/ambari_simplejson"
-OLD_OLD_COMMON_DIR="/usr/lib/ambari-agent/lib/common_functions"
-AMBARI_AGENT="/usr/lib/ambari-agent/lib/ambari_agent"
-PYTHON_WRAPER_TARGET="/usr/bin/ambari-python-wrap"
-AMBARI_AGENT_VAR="/var/lib/ambari-agent"
-AMBARI_AGENT_BINARY="/etc/init.d/ambari-agent"
-AMBARI_AGENT_BINARY_SYMLINK="/usr/sbin/ambari-agent"
+# WARNING. Please keep the script POSIX compliant and don't use bash extensions
 
+AMBARI_UNIT="ambari-agent"
+ACTION=$1
+AMBARI_AGENT_ROOT_DIR="/usr/lib/${AMBARI_UNIT}"
+AMBARI_SERVER_ROOT_DIR="/usr/lib/ambari-server"
+COMMON_DIR="${AMBARI_AGENT_ROOT_DIR}/lib/ambari_commons"
+RESOURCE_MANAGEMENT_DIR="${AMBARI_AGENT_ROOT_DIR}/lib/resource_management"
+JINJA_DIR="${AMBARI_AGENT_ROOT_DIR}/lib/ambari_jinja2"
+SIMPLEJSON_DIR="${AMBARI_AGENT_ROOT_DIR}/lib/ambari_simplejson"
+OLD_OLD_COMMON_DIR="${AMBARI_AGENT_ROOT_DIR}/lib/common_functions"
+AMBARI_AGENT="${AMBARI_AGENT_ROOT_DIR}/lib/ambari_agent"
+PYTHON_WRAPER_TARGET="/usr/bin/ambari-python-wrap"
+AMBARI_AGENT_VAR="/var/lib/${AMBARI_UNIT}"
+AMBARI_AGENT_BINARY="/etc/init.d/${AMBARI_UNIT}"
+AMBARI_AGENT_BINARY_SYMLINK="/usr/sbin/${AMBARI_UNIT}"
+AMBARI_ENV_RPMSAVE="/var/lib/${AMBARI_UNIT}/ambari-env.sh.rpmsave"
+AMBARI_HELPER="/var/lib/ambari-agent/install-helper.sh.orig"
+
+LOG_FILE=/dev/null
+
+CLEANUP_MODULES="resource_management;ambari_commons;ambari_agent;ambari_ws4py;ambari_stomp;ambari_jinja2;ambari_simplejson"
 
 OLD_COMMON_DIR="/usr/lib/python2.6/site-packages/ambari_commons"
 OLD_RESOURCE_MANAGEMENT_DIR="/usr/lib/python2.6/site-packages/resource_management"
@@ -37,14 +47,89 @@ OLD_JINJA_DIR="/usr/lib/python2.6/site-packages/ambari_jinja2"
 OLD_SIMPLEJSON_DIR="/usr/lib/python2.6/site-packages/ambari_simplejson"
 OLD_AMBARI_AGENT_DIR="/usr/lib/python2.6/site-packages/ambari_agent"
 
-clean_pyc_files(){
-  # cleaning old *.pyc files
-  find ${RESOURCE_MANAGEMENT_DIR:?} -name *.pyc -exec rm {} \;
-  find ${COMMON_DIR:?} -name *.pyc -exec rm {} \;
-  find ${AMBARI_AGENT:?} -name *.pyc -exec rm {} \;
-  find ${AMBARI_AGENT_VAR:?} -name *.pyc -exec rm {} \;
+
+resolve_log_file(){
+ local log_dir=/var/log/${AMBARI_UNIT}
+ local log_file="${log_dir}/${AMBARI_UNIT}-pkgmgr.log"
+
+ if [ ! -d "${log_dir}" ]; then
+   mkdir "${log_dir}" 1>/dev/null 2>&1
+ fi
+
+ if [ -d "${log_dir}" ]; then
+   touch ${log_file} 1>/dev/null 2>&1
+   if [ -f "${log_file}" ]; then
+    LOG_FILE="${log_file}"
+   fi
+ fi
+
+ echo "--> Install-helper custom action log started at $(date '+%d/%m/%y %H:%M') for '${ACTION}'" 1>>${LOG_FILE} 2>&1
 }
 
+clean_pyc_files(){
+  # cleaning old *.pyc files
+  local lib_dir="${AMBARI_AGENT_ROOT_DIR}/lib"
+
+  echo ${CLEANUP_MODULES} | tr ';' '\n' | while read item; do
+    local item="${lib_dir}/${item}"
+    echo "Cleaning pyc files from ${item}..."
+    if [ -d "${item}" ]; then
+      find ${item:?} -name *.pyc -exec rm {} \; 1>>${LOG_FILE} 2>&1
+    else
+      echo "Skipping ${item} pyc cleaning, as package not existing"
+    fi
+  done
+}
+
+remove_ambari_unit_dir(){
+  # removing empty dirs, which left after cleaning pyc files
+
+  find "${AMBARI_AGENT_ROOT_DIR}" -type d | tac | while read item; do
+    echo "Removing empty dir ${item}..."
+    rmdir --ignore-fail-on-non-empty ${item} 1>/dev/null 2>&1
+  done
+
+  rm -rf ${AMBARI_HELPER}
+  find "${AMBARI_AGENT_VAR}" -type d | tac | while read item; do
+    echo "Removing empty dir ${item}..."
+    rmdir --ignore-fail-on-non-empty ${item} 1>/dev/null 2>&1
+  done
+}
+
+remove_autostart(){
+  which chkconfig
+  if [ "$?" -eq 0 ] ; then
+    chkconfig --list | grep ambari-server && chkconfig --del ambari-agent
+  fi
+  which update-rc.d
+  if [ "$?" -eq 0 ] ; then
+    update-rc.d -f ambari-agent remove
+  fi
+}
+
+install_autostart(){
+  which chkconfig 1>>${LOG_FILE} 2>&1
+  if [ "$?" -eq 0 ] ; then
+    chkconfig --add ambari-agent
+  fi
+  which update-rc.d 1>>${LOG_FILE} 2>&1
+  if [ "$?" -eq 0 ] ; then
+    update-rc.d ambari-agent defaults
+  fi
+}
+
+locate_python(){
+  local python_binaries="/usr/bin/python;/usr/bin/python2;/usr/bin/python2.7"
+
+  echo ${python_binaries}| tr ';' '\n' | while read python_binary; do
+    ${python_binary} -c "import sys ; ver = sys.version_info ; sys.exit(not (ver >= (2,7) and ver<(3,0)))" 1>>${LOG_FILE} 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+      echo "${python_binary}"
+      break
+    fi
+  done
+}
 
 do_install(){
   if [ -d "/etc/ambari-agent/conf.save" ]; then
@@ -53,135 +138,115 @@ do_install(){
   fi
 
   # these symlinks (or directories) where created in ambari releases prior to ambari-2.6.2. Do clean up.   
-  rm -rf "$OLD_COMMON_DIR" "$OLD_RESOURCE_MANAGEMENT_DIR" "$OLD_JINJA_DIR" "$OLD_SIMPLEJSON_DIR" "$OLD_OLD_COMMON_DIR" "$OLD_AMBARI_AGENT_DIR"
+  rm -rf "${OLD_COMMON_DIR}" "${OLD_RESOURCE_MANAGEMENT_DIR}" "${OLD_JINJA_DIR}" "${OLD_SIMPLEJSON_DIR}" "${OLD_OLD_COMMON_DIR}" "${OLD_AMBARI_AGENT_DIR}"
 
   # setting up /usr/sbin/ambari-agent symlink
-  rm -f "$AMBARI_AGENT_BINARY_SYMLINK"
-  ln -s "$AMBARI_AGENT_BINARY" "$AMBARI_AGENT_BINARY_SYMLINK"
+  rm -f "${AMBARI_AGENT_BINARY_SYMLINK}"
+  ln -s "${AMBARI_AGENT_BINARY}" "${AMBARI_AGENT_BINARY_SYMLINK}"
 
   # on nano Ubuntu, when umask=027 those folders are created without 'x' bit for 'others'.
   # which causes failures when hadoop users try to access tmp_dir
-  chmod a+x $AMBARI_AGENT_VAR
+  chmod a+x ${AMBARI_AGENT_VAR}
 
-  chmod 1777 $AMBARI_AGENT_VAR/tmp
-  chmod 700 $AMBARI_AGENT_VAR/keys
-  chmod 700 $AMBARI_AGENT_VAR/data
+  chmod 1777 ${AMBARI_AGENT_VAR}/tmp
+  chmod 700 ${AMBARI_AGENT_VAR}/keys
+  chmod 700 ${AMBARI_AGENT_VAR}/data
 
-  #TODO we need this when upgrading from pre 2.4 versions to 2.4, remove this when upgrade from pre 2.4 versions will be
-  #TODO unsupported
-  clean_pyc_files
-
-  which chkconfig > /dev/null 2>&1
-  if [ "$?" -eq 0 ] ; then
-    chkconfig --add ambari-agent
-  fi
-  which update-rc.d > /dev/null 2>&1
-  if [ "$?" -eq 0 ] ; then
-    update-rc.d ambari-agent defaults
-  fi
+  install_autostart 1>>${LOG_FILE} 2>&1
 
   # remove old python wrapper
-  rm -f "$PYTHON_WRAPER_TARGET"
+  rm -f "${PYTHON_WRAPER_TARGET}"
 
-  AMBARI_PYTHON=""
-  python_binaries=( "/usr/bin/python" "/usr/bin/python2" "/usr/bin/python2.7" "/usr/bin/python2.6" )
-  for python_binary in "${python_binaries[@]}"
-  do
-    $python_binary -c "import sys ; ver = sys.version_info ; sys.exit(not (ver >= (2,6) and ver<(3,0)))" 1>/dev/null 2>/dev/null
+  local ambari_python=$(locate_python)
+  local bak=/etc/ambari-agent/conf/ambari-agent.ini.old
+  local orig=/etc/ambari-agent/conf/ambari-agent.ini
+  local upgrade_agent_configs_script=/var/lib/ambari-agent/upgrade_agent_configs.py
 
-    if [ $? -eq 0 ] ; then
-      AMBARI_PYTHON="$python_binary"
-      break;
-    fi
-  done
-
-  BAK=/etc/ambari-agent/conf/ambari-agent.ini.old
-  ORIG=/etc/ambari-agent/conf/ambari-agent.ini
-  UPGRADE_AGENT_CONFIGS_SCRIPT=/var/lib/ambari-agent/upgrade_agent_configs.py
-
-  if [ -z "$AMBARI_PYTHON" ] ; then
-    >&2 echo "Cannot detect python for Ambari to use. Please manually set $PYTHON_WRAPER_TARGET link to point to correct python binary"
-    >&2 echo "Cannot upgrade agent configs because python for Ambari is not configured. The old config file is saved as $BAK . Execution of $UPGRADE_AGENT_CONFIGS_SCRIPT was skipped."
+  if [ -z "${ambari_python}" ] ; then
+    >&2 echo "Cannot detect python for Ambari to use. Please manually set ${PYTHON_WRAPER_TARGET} link to point to correct python binary"
+    >&2 echo "Cannot upgrade agent configs because python for Ambari is not configured. The old config file is saved as ${bak} . Execution of ${upgrade_agent_configs_script} was skipped."
   else
-    ln -s "$AMBARI_PYTHON" "$PYTHON_WRAPER_TARGET"
+    ln -s "${ambari_python}" "${PYTHON_WRAPER_TARGET}"
 
-    if [ -f $BAK ]; then
-      if [ -f "$UPGRADE_AGENT_CONFIGS_SCRIPT" ]; then
-        $UPGRADE_AGENT_CONFIGS_SCRIPT
+    if [ -f ${bak} ]; then
+      if [ -f "${upgrade_agent_configs_script}" ]; then
+        ${upgrade_agent_configs_script}
       fi
-      mv $BAK ${BAK}_$(date '+%d_%m_%y_%H_%M').save
+      mv ${bak} ${bak}_$(date '+%d_%m_%y_%H_%M').save
     fi
   fi
 
-  if [ -f "$AMBARI_ENV_RPMSAVE" ] ; then
-    PYTHON_PATH_LINE='export PYTHONPATH=/usr/lib/ambari-agent/lib:$PYTHONPATH'
-    grep "^$PYTHON_PATH_LINE\$" "$AMBARI_ENV_RPMSAVE" > /dev/null
+  if [ -f "${AMBARI_ENV_RPMSAVE}" ] ; then
+    PYTHON_PATH_LINE="export PYTHONPATH=${AMBARI_AGENT_ROOT_DIR}/lib:\$\{PYTHONPATH\}"
+    grep "^${PYTHON_PATH_LINE}\$" "${AMBARI_ENV_RPMSAVE}" >>${LOG_FILE}
     if [ $? -ne 0 ] ; then
-      echo -e "\n$PYTHON_PATH_LINE" >> $AMBARI_ENV_RPMSAVE
+      echo -e "\n${PYTHON_PATH_LINE}" 1>>${AMBARI_ENV_RPMSAVE}
     fi
   fi
 }
 
+copy_helper(){
+  cp -f /var/lib/ambari-agent/install-helper.sh ${AMBARI_HELPER} 1>/dev/null 2>&1
+}
+
 do_remove(){
-  /usr/sbin/ambari-agent stop > /dev/null 2>&1
+  /usr/sbin/ambari-agent stop 1>>${LOG_FILE} 2>&1
 
-  clean_pyc_files
-
-  rm -f "$AMBARI_AGENT_BINARY_SYMLINK"
+  rm -f "${AMBARI_AGENT_BINARY_SYMLINK}" 1>>${LOG_FILE} 2>&1
 
   if [ -d "/etc/ambari-agent/conf.save" ]; then
     mv /etc/ambari-agent/conf.save /etc/ambari-agent/conf_$(date '+%d_%m_%y_%H_%M').save
   fi
-  mv /etc/ambari-agent/conf /etc/ambari-agent/conf.save
+  # first step / label: config_backup
+  cp -rf /etc/ambari-agent/conf /etc/ambari-agent/conf.save
 
-  if [ -f "$PYTHON_WRAPER_TARGET" ]; then
-    rm -f "$PYTHON_WRAPER_TARGET"
-  fi
+  remove_autostart 1>>${LOG_FILE} 2>&1
+  copy_helper 1>>${LOG_FILE} 2>&1
+}
 
-  if [ -d "$COMMON_DIR" ]; then
-    rm -rf $COMMON_DIR
-  fi
+do_cleanup(){
+  # do_cleanup is a function, which called after do_remove stage and is supposed to be save place to
+  # remove obsolete files generated by application activity
 
-  if [ -d "$RESOURCE_MANAGEMENT_DIR" ]; then
-    rm -rf $RESOURCE_MANAGEMENT_DIR
-  fi
+  clean_pyc_files 1>>${LOG_FILE} 2>&1
 
-  if [ -d "$JINJA_DIR" ]; then
-    rm -rf $JINJA_DIR
-  fi
+  # second step / label: config_backup
+  rm -rf /etc/ambari-agent/conf
 
-  if [ -d "$SIMPLEJSON_DIR" ]; then
-    rm -rf $SIMPLEJSON_DIR
-  fi
-
-  # if server package exists, restore their settings
-  if [ -f "$INSTALL_HELPER_SERVER" ]; then  #  call server shared files installer
-    $INSTALL_HELPER_SERVER install
+  if [ ! -d "${AMBARI_SERVER_ROOT_DIR}" ]; then
+    echo "Removing ${PYTHON_WRAPER_TARGET} ..." 1>>${LOG_FILE} 2>&1
+    rm -f ${PYTHON_WRAPER_TARGET} 1>>${LOG_FILE} 2>&1
   fi
 
-  which chkconfig > /dev/null 2>&1
-  if [ "$?" -eq 0 ] ; then
-    chkconfig --list | grep ambari-server && chkconfig --del ambari-agent
-  fi
-  which update-rc.d > /dev/null 2>&1
-  if [ "$?" -eq 0 ] ; then
-    update-rc.d -f ambari-agent remove
-  fi
+  remove_ambari_unit_dir 1>>${LOG_FILE} 2>&1
 }
 
 do_upgrade(){
   do_install
 }
 
+do_backup(){
+  # ToDo: find a way to move backup logic here from preinstall.sh and preinst scripts
+  # ToDo: general problem is that still no files are installed on step, when backup is supposed to be done
+  echo ""
+}
 
-case "$1" in
-install)
-  do_install
-  ;;
-remove)
-  do_remove
-  ;;
-upgrade)
-  do_upgrade
-;;
+resolve_log_file
+
+case "${ACTION}" in
+  install)
+    do_install
+    ;;
+  remove)
+    do_remove
+    ;;
+  upgrade)
+    do_upgrade
+    ;;
+  cleanup)
+    do_cleanup
+    ;;
+  *)
+    echo "Wrong command given"
+    ;;
 esac

--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -296,6 +296,10 @@
             <scriptFile>src/main/package/rpm/posttrans_agent.sh</scriptFile>
             <fileEncoding>utf-8</fileEncoding>
           </posttransScriptlet>
+          <postremoveScriptlet>
+            <scriptFile>src/main/package/rpm/postremove.sh</scriptFile>
+            <fileEncoding>utf-8</fileEncoding>
+          </postremoveScriptlet>
 
           <needarch>x86_64</needarch>
           <autoRequires>false</autoRequires>

--- a/ambari-agent/src/main/package/deb/control/postrm
+++ b/ambari-agent/src/main/package/deb/control/postrm
@@ -14,11 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-if [ "$1" == "upgrade" ]; # Action is upgrade
-then
-  if [ -d "/etc/ambari-agent/conf.save" ]
-  then
-      cp -f /etc/ambari-agent/conf.save/* /etc/ambari-agent/conf
-      mv /etc/ambari-agent/conf.save /etc/ambari-agent/conf_$(date '+%d_%m_%y_%H_%M').save
+INSTALL_HELPER="/var/lib/ambari-agent/install-helper.sh"
+
+if [ "$1" == "upgrade" ]; then
+  if [ -f "${INSTALL_HELPER}" ]; then
+    ${INSTALL_HELPER} upgrade
+  fi
+else
+  if  [ -f "/var/lib/ambari-agent/install-helper.sh.orig" ]; then
+    /var/lib/ambari-agent/install-helper.sh.orig cleanup
+    rm -f /var/lib/ambari-agent/install-helper.sh.orig 1>/dev/null 2>&1
   fi
 fi

--- a/ambari-agent/src/main/package/deb/control/preinst
+++ b/ambari-agent/src/main/package/deb/control/preinst
@@ -14,42 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-STACKS_FOLDER="/var/lib/ambari-agent/cache/stacks"
-STACKS_FOLDER_OLD=/var/lib/ambari-agent/cache/stacks_$(date '+%d_%m_%y_%H_%M').old
 
-COMMON_SERVICES_FOLDER="/var/lib/ambari-agent/cache/common-services"
-COMMON_SERVICES_FOLDER_OLD=/var/lib/ambari-agent/cache/common-services_$(date '+%d_%m_%y_%H_%M').old
+do_backups(){
+  local etc_dir="/etc/ambari-agent"
+  local var_dir="/var/lib/ambari-agent"
+  local sudoers_dir="/etc/sudoers.d"
 
-AMBARI_ENV="/var/lib/ambari-agent/ambari-env.sh"
-AMBARI_ENV_OLD="$AMBARI_ENV.rpmsave"
+  # format: title note source target
+  local backup_folders="stack folders::${var_dir}/cache/stacks:${var_dir}/cache/stacks_$(date '+%d_%m_%y_%H_%M').old
+common services folder::${var_dir}/cache/common-services:${var_dir}/cache/common-services_$(date '+%d_%m_%y_%H_%M').old
+ambari-agent.ini::${etc_dir}/conf/ambari-agent.ini:${etc_dir}/conf/ambari-agent.ini.old
+sudoers:Please restore the file if you were using it for ambari-agent non-root functionality:${sudoers_dir}/ambari-agent:${sudoers_dir}/ambari-agent.bak"
 
-if [ -d "/etc/ambari-agent/conf.save" ]
-then
-    mv /etc/ambari-agent/conf.save /etc/ambari-agent/conf_$(date '+%d_%m_%y_%H_%M').save
-fi
+  echo ${backup_folders} | while IFS=: read title notes source target; do
+    if [ -d "${source}" ] || [ -f "${source}" ]; then
+      echo -n "Moving ${title}: ${source} -> ${target}"
+      if [ ! -z notes ]; then
+        echo ", ${notes}"
+      else
+        echo ""
+      fi
+      mv -f "${source}" "${target}"
+    fi
+  done
+}
 
-BAK=/etc/ambari-agent/conf/ambari-agent.ini.old
-ORIG=/etc/ambari-agent/conf/ambari-agent.ini
-
-BAK_SUDOERS=/etc/sudoers.d/ambari-agent.bak
-ORIG_SUDOERS=/etc/sudoers.d/ambari-agent
-
-[ -f $ORIG ] && mv -f $ORIG $BAK
-[ -f $ORIG_SUDOERS ] && echo "Moving $ORIG_SUDOERS to $BAK_SUDOERS. Please restore the file if you were using it for ambari-agent non-root functionality" && mv -f $ORIG_SUDOERS $BAK_SUDOERS
-
-if [ -d "$STACKS_FOLDER" ]
-then
-    mv -f "$STACKS_FOLDER" "$STACKS_FOLDER_OLD"
-fi
-
-if [ -d "$COMMON_SERVICES_FOLDER" ]
-then
-    mv -f "$COMMON_SERVICES_FOLDER" "$COMMON_SERVICES_FOLDER_OLD"
-fi
-
-if [ -f "$AMBARI_ENV" ]
-then
-    mv -f "$AMBARI_ENV" "$AMBARI_ENV_OLD"
-fi
+do_backups
 
 exit 0

--- a/ambari-agent/src/main/package/deb/control/prerm
+++ b/ambari-agent/src/main/package/deb/control/prerm
@@ -18,6 +18,7 @@
 # during package update. See http://www.ibm.com/developerworks/library/l-rpm2/
 # for details
 
+
 if [ "$1" == "remove" ]; then # Action is uninstall
     if [ -f "/var/lib/ambari-agent/install-helper.sh" ]; then
       /var/lib/ambari-agent/install-helper.sh remove

--- a/ambari-agent/src/main/package/rpm/postremove.sh
+++ b/ambari-agent/src/main/package/rpm/postremove.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-# Warning: don't add changes to this script directly, please add changes to install-helper.sh.
 
-INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
-
-
-if [ "$1" == "remove" ] ; then # Action is uninstall
-    if [ -f "${INSTALL_HELPER}" ]; then
-      ${INSTALL_HELPER} remove
+if [ "$1" -eq 0 ]; then  # Action is uninstall
+    if [ -f "/var/lib/ambari-agent/install-helper.sh.orig" ]; then
+      /var/lib/ambari-agent/install-helper.sh.orig cleanup
+      rm -f /var/lib/ambari-agent/install-helper.sh.orig 1>/dev/null 2>&1
     fi
 fi
 

--- a/ambari-agent/src/main/package/rpm/posttrans_agent.sh
+++ b/ambari-agent/src/main/package/rpm/posttrans_agent.sh
@@ -18,8 +18,8 @@ AMBARI_AGENT_BINARY="/etc/init.d/ambari-agent"
 AMBARI_AGENT_BINARY_SYMLINK="/usr/sbin/ambari-agent"
 
 # setting ambari-agent binary symlink
-if [ ! -f "$AMBARI_AGENT_BINARY_SYMLINK" ]; then
-  ln -s "$AMBARI_AGENT_BINARY" "$AMBARI_AGENT_BINARY_SYMLINK"
+if [ ! -f "${AMBARI_AGENT_BINARY_SYMLINK}" ]; then
+  ln -s "${AMBARI_AGENT_BINARY}" "${AMBARI_AGENT_BINARY_SYMLINK}"
 fi
 
 exit 0

--- a/ambari-agent/src/main/package/rpm/preinstall.sh
+++ b/ambari-agent/src/main/package/rpm/preinstall.sh
@@ -13,34 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-STACKS_FOLDER="/var/lib/ambari-agent/cache/stacks"
-STACKS_FOLDER_OLD=/var/lib/ambari-agent/cache/stacks_$(date '+%d_%m_%y_%H_%M').old
 
-COMMON_SERVICES_FOLDER="/var/lib/ambari-agent/cache/common-services"
-COMMON_SERVICES_FOLDER_OLD=/var/lib/ambari-agent/cache/common-services_$(date '+%d_%m_%y_%H_%M').old
+do_backups(){
+  local etc_dir="/etc/ambari-agent"
+  local var_dir="/var/lib/ambari-agent"
+  local sudoers_dir="/etc/sudoers.d"
 
-if [ -d "/etc/ambari-agent/conf.save" ]
-then
-    mv /etc/ambari-agent/conf.save /etc/ambari-agent/conf_$(date '+%d_%m_%y_%H_%M').save
-fi
+  # format: title note source target
+  local backup_folders="stack folders::${var_dir}/cache/stacks:${var_dir}/cache/stacks_$(date '+%d_%m_%y_%H_%M').old
+common services folder::${var_dir}/cache/common-services:${var_dir}/cache/common-services_$(date '+%d_%m_%y_%H_%M').old
+ambari-agent.ini::${etc_dir}/conf/ambari-agent.ini:${etc_dir}/conf/ambari-agent.ini.old
+sudoers:Please restore the file if you were using it for ambari-agent non-root functionality:${sudoers_dir}/ambari-agent:${sudoers_dir}/ambari-agent.bak"
 
-BAK=/etc/ambari-agent/conf/ambari-agent.ini.old
-ORIG=/etc/ambari-agent/conf/ambari-agent.ini
+  echo "${backup_folders}" | while IFS=: read title notes source target; do
+    if [ -d "${source}" ] || [ -f "${source}" ]; then
+      echo -n "Moving ${title}: ${source} -> ${target}"
 
-BAK_SUDOERS=/etc/sudoers.d/ambari-agent.bak
-ORIG_SUDOERS=/etc/sudoers.d/ambari-agent
+      if [ ! -z ${notes} ]; then
+        echo ", ${notes}"
+      else
+        echo ""
+      fi
 
-[ -f $ORIG ] && mv -f $ORIG $BAK
-[ -f $ORIG_SUDOERS ] && echo "Moving $ORIG_SUDOERS to $BAK_SUDOERS. Please restore the file if you were using it for ambari-agent non-root functionality" && mv -f $ORIG_SUDOERS $BAK_SUDOERS
+      mv -f "${source}" "${target}"
+    fi
+  done
+}
 
-if [ -d "$STACKS_FOLDER" ]
-then
-    mv -f "$STACKS_FOLDER" "$STACKS_FOLDER_OLD"
-fi
-
-if [ -d "$COMMON_SERVICES_FOLDER" ]
-then
-    mv -f "$COMMON_SERVICES_FOLDER" "$COMMON_SERVICES_FOLDER_OLD"
-fi
+do_backups
 
 exit 0

--- a/ambari-agent/src/main/package/rpm/preremove.sh
+++ b/ambari-agent/src/main/package/rpm/preremove.sh
@@ -17,7 +17,6 @@
 # during package update. See http://www.ibm.com/developerworks/library/l-rpm2/
 # for details
 
-
 if [ "$1" -eq 0 ]; then  # Action is uninstall
     if [ -f "/var/lib/ambari-agent/install-helper.sh" ]; then
       /var/lib/ambari-agent/install-helper.sh remove

--- a/ambari-server/conf/unix/install-helper.sh
+++ b/ambari-server/conf/unix/install-helper.sh
@@ -13,39 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#########################################postinstall.sh#########################
+##################################################################
 #                      SERVER INSTALL HELPER                     #
 ##################################################################
+
+# WARNING. Please keep the script POSIX compliant and don't use bash extensions
+
 ROOT_DIR_PATH="${RPM_INSTALL_PREFIX}"
 ROOT=`echo "${RPM_INSTALL_PREFIX}" | sed 's|/$||g'` # Customized folder, which ambari-server files are installed into ('/' or '' are default).
-
-OLD_COMMON_DIR="${ROOT}/usr/lib/python2.6/site-packages/ambari_commons"
-OLD_RESOURCE_MANAGEMENT_DIR="${ROOT}/usr/lib/python2.6/site-packages/resource_management"
-OLD_JINJA_DIR="${ROOT}/usr/lib/python2.6/site-packages/ambari_jinja2"
-OLD_SIMPLEJSON_DIR="${ROOT}/usr/lib/python2.6/site-packages/ambari_simplejson"
-OLD_AMBARI_SERVER_DIR="${ROOT}/usr/lib/python2.6/site-packages/ambari_server"
-
-COMMON_DIR="${ROOT}/usr/lib/ambari-server/lib/ambari_commons"
-RESOURCE_MANAGEMENT_DIR="${ROOT}/usr/lib/ambari-server/lib/resource_management"
-JINJA_DIR="${ROOT}/usr/lib/ambari-server/lib/ambari_jinja2"
-SIMPLEJSON_DIR="${ROOT}/usr/lib/ambari-server/lib/ambari_simplejson"
-AMBARI_SERVER="${ROOT}/usr/lib/ambari-server/lib/ambari_server"
+AMBARI_UNIT="ambari-server"
+ACTION=$1
 
 
-INSTALL_HELPER_AGENT="/var/lib/ambari-agent/install-helper.sh"
-CA_CONFIG="${ROOT}/var/lib/ambari-server/keys/ca.config"
-COMMON_DIR_SERVER="${ROOT}/usr/lib/ambari-server/lib/ambari_commons"
-RESOURCE_MANAGEMENT_DIR_SERVER="${ROOT}/usr/lib/ambari-server/lib/resource_management"
-JINJA_SERVER_DIR="${ROOT}/usr/lib/ambari-server/lib/ambari_jinja2"
-SIMPLEJSON_SERVER_DIR="${ROOT}/usr/lib/ambari-server/lib/ambari_simplejson"
-AMBARI_PROPERTIES="${ROOT}/etc/ambari-server/conf/ambari.properties"
-AMBARI_ENV_RPMSAVE="${ROOT}/var/lib/ambari-server/ambari-env.sh.rpmsave" # this turns into ambari-env.sh during ambari-server start
-AMBARI_SERVER_KEYS_FOLDER="${ROOT}/var/lib/ambari-server/keys"
-AMBARI_SERVER_KEYS_DB_FOLDER="${ROOT}/var/lib/ambari-server/keys/db"
-AMBARI_SERVER_NEWCERTS_FOLDER="${ROOT}/var/lib/ambari-server/keys/db/newcerts"
+OLD_PYLIB_PATH="${ROOT}/usr/lib/python2.6/site-packages"
+OLD_PY_MODULES="ambari_commons;resource_management;ambari_jinja2;ambari_simplejson;ambari_server"
 
-PYTHON_WRAPER_DIR="${ROOT}/usr/bin/"
+AMBARI_SERVER_ROOT_DIR="${ROOT}/usr/lib/${AMBARI_UNIT}"
+AMBARI_AGENT_ROOT_DIR=="${ROOT}/usr/lib/ambari-agent"
+AMBARI_SERVER="${AMBARI_SERVER_ROOT_DIR}/lib/ambari_server"
+
+CA_CONFIG="${ROOT}/var/lib/${AMBARI_UNIT}/keys/ca.config"
+COMMON_DIR_SERVER="${ROOT}/usr/lib/${AMBARI_UNIT}/lib/ambari_commons"
+RESOURCE_MANAGEMENT_DIR_SERVER="${ROOT}/usr/lib/${AMBARI_UNIT}/lib/resource_management"
+JINJA_SERVER_DIR="${ROOT}/usr/lib/${AMBARI_UNIT}/lib/ambari_jinja2"
+SIMPLEJSON_SERVER_DIR="${ROOT}/usr/lib/${AMBARI_UNIT}/lib/ambari_simplejson"
+AMBARI_PROPERTIES="${ROOT}/etc/${AMBARI_UNIT}/conf/ambari.properties"
+AMBARI_ENV_RPMSAVE="${ROOT}/var/lib/${AMBARI_UNIT}/ambari-env.sh.rpmsave" # this turns into ambari-env.sh during ambari-server start
+AMBARI_SERVER_KEYS_FOLDER="${ROOT}/var/lib/${AMBARI_UNIT}/keys"
+AMBARI_SERVER_KEYS_DB_FOLDER="${ROOT}/var/lib/${AMBARI_UNIT}/keys/db"
+AMBARI_SERVER_NEWCERTS_FOLDER="${ROOT}/var/lib/${AMBARI_UNIT}/keys/db/newcerts"
+CLEANUP_MODULES="resource_management;ambari_commons;ambari_server;ambari_ws4py;ambari_stomp;ambari_jinja2;ambari_simplejson"
+AMBARI_SERVER_VAR="${ROOT}/var/lib/${AMBARI_UNIT}"
+AMBARI_HELPER="${ROOT}/var/lib/ambari-server/install-helper.sh.orig"
+
+PYTHON_WRAPER_DIR="${ROOT}/usr/bin"
 PYTHON_WRAPER_TARGET="${PYTHON_WRAPER_DIR}/ambari-python-wrap"
+
+LOG_FILE=/dev/null
 
 AMBARI_SERVER_EXECUTABLE_LINK="${ROOT}/usr/sbin/ambari-server"
 AMBARI_SERVER_EXECUTABLE="${ROOT}/etc/init.d/ambari-server"
@@ -55,136 +59,57 @@ AMBARI_CONFIGS_DIR_SAVE="${ROOT}/etc/ambari-server/conf.save"
 AMBARI_CONFIGS_DIR_SAVE_BACKUP="${ROOT}/etc/ambari-server/conf_$(date '+%d_%m_%y_%H_%M').save"
 AMBARI_LOG4J="${AMBARI_CONFIGS_DIR}/log4j.properties"
 
+
+resolve_log_file(){
+ local log_dir=/var/log/${AMBARI_UNIT}
+ local log_file="${log_dir}/${AMBARI_UNIT}-pkgmgr.log"
+
+ if [ ! -d "${log_dir}" ]; then
+   mkdir "${log_dir}" 1>/dev/null 2>&1
+ fi
+
+ if [ -d "${log_dir}" ]; then
+   touch ${log_file} 1>/dev/null 2>&1
+   if [ -f "${log_file}" ]; then
+    LOG_FILE="${log_file}"
+   fi
+ fi
+
+ echo "--> Install-helper custom action log started at $(date '+%d/%m/%y %H:%M') for '${ACTION}'" 1>>${LOG_FILE} 2>&1
+}
+
 clean_pyc_files(){
   # cleaning old *.pyc files
-  find ${RESOURCE_MANAGEMENT_DIR:?} -name *.pyc -exec rm {} \;
-  find ${COMMON_DIR:?} -name *.pyc -exec rm {} \;
-  find ${AMBARI_SERVER:?} -name *.pyc -exec rm {} \;
-}
+  local lib_dir="${AMBARI_SERVER_ROOT_DIR}/lib"
 
-
-do_install(){
-  rm -f "$AMBARI_SERVER_EXECUTABLE_LINK"
-  ln -s "$AMBARI_SERVER_EXECUTABLE" "$AMBARI_SERVER_EXECUTABLE_LINK"
- 
-rm -rf "$OLD_COMMON_DIR" "$OLD_RESOURCE_MANAGEMENT_DIR" "$OLD_JINJA_DIR" "$OLD_SIMPLEJSON_DIR" "$OLD_COMMON_DIR" "$OLD_AMBARI_SERVER_DIR"
-
-  #TODO we need this when upgrading from pre 2.4 versions to 2.4, remove this when upgrade from pre 2.4 versions will be
-  #TODO unsupported
-  clean_pyc_files
-
-  # remove old python wrapper
-  rm -f "$PYTHON_WRAPER_TARGET"
-
-  AMBARI_PYTHON=""
-  python_binaries=( "/usr/bin/python" "/usr/bin/python2" "/usr/bin/python2.7" "/usr/bin/python2.6" )
-  for python_binary in "${python_binaries[@]}"
-  do
-    $python_binary -c "import sys ; ver = sys.version_info ; sys.exit(not (ver >= (2,6) and ver<(3,0)))" 1>/dev/null 2>/dev/null
-
-    if [ $? -eq 0 ] ; then
-      AMBARI_PYTHON="$python_binary"
-      break;
+  echo ${CLEANUP_MODULES} | tr ';' '\n' | while read item; do
+    local item="${lib_dir}/${item}"
+    echo "Cleaning pyc files from ${item}..."
+    if [ -d "${item}" ]; then
+      find ${item:?} -name *.pyc -exec rm {} \; 1>>${LOG_FILE} 2>&1
+    else
+      echo "Skipping ${item} pyc cleaning, as package not existing"
     fi
   done
-
-  if [ -z "$AMBARI_PYTHON" ] ; then
-    >&2 echo "Cannot detect python for ambari to use. Please manually set $PYTHON_WRAPER link to point to correct python binary"
-  else
-	mkdir -p "$PYTHON_WRAPER_DIR"
-    ln -s "$AMBARI_PYTHON" "$PYTHON_WRAPER_TARGET"
-  fi
-
-  sed -i "s|ambari.root.dir\s*=\s*/|ambari.root.dir=${ROOT_DIR_PATH}|g" "$AMBARI_LOG4J"
-  sed -i "s|root_dir\s*=\s*/|root_dir = ${ROOT_DIR_PATH}|g" "$CA_CONFIG"
-  sed -i "s|^ROOT=\"/\"$|ROOT=\"${ROOT_DIR_PATH}\"|g" "$AMBARI_SERVER_EXECUTABLE"
-
-  AUTOSTART_SERVER_CMD="" 
-  which chkconfig > /dev/null 2>&1
-  if [ "$?" -eq 0 ] ; then
-    AUTOSTART_SERVER_CMD="chkconfig --add ambari-server"
-  fi
-  which update-rc.d > /dev/null 2>&1
-  if [ "$?" -eq 0 ] ; then
-    AUTOSTART_SERVER_CMD="update-rc.d ambari-server defaults"
-  fi
-    
-  # if installed to customized root folder, skip ambari-server service actions,
-  # as no file in /etc/init.d/ambari-server is present
-  if [ ! "${ROOT}/" -ef "/" ] ; then 
-	echo "Not adding ambari-server service to startup, as installed to customized root."
-	echo "If you need this functionality run the commands below, which create ambari-server service and configure it to run at startup: "
-	echo "sudo ln -s ${AMBARI_SERVER_EXECUTABLE} /etc/init.d/ambari-server"
-	echo "sudo $AUTOSTART_SERVER_CMD"
-  else
-	$AUTOSTART_SERVER_CMD
-  fi
-
-  if [ -d "$AMBARI_SERVER_KEYS_FOLDER" ]
-  then
-      chmod 700 "$AMBARI_SERVER_KEYS_FOLDER"
-      if [ -d "$AMBARI_SERVER_KEYS_DB_FOLDER" ]
-      then
-          chmod 700 "$AMBARI_SERVER_KEYS_DB_FOLDER"
-          if [ -d "$AMBARI_SERVER_NEWCERTS_FOLDER" ]
-          then
-              chmod 700 "$AMBARI_SERVER_NEWCERTS_FOLDER"
-
-          fi
-      fi
-  fi
-
-  if [ -f "$AMBARI_ENV_RPMSAVE" ] ; then
-    PYTHON_PATH_LINE='export PYTHONPATH=/usr/lib/ambari-server/lib:$PYTHONPATH'
-    grep "^$PYTHON_PATH_LINE\$" "$AMBARI_ENV_RPMSAVE" > /dev/null
-    if [ $? -ne 0 ] ; then
-      echo -e "\n$PYTHON_PATH_LINE" >> $AMBARI_ENV_RPMSAVE
-    fi
-  fi
 }
 
-do_remove(){
-  $AMBARI_SERVER_EXECUTABLE stop > /dev/null 2>&1
+remove_ambari_unit_dir(){
+  # removing empty dirs, which left after cleaning pyc files
 
-  clean_pyc_files
+  find "${AMBARI_SERVER_ROOT_DIR}" -type d | tac | while read item; do
+    echo "Removing empty dir ${item}..."
+    rmdir --ignore-fail-on-non-empty ${item} 1>/dev/null 2>&1
+  done
 
-  if [ -d "$AMBARI_CONFIGS_DIR_SAVE" ]; then
-    mv "$AMBARI_CONFIGS_DIR_SAVE" "$AMBARI_CONFIGS_DIR_SAVE_BACKUP"
-  fi
-  # Remove link created during install
-  rm -f "$AMBARI_SERVER_EXECUTABLE_LINK"
-  mv "$AMBARI_CONFIGS_DIR" "$AMBARI_CONFIGS_DIR_SAVE"
-    
-  if [ -f "$PYTHON_WRAPER_TARGET" ]; then
-    rm -f "$PYTHON_WRAPER_TARGET"
-  fi
+  rm -rf ${AMBARI_HELPER}
+  find "${AMBARI_SERVER_VAR}" -type d | tac | while read item; do
+    echo "Removing empty dir ${item}..."
+    rmdir --ignore-fail-on-non-empty ${item} 1>/dev/null 2>&1
+  done
+}
 
-  if [ -d "$COMMON_DIR" ]; then
-    rm -f $COMMON_DIR
-  fi
-
-  if [ -d "$RESOURCE_MANAGEMENT_DIR" ]; then
-    rm -f $RESOURCE_MANAGEMENT_DIR
-  fi
-
-  if [ -d "$JINJA_DIR" ]; then
-    rm -f $JINJA_DIR
-  fi
-
-  if [ -d "$SIMPLEJSON_DIR" ]; then
-    rm -f $SIMPLEJSON_DIR
-  fi
-
-  if [ -d "$AMBARI_SERVER" ]; then
-    rm -rf "$AMBARI_SERVER"
-  fi
-
-  # if server package exists, restore their settings
-  if [ -f "$INSTALL_HELPER_AGENT" ]; then  #  call agent shared files installer
-    $INSTALL_HELPER_AGENT install
-  fi
-
-  which chkconfig > /dev/null 2>&1
+remove_autostart(){
+   which chkconfig > /dev/null 2>&1
   if [ "$?" -eq 0 ] ; then
     chkconfig --list | grep ambari-server && chkconfig --del ambari-server
   fi
@@ -194,19 +119,155 @@ do_remove(){
   fi
 }
 
+install_autostart(){
+  local autostart_server_cmd=""
+  which chkconfig > /dev/null 2>&1
+  if [ "$?" -eq 0 ] ; then
+    autostart_server_cmd="chkconfig --add ambari-server"
+  fi
+  which update-rc.d > /dev/null 2>&1
+  if [ "$?" -eq 0 ] ; then
+    autostart_server_cmd="update-rc.d ambari-server defaults"
+  fi
+
+  # if installed to customized root folder, skip ambari-server service actions,
+  # as no file in /etc/init.d/ambari-server is present
+  if [ ! "${ROOT}/" -ef "/" ]; then
+    echo "Not adding ambari-server service to startup, as installed to customized root."
+    echo "If you need this functionality run the commands below, which create ambari-server service and configure it to run at startup: "
+    echo "sudo ln -s ${AMBARI_SERVER_EXECUTABLE} /etc/init.d/ambari-server"
+    echo "sudo ${autostart_server_cmd}"
+  else
+    ${autostart_server_cmd}
+  fi
+}
+
+locate_python(){
+  local python_binaries="/usr/bin/python;/usr/bin/python2;/usr/bin/python2.7"
+
+  echo ${python_binaries}| tr ';' '\n' | while read python_binary; do
+    ${python_binary} -c "import sys ; ver = sys.version_info ; sys.exit(not (ver >= (2,7) and ver<(3,0)))" 1>>${LOG_FILE} 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+      echo "${python_binary}"
+      break
+    fi
+  done
+}
+
+do_install(){
+
+  rm -f "${AMBARI_SERVER_EXECUTABLE_LINK}"
+  ln -s "${AMBARI_SERVER_EXECUTABLE}" "${AMBARI_SERVER_EXECUTABLE_LINK}"
+
+  echo ${OLD_PY_MODULES} | tr ';' '\n' | while read item; do
+   local old_path="${OLD_PYLIB_PATH}/${item}"
+   if [ -d "${old_path}" ]; then
+     echo "Removing old python module ${old_path}..."  1>>${LOG_FILE} 2>&1
+     rm -rf ${old_path} 1>/dev/null 2>&1
+   fi
+  done
+
+  # remove old python wrapper
+  rm -f "${PYTHON_WRAPER_TARGET}"
+
+  local ambari_python=$(locate_python)
+
+  if [ -z "${ambari_python}" ]; then
+    >&2 echo "Cannot detect Python for Ambari to use. Please manually set ${PYTHON_WRAPER_TARGET} link to point to correct Python binary"
+  else
+    mkdir -p "${PYTHON_WRAPER_DIR}"
+    ln -s "${ambari_python}" "${PYTHON_WRAPER_TARGET}"
+  fi
+
+  sed -i "s|ambari.root.dir\s*=\s*/|ambari.root.dir=${ROOT_DIR_PATH}|g" "${AMBARI_LOG4J}"
+  sed -i "s|root_dir\s*=\s*/|root_dir = ${ROOT_DIR_PATH}|g" "${CA_CONFIG}"
+  sed -i "s|^ROOT=\"/\"$|ROOT=\"${ROOT_DIR_PATH}\"|g" "${AMBARI_SERVER_EXECUTABLE}"
+
+  install_autostart |tee -a ${LOG_FILE}
+
+  if [ -d "${AMBARI_SERVER_KEYS_FOLDER}" ]; then
+      chmod 700 "${AMBARI_SERVER_KEYS_FOLDER}"
+      if [ -d "${AMBARI_SERVER_KEYS_DB_FOLDER}" ]; then
+          chmod 700 "${AMBARI_SERVER_KEYS_DB_FOLDER}"
+          if [ -d "${AMBARI_SERVER_NEWCERTS_FOLDER}" ]; then
+              chmod 700 "${AMBARI_SERVER_NEWCERTS_FOLDER}"
+          fi
+      fi
+  fi
+
+  if [ -f "${AMBARI_ENV_RPMSAVE}" ]; then
+    local python_path_line="export PYTHONPATH=${AMBARI_SERVER_ROOT_DIR}/lib:\$\{PYTHONPATH\}"
+    grep "^${python_path_line}\$" "${AMBARI_ENV_RPMSAVE}" > /dev/null
+    if [ $? -ne 0 ]; then
+      echo -e "\n${python_path_line}" >> ${AMBARI_ENV_RPMSAVE}
+    fi
+  fi
+}
+
+copy_helper(){
+  local install_helper="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
+  cp -f ${install_helper} ${AMBARI_HELPER} 1>/dev/null 2>&1
+}
+
+do_remove(){
+  ${AMBARI_SERVER_EXECUTABLE} stop > /dev/null 2>&1
+
+  if [ -d "${AMBARI_CONFIGS_DIR_SAVE}" ]; then
+    mv "${AMBARI_CONFIGS_DIR_SAVE}" "${AMBARI_CONFIGS_DIR_SAVE_BACKUP}"
+  fi
+  # part.1 Remove link created during install AMBARI_ENV_RPMSAVE
+  rm -f "${AMBARI_SERVER_EXECUTABLE_LINK}"
+  cp -rf "${AMBARI_CONFIGS_DIR}" "${AMBARI_CONFIGS_DIR_SAVE}"
+
+  remove_autostart 1>>${LOG_FILE} 2>&1
+  copy_helper
+}
+
+
+do_cleanup(){
+  # do_cleanup is a function, which called after do_remove stage and is supposed to be save place to
+  # remove obsolete files generated by application activity
+
+  clean_pyc_files 1>>${LOG_FILE} 2>&1
+  remove_ambari_unit_dir 1>>${LOG_FILE} 2>&1
+
+  if [ ! -d "${AMBARI_AGENT_ROOT_DIR}" ]; then
+    echo "Removing ${PYTHON_WRAPER_TARGET} ..." 1>>${LOG_FILE} 2>&1
+    rm -f ${PYTHON_WRAPER_TARGET} 1>>${LOG_FILE} 2>&1
+  fi
+
+  # part.2 Remove link created during install AMBARI_ENV_RPMSAVE
+  rm -rf "${AMBARI_CONFIGS_DIR}" 1>>${LOG_FILE} 2>&1
+}
+
+do_backup(){
+  # ToDo: find a way to move backup logic here from preinstall.sh and preinst scripts
+  # ToDo: general problem is that still no files are installed on step, when backup is supposed to be done
+  echo ""
+}
+
 do_upgrade(){
   # this function only gets called for rpm. Deb packages always call do_install directly.
   do_install
 }
 
-case "$1" in
-	install)
-	  do_install
-	  ;;
-	remove)
-	  do_remove
-	  ;;
-	upgrade)
-	  do_upgrade
-	  ;;
+resolve_log_file
+
+case "${ACTION}" in
+    install)
+      do_install
+      ;;
+    remove)
+      do_remove
+      ;;
+    upgrade)
+      do_upgrade
+      ;;
+    cleanup)
+      do_cleanup
+      ;;
+    *)
+      echo "Wrong command given"
+      ;;
 esac

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -556,6 +556,10 @@
             <scriptFile>src/main/package/rpm/posttrans_server.sh</scriptFile>
             <fileEncoding>utf-8</fileEncoding>
           </posttransScriptlet>
+          <postremoveScriptlet>
+            <scriptFile>src/main/package/rpm/postremove.sh</scriptFile>
+            <fileEncoding>utf-8</fileEncoding>
+          </postremoveScriptlet>
           <needarch>x86_64</needarch>
           <mappings>
             <mapping>

--- a/ambari-server/src/main/package/deb/control/postrm
+++ b/ambari-server/src/main/package/deb/control/postrm
@@ -13,3 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+
+INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
+
+if [ "$1" == "upgrade" ]; then
+  if [ -f "${INSTALL_HELPER}" ]; then
+    ${INSTALL_HELPER} upgrade
+  fi
+else
+  if [ -f "/var/lib/ambari-agent/install-helper.sh.orig" ]; then
+    /var/lib/ambari-agent/install-helper.sh.orig cleanup
+    rm -/var/lib/ambari-agent/install-helper.sh.orig 1>/dev/null 2>&1
+  fi
+fi

--- a/ambari-server/src/main/package/deb/control/postrm
+++ b/ambari-server/src/main/package/deb/control/postrm
@@ -15,14 +15,15 @@
 # limitations under the License
 
 INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
+INSTALL_HELPER_ORIG="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh.orig"
 
 if [ "$1" == "upgrade" ]; then
   if [ -f "${INSTALL_HELPER}" ]; then
     ${INSTALL_HELPER} upgrade
   fi
 else
-  if [ -f "/var/lib/ambari-agent/install-helper.sh.orig" ]; then
-    /var/lib/ambari-agent/install-helper.sh.orig cleanup
-    rm -/var/lib/ambari-agent/install-helper.sh.orig 1>/dev/null 2>&1
+  if [ -f "${INSTALL_HELPER_ORIG}" ]; then
+    ${INSTALL_HELPER_ORIG} cleanup
+    rm -f ${INSTALL_HELPER_ORIG} 1>/dev/null 2>&1
   fi
 fi

--- a/ambari-server/src/main/package/deb/control/preinst
+++ b/ambari-server/src/main/package/deb/control/preinst
@@ -14,127 +14,95 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-ROOT="${RPM_INSTALL_PREFIX}"
+ROOT=`echo "${RPM_INSTALL_PREFIX}" | sed 's|/$||g'`
 
-STACKS_FOLDER="${ROOT}/var/lib/ambari-server/resources/stacks"
-STACKS_FOLDER_OLD=${ROOT}/var/lib/ambari-server/resources/stacks_$(date '+%d_%m_%y_%H_%M').old
 
-COMMON_SERVICES_FOLDER="${ROOT}/var/lib/ambari-server/resources/common-services"
-COMMON_SERVICES_FOLDER_OLD=${ROOT}/var/lib/ambari-server/resources/common-services_$(date '+%d_%m_%y_%H_%M').old
+do_backups(){
+  local etc_dir="${ROOT}/etc/ambari-server"
+  local var_dir="${ROOT}/var/lib/ambari-server"
+  local usr_dir="${ROOT}/usr/lib/ambari-server"
+  local usr_backup_dir="${ROOT}/usr/lib/ambari-server-backups"
 
-MPACKS_FOLDER="${ROOT}/var/lib/ambari-server/resources/mpacks"
-MPACKS_FOLDER_OLD=${ROOT}/var/lib/ambari-server/resources/mpacks_$(date '+%d_%m_%y_%H_%M').old
+  local stacks_backup_folder="${var_dir}/resources/stacks_$(date '+%d_%m_%y_%H_%M').old"
+  local common_service_backup_folder="${var_dir}/resources/common-services_$(date '+%d_%m_%y_%H_%M').old"
 
-AMBARI_PROPERTIES="${ROOT}/etc/ambari-server/conf/ambari.properties"
-AMBARI_PROPERTIES_OLD="$AMBARI_PROPERTIES.rpmsave"
+  #  backup configuration
 
-AMBARI_ENV="${ROOT}/var/lib/ambari-server/ambari-env.sh"
-AMBARI_ENV_OLD="$AMBARI_ENV.rpmsave"
+  # data format:  "title:source:destination"; each new record on new line
+  local backup_folders="configs:${etc_dir}/conf.save:${etc_dir}/conf_$(date '+%d_%m_%y_%H_%M').save
+Ambari properties:${etc_dir}/conf/ambari.properties:${etc_dir}/conf/ambari.propertie.rpmsave
+Ambari properties:${var_dir}/ambari-env.sh:${var_dir}/ambari-env.sh.rpmsave
+JAAS login file:${etc_dir}/conf/krb5JAASLogin.conf:${etc_dir}/conf/krb5JAASLogin.conf.rpmsave
+stacks directory:${var_dir}/resources/stacks:${stacks_backup_folder}
+common-services directory:${var_dir}/resources/common-services:${common_service_backup_folder}"
 
-AMBARI_KRB_JAAS_LOGIN_FILE="${ROOT}/etc/ambari-server/conf/krb5JAASLogin.conf"
-AMBARI_KRB_JAAS_LOGIN_FILE_OLD="$AMBARI_KRB_JAAS_LOGIN_FILE.rpmsave"
+ echo "${backup_folders}"| while IFS=: read title source destination; do
+   if [ -d "${source}" ]; then
+     echo "Backing up ${title}: ${source} -> ${destination}" 1>&0
+     mv -f "${source}" "${destination}"
+   fi
+ done
 
-AMBARI_VIEWS_FOLDER="${ROOT}/var/lib/ambari-server/resources/views"
-AMBARI_VIEWS_BACKUP_FOLDER="$AMBARI_VIEWS_FOLDER/backups"
+  # backup mpacks
 
-AMBARI_SERVER_JAR_FILES="/usr/lib/ambari-server/ambari-server-*.jar"
-AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER="/usr/lib/ambari-server-backups"
-SERVER_CONF_SAVE="${ROOT}/etc/ambari-server/conf.save"
-SERVER_CONF_SAVE_BACKUP="${ROOT}/etc/ambari-server/conf_$(date '+%d_%m_%y_%H_%M').save"
+  local mpacks_folder="${ROOT}/var/lib/ambari-server/resources/mpacks"
+  local mpacks_folder_old=${ROOT}/var/lib/ambari-server/resources/mpacks_$(date '+%d_%m_%y_%H_%M').old
 
-if [ -d "$SERVER_CONF_SAVE" ]
-then
-    echo "Backing up configs $SERVER_CONF_SAVE -> $SERVER_CONF_SAVE_BACKUP"
-    mv "$SERVER_CONF_SAVE" "$SERVER_CONF_SAVE_BACKUP"
-fi
-
-if [ -f "$AMBARI_PROPERTIES" ]
-then
-    echo "Backing up Ambari properties $AMBARI_PROPERTIES -> $AMBARI_PROPERTIES_OLD"
-    mv -f "$AMBARI_PROPERTIES" "$AMBARI_PROPERTIES_OLD"
-fi
-
-if [ -f "$AMBARI_ENV" ]
-then
-    echo "Backing up Ambari properties $AMBARI_ENV -> $AMBARI_ENV_OLD"
-    mv -f "$AMBARI_ENV" "$AMBARI_ENV_OLD"
-fi
-
-if [ -f "$AMBARI_KRB_JAAS_LOGIN_FILE" ]
-then
-    echo "Backing up JAAS login file $AMBARI_KRB_JAAS_LOGIN_FILE -> $AMBARI_KRB_JAAS_LOGIN_FILE_OLD"
-    mv -f "$AMBARI_KRB_JAAS_LOGIN_FILE" "$AMBARI_KRB_JAAS_LOGIN_FILE_OLD"
-fi
-
-if [ -d "$STACKS_FOLDER" ]
-then
-    echo "Backing up stacks directory $STACKS_FOLDER -> $STACKS_FOLDER_OLD"
-    mv -f "$STACKS_FOLDER" "$STACKS_FOLDER_OLD"
-fi
-
-if [ -d "$COMMON_SERVICES_FOLDER" ]
-then
-    echo "Backing up common-services directory $COMMON_SERVICES_FOLDER -> $COMMON_SERVICES_FOLDER_OLD"
-    mv -f "$COMMON_SERVICES_FOLDER" "$COMMON_SERVICES_FOLDER_OLD"
-fi
-
-if [ -d "$MPACKS_FOLDER" ]
-then
+  if [ -d "${mpacks_folder}" ]; then
     # Make a copy of mpacks folder
-    if [ ! -d "$MPACKS_FOLDER_OLD" ]; then
-        echo "Backing up mpacks directory $MPACKS_FOLDER -> $MPACKS_FOLDER_OLD"
-        cp -R "$MPACKS_FOLDER" "$MPACKS_FOLDER_OLD"
+    if [ ! -d "${mpacks_folder_old}" ]; then
+      echo "Backing up mpacks directory: ${mpacks_folder} -> ${mpacks_folder_old}"
+      cp -R "${mpacks_folder}" "${mpacks_folder_old}"
     fi
 
-    # Update symlinks in $STACKS_FOLDER_OLD to point to $MPACKS_FOLDER_OLD
-    if [ -d "$STACKS_FOLDER_OLD" ]; then
-        for link in $(find "$STACKS_FOLDER_OLD" -type l)
-        do
-            target=`readlink $link`
-            if grep -q "$MPACKS_FOLDER/"<<<$target; then
-                new_target="${target/$MPACKS_FOLDER/$MPACKS_FOLDER_OLD}"
-                echo "Updating symlink $link -> $new_target"
-                ln -snf $new_target $link
-            fi
+    local symlink_update_folders="${stacks_backup_folder};${common_service_backup_folder}"
+
+    echo ${symlink_update_folders}| tr ';' '\n'| while read item; do
+      if [ -d "${item}" ]; then
+        for link in $(find "${item}" -type l); do
+          local target=`readlink ${link}`
+          echo ${target}|grep -q "${mpacks_folder}/" 1>/dev/null 2>&1
+          if [ $? -eq 0 ]; then
+            local new_target="${target/$mpacks_folder/$mpacks_folder_old}"
+            echo "Updating symlink ${link} -> ${new_target}"
+            ln -snf ${new_target} ${link}
+          fi
         done
-    fi
+      fi
+    done
+  fi
 
-    # Update symlinks in $COMMON_SERVICES_FOLDER_OLD to point to $MPACKS_FOLDER_OLD
-    if [ -d "$COMMON_SERVICES_FOLDER_OLD" ]; then
-    for link in $(find "$COMMON_SERVICES_FOLDER_OLD" -type l)
-        do
-            target=`readlink $link`
-            if grep -q "$MPACKS_FOLDER/"<<<$target; then
-                new_target="${target/$MPACKS_FOLDER/$MPACKS_FOLDER_OLD}"
-                echo "Updating symlink $link -> $new_target"
-                ln -snf $new_target $link
-            fi
-        done
-    fi
-fi
+  # backup Ambari Views
 
-if [ ! -d "$AMBARI_VIEWS_BACKUP_FOLDER" ] && [ -d "$AMBARI_VIEWS_FOLDER" ]
-then
-    mkdir "$AMBARI_VIEWS_BACKUP_FOLDER"
-fi
+  local ambari_views_folder="${var_dir}/resources/views"
+  local ambari_views_backup_folder="${ambari_views_folder}/backups"
 
-if [ -d "$AMBARI_VIEWS_FOLDER" ] && [ -d "$AMBARI_VIEWS_BACKUP_FOLDER" ]
-then
-    echo "Backing up Ambari view jars $AMBARI_VIEWS_FOLDER/*.jar -> $AMBARI_VIEWS_BACKUP_FOLDER/"
-    cp -u $AMBARI_VIEWS_FOLDER/*.jar $AMBARI_VIEWS_BACKUP_FOLDER/
-fi
+  if [ ! -d "${ambari_views_backup_folder}" ] && [ -d "${ambari_views_folder}" ]; then
+    mkdir "${ambari_views_backup_folder}"
+  fi
 
-for f in $AMBARI_SERVER_JAR_FILES;
-do
-    if [ -f "$f" ]
-    then
-        if [ ! -d "$AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER" ]
-        then
-            mkdir -p "$AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER"
-        fi
-        echo "Backing up Ambari server jar $f -> $AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER/"
-        mv -f $f $AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER/
-    fi
-done
+  ls ${ambari_views_folder}/*.jar > /dev/null 2>&1
+  local jars_exist=$?
+  if [ -d "${ambari_views_folder}" ] && [ -d "${ambari_views_backup_folder}" ] && [ ${jars_exist} -eq 0 ]; then
+      echo "Backing up Ambari view jars: ${ambari_views_folder}/*.jar -> ${ambari_views_backup_folder}/"
+      cp -u "${ambari_views_folder}/*.jar" "${ambari_views_backup_folder}/"
+  fi
 
-exit 0
+  # backup Ambari Server Jar
+
+  local ambari_server_jar_files="${usr_dir}/ambari-server-*.jar"
+  local ambari_server_jar_files_backup_folder="${usr_backup_dir}"
+
+  if [ ! -d "${ambari_server_jar_files_backup_folder}" ]; then
+      mkdir -p "${ambari_server_jar_files_backup_folder}"
+  fi
+
+  for f in ${ambari_server_jar_files}; do
+      if [ -f "${f}" ]; then
+          echo "Backing up Ambari server jar: ${f} -> ${ambari_server_jar_files_backup_folder}/"
+          mv -f "${f}" "${ambari_server_jar_files_backup_folder}/"
+      fi
+  done
+}
+
+do_backups

--- a/ambari-server/src/main/package/deb/control/preinst
+++ b/ambari-server/src/main/package/deb/control/preinst
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -38,7 +37,7 @@ common-services directory:${var_dir}/resources/common-services:${common_service_
 
  echo "${backup_folders}"| while IFS=: read title source destination; do
    if [ -d "${source}" ]; then
-     echo "Backing up ${title}: ${source} -> ${destination}" 1>&0
+     echo "Backing up ${title}: ${source} -> ${destination}"
      mv -f "${source}" "${destination}"
    fi
  done
@@ -85,20 +84,19 @@ common-services directory:${var_dir}/resources/common-services:${common_service_
   local jars_exist=$?
   if [ -d "${ambari_views_folder}" ] && [ -d "${ambari_views_backup_folder}" ] && [ ${jars_exist} -eq 0 ]; then
       echo "Backing up Ambari view jars: ${ambari_views_folder}/*.jar -> ${ambari_views_backup_folder}/"
-      cp -u "${ambari_views_folder}/*.jar" "${ambari_views_backup_folder}/"
+      cp -u ${ambari_views_folder}/*.jar "${ambari_views_backup_folder}/" 1>/dev/null 2>&1
   fi
 
   # backup Ambari Server Jar
 
-  local ambari_server_jar_files="${usr_dir}/ambari-server-*.jar"
+  local ambari_server_jar_files=${usr_dir}/ambari-server-*.jar
   local ambari_server_jar_files_backup_folder="${usr_backup_dir}"
-
-  if [ ! -d "${ambari_server_jar_files_backup_folder}" ]; then
-      mkdir -p "${ambari_server_jar_files_backup_folder}"
-  fi
 
   for f in ${ambari_server_jar_files}; do
       if [ -f "${f}" ]; then
+          if [ ! -d "${ambari_server_jar_files_backup_folder}" ]; then
+              mkdir -p "${ambari_server_jar_files_backup_folder}"
+          fi
           echo "Backing up Ambari server jar: ${f} -> ${ambari_server_jar_files_backup_folder}/"
           mv -f "${f}" "${ambari_server_jar_files_backup_folder}/"
       fi

--- a/ambari-server/src/main/package/rpm/postinstall.sh
+++ b/ambari-server/src/main/package/rpm/postinstall.sh
@@ -20,12 +20,12 @@ INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
 case "$1" in
   1) # Action install
     if [ -f "$INSTALL_HELPER" ]; then
-        $INSTALL_HELPER install
+        ${INSTALL_HELPER} install
     fi
   ;;
   2) # Action upgrade
     if [ -f "$INSTALL_HELPER" ]; then
-        $INSTALL_HELPER upgrade
+        ${INSTALL_HELPER} upgrade
     fi
   ;;
 esac

--- a/ambari-server/src/main/package/rpm/postremove.sh
+++ b/ambari-server/src/main/package/rpm/postremove.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-# Warning: don't add changes to this script directly, please add changes to install-helper.sh.
+INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh.orig"
 
-INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
-
-
-if [ "$1" == "remove" ] ; then # Action is uninstall
+if [ "$1" -eq 0 ]; then  # Action is uninstall
     if [ -f "${INSTALL_HELPER}" ]; then
-      ${INSTALL_HELPER} remove
+      ${INSTALL_HELPER} cleanup
+      rm -f ${INSTALL_HELPER} 1>/dev/null 2>&1
     fi
 fi
 

--- a/ambari-server/src/main/package/rpm/preinstall.sh
+++ b/ambari-server/src/main/package/rpm/preinstall.sh
@@ -15,127 +15,92 @@
 
 ROOT=`echo "${RPM_INSTALL_PREFIX}" | sed 's|/$||g'`
 
-STACKS_FOLDER="${ROOT}/var/lib/ambari-server/resources/stacks"
-STACKS_FOLDER_OLD="${ROOT}/var/lib/ambari-server/resources/stacks_$(date '+%d_%m_%y_%H_%M').old"
 
-COMMON_SERVICES_FOLDER=${ROOT}"/var/lib/ambari-server/resources/common-services"
-COMMON_SERVICES_FOLDER_OLD="${ROOT}/var/lib/ambari-server/resources/common-services_$(date '+%d_%m_%y_%H_%M').old"
+do_backups(){
+  local etc_dir="${ROOT}/etc/ambari-server"
+  local var_dir="${ROOT}/var/lib/ambari-server"
+  local usr_dir="${ROOT}/usr/lib/ambari-server"
+  local usr_backup_dir="${ROOT}/usr/lib/ambari-server-backups"
 
-MPACKS_FOLDER="${ROOT}/var/lib/ambari-server/resources/mpacks"
-MPACKS_FOLDER_OLD=${ROOT}/var/lib/ambari-server/resources/mpacks_$(date '+%d_%m_%y_%H_%M').old
+  local stacks_backup_folder="${var_dir}/resources/stacks_$(date '+%d_%m_%y_%H_%M').old"
+  local common_service_backup_folder="${var_dir}/resources/common-services_$(date '+%d_%m_%y_%H_%M').old"
 
-AMBARI_PROPERTIES="${ROOT}/etc/ambari-server/conf/ambari.properties"
-AMBARI_PROPERTIES_OLD="$AMBARI_PROPERTIES.rpmsave"
+  #  backup configuration
 
-AMBARI_ENV="${ROOT}/var/lib/ambari-server/ambari-env.sh"
-AMBARI_ENV_OLD="$AMBARI_ENV.rpmsave"
+  # data format:  "title:source:destination"; each new record on new line
+  local backup_folders="configs:${etc_dir}/conf.save:${etc_dir}/conf_$(date '+%d_%m_%y_%H_%M').save
+Ambari properties:${etc_dir}/conf/ambari.properties:${etc_dir}/conf/ambari.propertie.rpmsave
+Ambari properties:${var_dir}/ambari-env.sh:${var_dir}/ambari-env.sh.rpmsave
+JAAS login file:${etc_dir}/conf/krb5JAASLogin.conf:${etc_dir}/conf/krb5JAASLogin.conf.rpmsave
+stacks directory:${var_dir}/resources/stacks:${stacks_backup_folder}
+common-services directory:${var_dir}/resources/common-services:${common_service_backup_folder}"
 
-AMBARI_KRB_JAAS_LOGIN_FILE="${ROOT}/etc/ambari-server/conf/krb5JAASLogin.conf"
-AMBARI_KRB_JAAS_LOGIN_FILE_OLD="$AMBARI_KRB_JAAS_LOGIN_FILE.rpmsave"
+ echo "${backup_folders}"| while IFS=: read title source destination; do
+   if [ -d "${source}" ]; then
+     echo "Backing up ${title}: ${source} -> ${destination}"
+     mv -f "${source}" "${destination}"
+   fi
+ done
 
-AMBARI_VIEWS_FOLDER="${ROOT}/var/lib/ambari-server/resources/views"
-AMBARI_VIEWS_BACKUP_FOLDER="$AMBARI_VIEWS_FOLDER/backups"
+  # backup mpacks
 
-AMBARI_SERVER_JAR_FILES="/usr/lib/ambari-server/ambari-server-*.jar"
-AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER="/usr/lib/ambari-server-backups"
-SERVER_CONF_SAVE="${ROOT}/etc/ambari-server/conf.save"
-SERVER_CONF_SAVE_BACKUP="${ROOT}/etc/ambari-server/conf_$(date '+%d_%m_%y_%H_%M').save"
+  local mpacks_folder="${ROOT}/var/lib/ambari-server/resources/mpacks"
+  local mpacks_folder_old=${ROOT}/var/lib/ambari-server/resources/mpacks_$(date '+%d_%m_%y_%H_%M').old
 
-if [ -d "$SERVER_CONF_SAVE" ]
-then
-    echo "Backing up configs $SERVER_CONF_SAVE -> $SERVER_CONF_SAVE_BACKUP"
-    mv "$SERVER_CONF_SAVE" "$SERVER_CONF_SAVE_BACKUP"
-fi
-
-if [ -f "$AMBARI_PROPERTIES" ]
-then
-    echo "Backing up Ambari properties $AMBARI_PROPERTIES -> $AMBARI_PROPERTIES_OLD"
-    cp -n "$AMBARI_PROPERTIES" "$AMBARI_PROPERTIES_OLD"
-fi
-
-if [ -f "$AMBARI_ENV" ]
-then
-    echo "Backing up Ambari properties $AMBARI_ENV -> $AMBARI_ENV_OLD"
-    cp -n "$AMBARI_ENV" "$AMBARI_ENV_OLD"
-fi
-
-if [ -f "$AMBARI_KRB_JAAS_LOGIN_FILE" ]
-then
-    echo "Backing up JAAS login file $AMBARI_KRB_JAAS_LOGIN_FILE -> $AMBARI_KRB_JAAS_LOGIN_FILE_OLD"
-    cp -n "$AMBARI_KRB_JAAS_LOGIN_FILE" "$AMBARI_KRB_JAAS_LOGIN_FILE_OLD"
-fi
-
-if [ -d "$STACKS_FOLDER" ]
-then
-    echo "Backing up stacks directory $STACKS_FOLDER -> $STACKS_FOLDER_OLD"
-    mv -f "$STACKS_FOLDER" "$STACKS_FOLDER_OLD"
-fi
-
-if [ -d "$COMMON_SERVICES_FOLDER" ]
-then
-    echo "Backing up common-services directory $COMMON_SERVICES_FOLDER -> $COMMON_SERVICES_FOLDER_OLD"
-    mv -f "$COMMON_SERVICES_FOLDER" "$COMMON_SERVICES_FOLDER_OLD"
-fi
-
-if [ -d "$MPACKS_FOLDER" ]
-then
+  if [ -d "${mpacks_folder}" ]; then
     # Make a copy of mpacks folder
-    if [ ! -d "$MPACKS_FOLDER_OLD" ]; then
-        echo "Backing up mpacks directory $MPACKS_FOLDER -> $MPACKS_FOLDER_OLD"
-        cp -R "$MPACKS_FOLDER" "$MPACKS_FOLDER_OLD"
+    if [ ! -d "${mpacks_folder_old}" ]; then
+      echo "Backing up mpacks directory: ${mpacks_folder} -> ${mpacks_folder_old}"
+      cp -R "${mpacks_folder}" "${mpacks_folder_old}"
     fi
 
-    # Update symlinks in $STACKS_FOLDER_OLD to point to $MPACKS_FOLDER_OLD
-    if [ -d "$STACKS_FOLDER_OLD" ]; then
-        for link in $(find "$STACKS_FOLDER_OLD" -type l)
-        do
-            target=`readlink $link`
-            if grep -q "$MPACKS_FOLDER/"<<<$target; then
-                new_target="${target/$MPACKS_FOLDER/$MPACKS_FOLDER_OLD}"
-                echo "Updating symlink $link -> $new_target"
-                ln -snf $new_target $link
-            fi
+    local symlink_update_folders="${stacks_backup_folder};${common_service_backup_folder}"
+
+    echo ${symlink_update_folders}| tr ';' '\n'| while read item; do
+      if [ -d "${item}" ]; then
+        for link in $(find "${item}" -type l); do
+          local target=`readlink ${link}`
+          echo ${target}|grep -q "${mpacks_folder}/" 1>/dev/null 2>&1
+          if [ $? -eq 0 ]; then
+            local new_target="${target/$mpacks_folder/$mpacks_folder_old}"
+            echo "Updating symlink ${link} -> ${new_target}"
+            ln -snf ${new_target} ${link}
+          fi
         done
-    fi
+      fi
+    done
+  fi
 
-    # Update symlinks in $COMMON_SERVICES_FOLDER_OLD to point to $MPACKS_FOLDER_OLD
-    if [ -d "$COMMON_SERVICES_FOLDER_OLD" ]; then
-    for link in $(find "$COMMON_SERVICES_FOLDER_OLD" -type l)
-        do
-            target=`readlink $link`
-            if grep -q "$MPACKS_FOLDER/"<<<$target; then
-                new_target="${target/$MPACKS_FOLDER/$MPACKS_FOLDER_OLD}"
-                echo "Updating symlink $link -> $new_target"
-                ln -snf $new_target $link
-            fi
-        done
-    fi
-fi
+  # backup Ambari Views
 
-if [ ! -d "$AMBARI_VIEWS_BACKUP_FOLDER" ] && [ -d "$AMBARI_VIEWS_FOLDER" ]
-then
-    mkdir "$AMBARI_VIEWS_BACKUP_FOLDER"
-fi
+  local ambari_views_folder="${var_dir}/resources/views"
+  local ambari_views_backup_folder="${ambari_views_folder}/backups"
 
-ls $AMBARI_VIEWS_FOLDER/*.jar > /dev/null 2>&1
-JARS_EXIST="$?"
-if [ -d "$AMBARI_VIEWS_FOLDER" ] && [ -d "$AMBARI_VIEWS_BACKUP_FOLDER" ] && [ "$JARS_EXIST" -eq 0 ]
-then
-    echo "Backing up Ambari view jars $AMBARI_VIEWS_FOLDER/*.jar -> $AMBARI_VIEWS_BACKUP_FOLDER/"
-    cp -u $AMBARI_VIEWS_FOLDER/*.jar $AMBARI_VIEWS_BACKUP_FOLDER/
-fi
+  if [ ! -d "${ambari_views_backup_folder}" ] && [ -d "${ambari_views_folder}" ]; then
+    mkdir "${ambari_views_backup_folder}"
+  fi
 
-for f in $AMBARI_SERVER_JAR_FILES;
-do
-    if [ -f "$f" ]
-    then
-        if [ ! -d "$AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER" ]
-        then
-            mkdir -p "$AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER"
-        fi
-        echo "Backing up Ambari server jar $f -> $AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER/"
-        mv -f $f $AMBARI_SERVER_JAR_FILES_BACKUP_FOLDER/
-    fi
-done
+  ls ${ambari_views_folder}/*.jar > /dev/null 2>&1
+  local jars_exist=$?
+  if [ -d "${ambari_views_folder}" ] && [ -d "${ambari_views_backup_folder}" ] && [ ${jars_exist} -eq 0 ]; then
+      echo "Backing up Ambari view jars: ${ambari_views_folder}/*.jar -> ${ambari_views_backup_folder}/"
+      cp -u ${ambari_views_folder}/*.jar "${ambari_views_backup_folder}/" 1>/dev/null 2>&1
+  fi
 
-exit 0
+  # backup Ambari Server Jar
+
+  local ambari_server_jar_files=${usr_dir}/ambari-server-*.jar
+  local ambari_server_jar_files_backup_folder="${usr_backup_dir}"
+
+  for f in ${ambari_server_jar_files}; do
+      if [ -f "${f}" ]; then
+          if [ ! -d "${ambari_server_jar_files_backup_folder}" ]; then
+              mkdir -p "${ambari_server_jar_files_backup_folder}"
+          fi
+          echo "Backing up Ambari server jar: ${f} -> ${ambari_server_jar_files_backup_folder}/"
+          mv -f "${f}" "${ambari_server_jar_files_backup_folder}/"
+      fi
+  done
+}
+
+do_backups

--- a/ambari-server/src/main/package/rpm/preremove.sh
+++ b/ambari-server/src/main/package/rpm/preremove.sh
@@ -21,9 +21,10 @@
 
 INSTALL_HELPER="${RPM_INSTALL_PREFIX}/var/lib/ambari-server/install-helper.sh"
 
+
 if [ "$1" -eq 0 ]; then  # Action is uninstall
-    if [ -f "$INSTALL_HELPER" ]; then
-      $INSTALL_HELPER remove
+    if [ -f "${INSTALL_HELPER}" ]; then
+      ${INSTALL_HELPER} remove
     fi
 fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes:
- installation scripts for debian/ubuntu now are equal to installation scripts for centos
- bash extensions usage were removed and replaced to POSIX compatible structures, to support dash shell on ubuntu
- fixed various issues on package removal stage, when not all files were removed properly
- no more spam about auto-start registering/removing, not founded files and another abusive output
- implemented a way to log actions, if needed, to ambari log directory. All required logging now redirected to /var/log/ambari-[server|agent]-pkgmgr.log 
- removed python 2.6 support

## How was this patch tested?
On real clusters running under cenos and ubuntu. File system on each stage (install/upgrade/remove) were captured and compared against deploys without changes, no problems or regressions found