### PR TITLE
AMBARI-24624. Log Search: Field type 'key_lower_case' not found - in Solr

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/configsets/hadoop_logs/conf/solrconfig.xml
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/configsets/hadoop_logs/conf/solrconfig.xml
@@ -1213,7 +1213,7 @@
      -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 
-    <str name="queryAnalyzerFieldType">key_lower_case</str>
+    <str name="queryAnalyzerFieldType">lowercase</str>
 
     <!-- Multiple "Spell Checkers" can be declared and used by this
          component
@@ -1688,7 +1688,7 @@
       </arr>
     </processor>
     <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
-      <str name="defaultFieldType">key_lower_case</str>
+      <str name="defaultFieldType">lowercase</str>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Boolean</str>
         <str name="fieldType">booleans</str>

--- a/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/service_logs-solrconfig.xml.j2
+++ b/ambari-server/src/main/resources/common-services/LOGSEARCH/0.5.0/properties/service_logs-solrconfig.xml.j2
@@ -1216,7 +1216,7 @@ this file, see http://wiki.apache.org/solr/SolrConfigXml.
   -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 
-    <str name="queryAnalyzerFieldType">key_lower_case</str>
+    <str name="queryAnalyzerFieldType">lowercase</str>
 
     <!-- Multiple "Spell Checkers" can be declared and used by this
     component
@@ -1691,7 +1691,7 @@ this file, see http://wiki.apache.org/solr/SolrConfigXml.
       </arr>
     </processor>
     <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
-      <str name="defaultFieldType">key_lower_case</str>
+      <str name="defaultFieldType">lowercase</str>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Boolean</str>
         <str name="fieldType">boolean</str>


### PR DESCRIPTION
## What changes were proposed in this pull request?
in managed-schema of the service logs, key_lower_case was removed as a type, but there are references for that in the solrconfig.xml -> workaround, it can be changed to lowercase from key_lower_case in logsearch-service_logs-solrconfig content, and restart Log Search (after that: restart solr)

## How was this patch tested?
UTs passed, (not needed), new fields can be generated

please review @g-boros @kasakrisz @swagle 