### PR TITLE
[AMBARI-24820] Set cloud storage tracking property for GCS

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/core-site.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/core-site.xml
@@ -203,6 +203,16 @@ DEFAULT
     <on-ambari-upgrade add="false" />
   </property>
   <property>
+    <name>fs.gs.application.name.suffix</name>
+    <value> (GPN:Hortonworks; version 1.0) HDP/{{version}}</value>
+    <value-attributes>
+      <read-only>true</read-only>
+      <overridable>false</overridable>
+      <visible>false</visible>
+    </value-attributes>
+    <on-ambari-upgrade add="false" />
+  </property>
+  <property>
     <name>fs.s3a.user.agent.prefix</name>
     <value>User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}</value>
     <on-ambari-upgrade add="false" />

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/config-upgrade.xml
@@ -398,6 +398,7 @@
           <definition xsi:type="configure" id="hdfs_user_agent" summary="Set User-Agent">
             <type>core-site</type>
             <set key="fs.azure.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.azure.user.agent.prefix" if-key-state="absent" />
+            <set key="fs.gs.application.name.suffix" value=" (GPN:Hortonworks; version 1.0) HDP/{{version}}" if-type="core-site" if-key="fs.gs.application.name.suffix" if-key-state="absent" />
             <set key="fs.s3a.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.s3a.user.agent.prefix" if-key-state="absent" />
           </definition>
         </changes>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/config-upgrade.xml
@@ -282,6 +282,7 @@
           <definition xsi:type="configure" id="hdfs_user_agent" summary="Set User-Agent">
             <type>core-site</type>
             <set key="fs.azure.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.azure.user.agent.prefix" if-key-state="absent" />
+            <set key="fs.gs.application.name.suffix" value=" (GPN:Hortonworks; version 1.0) HDP/{{version}}" if-type="core-site" if-key="fs.gs.application.name.suffix" if-key-state="absent" />
             <set key="fs.s3a.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.s3a.user.agent.prefix" if-key-state="absent" />
           </definition>
         </changes>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/config-upgrade.xml
@@ -301,6 +301,7 @@
           <definition xsi:type="configure" id="hdfs_user_agent" summary="Set User-Agent">
             <type>core-site</type>
             <set key="fs.azure.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.azure.user.agent.prefix" if-key-state="absent" />
+            <set key="fs.gs.application.name.suffix" value=" (GPN:Hortonworks; version 1.0) HDP/{{version}}" if-type="core-site" if-key="fs.gs.application.name.suffix" if-key-state="absent" />
             <set key="fs.s3a.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.s3a.user.agent.prefix" if-key-state="absent" />
           </definition>
         </changes>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new property in `core-site` for tracking purposes on GCS.

https://issues.apache.org/jira/browse/AMBARI-24820

## How was this patch tested?

Tested fresh install of HDP 2.6.4.  Verified that `core-site` config contains the new property:

```
"fs.gs.application.name.suffix" : " (GPN:Hortonworks; version 1.0) HDP/{{version}}"
```

And so does `/etc/hadoop/conf/core-site.xml`:

```xml
<property>
  <name>fs.gs.application.name.suffix</name>
  <value> (GPN:Hortonworks; version 1.0) HDP/2.6.4.0-91</value>
</property>
```

Tested stack upgrade from HDP 2.5.6 to HDP 2.6.4.  Verified that the new property is added to `core-site` during upgrade:

```
core-site/fs.gs.application.name.suffix changed to " (GPN:Hortonworks; version 1.0) HDP/{{version}}"
```