### PR TITLE
[AMBARI-24613] [Log Search UI] Date picker preset ranges are not displayed properly

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/components/time-range-picker/time-range-picker.component.html
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/components/time-range-picker/time-range-picker.component.html
@@ -26,7 +26,7 @@
     <date-picker class="col-md-12 row" [time]="startTime" (timeChange)="setStartTime($event)"></date-picker>
     <div class="col-md-12 row text-uppercase">{{'filter.timeRange.to' | translate}}</div>
     <date-picker class="col-md-12 row" [time]="endTime" (timeChange)="setEndTime($event)"></date-picker>
-    <button class="btn btn-success pull-right" type="button" (click)="setCustomTimeRange()"
+    <button class="btn btn-success" type="button" (click)="setCustomTimeRange()"
             [disabled]="!startTime || !endTime || startTime >= endTime">
       {{'modal.apply' | translate}}
     </button>


### PR DESCRIPTION
(cherry picked from commit 4527fe08fba79fc7197ea5bb91c2f031a96f973d)

## What changes were proposed in this pull request?

Since we have the new UI it is already fixed. The only issue was that the Apply button was aligned on the right. So I removed the pull-right css class from the apply button.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 271 of 271 SUCCESS (10.473 secs / 10.381 secs)
✨  Done in 38.24s.
```
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.