### PR TITLE
[AMBARI-24441] [Log Search UI] The graphs are not always resized on window resize event.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/graph.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/graph.component.ts
@@ -23,7 +23,7 @@ import * as d3 from 'd3';
 import * as d3sc from 'd3-scale-chromatic';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/fromEvent';
-import 'rxjs/add/operator/throttleTime';
+import 'rxjs/add/operator/debounceTime';
 import {
 GraphPositionOptions, GraphMarginOptions, GraphTooltipInfo, LegendItem, GraphEventData, GraphEmittedEvent
 } from '@app/classes/graph';
@@ -52,10 +52,10 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
   width: number;
 
   @Input()
-  height: number = 150;
+  height = 150;
 
   @Input()
-  tickPadding: number = 10;
+  tickPadding = 10;
 
   @Input()
   colors: HomogeneousObject<string> = {};
@@ -68,42 +68,42 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
    * @type {boolean}
    */
   @Input()
-  isTimeGraph: boolean = false;
+  isTimeGraph = false;
 
   /**
    * Indicates whether X axis direction is right to left
    * @type {boolean}
    */
   @Input()
-  reverseXRange: boolean = false;
+  reverseXRange = false;
 
   /**
    * Indicates whether Y axis direction is top to bottom
    * @type {boolean}
    */
   @Input()
-  reverseYRange: boolean = false;
+  reverseYRange = false;
 
   /**
    * Indicates whether X axis ticks with fractional values should be displayed on chart (if any)
    * @type {boolean}
    */
   @Input()
-  allowFractionalXTicks: boolean = true;
+  allowFractionalXTicks = true;
 
   /**
    * Indicates whether Y axis ticks with fractional values should be displayed on chart (if any)
    * @type {boolean}
    */
   @Input()
-  allowFractionalYTicks: boolean = true;
+  allowFractionalYTicks = true;
 
   /**
    * Indicated whether Y values equal to 0 should be skipped in tooltip
    * @type {boolean}
    */
   @Input()
-  skipZeroValuesInTooltip: boolean = true;
+  skipZeroValuesInTooltip = true;
 
   /**
    * Indicates whether X axis event should be emitted with formatted string values that are displayed
@@ -111,7 +111,7 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
    * @type {boolean}
    */
   @Input()
-  emitFormattedXTick: boolean = false;
+  emitFormattedXTick = false;
 
   /**
    * Indicates whether Y axis event should be emitted with formatted string values that are displayed
@@ -119,7 +119,7 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
    * @type {boolean}
    */
   @Input()
-  emitFormattedYTick: boolean = false;
+  emitFormattedYTick = false;
 
   @Output()
   xTickContextMenu: EventEmitter<GraphEmittedEvent<MouseEvent>> = new EventEmitter();
@@ -135,9 +135,9 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
   })
   tooltipRef: ElementRef;
 
-  private readonly xAxisClassName: string = 'axis-x';
+  private readonly xAxisClassName = 'axis-x';
 
-  private readonly yAxisClassName: string = 'axis-y';
+  private readonly yAxisClassName = 'axis-y';
 
   protected utils: UtilsService;
 
@@ -179,7 +179,7 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
    * It should be true when the tooltip is out from the window.
    * @type {boolean}
    */
-  private tooltipOnTheLeft: boolean = false;
+  private tooltipOnTheLeft = false;
 
   protected subscriptions: Subscription[] = [];
 
@@ -196,7 +196,7 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
 
   ngOnInit() {
     this.subscriptions.push(
-      Observable.fromEvent(window, 'resize').throttleTime(100).subscribe(this.onWindowResize)
+      Observable.fromEvent(window, 'resize').debounceTime(100).subscribe(this.onWindowResize)
     );
     this.setLegendItems();
   }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.ts
@@ -20,9 +20,6 @@ import {Component, OnInit, ElementRef, ViewChild, HostListener, Input, OnDestroy
 import {FormGroup} from '@angular/forms';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/skipWhile';
-import 'rxjs/add/operator/skip';
-import 'rxjs/add/operator/throttleTime';
 import {LogsContainerService} from '@app/services/logs-container.service';
 import {ServiceLogsHistogramDataService} from '@app/services/storage/service-logs-histogram-data.service';
 import {AuditLogsGraphDataService} from '@app/services/storage/audit-logs-graph-data.service';
@@ -50,7 +47,7 @@ import {LogsStateService} from '@app/services/storage/logs-state.service';
 })
 export class LogsContainerComponent implements OnInit, OnDestroy {
 
-  private isFilterPanelFixedPostioned: boolean = false;
+  private isFilterPanelFixedPostioned = false;
 
   tabs: Observable<LogTypeTab[]> = this.tabsStorage.getAll().map((tabs: LogTypeTab[]) => {
     return tabs.map((tab: LogTypeTab) => {
@@ -159,7 +156,7 @@ export class LogsContainerComponent implements OnInit, OnDestroy {
 
     // set the position of the filter panel depending on the scroll height: so it is fixed when it would be out from the screen
     this.subscriptions.push(
-      Observable.fromEvent(window, 'scroll').subscribe(this.setFixedPositionValue)
+      Observable.fromEvent(window, 'scroll').debounceTime(10).subscribe(this.setFixedPositionValue)
     );
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `throttleTime` RXJS method was used to use in order to decrease the calls of the window resize and window scroll handlers.
But the right method from RXJS is the `debounceTime` since this will make sure that the handler will be called at least once when an event triggered.

All the previous wrong solution has been replaced by the `debounceTime` one.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (11.567 secs / 11.443 secs)
✨  Done in 47.47s.
```


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.