### PR TITLE
[AMBARI-24525] Accumulo does not startup in Federated Cluster

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step4_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step4_controller.js
@@ -50,6 +50,7 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
   },
 
   reconfigureServices: function () {
+    var servicesModel = App.Service.find();
     var configs = [];
     var data = this.get('content.serviceConfigProperties');
     var note = Em.I18n.t('admin.nameNodeFederation.wizard,step4.save.configuration.note');
@@ -58,10 +59,17 @@ App.NameNodeFederationWizardStep4Controller = App.HighAvailabilityProgressPageCo
         desired_config: this.reconfigureSites(['hdfs-site'], data, note)
       }
     });
-    if (App.Service.find().someProperty('serviceName', 'RANGER')) {
+    if (servicesModel.someProperty('serviceName', 'RANGER')) {
       configs.push({
         Clusters: {
           desired_config: this.reconfigureSites(['ranger-tagsync-site'], data, note)
+        }
+      });
+    }
+    if (servicesModel.someProperty('serviceName', 'ACCUMULO')) {
+      configs.push({
+        Clusters: {
+          desired_config: this.reconfigureSites(['accumulo-site'], data, note)
         }
       });
     }

--- a/ambari-web/app/data/configs/wizards/federation_properties.js
+++ b/ambari-web/app/data/configs/wizards/federation_properties.js
@@ -23,7 +23,8 @@ module.exports =
     displayName: 'MISC',
     configCategories: [
       App.ServiceConfigCategory.create({ name: 'HDFS', displayName: 'HDFS'}),
-      App.ServiceConfigCategory.create({ name: 'RANGER', displayName: 'Ranger'})
+      App.ServiceConfigCategory.create({ name: 'RANGER', displayName: 'Ranger'}),
+      App.ServiceConfigCategory.create({ name: 'ACCUMULO', displayName: 'Accumulo'})
     ],
     sites: ['core-site'],
     configs: [

--- a/ambari-web/test/controllers/main/admin/federation/step3_controller_test.js
+++ b/ambari-web/test/controllers/main/admin/federation/step3_controller_test.js
@@ -70,8 +70,7 @@ describe('App.NameNodeFederationWizardStep3Controller', function () {
       expect(App.ajax.send.calledWith({
         name: 'config.tags',
         sender: controller,
-        success: 'onLoadConfigsTags',
-        error: 'onTaskError'
+        success: 'onLoadConfigsTags'
       })).to.be.true;
     });
   });
@@ -91,6 +90,9 @@ describe('App.NameNodeFederationWizardStep3Controller', function () {
           },
           'ranger-hdfs-security': {
             tag: 'test4'
+          },
+          'accumulo-site': {
+            tag: 'test5'
           }
         }
       }
@@ -98,7 +100,7 @@ describe('App.NameNodeFederationWizardStep3Controller', function () {
 
     afterEach(function(){
       App.Service.find.restore();
-    })
+    });
 
     it('should build short url params if no Ranger present', function () {
       sinon.stub(App.Service, 'find').returns([]);
@@ -109,8 +111,7 @@ describe('App.NameNodeFederationWizardStep3Controller', function () {
         data: {
           urlParams: '(type=hdfs-site&tag=test)'
         },
-        success: 'onLoadConfigs',
-        error: 'onTaskError'
+        success: 'onLoadConfigs'
       }));
     });
 
@@ -123,8 +124,20 @@ describe('App.NameNodeFederationWizardStep3Controller', function () {
         data: {
           urlParams: '(type=hdfs-site&tag=test)|(type=core-site&tag=test1)|(type=ranger-tagsync-site&tag=test2)|(type=ranger-hdfs-security&tag=test3)'
         },
-        success: 'onLoadConfigs',
-        error: 'onTaskError'
+        success: 'onLoadConfigs'
+      }));
+    });
+
+    it('should build long url params if Accumulo is present', function () {
+      sinon.stub(App.Service, 'find').returns([{serviceName: 'ACCUMULO'}]);
+      controller.onLoadConfigsTags(data);
+      expect(App.ajax.send.calledWith({
+        name: 'admin.get.all_configurations',
+        sender: controller,
+        data: {
+          urlParams: '(type=hdfs-site&tag=test)|(type=accumulo-site&tag=test5)'
+        },
+        success: 'onLoadConfigs'
       }));
     });
   });


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a manually setup federated cluster (not through deployNG) --

Accumulo was installed and when trying to start, below error thrown --

```
2018-08-16 07:33:31,748 [start.Main] ERROR: Thread 'org.apache.accumulo.master.state.SetGoalState' died.
java.lang.IllegalArgumentException: Expected fully qualified URI for instance.volumes got ns2/apps/accumulo/data
	at org.apache.accumulo.core.volume.VolumeConfiguration.getVolumeUris(VolumeConfiguration.java:107)
	at org.apache.accumulo.server.fs.VolumeManagerImpl.get(VolumeManagerImpl.java:334)
```

Caused by incorrect config value:
`instance.volumes = hdfs://ns1,ns2/apps/accumulo/data`
where ns1 and ns2 are namespaces

Expected is --
`instance.volumes = hdfs://ns1/apps/accumulo/data,hdfs://ns2/apps/accumulo/data`

according to --
https://accumulo.apache.org/docs/2.0/administration/multivolume


## How was this patch tested?

Tested manually