### PR TITLE
[AMBARI-24622] Allow skipping package operations for LZO on sysprepped hosts

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/lzo_utils.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/lzo_utils.py
@@ -74,11 +74,22 @@ def should_install_lzo():
 
   return True
 
+def skip_package_operations():
+  """
+  Return true if LZO packages are assumed to be pre-installed
+  Needs to be separate from should_install_lzo, as that one is used during tarball creation, too
+  """
+  return default("/ambariLevelParams/host_sys_prepped", False) and default("/configurations/cluster-env/sysprep_skip_lzo_package_operations", False)
+
 def install_lzo_if_needed():
   """
   Install lzo package if {#should_install_lzo} is true
   """
   if not should_install_lzo():
+    return
+
+  if skip_package_operations():
+    Logger.info("Skipping LZO package installation as host is sys prepped")
     return
 
   # If user has just accepted GPL license. GPL repository can not yet be present.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2303, for `trunk`.  Cherry-pick, except:

 * `host_sys_prepped` was moved to `ambariLevelParams`
 * `cluster-env.xml` no longer exists