### PR TITLE
[AMBARI-24798] Add "maintainer" field to StackService API 

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
@@ -41,6 +41,7 @@ public class StackServiceResponse {
   private String comments;
   private String serviceVersion;
   private ServiceInfo.Selection selection;
+  private String maintainer;
   private boolean serviceCheckSupported;
   private List<String> customCommands;
 
@@ -100,6 +101,7 @@ public class StackServiceResponse {
     requiredServices = service.getRequiredServices();
     serviceCheckSupported = null != service.getCommandScript();
     selection = service.getSelection();
+    maintainer = service.getMaintainer();
 
     // the custom command names defined at the service (not component) level
     List<CustomCommandDefinition> definitions = service.getCustomCommands();
@@ -128,6 +130,11 @@ public class StackServiceResponse {
 
   public void setSelection(ServiceInfo.Selection selection) {
     this.selection = selection;
+  }
+
+  @ApiModelProperty(name = "maintainer")
+  public String getMaintainer(){
+    return maintainer;
   }
 
   @ApiModelProperty(name = "stack_name")

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
@@ -72,6 +72,9 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
   private static final String SELECTION_PROPERTY_ID = PropertyHelper.getPropertyId(
       "StackServices", "selection");
 
+  private static final String MAINTAINER_PROPERTY_ID = PropertyHelper.getPropertyId(
+          "StackServices", "maintainer");
+
   private static final String VERSION_PROPERTY_ID = PropertyHelper.getPropertyId(
       "StackServices", "service_version");
 
@@ -129,6 +132,7 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
       USER_NAME_PROPERTY_ID,
       COMMENTS_PROPERTY_ID,
       SELECTION_PROPERTY_ID,
+      MAINTAINER_PROPERTY_ID,
       VERSION_PROPERTY_ID,
       CONFIG_TYPES,
       REQUIRED_SERVICES_ID,
@@ -219,6 +223,9 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
 
     setResourceProperty(resource, SELECTION_PROPERTY_ID,
         response.getSelection(), requestedIds);
+
+    setResourceProperty(resource, MAINTAINER_PROPERTY_ID,
+        response.getMaintainer(), requestedIds);
 
     setResourceProperty(resource, CONFIG_TYPES,
         response.getConfigTypes(), requestedIds);

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceModule.java
@@ -300,6 +300,10 @@ public class ServiceModule extends BaseModule<ServiceModule, ServiceInfo> implem
       serviceInfo.setSelection(parent.getSelection());
     }
 
+    if (serviceInfo.isMaintainerEmpty()) {
+      serviceInfo.setMaintainer(parent.getMaintainer());
+    }
+
     if(null == serviceInfo.getSupportDeleteViaUIField()){
       serviceInfo.setSupportDeleteViaUI(parent.isSupportDeleteViaUI());
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -77,6 +77,7 @@ public class ServiceInfo implements Validable {
   private String comment;
   private String serviceType;
   private Selection selection;
+  private String maintainer;
 
   /**
    * Default to Python if not specified.
@@ -424,6 +425,18 @@ public class ServiceInfo implements Validable {
    */
   public boolean isSelectionEmpty() {
     return selection == null;
+  }
+
+  public String getMaintainer() {
+    return maintainer;
+  }
+
+  public void setMaintainer(String maintainer) {
+    this.maintainer = maintainer;
+  }
+
+  public boolean isMaintainerEmpty() {
+    return maintainer == null;
   }
 
   public String getComment() {


### PR DESCRIPTION
New field needs to be added for stack service api
maintainer: <String>. By default value should be empty or null

Also update LogSearch, Druid and Superset service with "selection" as "TECH_PREVIEW" and "maintainer" as "Hortonworks"

Deployed a cluster and access StackService API to see if new field is added.
Run UTs
![logsearch_30](https://user-images.githubusercontent.com/23040280/47188350-8036f400-d2ec-11e8-8101-5e369209e445.png)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.