### PR TITLE
AMBARI-24473. Ambari upgrade fails due to NPE when processing Ambari …

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1282,8 +1282,10 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
 
       for (KerberosServiceDescriptor serviceDescriptor : kerberosDescriptor.getServices().values()) {
         updateKerberosIdentities(serviceDescriptor);
-        for (KerberosComponentDescriptor componentDescriptor : serviceDescriptor.getComponents().values()) {
-          updateKerberosIdentities(componentDescriptor);
+        if (MapUtils.isNotEmpty(serviceDescriptor.getComponents())) {
+          for (KerberosComponentDescriptor componentDescriptor : serviceDescriptor.getComponents().values()) {
+            updateKerberosIdentities(componentDescriptor);
+          }
         }
       }
 


### PR DESCRIPTION
…Infra kerberos descriptor changes

## What changes were proposed in this pull request?
check against compoponents in kerberos descriptor as it can be missing (no check agains the service as we are adding that above that code line where the change happens)

## How was this patch tested?
FT: validated manually (replace ambari-server jar with the fix)

please review @rlevas @swagle @g-boros @zeroflag 
