### PR TITLE
AMBARI-24781 - Ambari setup-ldap: change group member default for IPA

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -550,7 +550,7 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--ldap-secondary-host', action="callback", callback=check_ldap_url_options, type='str', default=None, help="Secondary Host for LDAP (must not be used together with --ldap-secondary-url)", dest="ldap_secondary_host")
   parser.add_option('--ldap-secondary-port', action="callback", callback=check_ldap_url_options, type='int', default=None, help="Secondary Port for LDAP (must not be used together with --ldap-secondary-url)", dest="ldap_secondary_port")
   parser.add_option('--ldap-ssl', default=None, help="Use SSL [true/false] for LDAP", dest="ldap_ssl")
-  parser.add_option('--ldap-use-generic-defaults', action="store_true", default=None, help="Disables ldap type query and generic defaults will be offered for non existent properties".format("/".join(LDAP_TYPES)), dest="ldap_use_generic_defaults")
+  parser.add_option('--ldap-type', default=None, help="Specify ldap type [{}] for offering defaults for missing options.".format("/".join(LDAP_TYPES)), dest="ldap_type")
   parser.add_option('--ldap-user-class', default=None, help="User Attribute Object Class for LDAP", dest="ldap_user_class")
   parser.add_option('--ldap-user-attr', default=None, help="User Attribute Name for LDAP", dest="ldap_user_attr")
   parser.add_option('--ldap-group-class', default=None, help="Group Attribute Object Class for LDAP", dest="ldap_group_class")

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -727,7 +727,7 @@ def init_ldap_properties_list_reqd(properties, options):
     LdapPropTemplate(properties, options.ldap_user_attr, "ambari.ldap.attributes.user.name_attr", "User ID attribute{0}: ", REGEX_ANYTHING, False, LdapDefaultMap({LDAP_AD:'sAMAccountName', LDAP_IPA:'uid', LDAP_GENERIC:'uid'})),
     LdapPropTemplate(properties, options.ldap_group_class, "ambari.ldap.attributes.group.object_class", "Group object class{0}: ", REGEX_ANYTHING, False, LdapDefaultMap({LDAP_AD:'group', LDAP_IPA:'posixGroup', LDAP_GENERIC:'posixGroup'})),
     LdapPropTemplate(properties, options.ldap_group_attr, "ambari.ldap.attributes.group.name_attr", "Group name attribute{0}: ", REGEX_ANYTHING, False, LdapDefault("cn")),
-    LdapPropTemplate(properties, options.ldap_member_attr, "ambari.ldap.attributes.group.member_attr", "Group member attribute{0}: ", REGEX_ANYTHING, False, LdapDefaultMap({LDAP_AD:'member', LDAP_IPA:'memberUid', LDAP_GENERIC:'memberUid'})),
+    LdapPropTemplate(properties, options.ldap_member_attr, "ambari.ldap.attributes.group.member_attr", "Group member attribute{0}: ", REGEX_ANYTHING, False, LdapDefaultMap({LDAP_AD:'member', LDAP_IPA:'member', LDAP_GENERIC:'memberUid'})),
     LdapPropTemplate(properties, options.ldap_dn, "ambari.ldap.attributes.dn_attr", "Distinguished name attribute{0}: ", REGEX_ANYTHING, False, LdapDefaultMap({LDAP_AD:'distinguishedName', LDAP_IPA:'dn', LDAP_GENERIC:'dn'})),
     LdapPropTemplate(properties, options.ldap_base_dn, "ambari.ldap.attributes.user.search_base", "Search Base{0}: ", REGEX_ANYTHING, False, LdapDefaultMap({LDAP_AD:'dc=ambari,dc=apache,dc=org', LDAP_IPA:'cn=accounts,dc=ambari,dc=apache,dc=org', LDAP_GENERIC:'dc=ambari,dc=apache,dc=org'})),
     LdapPropTemplate(properties, options.ldap_referral, "ambari.ldap.advanced.referrals", "Referral method [follow/ignore]{0}: ", REGEX_REFERRAL, True, LdapDefault("follow")),
@@ -755,13 +755,14 @@ def should_query_ldap_type(ldap_property_list_reqd):
       return True
   return False
 
-def query_ldap_type():
+def query_ldap_type(ldap_type_option):
   return get_validated_string_input("Please select the type of LDAP you want to use [{}]({}):".format("/".join(LDAP_TYPES), LDAP_GENERIC),
                                     LDAP_GENERIC,
                                     REGEX_LDAP_TYPE,
                                     "Please enter one of the followings '{}'!".format("', '".join(LDAP_TYPES)),
                                     False,
-                                    False)
+                                    False,
+                                    answer = ldap_type_option)
 
 def setup_ldap(options):
   logger.info("Setup LDAP.")
@@ -807,8 +808,7 @@ def setup_ldap(options):
     LDAP_AD:'cn=ldapbind,dc=ambari,dc=apache,dc=org',
     LDAP_IPA:'uid=ldapbind,cn=users,cn=accounts,dc=ambari,dc=apache,dc=org',
     LDAP_GENERIC:'uid=ldapbind,cn=users,dc=ambari,dc=apache,dc=org'}))
-  ldap_type = LDAP_GENERIC if options.ldap_use_generic_defaults or not should_query_ldap_type(ldap_property_list_reqd) else query_ldap_type()
-
+  ldap_type = query_ldap_type(options.ldap_type) if options.ldap_type or should_query_ldap_type(ldap_property_list_reqd) else LDAP_GENERIC
   ldap_property_list_opt = [LDAP_MGR_USERNAME_PROPERTY,
                             LDAP_MGR_PASSWORD_PROPERTY,
                             LDAP_DISABLE_ENDPOINT_IDENTIFICATION,
@@ -821,7 +821,7 @@ def setup_ldap(options):
 
   ssl_truststore_type_default = get_value_from_properties(properties, SSL_TRUSTSTORE_TYPE_PROPERTY, "jks")
   ssl_truststore_path_default = get_value_from_properties(properties, SSL_TRUSTSTORE_PATH_PROPERTY)
-  disable_endpoint_identification_default = get_value_from_properties(properties, LDAP_DISABLE_ENDPOINT_IDENTIFICATION, "False")
+  disable_endpoint_identification_default = get_value_from_properties(properties, LDAP_DISABLE_ENDPOINT_IDENTIFICATION, "True")
 
   ldap_property_value_map = {}
   ldap_property_values_in_ambari_properties = {}

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -821,7 +821,7 @@ def setup_ldap(options):
 
   ssl_truststore_type_default = get_value_from_properties(properties, SSL_TRUSTSTORE_TYPE_PROPERTY, "jks")
   ssl_truststore_path_default = get_value_from_properties(properties, SSL_TRUSTSTORE_PATH_PROPERTY)
-  disable_endpoint_identification_default = get_value_from_properties(properties, LDAP_DISABLE_ENDPOINT_IDENTIFICATION, "True")
+  disable_endpoint_identification_default = get_value_from_properties(properties, LDAP_DISABLE_ENDPOINT_IDENTIFICATION, "False")
 
   ldap_property_value_map = {}
   ldap_property_values_in_ambari_properties = {}

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7161,6 +7161,7 @@ class TestAmbariServer(TestCase):
     urlopen_mock.return_value = response
 
     options = self._create_empty_options_mock()
+    options.ldap_type = LDAP_GENERIC
     setup_ldap(options)
     
     requestCall = urlopen_mock.call_args_list[0]


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Change the default value of "Group member attribute" for IPA to "member"
* Remove `--ldap-use-generic-defaults` option and add `--ldap-type` option to choose the default values for missing options in cli mode instead.

## How was this patch tested?

Run python tests in ambari-server
mvn test -DskipSurefireTests

Manual tests:

1. Install Ambari and replace the affected .py files.
2. start ambari server
3. Run ambari-server setup-ldap
4. check whether the ldap config properties are saved to the database table ambari_configuration
5. Restart ambari server
6. Run ambari-server sync-ldap
7. Log into the ambari server web UI using one of the users stored in ldap
8. Check that the users in Ambari are associated to any group

Use a one line command to to setup-ldap by passing all the ldap properties using cli options.
