### PR TITLE
AMBARI-24700 - Slider widget: insert a space char between label value and unit-name

### DIFF
--- a/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
@@ -434,7 +434,7 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
       step: mirrorStep,
       formatter: function (val) {
         var labelValue = Em.isArray(val) ? val[0] : val;
-        return self.formatTickLabel(labelValue);
+        return self.formatTickLabel(labelValue, ' ');
       }
     });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

On Ambari enhaced configuration UI on the slider widgets value and unit-name was written into one word. Like
```
100GB
```
Fix: insert a space character between the value and the unit-name
```
100 GB
```

## How was this patch tested?

ambari-web
mvn clean install

Manually:
- Install Ambari from rpms created from ambari trunk.
- Copy HDP 3.0 stack code
- Launch the Cluster creation wizard
- Choose a service which has slider widget in its config UI (ex. HDFS)
- Check slider widgets on the `Customize Services` step
