### PR TITLE
[AMBARI-24779] Move Namenode operation fails as it tries to install a…

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step4_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step4_controller.js
@@ -121,7 +121,8 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
     var dependenciesToInstall = App.StackServiceComponent.find(componentName)
         .get('dependencies')
         .filter(function (component) {
-          return !(component.scope == 'host' ? hostInstalledComponents : clusterInstalledComponents).contains(component.componentName) && (installedServices.contains(component.serviceName));
+          return !(component.scope == 'host' ? hostInstalledComponents : clusterInstalledComponents).contains(component.componentName) && (installedServices.contains(component.serviceName))
+            && (componentName === 'NAMENODE' ? App.get('isHaEnabled'): true);
         })
         .mapProperty('componentName');
     this.set('dependentHostComponents', dependenciesToInstall);


### PR DESCRIPTION
…nd start ZKFailoverController on non-HA cluster.

## What changes were proposed in this pull request?
Cherry-picking changes made in https://github.com/apache/ambari/pull/2460 for branch-2.7

## How was this patch tested?
21730 passing (23s)
  48 pending