### PR TITLE
AMBARI-24640. Log Search: support to remove suffixes from field names.

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LabelFallbackHandler.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LabelFallbackHandler.java
@@ -46,9 +46,9 @@ public class LabelFallbackHandler {
   }
 
   public String fallbackIfRequired(String field, String label, boolean replaceUnderscore,
-                                   boolean replaceUppercaseInWord, boolean capitalizeAll, List<String> prefixesToRemove) {
+                                   boolean replaceUppercaseInWord, boolean capitalizeAll, List<String> prefixesToRemove, List<String> suffixesToRemove) {
     if (isEnabled() && StringUtils.isBlank(label)) {
-      return fallback(field,replaceUnderscore, replaceUppercaseInWord, capitalizeAll, prefixesToRemove);
+      return fallback(field,replaceUnderscore, replaceUppercaseInWord, capitalizeAll, prefixesToRemove, suffixesToRemove);
     }
     return label;
   }
@@ -66,16 +66,24 @@ public class LabelFallbackHandler {
     return result;
   }
 
-  public String fallback(String field, boolean replaceUnderscore, boolean replaceUppercaseInWord, boolean capitalizeAll, List<String> prefixesToRemove) {
-    String fieldWithoutPrefix =  null;
+  public String fallback(String field, boolean replaceUnderscore, boolean replaceUppercaseInWord, boolean capitalizeAll,
+                         List<String> prefixesToRemove,  List<String> suffixesToRemove) {
+    String fieldWithoutPrefixAndSuffix =  null;
     if (!CollectionUtils.isEmpty(prefixesToRemove)) {
       for (String prefix : prefixesToRemove) {
         if (StringUtils.isNotBlank(field) && field.startsWith(prefix)) {
-          fieldWithoutPrefix = field.substring(prefix.length());
+          fieldWithoutPrefixAndSuffix = field.substring(prefix.length());
         }
       }
     }
-    return fallback(fieldWithoutPrefix != null ? fieldWithoutPrefix : field, replaceUnderscore, replaceUppercaseInWord, capitalizeAll);
+    if (!CollectionUtils.isEmpty(suffixesToRemove)) {
+      for (String suffix : suffixesToRemove) {
+        if (StringUtils.isNotBlank(field) && field.endsWith(suffix)) {
+          fieldWithoutPrefixAndSuffix = field.substring(0, field.length() - suffix.length());
+        }
+      }
+    }
+    return fallback(fieldWithoutPrefixAndSuffix != null ? fieldWithoutPrefixAndSuffix : field, replaceUnderscore, replaceUppercaseInWord, capitalizeAll);
   }
 
   private String deUnderScore(String input) {

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
@@ -72,7 +72,8 @@ public class LogSearchConstants {
   public static final String SERVICE_FIELD_VISIBLE_DEFAULTS = "log_message,level,logtime,type";
   public static final String SERVICE_FIELD_EXCLUDES_DEFAULTS = "id,tags,text,message,seq_num,case_id,bundle_id,rowtype,event_count";
   public static final String SERVICE_FIELD_FILTERABLE_EXLUDE_DEFAULTS = "";
-  public static final String SERVICE_FIELD_FALLBACK_PREFIX_DEFAULTS = "ws_,sdi_";
+  public static final String SERVICE_FIELD_FALLBACK_PREFIX_DEFAULTS = "ws_,sdi_,std_";
+  public static final String SERVICE_FIELD_FALLBACK_SUFFIX_DEFAULTS = "_i,_l,_s,_b";
 
   // audit  field / component label defaults
   public static final String AUDIT_COMPONENT_LABELS_DEFAULTS = "ambari:Ambari,hdfs:Hdfs,RangerAudit:Ranger";
@@ -86,6 +87,7 @@ public class LogSearchConstants {
   public static final String AUDIT_FIELD_FILTERABLE_EXCLUDES_DEFAULTS = "";
   public static final String AUDIT_FIELD_FILTERABLE_EXCLUDES_COMMON_DEFAULTS = "";
   public static final String AUDIT_FIELD_FALLBACK_PREFIX_DEFAULTS = "ws_,std_";
+  public static final String AUDIT_FIELD_FALLBACK_SUFFIX_DEFAULTS = "_i,_l,_s,_b";
 
   //Facet Constant
   public static final String FACET_FIELD = "facet.field";

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/UIMappingConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/UIMappingConfig.java
@@ -18,7 +18,6 @@
  */
 package org.apache.ambari.logsearch.conf;
 
-import org.apache.ambari.logsearch.common.LogSearchConstants;
 import org.apache.ambari.logsearch.config.api.LogSearchPropertyDescription;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +34,7 @@ import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_EXCLUDES_COMMON_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_EXCLUDES_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_FALLBACK_PREFIX_DEFAULTS;
+import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_FALLBACK_SUFFIX_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_FILTERABLE_EXCLUDES_COMMON_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_FILTERABLE_EXCLUDES_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_LABELS_DEFAULTS;
@@ -42,6 +42,7 @@ import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_
 import static org.apache.ambari.logsearch.common.LogSearchConstants.AUDIT_FIELD_VISIBLE_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PROPERTIES_FILE;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.SERVICE_FIELD_FALLBACK_PREFIX_DEFAULTS;
+import static org.apache.ambari.logsearch.common.LogSearchConstants.SERVICE_FIELD_FALLBACK_SUFFIX_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.SERVICE_FIELD_FILTERABLE_EXLUDE_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.SERVICE_GROUP_LABELS_DEFAULTS;
 import static org.apache.ambari.logsearch.common.LogSearchConstants.SERVICE_COMPONENT_LABELS_DEFAULTS;
@@ -222,7 +223,7 @@ public class UIMappingConfig {
   )
   private List<String> serviceFieldFallbackPrefixes;
 
-  @Value("#{propertiesSplitter.parseList('${logsearch.web.labels.service_logs.field.fallback.prefixes:" + AUDIT_FIELD_FALLBACK_PREFIX_DEFAULTS + "}')}")
+  @Value("#{propertiesSplitter.parseList('${logsearch.web.labels.audit_logs.field.fallback.prefixes:" + AUDIT_FIELD_FALLBACK_PREFIX_DEFAULTS + "}')}")
   @LogSearchPropertyDescription(
     name = "logsearch.web.labels.service_logs.field.fallback.prefixes",
     description = "List of prefixes that should be removed during fallback of audit field labels.",
@@ -231,6 +232,26 @@ public class UIMappingConfig {
     sources = {LOGSEARCH_PROPERTIES_FILE}
   )
   private List<String> auditFieldFallbackPrefixes;
+
+  @Value("#{propertiesSplitter.parseList('${logsearch.web.labels.service_logs.field.fallback.suffixes:" + SERVICE_FIELD_FALLBACK_PREFIX_DEFAULTS +"}')}")
+  @LogSearchPropertyDescription(
+    name = "logsearch.web.labels.service_logs.field.fallback.suffixes",
+    description = "List of suffixes that should be removed during fallback of service field labels.",
+    examples = {"_i,_l,_s,_b"},
+    defaultValue = SERVICE_FIELD_FALLBACK_SUFFIX_DEFAULTS,
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  private List<String> serviceFieldFallbackSuffixes;
+
+  @Value("#{propertiesSplitter.parseList('${logsearch.web.labels.audit_logs.field.fallback.suffixes:" + AUDIT_FIELD_FALLBACK_PREFIX_DEFAULTS + "}')}")
+  @LogSearchPropertyDescription(
+    name = "logsearch.web.labels.service_logs.field.fallback.suffixes",
+    description = "List of suffixes that should be removed during fallback of audit field labels.",
+    examples = {"_i,_l,_s,_b"},
+    defaultValue = AUDIT_FIELD_FALLBACK_SUFFIX_DEFAULTS,
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  private List<String> auditFieldFallbackSuffixes;
 
   private final Map<String, Map<String, String>> mergedAuditFieldLabelMap = new HashMap<>();
 
@@ -366,6 +387,22 @@ public class UIMappingConfig {
 
   public void setServiceFieldFilterableExcludesList(List<String> serviceFieldFilterableExcludesList) {
     this.serviceFieldFilterableExcludesList = serviceFieldFilterableExcludesList;
+  }
+
+  public List<String> getServiceFieldFallbackSuffixes() {
+    return serviceFieldFallbackSuffixes;
+  }
+
+  public void setServiceFieldFallbackSuffixes(List<String> serviceFieldFallbackSuffixes) {
+    this.serviceFieldFallbackSuffixes = serviceFieldFallbackSuffixes;
+  }
+
+  public List<String> getAuditFieldFallbackSuffixes() {
+    return auditFieldFallbackSuffixes;
+  }
+
+  public void setAuditFieldFallbackSuffixes(List<String> auditFieldFallbackSuffixes) {
+    this.auditFieldFallbackSuffixes = auditFieldFallbackSuffixes;
   }
 
   public Map<String, List<String>> getMergedAuditFieldVisibleMap() {

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/AuditLogsManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/AuditLogsManager.java
@@ -178,7 +178,8 @@ public class AuditLogsManager extends ManagerBase<AuditLogData, AuditLogResponse
           String fieldLabel = fieldLabelMap.get(componentName) != null ? fieldLabelMap.get(componentName).get(field): null;
           String fallbackedFieldLabel = labelFallbackHandler.fallbackIfRequired(field, fieldLabel,
             true, true, true,
-            uiMappingConfig.getAuditFieldFallbackPrefixes());
+            uiMappingConfig.getAuditFieldFallbackPrefixes(),
+            uiMappingConfig.getAuditFieldFallbackSuffixes());
 
           Boolean excludeFromFilter = fieldFilterableExcludeMap.get(componentName) != null && fieldFilterableExcludeMap.get(componentName).contains(field);
           Boolean visible = fieldVisibleeMap.get(componentName) != null && fieldVisibleeMap.get(componentName).contains(field);
@@ -196,7 +197,7 @@ public class AuditLogsManager extends ManagerBase<AuditLogData, AuditLogResponse
         Boolean excludeFromFilter = commonFieldFilterableExcludeList.contains(field);
         String fallbackedFieldLabel = labelFallbackHandler.fallbackIfRequired(field, fieldLabel,
           true, true, true,
-          uiMappingConfig.getAuditFieldFallbackPrefixes());
+          uiMappingConfig.getAuditFieldFallbackPrefixes(), uiMappingConfig.getAuditFieldFallbackSuffixes());
         defaults.add(new FieldMetadata(field, fallbackedFieldLabel, !excludeFromFilter, visible));
       }
     }

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ServiceLogsManager.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/ServiceLogsManager.java
@@ -432,7 +432,8 @@ public class ServiceLogsManager extends ManagerBase<ServiceLogData, ServiceLogRe
           labelFallbackHandler.fallbackIfRequired(
             e.getKey(), uiMappingConfig.getServiceFieldLabels().get(e.getKey()),
             true, false, true,
-            uiMappingConfig.getServiceFieldFallbackPrefixes()),
+            uiMappingConfig.getServiceFieldFallbackPrefixes(),
+            uiMappingConfig.getServiceFieldFallbackSuffixes()),
           !uiMappingConfig.getServiceFieldFilterableExcludesList().contains(e.getKey()),
           uiMappingConfig.getServiceFieldVisibleList().contains(e.getKey())))
       .collect(Collectors.toList());

--- a/ambari-logsearch/ambari-logsearch-server/src/test/java/org/apache/ambari/logsearch/common/LabelFallbackHandlerTest.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/test/java/org/apache/ambari/logsearch/common/LabelFallbackHandlerTest.java
@@ -43,7 +43,7 @@ public class LabelFallbackHandlerTest {
     // GIVEN
     String testInput = "my_field";
     // WHEN
-    String result = underTest.fallbackIfRequired(testInput, "spec label", true, false, true, null);
+    String result = underTest.fallbackIfRequired(testInput, "spec label", true, false, true, null, null);
     // THEN
     assertEquals("spec label", result);
   }
@@ -109,11 +109,27 @@ public class LabelFallbackHandlerTest {
   @Test
   public void testFallbackWithRemovingPrefixes() {
     // GIVEN
-    String testInput = "ws_request_id";
+    String testInput1 = "ws_request_id";
+    String testInput2 = "std_request_username";
     // WHEN
-    String result = underTest.fallback(testInput, true, true, true, Arrays.asList("ws_", "std_"));
+    String result1 = underTest.fallback(testInput1, true, true, true, Arrays.asList("ws_", "std_"), null);
+    String result2 = underTest.fallback(testInput2, true, true, true, Arrays.asList("ws_", "std_"), null);
     // THEN
-    assertEquals("Request Id", result);
+    assertEquals("Request Id", result1);
+    assertEquals("Request Username", result2);
+  }
+
+  @Test
+  public void testFallbackWithRemovingSuffixes() {
+    // GIVEN
+    String testInput1 = "request_id_i";
+    String testInput2 = "request_username_s";
+    // WHEN
+    String result1 = underTest.fallback(testInput1, true, true, true, null, Arrays.asList("_i", "_s"));
+    String result2 = underTest.fallback(testInput2, true, true, true, null, Arrays.asList("_i", "_s"));
+    // THEN
+    assertEquals("Request Id", result1);
+    assertEquals("Request Username", result2);
   }
 
   @Test
@@ -121,7 +137,7 @@ public class LabelFallbackHandlerTest {
     // GIVEN
     String testInput = "request_id";
     // WHEN
-    String result = underTest.fallback(testInput, true, true, true, Arrays.asList("ws_", "std_"));
+    String result = underTest.fallback(testInput, true, true, true, Arrays.asList("ws_", "std_"), null);
     // THEN
     assertEquals("Request Id", result);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
new available properties to remove suffixes:
logsearch.web.labels.service_logs.field.fallback.suffixes=_l,_s,_b,_i
logsearch.web.labels.audit_logs.field.fallback.suffixes=_l,_s,_b,_i

That can be used to remove prefixes from fields -> can be useful for using dynamic fields. (like use string docValue-> *_s -> myfield1_s, myfield2_s, these will be converted to myfield1 and myfield2)
## How was this patch tested?
updated UTs, tests passed

Please review @g-boros @swagle @kasakrisz 