### PR TITLE
AMBARI-24585 'yarn.nodemanager.linux-container-executor.cgroups.hierarchy' is not equal to the value of yarn_hierarchy in UI Deploy

### DIFF
--- a/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
+++ b/ambari-web/app/mixins/common/configs/config_recommendation_parser.js
@@ -137,6 +137,7 @@ App.ConfigRecommendationParser = Em.Mixin.create(App.ConfigRecommendations, {
           if (configs.length) {
             var mergedConfigs = configs.concat(stepConfig.get('configs'));
             stepConfig.set('configs', mergedConfigs);
+            stepConfig.propertyDidChange('redrawConfigs');
           }
         }
       }

--- a/ambari-web/app/views/common/configs/service_config_container_view.js
+++ b/ambari-web/app/views/common/configs/service_config_container_view.js
@@ -106,7 +106,7 @@ App.ServiceConfigContainerView = Em.ContainerView.extend({
     //terminate lazy loading when switch service
     if (this.get('lazyLoading')) lazyLoading.terminate(this.get('lazyLoading'));
     this.pushViewAfterRecommendation();
-  }.observes('controller.selectedService'),
+  }.observes('controller.selectedService', 'controller.selectedService.redrawConfigs'),
 
   pushViewAfterRecommendation: function() {
     if (this.get('controller.isRecommendedLoaded')) {


### PR DESCRIPTION
## How was this patch tested?
21728 passing (29s)
  48 pending
