### PR TITLE
[AMBARI-24671] Workaround for non-atomic directory creation

### DIFF
--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -36,6 +36,7 @@ from resource_management.core import File
 from resource_management.core import shell
 from resource_management.core.environment import Environment
 from resource_management.core.logger import Logger
+from resource_management.core.resources.system import Directory
 from resource_management.core.resources.system import Execute
 from resource_management.core.source import StaticFile
 from resource_management.libraries import ConfigDictionary
@@ -323,6 +324,40 @@ with Environment() as env:
 
   env.set_params(params)
   hadoop_conf_dir = params.hadoop_conf_dir
+
+  Directory('/var/lib/ambari-agent/tmp/hadoop_java_io_tmpdir',
+            owner=params.hdfs_user,
+            group=params.user_group,
+            mode=01777
+  )
+  Directory('/var/log/hadoop',
+            create_parents = True,
+            owner='root',
+            group=params.user_group,
+            mode=0775,
+            cd_access='a',
+  )
+  Directory('/var/run/hadoop',
+            create_parents = True,
+            owner='root',
+            group='root',
+            cd_access='a',
+  )
+  Directory('/var/run/hadoop/hdfs',
+            owner=params.hdfs_user,
+            cd_access='a',
+  )
+  Directory('/tmp/hadoop-hdfs',
+            create_parents = True,
+            owner=params.hdfs_user,
+            cd_access='a',
+  )
+  Directory('/tmp/hbase-hbase',
+            owner='hbase',
+            mode=0775,
+            create_parents = True,
+            cd_access="a",
+  )
 
   oozie_libext_dir = params.oozie_libext_dir
   sql_driver_filename = os.path.basename(SQL_DRIVER_PATH)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2357, for `trunk`, except:

 * added an additional directory for [`before-START`](https://github.com/apache/ambari/blob/3231893f6488bafed5d5c0d87d0aeaccb8d24498/ambari-server/src/main/resources/stack-hooks/before-START/scripts/shared_initialization.py#L54-L57)
 * added `import Directory`, which was removed in 6c46a0b54d300e4036737fcb6bc4f099b173acfd

## How was this patch tested?

Ran `Ambaripreupload.py` on Ambari server host.