### PR TITLE
[AMBARI-24597] Popup shown when Ambari started on a different port other than 8080

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
@@ -28,7 +28,7 @@ angular.module('ambariAdminConsole', [
 .constant('Settings', {
   siteRoot: '{proxy_root}/'.replace(/\{.+\}/g, ''),
 	baseUrl: '{proxy_root}/api/v1'.replace(/\{.+\}/g, ''),
-  testMode: (window.location.port == 8000),
+  testMode: false,
   mockDataPrefix: 'assets/data/',
   isLDAPConfigurationSupported: false,
   isLoginActivitiesSupported: false,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change the Ambari server port by setting the following

ambari.properties
client.api.port=8000

Ab error popup is observed.

## How was this patch tested?

PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 61 of 61 SUCCESS (1.117 secs / 1.018 secs)
TOTAL: 61 SUCCESS