### PR TITLE
[AMBARI-24804] - Unify Ambari Versioning Across Modules

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -27,7 +27,6 @@
   <artifactId>ambari-admin</artifactId>
   <packaging>jar</packaging>
   <name>Ambari Admin View</name>
-  <version>2.0.0.0-SNAPSHOT</version>
   <description>Admin control panel</description>
   <build>
     <plugins>

--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -19,13 +19,12 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-agent</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Ambari Agent</name>
   <description>Ambari Agent</description>
   <properties>
@@ -145,7 +144,7 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-utility</artifactId>
       <scope>test</scope>
-      <version>1.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -13,12 +13,11 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-funtest</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <packaging>${packagingFormat}</packaging>
   <name>Ambari Functional Tests</name>
   <description>Ambari Functional Tests</description>

--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-funtest</artifactId>
-  <packaging>${packagingFormat}</packaging>
+  <packaging>jar</packaging>
   <name>Ambari Functional Tests</name>
   <description>Ambari Functional Tests</description>
   <build>
@@ -119,7 +119,6 @@
         <fileextension.shell>sh</fileextension.shell>
         <fileextension.dot.shell-default></fileextension.dot.shell-default>
         <assemblydescriptor>src/main/assemblies/empty.xml</assemblydescriptor>
-        <packagingFormat>jar</packagingFormat>
       </properties>
     </profile>
     <profile>
@@ -137,7 +136,6 @@
         <fileextension.shell>cmd</fileextension.shell>
         <fileextension.dot.shell-default></fileextension.dot.shell-default>
         <assemblydescriptor>src/main/assemblies/empty.xml</assemblydescriptor>
-        <packagingFormat>jar</packagingFormat>
         </properties>
     </profile>
   </profiles>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -18,11 +18,10 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-project</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <description>Apache Ambari Project POM</description>
   <name>Apache Ambari Project POM</name>
   <packaging>pom</packaging>
@@ -699,7 +698,7 @@
             <dependency>
               <groupId>org.apache.ambari</groupId>
               <artifactId>ambari-utility</artifactId>
-              <version>1.0.0.0-SNAPSHOT</version>
+              <version>${revision}</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -665,11 +665,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>2.17</version>
           <configuration>

--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
   <artifactId>ambari-server-spi</artifactId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari-server</artifactId>
-  <packaging>${packagingFormat}</packaging>
+  <packaging>jar</packaging>
   <name>Ambari Server</name>
   <description>Ambari Server</description>
   <properties>
@@ -925,7 +925,6 @@
         <assemblydescriptor>src/main/assemblies/server-windows.xml</assemblydescriptor>
         <assemblybootstrap>src/main/assemblies/bootstrap-windows.xml</assemblybootstrap>
         <assemblychocodescriptor>src/main/assemblies/server-windows-choco.xml</assemblychocodescriptor>
-        <packagingFormat>jar</packagingFormat>
       </properties>
       <build>
         <plugins>
@@ -1027,7 +1026,6 @@
         <fileextension.dot.shell-default></fileextension.dot.shell-default>
         <path.python.1>${project.basedir}/../ambari-common/src/main/python:${project.basedir}/../ambari-agent/src/main/python:${project.basedir}/../ambari-common/src/main/python/ambari_jinja2:${project.basedir}/../ambari-common/src/main/python/ambari_commons:${project.basedir}/../ambari-common/src/test/python:${project.basedir}/src/main/python:${project.basedir}/src/main/python/ambari-server-state:${project.basedir}/src/main/resources/custom_actions:${project.basedir}/src/main/resources/scripts:${project.basedir}/src/test/python</path.python.1>
         <assemblydescriptor>src/main/assemblies/server.xml</assemblydescriptor>
-        <packagingFormat>jar</packagingFormat>
       </properties>
     </profile>
     <profile>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -20,7 +20,6 @@
   <artifactId>ambari-server</artifactId>
   <packaging>${packagingFormat}</packaging>
   <name>Ambari Server</name>
-  <version>2.0.0.0-SNAPSHOT</version>
   <description>Ambari Server</description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -1785,7 +1784,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-utility</artifactId>
-      <version>1.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
       <scope>provided</scope> <!-- for @ApiIgnore -->
       <exclusions>
         <exclusion>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -405,26 +405,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-maven</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.3.9,)</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.github.kongchen</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
         <configuration>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -23,13 +23,12 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
 
   <artifactId>ambari-utility</artifactId>
   <groupId>org.apache.ambari</groupId>
-  <version>1.0.0.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/ambari-views/examples/auto-cluster-view/pom.xml
+++ b/ambari-views/examples/auto-cluster-view/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>auto-cluster-view</artifactId>

--- a/ambari-views/examples/calculator-view/pom.xml
+++ b/ambari-views/examples/calculator-view/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>calculator-view</artifactId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/cluster-view/pom.xml
+++ b/ambari-views/examples/cluster-view/pom.xml
@@ -19,11 +19,10 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cluster-view</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Ambari Cluster View</name>
   <url>http://maven.apache.org</url>
@@ -34,7 +33,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/favorite-view/pom.xml
+++ b/ambari-views/examples/favorite-view/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>favorite-view</artifactId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/hello-servlet-view/pom.xml
+++ b/ambari-views/examples/hello-servlet-view/pom.xml
@@ -19,13 +19,12 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hello-servlet-view</artifactId>
   <packaging>jar</packaging>
   <name>Ambari Hello Servlet View</name>
-  <version>2.0.0.0-SNAPSHOT</version>
   <url>http://maven.apache.org</url>
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
@@ -46,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/hello-spring-view/pom.xml
+++ b/ambari-views/examples/hello-spring-view/pom.xml
@@ -19,13 +19,12 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hello-spring-view</artifactId>
   <packaging>war</packaging>
   <name>Ambari Hello Spring View</name>
-  <version>2.0.0.0-SNAPSHOT</version>
   <url>http://maven.apache.org</url>
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
@@ -46,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/helloworld-view/pom.xml
+++ b/ambari-views/examples/helloworld-view/pom.xml
@@ -19,13 +19,12 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>helloworld-view</artifactId>
   <packaging>jar</packaging>
   <name>Ambari Hello World View</name>
-  <version>2.0.0.0-SNAPSHOT</version>
   <url>http://maven.apache.org</url>
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
@@ -46,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/phone-list-upgrade-view/pom.xml
+++ b/ambari-views/examples/phone-list-upgrade-view/pom.xml
@@ -19,9 +19,8 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
-  <version>2.1.0.0-SNAPSHOT</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phone-list-upgrade-view</artifactId>
   <packaging>jar</packaging>
@@ -51,7 +50,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
@@ -67,7 +66,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>2.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/ambari-views/examples/phone-list-view/pom.xml
+++ b/ambari-views/examples/phone-list-view/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phone-list-view</artifactId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/pom.xml
+++ b/ambari-views/examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -27,7 +27,6 @@
   <artifactId>ambari-view-examples</artifactId>
   <packaging>pom</packaging>
   <name>Ambari View Examples</name>
-  <version>2.0.0.0-SNAPSHOT</version>
   <modules>
     <module>helloworld-view</module>
     <module>hello-servlet-view</module>

--- a/ambari-views/examples/property-validator-view/pom.xml
+++ b/ambari-views/examples/property-validator-view/pom.xml
@@ -19,11 +19,10 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>property-validator-view</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Ambari Property Validator View</name>
   <url>http://maven.apache.org</url>
@@ -34,7 +33,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/property-view/pom.xml
+++ b/ambari-views/examples/property-view/pom.xml
@@ -19,11 +19,10 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>property-view</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Ambari Property View</name>
   <url>http://maven.apache.org</url>
@@ -34,7 +33,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/restricted-view/pom.xml
+++ b/ambari-views/examples/restricted-view/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>restricted-view</artifactId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/examples/simple-view/pom.xml
+++ b/ambari-views/examples/simple-view/pom.xml
@@ -19,11 +19,10 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-view-examples</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>simple-view</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Ambari Simple View</name>
   <url>http://maven.apache.org</url>
@@ -34,7 +33,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-views</artifactId>
-      <version>[1.7.0.0,)</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/ambari-views/pom.xml
+++ b/ambari-views/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ambari</groupId>
         <artifactId>ambari-project</artifactId>
-        <version>2.0.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../ambari-project</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -28,7 +28,6 @@
     <artifactId>ambari-views</artifactId>
     <packaging>jar</packaging>
     <name>Ambari Views</name>
-    <version>2.0.0.0-SNAPSHOT</version>
     <description>Ambari View interfaces.</description>
     <dependencies>
         <dependency>

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -20,14 +20,13 @@
     <parent>
         <groupId>org.apache.ambari</groupId>
         <artifactId>ambari-project</artifactId>
-        <version>2.0.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../ambari-project</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ambari-web</artifactId>
     <packaging>pom</packaging>
     <name>Ambari Web</name>
-    <version>2.0.0.0-SNAPSHOT</version>
     <description>Ambari Web</description>
     <properties>
         <ambari.dir>${project.parent.parent.basedir}</ambari.dir>

--- a/contrib/management-packs/hdf-ambari-mpack/pom.xml
+++ b/contrib/management-packs/hdf-ambari-mpack/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.ambari.contrib.mpacks</groupId>
     <artifactId>ambari-contrib-mpacks</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <build>
     <plugins>

--- a/contrib/management-packs/isilon-onefs-mpack/pom.xml
+++ b/contrib/management-packs/isilon-onefs-mpack/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.ambari.contrib.mpacks</groupId>
     <artifactId>ambari-contrib-mpacks</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <build>
     <plugins>

--- a/contrib/management-packs/microsoft-r_mpack/pom.xml
+++ b/contrib/management-packs/microsoft-r_mpack/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.ambari.contrib.mpacks</groupId>
     <artifactId>ambari-contrib-mpacks</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>

--- a/contrib/management-packs/pom.xml
+++ b/contrib/management-packs/pom.xml
@@ -19,17 +19,16 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ambari.contrib.mpacks</groupId>
   <artifactId>ambari-contrib-mpacks</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Ambari Contrib Management Packs</name>
   <properties>
-    <ambari.version>2.0.0.0-SNAPSHOT</ambari.version>
+    <ambari.version>${revision}</ambari.version>
     <ambari.dir>${project.parent.parent.basedir}</ambari.dir>
     <hadoop.version>2.7.1</hadoop.version>
   </properties>

--- a/contrib/views/ambari-views-package/pom.xml
+++ b/contrib/views/ambari-views-package/pom.xml
@@ -21,12 +21,11 @@
 
   <groupId>org.apache.ambari.contrib.views</groupId>
   <artifactId>ambari-views-package</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Ambari Views Package</name>
   <parent>
     <groupId>org.apache.ambari.contrib.views</groupId>
     <artifactId>ambari-contrib-views</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <description>

--- a/contrib/views/capacity-scheduler/pom.xml
+++ b/contrib/views/capacity-scheduler/pom.xml
@@ -19,13 +19,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.ambari.contrib.views</groupId>
     <artifactId>capacity-scheduler</artifactId>
-    <version>1.0.0.0-SNAPSHOT</version>
     <name>Capacity Scheduler</name>
 
     <parent>
         <groupId>org.apache.ambari.contrib.views</groupId>
         <artifactId>ambari-contrib-views</artifactId>
-        <version>2.0.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <dependencies>
@@ -81,7 +80,7 @@
         <dependency>
             <groupId>org.apache.ambari.contrib.views</groupId>
             <artifactId>ambari-views-utils</artifactId>
-            <version>2.0.0.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>

--- a/contrib/views/commons/pom.xml
+++ b/contrib/views/commons/pom.xml
@@ -22,20 +22,19 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ambari-views-commons</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Ambari View Commons</name>
 
   <parent>
     <artifactId>ambari-contrib-views</artifactId>
     <groupId>org.apache.ambari.contrib.views</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.ambari.contrib.views</groupId>
       <artifactId>ambari-views-utils</artifactId>
-      <version>2.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
 
     <dependency>

--- a/contrib/views/files/pom.xml
+++ b/contrib/views/files/pom.xml
@@ -18,13 +18,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>files</artifactId>
-  <version>1.0.0.0-SNAPSHOT</version>
   <name>Files</name>
 
   <parent>
     <groupId>org.apache.ambari.contrib.views</groupId>
     <artifactId>ambari-contrib-views</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <dependencies>
     <dependency>
@@ -119,12 +118,12 @@
     <dependency>
       <groupId>org.apache.ambari.contrib.views</groupId>
       <artifactId>ambari-views-utils</artifactId>
-      <version>2.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari.contrib.views</groupId>
       <artifactId>ambari-views-commons</artifactId>
-      <version>2.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -184,7 +183,7 @@
           <yarnVersion>v0.23.2</yarnVersion>
           <workingDirectory>src/main/resources/ui/</workingDirectory>
           <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
-          <!-- setting npm_config_tmp environment variable is a workaround for 
+          <!-- setting npm_config_tmp environment variable is a workaround for
                https://github.com/Medium/phantomjs/issues/673 -->
           <environmentVariables>
             <npm_config_tmp>/tmp/npm_config_tmp</npm_config_tmp>

--- a/contrib/views/pig/pom.xml
+++ b/contrib/views/pig/pom.xml
@@ -18,13 +18,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>pig</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Pig</name>
 
   <parent>
     <groupId>org.apache.ambari.contrib.views</groupId>
     <artifactId>ambari-contrib-views</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>
@@ -142,18 +141,18 @@
     <dependency>
       <groupId>org.apache.ambari.contrib.views</groupId>
       <artifactId>ambari-views-utils</artifactId>
-      <version>2.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari.contrib.views</groupId>
       <artifactId>ambari-views-commons</artifactId>
-      <version>2.0.0.0-SNAPSHOT</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
 
   <properties>
     <ambari.dir>${project.parent.parent.parent.basedir}</ambari.dir>
-    <ambari.version>2.0.0.0-SNAPSHOT</ambari.version>
+    <ambari.version>${revision}</ambari.version>
     <ui.directory>${basedir}/src/main/resources/ui/pig-web</ui.directory>
   </properties>
   <build>
@@ -197,7 +196,7 @@
           <yarnVersion>v0.23.2</yarnVersion>
           <workingDirectory>${ui.directory}</workingDirectory>
           <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
-          <!-- setting npm_config_tmp environment variable is a workaround for 
+          <!-- setting npm_config_tmp environment variable is a workaround for
                https://github.com/Medium/phantomjs/issues/673 -->
           <environmentVariables>
             <npm_config_tmp>/tmp/npm_config_tmp</npm_config_tmp>

--- a/contrib/views/pom.xml
+++ b/contrib/views/pom.xml
@@ -19,17 +19,16 @@
   <parent>
     <groupId>org.apache.ambari</groupId>
     <artifactId>ambari-project</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../ambari-project</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ambari.contrib.views</groupId>
   <artifactId>ambari-contrib-views</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Ambari Contrib Views</name>
   <properties>
-    <ambari.version>2.0.0.0-SNAPSHOT</ambari.version>
+    <ambari.version>${revision}</ambari.version>
     <ambari.dir>${project.parent.parent.basedir}</ambari.dir>
     <jetty.version>9.3.19.v20170502</jetty.version>
     <hadoop.version>3.1.0</hadoop.version>
@@ -267,7 +266,7 @@
       <dependency>
         <groupId>org.apache.ambari</groupId>
         <artifactId>ambari-views</artifactId>
-        <version>2.0.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/contrib/views/utils/pom.xml
+++ b/contrib/views/utils/pom.xml
@@ -18,13 +18,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ambari-views-utils</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
   <name>Ambari View Utils</name>
 
   <parent>
     <groupId>org.apache.ambari.contrib.views</groupId>
     <artifactId>ambari-contrib-views</artifactId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>

--- a/contrib/views/wfmanager/pom.xml
+++ b/contrib/views/wfmanager/pom.xml
@@ -14,19 +14,18 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>wfmanager</artifactId>
 	<groupId>org.apache.ambari.contrib.views</groupId>
-	<version>0.1.0.0-SNAPSHOT</version>
 	<name>WF Manager View</name>
 	<parent>
 		<groupId>org.apache.ambari.contrib.views</groupId>
 		<artifactId>ambari-contrib-views</artifactId>
-		<version>2.0.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.ambari.contrib.views</groupId>
 			<artifactId>ambari-views-utils</artifactId>
-			<version>2.0.0.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.ambari</groupId>
@@ -36,7 +35,7 @@
 		<dependency>
 			<groupId>org.apache.ambari.contrib.views</groupId>
 			<artifactId>ambari-views-commons</artifactId>
-			<version>2.0.0.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.jersey</groupId>
@@ -144,7 +143,7 @@
 					<yarnVersion>v0.23.2</yarnVersion>
 					<workingDirectory>src/main/resources/ui/</workingDirectory>
 					<npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
-                    <!-- setting npm_config_tmp environment variable is a workaround for 
+                    <!-- setting npm_config_tmp environment variable is a workaround for
                      https://github.com/Medium/phantomjs/issues/673 -->
                     <environmentVariables>
                       <npm_config_tmp>/tmp/npm_config_tmp</npm_config_tmp>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,36 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <mailingLists>
+    <mailingList>
+      <name>Dev</name>
+      <subscribe>dev-subscribe@ambari.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@ambari.apache.org</unsubscribe>
+      <post>dev@ambari.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/ambari-dev/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Users</name>
+      <subscribe>users-subscribe@ambari.apache.org</subscribe>
+      <unsubscribe>users-unsubscribe@ambari.apache.org</unsubscribe>
+      <post>users@ambari.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/ambari-users</archive>
+    </mailingList>
+    <mailingList>
+      <name>Commits</name>
+      <subscribe>commits-subscribe@ambari.apache.org</subscribe>
+      <unsubscribe>commits-unsubscribe@ambari.apache.org</unsubscribe>
+      <post>commits@ambari.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/ambari-commits</archive>
+    </mailingList>
+    <mailingList>
+      <name>Issues</name>
+      <subscribe>issues-subscribe@ambari.apache.org</subscribe>
+      <unsubscribe>issues-unsubscribe@ambari.apache.org</unsubscribe>
+      <post>issues@ambari.apache.org</post>
+      <archive>http://mail-archives.apache.org/mod_mbox/ambari-issues</archive>
+    </mailingList>
+  </mailingLists>
   <organization>
     <name>Apache Software Foundation</name>
     <url>http://www.apache.org</url>
@@ -428,6 +458,32 @@
             <goals>
               <goal>clean</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.5.0</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>1.8</version>
+                </requireJavaVersion>
+                <requireOS>
+                  <family>unix</family>
+                </requireOS>
+              </rules>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -479,9 +479,6 @@
                 <requireJavaVersion>
                   <version>1.8</version>
                 </requireJavaVersion>
-                <requireOS>
-                  <family>unix</family>
-                </requireOS>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,16 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>21</version>
+  </parent>
   <groupId>org.apache.ambari</groupId>
   <artifactId>ambari</artifactId>
   <packaging>pom</packaging>
   <name>Ambari Main</name>
-  <version>2.0.0.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <description>Ambari</description>
   <url>http://ambari.apache.org/</url>
   <scm>
@@ -44,6 +49,7 @@
     <url>https://issues.apache.org/jira/browse/AMBARI</url>
   </issueManagement>
   <properties>
+    <revision>3.0.0.0-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <clover.license>${user.home}/clover.license</clover.license>
     <buildnumber-maven-plugin-version>1.2</buildnumber-maven-plugin-version>
@@ -57,9 +63,6 @@
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
-    <distMgmtStagingId>apache.staging.https</distMgmtStagingId>
-    <distMgmtStagingName>Apache Release Distribution Repository</distMgmtStagingName>
-    <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
     <assemblyPhase>package</assemblyPhase> <!-- use -DassemblyPhase=none to skip building tarball, useful when you want purely compile jar -->
     <eclipselink.version>2.6.2</eclipselink.version>
   </properties>
@@ -88,19 +91,6 @@
       <layout>default</layout>
     </pluginRepository>
   </pluginRepositories>
-
-  <distributionManagement>
-    <repository>
-      <id>${distMgmtStagingId}</id>
-      <name>${distMgmtStagingName}</name>
-      <url>${distMgmtStagingUrl}</url>
-    </repository>
-    <snapshotRepository>
-      <id>${distMgmtSnapshotsId}</id>
-      <name>${distMgmtSnapshotsName}</name>
-      <url>${distMgmtSnapshotsUrl}</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <repositories>
     <repository>
@@ -312,6 +302,8 @@
             <exclude>ambari-web/node_modules/**</exclude>
 
             <!--Contributions-->
+            <exclude>contrib/**/bower_components/**</exclude>
+            <exclude>contrib/**/dist/**</exclude>
             <exclude>contrib/management-packs/hdf-ambari-mpack/src/main/resources/stacks/HDF/2.0/hooks/before-START/files/fast-hdfs-resource.jar</exclude>
             <exclude>contrib/ambari-scom/management-pack/Hadoop_MP/**</exclude>
             <exclude>contrib/addons/test/dataServices/jmx/data/cluster_configuration.json.nohbase</exclude>
@@ -407,6 +399,37 @@
              </fileset>
           </filesets>
         </configuration>
+      </plugin>
+
+      <!--
+      Required when using the ${revision} placeholder to generate target/.flattened-pom.xml
+      See: https://maven.apache.org/maven-ci-friendly.html
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <configuration>
+          <flattenMode>oss</flattenMode>
+          <updatePomFile>true</updatePomFile>
+          <outputDirectory>${project.build.directory}</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def create_package_dir_map():
 
   return package_dirs
 
-__version__ = "2.0.0.0-SNAPSHOT"
+__version__ = "3.0.0.0-SNAPSHOT"
 
 def get_version():
   """
@@ -91,7 +91,7 @@ Example usage:
   python setup.py sdist -d "my/dist/location" upload -r "http://localhost:8080"
 
 Installing from pip:
-- pip install --extra-index-url=http://localhost:8080 ambari-python==2.7.1.0  // 2.0.0.0-SNAPSHOT is the snapshot version
+- pip install --extra-index-url=http://localhost:8080 ambari-python==2.7.1.0  // 3.0.0.0-SNAPSHOT is the snapshot version
 """
 setup(
   name = "ambari-python",


### PR DESCRIPTION
## What changes were proposed in this pull request?

It looks like Ambari’s trunk pom.xml has not been updated with a proper version in at least 4 years. It currently still lists trunk as 2.0.0.0-SNAPSHOT:
```
  <groupId>org.apache.ambari</groupId>
  <artifactId>ambari</artifactId>
  <packaging>pom</packaging>
  <name>Ambari Main</name>
  <version>2.0.0.0-SNAPSHOT</version>
  <description>Ambari</description>
```
        
This poses several problems as we try to make our artifacts more 3rd-party friendly since it becomes ambiguous what other maven projects are actually depending on. We need to change our process to keep this version updated with every release of Ambari. Other Apache projects seem to do this (I took a look at Nifi, Hive, Storm, etc) and in each case, their trunk pom.xml was at least a minor version ahead of their most recent release branch.

- We should change the version specified for Ambari and its submodules to use the next major version after a release, such as `3.0.0.0-SNAPSHOT`. Once 3.0 has been released, this will be changed to `4.0.0.0-SNAPSHOT` even if there are more builds in the 3.x line off of `trunk`.

- Maven 3.5.0 allows the ability to specify a `<version>${revision}</version>` placeholder value in the parent `pom.xml` which submodules can inherit. This seems cleaner than having all of the submodules updated and checked in using the `mvn versions:set -DnewVersion=3.0.0.0-SNAPSHOT` command.

- If any submodule inherits from `ambari` or `ambari-project`, then they should broadcast their version as the same. This includes submodules such as `ambari-utility` which are hard coded at `1.0.0.0-SNAPSHOT` which makes understanding what actually exists in local repos very difficult.

See Maven Build References:
- [Apache Recommendations for inheriting from `org.apache`](http://www.apache.org/dev/publishing-maven-artifacts.html#inherit-parent)
- [Using a Flattened `pom.xml` to limit the occurrences of the version in a project](https://maven.apache.org/maven-ci-friendly.html)

## How was this patch tested?

- Verified that the `pom.xml` files placed in `~/.m2` included all optional tags (which they didn't by default after flattening
- Verified the build correctly substituted `3.0.0.0-SNAPSHOT` for `${revision}`

```
[INFO] Ambari Main ........................................ SUCCESS [ 41.323 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.108 s]
[INFO] Ambari Web ......................................... SUCCESS [02:03 min]
[INFO] Ambari Views ....................................... SUCCESS [  1.694 s]
[INFO] Ambari Admin View .................................. SUCCESS [ 31.488 s]
[INFO] ambari-utility ..................................... SUCCESS [  2.823 s]
[INFO] Ambari Server SPI .................................. SUCCESS [  0.714 s]
[INFO] Ambari Service Advisor ............................. SUCCESS [  0.853 s]
[INFO] Ambari Server ...................................... SUCCESS [05:29 min]
[INFO] Ambari Functional Tests ............................ SUCCESS [  3.491 s]
[INFO] Ambari Agent ....................................... SUCCESS [01:13 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 10:09 min
[INFO] Finished at: 2018-10-18T13:31:23-04:00
[INFO] Final Memory: 219M/1274M
[INFO] ------------------------------------------------------------------------



[INFO] Reactor Summary:
[INFO]
[INFO] Ambari Contrib Views ............................... SUCCESS [  2.470 s]
[INFO] Ambari View Utils .................................. SUCCESS [ 13.848 s]
[INFO] Ambari View Commons ................................ SUCCESS [  1.657 s]
[INFO] Files .............................................. SUCCESS [01:23 min]
[INFO] Pig ................................................ SUCCESS [ 37.924 s]
[INFO] Capacity Scheduler ................................. SUCCESS [ 44.853 s]
[INFO] WF Manager View .................................... SUCCESS [01:46 min]
[INFO] Ambari Views Package ............................... SUCCESS [  0.072 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:50 min
[INFO] Finished at: 2018-10-18T13:39:48-04:00
[INFO] Final Memory: 87M/897M
[INFO] ------------------------------------------------------------------------
```