### PR TITLE
[AMBARI-24553] Cannot start Hive Metastore without HDFS

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/hive-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/hive-env.xml
@@ -60,6 +60,7 @@
     <display-name>hive-env template</display-name>
     <description>This is the jinja template for hive-env.sh file</description>
     <value>
+export JAVA_HOME={{java64_home}}
 export HADOOP_USER_CLASSPATH_FIRST=true  #this prevents old metrics libs from mapreduce lib from bringing in old jar deps overriding HIVE_LIB
 if [ "$SERVICE" = "cli" ]; then
   if [ -z "$DEBUG" ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Starting Hive Metastore fails at `schematool` if HDFS is not present in the cluster with the error: `JAVA_HOME is not set and could not be found.`

https://issues.apache.org/jira/browse/AMBARI-24553

## How was this patch tested?

Deployed ZK + Hive Metastore via blueprint (with topology validation disabled).