### PR TITLE
AMBARI-24355. Logfeeder: create CLI for checkpoints and include log type in checkpoint file names.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/manager/CheckpointManager.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/manager/CheckpointManager.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,27 +18,18 @@
  */
 package org.apache.ambari.logfeeder.plugin.manager;
 
+import org.apache.ambari.logfeeder.plugin.common.LogFeederProperties;
 import org.apache.ambari.logfeeder.plugin.input.Input;
+import org.apache.ambari.logfeeder.plugin.input.InputMarker;
 
-import java.io.File;
-import java.util.List;
+public interface CheckpointManager<I extends Input, IFM extends InputMarker, P extends LogFeederProperties> {
 
+  void init(P properties);
 
-public abstract class InputManager implements BlockManager {
+  void checkIn(I inputFile, IFM inputMarker);
 
-  public abstract void addToNotReady(Input input);
+  int resumeLineNumber(I input);
 
-  public abstract void checkInAll();
+  void cleanupCheckpoints();
 
-  public abstract List<Input> getInputList(String serviceName);
-
-  public abstract void add(String serviceName, Input input);
-
-  public abstract void removeInput(Input input);
-
-  public abstract void removeInputsForService(String serviceName);
-
-  public abstract void startInputs(String serviceName);
-
-  public abstract CheckpointManager getCheckpointHandler();
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/manager/CheckpointManager.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/manager/CheckpointManager.java
@@ -22,6 +22,8 @@ import org.apache.ambari.logfeeder.plugin.common.LogFeederProperties;
 import org.apache.ambari.logfeeder.plugin.input.Input;
 import org.apache.ambari.logfeeder.plugin.input.InputMarker;
 
+import java.io.IOException;
+
 public interface CheckpointManager<I extends Input, IFM extends InputMarker, P extends LogFeederProperties> {
 
   void init(P properties);
@@ -31,5 +33,11 @@ public interface CheckpointManager<I extends Input, IFM extends InputMarker, P e
   int resumeLineNumber(I input);
 
   void cleanupCheckpoints();
+
+  void printCheckpoints(String checkpointLocation, String logTypeFilter,
+                        String fileKeyFilter) throws IOException;
+
+  void cleanCheckpoint(String checkpointLocation, String logTypeFilter,
+                       String fileKeyFilter, boolean all) throws IOException;
 
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/ConfigHandler.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/ConfigHandler.java
@@ -421,7 +421,7 @@ public class ConfigHandler implements InputConfigMonitor {
   }
 
   public void cleanCheckPointFiles() {
-    inputManager.cleanCheckPointFiles();
+    inputManager.getCheckpointHandler().cleanupCheckpoints();
   }
 
   public void logStats() {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/ApplicationConfig.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/ApplicationConfig.java
@@ -24,6 +24,8 @@ import org.apache.ambari.logfeeder.docker.DockerContainerRegistry;
 import org.apache.ambari.logfeeder.common.LogFeederConstants;
 import org.apache.ambari.logfeeder.input.InputConfigUploader;
 import org.apache.ambari.logfeeder.input.InputManagerImpl;
+import org.apache.ambari.logfeeder.plugin.manager.CheckpointManager;
+import org.apache.ambari.logfeeder.input.file.checkpoint.FileCheckpointManager;
 import org.apache.ambari.logfeeder.loglevelfilter.LogLevelFilterHandler;
 import org.apache.ambari.logfeeder.common.ConfigHandler;
 import org.apache.ambari.logfeeder.metrics.MetricsManager;
@@ -148,7 +150,7 @@ public class ApplicationConfig {
 
 
   @Bean
-  @DependsOn("containerRegistry")
+  @DependsOn({"containerRegistry", "checkpointHandler"})
   public InputManager inputManager() {
     return new InputManagerImpl();
   }
@@ -156,6 +158,11 @@ public class ApplicationConfig {
   @Bean
   public OutputManager outputManager() {
     return new OutputManagerImpl();
+  }
+
+  @Bean
+  public CheckpointManager checkpointHandler() {
+    return new FileCheckpointManager();
   }
 
   @Bean

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/InputFile.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/InputFile.java
@@ -26,9 +26,7 @@ import org.apache.ambari.logfeeder.input.monitor.DockerLogFileUpdateMonitor;
 import org.apache.ambari.logfeeder.input.monitor.LogFileDetachMonitor;
 import org.apache.ambari.logfeeder.input.monitor.LogFilePathUpdateMonitor;
 import org.apache.ambari.logfeeder.input.reader.LogsearchReaderFactory;
-import org.apache.ambari.logfeeder.input.file.FileCheckInHelper;
 import org.apache.ambari.logfeeder.input.file.ProcessFileHelper;
-import org.apache.ambari.logfeeder.input.file.ResumeLineNumberHelper;
 import org.apache.ambari.logfeeder.plugin.filter.Filter;
 import org.apache.ambari.logfeeder.plugin.input.Input;
 import org.apache.ambari.logfeeder.util.FileUtil;
@@ -144,7 +142,7 @@ public class InputFile extends Input<LogFeederProps, InputFileMarker> {
 
   @Override
   public synchronized void checkIn(InputFileMarker inputMarker) {
-    FileCheckInHelper.checkIn(this, inputMarker);
+    getInputManager().getCheckpointHandler().checkIn(this, inputMarker);
   }
 
   @Override
@@ -304,7 +302,7 @@ public class InputFile extends Input<LogFeederProps, InputFileMarker> {
   }
 
   public int getResumeFromLineNumber() {
-    return ResumeLineNumberHelper.getResumeFromLineNumber(this);
+    return this.getInputManager().getCheckpointHandler().resumeLineNumber(this);
   }
 
   public void processFile(File logPathFile, boolean follow) throws Exception {
@@ -485,7 +483,7 @@ public class InputFile extends Input<LogFeederProps, InputFileMarker> {
     return fileKey;
   }
 
-  public String getBase64FileKey() throws Exception {
+  public String getBase64FileKey() {
     return base64FileKey;
   }
 

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/InputSimulate.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/InputSimulate.java
@@ -168,8 +168,14 @@ public class InputSimulate extends InputFile {
     return lineNumber;
   }
 
-  public String getBase64FileKey() throws Exception {
-    String fileKey = InetAddress.getLocalHost().getHostAddress() + "|" + getFilePath();
+  public String getBase64FileKey() {
+    String fileKey;
+    try {
+      fileKey = InetAddress.getLocalHost().getHostAddress() + "|" + getFilePath();
+    } catch (Exception e) {
+      // skip
+      fileKey = "localhost|" + getFilePath();
+    }
     return Base64.byteArrayToBase64(fileKey.getBytes());
   }
 

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/FileCheckpointManager.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/FileCheckpointManager.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.input.file.checkpoint;
+
+import org.apache.ambari.logfeeder.conf.LogFeederProps;
+import org.apache.ambari.logfeeder.input.InputFile;
+import org.apache.ambari.logfeeder.input.InputFileMarker;
+import org.apache.ambari.logfeeder.input.file.checkpoint.util.FileCheckInHelper;
+import org.apache.ambari.logfeeder.input.file.checkpoint.util.FileCheckpointCleanupHelper;
+import org.apache.ambari.logfeeder.input.file.checkpoint.util.ResumeLineNumberHelper;
+import org.apache.ambari.logfeeder.input.monitor.CheckpointCleanupMonitor;
+import org.apache.ambari.logfeeder.plugin.manager.CheckpointManager;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+public class FileCheckpointManager implements CheckpointManager<InputFile, InputFileMarker, LogFeederProps> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileCheckpointManager.class);
+
+  private static final String CHECKPOINT_SUBFOLDER_NAME = "logfeeder_checkpoints";
+
+  private String checkPointExtension;
+  private String checkPointFolder;
+  private File checkPointFolderFile;
+
+  @Override
+  public void init(LogFeederProps logFeederProps) {
+    checkPointExtension = logFeederProps.getCheckPointExtension();
+    LOG.info("Determining valid checkpoint folder");
+    boolean isCheckPointFolderValid = false;
+    // We need to keep track of the files we are reading.
+    checkPointFolder = logFeederProps.getCheckpointFolder();
+    if (!StringUtils.isEmpty(checkPointFolder)) {
+      checkPointFolderFile = new File(checkPointFolder);
+      isCheckPointFolderValid = verifyCheckPointFolder(checkPointFolderFile);
+    }
+
+    if (!isCheckPointFolderValid) {
+      // Let's use tmp folder
+      checkPointFolderFile = new File(logFeederProps.getTmpDir(), CHECKPOINT_SUBFOLDER_NAME);
+      LOG.info("Checking if tmp folder can be used for checkpoints. Folder=" + checkPointFolderFile);
+      isCheckPointFolderValid = verifyCheckPointFolder(checkPointFolderFile);
+      if (isCheckPointFolderValid) {
+        LOG.warn("Using tmp folder " + checkPointFolderFile + " to store check points. This is not recommended." +
+          "Please set logfeeder.checkpoint.folder property");
+      }
+    }
+
+    if (isCheckPointFolderValid) {
+      LOG.info("Using folder " + checkPointFolderFile + " for storing checkpoints");
+      // check checkpoint cleanup every 2000 min
+      Thread checkpointCleanupThread = new Thread(new CheckpointCleanupMonitor(this, 2000),"checkpoint_cleanup");
+      checkpointCleanupThread.setDaemon(true);
+      checkpointCleanupThread.start();
+    } else {
+      throw new IllegalStateException("Could not determine the checkpoint folder.");
+    }
+  }
+
+  @Override
+  public void checkIn(InputFile inputFile, InputFileMarker inputMarker) {
+    FileCheckInHelper.checkIn(inputFile, inputMarker);
+  }
+
+  @Override
+  public int resumeLineNumber(InputFile inputFile) {
+    return ResumeLineNumberHelper.getResumeFromLineNumber(inputFile, checkPointFolderFile);
+  }
+
+  @Override
+  public void cleanupCheckpoints() {
+    FileCheckpointCleanupHelper.cleanCheckPointFiles(checkPointFolderFile, checkPointExtension);
+  }
+
+  private boolean verifyCheckPointFolder(File folderPathFile) {
+    if (!folderPathFile.exists()) {
+      try {
+        if (!folderPathFile.mkdir()) {
+          LOG.warn("Error creating folder for check point. folder=" + folderPathFile);
+        }
+      } catch (Throwable t) {
+        LOG.warn("Error creating folder for check point. folder=" + folderPathFile, t);
+      }
+    }
+
+    if (folderPathFile.exists() && folderPathFile.isDirectory()) {
+      // Let's check whether we can create a file
+      File testFile = new File(folderPathFile, UUID.randomUUID().toString());
+      try {
+        testFile.createNewFile();
+        return testFile.delete();
+      } catch (IOException e) {
+        LOG.warn("Couldn't create test file in " + folderPathFile.getAbsolutePath() + " for checkPoint", e);
+      }
+    }
+    return false;
+  }
+
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/CheckpointFileReader.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/CheckpointFileReader.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.input.file.checkpoint.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class CheckpointFileReader {
+
+  private CheckpointFileReader() {
+  }
+
+  public static File[] getFiles(File checkPointFolderFile, String checkPointExtension) {
+    String searchPath = "*" + checkPointExtension;
+    FileFilter fileFilter = new WildcardFileFilter(searchPath);
+    return checkPointFolderFile.listFiles(fileFilter);
+  }
+
+  public static Map<String, String> getCheckpointObject(File checkPointFile) throws IOException {
+    final Map<String, String> jsonCheckPoint;
+    try (RandomAccessFile checkPointReader = new RandomAccessFile(checkPointFile, "r")) {
+      int contentSize = checkPointReader.readInt();
+      byte b[] = new byte[contentSize];
+      int readSize = checkPointReader.read(b, 0, contentSize);
+      if (readSize != contentSize) {
+        throw new IllegalArgumentException("Couldn't read expected number of bytes from checkpoint file. expected=" + contentSize + ", read="
+          + readSize + ", checkPointFile=" + checkPointFile);
+      } else {
+        String jsonCheckPointStr = new String(b, 0, readSize);
+        Gson gson = new GsonBuilder().create();
+        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        jsonCheckPoint = gson.fromJson(jsonCheckPointStr, type);
+      }
+    }
+    return jsonCheckPoint;
+  }
+
+
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/FileCheckInHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/FileCheckInHelper.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.ambari.logfeeder.input.file;
+package org.apache.ambari.logfeeder.input.file.checkpoint.util;
 
 import org.apache.ambari.logfeeder.input.InputFile;
 import org.apache.ambari.logfeeder.input.InputFileMarker;

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/FileCheckpointCleanupHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/FileCheckpointCleanupHelper.java
@@ -20,14 +20,12 @@ package org.apache.ambari.logfeeder.input.file.checkpoint.util;
 
 import org.apache.ambari.logfeeder.util.FileUtil;
 import org.apache.ambari.logfeeder.util.LogFeederUtil;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.solr.common.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.RandomAccessFile;
 import java.util.Map;
 
@@ -40,15 +38,13 @@ public class FileCheckpointCleanupHelper {
 
   public static void cleanCheckPointFiles(File checkPointFolderFile, String checkPointExtension) {
     if (checkPointFolderFile == null) {
-      LOG.info("Will not clean checkPoint files. checkPointFolderFile=" + checkPointFolderFile);
+      LOG.info("Will not clean checkPoint files. checkPointFolderFile=null");
       return;
     }
     LOG.info("Cleaning checkPoint files. checkPointFolderFile=" + checkPointFolderFile.getAbsolutePath());
     try {
       // Loop over the check point files and if filePath is not present, then move to closed
-      String searchPath = "*" + checkPointExtension;
-      FileFilter fileFilter = new WildcardFileFilter(searchPath);
-      File[] checkPointFiles = checkPointFolderFile.listFiles(fileFilter);
+      File[] checkPointFiles = CheckpointFileReader.getFiles(checkPointFolderFile, checkPointExtension);
       int totalCheckFilesDeleted = 0;
       if (checkPointFiles != null) {
         for (File checkPointFile : checkPointFiles) {

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/FileCheckpointCleanupHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/FileCheckpointCleanupHelper.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ambari.logfeeder.input.file.checkpoint.util;
+
+import org.apache.ambari.logfeeder.util.FileUtil;
+import org.apache.ambari.logfeeder.util.LogFeederUtil;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.apache.solr.common.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.RandomAccessFile;
+import java.util.Map;
+
+public class FileCheckpointCleanupHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileCheckpointCleanupHelper.class);
+
+  private FileCheckpointCleanupHelper() {
+  }
+
+  public static void cleanCheckPointFiles(File checkPointFolderFile, String checkPointExtension) {
+    if (checkPointFolderFile == null) {
+      LOG.info("Will not clean checkPoint files. checkPointFolderFile=" + checkPointFolderFile);
+      return;
+    }
+    LOG.info("Cleaning checkPoint files. checkPointFolderFile=" + checkPointFolderFile.getAbsolutePath());
+    try {
+      // Loop over the check point files and if filePath is not present, then move to closed
+      String searchPath = "*" + checkPointExtension;
+      FileFilter fileFilter = new WildcardFileFilter(searchPath);
+      File[] checkPointFiles = checkPointFolderFile.listFiles(fileFilter);
+      int totalCheckFilesDeleted = 0;
+      if (checkPointFiles != null) {
+        for (File checkPointFile : checkPointFiles) {
+          if (checkCheckPointFile(checkPointFile)) {
+            totalCheckFilesDeleted++;
+          }
+        }
+        LOG.info("Deleted " + totalCheckFilesDeleted + " checkPoint file(s). checkPointFolderFile=" +
+          checkPointFolderFile.getAbsolutePath());
+      }
+    } catch (Throwable t) {
+      LOG.error("Error while cleaning checkPointFiles", t);
+    }
+  }
+
+  private static boolean checkCheckPointFile(File checkPointFile) {
+    boolean deleted = false;
+    try (RandomAccessFile checkPointReader = new RandomAccessFile(checkPointFile, "r")) {
+      int contentSize = checkPointReader.readInt();
+      byte b[] = new byte[contentSize];
+      int readSize = checkPointReader.read(b, 0, contentSize);
+      if (readSize != contentSize) {
+        LOG.error("Couldn't read expected number of bytes from checkpoint file. expected=" + contentSize + ", read="
+          + readSize + ", checkPointFile=" + checkPointFile);
+      } else {
+        String jsonCheckPointStr = new String(b, 0, readSize);
+        Map<String, Object> jsonCheckPoint = LogFeederUtil.toJSONObject(jsonCheckPointStr);
+
+        String logFilePath = (String) jsonCheckPoint.get("file_path");
+        String logFileKey = (String) jsonCheckPoint.get("file_key");
+        Integer maxAgeMin = null;
+        if (jsonCheckPoint.containsKey("max_age_min")) {
+          maxAgeMin = Integer.parseInt(jsonCheckPoint.get("max_age_min").toString());
+        }
+        if (logFilePath != null && logFileKey != null) {
+          boolean deleteCheckPointFile = false;
+          File logFile = new File(logFilePath);
+          if (logFile.exists()) {
+            Object fileKeyObj = FileUtil.getFileKey(logFile);
+            String fileBase64 = Base64.byteArrayToBase64(fileKeyObj.toString().getBytes());
+            if (!logFileKey.equals(fileBase64)) {
+              LOG.info("CheckPoint clean: File key has changed. old=" + logFileKey + ", new=" + fileBase64 + ", filePath=" +
+                logFilePath + ", checkPointFile=" + checkPointFile.getAbsolutePath());
+              deleteCheckPointFile = !wasFileRenamed(logFile.getParentFile(), logFileKey);
+            } else if (maxAgeMin != null && maxAgeMin != 0 && FileUtil.isFileTooOld(logFile, maxAgeMin)) {
+              deleteCheckPointFile = true;
+              LOG.info("Checkpoint clean: File reached max age minutes (" + maxAgeMin + "):" + logFilePath);
+            }
+          } else {
+            LOG.info("CheckPoint clean: Log file doesn't exist. filePath=" + logFilePath + ", checkPointFile=" +
+              checkPointFile.getAbsolutePath());
+            deleteCheckPointFile = !wasFileRenamed(logFile.getParentFile(), logFileKey);
+          }
+          if (deleteCheckPointFile) {
+            LOG.info("Deleting CheckPoint file=" + checkPointFile.getAbsolutePath() + ", logFile=" + logFilePath);
+            checkPointFile.delete();
+            deleted = true;
+          }
+        }
+      }
+    } catch (EOFException eof) {
+      LOG.warn("Caught EOFException. Ignoring reading existing checkPoint file. " + checkPointFile);
+    } catch (Throwable t) {
+      LOG.error("Error while checking checkPoint file. " + checkPointFile, t);
+    }
+
+    return deleted;
+  }
+
+  private static boolean wasFileRenamed(File folder, String searchFileBase64) {
+    for (File file : folder.listFiles()) {
+      Object fileKeyObj = FileUtil.getFileKey(file);
+      String fileBase64 = Base64.byteArrayToBase64(fileKeyObj.toString().getBytes());
+      if (searchFileBase64.equals(fileBase64)) {
+        // even though the file name in the checkpoint file is different from the one it was renamed to, checkpoint files are
+        // identified by their name, which is generated from the file key, which would be the same for the renamed file
+        LOG.info("CheckPoint clean: File key matches file " + file.getAbsolutePath() + ", it must have been renamed");
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+}

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/ResumeLineNumberHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/checkpoint/util/ResumeLineNumberHelper.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.ambari.logfeeder.input.file;
+package org.apache.ambari.logfeeder.input.file.checkpoint.util;
 
 import org.apache.ambari.logfeeder.input.InputFile;
 import org.apache.ambari.logfeeder.util.LogFeederUtil;
@@ -36,15 +36,14 @@ public class ResumeLineNumberHelper {
   private ResumeLineNumberHelper() {
   }
 
-  public static int getResumeFromLineNumber(InputFile inputFile) {
+  public static int getResumeFromLineNumber(InputFile inputFile, File checkPointFolder) {
     int resumeFromLineNumber = 0;
 
     File checkPointFile = null;
     try {
       LOG.info("Checking existing checkpoint file. " + inputFile.getShortDescription());
 
-      String checkPointFileName = inputFile.getBase64FileKey() + inputFile.getCheckPointExtension();
-      File checkPointFolder = inputFile.getInputManager().getCheckPointFolderFile();
+      String checkPointFileName = getCheckpointFileName(inputFile);
       checkPointFile = new File(checkPointFolder, checkPointFileName);
       inputFile.getCheckPointFiles().put(inputFile.getBase64FileKey(), checkPointFile);
       Map<String, Object> jsonCheckPoint = null;
@@ -86,6 +85,11 @@ public class ResumeLineNumberHelper {
     }
 
     return resumeFromLineNumber;
+  }
+
+  private static String getCheckpointFileName(InputFile inputFile) {
+    return String.format("%s-%s%s", inputFile.getLogType(),
+      inputFile.getBase64FileKey(), inputFile.getCheckPointExtension());
   }
 
 }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/monitor/CheckpointCleanupMonitor.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/monitor/CheckpointCleanupMonitor.java
@@ -18,7 +18,7 @@
  */
 package org.apache.ambari.logfeeder.input.monitor;
 
-import org.apache.ambari.logfeeder.plugin.manager.InputManager;
+import org.apache.ambari.logfeeder.plugin.manager.CheckpointManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +27,11 @@ public class CheckpointCleanupMonitor implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointCleanupMonitor.class);
 
   private long waitIntervalMin;
-  private InputManager inputManager;
+  private CheckpointManager checkpointHandler;
 
-  public CheckpointCleanupMonitor(InputManager inputManager, long waitIntervalMin) {
+  public CheckpointCleanupMonitor(CheckpointManager checkpointHandler, long waitIntervalMin) {
     this.waitIntervalMin = waitIntervalMin;
-    this.inputManager = inputManager;
+    this.checkpointHandler = checkpointHandler;
   }
 
   @Override
@@ -39,7 +39,7 @@ public class CheckpointCleanupMonitor implements Runnable {
     while (!Thread.currentThread().isInterrupted()) {
       try {
         Thread.sleep(1000 * 60 * waitIntervalMin);
-        inputManager.cleanCheckPointFiles();
+        checkpointHandler.cleanupCheckpoints();
       } catch (Exception e) {
         LOG.error("Cleanup checkpoint files thread interrupted.", e);
       }

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
@@ -91,6 +91,7 @@ function print_usage() {
      start                         Start Log Feeder
      stop                          Stop Log Feeder
      status                        Check Log Feeder status (pid file)
+     checkpoints                   Checkpoint operations
      test                          Test Log Feeder shipper configs
      help                          Print usage
 
@@ -105,6 +106,14 @@ function print_usage() {
      -tsc, --test-shipper-config   Shipper configuration file for testing if log entry is parseable (required)
      -tgc, --test-global-config    Global configuration files (comma separated list) for testing if log entry is parseable
      -tli, --test-log-id           The id of the log to test
+
+   checkpoints command arguments:
+     -l, --list                    Print checkpoints
+     -cf, --checkpoints-folder     Checkpoints folder location
+     -c, --clean                   Remove a checkpoint file (by key/log type or use on all)
+     -k, --file-key                Filter on file key (for list and clean)
+     -lt, --log-type               Filter on log type (for list and clean)
+     -a, --all                     Flag all checkpoints to be deleted by clean command
 
 EOF
 }
@@ -263,6 +272,11 @@ function test() {
   $JVM -cp "$LOGFEEDER_CONF_DIR:$LOGFEEDER_LIBS_DIR/*" $LOGFEEDER_JAVA_OPTS org.apache.ambari.logfeeder.LogFeederCommandLine --test ${@}
 }
 
+function checkpoints() {
+  echo "Running command: $JVM -cp "$LOGFEEDER_CONF_DIR:$LOGFEEDER_LIBS_DIR/*" org.apache.ambari.logfeeder.LogFeederCommandLine --checkpoints ${@}"
+  $JVM -cp "$LOGFEEDER_CONF_DIR:$LOGFEEDER_LIBS_DIR/*" $LOGFEEDER_JAVA_OPTS org.apache.ambari.logfeeder.LogFeederCommandLine --checkpoints ${@}
+}
+
 if [ $# -gt 0 ]; then
     SCRIPT_CMD="$1"
     shift
@@ -283,6 +297,9 @@ case $SCRIPT_CMD in
   ;;
   test)
     test ${1+"$@"}
+  ;;
+  checkpoints)
+    checkpoints ${1+"$@"}
   ;;
   help)
     print_usage

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/test/java/org/apache/ambari/logfeeder/input/InputFileTest.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/test/java/org/apache/ambari/logfeeder/input/InputFileTest.java
@@ -26,8 +26,10 @@ import java.util.List;
 
 import org.apache.ambari.logfeeder.conf.LogEntryCacheConfig;
 import org.apache.ambari.logfeeder.conf.LogFeederProps;
+import org.apache.ambari.logfeeder.input.file.checkpoint.FileCheckpointManager;
 import org.apache.ambari.logfeeder.plugin.filter.Filter;
 import org.apache.ambari.logfeeder.plugin.input.InputMarker;
+import org.apache.ambari.logfeeder.plugin.manager.CheckpointManager;
 import org.apache.ambari.logfeeder.plugin.manager.InputManager;
 import org.apache.ambari.logsearch.config.json.model.inputconfig.impl.InputFileDescriptorImpl;
 import org.apache.commons.io.FileUtils;
@@ -77,6 +79,13 @@ public class InputFileTest {
     FileUtils.cleanDirectory(TEST_DIR);
   }
 
+  @AfterClass
+  public static void deleteDir() throws IOException {
+    if (TEST_DIR.exists()) {
+      FileUtils.deleteDirectory(TEST_DIR);
+    }
+  }
+
   @Before
   public void setUp() throws Exception {
     logFeederProps = new LogFeederProps();
@@ -85,6 +94,7 @@ public class InputFileTest {
     logEntryCacheConfig.setCacheLastDedupEnabled(false);
     logEntryCacheConfig.setCacheSize(10);
     logFeederProps.setLogEntryCacheConfig(logEntryCacheConfig);
+    logFeederProps.setCheckpointFolder("process3_checkpoint");
     testInputMarker = new InputFileMarker(inputFile, "", 0);
   }
 
@@ -125,13 +135,13 @@ public class InputFileTest {
   public void testInputFile_process3Rows() throws Exception {
     LOG.info("testInputFile_process3Rows()");
 
-    File checkPointDir = createCheckpointDir("process3_checkpoint");
     File testFile = createFile("process3.log");
 
     init(testFile.getAbsolutePath());
 
     InputManager inputManager = EasyMock.createStrictMock(InputManager.class);
-    EasyMock.expect(inputManager.getCheckPointFolderFile()).andReturn(checkPointDir);
+    CheckpointManager checkpointManager = new FileCheckpointManager();
+    EasyMock.expect(inputManager.getCheckpointHandler()).andReturn(checkpointManager);
     EasyMock.replay(inputManager);
     inputFile.setInputManager(inputManager);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
- create new cli options for logfeeder.sh script to list or cleanup checkpoints
- extend most of the checkpoint operations into interface / implementations (keep checkInAll in InputManager)
- move complicated methods to Helpers
- make checkpoint file names to readable e.g.: `hdfs-<filekey>.cp`

That patch does not include javadoc changes, i will do that later with a patch which will include other javadoc changes for the whole logfeeder plugin api.

## How was this patch tested?
UTs passed.
FT: with docker env, and with docker env which only included logsearch portal , solr and zookeeper and started logfeeder manually ...multiple times, to make sure checkpoints still working

Please review @kasakrisz @g-boros @swagle 