### PR TITLE
[AMBARI-24621] Badge with count of empty or invalid properties are missed ar the services panel during cluster installation

### DIFF
--- a/ambari-web/app/controllers/installer.js
+++ b/ambari-web/app/controllers/installer.js
@@ -738,7 +738,7 @@ App.InstallerController = App.WizardController.extend(App.Persist, {
       existedOS.isSelected = true;
       existedMap[existedOS.OperatingSystems.os_type] = existedOS;
     });
-    if (response.Versions['stack-errors'] && response.Versions['stack-errors'].length) {
+    if (response.Versions && response.Versions['stack-errors'] && response.Versions['stack-errors'].length) {
       this.showStackErrorAndSkipStepIfNeeded(response);
       return;
     }

--- a/ambari-web/app/templates/common/configs/services_config.hbs
+++ b/ambari-web/app/templates/common/configs/services_config.hbs
@@ -28,10 +28,10 @@
             <a href="#" {{action selectService tab target="controller"}} {{bindAttr data-target="tab.headingClass"}}
                data-toggle="tab">
               {{formatRole tab.serviceName}}
-              {{#if tab.errorsCount}}
+              {{#if tab.configsWithErrors}}
                 <span class="alert-badge">
                   <span class="counter label alerts-crit-count">
-                    {{tab.errorsCount}}
+                    {{tab.configsWithErrors.length}}
                   </span>
                 </span>
               {{/if}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:
1)Initiate cluster installation
2)Navigate to customize all services page
3)Navigate to service tab
4)Clear some service required property

Expected
Count of errors near service name

Actual
Count of errors near service name is absent

## How was this patch tested?

  21815 passing (59s)
  48 pending