### PR TITLE
[AMBARI-24540] Allow skipping Oozie DB schema creation for sysprepped cluster

### DIFF
--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_service.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/oozie_service.py
@@ -112,10 +112,13 @@ def oozie_service(action = 'start', upgrade_type=None):
                  user=params.oozie_user,
         )
 
-      Execute( format("cd {oozie_tmp_dir} && {oozie_home}/bin/ooziedb.sh create -sqlfile oozie.sql -run"), 
-               user = params.oozie_user, not_if = no_op_test,
-               ignore_failures = True 
-      )
+      if params.sysprep_skip_oozie_schema_create:
+        Logger.info("Skipping creation of oozie schema as host is sys prepped")
+      else:
+        Execute( format("cd {oozie_tmp_dir} && {oozie_home}/bin/ooziedb.sh create -sqlfile oozie.sql -run"),
+                 user = params.oozie_user, not_if = no_op_test,
+                 ignore_failures = True
+        )
       
       if params.security_enabled:
         Execute(kinit_if_needed,

--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/params.py
@@ -37,3 +37,4 @@ host_sys_prepped = default("/ambariLevelParams/host_sys_prepped", False)
 sysprep_skip_copy_oozie_share_lib_to_hdfs = False
 if host_sys_prepped:
   sysprep_skip_copy_oozie_share_lib_to_hdfs = default("/configurations/cluster-env/sysprep_skip_copy_oozie_share_lib_to_hdfs", False)
+sysprep_skip_oozie_schema_create = host_sys_prepped and default("/configurations/cluster-env/sysprep_skip_oozie_schema_create", False)

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
@@ -126,6 +126,17 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>sysprep_skip_oozie_schema_create</name>
+    <display-name>Whether to skip creating the Oozie DB schema on sysprepped cluster</display-name>
+    <value>false</value>
+    <description>Whether to skip creating the Oozie DB schema on sysprepped cluster, during both fresh install and stack upgrade</description>
+    <value-attributes>
+      <overridable>true</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>sysprep_skip_setup_jce</name>
     <display-name>Whether to skip setting up the unlimited key JCE policy on sysprepped cluster</display-name>
     <value>false</value>

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
@@ -129,7 +129,7 @@
     <name>sysprep_skip_oozie_schema_create</name>
     <display-name>Whether to skip creating the Oozie DB schema on sysprepped cluster</display-name>
     <value>false</value>
-    <description>Whether to skip creating the Oozie DB schema on sysprepped cluster, during both fresh install and stack upgrade</description>
+    <description>Whether to skip creating the Oozie DB schema on sysprepped cluster, during fresh install</description>
     <value-attributes>
       <overridable>true</overridable>
       <type>boolean</type>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2171 and #2179, for `branch-2.7`.

## How was this patch tested?

Ran unit tests.