### PR TITLE
[AMBARI-24795] Allow skipping Python unit tests

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -214,7 +214,7 @@
               <environmentVariables>
                 <PYTHONPATH>${path.python.1}${pathsep}$PYTHONPATH</PYTHONPATH>
               </environmentVariables>
-              <skip>${skipTests}</skip>
+              <skip>${skipPythonTests}</skip>
             </configuration>
             <id>python-test</id>
             <phase>test</phase>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -27,6 +27,7 @@
   <name>Apache Ambari Project POM</name>
   <packaging>pom</packaging>
   <properties>
+    <skipPythonTests>false</skipPythonTests>
     <solr.version>5.5.2</solr.version>
     <ambari.dir>${project.parent.basedir}</ambari.dir>
     <powermock.version>1.6.3</powermock.version>
@@ -81,6 +82,17 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>skipTestRun</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <skipPythonTests>true</skipPythonTests>
+      </properties>
     </profile>
   </profiles>
   <dependencyManagement>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -47,7 +47,6 @@
     <stackHooksLocation>src/main/resources/stack-hooks</stackHooksLocation>
     <stacksSrcLocation>src/main/resources/stacks/${stack.distribution}</stacksSrcLocation>
     <tarballResourcesFolder>src/main/resources</tarballResourcesFolder>
-    <skipPythonTests>false</skipPythonTests>
     <hadoop.version>2.7.2</hadoop.version>
     <ambari.metrics.version>2.7.0.0.0</ambari.metrics.version>
     <empty.dir>src/main/package</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
@@ -880,17 +879,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>skipTestRun</id>
-      <activation>
-        <property>
-          <name>skipTests</name>
-        </property>
-      </activation>
-      <properties>
-        <skipPythonTests>true</skipPythonTests>
-      </properties>
     </profile>
     <profile>
       <id>copy-swagger-generated-resources</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apply `-DskipPythonTests` to `ambari-agent`, too.

## How was this patch tested?

Tested with `-DskipPythonTests`, with `-DskipTests` and without either of them.

```
$ mvn -am -pl ambari-agent,ambari-server -DskipPythonTests clean test
...
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-server ---
[INFO] skipping execute as per configuraion
[INFO]
...
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-agent ---
[INFO] skipping execute as per configuraion
[INFO]
...

$ mvn -am -pl ambari-agent,ambari-server -DskipTests clean test
...
[INFO] --- maven-surefire-plugin:2.20:test (default-test) @ ambari-server ---
[INFO] Tests are skipped.
[INFO]
...
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-server ---
[INFO] skipping execute as per configuraion
[INFO]
...
[INFO] --- maven-surefire-plugin:2.20:test (default-test) @ ambari-agent ---
[INFO] Tests are skipped.
[INFO]
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-agent ---
[INFO] skipping execute as per configuraion
[INFO]
...

$ mvn -am -pl ambari-agent,ambari-server clean test
...
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-server ---
...
Total run:323
Total errors:0
Total failures:0
OK
...
[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-agent ---
...
Ran 353 tests in 32.145s
```