### PR TITLE
AMBARI-24642 hive service check failing related to LLAP in Ambari 

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
@@ -358,7 +358,10 @@ hive_server_interactive_ha = True if len(hive_server_interactive_hosts) > 1 else
 # End, Common Hosts and Ports
 
 hive_transport_mode = config['configurations']['hive-site']['hive.server2.transport.mode']
-hive_interactive_transport_mode = config['configurations']['hive-interactive-site']['hive.server2.transport.mode']
+if 'hive.server2.transport.mode' in config['configurations']['hive-interactive-site']:
+  hive_interactive_transport_mode = config['configurations']['hive-interactive-site']['hive.server2.transport.mode']
+else:
+  hive_interactive_transport_mode = hive_transport_mode
 
 if hive_transport_mode.lower() == "http":
   hive_server_port = config['configurations']['hive-site']['hive.server2.thrift.http.port']

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
@@ -358,6 +358,7 @@ hive_server_interactive_ha = True if len(hive_server_interactive_hosts) > 1 else
 # End, Common Hosts and Ports
 
 hive_transport_mode = config['configurations']['hive-site']['hive.server2.transport.mode']
+hive_interactive_transport_mode = config['configurations']['hive-interactive-site']['hive.server2.transport.mode']
 
 if hive_transport_mode.lower() == "http":
   hive_server_port = config['configurations']['hive-site']['hive.server2.thrift.http.port']
@@ -672,10 +673,11 @@ if has_hive_interactive:
     hive_interactive_heapsize = config['configurations']['hive-interactive-env']['hive_heapsize']
 
   # Service check related
-  if hive_transport_mode.lower() == "http":
+  if hive_interactive_transport_mode.lower() == "http":
     hive_server_interactive_port = config['configurations']['hive-interactive-site']['hive.server2.thrift.http.port']
   else:
     hive_server_interactive_port = default('/configurations/hive-interactive-site/hive.server2.thrift.port',"10500")
+   
   # Tez for Hive interactive related
   tez_interactive_config_dir = "/etc/tez_hive2/conf"
   tez_interactive_user = config['configurations']['tez-env']['tez_user']

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/service_check.py
@@ -72,7 +72,7 @@ class HiveServiceCheckDefault(HiveServiceCheck):
     Logger.info("Running Hive Server checks")
     Logger.info("--------------------------\n")
     self.check_hive_server(env, 'Hive Server', kinit_cmd, params.hive_server_hosts,
-                           int(format("{hive_server_port}")), params.hive_ssl_keystore_path, params.hive_ssl_keystore_password)
+                           int(format("{hive_server_port}")), params.hive_transport_mode, params.hive_ssl_keystore_path, params.hive_ssl_keystore_password)
 
 
     if params.has_hive_interactive  and params.hive_interactive_enabled:
@@ -80,13 +80,13 @@ class HiveServiceCheckDefault(HiveServiceCheck):
       Logger.info("--------------------------\n")
 
       self.check_hive_server(env, 'Hive Server2', kinit_cmd, params.hive_interactive_hosts,
-                             int(format("{hive_server_interactive_port}")), params.hive_interactive_ssl_keystore_path,
+                            int(format("{hive_server_interactive_port}")), params.hive_interactive_transport_mode, params.hive_interactive_ssl_keystore_path,
                              params.hive_interactive_ssl_keystore_password)
 
       Logger.info("Running LLAP checks")
       Logger.info("-------------------\n")
       self.check_llap(env, kinit_cmd, params.hive_interactive_hosts, int(format("{hive_server_interactive_port}")),
-                      params.hive_llap_principal, params.hive_server2_authentication, params.hive_transport_mode,
+                      params.hive_llap_principal, params.hive_server2_authentication, params.hive_interactive_transport_mode,
                       params.hive_http_endpoint)
 
 
@@ -98,7 +98,7 @@ class HiveServiceCheckDefault(HiveServiceCheck):
     Logger.info("---------------------\n")
     webhcat_service_check()
 
-  def check_hive_server(self, env, server_component_name, kinit_cmd, address_list, server_port, ssl_keystore, ssl_password):
+  def check_hive_server(self, env, server_component_name, kinit_cmd, address_list, server_port, transport_mode, ssl_keystore, ssl_password):
     import params
     env.set_params(params)
     Logger.info("Server Address List : {0}, Port : {1}, SSL KeyStore : {2}".format(address_list, server_port, ssl_keystore))
@@ -120,7 +120,7 @@ class HiveServiceCheckDefault(HiveServiceCheck):
       try:
         check_thrift_port_sasl(address, server_port, params.hive_server2_authentication,
                                params.hive_server_principal, kinit_cmd, params.smokeuser,
-                               transport_mode=params.hive_transport_mode, http_endpoint=params.hive_http_endpoint,
+                               transport_mode=transport_mode, http_endpoint=params.hive_http_endpoint,
                                ssl=params.hive_ssl, ssl_keystore=ssl_keystore,
                                ssl_password=ssl_password, ldap_username=params.hive_ldap_user,
                                ldap_password=params.hive_ldap_passwd)


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-24642 hive service check failing related to LLAP in Ambari 

ambari should check for hive_interactive_transport_mode instead of hive_transport_mode

## How was this patch tested?
tested as per functionality.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.