### PR TITLE
[AMBARI-24586] User get stuck between steps if API returns empty version_definitions array

### DIFF
--- a/ambari-web/app/controllers/installer.js
+++ b/ambari-web/app/controllers/installer.js
@@ -305,16 +305,22 @@ App.InstallerController = App.WizardController.extend(App.Persist, {
         }
       }, this);
     }
-
-    data.items.sortProperty('VersionDefinition.stack_version').reverse().forEach(function (versionDefinition) {
-      // to display repos panel, should map all available operating systems including empty ones
-      var stackInfo = {};
-      stackInfo.isStacksExistInDb = isStacksExistInDb;
-      stackInfo.stacks = stacks;
-      stackInfo.oses = oses;
-      stackInfo.repos = repos;
-      this.getSupportedOSList(versionDefinition, stackInfo, params.dfd);
-    }, this);
+    // if data.items is empty, we show error modal end return to back step
+    if (data.items && data.items.length) {
+      data.items.sortProperty('VersionDefinition.stack_version').reverse().forEach(function (versionDefinition) {
+        // to display repos panel, should map all available operating systems including empty ones
+        var stackInfo = {};
+        stackInfo.isStacksExistInDb = isStacksExistInDb;
+        stackInfo.stacks = stacks;
+        stackInfo.oses = oses;
+        stackInfo.repos = repos;
+        this.getSupportedOSList(versionDefinition, stackInfo, params.dfd);
+      }, this);
+    } else {
+      App.showAlertPopup(Em.I18n.t('common.error'), Em.I18n.t('installer.step1.noVersionDefinitions'), function() {
+        App.router.send('back');
+      });
+    }
   },
 
   mergeChanges: function (repos, oses, stacks) {

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -682,6 +682,7 @@ Em.I18n.translations = {
   'installer.step1.invalidURLAttention': '<b>Attention:</b> Please make sure all repository URLs are valid before proceeding.',
   'installer.step1.checkAtLeastOneAttention': '<b>Attention:</b> Please check at least one repository.',
   'installer.step1.retryRepoUrls': 'Click <b>here</b> to retry.',
+  'installer.step1.noVersionDefinitions': 'Unable to load versions data from server.',
 
   'installer.step2.header':'Install Options',
   'installer.step2.body':'Enter the list of hosts to be included in the cluster and provide your SSH key.',

--- a/ambari-web/test/controllers/wizard/step7_test.js
+++ b/ambari-web/test/controllers/wizard/step7_test.js
@@ -2366,9 +2366,18 @@ describe('App.InstallerStep7Controller', function () {
 
   describe('#showConfigProperty', function () {
 
+    beforeEach(function () {
+      sinon.stub(Em.run, 'next', Em.K);
+    });
+
+    afterEach(function() {
+      Em.run.next.restore();
+    });
+
     it('set props "isActive" to true in entered showConfigProperty event and "false" in all another stepConfigs', function() {
       var event = {context: Ember.Object.create({
           serviceName: 'AMBARI_METRICS',
+          propertyName: "all-configurations",
           name: 'all-configurations',
           isActive: false,
       })};
@@ -2378,9 +2387,9 @@ describe('App.InstallerStep7Controller', function () {
         Em.Object.create({serviceName: 'MAPREDUCE2', isActive: true, configGroups: [{},{}]}),
       ]));
       installerStep7Controller.set('filterColumns', [
-        {selected: true},
-        {selected: false},
-        {selected: true}
+        Em.Object.create({attributeName:"isOverridden", attributeValue:true, name:"Overridden properties",selected:true}),
+        Em.Object.create({attributeName:"isFinal", attributeValue:true, name:"Final properties", selected:false}),
+        Em.Object.create({attributeName:"hasIssues", attributeValue:true, name:"Show property issues", selected:false}),
       ]);
       installerStep7Controller.showConfigProperty(event);
       expect(installerStep7Controller.get('filterColumns').everyProperty('selected', false)).to.be.equal(true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Install Wizard when user goes to step1 API request to load version definitions is sent. Sometimes this request returns empty array and UI is not showing any error and just shows empty page.

## How was this patch tested?

  21804 passing (33s)
  48 pending