### PR TITLE
AMBARI-24784. Ambari-agent cannot register sometimes

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -417,8 +417,10 @@ class CustomServiceOrchestrator(object):
         self.commands_for_component_in_progress[cluster_id][command['role']] += 1
         incremented_commands_for_component = True
 
-        # reset status which was reported, so agent re-reports it after command finished
-        self.initializer_module.component_status_executor.reported_component_status[cluster_id][command['role']]['STATUS'] = None
+        if 'serviceName' in command:
+          service_component_name = command['serviceName'] + "/" + command['role']
+          # reset status which was reported, so agent re-reports it after command finished
+          self.initializer_module.component_status_executor.reported_component_status[cluster_id][service_component_name]['STATUS'] = None
 
       for py_file, current_base_dir in filtered_py_file_list:
         log_info_on_failure = command_name not in self.DONT_DEBUG_FAILURES_FOR_COMMANDS


### PR DESCRIPTION
ERROR 2018-10-11 13:45:57,401 HeartbeatThread.py:108 - Exception in HeartbeatThread. Re-running the registration
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/ambari_agent/HeartbeatThread.py", line 95, in run
    self.register()
  File "/usr/lib/ambari-agent/lib/ambari_agent/HeartbeatThread.py", line 163, in register
    self.force_component_status_update()
  File "/usr/lib/ambari-agent/lib/ambari_agent/HeartbeatThread.py", line 173, in force_component_status_update
    self.component_status_executor.force_send_component_statuses()
  File "/usr/lib/ambari-agent/lib/ambari_agent/ComponentStatusExecutor.py", line 206, in force_send_component_statuses
    service_name, component_name = service_and_component_name.split("/")
ValueError: need more than 1 value to unpack