### PR TITLE
[AMBARI-24628] Fix possible "Phishing by Navigating Browser Tabs" vulnerability

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
@@ -28,7 +28,7 @@ angular.module('ambariAdminConsole', [
 .constant('Settings', {
   siteRoot: '{proxy_root}/'.replace(/\{.+\}/g, ''),
 	baseUrl: '{proxy_root}/api/v1'.replace(/\{.+\}/g, ''),
-  testMode: (window.location.port == 8000),
+  testMode: false,
   mockDataPrefix: 'assets/data/',
   isLDAPConfigurationSupported: false,
   isLoginActivitiesSupported: false,

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -29,7 +29,7 @@ Em.I18n.translations = {
   'app.redirectIssuePopup.header': 'Login Redirect Issue',
   'app.redirectIssuePopup.body': 'For single sign-on, make sure that Knox Gateway and Ambari Server are located on the same host or subdomain.' +
     '<br/>Alternatively login as an Ambari local user using the local login page.<br />' +
-    '<a href="{0}" target="_blank">{0}</a>',
+    '<a rel="noopener noreferrer" href="{0}" target="_blank">{0}</a>',
 
   'app.loadingPlaceholder': 'Loading...',
   'app.versionMismatchAlert.title': 'Ambari Server / Web Client Version Mismatch',
@@ -2349,7 +2349,7 @@ Em.I18n.translations = {
   'services.service.config.configHistory.makeCurrent.message': 'Created from service config version {0}',
   'services.service.config.configHistory.comparing': 'Comparing Changes in',
   'services.service.config.setRecommendedValue': 'Set Recommended',
-  'services.service.config.database.msg.jdbcSetup.detailed': 'To use {0} with {6}, you must <a href="{3}" target="_blank">' +
+  'services.service.config.database.msg.jdbcSetup.detailed': 'To use {0} with {6}, you must <a rel="noopener noreferrer" href="{3}" target="_blank">' +
     'download the {4} from {0}</a>. Once downloaded to the Ambari Server host, run: <br/>' +
     '<b>ambari-server setup --jdbc-db={1} --jdbc-driver=/path/to/{1}/{2}</b>',
 

--- a/ambari-web/app/templates/common/host_progress_popup.hbs
+++ b/ambari-web/app/templates/common/host_progress_popup.hbs
@@ -343,7 +343,7 @@
                     <strong class="muted">{{hostLog.fileName}}</strong>
                     {{#view App.LogSearchUILinkView linkQueryParamsBinding="hostLog.linkTail" tagName="span"}}
                       <a {{bindAttr href="view.formatedLink" class=":pull-right view.isLodaded::disabled"}}
-                              target="_blank">
+                              target="_blank" rel="noopener noreferrer">
                         <i class="icon-external-link"></i>
                         {{t popup.logTail.openInLogSearch}}</a>
                     {{/view}}

--- a/ambari-web/app/templates/common/modal_popups/log_tail_popup.hbs
+++ b/ambari-web/app/templates/common/modal_popups/log_tail_popup.hbs
@@ -29,7 +29,7 @@
         <i class="icon-external-link"></i>
         {{t common.open}}
       </a>
-      <a class="open-in-log-search" {{bindAttr href="view.logSearchUrl"}} target="_blank">
+      <a class="open-in-log-search" {{bindAttr href="view.logSearchUrl"}} target="_blank" rel="noopener noreferrer">
         <i class="icon-external-link"></i>
         {{t popup.logTail.openInLogSearch}}
       </a>

--- a/ambari-web/app/templates/main/alerts/definition_details.hbs
+++ b/ambari-web/app/templates/main/alerts/definition_details.hbs
@@ -193,7 +193,7 @@
           {{#if controller.content.hasHelpUrl}}
             <div class="row">
               <div class="col-md-5 property-name">{{t alerts.table.header.helpUrl}}:</div>
-              <div class="col-md-7"><label for=""><a {{bindAttr href="controller.content.helpUrl"}} target="_blank">{{t common.link}}</a></label></div>
+              <div class="col-md-7"><label for=""><a {{bindAttr href="controller.content.helpUrl"}} target="_blank" rel="noopener noreferrer">{{t common.link}}</a></label></div>
             </div>
           {{/if}}
         </div>

--- a/ambari-web/app/templates/main/dashboard/widgets/hbase_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/hbase_links.hbs
@@ -54,7 +54,7 @@
               <td>
                 {{#if view.activeMaster}}
                   <a {{bindAttr href="view.hbaseMasterWebUrl"}}
-                          target="_blank">{{t dashboard.services.hbase.masterWebUI}}</a>
+                          target="_blank" rel="noopener noreferrer">{{t dashboard.services.hbase.masterWebUI}}</a>
                 {{else}}
                   {{t services.service.summary.notAvailable}}
                 {{/if}}
@@ -81,7 +81,7 @@
                             <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
                             <ul class="dropdown-menu">
                               {{#each quickLinks}}
-                                <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                                <li><a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a></li>
                               {{/each}}
                             </ul>
                           </li>
@@ -89,7 +89,7 @@
                       {{/each}}
                     {{else}}
                       {{#each view.quickLinks}}
-                        <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                        <li><a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a></li>
                       {{/each}}
                     {{/if}}
                   {{else}}

--- a/ambari-web/app/templates/main/dashboard/widgets/hdfs_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/hdfs_links.hbs
@@ -101,7 +101,7 @@
                           <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
                           <ul class="dropdown-menu">
                             {{#each quickLinks}}
-                              <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                              <li><a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a></li>
                             {{/each}}
                           </ul>
                         </li>
@@ -109,7 +109,7 @@
                     {{/each}}
                   {{else}}
                     {{#each view.quickLinks}}
-                      <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                      <li><a {{bindAttr href="url"}} target="_blank rel="noopener noreferrer"">{{label}}</a></li>
                     {{/each}}
                   {{/if}}
                 {{else}}

--- a/ambari-web/app/templates/main/dashboard/widgets/hdfs_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/hdfs_links.hbs
@@ -109,7 +109,7 @@
                     {{/each}}
                   {{else}}
                     {{#each view.quickLinks}}
-                      <li><a {{bindAttr href="url"}} target="_blank rel="noopener noreferrer"">{{label}}</a></li>
+                      <li><a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a></li>
                     {{/each}}
                   {{/if}}
                 {{else}}

--- a/ambari-web/app/templates/main/dashboard/widgets/yarn_links.hbs
+++ b/ambari-web/app/templates/main/dashboard/widgets/yarn_links.hbs
@@ -66,7 +66,7 @@
                             <a href="javascript:void(null)">{{quickLinks.publicHostNameLabel}} &nbsp;</a>
                             <ul class="dropdown-menu">
                               {{#each quickLinks}}
-                                <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                                <li><a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a></li>
                               {{/each}}
                             </ul>
                           </li>
@@ -74,7 +74,7 @@
                       {{/each}}
                     {{else}}
                       {{#each view.quickLinks}}
-                        <li><a {{bindAttr href="url"}} target="_blank">{{label}}</a></li>
+                        <li><a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a></li>
                       {{/each}}
                     {{/if}}
                   {{else}}

--- a/ambari-web/app/templates/main/host/logs.hbs
+++ b/ambari-web/app/templates/main/host/logs.hbs
@@ -43,7 +43,7 @@
               <div>
                 <a {{action openLogFile row file.filePath target="view.parentView"}} href="#" rel="log-file-name-tooltip" {{bindAttr data-original-title="file.filePath"}}>{{file.fileName}}</a>
                 {{#view App.LogSearchUILinkView linkQueryParamsBinding="file.linkTail" tagName="span"}}
-                  <a {{bindAttr href="view.formatedLink"}} target="_blank" rel="log-file-name-tooltip" {{translateAttr title="popup.logTail.openInLogSearch"}} class="pull-right external-link">
+                  <a {{bindAttr href="view.formatedLink"}} target="_blank" rel="log-file-name-tooltip noopener noreferrer" {{translateAttr title="popup.logTail.openInLogSearch"}} class="pull-right external-link">
                     <i class="icon-external-link"></i>
                     {{t popup.logTail.openInLogSearch}}
                   </a>

--- a/ambari-web/app/templates/main/service/info/summary.hbs
+++ b/ambari-web/app/templates/main/service/info/summary.hbs
@@ -98,7 +98,7 @@
                     {{#each quickLinks in group.links}}
                       <h6>{{quickLinks.publicHostNameLabel}}</h6>
                       {{#each quickLinks}}
-                        <a {{bindAttr href="url"}} target="_blank">{{label}}</a>
+                        <a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a>
                       {{/each}}
                     {{/each}}
                   </div>
@@ -106,7 +106,7 @@
               {{else}}
                 {{#if view.quickLinks}}
                   {{#each view.quickLinks}}
-                    <a {{bindAttr href="url"}} target="_blank">{{label}}</a>
+                    <a {{bindAttr href="url"}} target="_blank" rel="noopener noreferrer">{{label}}</a>
                   {{/each}}
                 {{else}}
                   <div class="alert alert-danger">


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to details found at https://www.netsparker.com/web-vulnerability-scanner/vulnerabilities/phishing-by-navigating-browser-tabs/, it is possible to change the "window.opener.location" value in browser windows opened using normal anchor tags where the "target" attribute is specified as "_blank".

This gives an attacker the ability to change the parent location and thus potentially allow for a phishing attack to invoked.

To help this situation, it is suggested that the following attribute be set along with the "target" attribute:
```
rel="noopener noreferrer"
```

For example:
```
<a href="..." target="_blank" rel="noopener noreferrer">...</a>
```

## How was this patch tested?

  21731 passing (39s)
  48 pending