### PR TITLE
[AMBARI-24610] [Log Search UI] Show user friendly component name in query input

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
@@ -21,7 +21,7 @@
 <ng-container *ngFor="let parameter of parameters">
 <label class="parameter-label" [class.exclude]="parameter.isExclude" [class.include]="!parameter.isExclude">
   {{parameter.label | translate}}:
-  <span class="parameter-value">{{parameter.value}}</span>
+  <span class="parameter-value">{{(parameter.name === 'type' ? (parameter.value | componentLabel | async) : parameter.value)}}</span>
   <span class="fa toggle-parameter action-icon" [ngClass]="{'fa-search-minus': parameter.isExclude, 'fa-search-plus': !parameter.isExclude}"
         (click)="toggleParameter($event, parameter.id)" tooltip="{{('filter.toggleTo.' + (parameter.isExclude ? 'include' : 'exclude')) | translate}}"></span>
   <span class="fa fa-times remove-parameter action-icon" (click)="removeParameter($event, parameter.id)"></span>

--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.spec.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/search-box/search-box.component.spec.ts
@@ -18,10 +18,14 @@
 
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {StoreModule} from '@ngrx/store';
+
 import {TranslationModules} from '@app/test-config.spec';
 import {UtilsService} from '@app/services/utils.service';
 
 import {SearchBoxComponent} from './search-box.component';
+import {ComponentsService, components} from '@app/services/storage/components.service';
+import {ComponentLabelPipe} from '@app/pipes/component-label';
 
 describe('SearchBoxComponent', () => {
   let component: SearchBoxComponent;
@@ -29,9 +33,18 @@ describe('SearchBoxComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SearchBoxComponent],
-      imports: TranslationModules,
+      declarations: [
+        ComponentLabelPipe,
+        SearchBoxComponent
+      ],
+      imports: [
+        ...TranslationModules,
+        StoreModule.provideStore({
+          components
+        })
+      ],
       providers: [
+        ComponentsService,
         UtilsService
       ],
       schemas: [NO_ERRORS_SCHEMA]


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added the `componentLabel` pipe to the parameter rendering template.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 271 of 271 SUCCESS (9.72 secs / 9.625 secs)
✨  Done in 37.85s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.