### PR TITLE
AMBARI-24566: Ambari-server cannot start

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackManager.java
@@ -696,18 +696,7 @@ public class StackManager {
       if (stack.isFile()) {
         continue;
       }
-      for (File stackFolder : stack.listFiles(StackDirectory.FILENAME_FILTER)) {
-        if (stackFolder.isFile()) {
-          continue;
-        }
-        String stackName = stackFolder.getParentFile().getName();
-        String stackVersion = stackFolder.getName();
-
-        StackModule stackModule = new StackModule(new StackDirectory(stackFolder.getPath()), stackContext);
-        String stackKey = stackName + StackManager.PATH_DELIMITER + stackVersion;
-        stackModules.put(stackKey, stackModule);
-        stackMap.put(stackKey, stackModule.getModuleInfo());
-      }
+      parseAllModulesInStack(stack, stackModules, stack.getName());
     }
 
     return stackModules;
@@ -719,6 +708,32 @@ public class StackManager {
 
   public void unlinkStackAndExtension(StackInfo stack, ExtensionInfo extension) throws AmbariException {
     stack.removeExtension(extension);
+  }
+
+  private void parseAllModulesInStack(File stack, Map<String, StackModule> stackModules, String stackName) throws AmbariException{
+    for (File stackFolder : stack.listFiles()) {
+      if (stackFolder.isFile()) {
+        continue;
+      }
+      // The current stack layout is: /var/lib/ambari-server/resource/HDP/{2.1/services}|{services}
+      for (File subFolder : stackFolder.listFiles()) {
+        if (subFolder.isFile()) {
+          continue;
+        }
+        if (subFolder.getName().equals("services")) {
+          // Now it is time to start processing each module
+          for (File module : subFolder.listFiles()) {
+            StackModule stackModule = new StackModule(new StackDirectory(module.getPath()), stackContext);
+            String moduleKey = module.getName();
+            stackModules.put(moduleKey, stackModule);
+            stackMap.put(moduleKey, stackModule.getModuleInfo());
+          }
+        } else {
+          // Handle /var/lib/ambari-server/resource/HDP/{2.1/services} case
+          parseAllModulesInStack(subFolder, stackModules, stackName);
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The layout in /var/lib/ambari-server/resource/stacks/ has been changed, the stackManager in ambari-server code cannot properly parse stackdirectory and get stackModule information, the fix is to recursively parse stackdirectory and create right stackModules map.

## How was this patch tested?
Manually tested, patch the latest ambari-server code and it can start successfully