### PR TITLE
AMBARI-24599 Post user creation script sets invalid owner to HDFS dir

### DIFF
--- a/ambari-server/src/main/resources/scripts/post-user-creation-hook.sh
+++ b/ambari-server/src/main/resources/scripts/post-user-creation-hook.sh
@@ -82,21 +82,32 @@ echo "Processing post user creation hook payload ..."
 JSON_INPUT="$CSV_FILE.json"
 echo "Generating json file $JSON_INPUT ..."
 
+REALM=${HDFS_PRINCIPAL##*@}
+
 echo "[" | cat > "$JSON_INPUT"
 while read -r LINE
 do
   USR_NAME=$(echo "$LINE" | awk -F, '{print $1}')
+
+  if [ "$SECURITY_TYPE" ==  "KERBEROS" ]
+  then
+    OWNER="${USR_NAME}@${REALM}"
+  else
+    OWNER="${USR_NAME}"
+  fi
+
   echo "Processing user name: $USR_NAME"
 
-  # encoding the username
+  # encoding the username and owner
   USR_NAME=$(printf "%q" "$USR_NAME")
+  OWNER=$(printf "%q" "$OWNER")
 
   cat <<EOF >> "$JSON_INPUT"
     {
     "target":"/user/$USR_NAME",
     "type":"directory",
     "action":"create",
-    "owner":"$USR_NAME",
+    "owner":"$OWNER",
     "group":"hdfs",
     "manageIfExists": "true"
   },


### PR DESCRIPTION
Change-Id: Iac7b37fbeb10700bdfb3e3d312ef754492d38785

## What changes were proposed in this pull request?

Post user creation script was creating `hdfs://user/username` directories with owner set as the username short name. This was causing issues in a secure cluster where full name should have been set as the owner. Otherwise FS permission was not in working as expected. 

## How was this patch tested?

manually tested on secure and non-secure cluster 

Please review @rlevas , @smolnar82 