### PR TITLE
AMBARI-24611. Disabling an Alert Does Not Clear It in the Web UI.

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/AlertSchedulerHandler.py
+++ b/ambari-agent/src/main/python/ambari_agent/AlertSchedulerHandler.py
@@ -50,7 +50,7 @@ class AlertSchedulerHandler():
   TYPE_RECOVERY = 'RECOVERY'
 
   def __init__(self, initializer_module, in_minutes=True):
-
+    self.initializer_module = initializer_module
     self.cachedir = initializer_module.config.alerts_cachedir
     self.stacks_dir = initializer_module.config.stacks_dir
     self.common_services_dir = initializer_module.config.common_services_dir
@@ -168,6 +168,8 @@ class AlertSchedulerHandler():
 
     definitions = self.__load_definitions()
     scheduled_jobs = self.__scheduler.get_jobs()
+
+    self.initializer_module.alert_status_reporter.reported_alerts.clear()
 
     # for every scheduled job, see if its UUID is still valid
     for scheduled_job in scheduled_jobs:

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertSummaryGroupedRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertSummaryGroupedRenderer.java
@@ -228,6 +228,18 @@ public class AlertSummaryGroupedRenderer extends AlertSummaryRenderer {
     }
   }
 
+  public static Map<String, AlertDefinitionSummary> generateEmptySummary(Long definitionId, String definitionName) {
+    Map<String, AlertDefinitionSummary> summaries = new HashMap<>();
+
+    AlertDefinitionSummary groupSummaryInfo = new AlertDefinitionSummary();
+    groupSummaryInfo.Id = definitionId;
+    groupSummaryInfo.Name = definitionName;
+
+    summaries.put(definitionName, groupSummaryInfo);
+
+    return summaries;
+  }
+
   /**
    * {@inheritDoc}
    * <p/>

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/AmbariMetaInfo.java
@@ -1240,7 +1240,8 @@ public class AmbariMetaInfo {
       for (AlertDefinitionEntity definition : definitionsToDisable) {
         definition.setEnabled(false);
         alertDefinitionDao.merge(definition);
-        eventPublisher.publish(new AlertDefinitionDisabledEvent(clusterId, definition.getDefinitionId()));
+        eventPublisher.publish(new AlertDefinitionDisabledEvent(clusterId, definition.getDefinitionId(),
+            definition.getDefinitionName()));
       }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertDefinitionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertDefinitionResourceProvider.java
@@ -328,7 +328,7 @@ public class AlertDefinitionResourceProvider extends AbstractControllerResourceP
         // a disabled event
         if (oldEnabled && !entity.getEnabled()) {
           AlertDefinitionDisabledEvent event = new AlertDefinitionDisabledEvent(
-              entity.getClusterId(), entity.getDefinitionId());
+              entity.getClusterId(), entity.getDefinitionId(), entity.getDefinitionName());
 
           eventPublisher.publish(event);
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/AlertDefinitionDisabledEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/AlertDefinitionDisabledEvent.java
@@ -31,6 +31,11 @@ public class AlertDefinitionDisabledEvent extends ClusterEvent {
   private final long m_definitionId;
 
   /**
+   * The alert definition name.
+   */
+  private final String definitionName;
+
+  /**
    * Constructor.
    *
    * @param clusterId
@@ -38,9 +43,10 @@ public class AlertDefinitionDisabledEvent extends ClusterEvent {
    * @param definitionId
    *          the alert definition being registered.
    */
-  public AlertDefinitionDisabledEvent(long clusterId, long definitionId) {
+  public AlertDefinitionDisabledEvent(long clusterId, long definitionId, String definitionName) {
     super(AmbariEventType.ALERT_DEFINITION_DISABLED, clusterId);
     m_definitionId = definitionId;
+    this.definitionName = definitionName;
   }
 
   /**
@@ -50,5 +56,14 @@ public class AlertDefinitionDisabledEvent extends ClusterEvent {
    */
   public long getDefinitionId() {
     return m_definitionId;
+  }
+
+  /**
+   * Gets the definition name.
+   *
+   * @return the definitionId name
+   */
+  public String getDefinitionName() {
+    return definitionName;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertDefinitionDisabledListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertDefinitionDisabledListener.java
@@ -28,7 +28,6 @@ import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.events.publishers.STOMPUpdatePublisher;
 import org.apache.ambari.server.orm.dao.AlertsDAO;
 import org.apache.ambari.server.orm.entities.AlertCurrentEntity;
-import org.apache.ambari.server.state.AlertState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,13 +78,9 @@ public class AlertDefinitionDisabledListener {
     m_alertsDao.removeCurrentDisabledAlerts();
 
     // send API STOMP alert update
-    Map<String, AlertSummaryGroupedRenderer.AlertDefinitionSummary> summaries = new HashMap<>();
-
-    AlertSummaryGroupedRenderer.updateSummary(summaries, event.getDefinitionId(),
-        event.getDefinitionName(), AlertState.UNKNOWN, null, null, "");
-
     Map<Long, Map<String, AlertSummaryGroupedRenderer.AlertDefinitionSummary>> alertUpdates = new HashMap<>();
-    alertUpdates.put(event.getClusterId(), summaries);
+    alertUpdates.put(event.getClusterId(), AlertSummaryGroupedRenderer.generateEmptySummary(event.getDefinitionId(),
+        event.getDefinitionName()));
     STOMPUpdatePublisher.publish(new AlertUpdateEvent(alertUpdates));
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertReceivedListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertReceivedListener.java
@@ -254,6 +254,14 @@ public class AlertReceivedListener {
 
           // create the event to fire later
           alertEvents.add(new InitialAlertEvent(clusterId, alert, current));
+
+          if (!alertUpdates.containsKey(clusterId)) {
+            alertUpdates.put(clusterId, new HashMap<>());
+          }
+          Map<String, AlertSummaryGroupedRenderer.AlertDefinitionSummary> summaries = alertUpdates.get(clusterId);
+
+          AlertSummaryGroupedRenderer.updateSummary(summaries, definition.getDefinitionId(),
+              definition.getDefinitionName(), alertState, alert.getTimestamp(), maintenanceState, alert.getText());
         } finally {
           // release the lock for this alert
           lock.unlock();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server fires API STOMP alert update on alert definition disable. Also ambari-agent sends last alert states on alert definitions update.

## How was this patch tested?

Manual testing.