### PR TITLE
[AMBARI-24513] Using current timestamp as created_time in case there is no value in users table in this column upon upgrading to 2.7

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -622,7 +622,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
         PreparedStatement pstmt = dbAccessor.getConnection().prepareStatement("SELECT " + USERS_USER_ID_COLUMN + ", " + USERS_CREATE_TIME_COLUMN + " FROM " + USERS_TABLE + " WHERE " + temporaryColumnName + " IS NULL ORDER BY " + USERS_USER_ID_COLUMN);
         ResultSet rs = pstmt.executeQuery()) {
       while (rs.next()) {
-        currentUserCreateTimes.put(rs.getInt(1), rs.getTimestamp(2));
+        currentUserCreateTimes.put(rs.getInt(1), rs.getTimestamp(2) == null ? new Timestamp(System.currentTimeMillis()) : rs.getTimestamp(2));
       }
     }
     return currentUserCreateTimes;

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -658,8 +658,8 @@ public class UpgradeCatalog270Test {
     final ResultSet resultSetMock = niceMock(ResultSet.class);
     expect(preparedStatementMock.executeQuery()).andReturn(resultSetMock);
     expect(resultSetMock.next()).andReturn(Boolean.TRUE).once();
-    expect(resultSetMock.getInt(1)).andReturn(1);
-    expect(resultSetMock.getTimestamp(2)).andReturn(new Timestamp(1l));
+    expect(resultSetMock.getInt(1)).andReturn(1).anyTimes();
+    expect(resultSetMock.getTimestamp(2)).andReturn(new Timestamp(1l)).anyTimes();
     replay(connectionMock, preparedStatementMock, resultSetMock);
 
     expect(dbAccessor.updateTable(eq(USERS_TABLE), eq(temporaryColumnName), eq(1l), anyString())).andReturn(anyInt());


### PR DESCRIPTION
## What changes were proposed in this pull request?

A NPE has been thrown when upgrading to Ambari 2.7 if `users.created_time` has been `NULL`. To avoid this issue we use current timestamp in the upgrade logic.

## How was this patch tested?

In addition to executing JUnit tests in `ambari-server` I manually tested the following scenario:

1. installed Ambari 2.6.2 (build 155)
2. updated `users.created_time` to `NULL` in the database
3. tried to upgrade to Ambari 2.7.1 (build 126); failed as expected
4. implemented the change; built the new JAR and replaced it in ` /usr/lib/ambari-server/`
5. re-tried the upgrade:

```
[root@c7401 ~]# ambari-server upgrade
Using python  /usr/bin/python
Upgrading ambari-server
INFO: Upgrade Ambari Server
INFO: Updating Ambari Server properties in ambari.properties ...
WARNING: Can not find ambari.properties.rpmsave file from previous version, skipping import of settings
INFO: Updating Ambari Server properties in ambari-env.sh ...
INFO: Can not find ambari-env.sh.rpmsave file from previous version, skipping restore of environment settings. ambari-env.sh may not include any user customization.
INFO: Fixing database objects owner
Ambari Server configured for Embedded Postgres. Confirm you have made a backup of the Ambari Server database [y/n] (n)? y
INFO: Upgrading database schema
INFO: Return code from schema upgrade command, retcode = 0
INFO: Console output from schema upgrade command:
INFO: {}


INFO: Schema upgrade completed
Adjusting ambari-server permissions and ownership...
Ambari repo file contains latest json url http://s3.amazonaws.com/dev.hortonworks.com/HDP/hdpdev_urlinfo.json, updating stacks repoinfos with it...
Ambari Server 'upgrade' completed successfully.
```