### PR TITLE
AMBARI-24717. Ambari-agent does for save data hashes correctly

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ClusterCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/ClusterCache.py
@@ -99,10 +99,7 @@ class ClusterCache(dict):
         del self[cache_id_to_delete]
 
     self.on_cache_update()
-    self.persist_cache()
-
-    # if all of above are sucessful finally set the hash
-    self.hash = cache_hash
+    self.persist_cache(cache_hash)
 
   def cache_update(self, update_dict, cache_hash):
     """
@@ -131,7 +128,7 @@ class ClusterCache(dict):
     with self._cache_lock:
       self[cluster_id] = immutable_cache
 
-  def persist_cache(self):
+  def persist_cache(self, cache_hash):
     # ensure that our cache directory exists
     if not os.path.exists(self.cluster_cache_dir):
       os.makedirs(self.cluster_cache_dir)
@@ -142,7 +139,10 @@ class ClusterCache(dict):
 
       if self.hash is not None:
         with open(self.__current_cache_hash_file, 'w') as fp:
-          fp.write(self.hash)
+          fp.write(cache_hash)
+
+    # if all of above are successful finally set the hash
+    self.hash = cache_hash
 
   def _get_mutable_copy(self):
     with self._cache_lock:

--- a/ambari-agent/src/main/python/ambari_agent/ClusterMetadataCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/ClusterMetadataCache.py
@@ -30,13 +30,20 @@ class ClusterMetadataCache(ClusterCache):
   topology properties.
   """
 
-  def __init__(self, cluster_cache_dir):
+  def __init__(self, cluster_cache_dir, config):
     """
     Initializes the topology cache.
     :param cluster_cache_dir:
     :return:
     """
+    self.config = config
     super(ClusterMetadataCache, self).__init__(cluster_cache_dir)
+
+  def on_cache_update(self):
+    try:
+      self.config.update_configuration_from_metadata(self['-1']['agentConfigs'])
+    except KeyError:
+      pass
 
   def cache_delete(self, cache_update, cache_hash):
     """

--- a/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
+++ b/ambari-agent/src/main/python/ambari_agent/InitializerModule.py
@@ -84,7 +84,7 @@ class InitializerModule:
     """
     self.is_registered = False
 
-    self.metadata_cache = ClusterMetadataCache(self.config.cluster_cache_dir)
+    self.metadata_cache = ClusterMetadataCache(self.config.cluster_cache_dir, self.config)
     self.topology_cache = ClusterTopologyCache(self.config.cluster_cache_dir, self.config)
     self.host_level_params_cache = ClusterHostLevelParamsCache(self.config.cluster_cache_dir)
     self.configurations_cache = ClusterConfigurationCache(self.config.cluster_cache_dir)

--- a/ambari-agent/src/main/python/ambari_agent/RecoveryManager.py
+++ b/ambari-agent/src/main/python/ambari_agent/RecoveryManager.py
@@ -103,6 +103,15 @@ class RecoveryManager:
     self.actions = {}
     self.update_config(6, 60, 5, 12, recovery_enabled, auto_start_only, auto_install_start)
 
+    # FIXME: Recovery manager does not support multiple clusters as of now.
+    if len(self.initializer_module.configurations_cache):
+      self.cluster_id = self.initializer_module.configurations_cache.keys()[0]
+      self.on_config_update()
+
+    if len(self.initializer_module.host_level_params_cache):
+      self.cluster_id = self.initializer_module.host_level_params_cache.keys()[0]
+      self.update_recovery_config(self.host_level_params_cache[self.cluster_id])
+
   def on_execution_command_start(self):
     with self.__active_command_lock:
       self.active_command_count += 1

--- a/ambari-agent/src/main/python/ambari_agent/listeners/MetadataEventListener.py
+++ b/ambari-agent/src/main/python/ambari_agent/listeners/MetadataEventListener.py
@@ -35,7 +35,6 @@ class MetadataEventListener(EventListener):
   def __init__(self, initializer_module):
     super(MetadataEventListener, self).__init__(initializer_module)
     self.metadata_cache = initializer_module.metadata_cache
-    self.config = initializer_module.config
 
   def on_event(self, headers, message):
     """
@@ -58,11 +57,6 @@ class MetadataEventListener(EventListener):
       self.metadata_cache.cache_delete(message['clusters'], message['hash'])
     else:
       logger.error("Unknown event type '{0}' for metadata event")
-
-    try:
-      self.config.update_configuration_from_metadata(message['clusters']['-1']['agentConfigs'])
-    except KeyError:
-      pass
 
   def get_handled_path(self):
     return Constants.METADATA_TOPIC


### PR DESCRIPTION
This causes all the data to be re-send during registration. Which can be very dramatic for perf clusters.