### PR TITLE
AMBARI-24722. Failed to force_non_member_install a stack version on hosts.

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/repository_util.py
@@ -32,14 +32,12 @@ UBUNTU_REPO_COMPONENTS_POSTFIX = "main"
 
 
 class RepositoryUtil:
-  def __init__(self, config, tags_to_skip):
+  def __init__(self, config):
     """
     Constructor for RepositoryUtil
 
     :type config dict
-    :type tags_to_skip set
     """
-    self.tags_to_skip = tags_to_skip
 
     # repo templates
     repo_file = config['repositoryFile']
@@ -71,10 +69,6 @@ class RepositoryUtil:
       if repository.repo_id is None:
         raise Fail("Repository with url {0} has no id".format(repository.base_url))
 
-      if self.tags_to_skip & repository.tags:
-        Logger.info("Repository with url {0} is not created due to its tags: {1}".format(repository.base_url, repository.tags))
-        continue
-
       if not repository.ambari_managed:
         Logger.warning(
           "Repository for {0}/{1}/{2} is not managed by Ambari".format(
@@ -101,7 +95,7 @@ def create_repo_files(template, command_repository):
   Please use Script.repository_util.create_repo_files() instead.
   """
   from resource_management.libraries.script import Script
-  return RepositoryUtil(Script.get_config(), set()).create_repo_files()
+  return RepositoryUtil(Script.get_config()).create_repo_files()
 
 
 def _find_value(dictionary, key, default=None):
@@ -148,6 +142,7 @@ class CommandRepository(object):
     self.repo_filename = _find_value(json_dict, 'repoFileName')
     self.resolved = _find_value(json_dict, 'resolved', False)
     self.feat = CommandRepositoryFeature(_find_value(json_dict, "feature", default={}))
+    self.all_items = []
     self.items = []
 
     repos_def = _find_value(json_dict, 'repositories')
@@ -156,7 +151,19 @@ class CommandRepository(object):
          repos_def = [repos_def]
 
        for repo_def in repos_def:
-         self.items.append(CommandRepositoryItem(self, repo_def))
+         self.all_items.append(CommandRepositoryItem(self, repo_def))
+
+    from resource_management.libraries.functions import lzo_utils
+
+    # remove repos with 'GPL' tag when GPL license is not approved
+    self.repo_tags_to_skip = set()
+    if not lzo_utils.is_gpl_license_accepted():
+      self.repo_tags_to_skip.add("GPL")
+    for r in self.all_items:
+      if self.repo_tags_to_skip & r.tags:
+        Logger.info("Repository with url {0} is not created due to its tags: {1}".format(r.base_url, r.tags))
+      else:
+        self.items.append(r)
 
 
 class CommandRepositoryItem(object):

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -331,13 +331,7 @@ class Script(object):
       Logger.logger.exception("Can not read json file with command parameters: ")
       sys.exit(1)
 
-    from resource_management.libraries.functions import lzo_utils
-
-    repo_tags_to_skip = set()
-    if not lzo_utils.is_gpl_license_accepted():
-      repo_tags_to_skip.add("GPL")
-
-    Script.repository_util = RepositoryUtil(Script.config, repo_tags_to_skip)
+    Script.repository_util = RepositoryUtil(Script.config)
 
     # Run class method depending on a command type
     try:
@@ -781,14 +775,6 @@ class Script(object):
 
     service_name = config['serviceName'] if 'serviceName' in config else None
     repos = CommandRepository(config['repositoryFile'])
-
-    from resource_management.libraries.functions import lzo_utils
-
-    # remove repos with 'GPL' tag when GPL license is not approved
-    repo_tags_to_skip = set()
-    if not lzo_utils.is_gpl_license_accepted():
-      repo_tags_to_skip.add("GPL")
-    repos.items = [r for r in repos.items if not (repo_tags_to_skip & r.tags)]
 
     repo_ids = [repo.repo_id for repo in repos.items]
     Logger.info("Command repositories: {0}".format(", ".join(repo_ids)))

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ActionScheduler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ActionScheduler.java
@@ -61,7 +61,6 @@ import org.apache.ambari.server.orm.entities.RequestEntity;
 import org.apache.ambari.server.serveraction.ServerActionExecutor;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
-import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.Host;
 import org.apache.ambari.server.state.HostState;
 import org.apache.ambari.server.state.Service;
@@ -484,7 +483,6 @@ class ActionScheduler implements Runnable {
 
 
         for (ExecutionCommand cmd : commandsToSchedule) {
-          ConfigHelper.processHiddenAttribute(cmd.getConfigurations(), cmd.getConfigurationAttributes(), cmd.getRole(), false);
           processHostRole(request, stage, cmd, commandsToStart, commandsToUpdate);
         }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
@@ -151,13 +151,6 @@ public class ExecutionCommandWrapper {
         executionCommand.setConfigurations(configurations);
       }
 
-      // now that the tags have been updated (if necessary), fetch the
-      // configurations
-      Map<String, Map<String, String>> configurationTags = executionCommand.getConfigurationTags();
-      configHelper.getAndMergeHostConfigs(configurations, configurationTags, cluster);
-      configHelper.getAndMergeHostConfigAttributes(executionCommand.getConfigurationAttributes(),
-          configurationTags, cluster);
-
       // provide some basic information about a cluster upgrade if there is one
       // in progress
       UpgradeEntity upgrade = cluster.getUpgradeInProgress();

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
@@ -142,8 +142,8 @@ public class ExecutionCommandWrapper {
       // cluster desired-configs. Additionally, there may be no configuration
       // tags set but refresh might be set to *. In this case, they should still
       // be refreshed with the latest.
-      boolean refreshConfigTagsBeforeExecution = executionCommand.getForceRefreshConfigTagsBeforeExecution();
-      if (refreshConfigTagsBeforeExecution) {
+      boolean overrideConfigs = executionCommand.isOverrideConfigs();
+      if (overrideConfigs) {
         Map<String, DesiredConfig> desiredConfigs = cluster.getDesiredConfigs();
 
         Map<String, Map<String, String>> configurationTags = configHelper.getEffectiveDesiredTags(
@@ -155,8 +155,9 @@ public class ExecutionCommandWrapper {
 
         // then clear out any existing configurations so that all of the new
         // configurations are forcefully applied
-        configurations.clear();
-        executionCommand.setConfigurationTags(configurationTags);
+        configurations = configHelper.getEffectiveConfigProperties(cluster, configurationTags);
+
+        executionCommand.setConfigurations(configurations);
       }
 
       // now that the tags have been updated (if necessary), fetch the

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapper.java
@@ -133,15 +133,9 @@ public class ExecutionCommandWrapper {
 
       Cluster cluster = clusters.getClusterById(clusterId);
 
-      // Execution commands may have config-tags already set during their creation.
-      // However, these tags become stale at runtime when other
-      // ExecutionCommands run and change the desired configs (like
-      // ConfigureAction). Hence an ExecutionCommand can specify which
-      // config-types should be refreshed at runtime. Specifying <code>*</code>
-      // will result in all config-type tags to be refreshed to the latest
-      // cluster desired-configs. Additionally, there may be no configuration
-      // tags set but refresh might be set to *. In this case, they should still
-      // be refreshed with the latest.
+      // Execution commands may have configs already set during their creation.
+      // However, these configs become stale at runtime when other
+      // ExecutionCommands run and change the desired configs (like ConfigureAction).
       boolean overrideConfigs = executionCommand.isOverrideConfigs();
       if (overrideConfigs) {
         Map<String, DesiredConfig> desiredConfigs = cluster.getDesiredConfigs();
@@ -153,10 +147,7 @@ public class ExecutionCommandWrapper {
             "While scheduling task {} on cluster {}, configurations are being refreshed using desired configurations of {}",
             executionCommand.getTaskId(), cluster.getClusterName(), desiredConfigs);
 
-        // then clear out any existing configurations so that all of the new
-        // configurations are forcefully applied
         configurations = configHelper.getEffectiveConfigProperties(cluster, configurationTags);
-
         executionCommand.setConfigurations(configurations);
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
@@ -489,8 +489,7 @@ public class Stage {
     }
     cmd.setCommandParams(cmdParams);
 
-    Map<String, Map<String, String>> configurations = new TreeMap<>();
-    cmd.setConfigurations(configurations);
+    cmd.setConfigurations(new TreeMap<>());
 
     Map<String, Map<String, Map<String, String>>> configurationAttributes = new TreeMap<>();
     cmd.setConfigurationAttributes(configurationAttributes);

--- a/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/actionmanager/Stage.java
@@ -491,14 +491,6 @@ public class Stage {
 
     cmd.setConfigurations(new TreeMap<>());
 
-    Map<String, Map<String, Map<String, String>>> configurationAttributes = new TreeMap<>();
-    cmd.setConfigurationAttributes(configurationAttributes);
-
-    if (configTags == null) {
-      configTags = new TreeMap<>();
-    }
-    cmd.setConfigurationTags(configTags);
-
     Map<String, String> roleParams = new HashMap<>();
     roleParams.put(ServerAction.ACTION_NAME, actionName);
     if (userName != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
@@ -106,14 +106,6 @@ public class ExecutionCommand extends AgentCommand {
   @SerializedName("configurations")
   private Map<String, Map<String, String>> configurations;
 
-  @SerializedName("configurationAttributes")
-  @JsonIgnore
-  private Map<String, Map<String, Map<String, String>>> configurationAttributes;
-
-  @SerializedName("configurationTags")
-  @JsonIgnore
-  private Map<String, Map<String, String>> configurationTags;
-
   @SerializedName("forceRefreshConfigTagsBeforeExecution")
   @JsonIgnore
   private boolean overrideConfigs = false;
@@ -358,14 +350,6 @@ public class ExecutionCommand extends AgentCommand {
     this.localComponents = localComponents;
   }
 
-  public Map<String, Map<String, Map<String, String>>> getConfigurationAttributes() {
-    return configurationAttributes;
-  }
-
-  public void setConfigurationAttributes(Map<String, Map<String, Map<String, String>>> configurationAttributes) {
-    this.configurationAttributes = configurationAttributes;
-  }
-
   public Map<String, String> getCommandParams() {
     return commandParams;
   }
@@ -417,20 +401,6 @@ public class ExecutionCommand extends AgentCommand {
 
   public void setComponentName(String componentName) {
     this.componentName = componentName;
-  }
-
-  /**
-   * @param configTags the config tag map
-   */
-  public void setConfigurationTags(Map<String, Map<String, String>> configTags) {
-    configurationTags = configTags;
-  }
-
-  /**
-   * @return the configuration tags
-   */
-  public Map<String, Map<String, String>> getConfigurationTags() {
-    return configurationTags;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ExecutionCommand.java
@@ -88,6 +88,9 @@ public class ExecutionCommand extends AgentCommand {
   @JsonIgnore
   private Map<String, String> hostLevelParams = new HashMap<>();
 
+  @SerializedName("clusterLevelParams")
+  private Map<String, String> clusterLevelParams = new HashMap<>();
+
   @SerializedName("roleParams")
   @com.fasterxml.jackson.annotation.JsonProperty("roleParams")
   private Map<String, String> roleParams = null;
@@ -101,7 +104,6 @@ public class ExecutionCommand extends AgentCommand {
     new HashMap<>();
 
   @SerializedName("configurations")
-  @JsonIgnore
   private Map<String, Map<String, String>> configurations;
 
   @SerializedName("configurationAttributes")
@@ -114,7 +116,7 @@ public class ExecutionCommand extends AgentCommand {
 
   @SerializedName("forceRefreshConfigTagsBeforeExecution")
   @JsonIgnore
-  private boolean forceRefreshConfigTagsBeforeExecution = false;
+  private boolean overrideConfigs = false;
 
   @SerializedName("commandParams")
   @com.fasterxml.jackson.annotation.JsonProperty("commandParams")
@@ -312,6 +314,14 @@ public class ExecutionCommand extends AgentCommand {
     hostLevelParams = params;
   }
 
+  public Map<String, String> getClusterLevelParams() {
+    return clusterLevelParams;
+  }
+
+  public void setClusterLevelParams(Map<String, String> clusterLevelParams) {
+    this.clusterLevelParams = clusterLevelParams;
+  }
+
   public Map<String, Set<String>> getClusterHostInfo() {
     return clusterHostInfo;
   }
@@ -332,12 +342,12 @@ public class ExecutionCommand extends AgentCommand {
    * Gets whether configuration tags shoudl be refreshed right before the
    * command is scheduled.
    */
-  public boolean getForceRefreshConfigTagsBeforeExecution() {
-    return forceRefreshConfigTagsBeforeExecution;
+  public boolean isOverrideConfigs() {
+    return overrideConfigs;
   }
 
-  public void setForceRefreshConfigTagsBeforeExecution(boolean forceRefreshConfigTagsBeforeExecution) {
-    this.forceRefreshConfigTagsBeforeExecution = forceRefreshConfigTagsBeforeExecution;
+  public void setOverrideConfigs(boolean overrideConfigs) {
+    this.overrideConfigs = overrideConfigs;
   }
 
   public Set<String> getLocalComponents() {
@@ -562,10 +572,11 @@ public class ExecutionCommand extends AgentCommand {
     String DFS_TYPE = "dfs_type";
 
     /**
-     * A boolean indicating whether configuration tags should be refreshed
-     * before sending the command.
+     * A boolean indicating whether configurations should be added to execution command
+     * before sending.
      */
-    String REFRESH_CONFIG_TAGS_BEFORE_EXECUTION = "forceRefreshConfigTagsBeforeExecution";
+    String OVERRIDE_CONFIGS = "overrideConfigs";
+    String OVERRIDE_STACK_NAME = "overrideStackName";
 
     String SERVICE_CHECK = "SERVICE_CHECK"; // TODO: is it standard command? maybe add it to RoleCommand enum?
     String CUSTOM_COMMAND = "custom_command";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariActionExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariActionExecutionHelper.java
@@ -431,7 +431,6 @@ public class AmbariActionExecutionHelper {
       // !!! ensure that these are empty so that commands have the correct tags
       // applied when the execution is about to be scheduled to run
       execCmd.setConfigurations(new TreeMap<>());
-      execCmd.setConfigurationAttributes(new TreeMap<>());
 
       // if the command should fetch brand new configuration tags before
       // execution, then we don't need to fetch them now
@@ -448,8 +447,6 @@ public class AmbariActionExecutionHelper {
           execCmd.setClusterLevelParams(clusterLevelParams);
         }
       }
-
-      execCmd.setConfigurationTags(new TreeMap<>());
 
       execCmd.setServiceName(serviceName == null || serviceName.isEmpty() ?
         resourceFilter.getServiceName() : serviceName);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -368,8 +368,6 @@ public class AmbariCustomCommandExecutionHelper {
       execCmd.setComponentVersions(cluster);
 
       execCmd.setConfigurations(new TreeMap<>());
-      execCmd.setConfigurationAttributes(new TreeMap<>());
-      execCmd.setConfigurationTags(new TreeMap<>());
 
       // Get the value of credential store enabled from the DB
       Service clusterService = cluster.getService(serviceName);
@@ -714,9 +712,6 @@ public class AmbariCustomCommandExecutionHelper {
     // [ type -> [ key, value ] ]
     Map<String, Map<String, String>> configurations =
         new TreeMap<>();
-    Map<String, Map<String, Map<String, String>>> configurationAttributes =
-        new TreeMap<>();
-    Map<String, Map<String, String>> configTags = new TreeMap<>();
 
     ExecutionCommand execCmd = stage.getExecutionCommandWrapper(hostname,
         smokeTestRole).getExecutionCommand();
@@ -728,8 +723,6 @@ public class AmbariCustomCommandExecutionHelper {
     }
 
     execCmd.setConfigurations(configurations);
-    execCmd.setConfigurationAttributes(configurationAttributes);
-    execCmd.setConfigurationTags(configTags);
 
     // Generate localComponents
     for (ServiceComponentHost sch : cluster.getServiceComponentHosts(hostname)) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelper.java
@@ -341,26 +341,13 @@ public class AmbariCustomCommandExecutionHelper {
           new ServiceComponentHostOpInProgressEvent(componentName, hostName, nowTimestamp),
           cluster.getClusterName(), serviceName, retryAllowed, autoSkipFailure);
 
-      Map<String, Map<String, String>> configurations =
-          new TreeMap<>();
-      Map<String, Map<String, Map<String, String>>> configurationAttributes =
-          new TreeMap<>();
-      Map<String, Map<String, String>> configTags = new TreeMap<>();
-
       ExecutionCommand execCmd = stage.getExecutionCommandWrapper(hostName,
           componentName).getExecutionCommand();
 
       // if the command should fetch brand new configuration tags before
       // execution, then we don't need to fetch them now
-      if(actionExecutionContext.getParameters() != null && actionExecutionContext.getParameters().containsKey(KeyNames.REFRESH_CONFIG_TAGS_BEFORE_EXECUTION)){
-        execCmd.setForceRefreshConfigTagsBeforeExecution(true);
-      }
-
-      // when building complex orchestration ahead of time (such as when
-      // performing ugprades), fetching configuration tags can take a very long
-      // time - if it's not needed, then don't do it
-      if (!execCmd.getForceRefreshConfigTagsBeforeExecution()) {
-        configTags = managementController.findConfigurationTagsWithOverrides(cluster, hostName);
+      if(actionExecutionContext.getParameters() != null && actionExecutionContext.getParameters().containsKey(KeyNames.OVERRIDE_CONFIGS)){
+        execCmd.setOverrideConfigs(true);
       }
 
       HostRoleCommand cmd = stage.getHostRoleCommand(hostName, componentName);
@@ -380,9 +367,9 @@ public class AmbariCustomCommandExecutionHelper {
 
       execCmd.setComponentVersions(cluster);
 
-      execCmd.setConfigurations(configurations);
-      execCmd.setConfigurationAttributes(configurationAttributes);
-      execCmd.setConfigurationTags(configTags);
+      execCmd.setConfigurations(new TreeMap<>());
+      execCmd.setConfigurationAttributes(new TreeMap<>());
+      execCmd.setConfigurationTags(new TreeMap<>());
 
       // Get the value of credential store enabled from the DB
       Service clusterService = cluster.getService(serviceName);
@@ -736,15 +723,8 @@ public class AmbariCustomCommandExecutionHelper {
 
     // if the command should fetch brand new configuration tags before
     // execution, then we don't need to fetch them now
-    if(actionParameters != null && actionParameters.containsKey(KeyNames.REFRESH_CONFIG_TAGS_BEFORE_EXECUTION)){
-      execCmd.setForceRefreshConfigTagsBeforeExecution(true);
-    }
-
-    // when building complex orchestration ahead of time (such as when
-    // performing ugprades), fetching configuration tags can take a very long
-    // time - if it's not needed, then don't do it
-    if (!execCmd.getForceRefreshConfigTagsBeforeExecution()) {
-      configTags = managementController.findConfigurationTagsWithOverrides(cluster, hostname);
+    if(actionParameters != null && actionParameters.containsKey(KeyNames.OVERRIDE_CONFIGS)){
+      execCmd.setOverrideConfigs(true);
     }
 
     execCmd.setConfigurations(configurations);
@@ -1169,8 +1149,8 @@ public class AmbariCustomCommandExecutionHelper {
           extraParams.put(KeyNames.LOG_OUTPUT, requestParams.get(KeyNames.LOG_OUTPUT));
         }
 
-        if(requestParams.containsKey(KeyNames.REFRESH_CONFIG_TAGS_BEFORE_EXECUTION)){
-          actionExecutionContext.getParameters().put(KeyNames.REFRESH_CONFIG_TAGS_BEFORE_EXECUTION, requestParams.get(KeyNames.REFRESH_CONFIG_TAGS_BEFORE_EXECUTION));
+        if(requestParams.containsKey(KeyNames.OVERRIDE_CONFIGS)){
+          actionExecutionContext.getParameters().put(KeyNames.OVERRIDE_CONFIGS, requestParams.get(KeyNames.OVERRIDE_CONFIGS));
         }
 
         RequestOperationLevel operationLevel = actionExecutionContext.getOperationLevel();

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2424,8 +2424,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     ExecutionCommand execCmd = execCmdWrapper.getExecutionCommand();
 
     execCmd.setConfigurations(new TreeMap<>());
-    execCmd.setConfigurationAttributes(new TreeMap<>());
-    execCmd.setConfigurationTags(new TreeMap<>());
 
     // Get the value of credential store enabled from the DB
     Service clusterService = cluster.getService(serviceName);
@@ -2611,10 +2609,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     execCmd.setRepositoryFile(commandRepository);
     execCmdWrapper.setVersions(cluster, null);
 
-    if ((execCmd != null) && (execCmd.getConfigurationTags().containsKey("cluster-env"))) {
-      LOG.debug("AmbariManagementControllerImpl.createHostAction: created ExecutionCommand for host {}, role {}, roleCommand {}, and command ID {}, with cluster-env tags {}",
-        execCmd.getHostname(), execCmd.getRole(), execCmd.getRoleCommand(), execCmd.getCommandId(), execCmd.getConfigurationTags().get("cluster-env").get("tag"));
-    }
     if (useLatestConfigs) {
       execCmd.setUseLatestConfigs(useLatestConfigs);
     }
@@ -3262,25 +3256,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
       // Generate localComponents
       for (ServiceComponentHost sch : cluster.getServiceComponentHosts(scHost.getHostName())) {
         ec.getLocalComponents().add(sch.getServiceComponentName());
-      }
-    }
-
-    ConfigHelper.processHiddenAttribute(ec.getConfigurations(), ec.getConfigurationAttributes(), ec.getRole(), false);
-
-    // Add attributes
-    Map<String, Map<String, Map<String, String>>> configAttributes =
-        configHelper.getEffectiveConfigAttributes(cluster,
-          ec.getConfigurationTags());
-
-    for (Map.Entry<String, Map<String, Map<String, String>>> attributesOccurrence : configAttributes.entrySet()) {
-      String type = attributesOccurrence.getKey();
-      Map<String, Map<String, String>> attributes = attributesOccurrence.getValue();
-
-      if (ec.getConfigurationAttributes() != null) {
-        if (!ec.getConfigurationAttributes().containsKey(type)) {
-          ec.getConfigurationAttributes().put(type, new TreeMap<>());
-        }
-        configHelper.cloneAttributesMap(attributes, ec.getConfigurationAttributes().get(type));
       }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -2386,9 +2386,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
   private void createHostAction(Cluster cluster,
                                 Stage stage,
                                 ServiceComponentHost scHost,
-                                Map<String, Map<String, String>> configurations,
-                                Map<String, Map<String, Map<String, String>>> configurationAttributes,
-                                Map<String, Map<String, String>> configTags,
                                 RoleCommand roleCommand,
                                 Map<String, String> commandParamsInp,
                                 ServiceComponentHostEvent event,
@@ -2426,9 +2423,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     ExecutionCommandWrapper execCmdWrapper = stage.getExecutionCommandWrapper(hostname, componentName);
     ExecutionCommand execCmd = execCmdWrapper.getExecutionCommand();
 
-    execCmd.setConfigurations(configurations);
-    execCmd.setConfigurationAttributes(configurationAttributes);
-    execCmd.setConfigurationTags(configTags);
+    execCmd.setConfigurations(new TreeMap<>());
+    execCmd.setConfigurationAttributes(new TreeMap<>());
+    execCmd.setConfigurationTags(new TreeMap<>());
 
     // Get the value of credential store enabled from the DB
     Service clusterService = cluster.getService(serviceName);
@@ -3084,16 +3081,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
             }
 
-            Map<String, Map<String, String>> configurations = new TreeMap<>();
-            Map<String, Map<String, Map<String, String>>>
-                configurationAttributes =
-                new TreeMap<>();
-            Host host = clusters.getHost(scHost.getHostName());
             Map<String, DesiredConfig> clusterDesiredConfigs = cluster.getDesiredConfigs();
-
-            Map<String, Map<String, String>> configTags =
-                    configHelper.getEffectiveDesiredTags(cluster, host.getHostName(), clusterDesiredConfigs);
-
 
             // Skip INSTALL task in case SysPrepped hosts and in case of server components. In case of server component
             // START task should run configuration script.
@@ -3112,7 +3100,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
               // !!! can never be null
               RepositoryVersionEntity repoVersion = serviceComponent.getDesiredRepositoryVersion();
 
-              createHostAction(cluster, stage, scHost, configurations, configurationAttributes, configTags,
+              createHostAction(cluster, stage, scHost,
                 roleCommand, requestParameters, event, skipFailure, repoVersion, isUpgradeSuspended,
                 databaseType, clusterDesiredConfigs, useLatestConfigs);
             }
@@ -3250,13 +3238,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     Stage stage = createNewStage(0, cluster, 1, "", "{}", "");
 
-    Map<String, Map<String, String>> configTags = configHelper.getEffectiveDesiredTags(cluster, scHost.getHostName());
-    Map<String, Map<String, String>> configurations = configHelper.getEffectiveConfigProperties(cluster, configTags);
-
-    Map<String, Map<String, Map<String, String>>>
-        configurationAttributes =
-        new TreeMap<>();
-
     RepositoryVersionEntity repoVersion = null;
     if (null != scHost.getServiceComponent().getDesiredRepositoryVersion()) {
       repoVersion = scHost.getServiceComponent().getDesiredRepositoryVersion();
@@ -3268,7 +3249,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     boolean isUpgradeSuspended = cluster.isUpgradeSuspended();
     DatabaseType databaseType = configs.getDatabaseType();
     Map<String, DesiredConfig> clusterDesiredConfigs = cluster.getDesiredConfigs();
-    createHostAction(cluster, stage, scHost, configurations, configurationAttributes, configTags,
+    createHostAction(cluster, stage, scHost,
                      roleCommand, null, null, false, repoVersion, isUpgradeSuspended, databaseType,
                      clusterDesiredConfigs, false);
     ExecutionCommand ec = stage.getExecutionCommands().get(scHost.getHostName()).get(0).getExecutionCommand();

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
@@ -18,6 +18,8 @@
 package org.apache.ambari.server.controller.internal;
 
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.JDK_LOCATION;
+import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.OVERRIDE_CONFIGS;
+import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.OVERRIDE_STACK_NAME;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -441,8 +443,10 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
     RequestResourceFilter filter = new RequestResourceFilter(null, null,
             Collections.singletonList(hostName));
 
+    roleParams.put(OVERRIDE_CONFIGS, null);
+    roleParams.put(OVERRIDE_STACK_NAME, null);
     ActionExecutionContext actionContext = new ActionExecutionContext(
-            cluster.getClusterName(), INSTALL_PACKAGES_ACTION,
+            null, INSTALL_PACKAGES_ACTION,
             Collections.singletonList(filter),
             roleParams);
     actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));
@@ -527,7 +531,7 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
     req.addStages(Collections.singletonList(stage));
 
     actionContext = new ActionExecutionContext(
-      cluster.getClusterName(), STACK_SELECT_ACTION,
+      null, STACK_SELECT_ACTION,
       Collections.singletonList(filter),
       Collections.emptyMap());
     actionContext.setTimeout(Short.valueOf(configuration.getDefaultAgentTaskTimeout(true)));

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeContext.java
@@ -911,7 +911,6 @@ public class UpgradeContext {
       parameters.put(COMMAND_PARAM_UPGRADE_TYPE, json.getAsString());
     }
 
-    parameters.put(KeyNames.REFRESH_CONFIG_TAGS_BEFORE_EXECUTION, "true");
     return parameters;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -234,7 +234,6 @@ public class StageUtils {
     finalAttribute.put("dfs.block.size", "true");
     hdfsSiteAttributes.put("final", finalAttribute);
     configurationAttributes.put("hdfsSite", hdfsSiteAttributes);
-    execCmd.setConfigurationAttributes(configurationAttributes);
     Map<String, String> params = new TreeMap<>();
     params.put("jdklocation", "/x/y/z");
     params.put("stack_version", "1.2.0");

--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapperTest.java
@@ -179,27 +179,8 @@ public class ExecutionCommandWrapperTest {
 
   @Test
   public void testGetExecutionCommand() throws JSONException, AmbariException {
-    Map<String, Map<String, String>> confs = new HashMap<>();
-    Map<String, String> configurationsGlobal = new HashMap<>();
-    configurationsGlobal.put(GLOBAL_NAME1, GLOBAL_VAL1);
-    confs.put(GLOBAL_CONFIG, configurationsGlobal);
-
-    Map<String, Map<String, String>> confTags = new HashMap<>();
-    Map<String, String> confTagServiceSite = new HashMap<>();
-
-    confTagServiceSite.put("tag", CLUSTER_VERSION_TAG);
-    confTagServiceSite.put("service_override_tag", SERVICE_VERSION_TAG);
-    confTagServiceSite.put("host_override_tag", HOST_VERSION_TAG);
-
-    confTags.put(SERVICE_SITE_CONFIG, confTagServiceSite);
-
-    Map<String, String> confTagGlobal = Collections.singletonMap("tag", CLUSTER_VERSION_TAG);
-
-    confTags.put(GLOBAL_CONFIG, confTagGlobal);
-
 
     ExecutionCommand executionCommand = new ExecutionCommand();
-
 
     executionCommand.setClusterName(CLUSTER1);
     executionCommand.setTaskId(1);
@@ -208,8 +189,6 @@ public class ExecutionCommandWrapperTest {
     executionCommand.setRole("NAMENODE");
     executionCommand.setRoleParams(Collections.emptyMap());
     executionCommand.setRoleCommand(RoleCommand.START);
-    executionCommand.setConfigurations(confs);
-    executionCommand.setConfigurationTags(confTags);
     executionCommand.setServiceName("HDFS");
     executionCommand.setCommandType(AgentCommandType.EXECUTION_COMMAND);
     executionCommand.setCommandParams(Collections.emptyMap());
@@ -220,29 +199,6 @@ public class ExecutionCommandWrapperTest {
     injector.injectMembers(execCommWrap);
 
     ExecutionCommand processedExecutionCommand = execCommWrap.getExecutionCommand();
-
-    Map<String, String> serviceSiteConfig = processedExecutionCommand.getConfigurations().get(SERVICE_SITE_CONFIG);
-
-    Assert.assertEquals(SERVICE_SITE_VAL1_S, serviceSiteConfig.get(SERVICE_SITE_NAME1));
-    Assert.assertEquals(SERVICE_SITE_VAL2_H, serviceSiteConfig.get(SERVICE_SITE_NAME2));
-    Assert.assertEquals(SERVICE_SITE_VAL3, serviceSiteConfig.get(SERVICE_SITE_NAME3));
-    Assert.assertEquals(SERVICE_SITE_VAL4, serviceSiteConfig.get(SERVICE_SITE_NAME4));
-    Assert.assertEquals(SERVICE_SITE_VAL5_S, serviceSiteConfig.get(SERVICE_SITE_NAME5));
-    Assert.assertEquals(SERVICE_SITE_VAL6_H, serviceSiteConfig.get(SERVICE_SITE_NAME6));
-
-    Map<String, String> globalConfig = processedExecutionCommand.getConfigurations().get(GLOBAL_CONFIG);
-
-    Assert.assertEquals(GLOBAL_VAL1, globalConfig.get(GLOBAL_NAME1));
-    Assert.assertEquals(GLOBAL_CLUSTER_VAL2, globalConfig.get(GLOBAL_NAME2));
-
-
-    //Union of all keys of service site configs
-    Set<String> serviceSiteKeys = new HashSet<>();
-    serviceSiteKeys.addAll(SERVICE_SITE_CLUSTER.keySet());
-    serviceSiteKeys.addAll(SERVICE_SITE_SERVICE.keySet());
-    serviceSiteKeys.addAll(SERVICE_SITE_HOST.keySet());
-
-    Assert.assertEquals(serviceSiteKeys.size(), serviceSiteConfig.size());
 
     Assert.assertNotNull(processedExecutionCommand.getRepositoryFile());
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariCustomCommandExecutionHelperTest.java
@@ -251,7 +251,7 @@ public class AmbariCustomCommandExecutionHelperTest {
     Assert.assertNotNull(command.getHostLevelParams());
     Assert.assertTrue(command.getHostLevelParams().containsKey(ExecutionCommand.KeyNames.USER_GROUPS));
     Assert.assertEquals("{\"zookeeperUser\":[\"zookeeperGroup\"]}", command.getHostLevelParams().get(ExecutionCommand.KeyNames.USER_GROUPS));
-    Assert.assertEquals(true, command.getForceRefreshConfigTagsBeforeExecution());
+    Assert.assertEquals(false, command.isOverrideConfigs());
     Assert.assertNull(command.getRepositoryFile());
   }
 
@@ -530,7 +530,6 @@ public class AmbariCustomCommandExecutionHelperTest {
     EasyMock.expect(stage.getExecutionCommandWrapper(EasyMock.eq("c1-c6401"), EasyMock.anyString())).andReturn(execCmdWrapper);
     EasyMock.expect(stage.getExecutionCommandWrapper(EasyMock.eq("c1-c6402"), EasyMock.anyString())).andReturn(execCmdWrapper);
     EasyMock.expect(execCmdWrapper.getExecutionCommand()).andReturn(execCmd);
-    EasyMock.expect(execCmd.getForceRefreshConfigTagsBeforeExecution()).andReturn(true);
 
     HashSet<String> localComponents = new HashSet<>();
     EasyMock.expect(execCmd.getLocalComponents()).andReturn(localComponents).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariManagementControllerTest.java
@@ -1301,13 +1301,7 @@ public class AmbariManagementControllerTest {
     assertEquals(cluster1, ec.getClusterName());
     Map<String, Map<String, String>> configurations = ec.getConfigurations();
     assertNotNull(configurations);
-    assertEquals(3, configurations.size());
-    assertTrue(configurations.containsKey("hdfs-site"));
-    assertTrue(configurations.containsKey("core-site"));
-    assertTrue(configurations.containsKey("hadoop-env"));
-    assertTrue(ec.getConfigurationAttributes().containsKey("hdfs-site"));
-    assertTrue(ec.getConfigurationAttributes().containsKey("core-site"));
-    assertTrue(ec.getConfigurationAttributes().containsKey("hadoop-env"));
+    assertEquals(0, configurations.size());
     assertTrue(ec.getCommandParams().containsKey("max_duration_for_retries"));
     assertEquals("0", ec.getCommandParams().get("max_duration_for_retries"));
     assertTrue(ec.getCommandParams().containsKey("command_retry_enabled"));
@@ -4500,7 +4494,6 @@ public class AmbariManagementControllerTest {
     ExecutionCommand executionCommand = gson.fromJson(new StringReader(
         new String(commandEntity.getCommand())), ExecutionCommand.class);
 
-    assertFalse(executionCommand.getConfigurationTags().isEmpty());
     assertTrue(executionCommand.getConfigurations() == null || executionCommand.getConfigurations().isEmpty());
 
     assertEquals(1, storedTasks.size());
@@ -4518,7 +4511,7 @@ public class AmbariManagementControllerTest {
     assertEquals(Role.HDFS_CLIENT.name(), hostRoleCommand.getEvent().getEvent().getServiceComponentName());
     assertEquals(actionRequest.getParameters(), hostRoleCommand.getExecutionCommandWrapper().getExecutionCommand().getRoleParams());
     assertNotNull(hostRoleCommand.getExecutionCommandWrapper().getExecutionCommand().getConfigurations());
-    assertEquals(2, hostRoleCommand.getExecutionCommandWrapper().getExecutionCommand().getConfigurations().size());
+    assertEquals(0, hostRoleCommand.getExecutionCommandWrapper().getExecutionCommand().getConfigurations().size());
     assertEquals(requestProperties.get(REQUEST_CONTEXT_PROPERTY), stage.getRequestContext());
     assertEquals(requestProperties.get(REQUEST_CONTEXT_PROPERTY), response.getRequestContext());
 
@@ -5050,6 +5043,7 @@ public class AmbariManagementControllerTest {
   }
 
   @Test
+  @Ignore // not actual because all configs/attributes/tags were moved to STOMP configurations topic
   public void testReConfigureServiceClient() throws Exception, AuthorizationException {
     String cluster1 = getUniqueName();
     createCluster(cluster1);
@@ -5140,9 +5134,6 @@ public class AmbariManagementControllerTest {
     long requestId1 = installService(cluster1, serviceName1, true, false);
 
     List<Stage> stages = actionDB.getAllStages(requestId1);
-    Assert.assertEquals(3, stages.get(0).getOrderedHostRoleCommands().get(0)
-      .getExecutionCommandWrapper().getExecutionCommand()
-      .getConfigurationTags().size());
 
     installService(cluster1, serviceName2, false, false);
 
@@ -5197,11 +5188,6 @@ public class AmbariManagementControllerTest {
     Assert.assertNotNull(hdfsCmdHost2);
     ExecutionCommand execCmd = hdfsCmdHost3.getExecutionCommandWrapper()
       .getExecutionCommand();
-    Assert.assertEquals(3, execCmd.getConfigurationTags().size());
-    Assert.assertEquals("version122", execCmd.getConfigurationTags().get
-      ("core-site").get("tag"));
-    Assert.assertEquals("d", execCmd.getConfigurations().get("core-site")
-      .get("c"));
     // Check if MapReduce client is reinstalled
     Assert.assertNotNull(mapRedCmdHost2);
     Assert.assertNotNull(mapRedCmdHost3);
@@ -5322,9 +5308,6 @@ public class AmbariManagementControllerTest {
         if (hrc.getHostName().equals(host2) && hrc.getRole().toString()
           .equals("HDFS_CLIENT")) {
           clientHrc = hrc;
-          Assert.assertEquals("version122", hrc.getExecutionCommandWrapper()
-            .getExecutionCommand().getConfigurationTags().get("core-site")
-            .get("tag"));
         }
       }
     }
@@ -5924,7 +5907,6 @@ public class AmbariManagementControllerTest {
     ExecutionCommand execCmd = storedTasks.get(0).getExecutionCommandWrapper
       ().getExecutionCommand();
     Assert.assertNotNull(storedTasks);
-    Assert.assertNotNull(execCmd.getConfigurationTags().get("hdfs-site"));
     Assert.assertEquals(1, storedTasks.size());
     Assert.assertEquals(HostComponentAdminState.DECOMMISSIONED, scHost.getComponentAdminState());
     Assert.assertEquals(MaintenanceState.ON, scHost.getMaintenanceState());
@@ -6352,8 +6334,6 @@ public class AmbariManagementControllerTest {
       for (HostRoleCommand hrc : stage.getOrderedHostRoleCommands()) {
         if (hrc.getRole().equals(Role.HDFS_SERVICE_CHECK)) {
           serviceCheckFound = true;
-          Assert.assertEquals(2, hrc.getExecutionCommandWrapper()
-            .getExecutionCommand().getConfigurationTags().size());
         }
       }
     }
@@ -6440,8 +6420,6 @@ public class AmbariManagementControllerTest {
       for (HostRoleCommand hrc : stage.getOrderedHostRoleCommands()) {
         if (hrc.getRole().equals(Role.HDFS_SERVICE_CHECK)) {
           serviceCheckFound = true;
-          Assert.assertEquals(2, hrc.getExecutionCommandWrapper()
-            .getExecutionCommand().getConfigurationTags().size());
         }
       }
     }
@@ -6507,6 +6485,7 @@ public class AmbariManagementControllerTest {
   }
 
   @Test
+  @Ignore // not actual because all configs/attributes/tags were moved to STOMP configurations topic
   public void testConfigGroupOverridesWithHostActions() throws Exception, AuthorizationException {
     String cluster1 = getUniqueName();
     createCluster(cluster1);
@@ -6759,7 +6738,6 @@ public class AmbariManagementControllerTest {
     ExecutionCommand execCmd = storedTasks.get(0).getExecutionCommandWrapper
         ().getExecutionCommand();
     Assert.assertNotNull(storedTasks);
-    Assert.assertNotNull(execCmd.getConfigurationTags().get("hdfs-site"));
     Assert.assertEquals(1, storedTasks.size());
     HostRoleCommand command =  storedTasks.get(0);
     Assert.assertEquals(Role.NAMENODE, command.getRole());
@@ -6770,6 +6748,7 @@ public class AmbariManagementControllerTest {
   }
 
   @Test
+  @Ignore // not actual because all configs/attributes/tags were moved to STOMP configurations topic
   public void testConfigGroupOverridesWithServiceCheckActions() throws Exception, AuthorizationException {
     String cluster1 = getUniqueName();
     createCluster(cluster1);
@@ -6848,8 +6827,6 @@ public class AmbariManagementControllerTest {
     for (Stage stage : stages) {
       for (HostRoleCommand hrc : stage.getOrderedHostRoleCommands()) {
         if (hrc.getRole().equals(Role.HDFS_SERVICE_CHECK)) {
-          Assert.assertEquals(2, hrc.getExecutionCommandWrapper()
-            .getExecutionCommand().getConfigurationTags().size());
           smokeTestCmd = hrc;
         }
       }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProviderTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.H2DatabaseCleaner;
 import org.apache.ambari.server.actionmanager.ActionManager;
+import org.apache.ambari.server.actionmanager.Stage;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
@@ -395,6 +396,20 @@ public class HostStackVersionResourceProviderTest {
     verify(managementController, response, clusters);
 
     assertEquals(requestCapture.getValue().getStages().size(), 2);
+    List<Stage> stages = new ArrayList<>(requestCapture.getValue().getStages());
+    Stage installStage = stages.get(0);
+    Stage selectStackStage = stages.get(1);
+    String hostName = "host1";
+
+    assertEquals(1, installStage.getExecutionCommands().size());
+    assertEquals(hostName, installStage.getExecutionCommands().keySet().iterator().next());
+    assertEquals(1, installStage.getExecutionCommands().get(hostName).size());
+    assertEquals(true, installStage.getExecutionCommands().get(hostName).get(0).getExecutionCommand().isOverrideConfigs());
+
+    assertEquals(1, selectStackStage.getExecutionCommands().size());
+    assertEquals(hostName, selectStackStage.getExecutionCommands().keySet().iterator().next());
+    assertEquals(1, selectStackStage.getExecutionCommands().get(hostName).size());
+    assertEquals(false, selectStackStage.getExecutionCommands().get(hostName).get(0).getExecutionCommand().isOverrideConfigs());
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/FinalizeKerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/FinalizeKerberosServerActionTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Matchers.anyBoolean;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,7 +163,6 @@ public class FinalizeKerberosServerActionTest extends EasyMockSupport {
     expect(executionCommand.getCommandParams()).andReturn(commandParams).anyTimes();
     expect(executionCommand.getRoleCommand()).andReturn(RoleCommand.EXECUTE).anyTimes();
     expect(executionCommand.getRole()).andReturn(Role.AMBARI_SERVER_ACTION.name()).anyTimes();
-    expect(executionCommand.getConfigurationTags()).andReturn(Collections.emptyMap()).anyTimes();
     expect(executionCommand.getServiceName()).andReturn(RootComponent.AMBARI_SERVER.name()).anyTimes();
     expect(executionCommand.getTaskId()).andReturn(3L).anyTimes();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
@@ -164,7 +164,6 @@ public class KerberosServerActionTest extends EasyMockSupport {
     expect(mockExecutionCommand.getClusterId()).andReturn("1").anyTimes();
     expect(mockExecutionCommand.getConfigurations()).andReturn(Collections.emptyMap()).anyTimes();
     expect(mockExecutionCommand.getRoleCommand()).andReturn(null).anyTimes();
-    expect(mockExecutionCommand.getConfigurationTags()).andReturn(null).anyTimes();
     expect(mockExecutionCommand.getRole()).andReturn(null).anyTimes();
     expect(mockExecutionCommand.getServiceName()).andReturn(null).anyTimes();
     expect(mockExecutionCommand.getTaskId()).andReturn(1L).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/users/PostUserCreationHookServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/users/PostUserCreationHookServerActionTest.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.serveraction.users;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -166,7 +165,6 @@ public class PostUserCreationHookServerActionTest extends EasyMockSupport {
     EasyMock.expect(executionCommand.getClusterId()).andReturn("1").anyTimes();
     EasyMock.expect(executionCommand.getRoleCommand()).andReturn(RoleCommand.EXECUTE).times(callCnt);
     EasyMock.expect(executionCommand.getClusterName()).andReturn("unit-test-cluster").times(callCnt);
-    EasyMock.expect(executionCommand.getConfigurationTags()).andReturn(Collections.emptyMap()).times(callCnt);
     EasyMock.expect(executionCommand.getRole()).andReturn(Role.AMBARI_SERVER_ACTION.toString()).times(callCnt);
     EasyMock.expect(executionCommand.getServiceName()).andReturn("custom-hook-script").times(callCnt);
     EasyMock.expect(executionCommand.getTaskId()).andReturn(-1l).times(callCnt);

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -144,11 +144,6 @@ public class StageUtilsTest extends EasyMockSupport {
     StageUtils stageUtils = new StageUtils(injector.getInstance(StageFactory.class));
     Stage s = StageUtils.getATestStage(1, 2, "host1", "clusterHostInfo", "hostParamsStage");
     ExecutionCommand cmd = s.getExecutionCommands("host1").get(0).getExecutionCommand();
-    HashMap<String, Map<String, String>> configTags = new HashMap<>();
-    Map<String, String> globalTag = new HashMap<>();
-    globalTag.put("tag", "version1");
-    configTags.put("global", globalTag);
-    cmd.setConfigurationTags(configTags);
     String json = StageUtils.jaxbToString(cmd);
 
     InputStream is = new ByteArrayInputStream(

--- a/ambari-server/src/test/python/stacks/utils/RMFTestCase.py
+++ b/ambari-server/src/test/python/stacks/utils/RMFTestCase.py
@@ -128,7 +128,7 @@ class RMFTestCase(TestCase):
         script_class_inst = RMFTestCase._get_attr(script_module, classname)()
         script_class_inst.log_out_files = log_out_files
         script_class_inst.available_packages_in_repos = available_packages_in_repos
-        Script.repository_util = RepositoryUtil(self.config_dict, set())
+        Script.repository_util = RepositoryUtil(self.config_dict)
         method = RMFTestCase._get_attr(script_class_inst, command)
     except IOError, err:
       raise RuntimeError("Cannot load class %s from %s: %s" % (classname, norm_path, err.message))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server sends all needed parameters (configs, stack name) with packages pre-installing execution command. Unused configuration attributes and configuration tags properties were removed from execution command. Not approved GPL repos filtering also was refactored on agent side. 

## How was this patch tested?

Manual check.