### PR TITLE
AMBARI-24572 Fixing the cluster name alignment

### DIFF
--- a/ambari-web/app/styles/top-nav.less
+++ b/ambari-web/app/styles/top-nav.less
@@ -29,7 +29,7 @@
       padding: @navbar-header-vertical-padding @navbar-header-padding-right @navbar-header-vertical-padding @navbar-header-padding-left;
       margin-top: -5px;
       font-size: @navbar-header-font-size;
-      width: ~"calc(100% - 400px)";
+      width: ~"calc(100% - 440px)";
       a {
         color: #313D54;
         cursor: pointer;
@@ -50,7 +50,6 @@
     }
     .navbar-text.brand-wrapper {
       margin-top: 17px;
-      margin-left: -10px;
     }
     .navbar-text.brand-wrapper, .cluster-notifications {
       color: @top-nav-brand-color;

--- a/ambari-web/app/styles/top-nav.less
+++ b/ambari-web/app/styles/top-nav.less
@@ -50,6 +50,7 @@
     }
     .navbar-text.brand-wrapper {
       margin-top: 17px;
+      margin-left: -10px;
     }
     .navbar-text.brand-wrapper, .cluster-notifications {
       color: @top-nav-brand-color;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Alignment of the cluster name with other elements in the top nav when cluster name is slightly longer.
<img width="442" alt="screen shot 2018-09-06 at 10 49 00 pm" src="https://user-images.githubusercontent.com/29371501/45175139-4624fd80-b22a-11e8-9e63-f06562124fdf.png">

## How was this patch tested?

Manually tested
<img width="471" alt="screen shot 2018-09-06 at 11 02 18 pm" src="https://user-images.githubusercontent.com/29371501/45175127-3efdef80-b22a-11e8-931b-167a04ba32a5.png">
