### PR TITLE
AMBARI-24486. Yarn Timeline Service V2 Reader is found down after EU …

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/FixTimelineReaderAddressTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/FixTimelineReaderAddressTest.java
@@ -67,7 +67,7 @@ public class FixTimelineReaderAddressTest extends EasyMockSupport {
     expect(cluster.getDesiredConfigByType("yarn-site")).andReturn(config).anyTimes();
     expect(config.getProperties()).andReturn(new HashMap<String, String>() {{
       put("yarn.timeline-service.reader.webapp.address", "localhost:8080");
-      put("yarn.timeline-service.reader.webapp.https.address", "localhost:8081");
+      put("yarn.timeline-service.reader.webapp.https.address", "{{timeline_reader_address_https}}");
     }}).anyTimes();
     expect(yarn.getServiceComponent("TIMELINE_READER")).andReturn(timelineReader).anyTimes();
     expect(timelineReader.getServiceComponentHosts()).andReturn(new HashMap<String, ServiceComponentHost>(){{
@@ -82,7 +82,7 @@ public class FixTimelineReaderAddressTest extends EasyMockSupport {
     }});
     expectLastCall();
     config.updateProperties(new HashMap<String, String>() {{
-      put("yarn.timeline-service.reader.webapp.https.address", "newhost:8081");
+      put("yarn.timeline-service.reader.webapp.https.address", "newhost:8199");
     }});
     expectLastCall();
     replayAll();


### PR DESCRIPTION
…(Atlantic to AtlanticM05) With error - Address already in use (amagyar)

## What changes were proposed in this pull request?

Ambari 2.7 is shipped with a stack where yarn-site/yarn.timeline-service.reader.webapp.address and yarn-site/yarn.timeline-service.reader.webapp.https.address contains placeholders like {{timeline_reader_address_http}} and {timeline_reader_address_https}}. The upgrade task that is responsible for replacing these properties expects localhost:port.

## How was this patch tested?

1) Deployed cluster with Ambari version: 2.7.0.0-897 and HDP version: 3.0.0.0-1634
2) Upgrade Ambari to 2.7.1.0-70
3) Stack Upgrade to 3.0.1.0-73
4) Checked that yarn-site/yarn.timeline-service.reader.webapp.address and yarn-site/yarn.timeline-service.reader.webapp.https.address had the correct value
