### PR TITLE
AMBARI-24794 Adding Ranger Password configs in Admin Settings section under Advanced config (mugdha)

### DIFF
--- a/ambari-web/app/data/configs/services/ranger_properties.js
+++ b/ambari-web/app/data/configs/services/ranger_properties.js
@@ -33,9 +33,23 @@ module.exports = [
   },
   {
     "category": "RANGER_ADMIN",
-    "filename": "admin-properties.xml",
+    "filename": "ranger-env.xml",
     "index": 2,
-    "name": "SQL_CONNECTOR_JAR",
+    "name": "rangerusersync_user_password",
+    "serviceName": "RANGER"
+  },
+  {
+    "category": "RANGER_ADMIN",
+    "filename": "ranger-env.xml",
+    "index": 3,
+    "name": "rangertagsync_user_password",
+    "serviceName": "RANGER"
+  },
+  {
+    "category": "RANGER_ADMIN",
+    "filename": "ranger-env.xml",
+    "index": 4,
+    "name": "keyadmin_user_password",
     "serviceName": "RANGER"
   },
   {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fix will add the below password configs to be shown in 'Admin Settings' section under Advanced Config section for Ranger service.

- rangerusersync_user_password
- rangertagsync_user_password
- keyadmin_user_password