### PR TITLE
[AMBARI-24540] Allow skipping Oozie DB schema creation for sysprepped cluster

### DIFF
--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_service.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_service.py
@@ -109,10 +109,13 @@ def oozie_service(action = 'start', upgrade_type=None):
                  user=params.oozie_user,
         )
 
-      Execute( format("cd {oozie_tmp_dir} && {oozie_home}/bin/ooziedb.sh create -sqlfile oozie.sql -run"), 
-               user = params.oozie_user, not_if = no_op_test,
-               ignore_failures = True 
-      )
+      if params.sysprep_skip_oozie_schema_create:
+        Logger.info("Skipping creation of oozie schema as host is sys prepped")
+      else:
+        Execute( format("cd {oozie_tmp_dir} && {oozie_home}/bin/ooziedb.sh create -sqlfile oozie.sql -run"),
+                 user = params.oozie_user, not_if = no_op_test,
+                 ignore_failures = True
+        )
       
       if params.security_enabled:
         Execute(kinit_if_needed,

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params_linux.py
@@ -69,7 +69,7 @@ upgrade_direction = default("/commandParams/upgrade_direction", None)
 agent_stack_retry_on_unavailability = config['hostLevelParams']['agent_stack_retry_on_unavailability']
 agent_stack_retry_count = expect("/hostLevelParams/agent_stack_retry_count", int)
 host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
-sysprep_skip_oozie_schema_create = host_sys_prepped and default("/configurations/cluster-env/skip_oozie_schema_create", False)
+sysprep_skip_oozie_schema_create = host_sys_prepped and default("/configurations/cluster-env/sysprep_skip_oozie_schema_create", False)
 
 stack_root = status_params.stack_root
 

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params_linux.py
@@ -68,6 +68,8 @@ stack_name_uppercase = stack_name.upper()
 upgrade_direction = default("/commandParams/upgrade_direction", None)
 agent_stack_retry_on_unavailability = config['hostLevelParams']['agent_stack_retry_on_unavailability']
 agent_stack_retry_count = expect("/hostLevelParams/agent_stack_retry_count", int)
+host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
+sysprep_skip_oozie_schema_create = host_sys_prepped and default("/configurations/cluster-env/skip_oozie_schema_create", False)
 
 stack_root = status_params.stack_root
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
@@ -126,6 +126,17 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>sysprep_skip_oozie_schema_create</name>
+    <display-name>Whether to skip creating the Oozie DB schema on sysprepped cluster</display-name>
+    <value>false</value>
+    <description>Whether to skip creating the Oozie DB schema on sysprepped cluster, during both fresh install and stack upgrade</description>
+    <value-attributes>
+      <overridable>true</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>sysprep_skip_setup_jce</name>
     <display-name>Whether to skip setting up the unlimited key JCE policy on sysprepped cluster</display-name>
     <value>false</value>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Oozie DB schema may be manually pre-created to save time during initial service start.  However, `ooziedb.sh` could still take quite some time to confirm that the schema exists.  The goal of this change is to allow users who pre-create Oozie DB schema to make Ambari skip managing the DB (create or check existence).

## How was this patch tested?

Deployed cluster via blueprint with pre-created Oozie DB.  Confirmed that `ooziedb.sh` call is skipped:

```
Skipping creation of oozie schema as host is sys prepped
```

Ran Oozie service check.