### PR TITLE
[AMBARI-24275] - Unable to Restart Hive When Using An Ambari-Managed MySQL Server.

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -964,7 +964,7 @@ class Script(object):
     else:
       # To remain backward compatible with older stacks, only pass upgrade_type if available.
       # TODO, remove checking the argspec for "upgrade_type" once all of the services support that optional param.
-      if True:
+      if "upgrade_type" in inspect.getargspec(self.stop).args:
         self.stop(env, upgrade_type=upgrade_type)
       else:
         if is_stack_upgrade:

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/mysql_server.py
@@ -42,12 +42,12 @@ class MysqlServer(Script):
     env.set_params(params)
     mysql_configure()
 
-  def start(self, env, rolling_restart=False):
+  def start(self, env):
     import params
     env.set_params(params)
     mysql_service(action='start')
 
-  def stop(self, env, rolling_restart=False):
+  def stop(self, env):
     import params
     env.set_params(params)
     mysql_service(action='stop')


### PR DESCRIPTION
Duplicate of https://github.com/apache/ambari/pull/1742 for branch-2.7. 