### PR TITLE
[AMBARI-24522] Cannot connect to MIT KDC admin server when port is specified in kerberos-env/admin_server_host

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandler.java
@@ -279,8 +279,8 @@ public class IPAKerberosOperationHandler extends KDCKerberosOperationHandler {
     }
 
     String[] createKeytabFileCommand = (StringUtils.isEmpty(encryptionTypeSpec))
-        ? new String[]{executableIpaGetKeytab, "-s", getAdminServerHost(), "-p", principal, "-k", keytabFileDestinationPath}
-        : new String[]{executableIpaGetKeytab, "-s", getAdminServerHost(), "-e", encryptionTypeSpec, "-p", principal, "-k", keytabFileDestinationPath};
+        ? new String[]{executableIpaGetKeytab, "-s", getAdminServerHost(true), "-p", principal, "-k", keytabFileDestinationPath}
+        : new String[]{executableIpaGetKeytab, "-s", getAdminServerHost(true), "-e", encryptionTypeSpec, "-p", principal, "-k", keytabFileDestinationPath};
 
     ShellCommandUtil.Result result = executeCommand(createKeytabFileCommand);
     if (!result.isSuccessful()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KDCKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KDCKerberosOperationHandler.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.security.credential.PrincipalKeyCredential;
+import org.apache.ambari.server.utils.HTTPUtils;
+import org.apache.ambari.server.utils.HostAndPort;
 import org.apache.ambari.server.utils.ShellCommandUtil;
 import org.apache.commons.collections.MapUtils;
 import org.apache.directory.server.kerberos.shared.keytab.Keytab;
@@ -48,6 +50,11 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
    * The FQDN of the host where KDC administration server is
    */
   private String adminServerHost = null;
+
+  /**
+   * The FQDN and port where KDC administration server is
+   */
+  private String adminServerHostAndPort = null;
 
   /**
    * A map of principal names to {@link Keytab} entries to ensure a Keyab file is not created/exported
@@ -83,7 +90,22 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
     super.open(administratorCredentials, realm, kerberosConfiguration);
 
     if (kerberosConfiguration != null) {
-      adminServerHost = kerberosConfiguration.get(KERBEROS_ENV_ADMIN_SERVER_HOST);
+      // Spit the host and port from the the admin_server_host value
+      String value = kerberosConfiguration.get(KERBEROS_ENV_ADMIN_SERVER_HOST);
+      HostAndPort hostAndPort = HTTPUtils.getHostAndPortFromProperty(value);
+
+      // hostAndPort will be null if the value is not in the form of host:port
+      if (hostAndPort == null) {
+        // host-only and host and port values are the same since there is no port
+        // both are equal to the value from the property
+        adminServerHost = value;
+        adminServerHostAndPort = value;
+      } else {
+        // host-only is the split value;
+        // host and port value is the value from the property
+        adminServerHost = hostAndPort.host;
+        adminServerHostAndPort = value;
+      }
     }
 
     // Pre-determine the paths to relevant Kerberos executables
@@ -106,6 +128,7 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
     executableKinit = null;
     cachedKeytabs = null;
     adminServerHost = null;
+    adminServerHostAndPort = null;
 
     super.close();
   }
@@ -225,8 +248,14 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
     return super.executeCommand(command, _envp, interactiveHandler);
   }
 
-  String getAdminServerHost() {
-    return adminServerHost;
+  /**
+   * Returns the KDC administration server host value (with or without the port)
+   *
+   * @param includePort <code>true</code> to include the port (if available); <code>false</code> to exclude the port
+   * @return the KDC administration server host value (with or without the port)
+   */
+  String getAdminServerHost(boolean includePort) {
+    return (includePort) ? adminServerHostAndPort : adminServerHost;
   }
 
   String getCredentialCacheFilePath() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandler.java
@@ -241,7 +241,7 @@ public class MITKerberosOperationHandler extends KDCKerberosOperationHandler {
     }
 
     // Add explicit KDC admin host, if available
-    String adminSeverHost = getAdminServerHost();
+    String adminSeverHost = getAdminServerHost(true);
     if (!StringUtils.isEmpty(adminSeverHost)) {
       command.add("-s");
       command.add(adminSeverHost);
@@ -340,7 +340,7 @@ public class MITKerberosOperationHandler extends KDCKerberosOperationHandler {
         "-c",
         credentialsCache,
         "-S",
-        String.format("kadmin/%s", getAdminServerHost()),
+        String.format("kadmin/%s", getAdminServerHost(false)),
         credentials.getPrincipal()
     };
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cannot connect to MIT KDC admin server when port is specified in `kerberos-env/admin_server_host`.  The following error is seen when validating the KDC admin credentials:

```
kinit: Server not found in Kerberos database while getting initial credentials
```

The reason for this is due to how the credentials are created for accessing the MIT KDC administration server. 

```
kinit -c <path> -S kadmin/<kerberos-env/admin_server_host>  <principal>
```

If a port was added to the {{kerberos-env/admin_server_host}} value then the server principal will be generated like `kadmin/kdc.example.com:4749` rather than `kadmin/kdc.example.com`. Therefore the server principal is not found.

This was cherry-picked from #2147 

## How was this patch tested?

Manually tested.

Added new unit tests, all unit tests passed.

```
mvn clean test package  -DthreadCount=2  -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 29:45 min
[INFO] Finished at: 2018-08-21T18:38:15-04:00
[INFO] Final Memory: 103M/1464M
[INFO] ------------------------------------------------------------------------
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.