### PR TITLE
[AMBARI-24562] Protect the ClusterConfig resource so that only authorized users may have read-only access the data

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
@@ -33,6 +33,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -64,6 +65,7 @@ import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.ambari.server.security.authorization.RoleAuthorization;
 import org.apache.ambari.server.state.ClientConfigFileDefinition;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
@@ -144,6 +146,8 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
   ClientConfigResourceProvider(@Assisted AmbariManagementController managementController) {
     super(Resource.Type.ClientConfig, propertyIds, keyPropertyIds, managementController);
     gson = new Gson();
+
+    setRequiredGetAuthorizations(EnumSet.of(RoleAuthorization.HOST_VIEW_CONFIGS, RoleAuthorization.SERVICE_VIEW_CONFIGS, RoleAuthorization.CLUSTER_VIEW_CONFIGS));
   }
 
   // ----- ResourceProvider ------------------------------------------------
@@ -159,7 +163,7 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
   }
 
   @Override
-  public Set<Resource> getResources(Request request, Predicate predicate)
+  public Set<Resource> getResourcesAuthorized(Request request, Predicate predicate)
           throws SystemException, UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
 
     Set<Resource> resources = new HashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProviderTest.java
@@ -270,7 +270,7 @@ public class AlertTargetResourceProviderTest {
     testCreateResources(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testCreateResourcesAsClusterAdministrator() throws Exception {
     testCreateResources(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -331,7 +331,7 @@ public class AlertTargetResourceProviderTest {
     testCreateResourcesWithGroups(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testCreateResourcesWithGroupsAsClusterAdministrator() throws Exception {
     testCreateResourcesWithGroups(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -407,7 +407,7 @@ public class AlertTargetResourceProviderTest {
     testCreateGlobalTarget(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testCreateGlobalTargetAsClusterAdministrator() throws Exception {
     testCreateGlobalTarget(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -473,7 +473,7 @@ public class AlertTargetResourceProviderTest {
     testCreateResourceWithRecipientArray(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testCreateResourceWithRecipientArrayAsClusterAdministrator() throws Exception {
     testCreateResourceWithRecipientArray(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -537,7 +537,7 @@ public class AlertTargetResourceProviderTest {
     testCreateResourceWithAlertStates(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testCreateResourceWithAlertStatesAsClusterAdministrator() throws Exception {
     testCreateResourceWithAlertStates(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -604,7 +604,7 @@ public class AlertTargetResourceProviderTest {
     testUpdateResources(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testUpdateResourcesAsClusterAdministrator() throws Exception {
     testUpdateResources(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -679,7 +679,7 @@ public class AlertTargetResourceProviderTest {
     testUpdateResourcesWithGroups(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testUpdateResourcesWithGroupsAsClusterAdministrator() throws Exception {
     testUpdateResourcesWithGroups(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -761,7 +761,7 @@ public class AlertTargetResourceProviderTest {
     testDeleteResources(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testDeleteResourcesAsClusterAdministrator() throws Exception {
     testDeleteResources(TestAuthenticationFactory.createClusterAdministrator());
   }
@@ -829,7 +829,7 @@ public class AlertTargetResourceProviderTest {
     testOverwriteDirective(TestAuthenticationFactory.createAdministrator());
   }
 
-  @Test(expected = AuthorizationException.class)
+  @Test
   public void testOverwriteDirectiveAsClusterAdministrator() throws Exception {
     testOverwriteDirective(TestAuthenticationFactory.createClusterAdministrator());
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProviderTest.java
@@ -56,6 +56,8 @@ import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.utilities.PredicateBuilder;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.ambari.server.security.TestAuthenticationFactory;
+import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.stack.StackManager;
 import org.apache.ambari.server.state.ClientConfigFileDefinition;
 import org.apache.ambari.server.state.Cluster;
@@ -76,6 +78,7 @@ import org.apache.ambari.server.state.UserGroupInfo;
 import org.apache.ambari.server.state.ValueAttributesInfo;
 import org.apache.ambari.server.utils.StageUtils;
 import org.easymock.EasyMock;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,6 +86,8 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * ClientConfigResourceProviderTest tests.
@@ -90,6 +95,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ClientConfigResourceProvider.class, StageUtils.class})
 public class ClientConfigResourceProviderTest {
+  @After
+  public void clearAuthentication() {
+    SecurityContextHolder.getContext().setAuthentication(null);
+  }
+
   @Test
   public void testCreateResources() throws Exception {
     Resource.Type type = Resource.Type.ClientConfig;
@@ -165,7 +175,102 @@ public class ClientConfigResourceProviderTest {
   }
 
   @Test
-  public void testGetResources() throws Exception {
+  public void testGetResourcesForAdministrator() throws Exception {
+    testGetResources(TestAuthenticationFactory.createAdministrator());
+  }
+
+  @Test
+  public void testGetResourcesForClusterAdministrator() throws Exception {
+    testGetResources(TestAuthenticationFactory.createClusterAdministrator());
+  }
+
+  @Test
+  public void testGetResourcesForClusterOperator() throws Exception {
+    testGetResources(TestAuthenticationFactory.createClusterOperator());
+  }
+
+  @Test
+  public void testGetResourcesForServiceAdministrator() throws Exception {
+    testGetResources(TestAuthenticationFactory.createServiceAdministrator());
+  }
+
+  @Test
+  public void testGetResourcesForServiceOperator() throws Exception {
+    testGetResources(TestAuthenticationFactory.createServiceOperator());
+  }
+
+  @Test
+  public void testGetResourcesForClusterUser() throws Exception {
+    testGetResources(TestAuthenticationFactory.createClusterUser());
+  }
+
+  @Test(expected = AuthorizationException.class)
+  public void testGetResourcesForNoRoleUser() throws Exception {
+    testGetResources(TestAuthenticationFactory.createNoRoleUser());
+  }
+
+  @Test
+  public void testGetResourcesFromCommonServicesForAdministrator() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createAdministrator());
+  }
+
+  @Test
+  public void testGetResourcesFromCommonServicesForClusterAdministrator() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createClusterAdministrator());
+  }
+
+  @Test
+  public void testGetResourcesFromCommonServicesForClusterOperator() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createClusterOperator());
+  }
+
+  @Test
+  public void testGetResourcesFromCommonServicesForServiceAdministrator() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createServiceAdministrator());
+  }
+
+  @Test
+  public void testGetResourcesFromCommonServicesForServiceOperator() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createServiceOperator());
+  }
+
+  @Test
+  public void testGetResourcesFromCommonServicesForClusterUser() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createClusterUser());
+  }
+
+  @Test(expected = AuthorizationException.class)
+  public void testGetResourcesFromCommonServicesForNoRoleUser() throws Exception {
+    testGetResourcesFromCommonServices(TestAuthenticationFactory.createNoRoleUser());
+  }
+
+  @Test
+  public void testDeleteResources() throws Exception {
+    Resource.Type type = Resource.Type.ClientConfig;
+
+    AmbariManagementController managementController = createMock(AmbariManagementController.class);
+
+    // replay
+    replay(managementController);
+
+    ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
+        type,
+        managementController);
+
+    Predicate predicate = new PredicateBuilder().property(
+        ClientConfigResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("HDFS_CLIENT").toPredicate();
+    try {
+      provider.deleteResources(new RequestImpl(null, null, null, null), predicate);
+      Assert.fail("Expected an UnsupportedOperationException");
+    } catch (SystemException e) {
+      // expected
+    }
+
+    // verify
+    verify(managementController);
+  }
+
+  private void testGetResources(Authentication authentication) throws Exception {
     Resource.Type type = Resource.Type.ClientConfig;
 
     AmbariManagementController managementController = createNiceMock(AmbariManagementController.class);
@@ -370,6 +475,8 @@ public class ClientConfigResourceProviderTest {
         runtime, process);
     PowerMock.replayAll();
 
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
     Set<Resource> resources = provider.getResources(request, predicate);
     assertFalse(resources.isEmpty());
     assertFalse(newFile.exists());
@@ -381,8 +488,7 @@ public class ClientConfigResourceProviderTest {
     PowerMock.verifyAll();
   }
 
-  @Test
-  public void testGetResourcesFromCommonServices() throws Exception {
+  private void testGetResourcesFromCommonServices(Authentication authentication) throws Exception {
     Resource.Type type = Resource.Type.ClientConfig;
 
     AmbariManagementController managementController = createNiceMock(AmbariManagementController.class);
@@ -553,6 +659,8 @@ public class ClientConfigResourceProviderTest {
         runtime, process);
     PowerMock.replayAll();
 
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
     Set<Resource> resources = provider.getResources(request, predicate);
     assertFalse(resources.isEmpty());
 
@@ -563,31 +671,5 @@ public class ClientConfigResourceProviderTest {
     PowerMock.verifyAll();
   }
 
-
-  @Test
-  public void testDeleteResources() throws Exception {
-    Resource.Type type = Resource.Type.ClientConfig;
-
-    AmbariManagementController managementController = createMock(AmbariManagementController.class);
-
-    // replay
-    replay(managementController);
-
-    ResourceProvider provider = AbstractControllerResourceProvider.getResourceProvider(
-        type,
-        managementController);
-
-    Predicate predicate = new PredicateBuilder().property(
-        ClientConfigResourceProvider.COMPONENT_COMPONENT_NAME_PROPERTY_ID).equals("HDFS_CLIENT").toPredicate();
-    try {
-      provider.deleteResources(new RequestImpl(null, null, null, null), predicate);
-      Assert.fail("Expected an UnsupportedOperationException");
-    } catch (SystemException e) {
-      // expected
-    }
-
-    // verify
-    verify(managementController);
-  }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/TestAuthenticationFactory.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/TestAuthenticationFactory.java
@@ -95,6 +95,14 @@ public class TestAuthenticationFactory {
     return createAmbariUserAuthentication(1, name, Collections.singleton(createViewUserGrantedAuthority(viewResourceId)));
   }
 
+  public static Authentication createNoRoleUser() {
+    return createNoRoleUser("noRoleUser", 4L);
+  }
+
+  public static Authentication createNoRoleUser(String name, Long clusterResourceId) {
+    return createAmbariUserAuthentication(1, name, Collections.emptySet());
+  }
+
   private static GrantedAuthority createAdministratorGrantedAuthority() {
     return new AmbariGrantedAuthority(createAdministratorPrivilegeEntity());
   }
@@ -174,45 +182,49 @@ public class TestAuthenticationFactory {
     permissionEntity.setResourceType(createResourceTypeEntity(ResourceType.CLUSTER));
     permissionEntity.setPrincipal(createPrincipalEntity(2L));
     permissionEntity.addAuthorizations(EnumSet.of(
-        RoleAuthorization.CLUSTER_MANAGE_CREDENTIALS,
-        RoleAuthorization.CLUSTER_MODIFY_CONFIGS,
-        RoleAuthorization.CLUSTER_MANAGE_CONFIG_GROUPS,
-        RoleAuthorization.CLUSTER_TOGGLE_ALERTS,
-        RoleAuthorization.CLUSTER_MANAGE_ALERTS,
-        RoleAuthorization.CLUSTER_TOGGLE_KERBEROS,
-        RoleAuthorization.CLUSTER_UPGRADE_DOWNGRADE_STACK,
-        RoleAuthorization.CLUSTER_VIEW_ALERTS,
-        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
-        RoleAuthorization.CLUSTER_VIEW_METRICS,
-        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
-        RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
-        RoleAuthorization.HOST_ADD_DELETE_COMPONENTS,
-        RoleAuthorization.HOST_ADD_DELETE_HOSTS,
-        RoleAuthorization.HOST_TOGGLE_MAINTENANCE,
-        RoleAuthorization.HOST_VIEW_CONFIGS,
-        RoleAuthorization.HOST_VIEW_METRICS,
-        RoleAuthorization.HOST_VIEW_STATUS_INFO,
-        RoleAuthorization.SERVICE_ADD_DELETE_SERVICES,
-        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
-        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
-        RoleAuthorization.SERVICE_ENABLE_HA,
-        RoleAuthorization.SERVICE_MANAGE_CONFIG_GROUPS,
-        RoleAuthorization.SERVICE_MODIFY_CONFIGS,
-        RoleAuthorization.SERVICE_MOVE,
-        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
-        RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
-        RoleAuthorization.SERVICE_START_STOP,
-        RoleAuthorization.SERVICE_TOGGLE_ALERTS,
-        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
-        RoleAuthorization.SERVICE_VIEW_ALERTS,
-        RoleAuthorization.SERVICE_VIEW_CONFIGS,
-        RoleAuthorization.SERVICE_VIEW_METRICS,
         RoleAuthorization.SERVICE_VIEW_STATUS_INFO,
         RoleAuthorization.SERVICE_VIEW_OPERATIONAL_LOGS,
-        RoleAuthorization.CLUSTER_RUN_CUSTOM_COMMAND,
+        RoleAuthorization.SERVICE_VIEW_METRICS,
+        RoleAuthorization.SERVICE_VIEW_CONFIGS,
+        RoleAuthorization.SERVICE_VIEW_ALERTS,
+        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
+        RoleAuthorization.SERVICE_TOGGLE_ALERTS,
+        RoleAuthorization.SERVICE_START_STOP,
+        RoleAuthorization.SERVICE_SET_SERVICE_USERS_GROUPS,
+        RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
+        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
+        RoleAuthorization.SERVICE_MOVE,
+        RoleAuthorization.SERVICE_MODIFY_CONFIGS,
+        RoleAuthorization.SERVICE_MANAGE_CONFIG_GROUPS,
         RoleAuthorization.SERVICE_MANAGE_AUTO_START,
+        RoleAuthorization.SERVICE_MANAGE_ALERTS,
+        RoleAuthorization.SERVICE_ENABLE_HA,
+        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
+        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
+        RoleAuthorization.SERVICE_ADD_DELETE_SERVICES,
+        RoleAuthorization.HOST_VIEW_STATUS_INFO,
+        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.HOST_VIEW_CONFIGS,
+        RoleAuthorization.HOST_TOGGLE_MAINTENANCE,
+        RoleAuthorization.HOST_ADD_DELETE_HOSTS,
+        RoleAuthorization.HOST_ADD_DELETE_COMPONENTS,
+        RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
+        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.CLUSTER_VIEW_METRICS,
+        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
+        RoleAuthorization.CLUSTER_VIEW_ALERTS,
+        RoleAuthorization.CLUSTER_UPGRADE_DOWNGRADE_STACK,
+        RoleAuthorization.CLUSTER_TOGGLE_KERBEROS,
+        RoleAuthorization.CLUSTER_TOGGLE_ALERTS,
+        RoleAuthorization.CLUSTER_RUN_CUSTOM_COMMAND,
+        RoleAuthorization.CLUSTER_MODIFY_CONFIGS,
+        RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA,
+        RoleAuthorization.CLUSTER_MANAGE_CREDENTIALS,
+        RoleAuthorization.CLUSTER_MANAGE_CONFIG_GROUPS,
         RoleAuthorization.CLUSTER_MANAGE_AUTO_START,
-        RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA));
+        RoleAuthorization.CLUSTER_MANAGE_ALERTS,
+        RoleAuthorization.CLUSTER_MANAGE_ALERT_NOTIFICATIONS
+    ));
     return permissionEntity;
   }
 
@@ -222,39 +234,38 @@ public class TestAuthenticationFactory {
     permissionEntity.setResourceType(createResourceTypeEntity(ResourceType.CLUSTER));
     permissionEntity.setPrincipal(createPrincipalEntity(3L));
     permissionEntity.addAuthorizations(EnumSet.of(
-        RoleAuthorization.HOST_VIEW_CONFIGS,
-        RoleAuthorization.HOST_ADD_DELETE_COMPONENTS,
-        RoleAuthorization.HOST_VIEW_METRICS,
-        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
-        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
-        RoleAuthorization.SERVICE_MANAGE_ALERTS,
-        RoleAuthorization.SERVICE_ENABLE_HA,
-        RoleAuthorization.SERVICE_VIEW_METRICS,
-        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
-        RoleAuthorization.HOST_VIEW_STATUS_INFO,
-        RoleAuthorization.CLUSTER_VIEW_METRICS,
         RoleAuthorization.SERVICE_VIEW_STATUS_INFO,
-        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
-        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
-        RoleAuthorization.SERVICE_VIEW_ALERTS,
-        RoleAuthorization.CLUSTER_MANAGE_CONFIG_GROUPS,
-        RoleAuthorization.SERVICE_TOGGLE_ALERTS,
-        RoleAuthorization.SERVICE_MOVE,
-        RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
-        RoleAuthorization.SERVICE_MODIFY_CONFIGS,
-        RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
-        RoleAuthorization.SERVICE_VIEW_CONFIGS,
-        RoleAuthorization.HOST_ADD_DELETE_HOSTS,
-        RoleAuthorization.SERVICE_START_STOP,
-        RoleAuthorization.CLUSTER_VIEW_ALERTS,
-        RoleAuthorization.HOST_TOGGLE_MAINTENANCE,
-        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
-        RoleAuthorization.SERVICE_MANAGE_CONFIG_GROUPS,
-        RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA,
         RoleAuthorization.SERVICE_VIEW_OPERATIONAL_LOGS,
+        RoleAuthorization.SERVICE_VIEW_METRICS,
+        RoleAuthorization.SERVICE_VIEW_CONFIGS,
+        RoleAuthorization.SERVICE_VIEW_ALERTS,
+        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
+        RoleAuthorization.SERVICE_START_STOP,
+        RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
+        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
+        RoleAuthorization.SERVICE_MOVE,
+        RoleAuthorization.SERVICE_MODIFY_CONFIGS,
+        RoleAuthorization.SERVICE_MANAGE_CONFIG_GROUPS,
         RoleAuthorization.SERVICE_MANAGE_AUTO_START,
-        RoleAuthorization.CLUSTER_MANAGE_AUTO_START,
-        RoleAuthorization.CLUSTER_MANAGE_CREDENTIALS));
+        RoleAuthorization.SERVICE_ENABLE_HA,
+        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
+        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
+        RoleAuthorization.HOST_VIEW_STATUS_INFO,
+        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.HOST_VIEW_CONFIGS,
+        RoleAuthorization.HOST_TOGGLE_MAINTENANCE,
+        RoleAuthorization.HOST_ADD_DELETE_HOSTS,
+        RoleAuthorization.HOST_ADD_DELETE_COMPONENTS,
+        RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
+        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.CLUSTER_VIEW_METRICS,
+        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
+        RoleAuthorization.CLUSTER_VIEW_ALERTS,
+        RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA,
+        RoleAuthorization.CLUSTER_MANAGE_CREDENTIALS,
+        RoleAuthorization.CLUSTER_MANAGE_CONFIG_GROUPS,
+        RoleAuthorization.CLUSTER_MANAGE_AUTO_START
+    ));
     return permissionEntity;
   }
 
@@ -264,33 +275,31 @@ public class TestAuthenticationFactory {
     permissionEntity.setResourceType(createResourceTypeEntity(ResourceType.CLUSTER));
     permissionEntity.setPrincipal(createPrincipalEntity(4L));
     permissionEntity.addAuthorizations(EnumSet.of(
-        RoleAuthorization.CLUSTER_VIEW_ALERTS,
-        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
-        RoleAuthorization.CLUSTER_VIEW_METRICS,
-        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
-        RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
-        RoleAuthorization.CLUSTER_MANAGE_CONFIG_GROUPS,
-        RoleAuthorization.HOST_VIEW_CONFIGS,
-        RoleAuthorization.HOST_VIEW_METRICS,
-        RoleAuthorization.HOST_VIEW_STATUS_INFO,
-        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
-        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
-        RoleAuthorization.SERVICE_ENABLE_HA,
-        RoleAuthorization.SERVICE_MANAGE_CONFIG_GROUPS,
-        RoleAuthorization.SERVICE_MODIFY_CONFIGS,
-        RoleAuthorization.SERVICE_MOVE,
-        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
-        RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
-        RoleAuthorization.SERVICE_START_STOP,
-        RoleAuthorization.SERVICE_TOGGLE_ALERTS,
-        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
-        RoleAuthorization.SERVICE_VIEW_ALERTS,
-        RoleAuthorization.SERVICE_VIEW_CONFIGS,
-        RoleAuthorization.SERVICE_VIEW_METRICS,
         RoleAuthorization.SERVICE_VIEW_STATUS_INFO,
         RoleAuthorization.SERVICE_VIEW_OPERATIONAL_LOGS,
+        RoleAuthorization.SERVICE_VIEW_METRICS,
+        RoleAuthorization.SERVICE_VIEW_CONFIGS,
+        RoleAuthorization.SERVICE_VIEW_ALERTS,
+        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
+        RoleAuthorization.SERVICE_START_STOP,
+        RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
+        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
+        RoleAuthorization.SERVICE_MODIFY_CONFIGS,
+        RoleAuthorization.SERVICE_MANAGE_CONFIG_GROUPS,
         RoleAuthorization.SERVICE_MANAGE_AUTO_START,
-        RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA));
+        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
+        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
+        RoleAuthorization.HOST_VIEW_STATUS_INFO,
+        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.HOST_VIEW_CONFIGS,
+        RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
+        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.CLUSTER_VIEW_METRICS,
+        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
+        RoleAuthorization.CLUSTER_VIEW_ALERTS,
+        RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA,
+        RoleAuthorization.CLUSTER_MANAGE_CONFIG_GROUPS
+    ));
     return permissionEntity;
   }
 
@@ -300,22 +309,24 @@ public class TestAuthenticationFactory {
     permissionEntity.setResourceType(createResourceTypeEntity(ResourceType.CLUSTER));
     permissionEntity.setPrincipal(createPrincipalEntity(5L));
     permissionEntity.addAuthorizations(EnumSet.of(
-        RoleAuthorization.SERVICE_VIEW_CONFIGS,
-        RoleAuthorization.SERVICE_VIEW_METRICS,
         RoleAuthorization.SERVICE_VIEW_STATUS_INFO,
-        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
+        RoleAuthorization.SERVICE_VIEW_METRICS,
+        RoleAuthorization.SERVICE_VIEW_CONFIGS,
         RoleAuthorization.SERVICE_VIEW_ALERTS,
+        RoleAuthorization.SERVICE_TOGGLE_MAINTENANCE,
         RoleAuthorization.SERVICE_START_STOP,
-        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
-        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
         RoleAuthorization.SERVICE_RUN_SERVICE_CHECK,
-        RoleAuthorization.HOST_VIEW_CONFIGS,
-        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.SERVICE_RUN_CUSTOM_COMMAND,
+        RoleAuthorization.SERVICE_DECOMMISSION_RECOMMISSION,
+        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
         RoleAuthorization.HOST_VIEW_STATUS_INFO,
-        RoleAuthorization.CLUSTER_VIEW_ALERTS,
-        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
-        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.HOST_VIEW_CONFIGS,
         RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
+        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.CLUSTER_VIEW_METRICS,
+        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
+        RoleAuthorization.CLUSTER_VIEW_ALERTS,
         RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA
     ));
     return permissionEntity;
@@ -327,20 +338,22 @@ public class TestAuthenticationFactory {
     permissionEntity.setResourceType(createResourceTypeEntity(ResourceType.CLUSTER));
     permissionEntity.setPrincipal(createPrincipalEntity(6L));
     permissionEntity.addAuthorizations(EnumSet.of(
-        RoleAuthorization.SERVICE_VIEW_CONFIGS,
-        RoleAuthorization.SERVICE_VIEW_METRICS,
         RoleAuthorization.SERVICE_VIEW_STATUS_INFO,
-        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
+        RoleAuthorization.SERVICE_VIEW_METRICS,
+        RoleAuthorization.SERVICE_VIEW_CONFIGS,
         RoleAuthorization.SERVICE_VIEW_ALERTS,
-        RoleAuthorization.HOST_VIEW_CONFIGS,
-        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.SERVICE_COMPARE_CONFIGS,
         RoleAuthorization.HOST_VIEW_STATUS_INFO,
-        RoleAuthorization.CLUSTER_VIEW_ALERTS,
-        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
-        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.HOST_VIEW_METRICS,
+        RoleAuthorization.HOST_VIEW_CONFIGS,
         RoleAuthorization.CLUSTER_VIEW_STATUS_INFO,
+        RoleAuthorization.CLUSTER_VIEW_STACK_DETAILS,
+        RoleAuthorization.CLUSTER_VIEW_METRICS,
+        RoleAuthorization.CLUSTER_VIEW_CONFIGS,
+        RoleAuthorization.CLUSTER_VIEW_ALERTS,
         RoleAuthorization.CLUSTER_MANAGE_USER_PERSISTED_DATA
     ));
+
     return permissionEntity;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Protect the ClientConfig resource so that only authorized users may have read-only access the data.

Users with the following permission should have read-only access:
* `CLUSTER.VIEW_CONFIGS`
* `SERVICE.VIEW_CONFIGS`
* `HOST.VIEW_CONFIGS`

These permissions should be allow for the following roles:
* `AMBARI.ADMINISTRATOR`
* `CLUSTER.ADMINISTRATOR`
* `CLUSTER.OPERATOR`
* `SERVICE.ADMINISTRATOR`
* `SERVICE.OPERATOR`
* `CLUSTER.USER`

Users with no role related to the cluster may not view the data.

The `org.apache.ambari.server.security.TestAuthenticationFactory` was updated to match the permission sets from the database. This exposed issues in the `org.apache.ambari.server.controller.internal.AlertTargetResourceProviderTest` class, which needed to be fixed.

This was cherry-picked from #2205 

## How was this patch tested?

Manually tested using users with various roles. 

Updated unit tests, all passed. 

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.