### PR TITLE
AMBARI-24767. Error while starting Timeline v2 Reader during Move operation (amagyar)

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step3_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step3_controller.js
@@ -118,6 +118,15 @@ App.ReassignMasterWizardStep3Controller = Em.Controller.extend({
       }
     },
     {
+      componentName: 'TIMELINE_READER',
+      configs: {
+        'yarn-site': {
+          'yarn.timeline-service.reader.webapp.address': '<replace-value>:8198',
+          'yarn.timeline-service.reader.webapp.https.address': '<replace-value>:8199'
+        }
+      }
+    },
+    {
       componentName: 'OOZIE_SERVER',
       configs: {
         'oozie-site': {

--- a/ambari-web/app/controllers/main/service/reassign_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign_controller.js
@@ -160,7 +160,8 @@ App.ReassignMasterController = App.WizardController.extend({
     'HIVE_SERVER': ['hive-site', 'webhcat-site', 'hive-env', 'core-site'],
     'HIVE_METASTORE': ['hive-site', 'webhcat-site', 'hive-env', 'core-site'],
     'MYSQL_SERVER': ['hive-site'],
-    'HISTORYSERVER': ['mapred-site']
+    'HISTORYSERVER': ['mapred-site'],
+    'TIMELINE_READER' : ['yarn-site']
   },
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

After moving timeline reader the webapp bind address config value is not updated. This causes timeline reader not to start on a kerberized cluster.

## How was this patch tested?

- manually moved TLR to a different host and checked its logfile