### PR TITLE
[AMBARI-24520] Fix set KDC admin credentials section in enable Kerberos doc

### DIFF
--- a/ambari-server/docs/security/kerberos/enabling_kerberos.md
+++ b/ambari-server/docs/security/kerberos/enabling_kerberos.md
@@ -275,7 +275,7 @@ Payload:
 #### Set the KDC administrator credentials
 
 ```
-curl -H "X-Requested-By:ambari" -u admin:admin -i -X POST -d @./payload http://AMBARI_SERVER:8080/api/v1/clusters/CLUSTER_NAME/credentials
+curl -H "X-Requested-By:ambari" -u admin:admin -i -X POST -d @./payload http://AMBARI_SERVER:8080/api/v1/clusters/CLUSTER_NAME/credentials/kdc.admin.credential
 ```
 
 Payload:


### PR DESCRIPTION
Fix set KDC admin credentials section in enable Kerberos doc

The current documentation at https://github.com/apache/ambari/blob/branch-2.7/ambari-server/docs/security/kerberos/enabling_kerberos.md#set-the-kdc-administrator-credentials indicates an incorrect URL for the API call. 

It should read:

```
http://AMBARI_SERVER:8080/api/v1/clusters/CLUSTER_NAME/credentials/kdc.admin.credential
```

This was cherry-picked from #2144 

## How was this patch tested?

No testing is necessary for a doc-only change.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.