### PR TITLE
[AMBARI-24569] Cannot deploy Hive Metastore with Kerberos without HDFS

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -46,12 +46,15 @@ import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.commons.lang.StringUtils;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 
 /**
  * Blueprint implementation.
  */
 public class BlueprintImpl implements Blueprint {
+
+  private static final Set<String> GLOBAL_CONFIG_TYPES = ImmutableSet.of("global", "core-site", ConfigHelper.CLUSTER_ENV);
 
   private String name;
   private Map<String, HostGroup> hostGroups = new HashMap<>();
@@ -617,10 +620,10 @@ public class BlueprintImpl implements Blueprint {
   }
 
   /**
-   * A config type is valid if there are services related to except cluster-env and global.
+   * A config type is valid if there are services related to except some special "global" ones.
    */
   public boolean isValidConfigType(String configType) {
-    if (ConfigHelper.CLUSTER_ENV.equals(configType) || "global".equals(configType)) {
+    if (GLOBAL_CONFIG_TYPES.contains(configType)) {
       return true;
     }
     return getStack().getServicesForConfigType(configType).stream().anyMatch(getServices()::contains);
@@ -653,4 +656,5 @@ public class BlueprintImpl implements Blueprint {
   public List<RepositorySetting> getRepositorySettings(){
     return repoSettings;
   }
+
 }

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive.py
@@ -319,6 +319,16 @@ def setup_metastore():
        content=StaticFile('startMetastore.sh')
   )
 
+  if params.hadoop_conf_dir and not params.has_hdfs and os.path.exists(params.hadoop_conf_dir):
+    XmlConfig("core-site.xml",
+              conf_dir=params.hadoop_conf_dir,
+              configurations=params.config['configurations']['core-site'],
+              configuration_attributes=params.config['configurationAttributes']['core-site'],
+              owner=params.hdfs_user,
+              group=params.user_group,
+              mode=0644
+    )
+
   if not is_empty(params.hive_exec_scratchdir):
     dirPathStr = urlparse(params.hive_exec_scratchdir).path
     pathComponents = dirPathStr.split("/")

--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/params_linux.py
@@ -427,7 +427,7 @@ hive_metastore_pid = status_params.hive_metastore_pid
 # Hive Server Interactive
 slider_am_container_mb = default("/configurations/hive-interactive-env/slider_am_container_mb", 341)
 
-hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
+hdfs_user = default('configurations/hadoop-env/hdfs_user', 'hdfs')
 yarn_user = config['configurations']['yarn-env']['yarn_user']
 user_group = config['configurations']['cluster-env']['user_group']
 artifact_dir = format("{tmp_dir}/AMBARI-artifacts/")
@@ -648,6 +648,11 @@ HdfsResource = functools.partial(
  )
 
 has_pig = 'pig-env' in config['configurations']
+namenode_hosts = default("/clusterHostInfo/namenode_hosts", [])
+hdfs_client_hosts = default("/clusterHostInfo/hdfs_client_hosts", [])
+has_hdfs_clients = len(hdfs_client_hosts) > 0
+has_namenode = len(namenode_hosts) > 0
+has_hdfs = has_hdfs_clients or has_namenode
 
 # Hive Interactive related
 hive_interactive_hosts = default('/clusterHostInfo/hive_server_interactive_hosts', [])

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
@@ -94,7 +94,7 @@ mapred_pid_dir_prefix = default("/configurations/mapred-env/mapred_pid_dir_prefi
 mapred_log_dir_prefix = default("/configurations/mapred-env/mapred_log_dir_prefix","/var/log/hadoop-mapreduce")
 
 #users and groups
-hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
+hdfs_user = default('configurations/hadoop-env/hdfs_user', 'hdfs')
 user_group = config['configurations']['cluster-env']['user_group']
 
 namenode_hosts = default("/clusterHostInfo/namenode_hosts", [])
@@ -103,18 +103,17 @@ has_hdfs_clients = len(hdfs_client_hosts) > 0
 has_namenode = len(namenode_hosts) > 0
 has_hdfs = has_hdfs_clients or has_namenode
 
-if has_hdfs or dfs_type == 'HCFS':
-  hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
+hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
+mount_table_xml_inclusion_file_full_path = None
+mount_table_content = None
 
-  mount_table_xml_inclusion_file_full_path = None
-  mount_table_content = None
-  if 'viewfs-mount-table' in config['configurations']:
-    xml_inclusion_file_name = 'viewfs-mount-table.xml'
-    mount_table = config['configurations']['viewfs-mount-table']
+if (has_hdfs or dfs_type == 'HCFS') and 'viewfs-mount-table' in config['configurations']:
+  xml_inclusion_file_name = 'viewfs-mount-table.xml'
+  mount_table = config['configurations']['viewfs-mount-table']
 
-    if 'content' in mount_table and mount_table['content'].strip():
-      mount_table_xml_inclusion_file_full_path = os.path.join(hadoop_conf_dir, xml_inclusion_file_name)
-      mount_table_content = mount_table['content']
+  if 'content' in mount_table and mount_table['content'].strip():
+    mount_table_xml_inclusion_file_full_path = os.path.join(hadoop_conf_dir, xml_inclusion_file_name)
+    mount_table_content = mount_table['content']
 
 link_configs_lock_file = get_config_lock_file()
 stack_select_lock_file = os.path.join(tmp_dir, "stack_select_lock_file")

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
@@ -94,7 +94,7 @@ mapred_pid_dir_prefix = default("/configurations/mapred-env/mapred_pid_dir_prefi
 mapred_log_dir_prefix = default("/configurations/mapred-env/mapred_log_dir_prefix","/var/log/hadoop-mapreduce")
 
 #users and groups
-hdfs_user = default('configurations/hadoop-env/hdfs_user', 'hdfs')
+hdfs_user = config['configurations']['hadoop-env']['hdfs_user']
 user_group = config['configurations']['cluster-env']['user_group']
 
 namenode_hosts = default("/clusterHostInfo/namenode_hosts", [])
@@ -103,17 +103,18 @@ has_hdfs_clients = len(hdfs_client_hosts) > 0
 has_namenode = len(namenode_hosts) > 0
 has_hdfs = has_hdfs_clients or has_namenode
 
-hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
-mount_table_xml_inclusion_file_full_path = None
-mount_table_content = None
+if has_hdfs or dfs_type == 'HCFS':
+  hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
 
-if (has_hdfs or dfs_type == 'HCFS') and 'viewfs-mount-table' in config['configurations']:
-  xml_inclusion_file_name = 'viewfs-mount-table.xml'
-  mount_table = config['configurations']['viewfs-mount-table']
+  mount_table_xml_inclusion_file_full_path = None
+  mount_table_content = None
+  if 'viewfs-mount-table' in config['configurations']:
+    xml_inclusion_file_name = 'viewfs-mount-table.xml'
+    mount_table = config['configurations']['viewfs-mount-table']
 
-  if 'content' in mount_table and mount_table['content'].strip():
-    mount_table_xml_inclusion_file_full_path = os.path.join(hadoop_conf_dir, xml_inclusion_file_name)
-    mount_table_content = mount_table['content']
+    if 'content' in mount_table and mount_table['content'].strip():
+      mount_table_xml_inclusion_file_full_path = os.path.join(hadoop_conf_dir, xml_inclusion_file_name)
+      mount_table_content = mount_table['content']
 
 link_configs_lock_file = get_config_lock_file()
 stack_select_lock_file = os.path.join(tmp_dir, "stack_select_lock_file")

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
@@ -77,7 +77,7 @@ def setup_config():
   else:
     Logger.warning("Parameter hadoop_conf_dir is missing or directory does not exist. This is expected if this host does not have any Hadoop components.")
 
-  if is_hadoop_conf_dir_present and (params.has_hdfs or stackversion.find('Gluster') >= 0 or params.dfs_type == 'HCFS'):
+  if is_hadoop_conf_dir_present:
     # create core-site only if the hadoop config directory exists
     XmlConfig("core-site.xml",
               conf_dir=params.hadoop_conf_dir,

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
@@ -77,7 +77,7 @@ def setup_config():
   else:
     Logger.warning("Parameter hadoop_conf_dir is missing or directory does not exist. This is expected if this host does not have any Hadoop components.")
 
-  if is_hadoop_conf_dir_present:
+  if is_hadoop_conf_dir_present and (params.has_hdfs or stackversion.find('Gluster') >= 0 or params.dfs_type == 'HCFS'):
     # create core-site only if the hadoop config directory exists
     XmlConfig("core-site.xml",
               conf_dir=params.hadoop_conf_dir,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hive MetaStore needs `core-site` for Kerberos, but `core-site` is ignored by Ambari if there are no HDFS components in the cluster.  Thus Hive Metastore start fails due to empty `core-site` with:

```
KeeperException$InvalidACLException: KeeperErrorCode = InvalidACL for /hive/cluster/delegationMETASTORE/keys
```

This change makes Ambari:

1. accept `core-site` config in blueprint
2. write `core-site.xml` to disk

even without HDFS components being present in the cluster.

## How was this patch tested?

Tested deployment with various blueprints:

 * Hive Metastore + ZooKeeper + Kerberos
 * HDFS
 * HDFS with custom `hdfs_user`
 * Kafka + Kerberos
 * ZooKeeper + Kerberos