### PR TITLE
AMBARI-24484. HDP-GPL repo's shouldn't be pushed to hosts when GPL license was not applied.

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -781,6 +781,13 @@ class Script(object):
 
     service_name = config['serviceName'] if 'serviceName' in config else None
     repos = CommandRepository(config['repositoryFile'])
+
+    from resource_management.libraries.functions import lzo_utils
+
+    repo_tags_to_skip = set()
+    if not lzo_utils.is_gpl_license_accepted():
+      repo_tags_to_skip.add("GPL")
+    repos.items = [r for r in repos.items if not (repo_tags_to_skip & r.tags)]
     repo_ids = [repo.repo_id for repo in repos.items]
     Logger.info("Command repositories: {0}".format(", ".join(repo_ids)))
     repos.items = [x for x in repos.items if (not x.applicable_services or service_name in x.applicable_services) ]

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -784,10 +784,12 @@ class Script(object):
 
     from resource_management.libraries.functions import lzo_utils
 
+    # remove repos with 'GPL' tag when GPL license is not approved
     repo_tags_to_skip = set()
     if not lzo_utils.is_gpl_license_accepted():
       repo_tags_to_skip.add("GPL")
     repos.items = [r for r in repos.items if not (repo_tags_to_skip & r.tags)]
+
     repo_ids = [repo.repo_id for repo in repos.items]
     Logger.info("Command repositories: {0}".format(", ".join(repo_ids)))
     repos.items = [x for x in repos.items if (not x.applicable_services or service_name in x.applicable_services) ]

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandRepository.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandRepository.java
@@ -272,6 +272,7 @@ public class CommandRepository {
     private List<String> m_applicableServices;
 
     @SerializedName("tags")
+    @JsonProperty("tags")
     private Set<RepoTag> m_tags;
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server sends tags in repos to agent. This allow to filter out repos with 'GPL' tag if needed.

## How was this patch tested?

Manual testing.