### PR TITLE
[AMBARI-24548] Allow skipping Hive Metastore schema creation for sysprepped cluster

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
@@ -391,6 +391,10 @@ def hive(name=None):
 def create_metastore_schema():
   import params
 
+  if params.sysprep_skip_hive_schema_create:
+    Logger.info("Skipping creation of Hive Metastore schema as host is sys prepped")
+    return
+
   create_schema_cmd = format("export HIVE_CONF_DIR={hive_server_conf_dir} ; "
                              "{hive_schematool_bin}/schematool -initSchema "
                              "-dbType {hive_metastore_db_type} "

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params.py
@@ -26,5 +26,7 @@ if OSCheck.is_windows_family():
 else:
   from params_linux import *
 
+host_sys_prepped = default("/hostLevelParams/host_sys_prepped", False)
+sysprep_skip_hive_schema_create = host_sys_prepped and default("/configurations/cluster-env/sysprep_skip_hive_schema_create", False)
 sysprep_skip_copy_tarballs_hdfs = get_sysprep_skip_copy_tarballs_hdfs()
 retryAble = default("/commandParams/command_retry_enabled", False)

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
@@ -137,6 +137,17 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>sysprep_skip_hive_schema_create</name>
+    <display-name>Whether to skip creating the Hive Metastore DB schema on sysprepped cluster</display-name>
+    <value>false</value>
+    <description>Whether to skip creating the Hive Metastore DB schema on sysprepped cluster, during fresh install</description>
+    <value-attributes>
+      <overridable>true</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>sysprep_skip_setup_jce</name>
     <display-name>Whether to skip setting up the unlimited key JCE policy on sysprepped cluster</display-name>
     <value>false</value>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive Metastore DB schema may be manually pre-created to save time during initial service start.  However, `schematool` could still take quite some time to confirm that the schema exists.  The goal of this change is to allow users who pre-create Hive Metastore DB schema to make Ambari skip managing the DB (create or check existence).

https://issues.apache.org/jira/browse/AMBARI-24548

## How was this patch tested?

Deployed cluster via blueprint with pre-created Hive Metastore DB. Confirmed that `schematool` call is skipped:

```
Skipping creation of Hive Metastore schema as host is sys prepped
```

Ran Hive service check.