### PR TITLE
[AMBARI-24536] Ambari SPNEGO breaks SSO redirect

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/AmbariErrorHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/AmbariErrorHandler.java
@@ -73,7 +73,7 @@ public class AmbariErrorHandler extends ErrorHandler {
     }
     errorMap.put("message", message);
 
-    if (code == HttpServletResponse.SC_FORBIDDEN) {
+    if ((code == HttpServletResponse.SC_FORBIDDEN) || (code == HttpServletResponse.SC_UNAUTHORIZED)) {
       //if SSO is configured we should provide info about it in case of access error
       JwtAuthenticationProperties jwtProperties = jwtAuthenticationPropertiesProvider.getProperties();
       if ((jwtProperties != null) && jwtProperties.isEnabledForAmbari()) {

--- a/ambari-web/app/router.js
+++ b/ambari-web/app/router.js
@@ -342,7 +342,7 @@ App.Router = Em.Router.extend({
    * @param {?object} data
    */
   onAuthenticationError: function (data) {
-    if (data.status === 403) {
+    if ((data.status === 403) || (data.status === 401)) {
       try {
         var responseJson = JSON.parse(data.responseText);
         if (responseJson.jwtProviderUrl && this.get('location.lastSetURL') !== this.get('localUserAuthUrl')) {

--- a/ambari-web/test/router_test.js
+++ b/ambari-web/test/router_test.js
@@ -462,6 +462,26 @@ describe('App.Router', function () {
         },
         redirectCalled: false,
         m: 'jwtProviderUrl is present, current location is local login url, no redirect'
+      },
+      {
+        lastSetURL: '/main/dashboard',
+        isResolved: false,
+        responseData: {
+          responseText: JSON.stringify({jwtProviderUrl: 'http://some.com?originalUrl='}),
+          status: 401
+        },
+        redirectCalled: true,
+        m: 'jwtProviderUrl is present, current location not local login url, redirect according to jwtProviderUrl value'
+      },
+      {
+        lastSetURL: '/login/local',
+        isResolved: false,
+        responseData: {
+          responseText: JSON.stringify({jwtProviderUrl: 'http://some.com?originalUrl='}),
+          status: 401
+        },
+        redirectCalled: false,
+        m: 'jwtProviderUrl is present, current location is local login url, no redirect'
       }
     ].forEach(function (test) {
       describe(test.m, function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When SPNEGO is enabled (`ambari-server setup-kerberos`), the SSO (`ambari-server setup-sso`) redirect no longer works.

**How to reproduce**:

1. Enable SSO `ambari-server setup-sso`
2. `ambari-server restart`
3. Visit Ambari and notice that you are redirected to the SSO system (i.e. Knox)
4. Enable SPNEGO `ambari-server setup-kerberos`
5. `ambari-server restart`
6. Visit Ambari and notice that you are *NOT redirected* to the SSO system (i.e. Knox)

**Solution**:
The Ambari server will provide the JWT provider URL when either an HTTP 403 (Forbidden) or an HTTP 401 (Unauthorized) response is sent to caller.   If an HTTP 403 is returned, and at least SSO is enabled, the frontend will redirect to the supplied JWT provider URL.  If an HTTP 401 is returned, and at least SSO is enabled, the "Negotiate" header will be returned with response. If the caller does not respond with a Kerberos token, the frontend will redirect to the supplied JWT provider URL.  

## How was this patch tested?

Manually tested.

Unit tests executed ambari-web and ambari-server.  

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.