### PR TITLE
AMBARI-24785. Removed double 'sudo' invocation

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/sudo.py
+++ b/ambari-common/src/main/python/resource_management/core/sudo.py
@@ -310,7 +310,7 @@ else:
     
   # shutil.copy replacement
   def copy(src, dst):
-    shell.checked_call(["sudo", "cp", "-r", src, dst], sudo=True)
+    shell.checked_call(["cp", "-r", src, dst], sudo=True)
 
   # os.listdir replacement
   def listdir(path):


### PR DESCRIPTION
## What changes were proposed in this pull request?

During NiFi start Ambari invokes ambari-common/src/main/python/resource_management/core/sudo.copy(src, dest) (line 306) in case of non-root configuration. Here the command we pass to the command wrapper within shell.py starts with 'sudo'. However the sudo flag is also set to True.

As a result we have a double 'sudo' invocation which may cause issues in ambari with non-root configuration.

## How was this patch tested?

Running JUnit tests:
```
mvn -Del.log=WARN -Dcheckstyle.skip -Dfindbugs.skip -Drat.skip -DskipSurefireTests=true -DfailIfNoTests=false -am -pl ambari-server clean test
...
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Main ........................................ SUCCESS [  5.120 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.006 s]
[INFO] Ambari Views ....................................... SUCCESS [  2.619 s]
[INFO] ambari-utility ..................................... SUCCESS [ 13.985 s]
[INFO] Ambari Server SPI .................................. SUCCESS [  0.473 s]
[INFO] Ambari Service Advisor ............................. SUCCESS [  0.397 s]
[INFO] Ambari Server ...................................... SUCCESS [ 59.435 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:25 min
[INFO] Finished at: 2018-10-16T15:24:22+02:00
[INFO] Final Memory: 124M/1672M
[INFO] ------------------------------------------------------------------------
```

In addition to this I tested this in an Ambari with non-root configuration where the issue was found.