### PR TITLE
AMBARI-24504. Solr API reports backup as complete while copy is still in progress.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/metainfo.xml
@@ -49,7 +49,8 @@
               <commandScript>
                 <script>scripts/infra_solr.py</script>
                 <scriptType>PYTHON</scriptType>
-                <timeout>1200</timeout>
+                <timeout>36000</timeout>
+                <background>true</background>
               </commandScript>
             </customCommand>
             <customCommand>

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/collection.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/collection.py
@@ -79,6 +79,9 @@ def backup_collection(env):
       command_commons.snapshot_status_check(status_check_cmd, status_check_json_output, core, True,
                                             log_output=command_commons.log_output, tries=command_commons.request_tries,
                                             time_interval=command_commons.request_time_interval)
+      snapshot_folder=format("{index_location}/snapshot.{core}")
+      if command_commons.check_folder_exists(snapshot_folder):
+        command_commons.check_folder_until_size_not_changes(snapshot_folder)
 
 
 def restore_collection(env):

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/command_commons.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/command_commons.py
@@ -365,7 +365,8 @@ def check_folder_until_size_not_changes(dir):
     if stdout:
       actual_size_str = stdout.strip()
       if actual_size_str == size_str:
-        break
+        size_changed = False
+        continue
       else:
         Logger.info(format("Actual size of '{dir}' is {actual_size_str}, wait 5 sec and check again, to make sure no copy operation is in progress..."))
         time.sleep(5)

--- a/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/command_commons.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_INFRA_SOLR/0.1.0/package/scripts/command_commons.py
@@ -352,3 +352,21 @@ def check_folder_exists(dir):
   if returncode:
     return False
   return True
+
+def check_folder_until_size_not_changes(dir):
+  """
+  Call du -d 0 <folder> | cut -f 1 on specific directory until the size not changes (so copy operation has finished)
+  """
+  cmd = format("du -d 0 {dir} | cut -f 1")
+  size_changed = True
+  size_str = "-1"
+  while size_changed:
+    returncode, stdout = call(cmd, user=params.infra_solr_user, timeout=300)
+    if stdout:
+      actual_size_str = stdout.strip()
+      if actual_size_str == size_str:
+        break
+      else:
+        Logger.info(format("Actual size of '{dir}' is {actual_size_str}, wait 5 sec and check again, to make sure no copy operation is in progress..."))
+        time.sleep(5)
+        size_str = actual_size_str


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the communication between the file system and Solr is really slow, its possible Solr api reports backup as finished, although copy process has not yet finished.

That could be a problem as after backup is finished, we are starting the delete command on collections (therefore we can loose all collections data before the backup is finished)

Simple solution:
Call `du -d 0` on the snapshot folders in every 5 sec, to make sure no copy operation is in progress.
We can assume there will be enough space on the disk for the index. (check-shards command before migration). no try-catch block included as if any exception occurs, backup can be failed.

Also increase backup operation time + change it to background task

## How was this patch tested?
manually. no UTs for command_commons.py + collections.py

Please review @swagle @kasakrisz @zeroflag @adoroszlai 