### PR TITLE
AMBARI-24752 upgrade ambari-utility,ambari-server-spi deps for JDK11

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -412,7 +412,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>shade-zkmigrator</id>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -365,6 +365,11 @@
         <version>3.1.0</version>
       </dependency>
       <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-core</artifactId>
         <version>1.19</version>

--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -173,5 +173,9 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -53,6 +53,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
Change-Id: Iaea6efbe1daa4e77576043584ab0c11c93a745ea

## What changes were proposed in this pull request?

Add `jaxb-api` as maven dependency since it has been moved out of the language in JDK11. 

## How was this patch tested?

```
± % mvn -version
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T17:41:47+01:00)
Maven home: /usr/local/Cellar/maven@3.3/3.3.9/libexec
Java version: 11, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home
Default locale: en_HU, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.4", arch: "x86_64", family: "mac"

± % mvn clean test -pl ambari-utility,ambari-server-spi
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] Ambari Server SPI
[INFO] ambari-utility
...
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Ambari Server SPI .................................. SUCCESS [  3.264 s]
[INFO] ambari-utility ..................................... SUCCESS [  3.519 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.181 s
[INFO] Finished at: 2018-10-09T14:49:08+02:00
[INFO] Final Memory: 35M/352M
[INFO] ------------------------------------------------------------------------
```

Please review @adoroszlai @oleewere @zeroflag 