### PR TITLE
AMBARI-24730. Support Java 9+ in Ambari Server setup

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -1303,11 +1303,12 @@ def check_ambari_java_version_is_valid(java_home, java_bin, min_version, propert
       err = "Checking JDK version command returned with exit code %s" % process.returncode
       raise FatalException(process.returncode, err)
     else:
-      actual_jdk_version = int(get_java_major_version(out))
+      java_major_version = get_java_major_version(out)
+      actual_jdk_version = int(java_major_version)
       print 'JDK version found: {0}'.format(actual_jdk_version)
       if actual_jdk_version < min_version:
         print 'Minimum JDK version is {0} for Ambari. Setup JDK again only for Ambari Server.'.format(min_version)
-        properties.process_pair(STACK_JAVA_VERSION, get_java_major_version(out))
+        properties.process_pair(STACK_JAVA_VERSION, java_major_version)
         result = False
       else:
         print 'Minimum JDK version is {0} for Ambari. Skipping to setup different JDK for Ambari Server.'.format(min_version)

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -80,7 +80,7 @@ UNTAR_JDK_ARCHIVE = "tar --no-same-owner -xvf {0}"
 JDK_PROMPT = "[{0}] {1}\n"
 JDK_VALID_CHOICES = "^[{0}{1:d}]$"
 
-JDK_VERSION_CHECK_CMD = """{0} -version 2>&1 | grep -i version | sed 's/.*version ".*\.\(.*\)\..*"/\\1/; 1q' 2>&1"""
+JDK_VERSION_CHECK_CMD = """{0} -version 2>&1 | grep -i version 2>&1"""
 
 def get_supported_jdbc_drivers():
   factory = DBMSConfigFactory()
@@ -1272,6 +1272,17 @@ def setup_jce_policy(args):
   print 'NOTE: Restart Ambari Server to apply changes' + \
         ' ("ambari-server restart|stop|start")'
 
+def get_ambari_major_version(cmd_out):
+  version_short = re.split("[java|openjdk|.*] version", cmd_out)[1].split(" ")[1][1:-1]
+  if re.match("1\.8.*", version_short): # 1.8.0_112
+    return version_short.split(".")[1]
+  elif re.match("[1-9][0-9]*\.[0-9].*", version_short): # 10.0.2
+    return version_short.split(".")[0]
+  elif re.match("^[1-9][0-9]*$", version_short): # 11
+    return version_short
+  elif re.match("^[1-9][0-9]*-.*$", version_short): # 12-ea
+    return version_short.split("-")[0]
+
 def check_ambari_java_version_is_valid(java_home, java_bin, min_version, properties):
   """
   Check that ambari uses the proper (minimum) JDK with a shell command.
@@ -1292,7 +1303,7 @@ def check_ambari_java_version_is_valid(java_home, java_bin, min_version, propert
       err = "Checking JDK version command returned with exit code %s" % process.returncode
       raise FatalException(process.returncode, err)
     else:
-      actual_jdk_version = int(out)
+      actual_jdk_version = int(get_ambari_major_version(out))
       print 'JDK version found: {0}'.format(actual_jdk_version)
       if actual_jdk_version < min_version:
         print 'Minimum JDK version is {0} for Ambari. Setup JDK again only for Ambari Server.'.format(min_version)

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -1272,7 +1272,7 @@ def setup_jce_policy(args):
   print 'NOTE: Restart Ambari Server to apply changes' + \
         ' ("ambari-server restart|stop|start")'
 
-def get_ambari_major_version(cmd_out):
+def get_java_major_version(cmd_out):
   version_short = re.split("[java|openjdk|.*] version", cmd_out)[1].split(" ")[1][1:-1]
   if re.match("1\.8.*", version_short): # 1.8.0_112
     return version_short.split(".")[1]
@@ -1303,7 +1303,7 @@ def check_ambari_java_version_is_valid(java_home, java_bin, min_version, propert
       err = "Checking JDK version command returned with exit code %s" % process.returncode
       raise FatalException(process.returncode, err)
     else:
-      actual_jdk_version = int(get_ambari_major_version(out))
+      actual_jdk_version = int(get_java_major_version(out))
       print 'JDK version found: {0}'.format(actual_jdk_version)
       if actual_jdk_version < min_version:
         print 'Minimum JDK version is {0} for Ambari. Setup JDK again only for Ambari Server.'.format(min_version)

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -1274,9 +1274,9 @@ def setup_jce_policy(args):
 
 def get_java_major_version(cmd_out):
   version_short = re.split("[java|openjdk|.*] version", cmd_out)[1].split(" ")[1][1:-1]
-  if re.match("1\.8.*", version_short): # 1.8.0_112
+  if re.match("^1\.[0-9].*", version_short): # 1.8.0_112
     return version_short.split(".")[1]
-  elif re.match("[1-9][0-9]*\.[0-9].*", version_short): # 10.0.2
+  elif re.match("^[1-9][0-9]*\.[0-9].*", version_short): # 10.0.2
     return version_short.split(".")[0]
   elif re.match("^[1-9][0-9]*$", version_short): # 11
     return version_short

--- a/ambari-server/src/main/python/ambari_server/serverSetup.py
+++ b/ambari-server/src/main/python/ambari_server/serverSetup.py
@@ -1307,7 +1307,7 @@ def check_ambari_java_version_is_valid(java_home, java_bin, min_version, propert
       print 'JDK version found: {0}'.format(actual_jdk_version)
       if actual_jdk_version < min_version:
         print 'Minimum JDK version is {0} for Ambari. Setup JDK again only for Ambari Server.'.format(min_version)
-        properties.process_pair(STACK_JAVA_VERSION, out)
+        properties.process_pair(STACK_JAVA_VERSION, get_java_major_version(out))
         result = False
       else:
         print 'Minimum JDK version is {0} for Ambari. Skipping to setup different JDK for Ambari Server.'.format(min_version)

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -3150,7 +3150,7 @@ class TestAmbariServer(TestCase):
     # case 1:  jdk7 is picked for stacks
     properties = Properties()
     p = MagicMock()
-    p.communicate.return_value = ('7', None)
+    p.communicate.return_value = ('java version "1.7.0_80"', None)
     p.returncode = 0
     popenMock.return_value = p
     result = check_ambari_java_version_is_valid('/usr/jdk64/jdk_1.7.0/', 'java', 8, properties)
@@ -3159,7 +3159,7 @@ class TestAmbariServer(TestCase):
 
     # case 2: jdk8 is picked for stacks
     properties = Properties()
-    p.communicate.return_value = ('8', None)
+    p.communicate.return_value = ('java version "1.8.0_112"', None)
     p.returncode = 0
     result = check_ambari_java_version_is_valid('/usr/jdk64/jdk_1.8.0/', 'java', 8, properties)
     self.assertFalse(properties.get_property(STACK_JAVA_VERSION))


### PR DESCRIPTION
Change-Id: Ie2e0f1e4d19c94d689e9cc4ad9565403c87c8549

## What changes were proposed in this pull request?

Change how `ambari-server setup` calculates Java major version to support anything beyond Java 8. 

## How was this patch tested?

Manually tested with Oracle and Open JDK 8,9,10,11,12: 

```

[root@gboros-jdk11-1 ~]# ambari-server setup -s -j /usr/jdk64/jdk1.8.0_112/ --stack-java-home /usr/jdk64/jdk1.8.0_112/ | grep 'JDK version found'
JDK version found: 8

[root@gboros-jdk11-1 ~]# ambari-server setup -s -j /usr/java/jdk-9.0.4/ --stack-java-home /usr/java/jdk-9.0.4/ | grep 'JDK version found'
JDK version found: 9

[root@gboros-jdk11-1 ~]# ambari-server setup -s -j /usr/java/jdk-10.0.2/ --stack-java-home /usr/java/jdk-10.0.2/ | grep 'JDK version found'
JDK version found: 10

[root@gboros-jdk11-1 ~]# ambari-server setup -s -j /usr/java/jdk-11/ --stack-java-home /usr/java/jdk-11/ | grep 'JDK version found'
JDK version found: 11

[root@gboros-jdk11-1 ~]# ambari-server setup -s -j /tmp/jdk-11/ --stack-java-home /tmp/jdk-11/| grep 'JDK version found'
JDK version found: 11

[root@gboros-jdk11-1 ~]# ambari-server setup -s -j /tmp/jdk-12/ --stack-java-home /tmp/jdk-12/ | grep 'JDK version found'
JDK version found: 12
```

Corresponding Java version outputs: 

```
[root@gboros-jdk11-1 ambari]# /usr/jdk64/jdk1.8.0_112/bin/java -version
java version "1.8.0_112"
Java(TM) SE Runtime Environment (build 1.8.0_112-b15)
Java HotSpot(TM) 64-Bit Server VM (build 25.112-b15, mixed mode)

[root@gboros-jdk11-1 ambari]# /usr/java/jdk-9.0.4/bin/java -version
java version "9.0.4"
Java(TM) SE Runtime Environment (build 9.0.4+11)
Java HotSpot(TM) 64-Bit Server VM (build 9.0.4+11, mixed mode)

[root@gboros-jdk11-1 ambari]# /usr/java/jdk-10.0.2/bin/java -version
java version "10.0.2" 2018-07-17
Java(TM) SE Runtime Environment 18.3 (build 10.0.2+13)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.2+13, mixed mode)

[root@gboros-jdk11-1 ambari]# /usr/java/jdk-11/bin/java -version
java version "11" 2018-09-25
Java(TM) SE Runtime Environment 18.9 (build 11+28)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11+28, mixed mode)

[root@gboros-jdk11-1 ~]# /tmp/jdk-12/bin/java --version
openjdk 12-ea 2019-03-19
OpenJDK Runtime Environment 19.3 (build 12-ea+13)
OpenJDK 64-Bit Server VM 19.3 (build 12-ea+13, mixed mode)
```

Please review @adoroszlai , @aonishuk 