### PR TITLE
AMBARI-24789. LogFeeder: fix CVE-2018-11771 - upgrade commons-compress lib

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.16.1</version>
+      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
commons-compress - upgrade to the latest version to fix CVE-2018-11771
## How was this patch tested?
will see the UT results