### PR TITLE
[AMBARI-24823] Set path encoding for GCS

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/core-site.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/core-site.xml
@@ -213,6 +213,17 @@ DEFAULT
     <on-ambari-upgrade add="false" />
   </property>
   <property>
+    <name>fs.gs.path.encoding</name>
+    <value>uri-path</value>
+    <description>The path encoding codec to be used for GCS</description>
+    <on-ambari-upgrade add="false" />
+  </property>
+  <property>
+    <name>fs.gs.working.dir</name>
+    <value>/</value>
+    <on-ambari-upgrade add="false" />
+  </property>
+  <property>
     <name>fs.s3a.user.agent.prefix</name>
     <value>User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}</value>
     <on-ambari-upgrade add="false" />

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/config-upgrade.xml
@@ -401,6 +401,12 @@
             <set key="fs.gs.application.name.suffix" value=" (GPN:Hortonworks; version 1.0) HDP/{{version}}" if-type="core-site" if-key="fs.gs.application.name.suffix" if-key-state="absent" />
             <set key="fs.s3a.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.s3a.user.agent.prefix" if-key-state="absent" />
           </definition>
+
+          <definition xsi:type="configure" id="gcs_properties" summary="Set properties for GCS">
+            <type>core-site</type>
+            <set key="fs.gs.path.encoding" value="uri-path" if-type="core-site" if-key="fs.gs.path.encoding" if-key-state="absent" />
+            <set key="fs.gs.working.dir" value="/" if-type="core-site" if-key="fs.gs.working.dir" if-key-state="absent" />
+          </definition>
         </changes>
       </component>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/nonrolling-upgrade-2.6.xml
@@ -307,6 +307,10 @@
         <task xsi:type="configure" id="hdfs_user_agent" />
       </execute-stage>
 
+      <execute-stage service="HDFS" component="HDFS_CLIENT" title="Set properties for GCS">
+        <task xsi:type="configure" id="gcs_properties" />
+      </execute-stage>
+
       <!-- YARN -->
       <execute-stage service="YARN" component="RESOURCEMANAGER" title="Calculating Yarn Properties for Spark">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.SparkShufflePropertyConfig">

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.6.xml
@@ -699,6 +699,7 @@
       <component name="HDFS_CLIENT">
         <pre-upgrade>
           <task xsi:type="configure" id="hdfs_user_agent" />
+          <task xsi:type="configure" id="gcs_properties" />
         </pre-upgrade>
         <pre-downgrade />
         <upgrade>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/config-upgrade.xml
@@ -285,6 +285,12 @@
             <set key="fs.gs.application.name.suffix" value=" (GPN:Hortonworks; version 1.0) HDP/{{version}}" if-type="core-site" if-key="fs.gs.application.name.suffix" if-key-state="absent" />
             <set key="fs.s3a.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.s3a.user.agent.prefix" if-key-state="absent" />
           </definition>
+
+          <definition xsi:type="configure" id="gcs_properties" summary="Set properties for GCS">
+            <type>core-site</type>
+            <set key="fs.gs.path.encoding" value="uri-path" if-type="core-site" if-key="fs.gs.path.encoding" if-key-state="absent" />
+            <set key="fs.gs.working.dir" value="/" if-type="core-site" if-key="fs.gs.working.dir" if-key-state="absent" />
+          </definition>
         </changes>
       </component>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/nonrolling-upgrade-2.6.xml
@@ -456,6 +456,10 @@
         <task xsi:type="configure" id="hdfs_user_agent" />
       </execute-stage>
 
+      <execute-stage service="HDFS" component="HDFS_CLIENT" title="Set properties for GCS">
+        <task xsi:type="configure" id="gcs_properties" />
+      </execute-stage>
+
       <!--SPARK-->
       <execute-stage service="SPARK" component="SPARK_CLIENT" title="Apply config changes for Spark">
         <task xsi:type="configure" id="hdp_2_5_0_0_spark_yarn_queue">

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.6.xml
@@ -704,6 +704,7 @@
       <component name="HDFS_CLIENT">
         <pre-upgrade>
           <task xsi:type="configure" id="hdfs_user_agent" />
+          <task xsi:type="configure" id="gcs_properties" />
         </pre-upgrade>
         <pre-downgrade />
         <upgrade>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/config-upgrade.xml
@@ -304,6 +304,12 @@
             <set key="fs.gs.application.name.suffix" value=" (GPN:Hortonworks; version 1.0) HDP/{{version}}" if-type="core-site" if-key="fs.gs.application.name.suffix" if-key-state="absent" />
             <set key="fs.s3a.user.agent.prefix" value="User-Agent: APN/1.0 Hortonworks/1.0 HDP/{{version}}" if-type="core-site" if-key="fs.s3a.user.agent.prefix" if-key-state="absent" />
           </definition>
+
+          <definition xsi:type="configure" id="gcs_properties" summary="Set properties for GCS">
+            <type>core-site</type>
+            <set key="fs.gs.path.encoding" value="uri-path" if-type="core-site" if-key="fs.gs.path.encoding" if-key-state="absent" />
+            <set key="fs.gs.working.dir" value="/" if-type="core-site" if-key="fs.gs.working.dir" if-key-state="absent" />
+          </definition>
         </changes>
       </component>
     </service>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.6.xml
@@ -300,6 +300,10 @@
         <task xsi:type="configure" id="hdfs_user_agent" />
       </execute-stage>
 
+      <execute-stage service="HDFS" component="HDFS_CLIENT" title="Set properties for GCS">
+        <task xsi:type="configure" id="gcs_properties" />
+      </execute-stage>
+
       <!--YARN-->
       <execute-stage service="MAPREDUCE2" component="MAPREDUCE2_CLIENT" title="Apply config changes for Mapreduce2 client">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FixLzoCodecPath">

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
@@ -643,6 +643,7 @@
       <component name="HDFS_CLIENT">
         <pre-upgrade>
           <task xsi:type="configure" id="hdfs_user_agent" />
+          <task xsi:type="configure" id="gcs_properties" />
         </pre-upgrade>
         <pre-downgrade />
         <upgrade>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `fs.gs.path.encoding=uri-path` to `core-site` to [support special chars](https://github.com/GoogleCloudPlatform/bigdata-interop/commit/acf5cf08e9547c39fd4ed3cb01a7ec3c41087a5d) by default, with ability to change the encoding if needed.

Also set `fs.gs.working.dir=/` by default.

https://issues.apache.org/jira/browse/AMBARI-24823

## How was this patch tested?

Tested fresh install of HDP 2.6.4.  Verified that `core-site` config contains the new properties:

```
"fs.gs.path.encoding" : "uri-path",
"fs.gs.working.dir" : "/"
```

And so does `/etc/hadoop/conf/core-site.xml`:

```xml
<property>
  <name>fs.gs.path.encoding</name>
  <value>uri-path</value>
</property>

<property>
  <name>fs.gs.working.dir</name>
  <value>/</value>
</property>
```

Tested stack upgrade from HDP 2.5.6 to HDP 2.6.4.  Verified that the new properties are added to `core-site` during upgrade:

```
core-site/fs.gs.path.encoding changed to "uri-path"
core-site/fs.gs.working.dir changed to "/"
```