### PR TITLE
[AMBARI-24474] Data in Install Wizard is restored even after logout

### DIFF
--- a/ambari-web/app/routes/installer.js
+++ b/ambari-web/app/routes/installer.js
@@ -448,9 +448,6 @@ module.exports = Em.Route.extend(App.RouterRedirections, {
         controller.saveComponentsFromConfigs(controller.get('content.componentsFromConfigs'));
         controller.setDBProperty('recommendationsHostGroup', wizardStep7Controller.get('content.recommendationsHostGroup'));
         controller.setDBProperty('masterComponentHosts', wizardStep7Controller.get('content.masterComponentHosts'));
-        App.clusterStatus.setClusterStatus({
-          localdb: App.db.data
-        });
         router.transitionTo('step8');
         console.timeEnd('step7 next');
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If user in Install Wizard goes up to Review step then all his changes are persisted to the server. So after every page refresh old data will be loaded even if later user goes back and makes another changes.

## How was this patch tested?

  21757 passing (35s)
  48 pending