### PR TITLE
AMBARI-24712. Backport Execution Command Library from branch 'branch-feature-AMBARI-14714' to Ambari 2.8.0

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/__init__.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/__init__.py
@@ -16,12 +16,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Ambari Agent
-
 """
-
-from resource_management.libraries.execution_command import *
-from resource_management.libraries.functions import *
-from resource_management.libraries.resources import *
-from resource_management.libraries.providers import *
-from resource_management.libraries.script import *

--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/cluster_settings.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/cluster_settings.py
@@ -57,7 +57,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         recovery_enabled =  self.__get_value("recovery_enabled")
-        return True if recovery_enabled and recovery_enabled.lower() == "true" else False
+        return recovery_enabled and recovery_enabled.lower() == "true"
 
     def get_recovery_type(self):
         """
@@ -107,7 +107,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         override_uid =  self.__get_value("override_uid")
-        return True if override_uid and override_uid.lower() == "true" else False
+        return override_uid and override_uid.lower() == "true"
 
     def check_sysprep_skip_copy_fast_jar_hdfs(self):
         """
@@ -115,7 +115,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         skip = self.__get_value("sysprep_skip_copy_fast_jar_hdfs")
-        return True if skip and skip.lower() == "true" else False
+        return skip and skip.lower() == "true"
 
     def check_sysprep_skip_lzo_package_operations(self):
         """
@@ -123,7 +123,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         skip = self.__get_value("sysprep_skip_lzo_package_operations")
-        return True if skip and skip.lower() == "true" else False
+        return skip and skip.lower() == "true"
 
     def check_sysprep_skip_setup_jce(self):
         """
@@ -131,7 +131,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         skip = self.__get_value("sysprep_skip_setup_jce")
-        return True if skip and skip.lower() == "true" else False
+        return skip and skip.lower() == "true"
 
     def check_sysprep_skip_create_users_and_groups(self):
         """
@@ -139,7 +139,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         skip = self.__get_value("sysprep_skip_create_users_and_groups")
-        return True if skip and skip.lower() == "true" else False
+        return skip and skip.lower() == "true"
 
     def check_ignore_groupsusers_create(self):
         """
@@ -147,7 +147,7 @@ class ClusterSettings(object):
         :return: True or False
         """
         ignored = self.__get_value("ignore_groupsusers_create")
-        return True if ignored and ignored.lower() == "true" else False
+        return ignored and ignored.lower() == "true"
 
     def check_fetch_nonlocal_groups(self):
         """
@@ -155,4 +155,4 @@ class ClusterSettings(object):
         :return: True or False
         """
         fetch_nonlocal_group = self.__get_value("fetch_nonlocal_groups")
-        return True if fetch_nonlocal_group and fetch_nonlocal_group.lower() == "true" else False
+        return fetch_nonlocal_group and fetch_nonlocal_group.lower() == "true"

--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/cluster_settings.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/cluster_settings.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+__all__ = ["ClusterSettings"]
+
+class ClusterSettings(object):
+    """
+    This class maps to "configurations->cluster-env" in command.json which includes cluster setting information of a cluster
+    """
+
+    def __init__(self, clusterSettings):
+        self.__cluster_settings = clusterSettings
+
+    def __get_value(self, key):
+        """
+        Get corresponding value from the key
+        :param key:
+        :return: value if key exist else None
+        """
+        return self.__cluster_settings.get(key)
+
+    def is_cluster_security_enabled(self):
+        """
+        Check cluster security enabled or not
+        :return: True or False
+        """
+        security_enabled = self.__get_value("security_enabled")
+        return security_enabled and security_enabled.lower() == "true"
+
+    def get_recovery_max_count(self):
+        """
+        Retrieve cluster recovery count
+        :return: String, need to convert to int
+        """
+        return int(self.__get_value("recovery_max_count"))
+
+    def check_recovery_enabled(self):
+        """
+        Check if the cluster can be enabled or not
+        :return: True or False
+        """
+        recovery_enabled =  self.__get_value("recovery_enabled")
+        return True if recovery_enabled and recovery_enabled.lower() == "true" else False
+
+    def get_recovery_type(self):
+        """
+        Retrieve cluster recovery type
+        :return: recovery type, i.e "AUTO_START"
+        """
+        return self.__get_value("recovery_type")
+
+    def get_kerberos_domain(self):
+        """
+        Retrieve kerberos domain
+        :return: String as kerberos domain
+        """
+        return self.__get_value("kerberos_domain")
+
+    def get_smokeuser(self):
+        """
+        Retrieve smokeuser
+        :return: smkeuser string
+        """
+        return self.__get_value("smokeuser")
+
+    def get_user_group(self):
+        """
+        Retrieve cluster usergroup
+        :return: usergroup string
+        """
+        return self.__get_value("user_group")
+
+    def get_repo_suse_rhel_template(self):
+        """
+        Retrieve template of suse and rhel repo
+        :return: template string
+        """
+        return self.__get_value("repo_suse_rhel_template")
+
+    def get_repo_ubuntu_template(self):
+        """
+        Retrieve template of ubuntu repo
+        :return: template string
+        """
+        return self.__get_value("repo_ubuntu_template")
+
+    def check_override_uid(self):
+        """
+        Check if override_uid is true or false
+        :return: True or False
+        """
+        override_uid =  self.__get_value("override_uid")
+        return True if override_uid and override_uid.lower() == "true" else False
+
+    def check_sysprep_skip_copy_fast_jar_hdfs(self):
+        """
+        Check sysprep_skip_copy_fast_jar_hdfs is true or false
+        :return: True or False
+        """
+        skip = self.__get_value("sysprep_skip_copy_fast_jar_hdfs")
+        return True if skip and skip.lower() == "true" else False
+
+    def check_sysprep_skip_lzo_package_operations(self):
+        """
+        Check sysprep_skip_lzo_package_operations is true or false
+        :return: True or False
+        """
+        skip = self.__get_value("sysprep_skip_lzo_package_operations")
+        return True if skip and skip.lower() == "true" else False
+
+    def check_sysprep_skip_setup_jce(self):
+        """
+        Check sysprep_skip_setup_jce is true or false
+        :return: True or False
+        """
+        skip = self.__get_value("sysprep_skip_setup_jce")
+        return True if skip and skip.lower() == "true" else False
+
+    def check_sysprep_skip_create_users_and_groups(self):
+        """
+        Check sysprep_skip_copy_create_users_and_groups is true or false
+        :return: True or False
+        """
+        skip = self.__get_value("sysprep_skip_create_users_and_groups")
+        return True if skip and skip.lower() == "true" else False
+
+    def check_ignore_groupsusers_create(self):
+        """
+        Check ignore_groupsuers_create is true or false
+        :return: True or False
+        """
+        ignored = self.__get_value("ignore_groupsusers_create")
+        return True if ignored and ignored.lower() == "true" else False
+
+    def check_fetch_nonlocal_groups(self):
+        """
+        Check fetch_nonlocal_group is true or false
+        :return: True or False
+        """
+        fetch_nonlocal_group = self.__get_value("fetch_nonlocal_groups")
+        return True if fetch_nonlocal_group and fetch_nonlocal_group.lower() == "true" else False

--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/execution_command.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/execution_command.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+__all__ = ["ExecutionCommand"]
+
+from resource_management.libraries.execution_command import module_configs
+from resource_management.libraries.execution_command import stack_settings
+from resource_management.libraries.execution_command import cluster_settings
+
+class ExecutionCommand(object):
+    """
+    The class has two private objects: _execution_command maps to a command.json and
+    _module_config maps to configurations block and configuratonAttributes within this
+     command.json. This class provides a set of APIs to retrieve all command related info.
+     The caller should not access the command.json to get the configuration info directly.
+    """
+
+    def __init__(self, command):
+        """
+        _execution_command is a wrapper object of a dict object maps to command.json
+        _module_config is an wrapper object of configuration and configurationAttributes dict
+        objects maps to configuration and configurationAttributes blocks within command.json
+        :param command: json string or a python dict object
+        """
+        self.__execution_command = command
+        self.__module_configs = module_configs.ModuleConfigs(self.__get_value("configurations"), self.__get_value("configurationAttributes"))
+        # TODO : 'stack_settings' and 'cluster_settings' may be segregated later out of 'cluster-env'
+        # as done in 'branch-feature-AMBARI-14714'.
+        self.__stack_settings = stack_settings.StackSettings(self.__get_value("configurations/cluster-env"))
+        self.__cluster_settings = cluster_settings.ClusterSettings(self.__get_value("configurations/cluster-env"))
+
+    def __get_value(self, key, default_value=None):
+        """
+        A private method to query value with the full path of key, if key does not exist, return default_value
+        :param key: query key string
+        :param default_value: if key does not exist, return this value
+        :return: the value maps to query key
+        """
+        sub_keys = filter(None, key.split('/'))
+        value = self.__execution_command
+        try:
+            for sub_key in sub_keys:
+                if not sub_key in value:
+                    return default_value
+                value = value[sub_key]
+                if value == None:
+                    value = default_value
+            return value
+        except:
+            return default_value
+
+    def get_value(self, query_string, default_value=None):
+        """
+        Generic query API to retrieve config attribute from execution_command directly
+        :param query_string: full query key string
+        :param default_value: if key does not exist, return default value
+        :return: config attribute
+        """
+        return self.__get_value(query_string, default_value)
+
+    """
+    Global variables section
+    """
+
+    def get_module_configs(self):
+        return self.__module_configs
+
+    def get_stack_settings(self):
+        return self.__stack_settings
+
+    def get_cluster_settings(self):
+        return self.__cluster_settings
+
+    def get_module_name(self):
+        """
+        Retrieve service type from command.json, eg. 'ZOOKEEPER', 'HDFS'
+        :return: service type
+        """
+        return self.__get_value("serviceName")
+
+    def get_component_type(self):
+        """
+        Retrieve host role from command.json, i.e "role": "ZOOKEEPER_SERVER"
+        :return:
+        """
+        return self.__get_value("role")
+
+    def get_component_instance_name(self):
+        """
+        Retrieve service name from command.json, eg. 'zk1'
+        :return: service name
+        """
+        module_name = self.get_module_name()
+        if module_name and '_CLIENTS' in module_name: # FIXME temporary hack
+            return 'default'
+        return self.__get_value("serviceName") # multi-service, but not multi-component per service
+
+    def get_cluster_name(self):
+        """
+        Retrieve cluster name from command.json
+        :return: cluster name
+        """
+        return self.__get_value("clusterName")
+
+    def get_repository_file(self):
+        """
+        Retrieve respository dict about mpack info from command.json
+        :return: repository file name
+        """
+        return self.__get_value("repositoryFile")
+
+    def get_local_components(self):
+        """
+        Retrieve a list of service components from command.json. i.e localComponents": ["ZOOKEEPER_CLIENT"]
+        :return: list of components
+        """
+        return self.__get_value("localComponents", [])
+
+    def get_role_command(self):
+        """
+        Retrieve execution command
+        :return: String, i.e "ACTIONEXECUTE", "INSTALL", "START" etc
+        """
+        return self.__get_value("roleCommand")
+
+    """
+    Ambari variables section
+    """
+
+    def get_jdk_location(self):
+        """
+        Retrieve URL of jdk from command.json. i.e "jdk_location": "http://c7302.ambari.apache.org:8080/resources/"
+        :return: jdk url string
+        """
+        return self.__get_value("ambariLevelParams/jdk_location")
+
+    def get_jdk_name(self):
+        """
+        Retrieve jdk name from command.json. i.e "jdk_name": "jdk-8u112-linux-x64.tar.gz"
+        :return: jdk name string
+        """
+        return self.__get_value("ambariLevelParams/jdk_name")
+
+    def get_java_home(self):
+        """
+        Retrieve java home from command.json. i.e "java_home": "/usr/jdk64/jdk1.8.0_112"
+        :return: java home string
+        """
+        return self.__get_value("ambariLevelParams/java_home")
+
+    def get_java_version(self):
+        """
+        Retrieve java version from command.json, i.e "java_version": "8", note "8" will convert to 8
+        :return: an integer represents java version
+        """
+        from resource_management.libraries.functions.expect import expect_v2
+        return expect_v2("ambariLevelParams/java_version", int)
+
+    def get_jce_name(self):
+        """
+        Retrieve jce name from command.json, i.e "jce_name": "jce_policy-8.zip"
+        :return: jce name string
+        """
+        return self.__get_value("ambariLevelParams/jce_name")
+
+    def get_db_driver_file_name(self):
+        """
+        Retrieve database driver file name, i.e "db_driver_filename": "mysql-connector-java.jar"
+        :return: DB driver name string
+        """
+        return self.__get_value('ambariLevelParams/db_driver_filename')
+
+    def get_db_name(self):
+        """
+        Retrieve database name, i.e Ambari server's db name is "db_name": "ambari"
+        :return: DB name
+        """
+        return self.__get_value('ambariLevelParams/db_name')
+
+    def get_oracle_jdbc_url(self):
+        """
+        Retrieve oracle database jdbc driver url,
+        i.e "oracle_jdbc_url": "http://c7302.ambari.apache.org:8080/resources//ojdbc6.jar"
+        :return: oracle jdbc url
+        """
+        return self.__get_value('ambariLevelParams/oracle_jdbc_url')
+
+    def get_mysql_jdbc_url(self):
+        """
+        Retrieve mysql database jdbc driver url,
+        i.e "mysql_jdbc_url": "http://c7302.ambari.apache.org:8080/resources//mysql-connector-java.jar"
+        :return: mysql jdbc url
+        """
+        return self.__get_value('ambariLevelParams/mysql_jdbc_url')
+
+    def get_agent_stack_retry_count(self):
+        """
+        Retrieve retry count for stack deployment on agent,
+        i.e "agent_stack_retry_count": "5"
+        :return: retry count for stack deployment on agent
+        """
+        from resource_management.libraries.functions.expect import expect_v2
+        return expect_v2('ambariLevelParams/agent_stack_retry_count', int, 5)
+
+    def check_agent_stack_want_retry_on_unavailability(self):
+        """
+        Check if retry is needed when agent is not reachable
+        :return: True or False
+        """
+        return self.__get_value('ambariLevelParams/agent_stack_retry_on_unavailability')
+
+    def get_ambari_server_host(self):
+        """
+        Retrieve ambari server host url from command.json, i.e "ambari_server_host": "c7302.ambari.apache.org"
+        :return: ambari server url
+        """
+        return self.__get_value("ambariLevelParams/ambari_server_host")
+
+    def get_ambari_server_port(self):
+        """
+        Retrieve ambar server port number from command.json, i.e "ambari_server_port": "8080"
+        :return: amabari server port number
+        """
+        return self.__get_value("ambariLevelParams/ambari_server_port")
+
+    def is_ambari_server_use_ssl(self):
+        """
+        Check if ssl is needed to connect to ambari server
+        :return: True or False
+        """
+        return self.__get_value("ambariLevelParams/ambari_server_use_ssl", False)
+
+    def is_host_system_prepared(self):
+        """
+        Check a global flag enabling or disabling the sysprep feature
+        :return: True or False
+        """
+        return self.__get_value("ambariLevelParams/host_sys_prepped", False)
+
+    def is_gpl_license_accepted(self):
+        """
+        Check ambari server accepts gpl license or not
+        :return: True or False
+        """
+        return self.__get_value("ambariLevelParams/gpl_license_accepted", False)
+
+
+    """
+    Cluster related variables section
+    TODO: deprecated, but some scripts still use them, need to remove them gradually
+    """
+
+    def get_mpack_name(self):
+        """
+        Retrieve mpack name from command.json, i.e "stack_name": "HDPCORE"
+        :return: mpack name string
+        """
+        return self.__get_value("clusterLevelParams/stack_name")
+
+    def get_mpack_version(self):
+        """
+        Retrieve mpack version from command.json, i.e "stack_version": "1.0.0-b224"
+        :return: mpack version string
+        """
+        return self.__get_value("clusterLevelParams/stack_version")
+
+    def get_user_groups(self):
+        """
+        Retrieve ambari server user groups, i.e "user_groups": "{\"zookeeper\":[\"hadoop\"],\"ambari-qa\":[\"hadoop\"]}"
+        :return: a user group dict object
+        """
+        return self.__get_value("clusterLevelParams/user_groups")
+
+    def get_group_list(self):
+        """
+        Retrieve a list of user groups from command.json, i.e "group_list": "[\"hadoop\"]"
+        :return: a list of groups
+        """
+        group_list = self.__get_value("clusterLevelParams/group_list")
+        if not group_list:
+            group_list = "[]"
+        return group_list
+
+    def get_user_list(self):
+        """
+        Retrieve a list of users from command.json, i.e "user_list": "[\"zookeeper\",\"ambari-qa\"]"
+        :return: a list of users
+        """
+        user_list = self.__get_value("clusterLevelParams/user_list")
+        if not user_list:
+            user_list = "[]"
+        return user_list
+
+
+    """
+    Agent related variable section
+    """
+
+    def get_host_name(self):
+        """
+        Retrieve host name on which ambari agent is running
+        :return: host name
+        """
+        return self.__get_value("agentLevelParams/hostname")
+
+    def get_agent_cache_dir(self):
+        """
+        The root directory in which ambari agent stores cache or log etc,
+        i.e "agentCacheDir": "/var/lib/ambari-agent/cache"
+        :return: the cache directory path
+        """
+        return self.__get_value('agentLevelParams/agentCacheDir')
+
+    def check_agent_config_execute_in_parallel(self):
+        """
+        Check if config commands can be executed in parallel in ambari agent
+        :return: True or False
+        """
+        return int(self.__get_value("agentLevelParams/agentConfigParams/agent/parallel_execution", 0))
+
+    def check_agent_proxy_settings(self):
+        """
+        Check if system proxy is set or not on agent
+        :return: True by default
+        """
+        return self.__get_value("agentLevelParams/agentConfigParams/agent/use_system_proxy_settings", True)
+
+
+    """
+    Host related variables section
+    """
+    #### TODO : Doesn't exist as of now. Evaluate if we would be having these in hostLevelParams.
+    '''
+    def get_repo_info(self):
+        return self.__get_value('hostLevelParams/repoInfo')
+
+    def get_service_repo_info(self):
+        return self.__get_value('hostLevelParams/service_repo_info')
+    '''
+
+    """
+    Component related variables section
+    """
+
+    def check_unlimited_key_jce_required(self):
+        """
+        Check unlimited jce key is required or not
+        :return: True or False
+        """
+        return self.__get_value('componentLevelParams/unlimited_key_jce_required', False)
+
+    """
+    Command related variables section
+    """
+
+    def get_new_mpack_version_for_upgrade(self):
+        """
+        New Cluster Stack Version that is defined during the RESTART of a Rolling Upgrade
+        :return:
+        """
+        return self.__get_value("commandParams/version")
+
+    def check_command_retry_enabled(self):
+        """
+        Check need to retry command or not
+        :return: True or False
+        """
+        return self.__get_value('commandParams/command_retry_enabled', False)
+
+    # TODO : Doesnt exist as of now.  Evaluate if we would be having these
+    '''
+    def check_upgrade_direction(self):
+        return self.__get_value('commandParams/upgrade_direction')
+    def get_upgrade_type(self):
+        return self.__get_value('commandParams/upgrade_type', '')
+    def is_rolling_restart_in_upgrade(self):
+        return self.__get_value('commandParams/rolling_restart', False)
+    def is_update_files_only(self):
+        return self.__get_value('commandParams/update_files_only', False)
+    def get_deploy_phase(self):
+        return self.__get_value('commandParams/phase')
+    '''
+
+    def get_dfs_type(self):
+        return self.__get_value('clusterLevelParams/dfs_type')
+
+    def get_module_package_folder(self):
+        return self.__get_value('commandParams/service_package_folder')
+
+    # TODO : Doesnt exist as of now. Evaluate if we need them.
+    '''
+    def get_ambari_java_home(self):
+        return self.__get_value('commandParams/ambari_java_home')
+    def get_ambari_java_name(self):
+        return self.__get_value('commandParams/ambari_java_name')
+    def get_ambari_jce_name(self):
+        return self.__get_value('commandParams/ambari_jce_name')
+    def get_ambari_jdk_name(self):
+        return self.__get_value('commandParams/ambari_jdk_name')
+    def need_refresh_topology(self):
+        return self.__get_value('commandParams/refresh_topology', False)
+    def check_only_update_files(self):
+        return self.__get_value('commandParams/update_files_only', False)
+    def get_desired_namenode_role(self):
+        """
+        The desired role is only available during a Non-Rolling Upgrade in HA.
+        The server calculates which of the two NameNodes will be the active,
+        and the other the standby since they are started using different commands.
+        :return: the node's role (active or standby)
+        """
+        return self.__get_value('commandParams/desired_namenode_role')
+    def get_node(self, type):
+        key = "commandParams/" + type + "node"
+        return self.__get_value(key)
+    
+    """
+    Role related variables section
+    """
+    def is_upgrade_suspended(self):
+        return self.__get_value('roleParams/upgrade_suspended', False)
+    '''
+
+
+    """
+    Cluster Host Info
+    """
+
+    def get_component_hosts(self, component_name):
+        key = "clusterHostInfo/" + component_name + "_hosts"
+        if component_name == "oozie_server":
+            key = "clusterHostInfo/" + component_name
+        return self.__get_value(key, [])
+
+    def get_component_host(self, component_name):
+        key = "clusterHostInfo/" + component_name + "_host"
+        return self.__get_value(key, [])
+
+    def get_all_hosts(self):
+        return self.__get_value('clusterHostInfo/all_hosts', [])
+
+    def get_all_racks(self):
+        return self.__get_value('clusterHostInfo/all_racks', [])
+
+    def get_all_ipv4_ips(self):
+        return self.__get_value('clusterHostInfo/all_ipv4_ips', [])

--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/module_configs.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/module_configs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+__all__ = ["ModuleConfigs"]
+
+
+class ModuleConfigs(object):
+    """
+    This class maps to "/configurations" and "/configurationAttributes in command.json which includes configuration information of a service
+    """
+
+    def __init__(self, configs, configAttributes):
+        self.__module_configs = configs
+        self.__module_config_attributes = configAttributes
+
+    def get_raw_config_dict(self):
+        """
+        Sometimes the caller needs to access to module_configs directly
+        :return: config dict
+        """
+        return self.__module_configs
+
+    def get_all_attributes(self, module_name, config_type):
+        """
+        Retrieve attributes from /configurationAttributes/config_type
+        :param module_name:
+        :param config_type:
+        :return:
+        """
+        if config_type not in self.__module_config_attributes:
+            return {}
+        try:
+            return self.__module_config_attributes[config_type]
+        except:
+            return {}
+
+    def get_all_properties(self, module_name, config_type):
+        if config_type not in self.__module_configs:
+            return {}
+        try:
+            return self.__module_configs[config_type]
+        except:
+            return {}
+
+    def get_properties(self, module_name, config_type, property_names, default=None):
+        properties = {}
+        try:
+            for property_name in property_names:
+                properties[property_name] = self.get_property_value(module_name, config_type, property_name, default)
+        except:
+            return {}
+        return properties
+
+    def get_property_value(self, module_name, config_type, property_name, default=None):
+        if config_type not in self.__module_configs or property_name not in self.__module_configs[config_type]:
+            return default
+        try:
+            value = self.__module_configs[config_type][property_name]
+            if value == None:
+                value = default
+            return value
+        except:
+            return default

--- a/ambari-common/src/main/python/resource_management/libraries/execution_command/stack_settings.py
+++ b/ambari-common/src/main/python/resource_management/libraries/execution_command/stack_settings.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+__all__ = ["StackSettings"]
+
+class StackSettings(object):
+
+    # Stack related configs from stack's stack_settings.json
+    STACK_NAME_SETTING = "stack_name"
+    STACK_TOOLS_SETTING = "stack_tools"
+    STACK_FEATURES_SETTING = "stack_features"
+    STACK_PACKAGES_SETTING = "stack_packages"
+    STACK_ROOT_SETTING = "stack_root"
+    STACK_SELECT_SETTING = "stack_select"
+
+    """
+    This class maps to "configurations->cluster-env" in command.json which includes cluster setting information of a cluster
+    """
+
+    def __init__(self, stackSettings):
+        self.__stack_settings = stackSettings
+
+    def __get_value(self, key):
+        """
+        Get corresponding value from the key
+        :param key:
+        :return: value if key exist else None
+        """
+        return self.__stack_settings.get(key)
+
+    def get_mpack_name(self):
+        """
+        Retrieve mpack name from command.json/cluster-env, i.e "stack_name": "HDPCORE"
+        :return: mpack name string
+        """
+        return self.__get_value("stack_name")
+
+    '''  TODO : Open it when we can serve them from stackSettings.
+    def get_mpack_version(self):
+        """
+        Retrieve mpack version from command.json, i.e "stack_version": "1.0.0-b224"
+        :return: mpack version string
+        """
+        return self.__get_value("stack_version")
+    
+    def get_user_groups(self):
+        """
+        Retrieve a list of ambari server user groups, i.e "user_groups": "{\"zookeeper\":[\"hadoop\"],\"ambari-qa\":[\"hadoop\"]}"
+        :return: String, as a user group dict object
+        """
+        return self.__get_value("user_groups")
+    '''
+
+    def get_group_list(self):
+        """
+        Retrieve a list of user groups from command.json, i.e "group_list": "[\"hadoop\"]"
+        :return: a list of groups
+        """
+        group_list = self.__get_value("group_list")
+        if not group_list:
+            group_list = "[]"
+        return group_list
+
+    def get_user_list(self):
+        """
+        Retrieve a list of users from command.json, i.e "user_list": "[\"zookeeper\",\"ambari-qa\"]"
+        :return: a list of users
+        """
+        user_list = self.__get_value("user_list")
+        if not user_list:
+            user_list = "[]"
+        return user_list
+
+    def get_stack_features(self):
+        """
+        Retrieve a string represents a dict of stack features
+        :return: String, can be loaded as python dict
+        """
+        return self.__get_value("stack_features")
+
+    def get_stack_packages(self):
+        """
+        Retrieve a string represents a list of packages can be installed from the stack
+        :return: String, can be loaded as python dict
+        """
+        return self.__get_value("stack_packages")
+
+    def get_stack_tools(self):
+        """
+        Retrieve a list of stack select tools
+        :return: String, can be loaded as python dict
+        """
+        return self.__get_value("stack_tools")

--- a/ambari-common/src/main/python/resource_management/libraries/functions/expect.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/expect.py
@@ -28,7 +28,7 @@ from resource_management.core.exceptions import Fail
 def expect(name, expected_type, default_value=None):
   """
   Expect configuration to be of certain type. If it is not, give a reasonable error message to user.
-  
+
   Optionally if the configuration is not found default_value for it can be returned.
   """
   subdicts = filter(None, name.split('/'))
@@ -42,7 +42,7 @@ def expect(name, expected_type, default_value=None):
         return default_value
       return UnknownConfiguration(curr_dict[-1])
   value = curr_dict
-  
+
   if expected_type == bool:
     if isinstance(value, bool):
       return value
@@ -56,6 +56,42 @@ def expect(name, expected_type, default_value=None):
     else:
       type_name = type(value).__name__
       raise Fail("Configuration {0} expected to be boolean (true or false), but found instance of unknown type '{1}'".format(name, type_name))
+  elif expected_type in [int, long, float]:
+    try:
+      value = expected_type(value)
+    except (ValueError, TypeError):
+      raise Fail("Configuration {0} expected to be number, but found '{1}'".format(name, value))
+  return value
+
+
+def expect_v2(name, expected_type, default_value=None):
+  """
+  Expect configuration to be of certain type. If it is not, give a reasonable error message to user.
+
+  Optionally if the configuration is not found default_value for it can be returned.
+  """
+
+  value = Script.get_execution_command().get_value(name, default_value)
+  if not value:
+    return UnknownConfiguration(name)
+  elif value == default_value:
+    return value
+
+  if expected_type == bool:
+    if isinstance(value, bool):
+      return value
+    elif isinstance(value, basestring):
+      if value != None and value.lower() == "true":
+        value = True
+      elif value != None and value.lower() == "false":
+        value = False
+      else:
+        raise Fail("Configuration {0} expected to be boolean (true or false), but found '{1}'".format(name, value))
+    else:
+      type_name = type(value).__name__
+      raise Fail(
+        "Configuration {0} expected to be boolean (true or false), but found instance of unknown type '{1}'".format(
+          name, type_name))
   elif expected_type in [int, long, float]:
     try:
       value = expected_type(value)

--- a/ambari-server/src/test/python/TestExecutionCommand.py
+++ b/ambari-server/src/test/python/TestExecutionCommand.py
@@ -1,0 +1,292 @@
+'''
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+from unittest import TestCase
+from resource_management.core.logger import Logger
+from resource_management.libraries.execution_command import execution_command
+
+import sys
+import json
+
+command_data_file = "TestExecutionCommand_command.json"
+
+class TestExecutionCommand(TestCase):
+
+    def setUp(self):
+        Logger.initialize_logger()
+        try:
+            with open(command_data_file) as f:
+                self.__execution_command = execution_command.ExecutionCommand(json.load(f))
+                from resource_management.libraries.script import Script
+                Script.execution_command = self.__execution_command
+                Script.module_configs = Script.get_module_configs()
+                Script.stack_settings = Script.get_stack_settings()
+                Script.cluster_settings = Script.get_cluster_settings()
+        except IOError:
+            Logger.error("Can not read json file with command parameters: ")
+            sys.exit(1)
+
+    def test_get_module_name(self):
+        module_name = self.__execution_command.get_module_name()
+        self.assertEquals(module_name, "HDFS")
+
+    # TODO : Check if this will be part of _hosts info in clusterHostInfo.
+    '''
+    def test_get_oozie_server_hosts(self):
+        oozie_server = self.__execution_command.get_component_hosts('oozie_server')
+        self.assertEqual(oozie_server, 'host2')
+
+    def test_get_ganglia_server_hosts(self):
+        ganglia_server_hosts = self.__execution_command.get_component_hosts('ganglia_server')
+        self.assertEqual(ganglia_server_hosts, 'host1')
+    '''
+
+    def test_get_java_version(self):
+        java_version = self.__execution_command.get_java_version()
+        self.assertEqual(java_version, 8)
+
+    def test_get_module_configs(self):
+        module_configs = self.__execution_command.get_module_configs()
+        self.assertNotEquals(module_configs, None)
+
+        zookeeper_client_port = module_configs.get_property_value("zookeeper", "zoo.cfg", "clientPort")
+        self.assertEquals(int(zookeeper_client_port), 2181)
+
+        zookeeper_client_port_fake = module_configs.get_property_value("zookeeper", "zoo.cfg", "clientPort1")
+        self.assertEquals(zookeeper_client_port_fake, None)
+
+        zookeeper_client_port_default_value = module_configs.get_property_value("zookeeper", "zoo.cfg", "clientPort1", 1111)
+        self.assertEquals(int(zookeeper_client_port_default_value), 1111)
+
+        zookeeper_empty_value = module_configs.get_all_properties("zookeeper", "zoo_fake")
+        self.assertEquals(zookeeper_empty_value, {})
+
+        zookeeper_log_max_backup_size = module_configs.get_property_value('zookeeper', 'zookeeper-log4j',
+                                                                          'zookeeper_log_max_backup_size', 10)
+        self.assertEquals(zookeeper_log_max_backup_size, u'10')
+
+        properties = module_configs.get_properties("zookeeper", "zoo.cfg", ['clientPort', 'dataDir', 'fake'])
+        self.assertEqual(int(properties.get('clientPort')), 2181)
+        self.assertEqual(properties.get('fake'), None)
+
+        sqoop = bool(module_configs.get_all_properties("zookeeper", 'sqoop-env'))
+        self.assertFalse(sqoop)
+
+    def test_access_to_module_configs(self):
+        module_configs = self.__execution_command.get_module_configs()
+
+        is_zoo_cfg_there = bool(module_configs.get_all_properties("zookeeper", "zoo.cfg"))
+        self.assertTrue(is_zoo_cfg_there)
+
+        zoo_cfg = module_configs.get_all_properties("zookeeper", "zoo.cfg")
+        self.assertTrue(isinstance(zoo_cfg, dict))
+
+    def test_null_value(self):
+        versions = self.__execution_command.get_value("Versions")
+        self.assertEqual(versions, None)
+
+        versions = self.__execution_command.get_value("Versions", "1.1.1.a")
+        self.assertEqual(versions, "1.1.1.a")
+
+        module_configs = self.__execution_command.get_module_configs()
+        version = module_configs.get_property_value("zookeeper", "zoo.cfg", "version")
+        self.assertEqual(version, None)
+
+        version = module_configs.get_property_value("zookeeper", "zoo.cfg", "version", "3.0.b")
+        self.assertEqual(version, "3.0.b")
+
+    def test_access_to_stack_settings(self):
+        stack_settings = self.__execution_command.get_stack_settings()
+
+        stack_name = stack_settings.get_mpack_name()
+        self.assertEquals(stack_name, "HDP")
+
+        stack_features = stack_settings.get_stack_features()
+        self.assertTrue("snappy" in stack_features)
+
+        stack_package = stack_settings.get_stack_packages()
+        self.assertTrue("ACCUMULO" in stack_package)
+
+        stack_tools = stack_settings.get_stack_tools()
+        self.assertTrue("conf_selector" in stack_tools)
+
+    def test_access_to_cluster_settings(self):
+        cluster_settings = self.__execution_command.get_cluster_settings()
+
+        security_enabled = cluster_settings.is_cluster_security_enabled()
+        self.assertFalse(security_enabled)
+
+        recovery_count = cluster_settings.get_recovery_max_count()
+        self.assertEqual(recovery_count, 6)
+
+        recovery_enabled = cluster_settings.check_recovery_enabled()
+        self.assertTrue(recovery_enabled)
+
+        recovery_type = cluster_settings.get_recovery_type()
+        self.assertEqual(recovery_type, "AUTO_START")
+
+        kerberos_domain = cluster_settings.get_kerberos_domain()
+        self.assertEqual(kerberos_domain, "EXAMPLE.COM")
+
+        smoke_user = cluster_settings.get_smokeuser()
+        self.assertEqual(smoke_user, "ambari-qa")
+
+        user_group = cluster_settings.get_user_group()
+        self.assertEqual(user_group, "hadoop")
+
+        suse_rhel_template = cluster_settings.get_repo_suse_rhel_template()
+        self.assertTrue("if mirror_list" in suse_rhel_template)
+
+        ubuntu_template = cluster_settings.get_repo_ubuntu_template()
+        self.assertTrue("package_type" in ubuntu_template)
+
+        override_uid = cluster_settings.check_override_uid()
+        self.assertTrue(override_uid)
+
+        skip_copy = cluster_settings.check_sysprep_skip_copy_fast_jar_hdfs()
+        self.assertFalse(skip_copy)
+
+        skip_lzo = cluster_settings.check_sysprep_skip_lzo_package_operations()
+        self.assertFalse(skip_lzo)
+
+        skip_setup_jce = cluster_settings.check_sysprep_skip_setup_jce()
+        self.assertFalse(skip_setup_jce)
+
+        ignored = cluster_settings.check_ignore_groupsusers_create()
+        self.assertFalse(ignored)
+
+    def test_access_to_execution_command(self):
+        exec_cmd = self.__execution_command
+
+        comp_type = exec_cmd.get_component_type()
+        self.assertEqual(comp_type, "NAMENODE")
+
+        comp_name = exec_cmd.get_component_instance_name()
+        self.assertEqual(comp_name, "HDFS")
+
+        cluster_name = exec_cmd.get_cluster_name()
+        self.assertEqual(cluster_name, "c1")
+
+        repo_file = exec_cmd.get_repository_file()
+        expected = {u'resolved': True, u'repoVersion': u'3.0.1.0-187', u'repositories': [{u'mirrorsList': None, u'tags': [], u'ambariManaged': True, u'baseUrl': u'http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.0.1.0-187', u'repoName': u'HDP', u'components': None, u'distribution': None, u'repoId': u'HDP-3.0-repo-1', u'applicableServices': []}, {u'mirrorsList': None, u'tags': [u'GPL'], u'ambariManaged': True, u'baseUrl': u'http://s3.amazonaws.com/dev.hortonworks.com/HDP-GPL/centos7/3.x/BUILDS/3.0.1.0-187', u'repoName': u'HDP-GPL', u'components': None, u'distribution': None, u'repoId': u'HDP-3.0-GPL-repo-1', u'applicableServices': []}, {u'mirrorsList': None, u'tags': [], u'ambariManaged': True, u'baseUrl': u'http://s3.amazonaws.com/dev.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7', u'repoName': u'HDP-UTILS', u'components': None, u'distribution': None, u'repoId': u'HDP-UTILS-1.1.0.22-repo-1', u'applicableServices': []}], u'feature': {u'preInstalled': False, u'scoped': True}, u'stackName': u'HDP', u'repoVersionId': 1, u'repoFileName': u'ambari-hdp-1'}
+        self.assertDictEqual(expected, repo_file)
+
+        local_components = exec_cmd.get_local_components()
+        expected = ["NAMENODE", "ZOOKEEPER_SERVER"]
+        self.assertListEqual(expected, local_components)
+
+        role_cmd = exec_cmd.get_role_command()
+        self.assertEqual(role_cmd, "START")
+
+        jdk_loc = exec_cmd.get_jdk_location()
+        self.assertEqual(jdk_loc, "http://host-1.openstacklocal:8080/resources")
+
+        jdk_name = exec_cmd.get_jdk_name()
+        self.assertEqual(jdk_name, "jdk-8u112-linux-x64.tar.gz")
+
+        java_ver = exec_cmd.get_java_version()
+        self.assertEqual(java_ver, 8)
+
+        jce_name = exec_cmd.get_jce_name()
+        self.assertEqual(jce_name, "jce_policy-8.zip")
+
+        db_driver_file_name = exec_cmd.get_db_driver_file_name()
+        self.assertEqual(db_driver_file_name, "mysql-connector-java.jar")
+
+        db_name = exec_cmd.get_db_name()
+        self.assertEqual(db_name, "ambari")
+
+        oracle_jdbc_url = exec_cmd.get_oracle_jdbc_url()
+        self.assertEqual(oracle_jdbc_url, "http://host-1.openstacklocal:8080/resources/ojdbc6.jar")
+
+        mysql_jdbc_url = exec_cmd.get_mysql_jdbc_url()
+        self.assertEqual(mysql_jdbc_url, "http://host-1.openstacklocal:8080/resources/mysql-connector-java.jar")
+
+        agent_stack_retry_count = exec_cmd.get_agent_stack_retry_count()
+        self.assertEqual(agent_stack_retry_count, 5)
+
+        agent_stack_want_retry_on_unavailability = exec_cmd.check_agent_stack_want_retry_on_unavailability()
+        self.assertEqual(agent_stack_want_retry_on_unavailability, 'false')
+
+        ambari_server_host = exec_cmd.get_ambari_server_host()
+        self.assertEqual(ambari_server_host, 'host-1.openstacklocal')
+
+        ambari_server_port = exec_cmd.get_ambari_server_port()
+        self.assertEqual(ambari_server_port, '8080')
+
+        ambari_server_use_ssl = exec_cmd.is_ambari_server_use_ssl()
+        self.assertEqual(ambari_server_use_ssl, 'false')
+
+        gpl_license_accepted = exec_cmd.is_gpl_license_accepted()
+        self.assertEqual(gpl_license_accepted, 'false')
+
+        mpack_name = exec_cmd.get_mpack_name()
+        self.assertEqual(mpack_name, 'HDP')
+
+        mpack_version = exec_cmd.get_mpack_version()
+        self.assertEqual(mpack_version, '3.0')
+
+        user_groups = exec_cmd.get_user_groups()
+        self.assertEqual(user_groups, u'{"zookeeper":["hadoop"],"ambari-qa":["hadoop","users"],"hdfs":["hdfs","hadoop"]}')
+        group_list = exec_cmd.get_group_list()
+        self.assertEqual(group_list, u'["hdfs","hadoop","users"]')
+
+        user_list = exec_cmd.get_user_list()
+        self.assertEqual(user_list, u'["zookeeper","ambari-qa","hdfs"]')
+
+        host_name = exec_cmd.get_host_name()
+        self.assertEqual(host_name, 'host-1.openstacklocal')
+
+        agent_cache_dir = exec_cmd.get_agent_cache_dir()
+        self.assertEqual(agent_cache_dir, '/var/lib/ambari-agent/cache')
+
+        agent_config_execute_in_parallel = exec_cmd.check_agent_config_execute_in_parallel()
+        self.assertEqual(agent_config_execute_in_parallel, 0)
+
+        agent_proxy_settings = exec_cmd.check_agent_proxy_settings()
+        self.assertEqual(agent_proxy_settings, True)
+
+        unlimited_key_jce_required = exec_cmd.check_unlimited_key_jce_required()
+        self.assertEqual(unlimited_key_jce_required, 'false')
+
+        new_mpack_version_for_upgrade = exec_cmd.get_new_mpack_version_for_upgrade()
+        self.assertEqual(new_mpack_version_for_upgrade, '3.0.1.0-187')
+
+        command_retry_enabled = exec_cmd.check_command_retry_enabled()
+        self.assertEqual(command_retry_enabled, 'false')
+
+        dfs_type = exec_cmd.get_dfs_type()
+        self.assertEqual(dfs_type, 'HDFS')
+
+        module_package_folder = exec_cmd.get_module_package_folder()
+        self.assertEqual(module_package_folder, 'stacks/HDP/3.0/services/HDFS/package')
+
+        component_hosts = exec_cmd.get_component_hosts("secondary_namenode")
+        self.assertEqual(component_hosts, ['host-2.openstacklocal'])
+
+        component_hosts1 = exec_cmd.get_component_hosts("zookeeper_server")
+        self.assertListEqual(component_hosts1, ['host-2.openstacklocal', 'host-1.openstacklocal'])
+
+        all_hosts = exec_cmd.get_all_hosts()
+        self.assertEqual(all_hosts, ['host-2.openstacklocal', 'host-1.openstacklocal'])
+
+        all_racks = exec_cmd.get_all_racks()
+        self.assertEqual(all_racks, ['/default-rack', '/default-rack'])
+
+        all_ipv4_ips = exec_cmd.get_all_ipv4_ips()
+        self.assertEqual(all_ipv4_ips, ['10.10.10.10', '10.10.10.11'])

--- a/ambari-server/src/test/python/TestExecutionCommand_command.json
+++ b/ambari-server/src/test/python/TestExecutionCommand_command.json
@@ -1,0 +1,497 @@
+{
+  "localComponents": [
+    "NAMENODE",
+    "ZOOKEEPER_SERVER"
+  ],
+  "clusterId": "2",
+  "agentLevelParams": {
+    "public_hostname": "host-1.openstacklocal",
+    "hostname": "host-1.openstacklocal",
+    "agentConfigParams": {
+      "agent": {
+        "parallel_execution": 0,
+        "use_system_proxy_settings": true
+      }
+    },
+    "agentCacheDir": "/var/lib/ambari-agent/cache"
+  },
+  "commandId": "4-1",
+  "serviceLevelParams": {
+    "configuration_credentials": {},
+    "credentialStoreEnabled": false,
+    "status_commands_timeout": 300,
+    "version": "3.1.0",
+    "service_package_folder": "stacks/HDP/3.0/services/HDFS/package"
+  },
+  "repositoryFile": {
+    "resolved": true,
+    "repoVersion": "3.0.1.0-187",
+    "repositories": [
+      {
+        "mirrorsList": null,
+        "tags": [],
+        "ambariManaged": true,
+        "baseUrl": "http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.0.1.0-187",
+        "repoName": "HDP",
+        "components": null,
+        "distribution": null,
+        "repoId": "HDP-3.0-repo-1",
+        "applicableServices": []
+      },
+      {
+        "mirrorsList": null,
+        "tags": [
+          "GPL"
+        ],
+        "ambariManaged": true,
+        "baseUrl": "http://s3.amazonaws.com/dev.hortonworks.com/HDP-GPL/centos7/3.x/BUILDS/3.0.1.0-187",
+        "repoName": "HDP-GPL",
+        "components": null,
+        "distribution": null,
+        "repoId": "HDP-3.0-GPL-repo-1",
+        "applicableServices": []
+      },
+      {
+        "mirrorsList": null,
+        "tags": [],
+        "ambariManaged": true,
+        "baseUrl": "http://s3.amazonaws.com/dev.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7",
+        "repoName": "HDP-UTILS",
+        "components": null,
+        "distribution": null,
+        "repoId": "HDP-UTILS-1.1.0.22-repo-1",
+        "applicableServices": []
+      }
+    ],
+    "feature": {
+      "preInstalled": false,
+      "scoped": true
+    },
+    "stackName": "HDP",
+    "repoVersionId": 1,
+    "repoFileName": "ambari-hdp-1"
+  },
+  "componentLevelParams": {
+    "unlimited_key_jce_required": "false",
+    "clientsToUpdateConfigs": "[\"*\"]"
+  },
+  "clusterLevelParams": {
+    "cluster_name": "c1",
+    "not_managed_hdfs_path_list": "[\"/tmp\"]",
+    "hooks_folder": "stack-hooks",
+    "stack_name": "HDP",
+    "user_list": "[\"zookeeper\",\"ambari-qa\",\"hdfs\"]",
+    "group_list": "[\"hdfs\",\"hadoop\",\"users\"]",
+    "user_groups": "{\"zookeeper\":[\"hadoop\"],\"ambari-qa\":[\"hadoop\",\"users\"],\"hdfs\":[\"hdfs\",\"hadoop\"]}",
+    "stack_version": "3.0",
+    "dfs_type": "HDFS",
+    "blueprint_provisioning_state": "NONE"
+  },
+  "serviceName": "HDFS",
+  "role": "NAMENODE",
+  "requestId": 4,
+  "clusterHostInfo": {
+    "zookeeper_client_hosts": [
+      "host-2.openstacklocal"
+    ],
+    "all_hosts": [
+      "host-2.openstacklocal",
+      "host-1.openstacklocal"
+    ],
+    "zookeeper_server_hosts": [
+      "host-2.openstacklocal",
+      "host-1.openstacklocal"
+    ],
+    "secondary_namenode_hosts": [
+      "host-2.openstacklocal"
+    ],
+    "hdfs_client_hosts": [
+      "host-2.openstacklocal"
+    ],
+    "all_racks": [
+      "/default-rack",
+      "/default-rack"
+    ],
+    "datanode_hosts": [
+      "host-2.openstacklocal"
+    ],
+    "all_ipv4_ips": [
+      "10.10.10.10",
+      "10.10.10.11"
+    ],
+    "namenode_hosts": [
+      "host-1.openstacklocal"
+    ]
+  },
+  "clusterName": "c1",
+  "commandType": "EXECUTION_COMMAND",
+  "taskId": 15,
+  "componentVersionMap": {
+    "HDFS": {
+      "SECONDARY_NAMENODE": "3.0.1.0-187",
+      "JOURNALNODE": "3.0.1.0-187",
+      "HDFS_CLIENT": "3.0.1.0-187",
+      "DATANODE": "3.0.1.0-187",
+      "NAMENODE": "3.0.1.0-187",
+      "NFS_GATEWAY": "3.0.1.0-187",
+      "ZKFC": "3.0.1.0-187"
+    },
+    "ZOOKEEPER": {
+      "ZOOKEEPER_SERVER": "3.0.1.0-187",
+      "ZOOKEEPER_CLIENT": "3.0.1.0-187"
+    }
+  },
+  "requiredConfigTimestamp": 1538508955998,
+  "ambariLevelParams": {
+    "jdk_location": "http://host-1.openstacklocal:8080/resources",
+    "agent_stack_retry_count": "5",
+    "java_home": "/usr/jdk64/jdk1.8.0_112",
+    "agent_stack_retry_on_unavailability": "false",
+    "ambari_db_rca_url": "jdbc:postgresql://host-1.openstacklocal/ambarirca",
+    "jce_name": "jce_policy-8.zip",
+    "java_version": "8",
+    "oracle_jdbc_url": "http://host-1.openstacklocal:8080/resources/ojdbc6.jar",
+    "ambari_server_host": "host-1.openstacklocal",
+    "ambari_db_rca_password": "mapred",
+    "gpl_license_accepted": "false",
+    "ambari_server_port": "8080",
+    "host_sys_prepped": "false",
+    "db_name": "ambari",
+    "ambari_db_rca_driver": "org.postgresql.Driver",
+    "ambari_server_use_ssl": "false",
+    "jdk_name": "jdk-8u112-linux-x64.tar.gz",
+    "ambari_db_rca_username": "mapred",
+    "db_driver_filename": "mysql-connector-java.jar",
+    "mysql_jdbc_url": "http://host-1.openstacklocal:8080/resources/mysql-connector-java.jar"
+  },
+  "roleCommand": "START",
+  "configurationAttributes": {
+    "ranger-hdfs-audit": {},
+    "ssl-client": {},
+    "ranger-hdfs-plugin-properties": {},
+    "ssl-server": {},
+    "ranger-hdfs-policymgr-ssl": {},
+    "core-site": {
+      "final": {
+        "fs.defaultFS": "true"
+      }
+    },
+    "viewfs-mount-table": {},
+    "zoo.cfg": {},
+    "ranger-hdfs-security": {},
+    "hdfs-site": {
+      "final": {
+        "dfs.datanode.failed.volumes.tolerated": "true",
+        "dfs.datanode.data.dir": "true",
+        "dfs.namenode.http-address": "true",
+        "dfs.namenode.name.dir": "true",
+        "dfs.webhdfs.enabled": "true"
+      }
+    },
+    "hadoop-metrics2.properties": {},
+    "hadoop-policy": {},
+    "hdfs-log4j": {},
+    "hadoop-env": {},
+    "zookeeper-env": {},
+    "zookeeper-log4j": {},
+    "cluster-env": {}
+  },
+  "hostLevelParams": {
+    "recoveryConfig": {
+      "components": []
+    },
+    "hostRepositories": {
+      "componentRepos": {
+        "ZOOKEEPER_SERVER": 1,
+        "NAMENODE": 1
+      },
+      "commandRepos": {
+        "1": {
+          "resolved": false,
+          "repoVersion": "3.0.1.0",
+          "repositories": [
+            {
+              "mirrorsList": null,
+              "tags": [],
+              "ambariManaged": true,
+              "baseUrl": "http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.0.1.0-187",
+              "repoName": "HDP",
+              "components": null,
+              "distribution": null,
+              "repoId": "HDP-3.0-repo-1",
+              "applicableServices": []
+            },
+            {
+              "mirrorsList": null,
+              "tags": [
+                "GPL"
+              ],
+              "ambariManaged": true,
+              "baseUrl": "http://s3.amazonaws.com/dev.hortonworks.com/HDP-GPL/centos7/3.x/BUILDS/3.0.1.0-187",
+              "repoName": "HDP-GPL",
+              "components": null,
+              "distribution": null,
+              "repoId": "HDP-3.0-GPL-repo-1",
+              "applicableServices": []
+            },
+            {
+              "mirrorsList": null,
+              "tags": [],
+              "ambariManaged": true,
+              "baseUrl": "http://s3.amazonaws.com/dev.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7",
+              "repoName": "HDP-UTILS",
+              "components": null,
+              "distribution": null,
+              "repoId": "HDP-UTILS-1.1.0.22-repo-1",
+              "applicableServices": []
+            }
+          ],
+          "feature": {
+            "preInstalled": false,
+            "scoped": true
+          },
+          "stackName": "HDP",
+          "repoVersionId": 1,
+          "repoFileName": "ambari-hdp-1"
+        }
+      }
+    }
+  },
+  "commandParams": {
+    "service_package_folder": "stacks/HDP/3.0/services/HDFS/package",
+    "hooks_folder": "stack-hooks",
+    "script": "scripts/namenode.py",
+    "version": "3.0.1.0-187",
+    "max_duration_for_retries": "0",
+    "command_retry_enabled": "false",
+    "command_timeout": "1800",
+    "refresh_topology": "True",
+    "script_type": "PYTHON"
+  },
+  "configurations": {
+    "ranger-hdfs-audit": {},
+    "ssl-client": {
+      "ssl.client.truststore.reload.interval": "10000",
+      "ssl.client.keystore.password": "",
+      "ssl.client.keystore.location": "",
+      "ssl.client.truststore.type": "jks",
+      "ssl.client.truststore.location": "",
+      "ssl.client.truststore.password": "",
+      "ssl.client.keystore.type": "jks"
+    },
+    "ranger-hdfs-plugin-properties": {},
+    "ssl-server": {
+      "ssl.server.truststore.type": "jks",
+      "ssl.server.keystore.keypassword": "bigdata",
+      "ssl.server.truststore.location": "/etc/security/serverKeys/all.jks",
+      "ssl.server.keystore.password": "bigdata",
+      "ssl.server.truststore.password": "bigdata",
+      "ssl.server.keystore.location": "/etc/security/serverKeys/keystore.jks",
+      "ssl.server.keystore.type": "jks",
+      "ssl.server.truststore.reload.interval": "10000"
+    },
+    "ranger-hdfs-policymgr-ssl": {},
+    "core-site": {
+      "net.topology.script.file.name": "/etc/hadoop/conf/topology_script.py",
+      "fs.s3a.fast.upload": "true",
+      "hadoop.security.instrumentation.requires.admin": "false",
+      "fs.s3a.fast.upload.buffer": "disk",
+      "fs.s3a.multipart.size": "67108864",
+      "fs.trash.interval": "360",
+      "fs.azure.user.agent.prefix": "User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}",
+      "ipc.server.tcpnodelay": "true",
+      "io.compression.codecs": "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.SnappyCodec",
+      "hadoop.proxyuser.root.groups": "*",
+      "hadoop.http.cross-origin.allowed-headers": "X-Requested-With,Content-Type,Accept,Origin,WWW-Authenticate,Accept-Encoding,Transfer-Encoding",
+      "ipc.client.connect.max.retries": "50",
+      "ipc.client.idlethreshold": "8000",
+      "io.file.buffer.size": "131072",
+      "fs.s3a.user.agent.prefix": "User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}",
+      "io.serializations": "org.apache.hadoop.io.serializer.WritableSerialization",
+      "hadoop.security.authentication": "simple",
+      "hadoop.http.filter.initializers": "org.apache.hadoop.security.AuthenticationFilterInitializer,org.apache.hadoop.security.HttpCrossOriginFilterInitializer",
+      "hadoop.proxyuser.root.hosts": "host-1.openstacklocal",
+      "mapreduce.jobtracker.webinterface.trusted": "false",
+      "hadoop.http.cross-origin.allowed-methods": "GET,PUT,POST,OPTIONS,HEAD,DELETE",
+      "hadoop.http.cross-origin.max-age": "1800",
+      "hadoop.proxyuser.hdfs.hosts": "*",
+      "fs.defaultFS": "hdfs://host-1.openstacklocal:8020",
+      "ha.failover-controller.active-standby-elector.zk.op.retries": "120",
+      "hadoop.security.authorization": "false",
+      "hadoop.http.authentication.simple.anonymous.allowed": "true",
+      "hadoop.proxyuser.hdfs.groups": "*",
+      "hadoop.security.auth_to_local": "DEFAULT",
+      "hadoop.http.cross-origin.allowed-origins": "*",
+      "ipc.client.connection.maxidletime": "30000"
+    },
+    "viewfs-mount-table": {
+      "content": " "
+    },
+    "zoo.cfg": {
+      "clientPort": "2181",
+      "autopurge.purgeInterval": "24",
+      "syncLimit": "5",
+      "dataDir": "/hadoop/zookeeper",
+      "initLimit": "10",
+      "tickTime": "3000",
+      "autopurge.snapRetainCount": "30"
+    },
+    "ranger-hdfs-security": {},
+    "hdfs-site": {
+      "dfs.namenode.avoid.write.stale.datanode": "true",
+      "dfs.namenode.startup.delay.block.deletion.sec": "3600",
+      "dfs.namenode.checkpoint.txns": "1000000",
+      "dfs.heartbeat.interval": "3",
+      "dfs.content-summary.limit": "5000",
+      "dfs.datanode.address": "0.0.0.0:50010",
+      "dfs.cluster.administrators": " hdfs",
+      "dfs.replication": "3",
+      "dfs.namenode.audit.log.async": "true",
+      "dfs.datanode.balance.bandwidthPerSec": "6250000",
+      "dfs.namenode.safemode.threshold-pct": "1",
+      "dfs.namenode.checkpoint.edits.dir": "${dfs.namenode.checkpoint.dir}",
+      "dfs.namenode.rpc-address": "host-1.openstacklocal:8020",
+      "dfs.permissions.enabled": "true",
+      "dfs.client.read.shortcircuit": "true",
+      "dfs.journalnode.https-address": "0.0.0.0:8481",
+      "dfs.namenode.https-address": "host-1.openstacklocal:50470",
+      "nfs.file.dump.dir": "/tmp/.hdfs-nfs",
+      "dfs.blocksize": "134217728",
+      "dfs.journalnode.edits.dir": "/hadoop/hdfs/journalnode",
+      "dfs.namenode.fslock.fair": "false",
+      "dfs.datanode.max.transfer.threads": "4096",
+      "hadoop.caller.context.enabled": "true",
+      "dfs.webhdfs.enabled": "true",
+      "dfs.namenode.handler.count": "50",
+      "dfs.namenode.checkpoint.dir": "/hadoop/hdfs/namesecondary",
+      "fs.permissions.umask-mode": "022",
+      "dfs.datanode.http.address": "0.0.0.0:50075",
+      "dfs.datanode.ipc.address": "0.0.0.0:8010",
+      "dfs.namenode.name.dir": "/hadoop/hdfs/namenode,/grid/0/hadoop/hdfs/namenode",
+      "dfs.datanode.failed.volumes.tolerated": "0",
+      "dfs.namenode.acls.enabled": "true",
+      "dfs.datanode.data.dir": "/hadoop/hdfs/data,/grid/0/hadoop/hdfs/data",
+      "manage.include.files": "false",
+      "dfs.blockreport.initialDelay": "120",
+      "dfs.encrypt.data.transfer.cipher.suites": "AES/CTR/NoPadding",
+      "dfs.namenode.accesstime.precision": "0",
+      "dfs.datanode.https.address": "0.0.0.0:50475",
+      "dfs.namenode.write.stale.datanode.ratio": "1.0f",
+      "dfs.namenode.secondary.http-address": "host-2.openstacklocal:50090",
+      "nfs.exports.allowed.hosts": "* rw",
+      "dfs.namenode.stale.datanode.interval": "30000",
+      "dfs.datanode.du.reserved": "33011188224",
+      "dfs.client.read.shortcircuit.streams.cache.size": "4096",
+      "dfs.http.policy": "HTTP_ONLY",
+      "dfs.block.access.token.enable": "true",
+      "dfs.namenode.http-address": "host-1.openstacklocal:50070",
+      "dfs.client.retry.policy.enabled": "false",
+      "dfs.permissions.superusergroup": "hdfs",
+      "dfs.https.port": "50470",
+      "dfs.journalnode.http-address": "0.0.0.0:8480",
+      "dfs.domain.socket.path": "/var/lib/hadoop-hdfs/dn_socket",
+      "dfs.namenode.avoid.read.stale.datanode": "true",
+      "dfs.hosts.exclude": "/etc/hadoop/conf/dfs.exclude",
+      "dfs.datanode.data.dir.perm": "750",
+      "dfs.namenode.name.dir.restore": "true",
+      "dfs.replication.max": "50",
+      "dfs.namenode.checkpoint.period": "21600"
+    },
+    "hadoop-metrics2.properties": {
+      "content": "\n{% if has_ganglia_server %}\n*.period=60\n\n*.sink.ganglia.class=org.apache.hadoop.metrics2.sink.ganglia.GangliaSink31\n*.sink.ganglia.period=10\n\n# default for supportsparse is false\n*.sink.ganglia.supportsparse=true\n\n.sink.ganglia.slope=jvm.metrics.gcCount=zero,jvm.metrics.memHeapUsedM=both\n.sink.ganglia.dmax=jvm.metrics.threadsBlocked=70,jvm.metrics.memHeapUsedM=40\n\n# Hook up to the server\nnamenode.sink.ganglia.servers={{ganglia_server_host}}:8661\ndatanode.sink.ganglia.servers={{ganglia_server_host}}:8659\njobtracker.sink.ganglia.servers={{ganglia_server_host}}:8662\ntasktracker.sink.ganglia.servers={{ganglia_server_host}}:8658\nmaptask.sink.ganglia.servers={{ganglia_server_host}}:8660\nreducetask.sink.ganglia.servers={{ganglia_server_host}}:8660\nresourcemanager.sink.ganglia.servers={{ganglia_server_host}}:8664\nnodemanager.sink.ganglia.servers={{ganglia_server_host}}:8657\nhistoryserver.sink.ganglia.servers={{ganglia_server_host}}:8666\njournalnode.sink.ganglia.servers={{ganglia_server_host}}:8654\nnimbus.sink.ganglia.servers={{ganglia_server_host}}:8649\nsupervisor.sink.ganglia.servers={{ganglia_server_host}}:8650\n\nresourcemanager.sink.ganglia.tagsForPrefix.yarn=Queue\n\n{% endif %}\n\n{% if has_metric_collector %}\n\n*.period={{metrics_collection_period}}\n*.sink.timeline.plugin.urls=file:///usr/lib/ambari-metrics-hadoop-sink/ambari-metrics-hadoop-sink.jar\n*.sink.timeline.class=org.apache.hadoop.metrics2.sink.timeline.HadoopTimelineMetricsSink\n*.sink.timeline.period={{metrics_collection_period}}\n*.sink.timeline.sendInterval={{metrics_report_interval}}000\n*.sink.timeline.slave.host.name={{hostname}}\n*.sink.timeline.zookeeper.quorum={{zookeeper_quorum}}\n*.sink.timeline.protocol={{metric_collector_protocol}}\n*.sink.timeline.port={{metric_collector_port}}\n*.sink.timeline.instanceId = {{cluster_name}}\n*.sink.timeline.set.instanceId = {{set_instanceId}}\n*.sink.timeline.host_in_memory_aggregation = {{host_in_memory_aggregation}}\n*.sink.timeline.host_in_memory_aggregation_port = {{host_in_memory_aggregation_port}}\n{% if is_aggregation_https_enabled %}\n*.sink.timeline.host_in_memory_aggregation_protocol = {{host_in_memory_aggregation_protocol}}\n{% endif %}\n\n# HTTPS properties\n*.sink.timeline.truststore.path = {{metric_truststore_path}}\n*.sink.timeline.truststore.type = {{metric_truststore_type}}\n*.sink.timeline.truststore.password = {{metric_truststore_password}}\n\ndatanode.sink.timeline.collector.hosts={{ams_collector_hosts}}\nnamenode.sink.timeline.collector.hosts={{ams_collector_hosts}}\nresourcemanager.sink.timeline.collector.hosts={{ams_collector_hosts}}\nnodemanager.sink.timeline.collector.hosts={{ams_collector_hosts}}\njobhistoryserver.sink.timeline.collector.hosts={{ams_collector_hosts}}\njournalnode.sink.timeline.collector.hosts={{ams_collector_hosts}}\nmaptask.sink.timeline.collector.hosts={{ams_collector_hosts}}\nreducetask.sink.timeline.collector.hosts={{ams_collector_hosts}}\napplicationhistoryserver.sink.timeline.collector.hosts={{ams_collector_hosts}}\n\nresourcemanager.sink.timeline.tagsForPrefix.yarn=Queue\n\n{% if is_nn_client_port_configured %}\n# Namenode rpc ports customization\nnamenode.sink.timeline.metric.rpc.client.port={{nn_rpc_client_port}}\n{% endif %}\n{% if is_nn_dn_port_configured %}\nnamenode.sink.timeline.metric.rpc.datanode.port={{nn_rpc_dn_port}}\n{% endif %}\n{% if is_nn_healthcheck_port_configured %}\nnamenode.sink.timeline.metric.rpc.healthcheck.port={{nn_rpc_healthcheck_port}}\n{% endif %}\n\n{% endif %}"
+    },
+    "hadoop-policy": {
+      "security.job.client.protocol.acl": "*",
+      "security.job.task.protocol.acl": "*",
+      "security.datanode.protocol.acl": "*",
+      "security.namenode.protocol.acl": "*",
+      "security.client.datanode.protocol.acl": "*",
+      "security.inter.tracker.protocol.acl": "*",
+      "security.refresh.usertogroups.mappings.protocol.acl": "hadoop",
+      "security.client.protocol.acl": "*",
+      "security.refresh.policy.protocol.acl": "hadoop",
+      "security.admin.operations.protocol.acl": "hadoop",
+      "security.inter.datanode.protocol.acl": "*"
+    },
+    "hdfs-log4j": {
+      "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#  http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n\n\n# Define some default values that can be overridden by system properties\n# To change daemon root logger use hadoop_root_logger in hadoop-env\nhadoop.root.logger=INFO,console\nhadoop.log.dir=.\nhadoop.log.file=hadoop.log\n\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hadoop.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshhold=ALL\n\n#\n# Daily Rolling File Appender\n#\n\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hadoop.log.dir}/${hadoop.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n#\n# TaskLog Appender\n#\n\n#Default values\nhadoop.tasklog.taskid=null\nhadoop.tasklog.iscleanup=false\nhadoop.tasklog.noKeepSplits=4\nhadoop.tasklog.totalLogFileSize=100\nhadoop.tasklog.purgeLogSplits=true\nhadoop.tasklog.logsRetainHours=12\n\nlog4j.appender.TLA=org.apache.hadoop.mapred.TaskLogAppender\nlog4j.appender.TLA.taskId=${hadoop.tasklog.taskid}\nlog4j.appender.TLA.isCleanup=${hadoop.tasklog.iscleanup}\nlog4j.appender.TLA.totalLogFileSize=${hadoop.tasklog.totalLogFileSize}\n\nlog4j.appender.TLA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.TLA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n\n#\n#Security audit appender\n#\nhadoop.security.logger=INFO,console\nhadoop.security.log.maxfilesize={{hadoop_security_log_max_backup_size}}MB\nhadoop.security.log.maxbackupindex={{hadoop_security_log_number_of_backup_files}}\nlog4j.category.SecurityLogger=${hadoop.security.logger}\nhadoop.security.log.file=SecurityAuth.audit\nlog4j.additivity.SecurityLogger=false\nlog4j.appender.DRFAS=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}\nlog4j.appender.DRFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.DRFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.appender.DRFAS.DatePattern=.yyyy-MM-dd\n\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.appender.RFAS.MaxFileSize=${hadoop.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hadoop.security.log.maxbackupindex}\n\n#\n# hdfs audit logging\n#\nhdfs.audit.logger=INFO,console\nlog4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=${hdfs.audit.logger}\nlog4j.additivity.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=false\nlog4j.appender.DRFAAUDIT=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFAAUDIT.File=${hadoop.log.dir}/hdfs-audit.log\nlog4j.appender.DRFAAUDIT.layout=org.apache.log4j.PatternLayout\nlog4j.appender.DRFAAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.DRFAAUDIT.DatePattern=.yyyy-MM-dd\n\n#\n# NameNode metrics logging.\n# The default is to retain two namenode-metrics.log files up to 64MB each.\n#\nnamenode.metrics.logger=INFO,NullAppender\nlog4j.logger.NameNodeMetricsLog=${namenode.metrics.logger}\nlog4j.additivity.NameNodeMetricsLog=false\nlog4j.appender.NNMETRICSRFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.NNMETRICSRFA.File=${hadoop.log.dir}/namenode-metrics.log\nlog4j.appender.NNMETRICSRFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.NNMETRICSRFA.layout.ConversionPattern=%d{ISO8601} %m%n\nlog4j.appender.NNMETRICSRFA.MaxBackupIndex=1\nlog4j.appender.NNMETRICSRFA.MaxFileSize=64MB\n\n#\n# mapred audit logging\n#\nmapred.audit.logger=INFO,console\nlog4j.logger.org.apache.hadoop.mapred.AuditLogger=${mapred.audit.logger}\nlog4j.additivity.org.apache.hadoop.mapred.AuditLogger=false\nlog4j.appender.MRAUDIT=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.MRAUDIT.File=${hadoop.log.dir}/mapred-audit.log\nlog4j.appender.MRAUDIT.layout=org.apache.log4j.PatternLayout\nlog4j.appender.MRAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.MRAUDIT.DatePattern=.yyyy-MM-dd\n\n#\n# Rolling File Appender\n#\n\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hadoop.log.dir}/${hadoop.log.file}\n\n# Logfile size and and 30-day backups\nlog4j.appender.RFA.MaxFileSize={{hadoop_log_max_backup_size}}MB\nlog4j.appender.RFA.MaxBackupIndex={{hadoop_log_number_of_backup_files}}\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} - %m%n\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n# Custom Logging levels\n\nhadoop.metrics.log.level=INFO\n#log4j.logger.org.apache.hadoop.mapred.JobTracker=DEBUG\n#log4j.logger.org.apache.hadoop.mapred.TaskTracker=DEBUG\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.metrics2=${hadoop.metrics.log.level}\n\n# Jets3t library\nlog4j.logger.org.jets3t.service.impl.rest.httpclient.RestS3Service=ERROR\n\n#\n# Null Appender\n# Trap security logger on the hadoop client side\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter\n\n# Removes \"deprecated\" messages\nlog4j.logger.org.apache.hadoop.conf.Configuration.deprecation=WARN\n\n#\n# HDFS block state change log from block manager\n#\n# Uncomment the following to suppress normal block state change\n# messages from BlockManager in NameNode.\n#log4j.logger.BlockStateChange=WARN\n\n# Adding logging for 3rd party library\nlog4j.logger.org.apache.commons.beanutils=WARN",
+      "hadoop_security_log_max_backup_size": "256",
+      "hadoop_log_max_backup_size": "256",
+      "hadoop_log_number_of_backup_files": "10",
+      "hadoop_security_log_number_of_backup_files": "20"
+    },
+    "hadoop-env": {
+      "hadoop_root_logger": "INFO,RFA",
+      "namenode_opt_maxnewsize": "128m",
+      "hdfs_user_nproc_limit": "65536",
+      "hdfs_log_dir_prefix": "/var/log/hadoop",
+      "keyserver_host": " ",
+      "hdfs_user": "hdfs",
+      "namenode_backup_dir": "/tmp/upgrades",
+      "keyserver_port": "",
+      "proxyuser_group": "users",
+      "hadoop_pid_dir_prefix": "/var/run/hadoop",
+      "content": "\n      # Set Hadoop-specific environment variables here.\n\n      # The only required environment variable is JAVA_HOME.  All others are\n      # optional.  When running a distributed configuration it is best to\n      # set JAVA_HOME in this file, so that it is correctly defined on\n      # remote nodes.\n\n      # The java implementation to use.  Required.\n      export JAVA_HOME={{java_home}}\n      export HADOOP_HOME_WARN_SUPPRESS=1\n\n      # Hadoop home directory\n      export HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n      # Hadoop Configuration Directory\n\n      {# this is different for HDP1 #}\n      # Path to jsvc required by secure HDP 2.0 datanode\n      export JSVC_HOME={{jsvc_path}}\n\n\n      # The maximum amount of heap to use, in MB. Default is 1000.\n      export HADOOP_HEAPSIZE=\"{{hadoop_heapsize}}\"\n\n      export HADOOP_NAMENODE_INIT_HEAPSIZE=\"-Xms{{namenode_heapsize}}\"\n\n      # Extra Java runtime options.  Empty by default.\n      export HADOOP_OPTS=\"-Djava.net.preferIPv4Stack=true ${HADOOP_OPTS}\"\n\n      USER=\"$(whoami)\"\n\n      # Command specific options appended to HADOOP_OPTS when specified\n      HADOOP_JOBTRACKER_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{jtnode_opt_newsize}} -XX:MaxNewSize={{jtnode_opt_maxnewsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xmx{{jtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dmapred.audit.logger=INFO,MRAUDIT -Dhadoop.mapreduce.jobsummary.logger=INFO,JSA ${HADOOP_JOBTRACKER_OPTS}\"\n\n      HADOOP_TASKTRACKER_OPTS=\"-server -Xmx{{ttnode_heapsize}} -Dhadoop.security.logger=ERROR,console -Dmapred.audit.logger=ERROR,console ${HADOOP_TASKTRACKER_OPTS}\"\n\n      {% if java_version < 8 %}\n      SHARED_HDFS_NAMENODE_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{namenode_opt_newsize}} -XX:MaxNewSize={{namenode_opt_maxnewsize}} -XX:PermSize={{namenode_opt_permsize}} -XX:MaxPermSize={{namenode_opt_maxpermsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -Xms{{namenode_heapsize}} -Xmx{{namenode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT\"\n      export HDFS_NAMENODE_OPTS=\"${SHARED_HDFS_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\"/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node\\\" -Dorg.mortbay.jetty.Request.maxFormContentSize=-1 ${HDFS_NAMENODE_OPTS}\"\n      export HDFS_DATANODE_OPTS=\"-server -XX:ParallelGCThreads=4 -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError=\\\"/usr/hdp/current/hadoop-hdfs-datanode/bin/kill-data-node\\\" -XX:ErrorFile=/var/log/hadoop/$USER/hs_err_pid%p.log -XX:NewSize=200m -XX:MaxNewSize=200m -XX:PermSize=128m -XX:MaxPermSize=256m -Xloggc:/var/log/hadoop/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{dtnode_heapsize}} -Xmx{{dtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HDFS_DATANODE_OPTS} -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly\"\n\n      export HDFS_SECONDARYNAMENODE_OPTS=\"${SHARED_HDFS_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\"/usr/hdp/current/hadoop-hdfs-secondarynamenode/bin/kill-secondary-name-node\\\" ${HDFS_SECONDARYNAMENODE_OPTS}\"\n\n      # The following applies to multiple commands (fs, dfs, fsck, distcp etc)\n      export HADOOP_CLIENT_OPTS=\"-Xmx${HADOOP_HEAPSIZE}m -XX:MaxPermSize=512m $HADOOP_CLIENT_OPTS\"\n\n      {% else %}\n      SHARED_HDFS_NAMENODE_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{namenode_opt_newsize}} -XX:MaxNewSize={{namenode_opt_maxnewsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -Xms{{namenode_heapsize}} -Xmx{{namenode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT\"\n      export HDFS_NAMENODE_OPTS=\"${SHARED_HDFS_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\"/usr/hdp/current/hadoop-hdfs-namenode/bin/kill-name-node\\\" -Dorg.mortbay.jetty.Request.maxFormContentSize=-1 ${HDFS_NAMENODE_OPTS}\"\n      export HDFS_DATANODE_OPTS=\"-server -XX:ParallelGCThreads=4 -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError=\\\"/usr/hdp/current/hadoop-hdfs-datanode/bin/kill-data-node\\\" -XX:ErrorFile=/var/log/hadoop/$USER/hs_err_pid%p.log -XX:NewSize=200m -XX:MaxNewSize=200m -Xloggc:/var/log/hadoop/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{dtnode_heapsize}} -Xmx{{dtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HDFS_DATANODE_OPTS} -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly\"\n\n      export HDFS_SECONDARYNAMENODE_OPTS=\"${SHARED_HDFS_NAMENODE_OPTS} -XX:OnOutOfMemoryError=\\\"/usr/hdp/current/hadoop-hdfs-secondarynamenode/bin/kill-secondary-name-node\\\" ${HDFS_SECONDARYNAMENODE_OPTS}\"\n\n      # The following applies to multiple commands (fs, dfs, fsck, distcp etc)\n      export HADOOP_CLIENT_OPTS=\"-Xmx${HADOOP_HEAPSIZE}m $HADOOP_CLIENT_OPTS\"\n      {% endif %}\n\n      {% if security_enabled %}\n      export HDFS_NAMENODE_OPTS=\"$HDFS_NAMENODE_OPTS -Djava.security.auth.login.config={{hadoop_conf_dir}}/hdfs_nn_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false\"\n      export HDFS_SECONDARYNAMENODE_OPTS=\"$HDFS_SECONDARYNAMENODE_OPTS -Djava.security.auth.login.config={{hadoop_conf_dir}}/hdfs_nn_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false\"\n      export HDFS_DATANODE_OPTS=\"$HDFS_DATANODE_OPTS -Djava.security.auth.login.config={{hadoop_conf_dir}}/hdfs_dn_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false\"\n      export HADOOP_JOURNALNODE_OPTS=\"$HADOOP_JOURNALNODE_OPTS -Djava.security.auth.login.config={{hadoop_conf_dir}}/hdfs_jn_jaas.conf -Djavax.security.auth.useSubjectCredsOnly=false\"\n      {% endif %}\n\n      HDFS_NFS3_OPTS=\"-Xmx{{nfsgateway_heapsize}}m -Dhadoop.security.logger=ERROR,DRFAS ${HDFS_NFS3_OPTS}\"\n      HADOOP_BALANCER_OPTS=\"-server -Xmx{{hadoop_heapsize}}m ${HADOOP_BALANCER_OPTS}\"\n\n\n      # On secure datanodes, user to run the datanode as after dropping privileges\n      export HDFS_DATANODE_SECURE_USER=${HDFS_DATANODE_SECURE_USER:-{{hadoop_secure_dn_user}}}\n\n      # Extra ssh options.  Empty by default.\n      export HADOOP_SSH_OPTS=\"-o ConnectTimeout=5 -o SendEnv=HADOOP_CONF_DIR\"\n\n      # Where log files are stored.  $HADOOP_HOME/logs by default.\n      export HADOOP_LOG_DIR={{hdfs_log_dir_prefix}}/$USER\n\n      # Where log files are stored in the secure data environment.\n      export HADOOP_SECURE_LOG_DIR=${HADOOP_SECURE_LOG_DIR:-{{hdfs_log_dir_prefix}}/$HDFS_DATANODE_SECURE_USER}\n\n      # File naming remote slave hosts.  $HADOOP_HOME/conf/slaves by default.\n      # export HADOOP_WORKERS=${HADOOP_HOME}/conf/slaves\n\n      # host:path where hadoop code should be rsync'd from.  Unset by default.\n      # export HADOOP_MASTER=master:/home/$USER/src/hadoop\n\n      # Seconds to sleep between slave commands.  Unset by default.  This\n      # can be useful in large clusters, where, e.g., slave rsyncs can\n      # otherwise arrive faster than the master can service them.\n      # export HADOOP_WORKER_SLEEP=0.1\n\n      # The directory where pid files are stored. /tmp by default.\n      export HADOOP_PID_DIR={{hadoop_pid_dir_prefix}}/$USER\n      export HADOOP_SECURE_PID_DIR=${HADOOP_SECURE_PID_DIR:-{{hadoop_pid_dir_prefix}}/$HDFS_DATANODE_SECURE_USER}\n\n      YARN_RESOURCEMANAGER_OPTS=\"-Dyarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY\"\n\n      # A string representing this instance of hadoop. $USER by default.\n      export HADOOP_IDENT_STRING=$USER\n\n      # The scheduling priority for daemon processes.  See 'man nice'.\n\n      # export HADOOP_NICENESS=10\n\n      # Add database libraries\n      JAVA_JDBC_LIBS=\"\"\n      if [ -d \"/usr/share/java\" ]; then\n      for jarFile in `ls /usr/share/java | grep -E \"(mysql|ojdbc|postgresql|sqljdbc)\" 2>/dev/null`\n      do\n      JAVA_JDBC_LIBS=${JAVA_JDBC_LIBS}:$jarFile\n      done\n      fi\n\n      # Add libraries to the hadoop classpath - some may not need a colon as they already include it\n      export HADOOP_CLASSPATH=${HADOOP_CLASSPATH}${JAVA_JDBC_LIBS}\n\n      # Setting path to hdfs command line\n      export HADOOP_LIBEXEC_DIR={{hadoop_libexec_dir}}\n\n      # Mostly required for hadoop 2.0\n      export JAVA_LIBRARY_PATH=${JAVA_LIBRARY_PATH}:{{hadoop_lib_home}}/native/Linux-{{architecture}}-64\n\n      {% if zk_principal_user is defined %}\n      HADOOP_OPTS=\"-Dzookeeper.sasl.client.username={{zk_principal_user}} $HADOOP_OPTS\"\n      {% endif %}\n\n      export HADOOP_OPTS=\"-Dhdp.version=$HDP_VERSION $HADOOP_OPTS\"\n\n\n      # Fix temporary bug, when ulimit from conf files is not picked up, without full relogin.\n      # Makes sense to fix only when runing DN as root\n      if [ \"$command\" == \"datanode\" ] && [ \"$EUID\" -eq 0 ] && [ -n \"$HDFS_DATANODE_SECURE_USER\" ]; then\n      {% if is_datanode_max_locked_memory_set %}\n      ulimit -l {{datanode_max_locked_memory}}\n      {% endif %}\n      ulimit -n {{hdfs_user_nofile_limit}}\n      fi\n      # Enable ACLs on zookeper znodes if required\n      {% if hadoop_zkfc_opts is defined %}\n      export HDFS_ZKFC_OPTS=\"{{hadoop_zkfc_opts}} $HDFS_ZKFC_OPTS\"\n      {% endif %}",
+      "hdfs_user_nofile_limit": "128000",
+      "namenode_opt_newsize": "128m",
+      "nfsgateway_heapsize": "1024",
+      "dtnode_heapsize": "1024m",
+      "namenode_heapsize": "1024m",
+      "hadoop_heapsize": "1024",
+      "namenode_opt_maxpermsize": "256m",
+      "namenode_opt_permsize": "128m",
+      "hdfs_tmp_dir": "/tmp"
+    },
+    "zookeeper-env": {
+      "content": "\nexport JAVA_HOME={{java64_home}}\nexport ZOOKEEPER_HOME={{zk_home}}\nexport ZOO_LOG_DIR={{zk_log_dir}}\nexport ZOOPIDFILE={{zk_pid_file}}\nexport SERVER_JVMFLAGS={{zk_server_heapsize}}\nexport JAVA=$JAVA_HOME/bin/java\nexport CLASSPATH=$CLASSPATH:/usr/share/zookeeper/*\n\n{% if security_enabled %}\nexport SERVER_JVMFLAGS=\"$SERVER_JVMFLAGS -Djava.security.auth.login.config={{zk_server_jaas_file}}\"\nexport CLIENT_JVMFLAGS=\"$CLIENT_JVMFLAGS -Djava.security.auth.login.config={{zk_client_jaas_file}} -Dzookeeper.sasl.client.username={{zk_principal_user}}\"\n{% endif %}",
+      "zk_log_dir": "/var/log/zookeeper",
+      "zk_server_heapsize": "1024m",
+      "zk_pid_dir": "/var/run/zookeeper",
+      "zk_user": "zookeeper"
+    },
+    "zookeeper-log4j": {
+      "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\n\n#\n# ZooKeeper Logging Configuration\n#\n\n# DEFAULT: console appender only\nlog4j.rootLogger=INFO, CONSOLE, ROLLINGFILE\n\n# Example with rolling log file\n#log4j.rootLogger=DEBUG, CONSOLE, ROLLINGFILE\n\n# Example with rolling log file and tracing\n#log4j.rootLogger=TRACE, CONSOLE, ROLLINGFILE, TRACEFILE\n\n#\n# Log INFO level and above messages to the console\n#\nlog4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\nlog4j.appender.CONSOLE.Threshold=INFO\nlog4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\nlog4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n\n\n#\n# Add ROLLINGFILE to rootLogger to get log file output\n#    Log DEBUG level and above messages to a log file\nlog4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender\nlog4j.appender.ROLLINGFILE.Threshold=DEBUG\nlog4j.appender.ROLLINGFILE.File={{zk_log_dir}}/zookeeper.log\n\n# Max log file size of 10MB\nlog4j.appender.ROLLINGFILE.MaxFileSize={{zookeeper_log_max_backup_size}}MB\n# uncomment the next line to limit number of backup files\n#log4j.appender.ROLLINGFILE.MaxBackupIndex={{zookeeper_log_number_of_backup_files}}\n\nlog4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout\nlog4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n\n\n\n#\n# Add TRACEFILE to rootLogger to get log file output\n#    Log DEBUG level and above messages to a log file\nlog4j.appender.TRACEFILE=org.apache.log4j.FileAppender\nlog4j.appender.TRACEFILE.Threshold=TRACE\nlog4j.appender.TRACEFILE.File=zookeeper_trace.log\n\nlog4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout\n### Notice we are including log4j's NDC here (%x)\nlog4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L][%x] - %m%n",
+      "zookeeper_log_max_backup_size": "10",
+      "zookeeper_log_number_of_backup_files": "10"
+    },
+    "cluster-env": {
+      "security_enabled": "false",
+      "hide_yarn_memory_widget": "false",
+      "stack_name": "HDP",
+      "enable_external_ranger": "false",
+      "override_uid": "true",
+      "kerberos_domain": "EXAMPLE.COM",
+      "one_dir_per_partition": "false",
+      "recovery_max_count": "6",
+      "repo_ubuntu_template": "{{package_type}} {{base_url}} {{components}}",
+      "stack_packages": "{\n  \"HDP\": {\n    \"stack-select\": {\n      \"ACCUMULO\": {\n        \"ACCUMULO_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"accumulo-client\",\n          \"INSTALL\": [\n            \"accumulo-client\"\n          ],\n          \"PATCH\": [\n            \"accumulo-client\"\n          ],\n          \"STANDARD\": [\n            \"accumulo-client\"\n          ]\n        },\n        \"ACCUMULO_GC\": {\n          \"STACK-SELECT-PACKAGE\": \"accumulo-gc\",\n          \"INSTALL\": [\n            \"accumulo-gc\"\n          ],\n          \"PATCH\": [\n            \"accumulo-gc\"\n          ],\n          \"STANDARD\": [\n            \"accumulo-gc\",\n            \"accumulo-client\"\n          ]\n        },\n        \"ACCUMULO_MASTER\": {\n          \"STACK-SELECT-PACKAGE\": \"accumulo-master\",\n          \"INSTALL\": [\n            \"accumulo-master\"\n          ],\n          \"PATCH\": [\n            \"accumulo-master\"\n          ],\n          \"STANDARD\": [\n            \"accumulo-master\",\n            \"accumulo-client\"\n          ]\n        },\n        \"ACCUMULO_MONITOR\": {\n          \"STACK-SELECT-PACKAGE\": \"accumulo-monitor\",\n          \"INSTALL\": [\n            \"accumulo-monitor\"\n          ],\n          \"PATCH\": [\n            \"accumulo-monitor\"\n          ],\n          \"STANDARD\": [\n            \"accumulo-monitor\",\n            \"accumulo-client\"\n          ]\n        },\n        \"ACCUMULO_TRACER\": {\n          \"STACK-SELECT-PACKAGE\": \"accumulo-tracer\",\n          \"INSTALL\": [\n            \"accumulo-tracer\"\n          ],\n          \"PATCH\": [\n            \"accumulo-tracer\"\n          ],\n          \"STANDARD\": [\n            \"accumulo-tracer\",\n            \"accumulo-client\"\n          ]\n        },\n        \"ACCUMULO_TSERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"accumulo-tablet\",\n          \"INSTALL\": [\n            \"accumulo-tablet\"\n          ],\n          \"PATCH\": [\n            \"accumulo-tablet\"\n          ],\n          \"STANDARD\": [\n            \"accumulo-tablet\",\n            \"accumulo-client\"\n          ]\n        }\n      },\n      \"ATLAS\": {\n        \"ATLAS_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"atlas-client\",\n          \"INSTALL\": [\n            \"atlas-client\"\n          ],\n          \"PATCH\": [\n            \"atlas-client\"\n          ],\n          \"STANDARD\": [\n            \"atlas-client\"\n          ]\n        },\n        \"ATLAS_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"atlas-server\",\n          \"INSTALL\": [\n            \"atlas-server\"\n          ],\n          \"PATCH\": [\n            \"atlas-server\"\n          ],\n          \"STANDARD\": [\n            \"atlas-server\"\n          ]\n        }\n      },\n      \"DRUID\": {\n        \"DRUID_COORDINATOR\": {\n          \"STACK-SELECT-PACKAGE\": \"druid-coordinator\",\n          \"INSTALL\": [\n            \"druid-coordinator\"\n          ],\n          \"PATCH\": [\n            \"druid-coordinator\"\n          ],\n          \"STANDARD\": [\n            \"druid-coordinator\"\n          ]\n        },\n        \"DRUID_OVERLORD\": {\n          \"STACK-SELECT-PACKAGE\": \"druid-overlord\",\n          \"INSTALL\": [\n            \"druid-overlord\"\n          ],\n          \"PATCH\": [\n            \"druid-overlord\"\n          ],\n          \"STANDARD\": [\n            \"druid-overlord\"\n          ]\n        },\n        \"DRUID_HISTORICAL\": {\n          \"STACK-SELECT-PACKAGE\": \"druid-historical\",\n          \"INSTALL\": [\n            \"druid-historical\"\n          ],\n          \"PATCH\": [\n            \"druid-historical\"\n          ],\n          \"STANDARD\": [\n            \"druid-historical\"\n          ]\n        },\n        \"DRUID_BROKER\": {\n          \"STACK-SELECT-PACKAGE\": \"druid-broker\",\n          \"INSTALL\": [\n            \"druid-broker\"\n          ],\n          \"PATCH\": [\n            \"druid-broker\"\n          ],\n          \"STANDARD\": [\n            \"druid-broker\"\n          ]\n        },\n        \"DRUID_MIDDLEMANAGER\": {\n          \"STACK-SELECT-PACKAGE\": \"druid-middlemanager\",\n          \"INSTALL\": [\n            \"druid-middlemanager\"\n          ],\n          \"PATCH\": [\n            \"druid-middlemanager\"\n          ],\n          \"STANDARD\": [\n            \"druid-middlemanager\"\n          ]\n        },\n        \"DRUID_ROUTER\": {\n          \"STACK-SELECT-PACKAGE\": \"druid-router\",\n          \"INSTALL\": [\n            \"druid-router\"\n          ],\n          \"PATCH\": [\n            \"druid-router\"\n          ],\n          \"STANDARD\": [\n            \"druid-router\"\n          ]\n        }\n      },\n      \"HBASE\": {\n        \"HBASE_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"hbase-client\",\n          \"INSTALL\": [\n            \"hbase-client\"\n          ],\n          \"PATCH\": [\n            \"hbase-client\"\n          ],\n          \"STANDARD\": [\n            \"hbase-client\",\n            \"phoenix-client\",\n            \"hadoop-client\"\n          ]\n        },\n        \"HBASE_MASTER\": {\n          \"STACK-SELECT-PACKAGE\": \"hbase-master\",\n          \"INSTALL\": [\n            \"hbase-master\"\n          ],\n          \"PATCH\": [\n            \"hbase-master\"\n          ],\n          \"STANDARD\": [\n            \"hbase-master\"\n          ]\n        },\n        \"HBASE_REGIONSERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"hbase-regionserver\",\n          \"INSTALL\": [\n            \"hbase-regionserver\"\n          ],\n          \"PATCH\": [\n            \"hbase-regionserver\"\n          ],\n          \"STANDARD\": [\n            \"hbase-regionserver\"\n          ]\n        },\n        \"PHOENIX_QUERY_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"phoenix-server\",\n          \"INSTALL\": [\n            \"phoenix-server\"\n          ],\n          \"PATCH\": [\n            \"phoenix-server\"\n          ],\n          \"STANDARD\": [\n            \"phoenix-server\"\n          ]\n        }\n      },\n      \"HDFS\": {\n        \"DATANODE\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-datanode\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-datanode\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-datanode\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-hdfs-datanode\"\n          ]\n        },\n        \"HDFS_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-client\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-client\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-client\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-client\"\n          ]\n        },\n        \"NAMENODE\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-namenode\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-namenode\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-namenode\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-hdfs-namenode\"\n          ]\n        },\n        \"NFS_GATEWAY\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-nfs3\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-nfs3\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-nfs3\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-hdfs-nfs3\"\n          ]\n        },\n        \"JOURNALNODE\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-journalnode\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-journalnode\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-journalnode\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-hdfs-journalnode\"\n          ]\n        },\n        \"SECONDARY_NAMENODE\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-secondarynamenode\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-secondarynamenode\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-secondarynamenode\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-hdfs-secondarynamenode\"\n          ]\n        },\n        \"ZKFC\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-hdfs-zkfc\",\n          \"INSTALL\": [\n            \"hadoop-hdfs-zkfc\"\n          ],\n          \"PATCH\": [\n            \"hadoop-hdfs-zkfc\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-hdfs-zkfc\"\n          ]\n        }\n      },\n      \"HIVE\": {\n        \"HIVE_METASTORE\": {\n          \"STACK-SELECT-PACKAGE\": \"hive-metastore\",\n          \"INSTALL\": [\n            \"hive-metastore\"\n          ],\n          \"PATCH\": [\n            \"hive-metastore\"\n          ],\n          \"STANDARD\": [\n            \"hive-metastore\"\n          ]\n        },\n        \"HIVE_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"hive-server2\",\n          \"INSTALL\": [\n            \"hive-server2\"\n          ],\n          \"PATCH\": [\n            \"hive-server2\"\n          ],\n          \"STANDARD\": [\n            \"hive-server2\"\n          ]\n        },\n        \"HIVE_SERVER_INTERACTIVE\": {\n          \"STACK-SELECT-PACKAGE\": \"hive-server2-hive\",\n          \"INSTALL\": [\n            \"hive-server2-hive\"\n          ],\n          \"PATCH\": [\n            \"hive-server2-hive\"\n          ],\n          \"STANDARD\": [\n            \"hive-server2-hive\"\n          ]\n        },\n        \"HIVE_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"hive-client\",\n          \"INSTALL\": [\n            \"hive-client\"\n          ],\n          \"PATCH\": [\n            \"hive-client\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-client\"\n          ]\n        }\n      },\n      \"KAFKA\": {\n        \"KAFKA_BROKER\": {\n          \"STACK-SELECT-PACKAGE\": \"kafka-broker\",\n          \"INSTALL\": [\n            \"kafka-broker\"\n          ],\n          \"PATCH\": [\n            \"kafka-broker\"\n          ],\n          \"STANDARD\": [\n            \"kafka-broker\"\n          ]\n        }\n      },\n      \"KNOX\": {\n        \"KNOX_GATEWAY\": {\n          \"STACK-SELECT-PACKAGE\": \"knox-server\",\n          \"INSTALL\": [\n            \"knox-server\"\n          ],\n          \"PATCH\": [\n            \"knox-server\"\n          ],\n          \"STANDARD\": [\n            \"knox-server\"\n          ]\n        }\n      },\n      \"MAPREDUCE2\": {\n        \"HISTORYSERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-mapreduce-historyserver\",\n          \"INSTALL\": [\n            \"hadoop-mapreduce-historyserver\"\n          ],\n          \"PATCH\": [\n            \"hadoop-mapreduce-historyserver\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-mapreduce-historyserver\"\n          ]\n        },\n        \"MAPREDUCE2_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-mapreduce-client\",\n          \"INSTALL\": [\n            \"hadoop-mapreduce-client\"\n          ],\n          \"PATCH\": [\n            \"hadoop-mapreduce-client\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-client\"\n          ]\n        }\n      },\n      \"OOZIE\": {\n        \"OOZIE_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"oozie-client\",\n          \"INSTALL\": [\n            \"oozie-client\"\n          ],\n          \"PATCH\": [\n            \"oozie-client\"\n          ],\n          \"STANDARD\": [\n            \"oozie-client\"\n          ]\n        },\n        \"OOZIE_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"oozie-server\",\n          \"INSTALL\": [\n            \"oozie-client\",\n            \"oozie-server\"\n          ],\n          \"PATCH\": [\n            \"oozie-server\",\n            \"oozie-client\"\n          ],\n          \"STANDARD\": [\n            \"oozie-client\",\n            \"oozie-server\"\n          ]\n        }\n      },\n      \"PIG\": {\n        \"PIG\": {\n          \"STACK-SELECT-PACKAGE\": \"pig-client\",\n          \"INSTALL\": [\n            \"pig-client\"\n          ],\n          \"PATCH\": [\n            \"pig-client\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-client\"\n          ]\n        }\n      },\n      \"RANGER\": {\n        \"RANGER_ADMIN\": {\n          \"STACK-SELECT-PACKAGE\": \"ranger-admin\",\n          \"INSTALL\": [\n            \"ranger-admin\"\n          ],\n          \"PATCH\": [\n            \"ranger-admin\"\n          ],\n          \"STANDARD\": [\n            \"ranger-admin\"\n          ]\n        },\n        \"RANGER_TAGSYNC\": {\n          \"STACK-SELECT-PACKAGE\": \"ranger-tagsync\",\n          \"INSTALL\": [\n            \"ranger-tagsync\"\n          ],\n          \"PATCH\": [\n            \"ranger-tagsync\"\n          ],\n          \"STANDARD\": [\n            \"ranger-tagsync\"\n          ]\n        },\n        \"RANGER_USERSYNC\": {\n          \"STACK-SELECT-PACKAGE\": \"ranger-usersync\",\n          \"INSTALL\": [\n            \"ranger-usersync\"\n          ],\n          \"PATCH\": [\n            \"ranger-usersync\"\n          ],\n          \"STANDARD\": [\n            \"ranger-usersync\"\n          ]\n        }\n      },\n      \"RANGER_KMS\": {\n        \"RANGER_KMS_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"ranger-kms\",\n          \"INSTALL\": [\n            \"ranger-kms\"\n          ],\n          \"PATCH\": [\n            \"ranger-kms\"\n          ],\n          \"STANDARD\": [\n            \"ranger-kms\"\n          ]\n        }\n      },\n      \"SPARK2\": {\n        \"LIVY2_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"livy2-client\",\n          \"INSTALL\": [\n            \"livy2-client\"\n          ],\n          \"PATCH\": [\n            \"livy2-client\"\n          ],\n          \"STANDARD\": [\n            \"livy2-client\"\n          ]\n        },\n        \"LIVY2_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"livy2-server\",\n          \"INSTALL\": [\n            \"livy2-server\"\n          ],\n          \"PATCH\": [\n            \"livy2-server\"\n          ],\n          \"STANDARD\": [\n            \"livy2-server\"\n          ]\n        },\n        \"SPARK2_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"spark2-client\",\n          \"INSTALL\": [\n            \"spark2-client\"\n          ],\n          \"PATCH\": [\n            \"spark2-client\"\n          ],\n          \"STANDARD\": [\n            \"spark2-client\"\n          ]\n        },\n        \"SPARK2_JOBHISTORYSERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"spark2-historyserver\",\n          \"INSTALL\": [\n            \"spark2-historyserver\"\n          ],\n          \"PATCH\": [\n            \"spark2-historyserver\"\n          ],\n          \"STANDARD\": [\n            \"spark2-historyserver\"\n          ]\n        },\n        \"SPARK2_THRIFTSERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"spark2-thriftserver\",\n          \"INSTALL\": [\n            \"spark2-thriftserver\"\n          ],\n          \"PATCH\": [\n            \"spark2-thriftserver\"\n          ],\n          \"STANDARD\": [\n            \"spark2-thriftserver\"\n          ]\n        }\n      },\n      \"SQOOP\": {\n        \"SQOOP\": {\n          \"STACK-SELECT-PACKAGE\": \"sqoop-client\",\n          \"INSTALL\": [\n            \"sqoop-client\"\n          ],\n          \"PATCH\": [\n            \"sqoop-client\"\n          ],\n          \"STANDARD\": [\n            \"sqoop-client\"\n          ]\n        }\n      },\n      \"STORM\": {\n        \"NIMBUS\": {\n          \"STACK-SELECT-PACKAGE\": \"storm-nimbus\",\n          \"INSTALL\": [\n            \"storm-client\",\n            \"storm-nimbus\"\n          ],\n          \"PATCH\": [\n            \"storm-client\",\n            \"storm-nimbus\"\n          ],\n          \"STANDARD\": [\n            \"storm-client\",\n            \"storm-nimbus\"\n          ]\n        },\n        \"SUPERVISOR\": {\n          \"STACK-SELECT-PACKAGE\": \"storm-supervisor\",\n          \"INSTALL\": [\n            \"storm-client\",\n            \"storm-supervisor\"\n          ],\n          \"PATCH\": [\n            \"storm-client\",\n            \"storm-supervisor\"\n          ],\n          \"STANDARD\": [\n            \"storm-client\",\n            \"storm-supervisor\"\n          ]\n        },\n        \"DRPC_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"storm-client\",\n          \"INSTALL\": [\n            \"storm-client\"\n          ],\n          \"PATCH\": [\n            \"storm-client\"\n          ],\n          \"STANDARD\": [\n            \"storm-client\"\n          ]\n        },\n        \"STORM_UI_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"storm-client\",\n          \"INSTALL\": [\n            \"storm-client\"\n          ],\n          \"PATCH\": [\n            \"storm-client\"\n          ],\n          \"STANDARD\": [\n            \"storm-client\"\n          ]\n        }\n      },\n      \"SUPERSET\": {\n        \"SUPERSET\": {\n          \"STACK-SELECT-PACKAGE\": \"superset\",\n          \"INSTALL\": [\n            \"superset\"\n          ],\n          \"PATCH\": [\n            \"superset\"\n          ],\n          \"STANDARD\": [\n            \"superset\"\n          ]\n        }\n      },\n      \"TEZ\": {\n        \"TEZ_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"tez-client\",\n          \"INSTALL\": [\n            \"tez-client\"\n          ],\n          \"PATCH\": [\n            \"tez-client\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-client\"\n          ]\n        }\n      },\n      \"YARN\": {\n        \"APP_TIMELINE_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-yarn-timelineserver\",\n          \"INSTALL\": [\n            \"hadoop-yarn-timelineserver\"\n          ],\n          \"PATCH\": [\n            \"hadoop-yarn-timelineserver\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-yarn-timelineserver\"\n          ]\n        },\n        \"TIMELINE_READER\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-yarn-timelinereader\",\n          \"INSTALL\": [\n            \"hadoop-yarn-timelinereader\"\n          ],\n          \"PATCH\": [\n            \"hadoop-yarn-timelinereader\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-yarn-timelinereader\"\n          ]\n        },\n        \"NODEMANAGER\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-yarn-nodemanager\",\n          \"INSTALL\": [\n            \"hadoop-yarn-nodemanager\"\n          ],\n          \"PATCH\": [\n            \"hadoop-yarn-nodemanager\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-yarn-nodemanager\"\n          ]\n        },\n        \"RESOURCEMANAGER\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-yarn-resourcemanager\",\n          \"INSTALL\": [\n            \"hadoop-yarn-resourcemanager\"\n          ],\n          \"PATCH\": [\n            \"hadoop-yarn-resourcemanager\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-yarn-resourcemanager\"\n          ]\n        },\n        \"YARN_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-yarn-client\",\n          \"INSTALL\": [\n            \"hadoop-yarn-client\"\n          ],\n          \"PATCH\": [\n            \"hadoop-yarn-client\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-client\"\n          ]\n        },\n        \"YARN_REGISTRY_DNS\": {\n          \"STACK-SELECT-PACKAGE\": \"hadoop-yarn-registrydns\",\n          \"INSTALL\": [\n            \"hadoop-yarn-registrydns\"\n          ],\n          \"PATCH\": [\n            \"hadoop-yarn-registrydns\"\n          ],\n          \"STANDARD\": [\n            \"hadoop-yarn-registrydns\"\n          ]\n        }\n      },\n      \"ZEPPELIN\": {\n        \"ZEPPELIN_MASTER\": {\n          \"STACK-SELECT-PACKAGE\": \"zeppelin-server\",\n          \"INSTALL\": [\n            \"zeppelin-server\"\n          ],\n          \"PATCH\": [\n            \"zeppelin-server\"\n          ],\n          \"STANDARD\": [\n            \"zeppelin-server\"\n          ]\n        }\n      },\n      \"ZOOKEEPER\": {\n        \"ZOOKEEPER_CLIENT\": {\n          \"STACK-SELECT-PACKAGE\": \"zookeeper-client\",\n          \"INSTALL\": [\n            \"zookeeper-client\"\n          ],\n          \"PATCH\": [\n            \"zookeeper-client\"\n          ],\n          \"STANDARD\": [\n            \"zookeeper-client\"\n          ]\n        },\n        \"ZOOKEEPER_SERVER\": {\n          \"STACK-SELECT-PACKAGE\": \"zookeeper-server\",\n          \"INSTALL\": [\n            \"zookeeper-server\"\n          ],\n          \"PATCH\": [\n            \"zookeeper-server\"\n          ],\n          \"STANDARD\": [\n            \"zookeeper-server\"\n          ]\n        }\n      }\n    },\n    \"conf-select\": {\n      \"accumulo\": [\n        {\n          \"conf_dir\": \"/etc/accumulo/conf\",\n          \"current_dir\": \"{0}/current/accumulo-client/conf\"\n        }\n      ],\n      \"atlas\": [\n        {\n          \"conf_dir\": \"/etc/atlas/conf\",\n          \"current_dir\": \"{0}/current/atlas-client/conf\"\n        }\n      ],\n      \"druid\": [\n        {\n          \"conf_dir\": \"/etc/druid/conf\",\n          \"current_dir\": \"{0}/current/druid-overlord/conf\"\n        }\n      ],\n      \"hadoop\": [\n        {\n          \"conf_dir\": \"/etc/hadoop/conf\",\n          \"current_dir\": \"{0}/current/hadoop-client/conf\"\n        }\n      ],\n      \"hbase\": [\n        {\n          \"conf_dir\": \"/etc/hbase/conf\",\n          \"current_dir\": \"{0}/current/hbase-client/conf\"\n        }\n      ],\n      \"hive\": [\n        {\n          \"conf_dir\": \"/etc/hive/conf\",\n          \"current_dir\": \"{0}/current/hive-client/conf\"\n        }\n      ],\n      \"hive2\": [\n        {\n          \"conf_dir\": \"/etc/hive2/conf\",\n          \"current_dir\": \"{0}/current/hive-server2-hive/conf\"\n        }\n      ],\n      \"hive-hcatalog\": [\n        {\n          \"conf_dir\": \"/etc/hive-webhcat/conf\",\n          \"prefix\": \"/etc/hive-webhcat\",\n          \"current_dir\": \"{0}/current/hive-webhcat/etc/webhcat\"\n        },\n        {\n          \"conf_dir\": \"/etc/hive-hcatalog/conf\",\n          \"prefix\": \"/etc/hive-hcatalog\",\n          \"current_dir\": \"{0}/current/hive-webhcat/etc/hcatalog\"\n        }\n      ],\n      \"kafka\": [\n        {\n          \"conf_dir\": \"/etc/kafka/conf\",\n          \"current_dir\": \"{0}/current/kafka-broker/conf\"\n        }\n      ],\n      \"knox\": [\n        {\n          \"conf_dir\": \"/etc/knox/conf\",\n          \"current_dir\": \"{0}/current/knox-server/conf\"\n        }\n      ],\n      \"livy2\": [\n        {\n          \"conf_dir\": \"/etc/livy2/conf\",\n          \"current_dir\": \"{0}/current/livy2-client/conf\"\n        }\n      ],\n      \"nifi\": [\n        {\n          \"conf_dir\": \"/etc/nifi/conf\",\n          \"current_dir\": \"{0}/current/nifi/conf\"\n        }\n      ],\n      \"oozie\": [\n        {\n          \"conf_dir\": \"/etc/oozie/conf\",\n          \"current_dir\": \"{0}/current/oozie-client/conf\"\n        }\n      ],\n      \"phoenix\": [\n        {\n          \"conf_dir\": \"/etc/phoenix/conf\",\n          \"current_dir\": \"{0}/current/phoenix-client/conf\"\n        }\n      ],\n      \"pig\": [\n        {\n          \"conf_dir\": \"/etc/pig/conf\",\n          \"current_dir\": \"{0}/current/pig-client/conf\"\n        }\n      ],\n      \"ranger-admin\": [\n        {\n          \"conf_dir\": \"/etc/ranger/admin/conf\",\n          \"current_dir\": \"{0}/current/ranger-admin/conf\"\n        }\n      ],\n      \"ranger-kms\": [\n        {\n          \"conf_dir\": \"/etc/ranger/kms/conf\",\n          \"current_dir\": \"{0}/current/ranger-kms/conf\"\n        }\n      ],\n      \"ranger-tagsync\": [\n        {\n          \"conf_dir\": \"/etc/ranger/tagsync/conf\",\n          \"current_dir\": \"{0}/current/ranger-tagsync/conf\"\n        }\n      ],\n      \"ranger-usersync\": [\n        {\n          \"conf_dir\": \"/etc/ranger/usersync/conf\",\n          \"current_dir\": \"{0}/current/ranger-usersync/conf\"\n        }\n      ],\n      \"spark2\": [\n        {\n          \"conf_dir\": \"/etc/spark2/conf\",\n          \"current_dir\": \"{0}/current/spark2-client/conf\"\n        }\n      ],\n      \"sqoop\": [\n        {\n          \"conf_dir\": \"/etc/sqoop/conf\",\n          \"current_dir\": \"{0}/current/sqoop-client/conf\"\n        }\n      ],\n      \"storm\": [\n        {\n          \"conf_dir\": \"/etc/storm/conf\",\n          \"current_dir\": \"{0}/current/storm-client/conf\"\n        }\n      ],\n      \"superset\": [\n        {\n          \"conf_dir\": \"/etc/superset/conf\",\n          \"current_dir\": \"{0}/current/superset/conf\"\n        }\n      ],\n      \"tez\": [\n        {\n          \"conf_dir\": \"/etc/tez/conf\",\n          \"current_dir\": \"{0}/current/tez-client/conf\"\n        }\n      ],\n      \"zeppelin\": [\n        {\n          \"conf_dir\": \"/etc/zeppelin/conf\",\n          \"current_dir\": \"{0}/current/zeppelin-server/conf\"\n        }\n      ],\n      \"zookeeper\": [\n        {\n          \"conf_dir\": \"/etc/zookeeper/conf\",\n          \"current_dir\": \"{0}/current/zookeeper-client/conf\"\n        }\n      ]\n    },\n    \"conf-select-patching\": {\n      \"ACCUMULO\": {\n        \"packages\": [\"accumulo\"]\n      },\n      \"ATLAS\": {\n        \"packages\": [\"atlas\"]\n      },\n      \"DRUID\": {\n        \"packages\": [\"druid\"]\n      },\n      \"FLUME\": {\n        \"packages\": [\"flume\"]\n      },\n      \"HBASE\": {\n        \"packages\": [\"hbase\"]\n      },\n      \"HDFS\": {\n        \"packages\": []\n      },\n      \"HIVE\": {\n        \"packages\": [\"hive\", \"hive-hcatalog\", \"hive2\", \"tez_hive2\"]\n      },\n      \"KAFKA\": {\n        \"packages\": [\"kafka\"]\n      },\n      \"KNOX\": {\n        \"packages\": [\"knox\"]\n      },\n      \"MAPREDUCE2\": {\n        \"packages\": []\n      },\n      \"OOZIE\": {\n        \"packages\": [\"oozie\"]\n      },\n      \"PIG\": {\n        \"packages\": [\"pig\"]\n      },\n      \"R4ML\": {\n        \"packages\": []\n      },\n      \"RANGER\": {\n        \"packages\": [\"ranger-admin\", \"ranger-usersync\", \"ranger-tagsync\"]\n      },\n      \"RANGER_KMS\": {\n        \"packages\": [\"ranger-kms\"]\n      },\n      \"SPARK2\": {\n        \"packages\": [\"spark2\", \"livy2\"]\n      },\n      \"SQOOP\": {\n        \"packages\": [\"sqoop\"]\n      },\n      \"STORM\": {\n        \"packages\": [\"storm\", \"storm-slider-client\"]\n      },\n      \"SUPERSET\": {\n        \"packages\": [\"superset\"]\n      },\n      \"SYSTEMML\": {\n        \"packages\": []\n      },\n      \"TEZ\": {\n        \"packages\": [\"tez\"]\n      },\n      \"TITAN\": {\n        \"packages\": []\n      },\n      \"YARN\": {\n        \"packages\": []\n      },\n      \"ZEPPELIN\": {\n        \"packages\": [\"zeppelin\"]\n      },\n      \"ZOOKEEPER\": {\n        \"packages\": [\"zookeeper\"]\n      }\n    },\n    \"upgrade-dependencies\" : {\n      \"ATLAS\": [\"STORM\"],\n      \"HIVE\": [\"TEZ\", \"MAPREDUCE2\", \"SQOOP\"],\n      \"TEZ\": [\"HIVE\"],\n      \"MAPREDUCE2\": [\"HIVE\"],\n      \"OOZIE\": [\"MAPREDUCE2\"]\n    }\n  }\n}",
+      "ignore_groupsusers_create": "false",
+      "alerts_repeat_tolerance": "1",
+      "namenode_rolling_restart_timeout": "4200",
+      "fetch_nonlocal_groups": "true",
+      "manage_dirs_on_root": "true",
+      "recovery_lifetime_max_count": "1024",
+      "recovery_type": "AUTO_START",
+      "sysprep_skip_copy_oozie_share_lib_to_hdfs": "false",
+      "ignore_bad_mounts": "false",
+      "recovery_window_in_minutes": "60",
+      "sysprep_skip_copy_tarballs_hdfs": "false",
+      "user_group": "hadoop",
+      "namenode_rolling_restart_safemode_exit_timeout": "3600",
+      "stack_tools": "{\n  \"HDP\": {\n    \"stack_selector\": [\n      \"hdp-select\",\n      \"/usr/bin/hdp-select\",\n      \"hdp-select\"\n    ],\n    \"conf_selector\": [\n      \"conf-select\",\n      \"/usr/bin/conf-select\",\n      \"conf-select\"\n    ]\n  }\n}",
+      "recovery_retry_interval": "5",
+      "stack_features": "{\n  \"HDP\": {\n    \"stack_features\": [\n      {\n        \"name\": \"snappy\",\n        \"description\": \"Snappy compressor/decompressor support\",\n        \"min_version\": \"2.0.0.0\",\n        \"max_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"lzo\",\n        \"description\": \"LZO libraries support\",\n        \"min_version\": \"2.2.1.0\"\n      },\n      {\n        \"name\": \"express_upgrade\",\n        \"description\": \"Express upgrade support\",\n        \"min_version\": \"2.1.0.0\"\n      },\n      {\n        \"name\": \"rolling_upgrade\",\n        \"description\": \"Rolling upgrade support\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"kafka_acl_migration_support\",\n        \"description\": \"ACL migration support\",\n        \"min_version\": \"2.3.4.0\"\n      },\n      {\n        \"name\": \"secure_zookeeper\",\n        \"description\": \"Protect ZNodes with SASL acl in secure clusters\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"config_versioning\",\n        \"description\": \"Configurable versions support\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"datanode_non_root\",\n        \"description\": \"DataNode running as non-root support (AMBARI-7615)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"remove_ranger_hdfs_plugin_env\",\n        \"description\": \"HDFS removes Ranger env files (AMBARI-14299)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"ranger\",\n        \"description\": \"Ranger Service support\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"ranger_tagsync_component\",\n        \"description\": \"Ranger Tagsync component support (AMBARI-14383)\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"phoenix\",\n        \"description\": \"Phoenix Service support\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"nfs\",\n        \"description\": \"NFS support\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"tez_for_spark\",\n        \"description\": \"Tez dependency for Spark\",\n        \"min_version\": \"2.2.0.0\",\n        \"max_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"timeline_state_store\",\n        \"description\": \"Yarn application timeline-service supports state store property (AMBARI-11442)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"copy_tarball_to_hdfs\",\n        \"description\": \"Copy tarball to HDFS support (AMBARI-12113)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"spark_16plus\",\n        \"description\": \"Spark 1.6+\",\n        \"min_version\": \"2.4.0.0\"\n      },\n      {\n        \"name\": \"spark_thriftserver\",\n        \"description\": \"Spark Thrift Server\",\n        \"min_version\": \"2.3.2.0\"\n      },\n      {\n        \"name\": \"storm_ams\",\n        \"description\": \"Storm AMS integration (AMBARI-10710)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"kafka_listeners\",\n        \"description\": \"Kafka listeners (AMBARI-10984)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"kafka_kerberos\",\n        \"description\": \"Kafka Kerberos support (AMBARI-10984)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"pig_on_tez\",\n        \"description\": \"Pig on Tez support (AMBARI-7863)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"ranger_usersync_non_root\",\n        \"description\": \"Ranger Usersync as non-root user (AMBARI-10416)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"ranger_audit_db_support\",\n        \"description\": \"Ranger Audit to DB support\",\n        \"min_version\": \"2.2.0.0\",\n        \"max_version\": \"2.4.99.99\"\n      },\n      {\n        \"name\": \"accumulo_kerberos_user_auth\",\n        \"description\": \"Accumulo Kerberos User Auth (AMBARI-10163)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"knox_versioned_data_dir\",\n        \"description\": \"Use versioned data dir for Knox (AMBARI-13164)\",\n        \"min_version\": \"2.3.2.0\"\n      },\n      {\n        \"name\": \"knox_sso_topology\",\n        \"description\": \"Knox SSO Topology support (AMBARI-13975)\",\n        \"min_version\": \"2.3.8.0\"\n      },\n      {\n        \"name\": \"atlas_rolling_upgrade\",\n        \"description\": \"Rolling upgrade support for Atlas\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"oozie_admin_user\",\n        \"description\": \"Oozie install user as an Oozie admin user (AMBARI-7976)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"oozie_create_hive_tez_configs\",\n        \"description\": \"Oozie create configs for Ambari Hive and Tez deployments (AMBARI-8074)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"oozie_setup_shared_lib\",\n        \"description\": \"Oozie setup tools used to shared Oozie lib to HDFS (AMBARI-7240)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"oozie_host_kerberos\",\n        \"description\": \"Oozie in secured clusters uses _HOST in Kerberos principal (AMBARI-9775)\",\n        \"min_version\": \"2.0.0.0\"\n      },\n      {\n        \"name\": \"falcon_extensions\",\n        \"description\": \"Falcon Extension\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"hive_metastore_upgrade_schema\",\n        \"description\": \"Hive metastore upgrade schema support (AMBARI-11176)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"hive_server_interactive\",\n        \"description\": \"Hive server interactive support (AMBARI-15573)\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"hive_purge_table\",\n        \"description\": \"Hive purge table support (AMBARI-12260)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"hive_server2_kerberized_env\",\n        \"description\": \"Hive server2 working on kerberized environment (AMBARI-13749)\",\n        \"min_version\": \"2.2.3.0\",\n        \"max_version\": \"2.2.5.0\"\n      },\n      {\n        \"name\": \"hive_env_heapsize\",\n        \"description\": \"Hive heapsize property defined in hive-env (AMBARI-12801)\",\n        \"min_version\": \"2.2.0.0\"\n      },\n      {\n        \"name\": \"ranger_kms_hsm_support\",\n        \"description\": \"Ranger KMS HSM support (AMBARI-15752)\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_log4j_support\",\n        \"description\": \"Ranger supporting log-4j properties (AMBARI-15681)\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_kerberos_support\",\n        \"description\": \"Ranger Kerberos support\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"hive_metastore_site_support\",\n        \"description\": \"Hive Metastore site support\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_usersync_password_jceks\",\n        \"description\": \"Saving Ranger Usersync credentials in jceks\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_install_infra_client\",\n        \"description\": \"Ambari Infra Service support\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"falcon_atlas_support_2_3\",\n        \"description\": \"Falcon Atlas integration support for 2.3 stack\",\n        \"min_version\": \"2.3.99.0\",\n        \"max_version\": \"2.4.0.0\"\n      },\n      {\n        \"name\": \"falcon_atlas_support\",\n        \"description\": \"Falcon Atlas integration\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"hbase_home_directory\",\n        \"description\": \"Hbase home directory in HDFS needed for HBASE backup\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"spark_livy\",\n        \"description\": \"Livy as slave component of spark\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"spark_livy2\",\n        \"description\": \"Livy2 as slave component of Spark2\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"atlas_ranger_plugin_support\",\n        \"description\": \"Atlas Ranger plugin support\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"atlas_conf_dir_in_path\",\n        \"description\": \"Prepend the Atlas conf dir (/etc/atlas/conf) to the classpath of Storm and Falcon\",\n        \"min_version\": \"2.3.0.0\",\n        \"max_version\": \"2.4.99.99\"\n      },\n      {\n        \"name\": \"atlas_upgrade_support\",\n        \"description\": \"Atlas supports express and rolling upgrades\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"atlas_hook_support\",\n        \"description\": \"Atlas support for hooks in Hive, Storm, Falcon, and Sqoop\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_pid_support\",\n        \"description\": \"Ranger Service support pid generation AMBARI-16756\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_kms_pid_support\",\n        \"description\": \"Ranger KMS Service support pid generation\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_admin_password_change\",\n        \"description\": \"Allow ranger admin credentials to be specified during cluster creation (AMBARI-17000)\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_setup_db_on_start\",\n        \"description\": \"Allows setup of ranger db and java patches to be called multiple times on each START\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"storm_metrics_apache_classes\",\n        \"description\": \"Metrics sink for Storm that uses Apache class names\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"spark_java_opts_support\",\n        \"description\": \"Allow Spark to generate java-opts file\",\n        \"min_version\": \"2.2.0.0\",\n        \"max_version\": \"2.4.0.0\"\n      },\n      {\n        \"name\": \"atlas_hbase_setup\",\n        \"description\": \"Use script to create Atlas tables in Hbase and set permissions for Atlas user.\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"ranger_hive_plugin_jdbc_url\",\n        \"description\": \"Handle Ranger hive repo config jdbc url change for stack 2.5 (AMBARI-18386)\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"zkfc_version_advertised\",\n        \"description\": \"ZKFC advertise version\",\n        \"min_version\": \"2.5.0.0\"\n      },\n      {\n        \"name\": \"phoenix_core_hdfs_site_required\",\n        \"description\": \"HDFS and CORE site required for Phoenix\",\n        \"max_version\": \"2.5.9.9\"\n      },\n      {\n        \"name\": \"ranger_tagsync_ssl_xml_support\",\n        \"description\": \"Ranger Tagsync ssl xml support.\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"ranger_xml_configuration\",\n        \"description\": \"Ranger code base support xml configurations\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"kafka_ranger_plugin_support\",\n        \"description\": \"Ambari stack changes for Ranger Kafka Plugin (AMBARI-11299)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"yarn_ranger_plugin_support\",\n        \"description\": \"Implement Stack changes for Ranger Yarn Plugin integration (AMBARI-10866)\",\n        \"min_version\": \"2.3.0.0\"\n      },\n      {\n        \"name\": \"ranger_solr_config_support\",\n        \"description\": \"Showing Ranger solrconfig.xml on UI\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"hive_interactive_atlas_hook_required\",\n        \"description\": \"Registering Atlas Hook for Hive Interactive.\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"atlas_install_hook_package_support\",\n        \"description\": \"Stop installing packages from 2.6\",\n        \"max_version\": \"2.5.9.9\"\n      },\n      {\n        \"name\": \"atlas_hdfs_site_on_namenode_ha\",\n        \"description\": \"Need to create hdfs-site under atlas-conf dir when Namenode-HA is enabled.\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"core_site_for_ranger_plugins\",\n        \"description\": \"Adding core-site.xml in when Ranger plugin is enabled for Storm, Kafka, and Knox.\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"secure_ranger_ssl_password\",\n        \"description\": \"Securing Ranger Admin and Usersync SSL and Trustore related passwords in jceks\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"ranger_kms_ssl\",\n        \"description\": \"Ranger KMS SSL properties in ambari stack\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"atlas_hdfs_site_on_namenode_ha\",\n        \"description\": \"Need to create hdfs-site under atlas-conf dir when Namenode-HA is enabled.\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"atlas_core_site_support\",\n        \"description\": \"Need to create core-site under Atlas conf directory.\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"toolkit_config_update\",\n        \"description\": \"Support separate input and output for toolkit configuration\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"nifi_encrypt_config\",\n        \"description\": \"Encrypt sensitive properties written to nifi property file\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"tls_toolkit_san\",\n        \"description\": \"Support subject alternative name flag\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"admin_toolkit_support\",\n        \"description\": \"Supports the nifi admin toolkit\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"nifi_jaas_conf_create\",\n        \"description\": \"Create NIFI jaas configuration when kerberos is enabled\",\n        \"min_version\": \"2.6.0.0\"\n      },\n      {\n        \"name\": \"registry_remove_rootpath\",\n        \"description\": \"Registry remove root path setting\",\n        \"min_version\": \"2.6.3.0\"\n      },\n      {\n        \"name\": \"nifi_encrypted_authorizers_config\",\n        \"description\": \"Support encrypted authorizers.xml configuration for version 3.1 onwards\",\n        \"min_version\": \"2.6.5.0\"\n      },\n      {\n        \"name\": \"multiple_env_sh_files_support\",\n        \"description\": \"This feature is supported by RANGER and RANGER_KMS service to remove multiple env sh files during upgrade to stack 3.0\",\n        \"max_version\": \"2.6.99.99\"\n      },\n      {\n        \"name\": \"registry_allowed_resources_support\",\n        \"description\": \"Registry allowed resources\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"registry_rewriteuri_filter_support\",\n        \"description\": \"Registry RewriteUri servlet filter\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"registry_support_schema_migrate\",\n        \"description\": \"Support schema migrate in registry for version 3.1 onwards\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"sam_support_schema_migrate\",\n        \"description\": \"Support schema migrate in SAM for version 3.1 onwards\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"sam_storage_core_in_registry\",\n        \"description\": \"Storage core module moved to registry\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"sam_db_file_storage\",\n        \"description\": \"DB based file storage in SAM\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"kafka_extended_sasl_support\",\n        \"description\": \"Support SASL PLAIN and GSSAPI\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"registry_support_db_user_creation\",\n        \"description\": \"Supports registry's database and user creation on the fly\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"streamline_support_db_user_creation\",\n        \"description\": \"Supports Streamline's database and user creation on the fly\",\n        \"min_version\": \"3.0.0.0\"\n      },\n      {\n        \"name\": \"nifi_auto_client_registration\",\n        \"description\": \"Supports NiFi's client registration in runtime\",\n        \"min_version\": \"3.0.0.0\"\n      }\n    ]\n  }\n}",
+      "sysprep_skip_setup_jce": "false",
+      "recovery_enabled": "true",
+      "agent_mounts_ignore_list": "",
+      "stack_root": "{\"HDP\":\"/usr/hdp\"}",
+      "sysprep_skip_create_users_and_groups": "false",
+      "repo_suse_rhel_template": "[{{repo_id}}]\nname={{repo_id}}\n{% if mirror_list %}mirrorlist={{mirror_list}}{% else %}baseurl={{base_url}}{% endif %}\n\npath=/\nenabled=1\ngpgcheck=0",
+      "smokeuser_keytab": "/etc/security/keytabs/smokeuser.headless.keytab",
+      "managed_hdfs_resource_property_names": "",
+      "smokeuser": "ambari-qa",
+      "sysprep_skip_copy_fast_jar_hdfs": "false",
+      "sysprep_skip_lzo_package_operations": "false"
+    }
+  }
+}

--- a/ambari-server/src/test/python/unitTests.py
+++ b/ambari-server/src/test/python/unitTests.py
@@ -101,7 +101,7 @@ def extract_extends_field_from_file(metainfo):
 def get_extends_field_from_metainfo(service_metainfo):
   """
   Parse the metainfo.xml file to retrieve the <extends> value.
-  
+
   @param service_metainfo: Path to the service metainfo.xml file
   :return Extract the "extends" field if it exists and return its value. Otherwise, return None.
   """
@@ -120,7 +120,7 @@ def resolve_paths_to_import_from_common_services(metainfo_file, base_stack_folde
   Get a list of paths to append to sys.path in order to import all of the needed modules.
   This is important when a service has  multiple definitions in common-services so that we import the correct one
   instead of a higher version.
-  
+
   @param metainfo_file: Path to the metainfo.xml file.
   @param base_stack_folder: Path to stacks folder that does not include the version number. This can potentially be None.
   @param common_services_parent_dir: Path to the common-services directory for a specified service, not including the version.


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Background:** Execution Command library was introduced in Ambari's branch 'branch-feature-AMBARI-14714'.

Now, we are back-porting Execution Command library for Ambari 2.8 release.

As of now, we have been parsing the Execution Command command*.json directly, which isn't ideal as there is no interface to : 
- shield the changes that we would like to make in command*.json structure, if need be, and
- Not a good programming approach.

Thus, Execution Command library creates an interface for accessing the command*.json structured data. Reference for a sample execution*.json can be checked at : **ambari-server/src/test/python/TestExecutionCommand_command.json**



## How was this patch tested?

Ran the added UT.


```
$ pwd
… ambari/ambari-server/src/test/python
$ python unitTests.py
....
....
Running tests for ambari-server
....
....
test_access_to_cluster_settings (TestExecutionCommand.TestExecutionCommand) ... ok
test_access_to_execution_command (TestExecutionCommand.TestExecutionCommand) ... ok
test_access_to_module_configs (TestExecutionCommand.TestExecutionCommand) ... ok
test_access_to_stack_settings (TestExecutionCommand.TestExecutionCommand) ... ok
test_get_java_version (TestExecutionCommand.TestExecutionCommand) ... ok
test_get_module_configs (TestExecutionCommand.TestExecutionCommand) ... ok
test_get_module_name (TestExecutionCommand.TestExecutionCommand) ... ok
test_null_value (TestExecutionCommand.TestExecutionCommand) ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.017s

OK
----------------------------------------------------------------------
Total run:8
Total errors:0
Total failures:0
OK

```