### PR TITLE
AMBARI-24570. Atlas should handle a customized Zookeeper service prin…

### DIFF
--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/configuration/atlas-env.xml
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/configuration/atlas-env.xml
@@ -116,7 +116,7 @@ export JAVA_HOME={{java64_home}}
 
 # any additional java opts you want to set. This will apply to both client and server operations
 {% if security_enabled %}
-export METADATA_OPTS="{{metadata_opts}} -Djava.security.auth.login.config={{atlas_jaas_file}}"
+export METADATA_OPTS="{{metadata_opts}} -Dzookeeper.sasl.client.username={{zk_principal_user}} -Djava.security.auth.login.config={{atlas_jaas_file}}"
 {% else %}
 export METADATA_OPTS="{{metadata_opts}}"
 {% endif %}

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/params.py
@@ -89,6 +89,9 @@ cluster_name = config['clusterName']
 
 java_version = expect("/ambariLevelParams/java_version", int)
 
+zk_principal_name = default("/configurations/zookeeper-env/zookeeper_principal_name", "zookeeper/_HOST@EXAMPLE.COM")
+zk_principal_user = zk_principal_name.split('/')[0]
+
 zk_root = default('/configurations/application-properties/atlas.server.ha.zookeeper.zkroot', '/apache_atlas')
 stack_supports_zk_security = check_stack_feature(StackFeature.SECURE_ZOOKEEPER, version_for_stack_feature_checks)
 atlas_kafka_group_id = default('/configurations/application-properties/atlas.kafka.hook.group.id', None)

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/ATLAS/configuration/atlas-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/ATLAS/configuration/atlas-env.xml
@@ -121,7 +121,7 @@
 
       # any additional java opts you want to set. This will apply to both client and server operations
       {% if security_enabled %}
-      export ATLAS_OPTS="{{metadata_opts}} -Djava.security.auth.login.config={{atlas_jaas_file}}"
+      export ATLAS_OPTS="{{metadata_opts}} -Dzookeeper.sasl.client.username={{zk_principal_user}} -Djava.security.auth.login.config={{atlas_jaas_file}}"
       {% else %}
       export ATLAS_OPTS="{{metadata_opts}}"
       {% endif %}


### PR DESCRIPTION
…cipal name (amagyar)

## What changes were proposed in this pull request?

Zookeeper service principal is no longer a constant. Atlas should override the default principal with the user supplied principal.

## How was this patch tested?

- Installed ATLAS
- Enabled kerberos
- Checked if atlas-env.sh had the correct principal