### PR TITLE
[AMBARI-24513] Using current timestamp as created_time in case there is no value in users table in this column upon upgrading to 2.7

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -622,7 +622,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
         PreparedStatement pstmt = dbAccessor.getConnection().prepareStatement("SELECT " + USERS_USER_ID_COLUMN + ", " + USERS_CREATE_TIME_COLUMN + " FROM " + USERS_TABLE + " WHERE " + temporaryColumnName + " IS NULL ORDER BY " + USERS_USER_ID_COLUMN);
         ResultSet rs = pstmt.executeQuery()) {
       while (rs.next()) {
-        currentUserCreateTimes.put(rs.getInt(1), rs.getTimestamp(2));
+        currentUserCreateTimes.put(rs.getInt(1), rs.getTimestamp(2) == null ? new Timestamp(System.currentTimeMillis()) : rs.getTimestamp(2));
       }
     }
     return currentUserCreateTimes;

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -658,8 +658,8 @@ public class UpgradeCatalog270Test {
     final ResultSet resultSetMock = niceMock(ResultSet.class);
     expect(preparedStatementMock.executeQuery()).andReturn(resultSetMock);
     expect(resultSetMock.next()).andReturn(Boolean.TRUE).once();
-    expect(resultSetMock.getInt(1)).andReturn(1);
-    expect(resultSetMock.getTimestamp(2)).andReturn(new Timestamp(1l));
+    expect(resultSetMock.getInt(1)).andReturn(1).anyTimes();
+    expect(resultSetMock.getTimestamp(2)).andReturn(new Timestamp(1l)).anyTimes();
     replay(connectionMock, preparedStatementMock, resultSetMock);
 
     expect(dbAccessor.updateTable(eq(USERS_TABLE), eq(temporaryColumnName), eq(1l), anyString())).andReturn(anyInt());


### PR DESCRIPTION
Exactly the same as #2130 (but this one will be merged into branch-2.7)