### PR TITLE
[AMBARI-24657] Fix exception in blueprint deployment with host group configs

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -69,6 +69,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -1160,7 +1161,10 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     Config config = configFactory.createNew(stackId, cluster, type, versionTag, properties,
         propertiesAttributes, serviceId);
-
+    // TODO: the constructor of ConfigImpl adds itself to the cluster so calling this method
+    // should not be necessary. It causes some confusion with service instance level configs
+    // (where a serviceId is present). The result of the extra addConfig() call adds these configs
+    // to the cluster level configs too adding confusion.
     cluster.addConfig(config);
     return config;
   }
@@ -1626,7 +1630,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       Config config = null;
       //TODO : Remove after getting rid of cluster configurations
       if (request.getServiceId() != null) {
-        config = cluster.getConfigByServiceId(request.getType(), request.getVersionTag(), request.getServiceId());
+        config = cluster.getConfig(request.getType(), request.getVersionTag(), Optional.of(request.getServiceId()));
         if (null != config) {
           response = new ConfigurationResponse(
                   cluster.getClusterName(), config, request.getServiceId(), request.getServiceGroupId());
@@ -1911,7 +1915,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
             }
           }
           note = cr.getServiceConfigVersionNote();
-          Config config = cluster.getConfig(configType, cr.getVersionTag());
+          Config config = cluster.getConfig(configType, cr.getVersionTag(), Optional.ofNullable(cr.getServiceId()));
           if (null != config) {
             configs.add(config);
           }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CompositeStack.java
@@ -243,18 +243,12 @@ public class CompositeStack implements StackDefinition {
 
   @Override
   public Stream<String> getServicesForConfigType(String config) {
-    if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
-      return Stream.empty();
-    }
-    return stacks.stream()
-      .map(m -> {
-        try {
-          return m.getServiceForConfigType(config);
-        } catch (IllegalArgumentException e) {
-          return null;
-        }
-      })
-      .filter(Objects::nonNull);
+    return stacks.stream().flatMap(s -> s.getServicesForConfigType(config));
+  }
+
+  @Override
+  public Stream<Pair<StackId, String>> getStackServicesForConfigType(String config) {
+    return stacks.stream().flatMap(m -> m.getStackServicesForConfigType(config));
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -431,11 +431,20 @@ public class Stack implements StackDefinition {
 
   @Override
   public Stream<String> getServicesForConfigType(String config) {
+    if (ConfigHelper.CLUSTER_ENV.equals(config)) { // for backwards compatibility
+      return Stream.empty();
+    }
     return serviceConfigurations.entrySet().stream()
       .filter(e -> e.getValue().containsKey(config))
       .filter(e -> !getExcludedConfigurationTypes(e.getKey()).contains(config))
       .map(Map.Entry::getKey);
   }
+
+  @Override
+  public Stream<Pair<StackId, String>> getStackServicesForConfigType(String config) {
+    return getServicesForConfigType(config).map(service -> Pair.of(getStackId(), service));
+  }
+
 
   @Override
   public Collection<DependencyInfo> getDependenciesForComponent(String component) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackDefinition.java
@@ -229,6 +229,12 @@ public interface StackDefinition {
   Stream<String> getServicesForConfigType(String config);
 
   /**
+   * @return stream of service names along with the id of their defining stack which correspond
+   * to the specified configuration type name
+   */
+  Stream<Pair<StackId, String>> getStackServicesForConfigType(String config);
+
+  /**
    * Return the dependencies specified for the given component.
    *
    * @param component  component to get dependency information for

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -23,7 +23,10 @@ import static java.util.stream.Collectors.toSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+
+import javax.annotation.Nonnull;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.ClusterSettingNotFoundException;
@@ -415,6 +418,8 @@ public interface Cluster {
   Map<PropertyInfo.PropertyType, Set<String>> getConfigPropertiesTypes(String configType);
 
   /**
+   * @deprecated {@link #getConfig(String, String, Optional)} should be preferred
+   *
    * Gets the specific config that matches the specified type and tag.  This not
    * necessarily a DESIRED configuration that applies to a cluster.
    *
@@ -423,19 +428,23 @@ public interface Cluster {
    * @return a {@link Config} object, or <code>null</code> if the specific type
    * and version have not been set.
    */
-  Config getConfig(String configType, String versionTag);
+  @Deprecated
+  Config getConfig(@Nonnull String configType, @Nonnull String versionTag);
 
   /**
-   * Gets the specific config that matches the specified type and tag.  This not
+   * Gets the specific config that matches the specified type and tag. This not
    * necessarily a DESIRED configuration that applies to a cluster.
+   *
+   * If {@code serviceId} is present, the config will be first looked up in service instance level configs, when absent,
+   * cluster level configs will be searched.
    *
    * @param configType the config type to find
    * @param versionTag the config version tag to find
-   * @param serviceId the service for the config
+   * @param serviceId The optional serviceid. When present, the config will be looked up from service leve configs
    * @return a {@link Config} object, or <code>null</code> if the specific type
    * and version have not been set.
    */
-  Config getConfigByServiceId(String configType, String versionTag, Long serviceId);
+  Config getConfig(@Nonnull String configType, @Nonnull String versionTag, @Nonnull Optional<Long> serviceId);
 
   /**
    * Get latest (including inactive ones) configurations with any of the given types.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/configgroup/ConfigGroupImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/configgroup/ConfigGroupImpl.java
@@ -438,7 +438,7 @@ public class ConfigGroupImpl implements ConfigGroup {
 
           //TODO check the serviceid = null for the right use case
           config = configFactory.createNew(service.getStackId(), cluster, config.getType(),
-              config.getTag(), config.getProperties(), config.getPropertiesAttributes(), null);
+              config.getTag(), config.getProperties(), config.getPropertiesAttributes(), serviceId);
 
           entry.setValue(config);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/configgroup/ConfigGroupImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/configgroup/ConfigGroupImpl.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -175,8 +176,10 @@ public class ConfigGroupImpl implements ConfigGroup {
 
     // Populate configs
     for (ConfigGroupConfigMappingEntity configMappingEntity : configGroupEntity.getConfigGroupConfigMappingEntities()) {
-      Config config = cluster.getConfig(configMappingEntity.getConfigType(),
-        configMappingEntity.getVersionTag());
+      Config config = cluster.getConfig(
+        configMappingEntity.getConfigType(),
+        configMappingEntity.getVersionTag(),
+        Optional.ofNullable(serviceId));
 
       if (config != null) {
         m_configurations.put(config.getType(), config);
@@ -436,9 +439,16 @@ public class ConfigGroupImpl implements ConfigGroup {
         if (clusterConfigEntity == null) {
           Service service = cluster.getService(serviceId);
 
-          //TODO check the serviceid = null for the right use case
           config = configFactory.createNew(service.getStackId(), cluster, config.getType(),
               config.getTag(), config.getProperties(), config.getPropertiesAttributes(), serviceId);
+          // TODO: the following line should not be here, adding only temporarily for compatibility
+          // ClusterImpl keeps cluster level configs and service instance level configs (those associated with
+          // a serviceId) separately. Most of current Ambari code only uses cluster level configs. (TODO: fix it!)
+          // When a service instance level config is created using AmbariManagementController.createConfig() it will
+          // be added to the cluster both as service level and cluster level configs. To keep consistency with
+          // this behavior service level configs created here will too be added as cluster level configs until
+          // this thing gets fixed.
+          cluster.addConfig(config);
 
           entry.setValue(config);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -714,7 +714,7 @@ public class AmbariContext {
       String type = entry.getKey();
       List<Pair<StackId, String>> stackServices = stack.getStackServicesForConfigType(type).
         filter(each -> topology.getServiceTypes().contains(each.getValue())).collect(Collectors.toList());
-      Preconditions.checkArgument(!stackServices.isEmpty(), new IllegalArgumentException("Specified configuration type is not associated with any service in the blueprint: " + type));
+      Preconditions.checkArgument(!stackServices.isEmpty(), "Specified configuration type is not associated with any service in the blueprint: " + type);
       stackServices.forEach( stackService -> {
         Config config = configFactory.createReadOnly(type, groupName, entry.getValue(), null);
         //todo: attributes

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/AmbariContext.java
@@ -726,7 +726,7 @@ public class AmbariContext {
     for (Map.Entry<Pair<StackId, String>, Map<String, Config>> entry : groupConfigs.entrySet()) {
       Pair<StackId, String> stackService = entry.getKey();
       StackId stackId = entry.getKey().getLeft();
-      String service =entry.getKey().getRight();
+      String service = entry.getKey().getRight();
       Map<String, Config> serviceConfigs = entry.getValue();
       String absoluteGroupName = getConfigurationGroupName(bpName, groupName);
       Collection<String> groupHosts;

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/CollectionUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/CollectionUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.utils;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Utilities for collections
+ */
+public class CollectionUtils {
+
+  /**
+   * Returns a singleton instance of an empty immutable {@link ConcurrentMap}
+   * @param <K> key type
+   * @param <V> value type
+   * @return a singleton instance of an empty immutable {@link ConcurrentMap}
+   */
+  public static <K, V> ConcurrentMap<K, V> emptyConcurrentMap() {
+    return (ConcurrentMap<K, V>)EmptyConcurrentMap.INSTANCE;
+  }
+
+
+  private static class EmptyConcurrentMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {
+    @SuppressWarnings({"rawtypes"})
+    private static final EmptyConcurrentMap INSTANCE = new EmptyConcurrentMap();
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V replace(K key, V newValue) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompositeStackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/CompositeStackTest.java
@@ -29,8 +29,11 @@ import java.util.Set;
 import org.apache.ambari.server.stack.StackManager;
 import org.apache.ambari.server.stack.StackManagerTest;
 import org.apache.ambari.server.state.StackId;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
 
 public class CompositeStackTest {
 
@@ -63,6 +66,22 @@ public class CompositeStackTest {
       services.removeAll(stack.getServices());
     }
     assertEquals(emptySet(), services);
+  }
+
+  @Test
+  public void getServicesByConfigType() {
+    assertEquals(
+      ImmutableSet.of("HDFS"),
+      composite.getServicesForConfigType("hdfs-site").collect(toSet()));
+  }
+
+  @Test
+  public void getStackServicesByConfigType() {
+    assertEquals(
+      ImmutableSet.of(
+        Pair.of(new StackId("HDP", "0.1"), "HDFS"),
+        Pair.of(new StackId("OTHER", "1.0"), "HDFS")),
+      composite.getStackServicesForConfigType("hdfs-site").collect(toSet()));
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackTest.java
@@ -28,7 +28,9 @@ import static org.junit.Assert.assertSame;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.ambari.server.controller.StackLevelConfigurationResponse;
@@ -45,6 +47,7 @@ import org.easymock.EasyMockSupport;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -57,6 +60,7 @@ public class StackTest {
   private static final String STACK_CONFIG_FILE = STACK_CONFIG_TYPE + ".xml";
   private static final String SERVICE_CONFIG_TYPE = "test-site";
   private static final String SERVICE_CONFIG_FILE = SERVICE_CONFIG_TYPE + ".xml";
+  public static final String SERVICE_NAME = "some service";
 
   private StackInfo stackInfo;
   private ServiceInfo serviceInfo;
@@ -73,7 +77,7 @@ public class StackTest {
     stackInfo.setVersion(STACK_ID.getStackVersion());
 
     serviceInfo = new ServiceInfo();
-    serviceInfo.setName("some service");
+    serviceInfo.setName(SERVICE_NAME);
     stackInfo.getServices().add(serviceInfo);
 
     componentInfo = new ComponentInfo();
@@ -133,6 +137,54 @@ public class StackTest {
 
     // THEN
     assertEquals(ImmutableSet.of(serviceInfo.getName()), ImmutableSet.copyOf(services));
+  }
+
+  @Test
+  public void getServicesForConfigType() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    List<String> services = stack.getServicesForConfigType(SERVICE_CONFIG_TYPE).collect(Collectors.toList());
+
+    // THEN
+    assertEquals(ImmutableList.of(SERVICE_NAME), services);
+  }
+
+  @Test
+  public void getServicesForConfigType_ClusterEnv() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    List<String> services = stack.getServicesForConfigType(STACK_CONFIG_TYPE).collect(Collectors.toList());
+
+    // THEN
+    assertEquals(ImmutableList.of(), services);
+  }
+
+  @Test
+  public void getStackServicesForConfigType() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    List<Pair<StackId, String>> stackServices = stack.getStackServicesForConfigType(SERVICE_CONFIG_TYPE).collect(Collectors.toList());
+
+    // THEN
+    assertEquals(ImmutableList.of(Pair.of(STACK_ID, SERVICE_NAME)), stackServices);
+  }
+
+  @Test
+  public void getStackServicesForConfigType_ClusterEnv() throws Exception {
+    // GIVEN
+    Stack stack = new Stack(stackInfo);
+
+    // WHEN
+    List<String> stackServices = stack.getServicesForConfigType(STACK_CONFIG_TYPE).collect(Collectors.toList());
+
+    // THEN
+    assertEquals(ImmutableList.of(), stackServices);
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -269,7 +269,9 @@ public class AmbariContextTest {
     expect(stack.getVersion()).andReturn(STACK_VERSION).anyTimes();
 
     for (Map.Entry<String, String> entry : configTypeServiceMapping.entrySet()) {
-      expect(stack.getServicesForConfigType(entry.getKey())).andReturn(Stream.of(entry.getValue())).anyTimes();
+      expect(stack.getStackServicesForConfigType(entry.getKey()))
+        .andReturn( Stream.of(Pair.of(STACK_ID, entry.getValue())) )
+        .anyTimes();
     }
 
     expect(controller.getClusters()).andReturn(clusters).anyTimes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed a _NullPointerException_ during blueprint install with host group level configs. Also prepared the code in _AmbariContext.createConfigGroupsAndRegisterHost_ to support multiple service instances.

## How was this patch tested?
- tested blueprint installation manually
- wrote new unit test and fixed/enhanced existing tests
