### PR TITLE
AMBARI-24757. Grafana start failing on U14 fails with error "AttributeError: 'module' object has no attribute 'PROTOCOL_TLSv1_2'"

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
+++ b/ambari-agent/src/main/python/ambari_agent/AmbariConfig.py
@@ -24,6 +24,7 @@ import StringIO
 import hostname
 import ambari_simplejson as json
 import os
+import ssl
 
 from ambari_agent.FileCache import FileCache
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
@@ -376,7 +377,8 @@ class AmbariConfig:
 
     :return: protocol name, PROTOCOL_TLSv1_2 by default
     """
-    return self.get('security', 'force_https_protocol', default="PROTOCOL_TLSv1_2")
+    default = "PROTOCOL_TLSv1_2" if hasattr(ssl, "PROTOCOL_TLSv1_2") else "PROTOCOL_TLSv1"
+    return self.get('security', 'force_https_protocol', default=default)
 
   def get_force_https_protocol_value(self):
     """
@@ -384,7 +386,6 @@ class AmbariConfig:
 
     :return: protocol value
     """
-    import ssl
     return getattr(ssl, self.get_force_https_protocol_name())
 
   def get_ca_cert_file_path(self):

--- a/ambari-common/src/main/python/resource_management/libraries/script/script.py
+++ b/ambari-common/src/main/python/resource_management/libraries/script/script.py
@@ -24,6 +24,7 @@ __all__ = ["Script"]
 import re
 import os
 import sys
+import ssl
 import logging
 import platform
 import inspect
@@ -134,7 +135,7 @@ class Script(object):
 
   # Class variable
   tmp_dir = ""
-  force_https_protocol = "PROTOCOL_TLSv1_2"
+  force_https_protocol = "PROTOCOL_TLSv1_2" if hasattr(ssl, "PROTOCOL_TLSv1_2") else "PROTOCOL_TLSv1"
   ca_cert_file_path = None
 
   def load_structured_out(self):
@@ -663,7 +664,6 @@ class Script(object):
 
     :return: protocol value
     """
-    import ssl
     return getattr(ssl, Script.get_force_https_protocol_name())
 
   @staticmethod


### PR DESCRIPTION
Grafana start failing on U14 fails with error "AttributeError: 'module' object has no attribute 'PROTOCOL_TLSv1_2'"

Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_grafana.py", line 83, in <module>
    AmsGrafana().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 351, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_grafana.py", line 58, in start
    create_grafana_admin_pwd()
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_grafana_util.py", line 252, in create_grafana_admin_pwd
    response = perform_grafana_get_call(GRAFANA_USER_URL, serverCall1)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_grafana_util.py", line 63, in perform_grafana_get_call
    ssl_version=Script.get_force_https_protocol_value()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 626, in get_force_https_protocol_value
    return getattr(ssl, Script.get_force_https_protocol_name())
AttributeError: 'module' object has no attribute 'PROTOCOL_TLSv1_2'
root@u14-deploy-sj-1:~# python --version
Python 2.7.6