### PR TITLE
[AMBARI-24622] Allow skipping package operations for LZO on sysprepped hosts

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/lzo_utils.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/lzo_utils.py
@@ -82,11 +82,22 @@ def should_install_lzo():
 
   return True
 
+def skip_package_operations():
+  """
+  Return true if LZO packages are assumed to be pre-installed
+  Needs to be separate from should_install_lzo, as that one is used during tarball creation, too
+  """
+  return default("/hostLevelParams/host_sys_prepped", False) and default("/configurations/cluster-env/sysprep_skip_lzo_package_operations", False)
+
 def install_lzo_if_needed():
   """
   Install lzo package if {#should_install_lzo} is true
   """
   if not should_install_lzo():
+    return
+
+  if skip_package_operations():
+    Logger.info("Skipping LZO package installation as host is sys prepped")
     return
 
   # If user has just accepted GPL license. GPL repository can not yet be present.

--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/configuration/cluster-env.xml
@@ -148,6 +148,17 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>sysprep_skip_lzo_package_operations</name>
+    <display-name>Whether LZO packages are also pre-installed on sysprepped cluster</display-name>
+    <value>false</value>
+    <description>In sysprepped environments true value indicates that LZO packages are pre-installed and should not be managed by Ambari</description>
+    <value-attributes>
+      <overridable>true</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>sysprep_skip_setup_jce</name>
     <display-name>Whether to skip setting up the unlimited key JCE policy on sysprepped cluster</display-name>
     <value>false</value>


### PR DESCRIPTION
## What changes were proposed in this pull request?

LZO packages may be pre-installed in sysprepped environments, but Ambari still manages the repo and checks for existence of the packages, which takes time.  The goal of this change is to allow users who pre-install packages to skip package manager operations for LZO packages, too.

This is achieved by adding a new "sysprep" flag: `sysprep_skip_lzo_package_operations`.

https://issues.apache.org/jira/browse/AMBARI-24622

## How was this patch tested?

Deployed cluster via blueprint with pre-installed LZO packages (`hadooplzo*` and `liblzo2-2`).

Prior to this change:

```
checked_call[['apt-get', 'update', '-qq', '-o', u'Dir::Etc::sourcelist=sources.list.d/ambari-hdp-1.list', '-o', 'Dir::Etc::sourceparts=-', '-o', 'APT::Get::List-Cleanup=0']] {'sudo': True, 'quiet': False}
...
Package['liblzo2-2'] {'retry_on_repo_unavailability': False, 'retry_count': 5}
Installing package liblzo2-2 ('/usr/bin/apt-get -q -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install liblzo2-2')
Package['hadooplzo'] {'retry_on_repo_unavailability': False, 'retry_count': 5}
Skipping installation of existing package hadooplzo
Package['hadooplzo-native'] {'retry_on_repo_unavailability': False, 'retry_count': 5}
Skipping installation of existing package hadooplzo-native
```

(Note that although `liblzo2-2` is already installed it is not "skipped" by Ambari due to a [bug in package existence check](https://issues.apache.org/jira/browse/AMBARI-24632).)

Confirmed that with this change `apt-get` calls are skipped:

```
Skipping LZO package installation as host is sys prepped
```