### PR TITLE
AMBARI-24563. global name 'VERIFY_DEPENDENCY_CMD' is not defined' (am…

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -215,7 +215,7 @@ class AptManager(GenericManager):
     pattern = re.compile("has missing dependency|E:")
 
     if r.code or (r.out and pattern.search(r.out)):
-      err_msg = Logger.filter_text("Failed to verify package dependencies. Execution of '%s' returned %s. %s" % (VERIFY_DEPENDENCY_CMD, code, out))
+      err_msg = Logger.filter_text("Failed to verify package dependencies. Execution of '%s' returned %s. %s" % (self.properties.verify_dependency_cmd, r.code, r.out))
       Logger.error(err_msg)
       return False
 


### PR DESCRIPTION
…agyar)

## What changes were proposed in this pull request?

The following error in the python code comes when there is an error during package install on ubuntu.

```text
2018-08-29 16:47:27,250 - Could not install packages. Error: global name 'VERIFY_DEPENDENCY_CMD' is not defined
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 136, in actionexecute
    ret_code = self.install_packages(package_list)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 447, in install_packages
    if not self.repo_mgr.verify_dependencies():
  File "/usr/lib/ambari-agent/lib/ambari_commons/repo_manager/apt_manager.py", line 218, in verify_dependencies
    err_msg = Logger.filter_text("Failed to verify package dependencies. Execution of '%s' returned %s. %s" % (VERIFY_DEPENDENCY_CMD, code, out))
NameError: global name 'VERIFY_DEPENDENCY_CMD' is not defined
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 136, in actionexecute
    ret_code = self.install_packages(package_list)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 447, in install_packages
    if not self.repo_mgr.verify_dependencies():
  File "/usr/lib/ambari-agent/lib/ambari_commons/repo_manager/apt_manager.py", line 218, in verify_dependencies
    err_msg = Logger.filter_text("Failed to verify package dependencies. Execution of '%s' returned %s. %s" % (VERIFY_DEPENDENCY_CMD, code, out))
NameError: global name 'VERIFY_DEPENDENCY_CMD' is not defined

The above exception was the cause of the following exception:

Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 486, in <module>
    InstallPackages().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 351, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/install_packages.py", line 149, in actionexecute
    raise Fail("Failed to distribute repositories/install packages")
resource_management.core.exceptions.Fail: Failed to distribute repositories/install packages
```

(Please fill in changes proposed in this fix)

## How was this patch tested?

- retried installation with the fix