### PR TITLE
AMBARI-24716 : Restrict user permissions for Atlas configuration file.

### DIFF
--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
@@ -114,7 +114,7 @@ def metadata(type='server'):
           Execute(('chown', format('{metadata_user}:{user_group}'), file),
                   sudo=True
                   )
-          Execute(('chmod', '644', file),
+          Execute(('chmod', '640', file),
                   sudo=True
                   )
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Need to restrict user permissions for Atlas configuration file.


## How was this patch tested?
Tested by setting up a fresh cluster. 
