### PR TITLE
AMBARI-24526. Status of components does not become RED if their daemon goes down immediately after successful start

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -80,6 +80,7 @@ class CustomServiceOrchestrator(object):
   CREDENTIAL_STORE_CLASS_PATH_NAME = 'credentialStoreClassPath'
 
   def __init__(self, initializer_module):
+    self.initializer_module = initializer_module
     self.configuration_builder = initializer_module.configuration_builder
     self.host_level_params_cache = initializer_module.host_level_params_cache
     self.config = initializer_module.config
@@ -410,9 +411,12 @@ class CustomServiceOrchestrator(object):
       except NoOptionError:
        log_out_files = None
 
-      if cluster_id != '-1' and cluster_id != 'null':
+      if cluster_id != '-1' and cluster_id != 'null' and not is_status_command:
         self.commands_for_component_in_progress[cluster_id][command['role']] += 1
         incremented_commands_for_component = True
+
+        # reset status which was reported, so agent re-reports it after command finished
+        self.initializer_module.component_status_executor.reported_component_status[cluster_id][command['role']]['STATUS'] = None
 
       for py_file, current_base_dir in filtered_py_file_list:
         log_info_on_failure = command_name not in self.DONT_DEBUG_FAILURES_FOR_COMMANDS


### PR DESCRIPTION
Status of component gets cached on agent and so it does not tell server that component is down after start finished successfully.