### PR TITLE
AMBARI-24669. Component status can stuck in starting/stopping status on heartbeat lost.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatMonitor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartbeatMonitor.java
@@ -345,7 +345,6 @@ public class HeartbeatMonitor implements Runnable {
           LOG.warn("Setting component state to UNKNOWN for component " + sc.getName() + " on " + host);
           State oldState = sch.getState();
           sch.setState(State.UNKNOWN);
-          sch.setLastValidState(oldState);
         }
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -101,10 +101,6 @@ public class HostComponentStateEntity {
   private State currentState = State.INIT;
 
   @Enumerated(value = EnumType.STRING)
-  @Column(name = "last_live_state", nullable = true, insertable = true, updatable = true)
-  private State lastLiveState = State.INIT;
-
-  @Enumerated(value = EnumType.STRING)
   @Column(name = "upgrade_state", nullable = false, insertable = true, updatable = true)
   private UpgradeState upgradeState = UpgradeState.NONE;
 
@@ -163,14 +159,6 @@ public class HostComponentStateEntity {
     this.currentState = currentState;
   }
 
-  public State getLastLiveState() {
-    return lastLiveState;
-  }
-
-  public void setLastLiveState(State lastLiveState) {
-    this.lastLiveState = lastLiveState;
-  }
-
   public UpgradeState getUpgradeState() {
     return upgradeState;
   }
@@ -217,11 +205,6 @@ public class HostComponentStateEntity {
       return false;
     }
 
-    if (lastLiveState != null ? !lastLiveState.equals(that.lastLiveState)
-        : that.lastLiveState != null) {
-      return false;
-    }
-
     if (upgradeState != null ? !upgradeState.equals(that.upgradeState)
         : that.upgradeState != null) {
       return false;
@@ -249,7 +232,6 @@ public class HostComponentStateEntity {
     result = 31 * result + (hostEntity != null ? hostEntity.hashCode() : 0);
     result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
     result = 31 * result + (currentState != null ? currentState.hashCode() : 0);
-    result = 31 * result + (lastLiveState != null ? lastLiveState.hashCode() : 0);
     result = 31 * result + (upgradeState != null ? upgradeState.hashCode() : 0);
     result = 31 * result + (serviceName != null ? serviceName.hashCode() : 0);
     result = 31 * result + (version != null ? version.hashCode() : 0);

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHost.java
@@ -96,10 +96,6 @@ public interface ServiceComponentHost {
 
   void setState(State state);
 
-  State getLastValidState();
-
-  void setLastValidState(State state);
-
   /**
    * Gets the version of the component.
    *

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
@@ -71,11 +71,8 @@ import org.apache.ambari.server.state.HostHealthStatus;
 import org.apache.ambari.server.state.HostHealthStatus.HealthStatus;
 import org.apache.ambari.server.state.HostState;
 import org.apache.ambari.server.state.MaintenanceState;
-import org.apache.ambari.server.state.Service;
-import org.apache.ambari.server.state.ServiceComponent;
 import org.apache.ambari.server.state.ServiceComponentHost;
 import org.apache.ambari.server.state.StackId;
-import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.state.UpgradeState;
 import org.apache.ambari.server.state.configgroup.ConfigGroup;
 import org.apache.ambari.server.state.fsm.InvalidStateTransitionException;
@@ -362,11 +359,7 @@ public class HostImpl implements Host {
       }
 
       host.topologyManager.onHostRegistered(host, associatedWithCluster);
-      try {
-        host.restoreComponentsStatuses();
-      } catch (AmbariException e1) {
-        LOG.error("Unable to restore last valid host components status for host", e1);
-      }
+
       // initialize agent times in the last time to prevent setting registering/heartbeat times for failed registration.
       host.updateHostTimestamps(e);
     }
@@ -1210,28 +1203,6 @@ public class HostImpl implements Host {
     }
 
     return false;
-  }
-
-  public void restoreComponentsStatuses() throws AmbariException {
-    Long clusterId = null;
-    for (Cluster cluster : clusters.getClustersForHost(getHostName())) {
-      clusterId = cluster.getClusterId();
-      for (ServiceComponentHost sch : cluster.getServiceComponentHosts(getHostName())) {
-        Service s = cluster.getService(sch.getServiceName());
-        ServiceComponent sc = s.getServiceComponent(sch.getServiceComponentName());
-        if (!sc.isClientComponent() &&
-            sch.getState().equals(State.UNKNOWN)) {
-          State lastValidState = sch.getLastValidState();
-          LOG.warn("Restore component state to last valid state for component " + sc.getName() + " on " +
-              getHostName() + " to " + lastValidState);
-          sch.setState(lastValidState);
-        }
-      }
-    }
-    //TODO
-    if (clusterId != null) {
-      calculateHostStatus(clusterId);
-    }
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -913,39 +913,11 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
     HostComponentStateEntity stateEntity = getStateEntity();
     if (stateEntity != null) {
       stateEntity.setCurrentState(state);
-      if (state != State.UNKNOWN) {
-        stateEntity.setLastLiveState(state);
-      }
       stateEntity = hostComponentStateDAO.merge(stateEntity);
       if (!oldState.equals(state)) {
         STOMPUpdatePublisher.publish(new HostComponentsUpdateEvent(Collections.singletonList(
             HostComponentUpdate.createHostComponentStatusUpdate(stateEntity, oldState))));
       }
-    } else {
-      LOG.warn("Setting a member on an entity object that may have been "
-          + "previously deleted, serviceName = " + getServiceName() + ", " + "componentName = "
-          + getServiceComponentName() + ", " + "hostName = " + getHostName());
-    }
-  }
-
-  @Override
-  public State getLastValidState() {
-    HostComponentStateEntity stateEntity = getStateEntity();
-    if (stateEntity != null) {
-      return stateEntity.getLastLiveState();
-    }
-    return State.UNKNOWN;
-  }
-
-  @Override
-  public void setLastValidState(State state) {
-    if (state == State.UNKNOWN) {
-      return;
-    }
-    HostComponentStateEntity stateEntity = getStateEntity();
-    if (stateEntity != null) {
-      stateEntity.setLastLiveState(state);
-      hostComponentStateDAO.merge(stateEntity);
     } else {
       LOG.warn("Setting a member on an entity object that may have been "
           + "previously deleted, serviceName = " + getServiceName() + ", " + "componentName = "

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1058,7 +1058,6 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     setStatusOfStagesAndRequests();
     updateLogSearchConfigs();
     updateKerberosConfigurations();
-    updateHostComponentLastStateTable();
     moveAmbariPropertiesToAmbariConfiguration();
     createRoleAuthorizations();
     addUserAuthenticationSequence();
@@ -1774,24 +1773,6 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     map.put(AmbariServerConfigurationKey.SSO_JWT_COOKIE_NAME, "authentication.jwt.cookieName");
 
     return map;
-  }
-
-  protected void updateHostComponentLastStateTable() throws SQLException {
-    executeInTransaction(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          HostComponentStateDAO hostComponentStateDAO = injector.getInstance(HostComponentStateDAO.class);
-          List<HostComponentStateEntity> hostComponentStateEntities = hostComponentStateDAO.findAll();
-          for (HostComponentStateEntity hostComponentStateEntity : hostComponentStateEntities) {
-            hostComponentStateEntity.setLastLiveState(hostComponentStateEntity.getCurrentState());
-            hostComponentStateDAO.merge(hostComponentStateEntity);
-          }
-        } catch (Exception e) {
-          LOG.warn("Setting status for stages and Requests threw exception. ", e);
-        }
-      }
-    });
   }
 
   protected void updateSolrConfigurations() throws AmbariException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog272.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog272.java
@@ -50,8 +50,10 @@ public class UpgradeCatalog272 extends AbstractUpgradeCatalog {
       AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN, LDAP_CONFIGURATION_CORRECT_COLLISION_BEHAVIOR_PROPERTY_NAME, AMBARI_CONFIGURATION_CATEGORY_NAME_COLUMN,
       LDAP_CONFIGURATION.getCategoryName(), AMBARI_CONFIGURATION_PROPERTY_NAME_COLUMN, LDAP_CONFIGURATION_WRONG_COLLISION_BEHAVIOR_PROPERTY_NAME);
   protected static final String HOST_COMPONENT_DESIRED_STATE_TABLE = "hostcomponentdesiredstate";
+  protected static final String HOST_COMPONENT_STATE_TABLE = "hostcomponentstate";
   protected static final String CLUSTERS_TABLE = "clusters";
   protected static final String BLUEPRINT_PROVISIONING_STATE_COLUMN = "blueprint_provisioning_state";
+  protected static final String LAST_LIVE_STATE_COLUMN = "last_live_state";
 
   @Inject
   public UpgradeCatalog272(Injector injector) {
@@ -71,6 +73,7 @@ public class UpgradeCatalog272 extends AbstractUpgradeCatalog {
   @Override
   protected void executeDDLUpdates() throws AmbariException, SQLException {
     moveBlueprintProvisioningState();
+    removeLastValidState();
   }
 
   @Override
@@ -108,5 +111,9 @@ public class UpgradeCatalog272 extends AbstractUpgradeCatalog {
     dbAccessor.addColumn(HOST_COMPONENT_DESIRED_STATE_TABLE,
         new DBAccessor.DBColumnInfo(BLUEPRINT_PROVISIONING_STATE_COLUMN, String.class, 255,
             BlueprintProvisioningState.NONE, true));
+  }
+
+  protected void removeLastValidState() throws SQLException {
+    dbAccessor.dropColumn(HOST_COMPONENT_STATE_TABLE, LAST_LIVE_STATE_COLUMN);
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -320,7 +320,6 @@ public class UpgradeCatalog270Test {
     Method setStatusOfStagesAndRequests = UpgradeCatalog270.class.getDeclaredMethod("setStatusOfStagesAndRequests");
     Method updateLogSearchConfigs = UpgradeCatalog270.class.getDeclaredMethod("updateLogSearchConfigs");
     Method updateKerberosConfigurations = UpgradeCatalog270.class.getDeclaredMethod("updateKerberosConfigurations");
-    Method updateHostComponentLastStateTable = UpgradeCatalog270.class.getDeclaredMethod("updateHostComponentLastStateTable");
     Method upgradeLdapConfiguration = UpgradeCatalog270.class.getDeclaredMethod("moveAmbariPropertiesToAmbariConfiguration");
     Method createRoleAuthorizations = UpgradeCatalog270.class.getDeclaredMethod("createRoleAuthorizations");
     Method addUserAuthenticationSequence = UpgradeCatalog270.class.getDeclaredMethod("addUserAuthenticationSequence");
@@ -337,7 +336,6 @@ public class UpgradeCatalog270Test {
         .addMockedMethod(setStatusOfStagesAndRequests)
         .addMockedMethod(updateLogSearchConfigs)
         .addMockedMethod(updateKerberosConfigurations)
-        .addMockedMethod(updateHostComponentLastStateTable)
         .addMockedMethod(upgradeLdapConfiguration)
         .addMockedMethod(createRoleAuthorizations)
         .addMockedMethod(addUserAuthenticationSequence)
@@ -363,8 +361,6 @@ public class UpgradeCatalog270Test {
     expectLastCall().once();
 
     upgradeCatalog270.updateLogSearchConfigs();
-    upgradeCatalog270.updateHostComponentLastStateTable();
-    expectLastCall().once();
 
     upgradeCatalog270.updateKerberosConfigurations();
     expectLastCall().once();

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog272Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog272Test.java
@@ -21,6 +21,8 @@ import static org.apache.ambari.server.upgrade.UpgradeCatalog270.AMBARI_CONFIGUR
 import static org.apache.ambari.server.upgrade.UpgradeCatalog272.BLUEPRINT_PROVISIONING_STATE_COLUMN;
 import static org.apache.ambari.server.upgrade.UpgradeCatalog272.CLUSTERS_TABLE;
 import static org.apache.ambari.server.upgrade.UpgradeCatalog272.HOST_COMPONENT_DESIRED_STATE_TABLE;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog272.HOST_COMPONENT_STATE_TABLE;
+import static org.apache.ambari.server.upgrade.UpgradeCatalog272.LAST_LIVE_STATE_COLUMN;
 import static org.apache.ambari.server.upgrade.UpgradeCatalog272.RENAME_COLLISION_BEHAVIOR_PROPERTY_SQL;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMockBuilder;
@@ -63,6 +65,9 @@ public class UpgradeCatalog272Test {
 
     Capture<DBAccessor.DBColumnInfo> blueprintProvisioningStateColumnCapture = newCapture(CaptureType.ALL);
     dbAccessor.addColumn(eq(HOST_COMPONENT_DESIRED_STATE_TABLE), capture(blueprintProvisioningStateColumnCapture));
+    expectLastCall().once();
+
+    dbAccessor.dropColumn(eq(HOST_COMPONENT_STATE_TABLE), eq(LAST_LIVE_STATE_COLUMN));
     expectLastCall().once();
 
     replay(dbAccessor, injector);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server does not save last host component state before heartbeat lost.

## How was this patch tested?

Manual check.