### PR TITLE
[AMBARI-24439] [Log Search UI] center the log tabs so they're aligned with the buttons

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.less
@@ -19,7 +19,6 @@
 
 :host {
   display: block;
-  margin-left: auto;
   menu-button {
     margin: 0 1em;
     /deep/ .stop-icon {

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.html
@@ -18,10 +18,10 @@
 <div class="tabs-container container-fluid">
   <div class="row">
     <div class="col-md-12 tabs-menu-container">
-      <tabs class="pull-left" [items]="tabs | async" (tabSwitched)="onSwitchTab($event)"
+      <tabs [items]="tabs | async" (tabSwitched)="onSwitchTab($event)"
         (tabClosed)="onCloseTab($event[0], $event[1])"
         [switchMode]="'ROUTE_SEGMENT'" [basePathForRoutingMode]="routerPath" queryParamsHandling="merge"></tabs>
-      <action-menu class="pull-right"></action-menu>
+      <action-menu></action-menu>
     </div>
   </div>
 </div>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.less
@@ -28,6 +28,13 @@
     border-bottom: 1px solid @table-border-color;
     .tabs-menu-container {
       .flex-vertical-align;
+      height: 62px;
+      action-menu {
+        margin-left: auto;
+      }
+      /deep/ tabs ul.nav.nav-tabs {
+        margin: 0;
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The alignment related styling has been removed from the component scope and added to its parent one. So that it can manage all the child components' alignment.

## How was this patch tested?

It was tested manually and by unit tests: 
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (9.364 secs / 9.238 secs)
✨  Done in 40.67s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.