### PR TITLE
AMBARI-24775 - Configuration warning: insert a space char between label value and unit-name

### DIFF
--- a/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
@@ -281,13 +281,13 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
       if (parsed > max) {
         this.set('isMirrorValueValid', false);
         this.get('config').setProperties({
-          warnMessage: Em.I18n.t('config.warnMessage.outOfBoundaries.greater').format(max + this.get('unitLabel')),
+          warnMessage: Em.I18n.t('config.warnMessage.outOfBoundaries.greater').format(this.formatTickLabel(max, ' ')),
           warn: true
         });
       } else if (parsed < min) {
         this.set('isMirrorValueValid', false);
         this.get('config').setProperties({
-          warnMessage: Em.I18n.t('config.warnMessage.outOfBoundaries.less').format(min + this.get('unitLabel')),
+          warnMessage: Em.I18n.t('config.warnMessage.outOfBoundaries.less').format(this.formatTickLabel(min, ' ')),
           warn: true
         });
       } else {

--- a/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
@@ -653,7 +653,7 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
         var min = this.get('parseFunction')(this.getValueAttributeByGroup('minimum'));
         if (configValue < min) {
           min = this.widgetValueByConfigAttributes(min);
-          this.updateWarningsForCompatibilityWithWidget(Em.I18n.t('config.warnMessage.outOfBoundaries.less').format(min + this.get('unitLabel')));
+          this.updateWarningsForCompatibilityWithWidget(Em.I18n.t('config.warnMessage.outOfBoundaries.less').format(this.formatTickLabel(min, ' ')));
           return false;
         }
       }
@@ -661,7 +661,7 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
         var max = this.get('parseFunction')(this.getValueAttributeByGroup('maximum'));
         if (configValue > max) {
           max = this.widgetValueByConfigAttributes(max);
-          this.updateWarningsForCompatibilityWithWidget(Em.I18n.t('config.warnMessage.outOfBoundaries.greater').format(max + this.get('unitLabel')));
+          this.updateWarningsForCompatibilityWithWidget(Em.I18n.t('config.warnMessage.outOfBoundaries.greater').format(this.formatTickLabel(max, ' ')));
           return false;
         }
       }
@@ -680,7 +680,6 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
    */
   formatTickLabel: function (tick, separator) {
     var label,
-      separator = separator || '',
       valueLabel = tick,
       units = ['B', 'KB', 'MB', 'GB', 'TB'],
       unitLabel = this.get('unitLabel'),
@@ -693,6 +692,7 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
       unitLabel = units[unitLabelIndex];
       valueLabel = this._extraRound(tick);
     }
+    var separator = (separator && unitLabel) ? separator : '';
     label = valueLabel + separator + unitLabel;
     return label;
   }

--- a/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
+++ b/ambari-web/app/views/common/configs/widgets/slider_config_widget_view.js
@@ -692,8 +692,7 @@ App.SliderConfigWidgetView = App.ConfigWidgetView.extend({
       unitLabel = units[unitLabelIndex];
       valueLabel = this._extraRound(tick);
     }
-    var separator = (separator && unitLabel) ? separator : '';
-    label = valueLabel + separator + unitLabel;
+    label = valueLabel + ((separator && unitLabel) ? separator : '') + unitLabel;
     return label;
   }
 

--- a/ambari-web/test/views/common/configs/widgets/slider_config_widget_view_test.js
+++ b/ambari-web/test/views/common/configs/widgets/slider_config_widget_view_test.js
@@ -386,7 +386,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [5, 16, 22, 28, 35, 39, 50],
-          ticksLabels: ['5 ','', '', '28 ', '', '', '50 ']
+          ticksLabels: ['5','', '', '28', '', '', '50']
         }
       },
       {
@@ -403,7 +403,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [1,2],
-          ticksLabels: ['1 ', '2 ']
+          ticksLabels: ['1', '2']
         }
       },
       {
@@ -420,7 +420,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [1,2,3],
-          ticksLabels: ['1 ', '2 ', '3 ']
+          ticksLabels: ['1', '2', '3']
         }
       },
       {
@@ -437,7 +437,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [0,1,2,3],
-          ticksLabels: ['0 ', '1 ', '2 ', '3 ']
+          ticksLabels: ['0', '1', '2', '3']
         }
       },
       {
@@ -454,7 +454,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [1,2,3,4,5],
-          ticksLabels: ['1 ', '', '3 ', '', '5 ']
+          ticksLabels: ['1', '', '3', '', '5']
         }
       },
       {
@@ -471,7 +471,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [0,2,3,5],
-          ticksLabels: ['0 ', '2 ', '3 ', '5 ']
+          ticksLabels: ['0', '2', '3', '5']
         }
       },
       {
@@ -488,7 +488,7 @@ describe('App.SliderConfigWidgetView', function () {
         },
         e: {
           ticks: [0,2,6,12,17,20,23],
-          ticksLabels: ['0 ', '', '', '12 ', '', '', '23 ']
+          ticksLabels: ['0', '', '', '12', '', '', '23']
         }
       },
       {


### PR DESCRIPTION
## What changes were proposed in this pull request?

On Ambari enhaced configuration UI on the slider widgets in the warning tooltip and on the Configuration warning page the value and unit-name was written into one word 
```
100GB
```
Fix: insert a space character between the value and the unit-name
```
100 GB
```

## How was this patch tested?

ambari-web
mvn clean install

Manually:
- Install Ambari.
- Launch the Cluster creation wizard
- Choose a service which has slider widget in its config UI (ex. HDFS)
- On the `Customize Services` step enter a bigger value that the maximum allowed
- Check the warning tooltip text
- Hit 'Save'
- Check the warning message on the 'Configuration warning dialog'