### PR TITLE
[AMBARI-24481] Orchestration: Remove singular upgrade pack from Upgra…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -433,25 +433,6 @@ public class UpgradeContext {
   }
 
   /**
-   * Gets the upgrade pack for this upgrade.
-   *
-   * @return the upgrade pack
-   */
-  public UpgradePack getUpgradePack() {
-    return m_upgradePack;
-  }
-
-  /**
-   * Sets the upgrade pack for this upgrade
-   *
-   * @param upgradePack
-   *          the upgrade pack to set
-   */
-  public void setUpgradePack(UpgradePack upgradePack) {
-    m_upgradePack = upgradePack;
-  }
-
-  /**
    * Gets the cluster that the upgrade is for.
    *
    * @return the cluster (never {@code null}).
@@ -601,7 +582,13 @@ public class UpgradeContext {
       return false;
     }
 
-    return m_upgradePack.isDowngradeAllowed();
+    for (MpackChangeSummary summary : m_serviceGroups.values()) {
+      if (!summary.getUpgradePack().isDowngradeAllowed()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeHelper.java
@@ -251,7 +251,7 @@ public class UpgradeHelper {
 
     for (LifecycleType lifecycle : LifecycleType.ordered()) {
 
-      groupsInUpgrade.values().forEach(detail -> {
+      groupsInUpgrade.forEach((serviceGroup, detail) -> {
 
         Mpack target = detail.getTarget();
         UpgradePack upgradePack = detail.getUpgradePack();
@@ -262,7 +262,7 @@ public class UpgradeHelper {
         }
 
         try {
-          groups.addAll(createSequence(context, upgradePack, target, lifecycle));
+          groups.addAll(createSequence(context, upgradePack, target, serviceGroup, lifecycle));
         } catch (AmbariException e) {
           throw new IllegalArgumentException(e);
         }
@@ -286,7 +286,7 @@ public class UpgradeHelper {
    * @return the list of holders
    */
   private List<UpgradeGroupHolder> createSequence(UpgradeContext context, UpgradePack upgradePack,
-      Mpack mpack, LifecycleType lifecycleType) throws AmbariException {
+      Mpack mpack, ServiceGroup serviceGroup, LifecycleType lifecycleType) throws AmbariException {
 
     Cluster cluster = context.getCluster();
     MasterHostResolver mhr = context.getResolver();
@@ -320,6 +320,8 @@ public class UpgradeHelper {
       groupHolder.supportsAutoSkipOnFailure = group.supportsAutoSkipOnFailure;
       groupHolder.allowRetry = group.allowRetry;
       groupHolder.processingGroup = group.isProcessingGroup();
+      groupHolder.upgradePack = upgradePack;
+      groupHolder.serviceGroup = serviceGroup;
 
       // !!! all downgrades are skippable
       if (context.getDirection().isDowngrade()) {
@@ -785,6 +787,16 @@ public class UpgradeHelper {
      * List of stages for the group
      */
     public List<StageWrapper> items = new ArrayList<>();
+
+    /**
+     * Upgrade Pack backing this grouping
+     */
+    public UpgradePack upgradePack;
+
+    /**
+     * Service Group backing this grouping
+     */
+    public ServiceGroup serviceGroup;
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
…deContext; resolve ServiceGroup names

## What changes were proposed in this pull request?

In order to orchestrate properly, the service group names need to be resolved.  In addition, `UpgradeContext` can no longer be the source of an upgrade pack since each service group may have its own.

## How was this patch tested?

Manual testing until unit tests should be made.

Unit test verification in-progress.