### PR TITLE
[AMBARI-20390] Inappropriate kafka log4j configuration results in too much kafka logs 

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/configuration/kafka-log4j.xml
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/configuration/kafka-log4j.xml
@@ -96,8 +96,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
 log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
@@ -122,8 +121,7 @@ log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n


### PR DESCRIPTION
## What changes were proposed in this pull request?
Inappropriate kafka log4j configuration results in too much kafka logs which are constantly increasing and never be removed.
Besides,DailyRollingFileAppender does not support property:maxBackupIndex and maxFileSize, Only RollingFileAppender supports it.

## How was this patch tested?

Mannual Tested

@afernandez @zjffdu @YolandaMDavis @zeroflag