### PR TITLE
AMBARI-24550. Yarn Timeline Service V2 Reader goes down after Ambari …

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog271Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog271Test.java
@@ -95,6 +95,7 @@ public class UpgradeCatalog271Test {
     Method renameAmbariInfraInConfigGroups = UpgradeCatalog271.class.getDeclaredMethod("renameAmbariInfraService");
     Method removeLogSearchPatternConfigs = UpgradeCatalog271.class.getDeclaredMethod("removeLogSearchPatternConfigs");
     Method updateSolrConfigurations = UpgradeCatalog271.class.getDeclaredMethod("updateSolrConfigurations");
+    Method updateTimelineReaderAddress = UpgradeCatalog271.class.getDeclaredMethod("updateTimelineReaderAddress");
 
     UpgradeCatalog271 upgradeCatalog271 = createMockBuilder(UpgradeCatalog271.class)
       .addMockedMethod(updateRangerKmsDbUrl)
@@ -103,6 +104,7 @@ public class UpgradeCatalog271Test {
       .addMockedMethod(renameAmbariInfraInConfigGroups)
       .addMockedMethod(removeLogSearchPatternConfigs)
       .addMockedMethod(updateSolrConfigurations)
+      .addMockedMethod(updateTimelineReaderAddress)
       .createMock();
 
     upgradeCatalog271.addNewConfigurationsFromXml();
@@ -121,6 +123,9 @@ public class UpgradeCatalog271Test {
     expectLastCall().once();
 
     upgradeCatalog271.updateSolrConfigurations();
+    expectLastCall().once();
+
+    upgradeCatalog271.updateTimelineReaderAddress();
     expectLastCall().once();
 
     replay(upgradeCatalog271);


### PR DESCRIPTION
…Upgrade from 2.7.0.0 to 2.7.1.0 (amagyar)

## What changes were proposed in this pull request?

TimelineReader goes down with a BindException port already in use error after upgrading ambari. In 2.7 jinja placeholders were used in yarn.timeline-service.reader.webapp.address/yarn.timeline-service.reader.webapp.https.address. The replacement of these placeholders was done by the stack code. In 2.7.1 this logic was moved to the stack advisor. After the upgrade the stack code no longer replaces these palceholders in the existing config.

## How was this patch tested?

* installed ambari 2.7.0.0
* checked that both yarn.timeline-service.reader.webapp.address and yarn.timeline-service.reader.webapp.https.address had the placeholders
* upgraded to 2.7.1.
* checked that the placeholders were replaced by the upgradecatalog