### PR TITLE
AMBARI-24496. Ambari updates lates_url info for HDF stacks with HDP l…

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -46,7 +46,7 @@ from ambari_server.serverConfiguration import configDefaults, JDKRelease, get_st
 from ambari_server.serverUtils import is_server_runing
 from ambari_server.setupSecurity import adjust_directory_permissions
 from ambari_server.userInput import get_YN_input, get_validated_string_input
-from ambari_server.utils import locate_file, update_latest_in_repoinfos_for_all_stacks, get_json_url_from_repo_file
+from ambari_server.utils import locate_file, update_latest_in_repoinfos_for_stacks, get_json_url_from_repo_file
 from ambari_server.serverClassPath import ServerClassPath
 from ambari_server.ambariPath import AmbariPath
 
@@ -1221,7 +1221,7 @@ def setup(options):
     print "Ambari repo file contains latest json url {0}, updating stacks repoinfos with it...".format(json_url)
     properties = get_ambari_properties()
     stack_root = get_stack_location(properties)
-    update_latest_in_repoinfos_for_all_stacks(stack_root, json_url)
+    update_latest_in_repoinfos_for_stacks(stack_root, json_url)
   else:
     print "Ambari repo file doesn't contain latest json url, skipping repoinfos modification"
 

--- a/ambari-server/src/main/python/ambari_server/serverUpgrade.py
+++ b/ambari-server/src/main/python/ambari_server/serverUpgrade.py
@@ -45,7 +45,7 @@ from ambari_server.serverConfiguration import configDefaults, get_resources_loca
   AMBARI_ENV_FILE, JDBC_DATABASE_PROPERTY, get_default_views_dir, write_gpl_license_accepted, set_property
 from ambari_server.setupSecurity import adjust_directory_permissions, \
   generate_env, ensure_can_start_under_current_user
-from ambari_server.utils import compare_versions, get_json_url_from_repo_file, update_latest_in_repoinfos_for_all_stacks
+from ambari_server.utils import compare_versions, get_json_url_from_repo_file, update_latest_in_repoinfos_for_stacks
 from ambari_server.serverUtils import is_server_runing, get_ambari_server_api_base, get_ssl_context
 from ambari_server.userInput import get_validated_string_input, get_prompt_default, read_password, get_YN_input
 from ambari_server.serverClassPath import ServerClassPath
@@ -321,7 +321,7 @@ def upgrade(args):
     print "Ambari repo file contains latest json url {0}, updating stacks repoinfos with it...".format(json_url)
     properties = get_ambari_properties()
     stack_root = get_stack_location(properties)
-    update_latest_in_repoinfos_for_all_stacks(stack_root, json_url)
+    update_latest_in_repoinfos_for_stacks(stack_root, json_url)
   else:
     print "Ambari repo file doesn't contain latest json url, skipping repoinfos modification"
 

--- a/ambari-server/src/main/python/ambari_server/utils.py
+++ b/ambari-server/src/main/python/ambari_server/utils.py
@@ -366,12 +366,13 @@ XML_HEADER = """<?xml version="1.0"?>
 
 # Go though all stacks and update the repoinfo.xml files
 # replace <latest> tag with the passed url
-def update_latest_in_repoinfos_for_all_stacks(stacks_root, json_url_string):
+def update_latest_in_repoinfos_for_stacks(stacks_root, json_url_string, predicate=lambda stack_name: stack_name == 'HDP'):
   for stack_name in os.walk(stacks_root).next()[1]:
-    for stack_version in os.walk(os.path.join(stacks_root, stack_name)).next()[1]:
-      repoinfo_xml_path = os.path.join(stacks_root, stack_name, stack_version, "repos", "repoinfo.xml")
-      if os.path.exists(repoinfo_xml_path):
-        replace_latest(repoinfo_xml_path, json_url_string)
+    if predicate(stack_name):
+      for stack_version in os.walk(os.path.join(stacks_root, stack_name)).next()[1]:
+        repoinfo_xml_path = os.path.join(stacks_root, stack_name, stack_version, "repos", "repoinfo.xml")
+        if os.path.exists(repoinfo_xml_path):
+          replace_latest(repoinfo_xml_path, json_url_string)
 
 
 # replace <latest> tag in the file with the passed url


### PR DESCRIPTION
…ink (amagyar)

## What changes were proposed in this pull request?

Ambari updates the repoinfo.xml files in each stack and changes the latest value to the json.url which is found in the repo file (for example /etc/yum.d/ambari.repo). In a non-HDP stack this causes the wrong url to be added to repoinfo.xml

## How was this patch tested?

by calling utils.update_latest_in_repoinfos_for_all_stacks('/var/lib/ambari-server/resources/stacks', 'new-url') manully