### PR TITLE
AMBARI-23058. yum installation fails if there is any transaction files

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/yum_manager.py
@@ -450,6 +450,9 @@ Ambari has detected that there are incomplete Yum transactions on this host. Thi
 - Identify the pending transactions with the command 'yum history list <packages failed>'
 - Revert each pending transaction with the command 'yum history undo'
 - Flush the transaction log with 'yum-complete-transaction --cleanup-only'
+
+If the issue persists, old transaction files may be the cause.
+Please delete them from /var/lib/yum/transaction*
 """
 
     for line in help_msg.split("\n"):


### PR DESCRIPTION
Starting from 2.6.1 Ambari started checking transaction files during the repo/service installation and it fails with below error.

2018-02-16 16:12:21,639 - File['/etc/yum.repos.d/ambari-hdp-104.repo'] {'content': '[HDP-2.6-repo-104]\nname=HDP-2.6-repo-104\nbaseurl=http://xxxxxxx/vcm_hadoop/HDP/centos6/2.6.4.0-91\n\npath=/\nenabled=1\ngpgcheck=0\n[HDP-UTILS-1.1.0.22-repo-104]\nname=HDP-UTILS-1.1.0.22-repo-104\nbaseurl=http://xxxxxx/vcm_hadoop/HDP-UTILS-1.1.0.22\n\npath=/\nenabled=1\ngpgcheck=0'} 
2.  2018-02-16 16:12:21,639 - Writing File['/etc/yum.repos.d/ambari-hdp-104.repo'] because contents don't match 
3.  2018-02-16 16:12:21,639 - Yum non-completed transactions check failed, found 1 non-completed transaction(s): 
4.  2018-02-16 16:12:21,640 - [2015-03-12.17:13.28.disabled] Packages broken: hue-common-2.6.1.2.2.0.0-2041.el6.x86_64; Packages not-installed hue-hcatalog-2.6.1.2.2.0.0-2041.el6.x86_64, hue-2.6.1.2.2.0.0-2041.el6.x86_64, hue-pig-2.6.1.2.2.0.0-2041.el6.x86_64, hue-oozie-2.6.1.2.2.0.0-2041.el6.x86_64, hue-beeswax-2.6.1.2.2.0.0-2041.el6.x86_64, hue-server-2.6.1.2.2.0.0-2041.el6.x86_64 
5.  2018-02-16 16:12:21,640 - *** Incomplete Yum Transactions *** 
6.  2018-02-16 16:12:21,640 - 
7.  2018-02-16 16:12:21,640 - Ambari has detected that there are incomplete Yum transactions on this host. This will interfere with the installation process and must be resolved before continuing. 
8.  2018-02-16 16:12:21,640 - 
9.  2018-02-16 16:12:21,640 - - Identify the pending transactions with the command 'yum history list <packages failed>' 
10. 2018-02-16 16:12:21,640 - - Revert each pending transaction with the command 'yum history undo' 
11. 2018-02-16 16:12:21,640 - - Flush the transaction log with 'yum-complete-transaction --cleanup-only' 
After cleaning up with 'yum-complete-transaction --cleanup-only' still Ambari could not able to proceed further with same error.

When user tried to do yum install it was going through successfully.

Finally had to delete /var/lib/yum/transaction* manually for ambari to proceed further with installation. these transactions files were very old and nothing to do with any latest installation but still ambari does not proceed further.

What is expected: If this validation was done intentionally then it should throw proper message guiding the user to remove those files