### PR TITLE
AMBARI-24654. Tasks fail on ambari-agent intermittently under cpu load

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/Utils.py
+++ b/ambari-agent/src/main/python/ambari_agent/Utils.py
@@ -171,7 +171,8 @@ class ImmutableDictionary(dict):
     """
     Recursively turn dict to ImmutableDictionary
     """
-    for k, v in dictionary.iteritems():
+    if not isinstance(dictionary, ImmutableDictionary):
+      for k, v in dictionary.iteritems():
         dictionary[k] = Utils.make_immutable(v)
 
     super(ImmutableDictionary, self).__init__(dictionary)
@@ -220,6 +221,17 @@ def lazy_property(undecorated):
       return v
 
   return decorated
+
+def synchronized(lock):
+    def wrap(f):
+        def newFunction(*args, **kw):
+            lock.acquire()
+            try:
+                return f(*args, **kw)
+            finally:
+                lock.release()
+        return newFunction
+    return wrap
 
 def execute_with_retries(tries, try_sleep, retry_exception_class, func, *args, **kwargs):
   for i in range(tries):


### PR DESCRIPTION
INFO 2018-09-13 18:30:15,817 ClusterCache.py:125 - Rewriting cache ClusterTopologyCache for cluster 2
ERROR 2018-09-13 18:30:16,386 CustomServiceOrchestrator.py:456 - Caught an exception while executing custom service command: <type 'exceptions.TypeError'>: 'NoneType' object has no attribute '__getitem__'; 'NoneType' object has no attribute '__getitem__'
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/ambari_agent/CustomServiceOrchestrator.py", line 324, in runCommand
    command = self.generate_command(command_header)
  File "/usr/lib/ambari-agent/lib/ambari_agent/CustomServiceOrchestrator.py", line 504, in generate_command
    command_dict = self.configuration_builder.get_configuration(cluster_id, service_name, component_name, required_config_timestamp)
  File "/usr/lib/ambari-agent/lib/ambari_agent/ConfigurationBuilder.py", line 46, in get_configuration
    'agentLevelParams': {'hostname': self.topology_cache.get_current_host_info(cluster_id)['hostName']},
TypeError: 'NoneType' object has no attribute '__getitem__'
This was found while perf testing.
However can occur under any circumstances if ambari-agent node if slow enough.