### PR TITLE
[AMBARI-24830] Add datatype option to the SwaggerUi client being used for api-docs

### DIFF
--- a/ambari-web/api-docs/index.html
+++ b/ambari-web/api-docs/index.html
@@ -51,6 +51,7 @@
 
       window.swaggerUi = new SwaggerUi({
         url: url,
+        dataType: 'json',
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function (swaggerApi, swaggerUi) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Explicitly state that the dataType is always going to be Json for SwaggerUI client

## How was this patch tested?
Verified by applying the patch on a cluster that it does not cause any regression