### PR TITLE
[AMBARI-24555] Nifi Registry install fails

### DIFF
--- a/ambari-web/app/mixins/wizard/addSecurityConfigs.js
+++ b/ambari-web/app/mixins/wizard/addSecurityConfigs.js
@@ -895,7 +895,7 @@ App.AddSecurityConfigs = Em.Mixin.create({
    * @returns {object}
    */
   removeIdentityReferences: function(kerberosDescriptor) {
-    const notReference = (identity) => Em.isNone(identity.reference);
+    const notReference = (identity) => (Em.isNone(identity.reference) && !identity.name.startsWith('/'));
     kerberosDescriptor.services.forEach((service) => {
       if (service.identities) {
         service.identities = service.identities.filter(notReference);

--- a/ambari-web/test/mixins/wizard/addSeccurityConfigs_test.js
+++ b/ambari-web/test/mixins/wizard/addSeccurityConfigs_test.js
@@ -337,6 +337,9 @@ describe('App.AddSecurityConfigs', function () {
               },
               {
                 name: 'foo'
+              },
+              {
+                name: '/foo'
               }
             ],
             components: [
@@ -347,6 +350,9 @@ describe('App.AddSecurityConfigs', function () {
                   },
                   {
                     name: 'foo'
+                  },
+                  {
+                    name: '/foo'
                   }
                 ]
               }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Ambari UI should not display any properties from Kerberos identity blocks that indicate they are referencing another Kerberos identity. There are 2 ways we know this:

- The new/preferred way: the identity block has a non-empty/non-null "reference" attribute
- The old (backwards compatible way): the identity block has a "name" attribute the starts with a '/'.

## How was this patch tested?

Tested manually