### PR TITLE
[AMBARI-24598] Broken markup for alert on Installer Step7

### DIFF
--- a/ambari-web/app/styles/wizard.less
+++ b/ambari-web/app/styles/wizard.less
@@ -995,6 +995,11 @@
     overflow: hidden;
   }
 }
+.service-config-alert {
+  float: left;
+  width: 100%;
+  margin-bottom: 20px;
+}
 
 #directories {
   .config-actions {

--- a/ambari-web/app/templates/common/configs/services_config.hbs
+++ b/ambari-web/app/templates/common/configs/services_config.hbs
@@ -95,14 +95,14 @@
 {{/if}}
 {{#if hasChangedDependencies}}
   {{#unless controller.isInstallWizard}}
-    <div class="alert alert-warning">
+    <div class="alert alert-warning service-config-alert">
       <span>{{dependenciesMessage}}</span> <a
         href="#" {{action "showChangedDependentConfigs" target="controller"}}>{{t common.showDetails}}</a>
     </div>
   {{/unless}}
 {{/if}}
 {{#if showSelectGroupsPopup}}
-  <div class="alert alert-warning">
+  <div class="alert alert-warning service-config-alert">
     <span>{{dependenciesGroupMessage}}</span> <a
       href="#" {{action "changedDependentGroup" target="controller"}}>{{t common.showDetails}}</a>
   </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install Wizard -> Step 7 shows alert popup on the top of the page when user creates config group and switches to it. Looks like it has broken markup or styles.

## How was this patch tested?

  21817 passing (33s)
  48 pending