### PR TITLE
[AMBARI-24791] Node Managers fail to start after RM is moved to a dif…

### DIFF
--- a/ambari-web/app/controllers/main/admin/highAvailability/resourceManager/step3_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability/resourceManager/step3_controller.js
@@ -126,9 +126,11 @@ App.RMHighAvailabilityWizardStep3Controller = Em.Controller.extend(App.Blueprint
     var portValue = zooCfg && Em.get(zooCfg, 'properties.clientPort');
     var webAddressPort = yarnSite && yarnSite.properties ? yarnSite.properties['yarn.resourcemanager.webapp.address'] : '';
     var httpsWebAddressPort = yarnSite && yarnSite.properties ? yarnSite. properties['yarn.resourcemanager.webapp.https.address'] : '';
+    const trackerAddressPort = yarnSite && yarnSite.properties ? yarnSite.properties['yarn.resourcemanager.resource-tracker.address'] : '';
 
     ret.webAddressPort = webAddressPort && webAddressPort.contains(':') ? webAddressPort.split(':')[1] : '8088';
     ret.httpsWebAddressPort = httpsWebAddressPort && httpsWebAddressPort.contains(':') ? httpsWebAddressPort.split(':')[1] : '8090';
+    ret.trackerAddressPort = trackerAddressPort && trackerAddressPort.contains(':') ? trackerAddressPort.split(':')[1]: '8025';
     ret.zkClientPort = portValue ? portValue : '2181';
     return ret;
   },

--- a/ambari-web/app/data/configs/wizards/rm_ha_properties.js
+++ b/ambari-web/app/data/configs/wizards/rm_ha_properties.js
@@ -63,7 +63,28 @@ module.exports =
         "filename": "yarn-site",
         serviceName: 'MISC'
       },
-
+      {
+        "name": "yarn.resourcemanager.resource-tracker.address.rm1",
+        "displayName": "yarn.resourcemanager.resource-tracker.address.rm1",
+        "isReconfigurable": false,
+        "recommendedValue": "",
+        "isOverridable": false,
+        "value": "",
+        "category": "YARN",
+        "filename": "yarn-site",
+        serviceName: 'MISC'
+      },
+      {
+        "name": "yarn.resourcemanager.resource-tracker.address.rm2",
+        "displayName": "yarn.resourcemanager.resource-tracker.address.rm2",
+        "isReconfigurable": false,
+        "recommendedValue": "",
+        "isOverridable": false,
+        "value": "",
+        "category": "YARN",
+        "filename": "yarn-site",
+        serviceName: 'MISC'
+      },
       {
         "name": "yarn.resourcemanager.webapp.address.rm1",
         "displayName": "yarn.resourcemanager.webapp.address.rm1",

--- a/ambari-web/app/utils/configs/move_rm_config_initializer.js
+++ b/ambari-web/app/utils/configs/move_rm_config_initializer.js
@@ -57,6 +57,7 @@ App.MoveRmConfigInitializer = App.MoveComponentConfigInitializerClass.create({
     'yarn.resourcemanager.hostname.{{suffix}}': getRmHaDependedConfig(true),
     'yarn.resourcemanager.webapp.address.{{suffix}}': getRmHaDependedConfig(true),
     'yarn.resourcemanager.webapp.https.address.{{suffix}}': getRmHaDependedConfig(true),
+    'yarn.resourcemanager.resource-tracker.address.{{suffix}}': getRmHaDependedConfig(true),
     'yarn.resourcemanager.ha': getRmHaHawqConfig(true),
     'yarn.resourcemanager.scheduler.ha': getRmHaHawqConfig(true)
   },

--- a/ambari-web/app/utils/configs/rm_ha_config_initializer.js
+++ b/ambari-web/app/utils/configs/rm_ha_config_initializer.js
@@ -47,6 +47,8 @@ App.RmHaConfigInitializer = App.HaConfigInitializerClass.create(App.HostsBasedIn
       'yarn.resourcemanager.hostname.rm1': this.getHostWithPortConfig('RESOURCEMANAGER', true, '', '', ''),
       'yarn.resourcemanager.hostname.rm2': this.getHostWithPortConfig('RESOURCEMANAGER', false,'', '', ''),
       'yarn.resourcemanager.zk-address': this.getHostsWithPortConfig('ZOOKEEPER_SERVER', '', '', ',', 'zkClientPort', true),
+      'yarn.resourcemanager.resource-tracker.address.rm1': this.getHostWithPortConfig('RESOURCEMANAGER', true, '', '', 'trackerAddressPort', true),
+      'yarn.resourcemanager.resource-tracker.address.rm2': this.getHostWithPortConfig('RESOURCEMANAGER', false, '', '', 'trackerAddressPort', true),
       'yarn.resourcemanager.webapp.address.rm1': this.getHostWithPortConfig('RESOURCEMANAGER', true, '', '', 'webAddressPort', true),
       'yarn.resourcemanager.webapp.address.rm2': this.getHostWithPortConfig('RESOURCEMANAGER', false, '', '', 'webAddressPort', true),
       'yarn.resourcemanager.webapp.https.address.rm1': this.getHostWithPortConfig('RESOURCEMANAGER', true, '', '', 'httpsWebAddressPort', true),


### PR DESCRIPTION
…ferent host as 'resource-tracker.address' config is not updated.

## What changes were proposed in this pull request?
Cherry picking changes made in https://github.com/apache/ambari/pull/2476

## How was this patch tested?
  21730 passing (25s)
  48 pending