### PR TITLE
AMBARI-24670. Directory creation sometimes fails with parallel_execution=1

### DIFF
--- a/ambari-agent/src/test/python/resource_management/TestLinkResource.py
+++ b/ambari-agent/src/test/python/resource_management/TestLinkResource.py
@@ -34,7 +34,7 @@ class TestLinkResource(TestCase):
 
   @patch.object(os.path, "realpath")
   @patch("resource_management.core.sudo.path_lexists")
-  @patch("resource_management.core.sudo.path_lexists")
+  @patch("resource_management.core.sudo.path_islink")
   @patch("resource_management.core.sudo.unlink")
   @patch("resource_management.core.sudo.symlink")
   def test_action_create_relink(self, symlink_mock, unlink_mock, 

--- a/ambari-common/src/main/python/resource_management/core/source.py
+++ b/ambari-common/src/main/python/resource_management/core/source.py
@@ -72,7 +72,7 @@ class StaticFile(Source):
       basedir = self.env.config.basedir
       path = os.path.join(basedir, "files", self.name)
       
-    if not sudo.path_isfile(path) and not sudo.path_lexists(path):
+    if not sudo.path_isfile(path):
       raise Fail("{0} Source file {1} is not found".format(repr(self), path))
 
     return self.read_file(path)

--- a/ambari-common/src/main/python/resource_management/core/sudo.py
+++ b/ambari-common/src/main/python/resource_management/core/sudo.py
@@ -159,7 +159,10 @@ if os.geteuid() == 0:
   
   def path_isdir(path):
     return os.path.isdir(path)
-  
+
+  def path_islink(path):
+    return os.path.islink(path)
+
   def path_lexists(path):
     return os.path.lexists(path)
   
@@ -267,10 +270,14 @@ else:
   # os.path.isdir
   def path_isdir(path):
     return (shell.call(["test", "-d", path], sudo=True)[0] == 0)
+
+  # os.path.islink
+  def path_islink(path):
+    return (shell.call(["test", "-L", path], sudo=True)[0] == 0)
   
   # os.path.lexists
   def path_lexists(path):
-    return (shell.call(["test", "-L", path], sudo=True)[0] == 0)
+    return (shell.call(["test", "-e", path], sudo=True)[0] == 0)
   
   # os.readlink
   def readlink(path):


### PR DESCRIPTION
If parallel execution is enabled on Ambari Agent, concurrent directory creation may fail with:

errors-62.txt
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/2.0.6/hooks/before-ANY/scripts/hook.py", line 35, in <module>
    BeforeAnyHook().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 375, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/2.0.6/hooks/before-ANY/scripts/hook.py", line 31, in hook
    setup_hadoop_env()
  File "/var/lib/ambari-agent/cache/stacks/HDP/2.0.6/hooks/before-ANY/scripts/shared_initialization.py", line 203, in setup_hadoop_env
    mode=01777
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/system.py", line 191, in action_create
    sudo.makedir(path, self.resource.mode or 0755)
  File "/usr/lib/ambari-agent/lib/resource_management/core/sudo.py", line 121, in makedir
    os.mkdir(path)
OSError: [Errno 17] File exists: '/var/lib/ambari-agent/tmp/hadoop_java_io_tmpdir'
or

errors-63.txt
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/2.0.6/hooks/before-ANY/scripts/hook.py", line 35, in <module>
    BeforeAnyHook().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 375, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/2.0.6/hooks/before-ANY/scripts/hook.py", line 31, in hook
    setup_hadoop_env()
  File "/var/lib/ambari-agent/cache/stacks/HDP/2.0.6/hooks/before-ANY/scripts/shared_initialization.py", line 203, in setup_hadoop_env
    mode=01777
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/core/providers/system.py", line 179, in action_create
    path = sudo.readlink(path)
  File "/usr/lib/ambari-agent/lib/resource_management/core/sudo.py", line 161, in readlink
    return os.readlink(path)
OSError: [Errno 22] Invalid argument: '/var/lib/ambari-agent/tmp/hadoop_java_io_tmpdir'
The failed tasks need to be retried to succeed, causing delays.