### PR TITLE
 [AMBARI-24440] [Log Search UI] Default logs list length per page should be 100 instead of 10

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-filtering-utils.service.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/services/logs-filtering-utils.service.ts
@@ -265,8 +265,8 @@ export class LogsFilteringUtilsService {
       }
     },
     pageSize: [{
-      label: '10',
-      value: '10'
+      label: '100',
+      value: '100'
     }],
     page: 0,
     query: [],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Trivial default value change.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (10.8 secs / 10.708 secs)
✨  Done in 50.43s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.