### PR TITLE
[AMBARI-24433] [Log Search UI] Reset to default selection in the drop…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
@@ -28,8 +28,10 @@
                          [isRightAlign]="true"></filter-dropdown>
       </form>
       <dropdown-button label="{{'logs.columns' | translate}}" [options]="columns" [isRightAlign]="true"
-                       [isMultipleChoice]="true" (selectItem)="updateSelectedColumns($event)"
-                       [listItemArguments]="logsTypeMapObject.fieldsModel">
+                       (selectItem)="updateSelectedColumns($event)"
+                       [listItemArguments]="logsTypeMapObject.fieldsModel"
+                       [isMultipleChoice]="true"
+                       [useClearToDefaultSelection]="true">
       </dropdown-button>
       <div class="layout-btn-group">
         <a *ngIf="layout==='FLEX'" class="btn" (click)="toggleShowLabels()" tooltip="{{'logs.toggleLabels' | translate}}">

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.html
@@ -29,7 +29,8 @@
       <span *ngIf="!hideCaret" class="caret"></span>
     </span>
   </button>
-  <ul data-component="dropdown-list" [ngClass]="{'dropdown-menu': true, 'dropdown-menu-right': isRightAlign}"
-      [items]="options" [isMultipleChoice]="isMultipleChoice" (selectedItemChange)="updateSelection($event)"
-      [actionArguments]="listItemArguments"></ul>
+  <ul data-component="dropdown-list" (selectedItemChange)="updateSelection($event)"
+    [ngClass]="{'dropdown-menu': true, 'dropdown-menu-right': isRightAlign}"
+    [items]="options" [actionArguments]="listItemArguments" [isMultipleChoice]="isMultipleChoice"
+    [useClearToDefaultSelection]="useClearToDefaultSelection"></ul>
 </div>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.ts
@@ -31,36 +31,41 @@ export class DropdownButtonComponent {
   label?: string;
 
   @Input()
-  buttonClass: string = 'btn-link';
+  buttonClass = 'btn-link';
 
   @Input()
   iconClass?: string;
 
   @Input()
-  hideCaret: boolean = false;
+  hideCaret = false;
 
   @Input()
-  showSelectedValue: boolean = true;
+  showSelectedValue = true;
 
-  @Input() options: ListItem[] = [];
+  @Input()
+  isRightAlign = false;
+
+  @Input()
+  isDropup = false;
+
+  @Input()
+  showCommonLabelWithSelection = false;
+
+  @Output()
+  selectItem: EventEmitter<any> = new EventEmitter();
+
+  // PROXY PROPERTIES TO DROPDOWN LIST COMPONENT
+  @Input()
+  options: ListItem[] = [];
 
   @Input()
   listItemArguments: any[] = [];
 
   @Input()
-  isMultipleChoice: boolean = false;
+  isMultipleChoice = false;
 
   @Input()
-  isRightAlign: boolean = false;
-
-  @Input()
-  isDropup: boolean = false;
-
-  @Input()
-  showCommonLabelWithSelection: boolean = false;
-
-  @Output()
-  selectItem: EventEmitter<any> = new EventEmitter();
+  useClearToDefaultSelection = false;
 
   protected selectedItems?: ListItem[] = [];
 

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.html
@@ -53,9 +53,12 @@
     </label>
   </li>
   <li *ngIf="items && items.length" class="divider"></li>
-  <li class="selections" *ngIf="itemsSelected.length>0">
-    <span>{{'dropdown.selection' | translate:({total: itemsSelected.length})}}</span>
-    <a href="#" (click)="onClearSelectionClick($event)">{{'dropdown.selection.clear' | translate}}</a>
+  <li *ngIf="itemsSelected.length>0 || (useClearToDefaultSelection && defaultSelection && defaultSelection.length)"
+    class="selections" [class.use-clear-to-default]="useClearToDefaultSelection && defaultSelection && defaultSelection.length">
+    <span class="total-selection">{{'dropdown.selection' | translate:({total: itemsSelected.length})}}</span>
+    <a *ngIf="useClearToDefaultSelection && defaultSelection && defaultSelection.length" href="#" class="clear-to-default"
+     (click)="onClearToDefaultSelectionClick($event)">{{'dropdown.selection.clearToDefault' | translate}}</a>
+    <a href="#" class="clear" (click)="onClearSelectionClick($event)">{{'dropdown.selection.clear' | translate}}</a>
   </li>
   <ng-container *ngFor="let item of itemsSelected">
     <ng-container

--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.less
@@ -76,10 +76,31 @@
     }
     &.selections {
       font-size: .75em;
-      padding: .1em 20px;
+      padding: .5em 20px;
+      &.use-clear-to-default {
+        span.total-selection {
+          display: block;
+        }
+        a {
+          padding: 3px 5px;
+          &:first-of-type {
+            padding-left: 0;
+          }
+          &:last-of-type {
+            padding-right: 0;
+          }
+        }
+      }
       a {
         display: inline;
+        &:hover {
+          background: transparent none;
+          text-decoration: underline;
+        }
       }
+    }
+    &.selections:hover {
+      background: transparent none;
     }
   }
 }

--- a/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
@@ -12,6 +12,7 @@
 
   "dropdown.selection": "Selected ({{total}})",
   "dropdown.selection.clear": "(Clear)",
+  "dropdown.selection.clearToDefault": "(Set defaults)",
   "dropdown.selection.all": "All {{listName}} ({{total}})",
 
   "modal.submit": "OK",


### PR DESCRIPTION
## What changes were proposed in this pull request?

- default selection property has been added to dropdown list component: initialised on init or on the first onChanges when the default selection is empty
- link to clear to default when it is enabled and has default selection

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (8.679 secs / 8.57 secs)
✨  Done in 38.62s.
```
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.