### PR TITLE
[AMBARI-24523] Hive and Oozie JDBC url reset after set manually.

### DIFF
--- a/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
@@ -158,7 +158,7 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
         fileName = Em.get(config, 'filename'),
         group = Em.get(config, 'group.name'),
         value = Em.get(config, 'value'),
-        prevRecommeneded = Em.get(config, 'recommendedValue');
+        isUserOverriden = Em.get(config, 'didUserOverrideValue');;
     Em.set(config, 'recommendedValue', recommendedValue);
     if (this.allowUpdateProperty(parentProperties, name, fileName, group, value)) {
       var allowConfigUpdate = true;
@@ -170,7 +170,7 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
         }
       }
 
-      if (prevRecommeneded !== value && name !== "capacity-scheduler") {
+      if (isUserOverriden && name !== "capacity-scheduler") {
         allowConfigUpdate = false;
       }
 
@@ -184,7 +184,12 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
       if (!Em.isNone(recommendedValue) && !Em.get(config, 'hiddenBySection')) {
         Em.set(config, 'isVisible', true);
       }
-      this.applyRecommendation(name, fileName, group, recommendedValue, this._getInitialValue(config), parentProperties, Em.get(config, 'isEditable'));
+      let recommendationExists = this.getRecommendation(name, fileName, group);
+      if (recommendationExists && isUserOverriden) {
+        this.removeRecommendation(name, fileName, group);
+      } else if (!isUserOverriden) {
+        this.applyRecommendation(name, fileName, group, recommendedValue, this._getInitialValue(config), parentProperties, Em.get(config, 'isEditable'));
+      }
     }
     if (this.updateInitialOnRecommendations(Em.get(config, 'serviceName'))) {
       Em.set(config, 'initialValue', recommendedValue);

--- a/ambari-web/app/mixins/common/configs/enhanced_configs.js
+++ b/ambari-web/app/mixins/common/configs/enhanced_configs.js
@@ -628,14 +628,23 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
   },
 
   /**
-   * disable saving recommended value for current config
+   * disable saving recommended value for current config. Remove recommendation for useroverriden values
    * @param config
    * @param {boolean} saveRecommended
    * @method removeCurrentFromDependentList
    */
   removeCurrentFromDependentList: function (config, saveRecommended) {
-    var recommendation = this.getRecommendation(config.get('name'), config.get('filename'), config.get('group.name'));
-    if (recommendation) this.saveRecommendation(recommendation, saveRecommended);
+    let name = config.get('name'),
+      fileName = config.get('filename'),
+      group = config.get('group.name');
+    var recommendation = this.getRecommendation(name, fileName, group);
+    if (recommendation) {
+      if (config.get('didUserOverrideValue')) {
+        this.removeRecommendation(name, fileName, group);
+      } else {
+        this.saveRecommendation(recommendation, saveRecommended);
+      }
+    }
   },
 
   updateAttributesFromTheme: function (serviceName) {

--- a/ambari-web/app/views/common/controls_view.js
+++ b/ambari-web/app/views/common/controls_view.js
@@ -170,6 +170,7 @@ App.ValueObserver = Em.Mixin.create(App.SupportsDependentConfigs, {
     if (this.get('selected') || this.get('serviceConfig.changedViaUndoValue')) {
       var self = this, config = this.get('serviceConfig'),
         controller = this.get('controller');
+      Em.set(config, 'didUserOverrideValue', true);
       delay(function(){
         self.sendRequestRorDependentConfigs(config, controller);
       }, 500);
@@ -186,6 +187,7 @@ App.WidgetValueObserver = Em.Mixin.create(App.ValueObserver, {
     if (this.get('selected')) {
       var self = this, config = this.get('config'),
         controller = this.get('controller');
+      Em.set(config, 'didUserOverrideValue', true);
       delay(function(){
         self.sendRequestRorDependentConfigs(config, controller);
       }, 500);

--- a/ambari-web/test/mixins/common/configs/config_recommendation_parser_test.js
+++ b/ambari-web/test/mixins/common/configs/config_recommendation_parser_test.js
@@ -229,6 +229,7 @@ describe('App.ConfigRecommendationParser', function() {
       describe('update recommendation', function() {
         beforeEach(function() {
           sinon.spy(instanceObject, 'applyRecommendation');
+          sinon.stub(instanceObject, 'getRecommendation').returns(false);
           sinon.stub(instanceObject, 'allowUpdateProperty').returns(c.allowUpdateProperty);
           sinon.stub(instanceObject, 'updateInitialOnRecommendations').returns(c.updateInitialOnRecommendations);
         });
@@ -236,6 +237,7 @@ describe('App.ConfigRecommendationParser', function() {
           instanceObject.allowUpdateProperty.restore();
           instanceObject.updateInitialOnRecommendations.restore();
           instanceObject.applyRecommendation.restore();
+          instanceObject.getRecommendation.restore();
         });
 
         it(c.m, function() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Don't allow recommendations to update config values which have been overriden by user. Also don't show them as a part of applied recommendations.

## How was this patch tested?
  21728 passing (31s)
  48 pending
