### PR TITLE
[AMBARI-24561] Update styles for pre-upgrade modals

### DIFF
--- a/ambari-web/app/controllers/main/admin/stack_and_upgrade_controller.js
+++ b/ambari-web/app/controllers/main/admin/stack_and_upgrade_controller.js
@@ -896,7 +896,7 @@ App.MainAdminStackAndUpgradeController = Em.Controller.extend(App.LocalStorage, 
    */
   showPreparingUpgradeIndicator: function () {
     return App.ModalPopup.show({
-      header: '',
+      header: Em.I18n.t('admin.stackUpgrade.dialog.prepareUpgrade.header'),
       showFooter: false,
       showCloseButton: false,
       bodyClass: Em.View.extend({
@@ -909,12 +909,6 @@ App.MainAdminStackAndUpgradeController = Em.Controller.extend(App.LocalStorage, 
          */
         barWidth: 'width: 100%;',
         progressBarClass: 'progress log_popup',
-
-        /**
-         * Popup-message
-         * @type {string}
-         */
-        message: Em.I18n.t('admin.stackUpgrade.dialog.prepareUpgrade.header'),
 
         /**
          * Hide popup when upgrade wizard is open

--- a/ambari-web/app/styles/stack_versions.less
+++ b/ambari-web/app/styles/stack_versions.less
@@ -618,6 +618,8 @@
     }
     .img-thumbnail {
       background-color: #e4e4e4;
+      text-align: center;
+      padding: 10px;
       .method-name,.method-icon,.method-description {
         color: #333;
       }
@@ -630,25 +632,13 @@
       .method-name {
         font-size: 16px;
         font-weight: bold;
-        text-align: center;
         margin-top: 2px;
       }
       .method-description {
         margin-top: 5px;
-        text-align: center;
       }
     }
 
-    .ROLLING {
-      .method-icon {
-        margin-left: 88px;
-      }
-    }
-    .NON_ROLLING, .HOST_ORDERED {
-      .method-icon {
-        margin-left: 94px;
-      }
-    }
     .selected.ROLLING, .selected.NON_ROLLING {
       background-color: #d3e7ca;
       box-shadow: 0 8px 6px -6px #b3b3b3;
@@ -700,7 +690,6 @@
         display: inline-block;
         width: auto;
         height: @spinner-small-height;
-        padding-left: @spinner-small-width + 4px;
         i {
           font-size: 1em;
         }
@@ -727,10 +716,13 @@
       font-size: 16px;
     }
   }
-  .tolerance-text .tolerance-option {
-    margin: 5px 15px;
-    .ember-checkbox {
-      margin-top: 0;
+  .tolerance-text {
+    margin-bottom: 30px;
+    .tolerance-option {
+      margin: 5px 15px;
+      .ember-checkbox {
+        margin-top: 0;
+      }
     }
   }
   .text {

--- a/ambari-web/app/templates/common/modal_popups/cluster_check_dialog.hbs
+++ b/ambari-web/app/templates/common/modal_popups/cluster_check_dialog.hbs
@@ -24,9 +24,9 @@
       <h4>{{view.failTitle}}</h4>
     {{/if}}
     {{#if view.failAlert}}
-      <div class="alert alert-warning">
+      <p>
         {{view.failAlert}}
-      </div>
+      </p>
     {{/if}}
     <div class="limited-height-2">
       {{#each item in view.fails}}
@@ -42,9 +42,9 @@
       <h4>{{view.failTitle}}</h4>
     {{/if}}
     {{#if view.failAlert}}
-      <div class="alert alert-warning">
+      <p>
         {{view.failAlert}}
-      </div>
+      </p>
     {{/if}}
     <div class="limited-height-2">
       {{#each item in view.bypass}}
@@ -59,9 +59,9 @@
       <h4>{{view.warningTitle}}</h4>
     {{/if}}
     {{#if view.warningAlert}}
-      <div class="alert alert-warning">
+      <p>
         {{view.warningAlert}}
-      </div>
+      </p>
     {{/if}}
     <div class="limited-height-2">
       {{#each item in view.warnings}}

--- a/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_configs_merge_table.hbs
+++ b/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_configs_merge_table.hbs
@@ -20,9 +20,9 @@
 <a {{action openConfigsInNewWindow view.configs target="App.router.mainAdminStackAndUpgradeController"}} {{translateAttr title="common.openNewWindow"}} class="pull-right open-in-new-window" href="#">
   <i class="icon-external-link"></i> <span>{{t common.open}}</span>
 </a>
-<div class="alert alert-warning">
+<p>
   {{t popup.clusterCheck.Upgrade.configsMerge.alert}}
-</div>
+</p>
 <table class="configs-table table table-hover">
   <thead>
     <tr>

--- a/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_configs_recommend_table.hbs
+++ b/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_configs_recommend_table.hbs
@@ -20,9 +20,9 @@
 <a {{action openConfigsInNewWindow view.configs target="App.router.mainAdminStackAndUpgradeController"}} {{translateAttr title="common.openNewWindow"}} class="pull-right open-in-new-window" href="#">
   <i class="icon-external-link"></i> <span id="i18n-34">{{t common.open}}</span>
 </a>
-<div class="alert alert-warning">
+<p>
   {{t popup.clusterCheck.Upgrade.configsRecommend.alert}}
-</div>
+</p>
 <div class="configs-table-header">
   <table class="configs-table table table-striped">
     <thead>

--- a/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_options.hbs
+++ b/ambari-web/app/templates/main/admin/stack_upgrade/upgrade_options.hbs
@@ -17,72 +17,72 @@
 }}
 
 {{#if view.parentView.controller.isUpgradeTypesLoaded}}
-    {{#if view.parentView.controller.getSupportedUpgradeError}}
-        <i class="glyphicon glyphicon-remove"/>{{t admin.stackVersions.version.upgrade.upgradeOptions.error}}
-        <pre>{{view.parentView.controller.getSupportedUpgradeError}}</pre>
-    {{else}}
-      <div id="upgrade-options-popup-content">
-        <div class="text">{{{view.versionText}}}</div>
-        {{#if view.upgradeShow}}
-          <div class="text method-text">{{t admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.method}}</div>
-        {{/if}}
-        <div {{bindAttr class=":row :method-options view.isInUpgradeWizard:disabled"}}>
-            {{#each method in view.upgradeMethods}}
-                {{#unless method.cantBeStarted}}
-                  <div class="method-option col-md-6">
-                    <div {{bindAttr class="method.allowed::not-allowed method.allowed::not-allowed-by-version
+  {{#if view.parentView.controller.getSupportedUpgradeError}}
+    <i class="glyphicon glyphicon-remove"/>{{t admin.stackVersions.version.upgrade.upgradeOptions.error}}
+    <pre>{{view.parentView.controller.getSupportedUpgradeError}}</pre>
+  {{else}}
+    <div id="upgrade-options-popup-content">
+      <p class="text">{{{view.versionText}}}</p>
+      {{#if view.upgradeShow}}
+        <p class="text method-text">{{t admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.method}}</p>
+      {{/if}}
+      <div {{bindAttr class=":row :method-options view.isInUpgradeWizard:disabled"}}>
+        {{#each method in view.upgradeMethods}}
+          {{#unless method.cantBeStarted}}
+            <div class="method-option col-md-6">
+              <div {{bindAttr class="method.allowed::not-allowed method.allowed::not-allowed-by-version
                             method.isPrecheckFailed:not-allowed method.isPrecheckFailed:check-failed
                             method.selected:selected method.type :img-thumbnail
                             view.upgradeShow::default-cursor"}}
-                        {{action selectMethod method target="view"}}>
-                      <div {{bindAttr class="method.icon :method-icon"}}></div>
-                      <div class="method-name">{{method.displayName}}</div>
-                      <div class="method-description">{{{method.description}}}</div>
-                        {{#if view.showPreUpgradeChecks}}
-                            {{#if method.isCheckRequestInProgress}}
-                              <div class="method-precheck-message checking">
-                                  {{view App.SpinnerView message="admin.stackVersions.version.upgrade.upgradeOptions.preCheck.msg.checking"}}
-                              </div>
-                            {{else}}
-                              <div {{bindAttr class=":method-precheck-message method.precheckResultsMessageClass"}}>
-                                <i {{bindAttr class="method.precheckResultsMessageIconClass"}}></i>
-                                <b>{{method.precheckResultsTitle}}</b>&nbsp;
-                                <a {{action runAction method target="view"}}>
-                                    {{method.precheckResultsMessage}}
-                                </a>
-                                  {{#if method.bypassedFailures}}
-                                    <div
-                                      class="alert-danger">{{t admin.stackVersions.version.upgrade.upgradeOptions.errors_bypassed}}</div>
-                                  {{/if}}
-                              </div>
-                            {{/if}}
-                        {{/if}}
+                {{action selectMethod method target="view"}}>
+                <div {{bindAttr class="method.icon :method-icon"}}></div>
+                <div class="method-name">{{method.displayName}}</div>
+                <div class="method-description">{{{method.description}}}</div>
+                {{#if view.showPreUpgradeChecks}}
+                  {{#if method.isCheckRequestInProgress}}
+                    <div class="method-precheck-message checking">
+                      {{view App.SpinnerView message="admin.stackVersions.version.upgrade.upgradeOptions.preCheck.msg.checking"}}
                     </div>
-                  </div>
-                {{/unless}}
-            {{/each}}
-        </div>
-        {{#if view.upgradeShow}}
-          <div class="text tolerance-text">{{t admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.tolerance}}
-            <i class="glyphicon glyphicon-question-sign failure-tolerance-tooltip" data-toggle="tooltip"></i>
-            <div>
-              {{view App.CheckboxView
-                labelClassNames="tolerance-option"
-                labelTranslate="admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option2"
-                checkedBinding="view.parentView.skipSCFailures"}}
+                  {{else}}
+                    <div {{bindAttr class=":method-precheck-message method.precheckResultsMessageClass"}}>
+                      <i {{bindAttr class="method.precheckResultsMessageIconClass"}}></i>
+                      <b>{{method.precheckResultsTitle}}</b>&nbsp;
+                      <a {{action runAction method target="view"}}>
+                        {{method.precheckResultsMessage}}
+                      </a>
+                      {{#if method.bypassedFailures}}
+                        <div
+                          class="alert-danger">{{t admin.stackVersions.version.upgrade.upgradeOptions.errors_bypassed}}</div>
+                      {{/if}}
+                    </div>
+                  {{/if}}
+                {{/if}}
+              </div>
             </div>
-            <div>
-              {{view App.CheckboxView
-                labelClassNames="tolerance-option"
-                labelTranslate="admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option1"
-                checkedBinding="view.parentView.skipComponentFailures"
-              }}
-            </div>
-          </div>
-        {{/if}}
-        <div class="alert alert-warning">{{t admin.stackVersions.version.upgrade.alertsWarning}}</div>
+          {{/unless}}
+        {{/each}}
       </div>
-    {{/if}}
+      {{#if view.upgradeShow}}
+        <div class="text tolerance-text">{{t admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.tolerance}}
+          <i class="glyphicon glyphicon-question-sign failure-tolerance-tooltip" data-toggle="tooltip"></i>
+          <div>
+            {{view App.CheckboxView
+            labelClassNames="tolerance-option"
+            labelTranslate="admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option2"
+            checkedBinding="view.parentView.skipSCFailures"}}
+          </div>
+          <div>
+            {{view App.CheckboxView
+            labelClassNames="tolerance-option"
+            labelTranslate="admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option1"
+            checkedBinding="view.parentView.skipComponentFailures"
+            }}
+          </div>
+        </div>
+      {{/if}}
+      <div class="alert alert-warning">{{t admin.stackVersions.version.upgrade.alertsWarning}}</div>
+    </div>
+  {{/if}}
 {{else}}
   <div class="row">
     <div class="col-md-1 col-md-offset-3">{{view App.SpinnerView}}</div>
@@ -90,12 +90,12 @@
       {{t admin.stackVersions.version.upgrade.upgradeOptions.loading}}
     </div>
   </div>
-      <div class="text tolerance-text">{{t admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.tolerance}}
-        <i class="icon-question-sign failure-tolerance-tooltip" data-toggle="tooltip"></i>
-        <label class="tolerance-option">{{view Ember.Checkbox checkedBinding="view.parentView.skipSCFailures"}}
-            {{t admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option2}}</label>
-        <label class="tolerance-option">{{view Ember.Checkbox checkedBinding="view.parentView.skipComponentFailures"}}
-           {{t admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option1}}</label>
-    </div>
-    <div class="alert alert-warning">{{t admin.stackVersions.version.upgrade.alertsWarning}}</div>
-  {{/if}}
+  <div class="text tolerance-text">{{t admin.stackVersions.version.upgrade.upgradeOptions.bodyMsg.tolerance}}
+    <i class="icon-question-sign failure-tolerance-tooltip" data-toggle="tooltip"></i>
+    <label class="tolerance-option">{{view Ember.Checkbox checkedBinding="view.parentView.skipSCFailures"}}
+      {{t admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option2}}</label>
+    <label class="tolerance-option">{{view Ember.Checkbox checkedBinding="view.parentView.skipComponentFailures"}}
+      {{t admin.stackVersions.version.upgrade.upgradeOptions.tolerance.option1}}</label>
+  </div>
+  <div class="alert alert-warning">{{t admin.stackVersions.version.upgrade.alertsWarning}}</div>
+{{/if}}

--- a/ambari-web/app/templates/wizard/step8/step8_log_popup.hbs
+++ b/ambari-web/app/templates/wizard/step8/step8_log_popup.hbs
@@ -15,7 +15,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 }}
-<p>{{view.message}}</p>
 <div {{bindAttr class="view.progressBarClass"}}>
     <div class="progress-bar progress-bar-striped active" {{bindAttr style="view.barWidth"}}>
     </div>

--- a/ambari-web/app/views/common/modal_popups/cluster_check_popup.js
+++ b/ambari-web/app/views/common/modal_popups/cluster_check_popup.js
@@ -59,6 +59,7 @@ App.showClusterCheckPopup = function (data, popup, configs) {
     secondary: secondary,
     header: popup.header,
     classNames: ['cluster-check-popup'],
+    modalDialogClasses: ['modal-xlg'],
     bodyClass: Em.View.extend({
       failTitle: popup.failTitle,
       failAlert: popup.failAlert,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Move 'Preparing the Upgrade' text from the corresponding modal to its header
- Upgrade Options popup: add some vertical padding between peragraphs
- Upgrade Options popup: center the contents of upgrade type blocks and add more padding to them
- Make pre-upgrade checks popup wider
- Pre-upgrade checks popup: display warnings as regular text instead of well blocks

## How was this patch tested?

Tested manually