### PR TITLE
AMBARI-24689. All component statuses should be re-send on registration

### DIFF
--- a/ambari-agent/src/test/python/resource_management/TestLinkResource.py
+++ b/ambari-agent/src/test/python/resource_management/TestLinkResource.py
@@ -34,7 +34,7 @@ class TestLinkResource(TestCase):
 
   @patch.object(os.path, "realpath")
   @patch("resource_management.core.sudo.path_lexists")
-  @patch("resource_management.core.sudo.path_lexists")
+  @patch("resource_management.core.sudo.path_islink")
   @patch("resource_management.core.sudo.unlink")
   @patch("resource_management.core.sudo.symlink")
   def test_action_create_relink(self, symlink_mock, unlink_mock, 

--- a/ambari-agent/src/test/python/resource_management/TestLinkResource.py
+++ b/ambari-agent/src/test/python/resource_management/TestLinkResource.py
@@ -34,7 +34,7 @@ class TestLinkResource(TestCase):
 
   @patch.object(os.path, "realpath")
   @patch("resource_management.core.sudo.path_lexists")
-  @patch("resource_management.core.sudo.path_islink")
+  @patch("resource_management.core.sudo.path_lexists")
   @patch("resource_management.core.sudo.unlink")
   @patch("resource_management.core.sudo.symlink")
   def test_action_create_relink(self, symlink_mock, unlink_mock, 


### PR DESCRIPTION
as per Myroslav this should help to solve the issue "Ambari Metrics collector stuck at stopping status; unable to perform any other operation on it." where statuses are not correctly handled on server after HB_LOST.