### PR TITLE
AMBARI-24609. Ability to install common ambari python libraries to maven repository (local / remote).

### DIFF
--- a/install-ambari-python.sh
+++ b/install-ambari-python.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# requires: pip setuptools wheel
+
+readlinkf(){
+  # get real path on mac OSX
+  perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+if [ "$(uname -s)" = 'Linux' ]; then
+  SCRIPT_DIR="`dirname "$(readlink -f "$0")"`"
+else
+  SCRIPT_DIR="`dirname "$(readlinkf "$0")"`"
+fi
+
+function print_help() {
+  cat << EOF
+   Usage: ./install-ambari-python.sh [additional options]
+
+   -c, --clean                  clean generated python distribution directories
+   -d, --deploy                 deploy ambari-python artifact to maven remote repository
+   -v, --version <version>      override ambari-python artifact versison
+   -i, --repository-id <id>     repository id in settings.xml for remote repository
+   -r, --repository-url <url>   repository url of remote repository
+   -h, --help                   print help
+EOF
+}
+
+function get_python_artifact_file() {
+  local artifact_file=$(ls $SCRIPT_DIR/dist/ | head -n 1)
+  echo $artifact_file
+}
+
+function get_version() {
+  local artifact_file=$(get_python_artifact_file)
+  local artifact_version=$(echo $artifact_file | perl -lne '/ambari-python-(.*?)\.tar\.gz/ && print $1')
+  echo $artifact_version
+}
+
+function clean() {
+  if [ -d "$SCRIPT_DIR/dist" ]; then
+    echo "Removing '$SCRIPT_DIR/dist' directoy ..."
+    rm -r "$SCRIPT_DIR/dist"
+    echo "Directory '$SCRIPT_DIR/dist' successfully deleted."
+  fi
+  if [ -d "$SCRIPT_DIR/ambari_python.egg-info" ]; then
+    echo "Removing '$SCRIPT_DIR/ambari_python.egg-info' directoy ..."
+    rm -r "$SCRIPT_DIR/ambari_python.egg-info"
+    echo "Directory '$SCRIPT_DIR/ambari_python.egg-info' successfully deleted."
+  fi
+  if [ -d "$SCRIPT_DIR/target/ambari-python-dist" ]; then
+    echo "Removing '$SCRIPT_DIR/target/ambari-python' directoy ..."
+    rm -r "$SCRIPT_DIR/target/ambari-python-dist"
+    echo "Directory '$SCRIPT_DIR/target/ambari-python' successfully deleted."
+  fi
+}
+
+function generate_site_packages() {
+  local version="$1"
+  pip install $SCRIPT_DIR/dist/ambari-python-$version.tar.gz -I --install-option="--prefix=$SCRIPT_DIR/target/ambari-python-dist"
+}
+
+function archive_python_dist() {
+  local artifact="$1"
+  local site_packages_dir=$(find $SCRIPT_DIR/target/ambari-python-dist -name "site-packages")
+  local base_dir="`dirname $site_packages_dir`" # use this to make it work with different python versions
+  if [[ -f "$SCRIPT_DIR/target/$artifact" ]]; then
+    echo "Removing '$SCRIPT_DIR/target/$artifact' file ..."
+    echo "File '$SCRIPT_DIR/target/$artifact' successfully deleted."
+  fi
+  tar -zcf $SCRIPT_DIR/target/$artifact -C $base_dir site-packages
+}
+
+function install() {
+  local artifact_file="$1"
+  local version="$2"
+  mvn install:install-file -Dfile=$artifact_file -DgeneratePom=true -Dversion=$version -DartifactId=ambari-python -DgroupId=org.apache.ambari -Dpackaging=tar.gz
+}
+
+function deploy() {
+  local artifact_file="$1"
+  local version="$2"
+  local repo_id="$3"
+  local repo_url="$4"
+  mvn deploy:deploy-file -Dfile=$artifact_file -Dpackaging=tar.gz -DgeneratePom=true -Dversion=$version -DartifactId=ambari-python -DgroupId=org.apache.ambari -Durl="$repo_url" -DrepositoryId="$repo_url"
+}
+
+function run_setup_py() {
+  local version="$1"
+  if [[ ! -z "$version" ]]; then
+    env AMBARI_VERSION="$version" python setup.py sdist
+  else
+    python setup.py sdist
+  fi
+}
+
+function main() {
+  while [[ $# -gt 0 ]]
+    do
+      key="$1"
+      case $key in
+        -d|--deploy)
+          local DEPLOY="true"
+          shift 1
+        ;;
+        -c|--clean)
+          local CLEAN="true"
+          shift 1
+        ;;
+        -v|--version)
+          local VERSION="$2"
+          shift 2
+        ;;
+        -i|--repository-id)
+          local REPOSITORY_ID="$2"
+          shift 2
+        ;;
+        -r|--repository-url)
+          local REPOSITORY_URL="$2"
+          shift 2
+        ;;
+        -h|--help)
+          shift 1
+          print_help
+          exit 0
+        ;;
+        *)
+          echo "Unknown option: $1"
+          exit 1
+        ;;
+      esac
+  done
+
+  if [[ -z "$DEPLOY" ]] ; then
+    DEPLOY="false"
+  fi
+
+  if [ "$(uname -s)" = 'Linux' ]; then
+    SCRIPT_DIR="`dirname "$(readlink -f "$0")"`"
+  else
+    SCRIPT_DIR="`dirname "$(readlinkf "$0")"`"
+  fi
+
+  clean
+  if [[ "$CLEAN" == "true" ]]; then
+    return 0
+  fi
+
+  run_setup_py "$VERSION"
+  local artifact_name=$(get_python_artifact_file)
+  local artifact_version=$(get_version)
+
+  generate_site_packages "$artifact_version"
+  archive_python_dist "$artifact_name"
+
+  install "$SCRIPT_DIR/target/$artifact_name" "$artifact_version"
+
+  if [[ "$DEPLOY" == "true" ]] ; then
+    if [[ -z "$REPOSITORY_ID" ]] ; then
+      echo "Repository id option is required  for deploying ambari-python artifact (-i or --repository-id)"
+      exit 1
+    fi
+    if [[ -z "$REPOSITORY_URL" ]] ; then
+      echo "Repository url option is required for deploying ambari-python artifact (-r or --repository-url)"
+      exit 1
+    fi
+    deploy "$SCRIPT_DIR/target/$artifact_name" "$artifact_version" "$REPOSITORY_ID" "$REPOSITORY_URL"
+  else
+    echo "Skip deploying ambari-python artifact to remote repository."
+  fi
+}
+
+main ${1+"$@"}

--- a/install-ambari-python.sh
+++ b/install-ambari-python.sh
@@ -53,17 +53,17 @@ function get_version() {
 }
 
 function clean() {
-  if [ -d "$SCRIPT_DIR/dist" ]; then
+  if [[ -d "$SCRIPT_DIR/dist" ]]; then
     echo "Removing '$SCRIPT_DIR/dist' directoy ..."
     rm -r "$SCRIPT_DIR/dist"
     echo "Directory '$SCRIPT_DIR/dist' successfully deleted."
   fi
-  if [ -d "$SCRIPT_DIR/ambari_python.egg-info" ]; then
+  if [[ -d "$SCRIPT_DIR/ambari_python.egg-info" ]]; then
     echo "Removing '$SCRIPT_DIR/ambari_python.egg-info' directoy ..."
     rm -r "$SCRIPT_DIR/ambari_python.egg-info"
     echo "Directory '$SCRIPT_DIR/ambari_python.egg-info' successfully deleted."
   fi
-  if [ -d "$SCRIPT_DIR/target/ambari-python-dist" ]; then
+  if [[ -d "$SCRIPT_DIR/target/ambari-python-dist" ]]; then
     echo "Removing '$SCRIPT_DIR/target/ambari-python' directoy ..."
     rm -r "$SCRIPT_DIR/target/ambari-python-dist"
     echo "Directory '$SCRIPT_DIR/target/ambari-python' successfully deleted."
@@ -148,12 +148,6 @@ function main() {
 
   if [[ -z "$DEPLOY" ]] ; then
     DEPLOY="false"
-  fi
-
-  if [ "$(uname -s)" = 'Linux' ]; then
-    SCRIPT_DIR="`dirname "$(readlink -f "$0")"`"
-  else
-    SCRIPT_DIR="`dirname "$(readlinkf "$0")"`"
   fi
 
   clean


### PR DESCRIPTION
## What changes were proposed in this pull request?
New cli script to create a maven tar.gz artifact:
- `--clean` option to just delete dist directories
- by default it uses `mvn install` on the generated tar.gz, that install the artifact into local maven repository
- `--deploy` option to use `mvn deploy` for uploading generated tar.gz artifact to remote maven repository
- `--version` option to provide the artifact and generated python dist version
- update setup.py script to read the version from pom.xml during dist building, otherwise it uses PKG-INFO to get the right version, therefore if you are overriding the version during the build, it will always use the right version with pip or setup.py

How it works:
with setup.py an installable distribution created, with pip the packages are installed locally, then the install-ambari-python script creates a tar.gz from the installd packages and upload it to a maven repo (tar.gz content is the site-packages, the python version before that is not included)

after the artifacts are installed to maven repos, these could be provided in external projects (to use to extend PYTHONPATH variable, in order to run tests against any stack code, like in MPacks);
Maven example:
```xml
<dependency>
      <groupId>org.apache.ambari</groupId>
      <artifactId>ambari-python</artifactId>
      <version>2.0.0.0-SNAPSHOT</version>
      <scope>test</scop>
</dependency>
```
Gradle example:
```groovy
testCompile "org.apache.ambari:ambari-python:2.0.0.0-SNAPSHOT@tar.gz"
```

So in an external project, the ambari python files can be extracted during build time, and add them to the PYTHONPATH

Usage examples:
Install to maven local repo
```bash
./install-ambari-python.sh
```

Deploy to maven remote repo
```bash
./install-ambari-python.sh --deploy -i <repoId> -r <repoUrl>
```

## How was this patch tested?
Manually, and include ambari packages in external repos (untar pyton files into the build folder and put them to PYTHONPATH before that)

Please review @g-boros @jonathan-hurley @rlevas @zeroflag @adoroszlai 