### PR TITLE
AMBARI-24506. Upgrade: Infra Solr service is not renamed in Upgrade History table.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog271.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog271.java
@@ -35,6 +35,7 @@ import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.dao.DaoUtils;
 import org.apache.ambari.server.orm.entities.ServiceConfigEntity;
+import org.apache.ambari.server.orm.entities.UpgradeHistoryEntity;
 import org.apache.ambari.server.state.BlueprintProvisioningState;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
@@ -112,7 +113,7 @@ public class UpgradeCatalog271 extends AbstractUpgradeCatalog {
     addNewConfigurationsFromXml();
     updateRangerLogDirConfigs();
     updateRangerKmsDbUrl();
-    renameAmbariInfraInConfigGroups();
+    renameAmbariInfraInConfigGroupsAndUpgradeHistory();
     removeLogSearchPatternConfigs();
   }
 
@@ -212,7 +213,7 @@ public class UpgradeCatalog271 extends AbstractUpgradeCatalog {
     }
   }
 
-  protected void renameAmbariInfraInConfigGroups() {
+  protected void renameAmbariInfraInConfigGroupsAndUpgradeHistory() {
     LOG.info("Renaming service AMBARI_INFRA to AMBARI_INFRA_SOLR in config group records");
     AmbariManagementController ambariManagementController = injector.getInstance(AmbariManagementController.class);
     Clusters clusters = ambariManagementController.getClusters();
@@ -239,6 +240,14 @@ public class UpgradeCatalog271 extends AbstractUpgradeCatalog {
       serviceConfigUpdate.setParameter("newServiceName", AMBARI_INFRA_NEW_NAME);
       serviceConfigUpdate.setParameter("oldServiceName", AMBARI_INFRA_OLD_NAME);
       serviceConfigUpdate.executeUpdate();
+    });
+
+    executeInTransaction(() -> {
+      TypedQuery<UpgradeHistoryEntity> upgradeHistoryUpdate = entityManager.createQuery(
+        "UPDATE UpgradeHistoryEntity SET service_name = :newServiceName WHERE service_name = :oldServiceName", UpgradeHistoryEntity.class);
+      upgradeHistoryUpdate.setParameter("newServiceName", AMBARI_INFRA_NEW_NAME);
+      upgradeHistoryUpdate.setParameter("oldServiceName", AMBARI_INFRA_OLD_NAME);
+      upgradeHistoryUpdate.executeUpdate();
     });
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog271.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog271.java
@@ -113,7 +113,7 @@ public class UpgradeCatalog271 extends AbstractUpgradeCatalog {
     addNewConfigurationsFromXml();
     updateRangerLogDirConfigs();
     updateRangerKmsDbUrl();
-    renameAmbariInfraInConfigGroupsAndUpgradeHistory();
+    renameAmbariInfraService();
     removeLogSearchPatternConfigs();
   }
 
@@ -213,7 +213,7 @@ public class UpgradeCatalog271 extends AbstractUpgradeCatalog {
     }
   }
 
-  protected void renameAmbariInfraInConfigGroupsAndUpgradeHistory() {
+  protected void renameAmbariInfraService() {
     LOG.info("Renaming service AMBARI_INFRA to AMBARI_INFRA_SOLR in config group records");
     AmbariManagementController ambariManagementController = injector.getInstance(AmbariManagementController.class);
     Clusters clusters = ambariManagementController.getClusters();

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog271Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog271Test.java
@@ -90,7 +90,7 @@ public class UpgradeCatalog271Test {
     Method addNewConfigurationsFromXml = AbstractUpgradeCatalog.class.getDeclaredMethod("addNewConfigurationsFromXml");
     Method updateRangerLogDirConfigs = UpgradeCatalog271.class.getDeclaredMethod("updateRangerLogDirConfigs");
     Method updateRangerKmsDbUrl = UpgradeCatalog271.class.getDeclaredMethod("updateRangerKmsDbUrl");
-    Method renameAmbariInfraInConfigGroups = UpgradeCatalog271.class.getDeclaredMethod("renameAmbariInfraInConfigGroupsAndUpgradeHistory");
+    Method renameAmbariInfraInConfigGroups = UpgradeCatalog271.class.getDeclaredMethod("renameAmbariInfraService");
     Method removeLogSearchPatternConfigs = UpgradeCatalog271.class.getDeclaredMethod("removeLogSearchPatternConfigs");
 
     UpgradeCatalog271 upgradeCatalog271 = createMockBuilder(UpgradeCatalog271.class)
@@ -110,7 +110,7 @@ public class UpgradeCatalog271Test {
     upgradeCatalog271.updateRangerKmsDbUrl();
     expectLastCall().once();
 
-    upgradeCatalog271.renameAmbariInfraInConfigGroupsAndUpgradeHistory();
+    upgradeCatalog271.renameAmbariInfraService();
     expectLastCall().once();
 
     upgradeCatalog271.removeLogSearchPatternConfigs();

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog271Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog271Test.java
@@ -90,7 +90,7 @@ public class UpgradeCatalog271Test {
     Method addNewConfigurationsFromXml = AbstractUpgradeCatalog.class.getDeclaredMethod("addNewConfigurationsFromXml");
     Method updateRangerLogDirConfigs = UpgradeCatalog271.class.getDeclaredMethod("updateRangerLogDirConfigs");
     Method updateRangerKmsDbUrl = UpgradeCatalog271.class.getDeclaredMethod("updateRangerKmsDbUrl");
-    Method renameAmbariInfraInConfigGroups = UpgradeCatalog271.class.getDeclaredMethod("renameAmbariInfraInConfigGroups");
+    Method renameAmbariInfraInConfigGroups = UpgradeCatalog271.class.getDeclaredMethod("renameAmbariInfraInConfigGroupsAndUpgradeHistory");
     Method removeLogSearchPatternConfigs = UpgradeCatalog271.class.getDeclaredMethod("removeLogSearchPatternConfigs");
 
     UpgradeCatalog271 upgradeCatalog271 = createMockBuilder(UpgradeCatalog271.class)
@@ -110,7 +110,7 @@ public class UpgradeCatalog271Test {
     upgradeCatalog271.updateRangerKmsDbUrl();
     expectLastCall().once();
 
-    upgradeCatalog271.renameAmbariInfraInConfigGroups();
+    upgradeCatalog271.renameAmbariInfraInConfigGroupsAndUpgradeHistory();
     expectLastCall().once();
 
     upgradeCatalog271.removeLogSearchPatternConfigs();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade History page is blank after cluster is upgraded multiple times
upgrade history api contains the following after upgrade:
```json
"versions" : {
          "AMBARI_INFRA" : {
            "from_repository_id" : 1,
            "from_repository_version" : "2.6.2.14-5",
            "to_repository_id" : 2,
            "to_repository_version" : "2.6.5.0-292"
          },
          ...
        }
```
as there are no references betweens service names and history api, that would require to fix the service name in history entity itself.
## How was this patch tested?
No UTs yet - add after release. FT: done

Please review @kasakrisz @adoroszlai @jonathan-hurley @swagle 