### PR TITLE
AMBARI-24818 - Knox topology files installed via Ambari are world rea…

### DIFF
--- a/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/knox.py
+++ b/ambari-server/src/main/resources/common-services/KNOX/0.5.0.2.2/package/scripts/knox.py
@@ -57,6 +57,7 @@ def knox():
   )
 
   File(os.path.join(params.knox_conf_dir, "topologies", "default.xml"),
+       mode=0600,
        group=params.knox_group,
        owner=params.knox_user,
        content=InlineTemplate(params.topology_template)
@@ -64,6 +65,7 @@ def knox():
 
   if params.admin_topology_template:
     File(os.path.join(params.knox_conf_dir, "topologies", "admin.xml"),
+       mode=0600,
        group=params.knox_group,
        owner=params.knox_user,
        content=InlineTemplate(params.admin_topology_template)
@@ -73,6 +75,7 @@ def knox():
     knoxsso_topology_template_content = get_config("knoxsso-topology")
     if knoxsso_topology_template_content:
       File(os.path.join(params.knox_conf_dir, "topologies", "knoxsso.xml"),
+        mode=0600,
         group=params.knox_group,
         owner=params.knox_user,
         content=InlineTemplate(params.knoxsso_topology_template)
@@ -118,6 +121,7 @@ def knox():
     )
 
     File(format("{params.knox_conf_dir}/topologies/default.xml"),
+         mode=0600,
          group=params.knox_group,
          owner=params.knox_user,
          content=InlineTemplate(params.topology_template)
@@ -125,6 +129,7 @@ def knox():
 
     if params.admin_topology_template:
       File(format("{params.knox_conf_dir}/topologies/admin.xml"),
+           mode=0600,
            group=params.knox_group,
            owner=params.knox_user,
            content=InlineTemplate(params.admin_topology_template)
@@ -134,6 +139,7 @@ def knox():
       knoxsso_topology_template_content = get_config("knoxsso-topology")
       if knoxsso_topology_template_content:
         File(os.path.join(params.knox_conf_dir, "topologies", "knoxsso.xml"),
+            mode=0600,
             group=params.knox_group,
             owner=params.knox_user,
             content=InlineTemplate(params.knoxsso_topology_template)
@@ -187,6 +193,6 @@ def update_knox_logfolder_permissions():
             group = params.knox_group,
             create_parents = True,
             cd_access = "a",
-            mode = 0755,
+            mode = 0700,
             recursive_ownership = True,
   )

--- a/ambari-server/src/test/python/stacks/2.2/KNOX/test_knox_gateway.py
+++ b/ambari-server/src/test/python/stacks/2.2/KNOX/test_knox_gateway.py
@@ -97,11 +97,13 @@ class TestKnoxGateway(RMFTestCase):
     self.assertResourceCalled('File', '/usr/hdp/current/knox-server/conf/topologies/default.xml',
                               group='knox',
                               owner = 'knox',
+                              mode = 0600,
                               content = InlineTemplate(self.getConfig()['configurations']['topology']['content'])
     )
     self.assertResourceCalled('File', '/usr/hdp/current/knox-server/conf/topologies/admin.xml',
                               group='knox',
                               owner = 'knox',
+                              mode = 0600,
                               content = InlineTemplate(self.getConfig()['configurations']['admin-topology']['content'])
     )
     self.assertResourceCalled('Execute', '/usr/hdp/current/knox-server/bin/knoxcli.sh create-master --master sa',
@@ -406,11 +408,13 @@ class TestKnoxGateway(RMFTestCase):
     self.assertResourceCalled('File', '/usr/hdp/current/knox-server/conf/topologies/default.xml',
                               group='knox',
                               owner = 'knox',
+                              mode = 0600,
                               content = InlineTemplate(self.getConfig()['configurations']['topology']['content'])
     )
     self.assertResourceCalled('File', '/usr/hdp/current/knox-server/conf/topologies/admin.xml',
                               group='knox',
                               owner = 'knox',
+                              mode = 0600,
                               content = InlineTemplate(self.getConfig()['configurations']['admin-topology']['content'])
     )
     self.assertResourceCalled('Execute', '/usr/hdp/current/knox-server/bin/knoxcli.sh create-master --master sa',
@@ -440,7 +444,7 @@ class TestKnoxGateway(RMFTestCase):
     )
     self.assertResourceCalled('Directory', '/var/log/knox',
                               owner = 'knox',
-                              mode = 0755,
+                              mode = 0700,
                               group = 'knox',
                               create_parents = True,
                               cd_access = 'a',


### PR DESCRIPTION
This PR changes the permissions of knox topology files to be only be readable by user running Knox and limits world readable permissions. 

## What changes were proposed in this pull request?

Update Knox topology file permissions from 655 (default) to 600

## How was this patch tested?

This patch was manually tested. 
