### PR TITLE
AMBARI-24758. Ambari-agent takes up too many cpu on perf

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/AmbariAgent.py
+++ b/ambari-agent/src/main/python/ambari_agent/AmbariAgent.py
@@ -51,6 +51,8 @@ def main():
   mergedArgs = [PYTHON, AGENT_SCRIPT] + args
 
   while status == AGENT_AUTO_RESTART_EXIT_CODE:
+    with open("/tmp/x" , "w") as fp:
+      fp.write(str(mergedArgs))
     mainProcess = subprocess32.Popen(mergedArgs)
     mainProcess.communicate()
     status = mainProcess.returncode

--- a/ambari-agent/src/main/python/ambari_agent/AmbariAgent.py
+++ b/ambari-agent/src/main/python/ambari_agent/AmbariAgent.py
@@ -51,8 +51,6 @@ def main():
   mergedArgs = [PYTHON, AGENT_SCRIPT] + args
 
   while status == AGENT_AUTO_RESTART_EXIT_CODE:
-    with open("/tmp/x" , "w") as fp:
-      fp.write(str(mergedArgs))
     mainProcess = subprocess32.Popen(mergedArgs)
     mainProcess.communicate()
     status = mainProcess.returncode

--- a/ambari-agent/src/main/python/ambari_agent/HostCheckReportFileHandler.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCheckReportFileHandler.py
@@ -28,7 +28,7 @@ import ConfigParser
 
 HADOOP_ROOT_DIR = "/usr/hdp"
 HADOOP_PERM_REMOVE_LIST = ["current"]
-HADOOP_ITEMDIR_REGEX = "(\d\.){3}\d-\d{4}"
+HADOOP_ITEMDIR_REGEXP = re.compile("(\d\.){3}\d-\d{4}")
 logger = logging.getLogger(__name__)
 
 class HostCheckReportFileHandler:
@@ -96,7 +96,6 @@ class HostCheckReportFileHandler:
     if not os.path.exists(HADOOP_ROOT_DIR):
       return []
 
-    matcher = re.compile(HADOOP_ITEMDIR_REGEX)  # pre-compile regexp
     folder_content = os.listdir(HADOOP_ROOT_DIR)
     remove_list = []
 
@@ -108,7 +107,7 @@ class HostCheckReportFileHandler:
         remove_list.append(full_path)
         remlist_items_count += 1
 
-      if matcher.match(item) is not None:
+      if HADOOP_ITEMDIR_REGEXP.match(item) is not None:
         remove_list.append(full_path)
         remlist_items_count += 1
 

--- a/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
@@ -375,6 +375,7 @@ class HostCleanup:
     pidList = []
     cmd = "ps auxww"
     (returncode, stdoutdata, stderrdata) = self.run_os_command(cmd)
+    line_regexp = re.compile("\s\s+")
 
     if 0 == returncode and stdoutdata:
       lines = stdoutdata.split('\n')
@@ -384,7 +385,7 @@ class HostCleanup:
           identifier = identifier.strip()
           if identifier in line:
             logger.debug("Found " + line + " for " + identifier);
-            line = re.sub("\s\s+" , " ", line) #replace multi spaces with single space before calling the split
+            line = line_regexp.sub(" ", line) #replace multi spaces with single space before calling the split
             tokens = line.split(' ')
             logger.debug(tokens)
             logger.debug(len(tokens))

--- a/ambari-agent/src/main/python/ambari_agent/HostInfo.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostInfo.py
@@ -196,6 +196,8 @@ class HostInfoLinux(HostInfo):
   THP_FILE_REDHAT = "/sys/kernel/mm/redhat_transparent_hugepage/enabled"
   THP_FILE_UBUNTU = "/sys/kernel/mm/transparent_hugepage/enabled"
 
+  THP_REGEXP = re.compile("\[(.+)\]")
+
   def __init__(self, config=None):
     super(HostInfoLinux, self).__init__(config)
 
@@ -267,7 +269,6 @@ class HostInfoLinux(HostInfo):
       logger.exception("Checking java processes failed")
 
   def getTransparentHugePage(self):
-    thp_regex = "\[(.+)\]"
     file_name = None
     if OSCheck.is_ubuntu_family():
       file_name = self.THP_FILE_UBUNTU
@@ -277,7 +278,7 @@ class HostInfoLinux(HostInfo):
     if file_name and os.path.isfile(file_name):
       with open(file_name) as f:
         file_content = f.read()
-        return re.search(thp_regex, file_content).groups()[0]
+        return HostInfoLinux.THP_REGEXP.search(file_content).groups()[0]
     else:
       return ""
 

--- a/ambari-agent/src/main/python/ambari_agent/alerts/ams_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/ams_alert.py
@@ -22,7 +22,7 @@ import httplib
 import imp
 import time
 import urllib
-from alerts.metric_alert import MetricAlert
+from alerts.metric_alert import MetricAlert, REALCODE_REGEXP
 import ambari_simplejson as json
 import logging
 import re
@@ -212,7 +212,7 @@ def f(args):
     self.minimum_value = metric_info['minimum_value']
 
     if 'value' in metric_info:
-      realcode = re.sub('(\{(\d+)\})', 'args[\g<2>][k]', metric_info['value'])
+      realcode = REALCODE_REGEXP.sub('(\{(\d+)\})', 'args[\g<2>][k]', metric_info['value'])
 
       self.custom_value_module =  imp.new_module(str(uuid.uuid4()))
       code = self.DYNAMIC_CODE_VALUE_TEMPLATE.format(realcode)

--- a/ambari-agent/src/main/python/ambari_agent/alerts/ams_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/ams_alert.py
@@ -212,7 +212,7 @@ def f(args):
     self.minimum_value = metric_info['minimum_value']
 
     if 'value' in metric_info:
-      realcode = REALCODE_REGEXP.sub('(\{(\d+)\})', 'args[\g<2>][k]', metric_info['value'])
+      realcode = REALCODE_REGEXP.sub('args[\g<2>][k]', metric_info['value'])
 
       self.custom_value_module =  imp.new_module(str(uuid.uuid4()))
       code = self.DYNAMIC_CODE_VALUE_TEMPLATE.format(realcode)

--- a/ambari-agent/src/main/python/ambari_agent/alerts/base_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/base_alert.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 AlertUri = namedtuple('AlertUri', 'uri is_ssl_enabled')
 
 class BaseAlert(object):
+  CONFIG_KEY_REGEXP = re.compile('{{(\S+?)}}')
   # will force a kinit even if klist says there are valid tickets (4 hour default)
   _DEFAULT_KINIT_TIMEOUT = 14400000
 
@@ -214,7 +215,7 @@ class BaseAlert(object):
     # parse {{foo-bar/baz}}/whatever/{{foobar-site/blah}}
     # into
     # ['foo-bar/baz', 'foobar-site/blah']
-    placeholder_keys = re.findall("{{(\S+?)}}", key)
+    placeholder_keys = BaseAlert.CONFIG_KEY_REGEXP.findall(key)
 
     # if none found, then return the original
     if placeholder_keys is None or len(placeholder_keys) == 0:

--- a/ambari-agent/src/main/python/ambari_agent/alerts/metric_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/metric_alert.py
@@ -39,6 +39,7 @@ SECURITY_ENABLED_KEY = '{{cluster-env/security_enabled}}'
 
 # default timeout
 DEFAULT_CONNECTION_TIMEOUT = 5.0
+REALCODE_REGEXP = re.compile('(\{(\d+)\})')
 
 class MetricAlert(BaseAlert):
 
@@ -282,14 +283,13 @@ from __future__ import division
 def f(args):
   return {0}
 """
-
   def __init__(self, jmx_info):
     self.custom_module = None
     self.property_list = jmx_info['property_list']
     self.property_map = {}
 
     if 'value' in jmx_info:
-      realcode = re.sub('(\{(\d+)\})', 'args[\g<2>]', jmx_info['value'])
+      realcode = REALCODE_REGEXP.sub('args[\g<2>]', jmx_info['value'])
 
       self.custom_module =  imp.new_module(str(uuid.uuid4()))
       code = self.DYNAMIC_CODE_TEMPLATE.format(realcode)

--- a/ambari-agent/src/main/python/ambari_agent/alerts/script_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/script_alert.py
@@ -31,6 +31,7 @@ from ambari_commons.constants import AGENT_TMP_DIR
 logger = logging.getLogger(__name__)
 
 class ScriptAlert(BaseAlert):
+  PATH_TO_SCRIPT_REGEXP = re.compile(r'((.*)services(.*)package)')
 
   def __init__(self, alert_meta, alert_source_meta, config):
 
@@ -112,7 +113,7 @@ class ScriptAlert(BaseAlert):
 
       # try to get basedir for scripts
       # it's needed for server side scripts to properly use resource management
-      matchObj = re.match( r'((.*)services(.*)package)', self.path_to_script)
+      matchObj = ScriptAlert.PATH_TO_SCRIPT_REGEXP.match(self.path_to_script)
       if matchObj:
         basedir = matchObj.group(1)
         with Environment(basedir, tmp_dir=AGENT_TMP_DIR, logger=logging.getLogger('alerts')) as env:

--- a/ambari-agent/src/main/python/ambari_agent/main.py
+++ b/ambari-agent/src/main/python/ambari_agent/main.py
@@ -88,6 +88,7 @@ import time
 import locale
 import platform
 import ConfigParser
+import signal
 import resource
 from logging.handlers import SysLogHandler
 import AmbariConfig
@@ -364,7 +365,7 @@ def run_threads(initializer_module):
   initializer_module.action_queue.start()
 
   while not initializer_module.stop_event.is_set():
-    time.sleep(0.1)
+    signal.pause()
 
   initializer_module.action_queue.interrupt()
 


### PR DESCRIPTION
Profiling results:

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    14129 1426.122    0.101 1426.122    0.101 {time.sleep}
        1    0.337    0.337 1426.769 1426.769 main.py:358(run_threads)
      331    0.219    0.001    0.219    0.001 {method 'acquire' of 'thread.lock' objects}
       11    0.181    0.016    0.181    0.016 {built-in method poll}
        1    0.108    0.108    0.108    0.108 {method 'do_handshake' of '_ssl._SSLSocket' objects}
    14151    0.042    0.000    0.042    0.000 threading.py:571(isSet)
      125    0.028    0.000    0.028    0.000 {method 'flush' of 'file' objects}
     5078    0.027    0.000    0.052    0.000 decoder.py:65(py_scanstring)
       15    0.020    0.001    0.020    0.001 {posix.read}
     5093    0.020    0.000    0.024    0.000 {method 'sub' of '_sre.SRE_Pattern' objects}
        1    0.019    0.019    0.019    0.019 {method 'connect' of '_socket.socket' objects}
    15365    0.018    0.000    0.018    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
55424/13131    0.016    0.000    0.057    0.000 encoder.py:332(_iterencode_dict)
    38241    0.014    0.000    0.014    0.000 {isinstance}
       21    0.013    0.001    0.022    0.001 collections.py:282(namedtuple)
    473/5    0.012    0.000    0.073    0.015 decoder.py:148(JSONObject)
     5078    0.009    0.000    0.034    0.000 encoder.py:43(py_encode_basestring_ascii)
        5    0.006    0.001    0.070    0.014 __init__.py:122(dump)
    13251    0.005    0.000    0.005    0.000 {method 'write' of 'file' objects}
        7    0.004    0.001    0.004    0.001 {ambari_commons.libs.x86_64._posixsubprocess.fork_exec}
     5638    0.004    0.000    0.004    0.000 encoder.py:49(replace)
   3167/5    0.003    0.000    0.073    0.015 scanner.py:27(_scan_once)
13353/9909    0.003    0.000    0.030    0.000 encoder.py:279(_iterencode_list)
       75    0.003    0.000    0.003    0.000 {method 'read' of '_ssl._SSLSocket' objects}
   3177/8    0.003    0.000    0.008    0.001 Utils.py:124(make_immutable)
    13131    0.003    0.000    0.060    0.000 encoder.py:409(_iterencode)
    11128    0.003    0.000    0.003    0.000 {method 'groups' of '_sre.SRE_Match' objects}
  2202/45    0.003    0.000    0.004    0.000 Utils.py:135(get_mutable_copy)
   474/10    0.002    0.000    0.008    0.001 Utils.py:170(__init__)
      238    0.002    0.000    0.002    0.000 {time.localtime}
      119    0.002    0.000    0.004    0.000 __init__.py:242(__init__)
     3759    0.002    0.000    0.002    0.000 {method 'isalnum' of 'str' objects}
    14752    0.002    0.000    0.002    0.000 {method 'end' of '_sre.SRE_Match' objects}
    16854    0.002    0.000    0.002    0.000 {method 'append' of 'list' objects}
     5098    0.002    0.000    0.002    0.000 {method 'join' of 'unicode' objects}
      238    0.002    0.000    0.007    0.000 __init__.py:451(format)
       13    0.002    0.000    0.004    0.000 metric_alert.py:286(__init__)
        7    0.001    0.000    0.026    0.004 subprocess32.py:1153(_execute_child)
       41    0.001    0.000    0.001    0.000 {open}
      616    0.001    0.000    0.001    0.000 {method 'format' of 'str' objects}
      238    0.001    0.000    0.004    0.000 __init__.py:404(formatTime)
       18    0.001    0.000    0.001    0.000 {posix.listdir}
        5    0.001    0.000    0.072    0.014 ClusterCache.py:131(persist_cache)
     4032    0.001    0.000    0.003    0.000 collections.py:323(<genexpr>)
       18    0.001    0.000    0.001    0.000 {method 'sort' of 'list' objects}
       90    0.001    0.000    0.001    0.000 {built-in method now}
      238    0.001    0.000    0.001    0.000 {time.strftime}
      119    0.001    0.000    0.001    0.000 __init__.py:1215(findCaller)
     5706    0.001    0.000    0.001    0.000 {method 'group' of '_sre.SRE_Match' objects}
      281    0.001    0.000    0.001    0.000 threading.py:146(acquire)
      281    0.001    0.000    0.001    0.000 threading.py:186(release)
      119    0.001    0.000    0.001    0.000 {method 'seek' of 'file' objects}
        1    0.001    0.001    0.001    0.001 ClusterTopologyCache.py:58(on_cache_update)
      119    0.001    0.000    0.005    0.000 handlers.py:144(shouldRollover)
     50/5    0.001    0.000    0.035    0.007 decoder.py:223(JSONArray)
Major cpu cosumers:
1) Regexp operation: 
As we can see a lot of time is took for regexp operations. This happens because we use non-compiled regular expressions.
2) Json operations:
Another major cpu consumer is json module, because _speedups.so is not compiled for python2.7 currently. We have this situation. This is tackled by other issue 
3) Main thread waking up/sleeping too often.
This seems to create quite a bit cpu usage.
The approach was implemented so agent can check for SIGTERM (ambari-agent stop). A proper solution should be a usage signal.pause() instead of sleep/wakeup.