### PR TITLE
[AMBARI-24788] Fix async bug in installer config page initial load

### DIFF
--- a/ambari-web/app/controllers/installer.js
+++ b/ambari-web/app/controllers/installer.js
@@ -1402,9 +1402,7 @@ App.InstallerController = App.WizardController.extend(App.Persist, {
     
     if (!this.get('stackConfigsLoaded')) {
       // Load stack configs before loading themes
-      App.config.loadClusterConfigsFromStack().always(self.loadServiceConfigs.bind(self)).always(() => {
-        dfd.resolve();
-      });
+      App.config.loadClusterConfigsFromStack().always(() => self.loadServiceConfigs().always(() => dfd.resolve()));
     } else {
       dfd.resolve();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed a bug in the loading process of the installer wizard config page that was causing it to appear blank initially. This was simply an async timing issue.

## How was this patch tested?

All unit tests passing.