### PR TITLE
AMBARI-24633. Ambari strips leading space for valid YARN configs on the config compare screen

### DIFF
--- a/ambari-web/app/styles/service_configurations.less
+++ b/ambari-web/app/styles/service_configurations.less
@@ -44,6 +44,9 @@
   .comparison-row {
     margin-left: -25px;
     padding: 10px 0;
+    .compare-config-cell {
+      white-space: pre;
+    }
   }
 
   .undefined {

--- a/ambari-web/app/templates/common/configs/configs_comparison_cell.hbs
+++ b/ambari-web/app/templates/common/configs/configs_comparison_cell.hbs
@@ -16,9 +16,7 @@
 * limitations under the License.
 }}
 
-<span {{bindAttr class="compareConfig.isMock:undefined"}}>
-  {{compareConfig.value}}&nbsp;{{compareConfig.unit}}
-</span>
+<span {{bindAttr class="compareConfig.isMock:undefined :compare-config-cell"}}>{{compareConfig.value}}&nbsp;{{compareConfig.unit}}</span>
 {{#unless compareConfig.isMock}}
   {{#if compareConfig.supportsFinal}}
     <i {{bindAttr class=":glyphicon :glyphicon-lock compareConfig.isFinal::hidden" }}></i>

--- a/ambari-web/app/templates/common/configs/configs_comparison_row.hbs
+++ b/ambari-web/app/templates/common/configs/configs_comparison_row.hbs
@@ -32,7 +32,7 @@
   <div class="col-md-4 property-value-column">
     {{#if controller.selectedConfigGroup.isDefault}}
       {{! Comparing config-versions from Default config-group}}
-      <span {{bindAttr class="configData.isMock:undefined"}}>{{configData.value}}&nbsp;{{configData.unit}}</span>
+      <span {{bindAttr class="configData.isMock:undefined :compare-config-cell"}}>{{configData.value}}&nbsp;{{configData.unit}}</span>
       {{#unless configData.isMock}}
         {{#if configData.supportsFinal}}
           <i {{bindAttr class=":glyphicon :glyphicon-lock configData.isFinal::hidden" }}></i>


### PR DESCRIPTION
## What changes were proposed in this pull request?
 Ambari strips leading space for valid YARN configs on the config compare screen

## How was this patch tested?
manually, style issue

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.