### PR TITLE
AMBARI-24596. Stack Advisor reported an error. Exit Code: 2. Error: K…

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -138,6 +138,9 @@ else:
 
     def getServiceConfigurationsValidationItems(self, configs, recommendedDefaults, services, hosts):
       validation_errors = []
-      validation_errors.extend(self.toConfigurationValidationProblems(CoreSite(services).validate(), 'core-site'))
-      validation_errors.extend(self.toConfigurationValidationProblems(HdfsSite(services).validate(), 'hdfs-site'))
+      try:
+        validation_errors.extend(self.toConfigurationValidationProblems(CoreSite(services).validate(), 'core-site'))
+        validation_errors.extend(self.toConfigurationValidationProblems(HdfsSite(services).validate(), 'hdfs-site'))
+      except KeyError as e:
+        self.logger.info('Cannot get OneFS properties from config. KeyError: %s' % e)
       return validation_errors


### PR DESCRIPTION
…eyError: 'onefs' (amagyar)

## What changes were proposed in this pull request?

When changing the config of a service other than ONEFS ambari UI invokes validate-configurations without passing onefs related configs. This causes a KeyError. Validation in this case is not needed so I added an exception handler which logs this out.

## How was this patch tested?

- installed ONEFS with SUPERSET
- changed Advanced superset/SUPERSET_TIMEOUT
- saved the configuration successfully