### PR TITLE
[AMBARI-24779] Move Namenode operation fails as it tries to install a…

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step4_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step4_controller.js
@@ -121,7 +121,8 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
     var dependenciesToInstall = App.StackServiceComponent.find(componentName)
         .get('dependencies')
         .filter(function (component) {
-          return !(component.scope == 'host' ? hostInstalledComponents : clusterInstalledComponents).contains(component.componentName) && (installedServices.contains(component.serviceName));
+          return !(component.scope == 'host' ? hostInstalledComponents : clusterInstalledComponents).contains(component.componentName) && (installedServices.contains(component.serviceName))
+            && (componentName === 'NAMENODE' ? App.get('isHaEnabled'): true);
         })
         .mapProperty('componentName');
     this.set('dependentHostComponents', dependenciesToInstall);


### PR DESCRIPTION
…nd start ZKFailoverController on non-HA cluster.

## What changes were proposed in this pull request?
Included logic to add namenode dependency only if HA is enabled

## How was this patch tested?
21864 passing (22s)
  48 pending