### PR TITLE
[AMBARI-24551] [Log Search UI] get rid of redundant requests after undoing or redoing several history steps

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.html
@@ -25,3 +25,7 @@
 <data-loading-indicator *ngIf="!(isBaseDataAvailable$ | async) && (isAuthorized$ | async)"></data-loading-indicator>
 <main-container *ngIf="!(isAuthorized$ | async) || (isBaseDataAvailable$ | async)"></main-container>
 <simple-notifications [options]="notificationServiceOptions"></simple-notifications>
+<div class="request-indicator" [class.open]="httpClient.requestInProgress | async">
+  <i class="fa fa-spin fa-gear"></i>
+  {{ 'common.loading' | translate }}
+</div>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.less
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.less
@@ -59,4 +59,17 @@
       }
     }
   }
+  .request-indicator {
+    background: #fff;
+    bottom: calc(-1 * (3em + .3em));
+    color: @info-color;
+    opacity: .7;
+    padding: .3em;
+    position: fixed;
+    right: 0;
+    transition: bottom 500ms ease-in-out;
+    &.open {
+      bottom: 0;
+    }
+  }
 }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/app.component.ts
@@ -22,6 +22,7 @@ import {Observable} from 'rxjs/Observable';
 import {Options} from 'angular2-notifications/src/options.type';
 import {notificationIcons} from '@modules/shared/services/notification.service';
 import { DataAvailability, DataAvailabilityValues } from '@app/classes/string';
+import {HttpClientService} from '@app/services/http-client.service';
 
 @Component({
   selector: 'app-root',
@@ -45,7 +46,8 @@ export class AppComponent {
   };
 
   constructor(
-    private appState: AppStateService
+    private appState: AppStateService,
+    public httpClient: HttpClientService
   ) {}
 
 }

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.ts
@@ -137,7 +137,8 @@ export class LogsContainerComponent implements OnInit, OnDestroy {
     //// SYNC BETWEEN PARAMS AND FORM
     // sync to filters form when the query params changed (only when there is no other way sync)
     this.subscriptions.push(
-      this.activatedRoute.params.filter(() => !this.paramsSyncInProgress.getValue())
+      this.activatedRoute.params
+        .filter(() => !this.paramsSyncInProgress.getValue())
         .subscribe(this.onParamsChange)
     );
     // Sync from form to params on form values change

--- a/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch/ambari-logsearch-web/src/assets/i18n/en.json
@@ -7,6 +7,7 @@
   "common.name": "Name",
   "common.value": "Value",
   "common.settings": "Settings",
+  "common.loading": "Loading...",
 
   "common.form.errors.required": "This field is required",
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

By storing the subscriptions within the `loadLogs` we can unsubscribe from them which means cancellation of the HTTP request. So that we do not wait the result and do not render the response.
Also a small UX fix has been added: a small request indicator in the right bottom corner will be displayed when there is (at least one) a background request. This was for testing purpose but still we need a "request in progress" feedback for the user, I styled a bit.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 268 of 268 SUCCESS (8.929 secs / 8.843 secs)
✨  Done in 35.98s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.