### PR TITLE
AMBARI-24593. Download client config fails if user running Ambari ser…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClientConfigResourceProvider.java
@@ -816,6 +816,8 @@ public class ClientConfigResourceProvider extends AbstractControllerResourceProv
         BufferedOutputStream bOut = new BufferedOutputStream(fOut);
         GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(bOut);
         TarArchiveOutputStream tOut = new TarArchiveOutputStream(gzOut);
+        tOut.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+        tOut.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
 
         try {
           for (ServiceComponentHostResponse schResponse : serviceComponentHostResponses) {


### PR DESCRIPTION
…ver has UID>2097151 (amagyar)

## What changes were proposed in this pull request?

When ambari is running with a user that has UID/GID >2097151 download client configs fails with the following error:

```json
{ 
"status" : 500, 
"message" : "org.apache.ambari.server.controller.spi.SystemException: group id '19600006' is too big ( > 2097151 )" 
} 
```

This is caused by a limitation in the tar file format which can be fixed by applying an extension (LONGFILE_POSIX/BIGNUMBER_POSIX)

## How was this patch tested?

- Configured ambari to run with a custom non-root user that had UID 1704000003.
- Downloaded client config (requestComponentName="")
- Checked the tar file content

