### PR TITLE
[AMBARI-24805] Fix format string errors in ambari_common.inet_utils

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/inet_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/inet_utils.py
@@ -125,7 +125,7 @@ def find_range_components(meta):
     if len(range_comp1) > 1:
       range_comp2 = range_comp1[0].split(' ') #split away the "bytes" prefix
       if len(range_comp2) == 0:
-        raise FatalException(12, 'Malformed Content-Range response header: "{0}".' % hdr_range)
+        raise FatalException(12, 'Malformed Content-Range response header: "{0}".'.format(hdr_range))
       range_comp3 = range_comp2[1].split('-')
       seek_pos = int(range_comp3[0])
       if range_comp1[1] != '*': #'*' == unknown length
@@ -146,7 +146,7 @@ def force_download_file(link, destination, chunk_size = 16 * 1024, progress_func
 
   if os.path.exists(destination) and not os.path.isfile(destination):
     #Directory specified as target? Must be a mistake. Bail out, don't assume anything.
-    err = 'Download target {0} is a directory.' % destination
+    err = 'Download target {0} is a directory.'.format(destination)
     raise FatalException(1, err)
 
   (dest_path, file_name) = os.path.split(destination)
@@ -207,7 +207,7 @@ def force_download_file(link, destination, chunk_size = 16 * 1024, progress_func
 
   downloaded_size = os.stat(temp_dest).st_size
   if downloaded_size != file_size:
-    err = 'Size of downloaded file {0} is {1} bytes, it is probably damaged or incomplete' % (destination, downloaded_size)
+    err = 'Size of downloaded file {0} is {1} bytes, it is probably damaged or incomplete'.format(destination, downloaded_size)
     raise FatalException(1, err)
 
   # when download is complete -> mv temp_dest destination


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix format string errors in `ambari_common.inet_utils`.

## How was this patch tested?

This patch was manually tested:
```
Python 2.7.5 (default, Jul 13 2018, 13:06:57)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-28)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> hdr_range = 'foo'
>>> 'Malformed Content-Range response header: "{0}".' % hdr_range
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
>>> 'Malformed Content-Range response header: "{0}".'.format(hdr_range)
'Malformed Content-Range response header: "foo".'
>>> destination = 'bar'
>>> 'Download target {0} is a directory.' % destination
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
>>> 'Download target {0} is a directory.'.format(destination)
'Download target bar is a directory.'
>>> downloaded_size = 5
>>> 'Size of downloaded file {0} is {1} bytes, it is probably damaged or incomplete' % (destination, downloaded_size)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
>>> 'Size of downloaded file {0} is {1} bytes, it is probably damaged or incomplete'.format(destination, downloaded_size)
'Size of downloaded file bar is 5 bytes, it is probably damaged or incomplete'
```