### PR TITLE
AMBARI-24635. Web Client Chooses Wrong Version When Reverting Configs

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
@@ -28,7 +28,7 @@ angular.module('ambariAdminConsole', [
 .constant('Settings', {
   siteRoot: '{proxy_root}/'.replace(/\{.+\}/g, ''),
 	baseUrl: '{proxy_root}/api/v1'.replace(/\{.+\}/g, ''),
-  testMode: (window.location.port == 8000),
+  testMode: false,
   mockDataPrefix: 'assets/data/',
   isLDAPConfigurationSupported: false,
   isLoginActivitiesSupported: false,

--- a/ambari-web/app/templates/common/configs/config_versions_control.hbs
+++ b/ambari-web/app/templates/common/configs/config_versions_control.hbs
@@ -34,7 +34,7 @@
   {{else}}
     {{view App.ConfigVersionsDropdownView serviceVersionsBinding="view.serviceVersions"}}
     {{#unless view.displayedServiceVersion.isCurrent}}
-      <button class="btn btn-secondary make-current" {{action makeCurrent view.displayedServiceVersion target="view"}}>
+      <button class="btn btn-secondary make-current" {{action makeCurrent target="view"}}>
         {{t dashboard.configHistory.info-bar.revert.button}}
       </button>
     {{/unless}}

--- a/ambari-web/app/views/common/configs/config_versions_control_view.js
+++ b/ambari-web/app/views/common/configs/config_versions_control_view.js
@@ -155,9 +155,9 @@ App.ConfigVersionsControlView = Em.View.extend({
   /**
    * revert config values to chosen version and apply reverted configs to server
    */
-  makeCurrent: function (event) {
+  makeCurrent: function () {
     const self = this;
-    const serviceConfigVersion = event.contexts[0];
+    const serviceConfigVersion = this.get('displayedServiceVersion');
     const versionText = serviceConfigVersion.get('versionText');
     return App.ModalPopup.show({
       header: Em.I18n.t('dashboard.configHistory.info-bar.makeCurrent.popup.title'),

--- a/ambari-web/test/views/common/configs/config_versions_control_view_test.js
+++ b/ambari-web/test/views/common/configs/config_versions_control_view_test.js
@@ -101,12 +101,12 @@ describe('App.ConfigVersionsControlView', function () {
       view.sendRevertCall.restore();
     });
     it('context passed', function () {
-      view.makeCurrent({contexts: [
-        Em.Object.create({
-          version: 1,
-          serviceName: 'S1'
-        })
-      ]});
+      view.set('displayedServiceVersion', Em.Object.create({
+        version: 1,
+        serviceName: 'S1'
+      }));
+
+      view.makeCurrent();
 
       expect(App.ModalPopup.show.calledOnce).to.be.true;
       expect(view.sendRevertCall.calledWith(Em.Object.create({


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:

Setup a simple cluster with ZK, HDFS, YARN, Hive, Pig
 - Create at least 5 different configuration versions for Pig
 - Load the Pig configuration page and select v4
 - Now select V3 and then choose "Make Current"
 - At this point, the web client will populate a dialog that says Created from service config version V4 and indeed it restores v4, not v3.

## How was this patch tested?

  21814 passing (48s)
  48 pending