### PR TITLE
 AMBARI-24539: OneFS mpack should not include webhdfs enable setting

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
@@ -19,18 +19,6 @@
 <!-- Put site-specific property overrides in this file. -->
 <configuration supports_final="true">
   <property>
-    <name>dfs.webhdfs.enabled</name>
-    <value>false</value>
-    <display-name>WebHDFS enabled</display-name>
-    <description>Whether to enable WebHDFS feature</description>
-    <final>true</final>
-    <value-attributes>
-      <type>boolean</type>
-      <overridable>false</overridable>
-    </value-attributes>
-    <on-ambari-upgrade add="true"/>
-  </property>
-  <property>
     <name>dfs.namenode.http-address</name>
     <value>localhost:8082</value>
     <description>The name of the default file system.  Either the


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modify the OneFS management pack for Ambari Server. Remove dfs.webhdfs.enabled setting. It is no longer needed for OneFS integration.

## How was this patch tested?

This patch was tested manually by changing `/var/lib/ambari-server/resources/mpacks/onefs-ambari-mpack-0.1/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml`, doing `ambari-server restart` and confirming that the setting is removed from the OneFS service UI.