### PR TITLE
AMBARI-24680. Remove out-dated and insecure encryption algorithms use…

### DIFF
--- a/ambari-agent/src/test/python/ambari_agent/TestKerberosCommon.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestKerberosCommon.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+from ambari_commons.kerberos.kerberos_common import resolve_encryption_family_list, resolve_encryption_families
+
+class TestEncryptionTypes(TestCase):
+
+  def test_resolves_family(self):
+    expected = set([
+      'aes256-cts-hmac-sha1-96',
+      'aes128-cts-hmac-sha1-96',
+      'aes256-cts-hmac-sha384-192',
+      'aes128-cts-hmac-sha256-128',
+      'rc4-hmac'])
+    self.assertEquals(expected, resolve_encryption_family_list(['rc4', 'aes']))
+
+  def test_no_resolve_if_no_family_is_given(self):
+    expected = set(['aes256-cts-hmac-sha1-96', 'rc4-hmac'])
+    self.assertEquals(expected, resolve_encryption_family_list(['rc4-hmac', 'aes256-cts-hmac-sha1-96']))
+
+  def test_eliminates_duplications(self):
+    expected = set([
+      'aes256-cts-hmac-sha1-96',
+      'aes128-cts-hmac-sha1-96',
+      'aes256-cts-hmac-sha384-192',
+      'aes128-cts-hmac-sha256-128'])
+    self.assertEquals(expected, resolve_encryption_family_list(['aes', 'aes128-cts-hmac-sha1-96']))
+
+  def test_translate_str(self):
+    self.assertEquals('rc4-hmac', resolve_encryption_families('rc4'))

--- a/ambari-agent/src/test/python/ambari_agent/TestKerberosCommon.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestKerberosCommon.py
@@ -1,3 +1,23 @@
+#!/usr/bin/env python
+
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
 from unittest import TestCase
 from ambari_commons.kerberos.kerberos_common import resolve_encryption_family_list, resolve_encryption_families
 

--- a/ambari-common/src/main/python/ambari_commons/kerberos/kerberos_common.py
+++ b/ambari-common/src/main/python/ambari_commons/kerberos/kerberos_common.py
@@ -169,3 +169,22 @@ def find_missing_keytabs(params, output_hook=lambda missing_keytabs: None):
   missing_keytabs = MissingKeytabs.from_kerberos_records(params.kerberos_command_params, params.hostname)
   Logger.info(str(missing_keytabs))
   output_hook(missing_keytabs.as_dict())
+
+# Encryption families from: http://web.mit.edu/KERBEROS/krb5-latest/doc/admin/conf_files/kdc_conf.html#encryption-types
+ENCRYPTION_FAMILY_MAP = {
+  'aes'       : ['aes256-cts-hmac-sha1-96', 'aes128-cts-hmac-sha1-96', 'aes256-cts-hmac-sha384-192', 'aes128-cts-hmac-sha256-128'],
+  'rc4'       : ['rc4-hmac'],
+  'camellia'  : ['camellia256-cts-cmac', 'camellia128-cts-cmac'],
+  'des3'      : ['des3-cbc-sha1'],
+  'des'       : ['des-cbc-crc', 'des-cbc-md5', 'des-cbc-md4']
+}
+
+def resolve_encryption_family_list(enc_types_list):
+  result = []
+  for each in enc_types_list:
+    result.extend(ENCRYPTION_FAMILY_MAP[each] if each in ENCRYPTION_FAMILY_MAP else [each])
+  return set(result)
+
+def resolve_encryption_families(enc_types_str):
+  return None if enc_types_str is None \
+    else ' '.join(resolve_encryption_family_list(enc_types_str.split()))


### PR DESCRIPTION
…d by default by Kerberos (amagyar)

## What changes were proposed in this pull request?

If an encryption family is used in kerberos-env/encryption_types then the family should be resolved and substituted with the corresponding encryption types.

This will be used in stack code (different branch).

## How was this patch tested?

* Added the stack code that uses the function from this patch.
* Set  kerberos-env/encryption_types to "aes des3 rc4"
* Enabled kerberos
* Checked that in /etc/krb5.conf default_tgs_enctypes, default_tkt_enctypes, permitted_enctypes were:

```text
aes128-cts-hmac-sha256-128 rc4-hmac aes256-cts-hmac-sha1-96 des3-cbc-sha1 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha1-96
```