### PR TITLE
[AMBARI-24470] HDP 3.0 Livy2-Server fails to start.

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/params.py
@@ -214,6 +214,7 @@ if stack_version_formatted and check_stack_feature(StackFeature.SPARK_LIVY2, sta
   livy2_hdfs_user_dir = format("/user/{livy2_user}")
   livy2_server_pid_file = status_params.livy2_server_pid_file
   livy2_recovery_dir = default("/configurations/livy2-conf/livy.server.recovery.state-store.url", "/livy2-recovery")
+  livy2_recovery_store = default("/configurations/livy2-conf/livy.server.recovery.state-store", "filesystem")
 
   livy2_server_start = format("{livy2_home}/bin/livy-server start")
   livy2_server_stop = format("{livy2_home}/bin/livy-server stop")

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/setup_livy2.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/setup_livy2.py
@@ -42,13 +42,14 @@ def setup_livy(env, type, upgrade_type = None, action = None):
     )
     params.HdfsResource(None, action="execute")
 
-    params.HdfsResource(params.livy2_recovery_dir,
-                        type="directory",
-                        action="create_on_execute",
-                        owner=params.livy2_user,
-                        mode=0700
-       )
-    params.HdfsResource(None, action="execute")
+    if params.livy2_recovery_store == 'filesystem':
+      params.HdfsResource(params.livy2_recovery_dir,
+                          type="directory",
+                          action="create_on_execute",
+                          owner=params.livy2_user,
+                          mode=0700
+                          )
+      params.HdfsResource(None, action="execute")
 
   # create livy-env.sh in etc/conf dir
   File(os.path.join(params.livy2_conf, 'livy-env.sh'),


### PR DESCRIPTION
## What changes were proposed in this pull request?

The use of 'zookeeper' as the Livy recovery store does not seem to be supported by Ambari. The Ambari script is trying to create a HDFS directory with the value of livy2-conf/livy.server.recovery.state-store.url which is actually a Zk quorum. Ideally, it needs to look at livy2-conf/livy.server.recovery.state-store and only create the directory if it is 'filesystem'. In this case, the store is 'zookeeper'.

## How was this patch tested?
Manually tested.