### PR TITLE
AMBARI-24770 Convert Hive Tables step use Hive 1 starting from HDP 3.…

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
@@ -100,9 +100,15 @@ class HivePreUpgrade(Script):
       hive_kinit_cmd = format("{kinit_path_local} -kt {hive_server2_keytab} {hive_principal}; ")
       Execute(hive_kinit_cmd, user = params.hive_user)
     
-    classpath = format("{source_dir}/hive2/lib/*:{source_dir}/hadoop/*:{source_dir}/hadoop/lib/*:{source_dir}/hadoop-mapreduce/*:{source_dir}/hadoop-mapreduce/lib/*:{source_dir}/hadoop-hdfs/*:{source_dir}/hadoop-hdfs/lib/*:{source_dir}/hadoop/etc/hadoop/:{target_dir}/hive/lib/hive-pre-upgrade.jar:{source_dir}/hive/conf/conf.server")
+    # in the M10 release PreUpgradeTool was fixed to use Hive1 instead of Hive2 
+    if target_version >= "3.0.3":
+      hive_lib_dir = format("{source_dir}/hive/lib")
+    else:
+      hive_lib_dir = format("{source_dir}/hive2/lib")
+    
+    classpath = format("{hive_lib_dir}/*:{source_dir}/hadoop/*:{source_dir}/hadoop/lib/*:{source_dir}/hadoop-mapreduce/*:{source_dir}/hadoop-mapreduce/lib/*:{source_dir}/hadoop-hdfs/*:{source_dir}/hadoop-hdfs/lib/*:{source_dir}/hadoop/etc/hadoop/:{target_dir}/hive/lib/hive-pre-upgrade.jar:{source_dir}/hive/conf/conf.server")
     # hack to avoid derby cp issue we want derby-10.10.2.0.jar to appear first in cp, if its available, note other derby jars are derbyclient-10.11.1.1.jar  derbynet-10.11.1.1.jar
-    derby_jars = glob.glob(source_dir+"/hive2/lib/*derby-*.jar")
+    derby_jars = glob.glob(source_dir + "/hive2/lib/*derby-*.jar")
     if len(derby_jars) == 1:
       classpath = derby_jars[0] + ":" + classpath
     cmd = format("{java64_home}/bin/java -Djavax.security.auth.useSubjectCredsOnly=false -cp {classpath} org.apache.hadoop.hive.upgrade.acid.PreUpgradeTool -execute")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Starting from HDP 3.0.3. the "Convert Hive Tables" step in the upgrade process from 2.6 needs to use Hive 1 jars instead of Hive 2 jars.

## How was this patch tested?

Tested on local cluster by upgrading with the modification to version both before and after 3.0.3.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.