### PR TITLE
[AMBARI-24540] Remove duplicate `host_sys_prepped` variable

### DIFF
--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params.py
@@ -37,3 +37,4 @@ host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
 sysprep_skip_copy_oozie_share_lib_to_hdfs = False
 if host_sys_prepped:
   sysprep_skip_copy_oozie_share_lib_to_hdfs = default("/configurations/cluster-env/sysprep_skip_copy_oozie_share_lib_to_hdfs", False)
+sysprep_skip_oozie_schema_create = host_sys_prepped and default("/configurations/cluster-env/sysprep_skip_oozie_schema_create", False)

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params_linux.py
@@ -68,8 +68,6 @@ stack_name_uppercase = stack_name.upper()
 upgrade_direction = default("/commandParams/upgrade_direction", None)
 agent_stack_retry_on_unavailability = config['hostLevelParams']['agent_stack_retry_on_unavailability']
 agent_stack_retry_count = expect("/hostLevelParams/agent_stack_retry_count", int)
-host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
-sysprep_skip_oozie_schema_create = host_sys_prepped and default("/configurations/cluster-env/sysprep_skip_oozie_schema_create", False)
 
 stack_root = status_params.stack_root
 

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
@@ -129,7 +129,7 @@
     <name>sysprep_skip_oozie_schema_create</name>
     <display-name>Whether to skip creating the Oozie DB schema on sysprepped cluster</display-name>
     <value>false</value>
-    <description>Whether to skip creating the Oozie DB schema on sysprepped cluster, during both fresh install and stack upgrade</description>
+    <description>Whether to skip creating the Oozie DB schema on sysprepped cluster, during fresh install</description>
     <value-attributes>
       <overridable>true</overridable>
       <type>boolean</type>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After merging #2171 I noticed that `params.py` already defines `host_sys_prepped`.  This minor change only removes the duplicate one, and moves `sysprep_skip_oozie_schema_create` to `params.py` as well.

The documentation for `sysprep_skip_oozie_schema_create` is also fixed to clarify that it does not affect stack upgrade.

## How was this patch tested?

Ran Python unit tests.