### PR TITLE
[AMBARI-24704] Problems with accounts page when sysprep_skip_create_users_and_groups is absent

### DIFF
--- a/ambari-web/app/views/wizard/step7/accounts_tab_view.js
+++ b/ambari-web/app/views/wizard/step7/accounts_tab_view.js
@@ -44,11 +44,12 @@ App.AccountsTabOnStep7View = Em.View.extend(App.WizardMiscPropertyChecker, {
 
   checkboxes: function () {
     var miscConfigs = this.get('controller.stepConfigs').findProperty('serviceName', 'MISC').get('configs');
-    return [
-      miscConfigs.findProperty('name', 'sysprep_skip_create_users_and_groups'),
-      miscConfigs.findProperty('name', 'ignore_groupsusers_create'),
-      miscConfigs.findProperty('name', 'override_uid')
-    ];
+    const miscProperties = ['sysprep_skip_create_users_and_groups', 'ignore_groupsusers_create', 'override_uid'];
+    const checkboxArr = [];
+    miscProperties.forEach(property => {
+      if (miscConfigs.findProperty('name', property)) checkboxArr.push(miscConfigs.findProperty('name', property));
+    });
+    return checkboxArr;
   }.property('controller.stepConfigsCreated')
 
 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

When sysprep_skip_create_users_and_groups property is absent accounts page can not load.

## How was this patch tested?

  21835 passing (52s)
  48 pending