### PR TITLE
AMBARI-24618. Ambari generates wrong zookeeper connection string for KMS HA configuration 

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1574,8 +1574,8 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
   },
 
   getZookeeperConnectionString: function () {
-    var zookeeperHosts = App.HostComponent.find().filterProperty('componentName', 'ZOOKEEPER_SERVER').mapProperty('hostName')
-    return this.getRangerKMSServerHosts().map(function (host) {
+    var zookeeperHosts = App.HostComponent.find().filterProperty('componentName', 'ZOOKEEPER_SERVER').mapProperty('hostName');
+    return zookeeperHosts.map(function (host) {
       return host + ':2181';
     }).join(',');
   },

--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1574,6 +1574,7 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
   },
 
   getZookeeperConnectionString: function () {
+    var zookeeperHosts = App.HostComponent.find().filterProperty('componentName', 'ZOOKEEPER_SERVER').mapProperty('hostName')
     return this.getRangerKMSServerHosts().map(function (host) {
       return host + ':2181';
     }).join(',');


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ambari generates wrong zookeeper connection string for KMS HA configuration

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.