### PR TITLE
[AMBARI-24490] [Log Search UI] Time Histogram Chart keep invert grey selection area when no selection happened

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
@@ -250,9 +250,9 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
           const dateRange: [number, number] = this.getTimeRangeByXRanges(startX, endX);
           this.selectArea.emit(dateRange);
           this.dragArea.remove();
-          this.clearInvertDragArea();
           this.setChartTimeGap(new Date(dateRange[0]), new Date(dateRange[1]));
         }
+        this.clearInvertDragArea();
       })
     );
     d3.selectAll(`svg#${this.svgId} .value, svg#${this.svgId} .axis`).call(d3.drag().on('start', (): void => {

--- a/ambari-logsearch/ambari-logsearch-web/src/index.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/index.html
@@ -25,6 +25,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <style>
+    body {
+      background-color: #ECECEC;
+    }
     .spinner {
       width: 40px;
       height: 40px;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moving out the clear action of the invert selection area from the condition of drag&drop check.
+1 fix: add app background to the body to decrease the style change during the application loading.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (10.524 secs / 10.414 secs)
✨  Done in 44.20s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.