### PR TITLE
AMBARI-24538: OneFS mpack quicklinks require port, https

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/quicklinks/quicklinks.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/quicklinks/quicklinks.json
@@ -3,16 +3,22 @@
   "description": "default quick links configuration",
   "configuration": {
     "protocol": {
-      "type": "HTTP_ONLY"
+      "type": "HTTPS_ONLY"
     },
     "links": [
       {
         "component_name" : "ONEFS_CLIENT",
         "name": "onefs_web_ui",
         "label": "OneFS Web UI",
-        "url": "%@://%@",
+        "url": "%@://%@:%@",
+        "port": {
+          "http_default_port": "8080",
+          "https_default_port": "8080"
+        },
+
         "host": {
           "http_property": "fs.defaultFS",
+          "https_property": "fs.defaultFS",
           "site": "core-site"
         }
       },
@@ -20,9 +26,14 @@
         "component_name" : "ONEFS_CLIENT",
         "name": "onefs_hdfs_web_ui",
         "label": "OneFS HDFS Settings",
-        "url": "%@://%@/OneFS#HDFS/Settings",
+        "url": "%@://%@:%@/OneFS#HDFS/Settings",
+        "port": {
+          "http_default_port": "8080",
+          "https_default_port": "8080"
+        },
         "host": {
           "http_property": "fs.defaultFS",
+          "https_property": "fs.defaultFS",
           "site": "core-site"
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modify the OneFS management pack for Ambari. Add port to url, define port, and switch protocol to https.

## How was this patch tested?

This patch was tested manually by changing `/var/lib/ambari-server/resources/mpacks/onefs-ambari-mpack-0.1/addon-services/ONEFS/1.0.0/quicklinks/quicklinks.json`, doing `ambari-server restart` and confirming that the links appear correctly in Ambari. Then the links were followed after enabling http file browse on OneFS and after setting OneFS back to http redirect (to adminstration ui).