### PR TITLE
AMBARI-24407: Add rpm support infra and logsearch

### DIFF
--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -99,6 +99,28 @@
   <build>
     <pluginManagement>
       <plugins>
+       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>rpm-maven-plugin</artifactId>
+        <version>2.1.4</version>
+        <executions>
+          <execution>
+            <!-- unbinds rpm creation from maven lifecycle -->
+            <phase>none</phase>
+            <goals>
+              <goal>attached-rpm</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <copyright>2012, Apache Software Foundation</copyright>
+          <group>Development</group>
+          <description>Maven Recipe: RPM Package.</description>
+          <release>${package-release}</release>
+          <version>${package-version}</version>
+          <mappings/>
+        </configuration>
+      </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -131,6 +131,28 @@
       </plugins>
     </pluginManagement>
     <plugins>
+       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>rpm-maven-plugin</artifactId>
+        <version>2.1.4</version>
+        <executions>
+          <execution>
+            <!-- unbinds rpm creation from maven lifecycle -->
+            <phase>none</phase>
+            <goals>
+              <goal>attached-rpm</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <copyright>2012, Apache Software Foundation</copyright>
+          <group>Development</group>
+          <description>Maven Recipe: RPM Package.</description>
+          <release>${package-release}</release>
+          <version>${package-version}</version>
+          <mappings/>
+        </configuration>
+      </plugin>
       <plugin>
         <inherited>false</inherited>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
The patch will add rpm support for the following
packages.
-ambari-infra
-ambari-logsearch

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>

## What changes were proposed in this pull request?

Add rpm package creation support

## How was this patch tested?

The build has been done on AArch64 machine installed with CentOS 7.4

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.