### PR TITLE
AMBARI-24499 blueprint support for multiple TIMELINE_READER components (benyoka)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -1943,7 +1943,7 @@ public class BlueprintConfigurationProcessor {
 
             throw new IllegalArgumentException(
               String.format("Unable to update configuration property '%s' with topology information. " +
-                "Component '%s' is mapped to an invalid number of hosts '%s'.", propertyName, component, matchingGroupCount));
+                "Component '%s' is mapped to an invalid number of host groups '%s'.", propertyName, component, matchingGroupCount));
           }
         }
       }
@@ -2946,8 +2946,8 @@ public class BlueprintConfigurationProcessor {
     yarnSiteMap.put("yarn.log.server.web-service.url", new SingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
 
     // TIMELINE_READER
-    yarnSiteMap.put("yarn.timeline-service.reader.webapp.address", new SingleHostTopologyUpdater("TIMELINE_READER"));
-    yarnSiteMap.put("yarn.timeline-service.reader.webapp.https.address", new SingleHostTopologyUpdater("TIMELINE_READER"));
+    yarnSiteMap.put("yarn.timeline-service.reader.webapp.address", new MultipleHostTopologyUpdater("TIMELINE_READER"));
+    yarnSiteMap.put("yarn.timeline-service.reader.webapp.https.address", new MultipleHostTopologyUpdater("TIMELINE_READER"));
 
     // HIVE_SERVER
     hiveSiteMap.put("hive.server2.authentication.ldap.url", new SingleHostTopologyUpdater("HIVE_SERVER2"));


### PR DESCRIPTION
This is the branch-2.7 version of https://github.com/apache/ambari/pull/2136

## What changes were proposed in this pull request?

Enable the MultipleTopologyHostUpdaters in BlueprintConfigurationProcessor for these properties:
- yarn.timeline-service.reader.webapp.address
- yarn.timeline-service.reader.webapp.https.address

## How was this patch tested?
- Tested manually (blueprint deployment with 2 TIMELINE_READER components), properties were replaced in order
- Run the unit tests for BlueprintConfigurationProcessor.
