### PR TITLE
[AMBARI-24812] - Implement New Upgrade Check Which Warns About Missing Plugin Checks

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/PluginChecksLoadedCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/PluginChecksLoadedCheck.java
@@ -51,7 +51,8 @@ public class PluginChecksLoadedCheck extends ClusterCheck {
       "PLUGIN_CHECK_LOAD_FAILURE", UpgradeCheckType.CLUSTER, "Plugin Upgrade Checks",
       new ImmutableMap.Builder<String, String>().put(UpgradeCheckDescription.DEFAULT,
           "The following upgrade checks could not be loaded and were not run. "
-              + "Although this will not stop your upgrade, it is advised that these checks be corrected to ensure a successful upgrade.").build());
+              + "Although this will not prevent your ability to upgrade, it is advised that you "
+              + "correct these checks before proceeding.").build());
 
   @Inject
   Provider<UpgradeCheckRegistry> m_upgradeCheckRegistryProvider;
@@ -84,7 +85,7 @@ public class PluginChecksLoadedCheck extends ClusterCheck {
         .collect(Collectors.toSet());
 
     // check for failure
-    if( failedPluginClasses.size() > 0 ) {
+    if (failedPluginClasses.size() > 0) {
       result.setStatus(UpgradeCheckStatus.WARNING);
       result.getFailedDetail().addAll(failedPluginSimpleClasses);
       result.setFailReason(getFailReason(result, request));

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/PluginChecksLoadedCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/PluginChecksLoadedCheck.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.checks;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.ambari.annotations.UpgradeCheckInfo;
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.spi.upgrade.UpgradeCheckDescription;
+import org.apache.ambari.spi.upgrade.UpgradeCheckGroup;
+import org.apache.ambari.spi.upgrade.UpgradeCheckRequest;
+import org.apache.ambari.spi.upgrade.UpgradeCheckResult;
+import org.apache.ambari.spi.upgrade.UpgradeCheckStatus;
+import org.apache.ambari.spi.upgrade.UpgradeCheckType;
+import org.apache.ambari.spi.upgrade.UpgradeType;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+
+/**
+ * The {@link PluginChecksLoadedCheck} class is used to display warnings if
+ * there were any stack plugin checks which were not able to be loaded.
+ */
+@Singleton
+@UpgradeCheckInfo(
+    group = UpgradeCheckGroup.INFORMATIONAL_WARNING,
+    required = { UpgradeType.ROLLING, UpgradeType.NON_ROLLING, UpgradeType.HOST_ORDERED })
+public class PluginChecksLoadedCheck extends ClusterCheck {
+
+  private static final UpgradeCheckDescription PLUGIN_CHECK_LOAD_FAILURE = new UpgradeCheckDescription(
+      "PLUGIN_CHECK_LOAD_FAILURE", UpgradeCheckType.CLUSTER, "Plugin Upgrade Checks",
+      new ImmutableMap.Builder<String, String>().put(UpgradeCheckDescription.DEFAULT,
+          "The following upgrade checks could not be loaded and were not run. "
+              + "Although this will not stop your upgrade, it is advised that these checks be corrected to ensure a successful upgrade.").build());
+
+  @Inject
+  Provider<UpgradeCheckRegistry> m_upgradeCheckRegistryProvider;
+
+  /**
+   * Constructor.
+   */
+  public PluginChecksLoadedCheck() {
+    super(PLUGIN_CHECK_LOAD_FAILURE);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public UpgradeCheckResult perform(UpgradeCheckRequest request) throws AmbariException {
+    UpgradeCheckResult result = new UpgradeCheckResult(this, UpgradeCheckStatus.PASS);
+
+    // get the fully-qualified class names
+    Set<String> failedPluginClasses = m_upgradeCheckRegistryProvider.get().getFailedPluginClassNames();
+
+    // quick return a pass
+    if (null == failedPluginClasses || failedPluginClasses.isEmpty()) {
+      return result;
+    }
+
+    // strip out the package name for readability
+    Set<FailedPluginClassDetail> failedPluginSimpleClasses = failedPluginClasses.stream()
+        .map(FailedPluginClassDetail::new)
+        .collect(Collectors.toSet());
+
+    // check for failure
+    if( failedPluginClasses.size() > 0 ) {
+      result.setStatus(UpgradeCheckStatus.WARNING);
+      result.getFailedDetail().addAll(failedPluginSimpleClasses);
+      result.setFailReason(getFailReason(result, request));
+
+      result.getFailedOn().addAll(failedPluginSimpleClasses.stream()
+          .map(detail -> detail.toSimpleString())
+          .collect(Collectors.toSet()));
+    }
+
+    return result;
+  }
+
+  /**
+   * Used to represent serializable structured information about plugin upgrade
+   * checks which could not load.
+   */
+  static class FailedPluginClassDetail {
+    final String m_fullyQualifiedClass;
+
+    @JsonProperty("package_name")
+    final String m_packageName;
+
+    @JsonProperty("class_name")
+    final String m_className;
+
+    FailedPluginClassDetail(String fullyQualifiedClass) {
+      m_fullyQualifiedClass = fullyQualifiedClass;
+
+      int indexOfLastDot = fullyQualifiedClass.lastIndexOf('.');
+      if(indexOfLastDot >= 0) {
+        m_packageName = fullyQualifiedClass.substring(0, indexOfLastDot);
+        m_className = fullyQualifiedClass.substring(indexOfLastDot + 1);
+      } else {
+        m_packageName = "";
+        m_className = fullyQualifiedClass;
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+      return m_fullyQualifiedClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toSimpleString() {
+      return m_className;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(m_packageName, m_className);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+
+      if (obj == null) {
+        return false;
+      }
+
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+
+      FailedPluginClassDetail other = (FailedPluginClassDetail) obj;
+      return Objects.equals(m_packageName, other.m_packageName)
+          && Objects.equals(m_className, other.m_className);
+    }
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/PluginChecksLoadedCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/PluginChecksLoadedCheckTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.checks;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.ambari.spi.upgrade.UpgradeCheckRequest;
+import org.apache.ambari.spi.upgrade.UpgradeCheckResult;
+import org.apache.ambari.spi.upgrade.UpgradeCheckStatus;
+import org.apache.ambari.spi.upgrade.UpgradeType;
+import org.apache.commons.lang.StringUtils;
+import org.easymock.EasyMockSupport;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Provider;
+
+/**
+ * Tests for {@link PluginChecksLoadedCheck}
+ */
+public class PluginChecksLoadedCheckTest extends EasyMockSupport {
+
+  private final PluginChecksLoadedCheck m_check = new PluginChecksLoadedCheck();
+  private final UpgradeCheckRegistry m_upgradeCheckRegistry = createNiceMock(
+      UpgradeCheckRegistry.class);
+
+  @Before
+  public void before() throws Exception {
+
+    m_check.m_upgradeCheckRegistryProvider = new Provider<UpgradeCheckRegistry>() {
+      @Override
+      public UpgradeCheckRegistry get() {
+        return m_upgradeCheckRegistry;
+      }
+    };
+  }
+
+  /**
+   * @throws Exception
+   */
+  @Test
+  public void testPerform() throws Exception {
+    Set<String> failedClasses = Sets.newHashSet("foo.bar.Baz", "foo.bar.Baz2");
+    expect(m_upgradeCheckRegistry.getFailedPluginClassNames()).andReturn(
+        failedClasses).atLeastOnce();
+
+    replayAll();
+
+    UpgradeCheckRequest request = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null);
+    UpgradeCheckResult check = m_check.perform(request);
+
+    Assert.assertEquals(UpgradeCheckStatus.WARNING, check.getStatus());
+    List<Object> failedDetails = check.getFailedDetail();
+    assertEquals(2, failedDetails.size());
+    assertEquals(2, check.getFailedOn().size());
+    assertTrue(check.getFailedOn().contains("Baz"));
+
+    verifyAll();
+  }
+
+  /**
+   * @throws Exception
+   */
+  @Test
+  public void testPerformWithSuccess() throws Exception {
+    expect(m_upgradeCheckRegistry.getFailedPluginClassNames()).andReturn(
+        new HashSet<>()).atLeastOnce();
+    replayAll();
+
+    UpgradeCheckRequest request = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null);
+    UpgradeCheckResult check = m_check.perform(request);
+
+    Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());
+    Assert.assertTrue(StringUtils.isBlank(check.getFailReason()));
+
+    verifyAll();
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -227,7 +227,7 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
     // types. The value being asserted here is a combination of built-in checks
     // which are required for the upgrade type as well as any provided checks
     // discovered in the stack
-    Assert.assertEquals(19, resources.size());
+    Assert.assertEquals(20, resources.size());
 
     // find the service check provided by the library classloader and verify it ran
     Resource customUpgradeCheck = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-24737 removed stack upgrade checks from being shipped with Ambari and instead expects the stacks to deliver their own implementations. In the event that an upgrade check is defined in an upgrade pack but cannot be found or instantiated, there should be a warning displayed before allowing the upgrade to proceed.

For example:
```
  {
      "href" : "http://localhost:8080/api/v1/clusters/c1/rolling_upgrades_check/PLUGIN_CHECK_LOAD_FAILURE",
      "UpgradeChecks" : {
        "check" : "Plugin Upgrade Checks",
        "check_type" : "CLUSTER",
        "cluster_name" : "c1",
        "failed_detail" : [
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "ServicesYarnWorkPreservingCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "DruidHighAvailabilityCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "ServicesNamenodeHighAvailabilityCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "MapReduce2JobHistoryStatePreservingCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "YarnRMHighAvailabilityCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "ServicesMapReduceDistributedCacheCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "ServicesTezDistributedCacheCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "YarnTimelineServerStatePreservingCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "HiveMultipleMetastoreCheck"
          },
          {
            "package_name" : "org.apache.ambari.server.checks",
            "class_name" : "SecondaryNamenodeDeletedCheck"
          }
        ],
        "failed_on" : [
          "ServicesMapReduceDistributedCacheCheck",
          "ServicesTezDistributedCacheCheck",
          "SecondaryNamenodeDeletedCheck",
          "YarnTimelineServerStatePreservingCheck",
          "YarnRMHighAvailabilityCheck",
          "DruidHighAvailabilityCheck",
          "ServicesNamenodeHighAvailabilityCheck",
          "HiveMultipleMetastoreCheck",
          "MapReduce2JobHistoryStatePreservingCheck",
          "ServicesYarnWorkPreservingCheck"
        ],
        "id" : "PLUGIN_CHECK_LOAD_FAILURE",
        "reason" : "The following upgrade checks could not be loaded and were not run. Although this will not stop your upgrade, it is advised that these checks be corrected to ensure a successful upgrade.",
        "repository_version_id" : 2,
        "status" : "FAIL",
        "upgrade_type" : "NON_ROLLING"
      }
```

## How was this patch tested?

New unit tests written, manual verification of missing upgrade check warnings.