### PR TITLE
[AMBARI-24729] Ambari Server stops with Java 9 due to Guice error

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -89,6 +89,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>20.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -36,7 +36,7 @@
     <swagger.version>1.5.19</swagger.version>
     <swagger.maven.plugin.version>3.1.4</swagger.maven.plugin.version>
     <slf4j.version>1.7.20</slf4j.version>
-    <guice.version>4.1.0</guice.version>
+    <guice.version>4.2.1</guice.version>
     <spring.version>4.3.17.RELEASE</spring.version>
     <spring.security.version>4.2.7.RELEASE</spring.security.version>
     <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
@@ -219,8 +219,19 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
+        <artifactId>javax.persistence</artifactId>
+        <version>2.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.persistence</groupId>
         <artifactId>eclipselink</artifactId>
         <version>${eclipselink.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
@@ -230,7 +241,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>18.0</version>
+        <version>26.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -219,19 +219,8 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
-        <artifactId>javax.persistence</artifactId>
-        <version>2.1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.persistence</groupId>
-        <artifactId>eclipselink</artifactId>
+        <artifactId>org.eclipse.persistence.jpa</artifactId>
         <version>${eclipselink.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1273,11 +1273,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
-      <artifactId>javax.persistence</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>eclipselink</artifactId>
+      <artifactId>org.eclipse.persistence.jpa</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1273,6 +1273,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
+      <artifactId>javax.persistence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
     </dependency>
     <dependency>

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ClusterConfigEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ClusterConfigEntity.java
@@ -303,7 +303,7 @@ public class ClusterConfigEntity {
    */
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return com.google.common.base.MoreObjects.toStringHelper(this)
       .add("clusterId", clusterId)
       .add("type", type)
       .add("version", version)

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
@@ -41,6 +41,7 @@ import org.apache.ambari.server.state.HostComponentAdminState;
 import org.apache.ambari.server.state.MaintenanceState;
 import org.apache.ambari.server.state.State;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 
@@ -278,7 +279,7 @@ public class HostComponentDesiredStateEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
+    return MoreObjects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
         componentName).add("hostId", hostId).add("desiredState", desiredState).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -36,7 +36,7 @@ import javax.persistence.TableGenerator;
 import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.state.UpgradeState;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 @Entity
 @Table(name = "hostcomponentstate")
@@ -260,7 +260,7 @@ public class HostComponentStateEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
+    return MoreObjects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
         componentName).add("hostId", hostId).add("state", currentState).toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeHistoryEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeHistoryEntity.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ambari.server.orm.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -32,7 +34,7 @@ import javax.persistence.UniqueConstraint;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * The {@link UpgradeHistoryEntity} represents the version history of components
@@ -214,7 +216,7 @@ public class UpgradeHistoryEntity {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, upgradeId, serviceName, componentName);
+    return Objects.hash(id, upgradeId, serviceName, componentName);
   }
 
   /**
@@ -222,7 +224,7 @@ public class UpgradeHistoryEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("id", id)
         .add("upgradeId", upgradeId)
         .add("serviceName", serviceName)

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FinalizeUpgradeAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FinalizeUpgradeAction.java
@@ -552,7 +552,7 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
      */
     @Override
     public String toString() {
-      return com.google.common.base.Objects.toStringHelper(this)
+      return com.google.common.base.MoreObjects.toStringHelper(this)
           .add("host", hostName)
           .add("component", componentName)
           .add("current", currentVersion)

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/ConfigurationCondition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/ConfigurationCondition.java
@@ -31,7 +31,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * The {@link ConfigurationCondition} class is used to represent a condition on
@@ -119,7 +119,7 @@ public final class ConfigurationCondition extends Condition {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", type).add("property", property).add("value",
+    return MoreObjects.toStringHelper(this).add("type", type).add("property", property).add("value",
         value).add("comparison", comparisonType).omitNullValues().toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/Grouping.java
@@ -42,7 +42,7 @@ import org.apache.ambari.server.stack.upgrade.orchestrate.UpgradeContext;
 import org.apache.ambari.server.utils.SetUtils;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  *
@@ -424,6 +424,6 @@ public class Grouping {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("name", name).toString();
+    return MoreObjects.toStringHelper(this).add("name", name).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/HostOrderItem.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/HostOrderItem.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * The {@link HostOrderItem} class represents the orchestration order of hosts
@@ -95,7 +95,7 @@ public class HostOrderItem {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", m_type).add("items",
+    return MoreObjects.toStringHelper(this).add("type", m_type).add("items",
         StringUtils.join(m_actionItems, ", ")).omitNullValues().toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1662,7 +1662,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
           final HostAndPort hostAndPort = HostAndPort.fromString(propertyValue);
           AmbariServerConfigurationKey keyToBesaved = AmbariServerConfigurationKey.SERVER_HOST == key ? AmbariServerConfigurationKey.SERVER_HOST
               : AmbariServerConfigurationKey.SECONDARY_SERVER_HOST;
-          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, hostAndPort.getHostText());
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, hostAndPort.getHost());
 
           keyToBesaved = AmbariServerConfigurationKey.SERVER_HOST == key ? AmbariServerConfigurationKey.SERVER_PORT : AmbariServerConfigurationKey.SECONDARY_SERVER_PORT;
           populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, String.valueOf(hostAndPort.getPort()));

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <distMgmtStagingName>Apache Release Distribution Repository</distMgmtStagingName>
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
     <assemblyPhase>package</assemblyPhase> <!-- use -DassemblyPhase=none to skip building tarball, useful when you want purely compile jar -->
-    <eclipselink.version>2.6.2</eclipselink.version>
+    <eclipselink.version>2.7.3</eclipselink.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make it possible to run Ambari Server with JDK 9/10.

1. Upgrade Guice to avoid:
    ```
    1) No scope is bound to org.apache.ambari.server.AmbariService.
    at org.apache.ambari.server.state.services.MetricsRetrievalService.class(MetricsRetrievalService.java:85)
    ```
2. Upgrade Guava to avoid `NoSuchMethodError`.
3. Update references to `Objects.toStringHelper`, as the method was moved to `MoreObjects`.
4. Update reference to `HostAndPort.getHostText()`, which was renamed to `getHost()`.
5. Upgrade EclipseLink to avoid [NPE](https://bugs.eclipse.org/bugs/show_bug.cgi?id=486473):
    ```
    java.lang.NullPointerException
      at org.eclipse.persistence.internal.jpa.EntityManagerSetupImpl.predeploy(EntityManagerSetupImpl.java:2027)
      at org.eclipse.persistence.internal.jpa.deployment.JPAInitializer.callPredeploy(JPAInitializer.java:100)
      at org.eclipse.persistence.jpa.PersistenceProvider.createEntityManagerFactoryImpl(PersistenceProvider.java:104)
    ```
6. Work around [signature mismatch between EclipseLink 2.7 and JPA API 2.2](https://stackoverflow.com/questions/45870753/eclipselink-2-7-0-and-jpa-api-2-2-0-signature-mismatch).

Note that JDK was configured directly in `ambari.properties`, as `ambari-server setup` has [issues with newer JDKs](https://issues.apache.org/jira/browse/AMBARI-24730).

## How was this patch tested?

Compiled Ambari Server using JDK8.  Started Ambari Server with Oracle JDK 10.  Deployed ZooKeeper-only cluster via blueprint.

Unit tests pending.