### PR TITLE
[AMBARI-21158] Eliminate Maven warning in Log Feeder Container Registry

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
@@ -73,6 +73,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <excludes>
             <exclude>**/log4j.properties</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2075.

Get rid of Maven warning:

```
[WARNING] Some problems were encountered while building the effective model for org.apache.ambari:ambari-logsearch-logfeeder-container-registry:jar:2.0.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.apache.ambari:ambari-logsearch-logfeeder-container-registry:[unknown-version], ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml, line 73, column 15
```

## How was this patch tested?

```
$ mvn -am -pl ambari-logsearch/ambari-logsearch-logfeeder-container-registry clean package
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] ambari-logsearch                                                   [pom]
[INFO] Ambari Logsearch Log Feeder Container Registry                     [jar]
...
[INFO] BUILD SUCCESS
```