### PR TITLE
BUG-111390 - Infra Solr: manage autoscaling properties in Ambari

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/solr_cloud_util.py
@@ -16,18 +16,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """
-import random
 import json
-from random import randrange
+import random
 from ambari_commons.constants import AMBARI_SUDO_BINARY
 from ambari_jinja2 import Environment as JinjaEnvironment
-from resource_management.libraries.functions import get_kinit_path
-from resource_management.libraries.functions.default import default
-from resource_management.libraries.functions.format import format
+from random import randrange
+from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Directory, Execute, File
 from resource_management.core.source import StaticFile
-from resource_management.core.shell import as_sudo
-from resource_management.core.logger import Logger
+from resource_management.libraries.functions import get_kinit_path
+from resource_management.libraries.functions.format import format
 
 __all__ = ["upload_configuration_to_zk", "create_collection", "setup_kerberos", "set_cluster_prop",
            "setup_kerberos_plugin", "create_znode", "check_znode", "secure_solr_znode", "secure_znode"]
@@ -167,6 +165,14 @@ def set_cluster_prop(zookeeper_quorum, solr_znode, prop_name, prop_value, java64
   """
   solr_cli_prefix = __create_solr_cloud_cli_prefix(zookeeper_quorum, solr_znode, java64_home, java_opts, jaas_file)
   set_cluster_prop_cmd = format('{solr_cli_prefix} --cluster-prop --property-name {prop_name} --property-value {prop_value}')
+  Execute(set_cluster_prop_cmd)
+
+def set_autoscaling_props(zookeeper_quorum, solr_znode, autoscaling_json_file_location, java64_home, jaas_file = None, java_opts=None):
+  """
+  Set a cluster property on the Solr znode in autoscaling.json
+  """
+  solr_cli_prefix = __create_solr_cloud_cli_prefix(zookeeper_quorum, solr_znode, java64_home, java_opts, jaas_file, True)
+  set_cluster_prop_cmd = format('{solr_cli_prefix} --set-autoscaling --autoscaling-json-location {autoscaling_json_file_location}')
   Execute(set_cluster_prop_cmd)
 
 def secure_znode(config, zookeeper_quorum, solr_znode, jaas_file, java64_home, sasl_users=[], retry = 5 , interval = 10, java_opts=None):


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the feature upload autoscaling.json to solr_cloud_util.py

## How was this patch tested?

Manually:

- Deploy Ambari
- install ambari-infra-solr-client to a host where infra-solr will be installed using yum
- install infra-solr using ambari
- check the content of Cloud/Tree/autoscaling.json on Solr Admin page 
- change some autoscaling settings on Ambari UI and check the content of Cloud/Tree/autoscaling.json on Solr Admin page again
