### PR TITLE
[AMBARI-24827] LDAP users fail to authenticate using LDAPS due to 'No subject alternative DNS name' exception

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/AmbariLdapAuthenticationProvider.java
@@ -52,7 +52,8 @@ import com.google.inject.Inject;
  * Provides LDAP user authorization logic for Ambari Server
  */
 public class AmbariLdapAuthenticationProvider extends AmbariAuthenticationProvider {
-  static Logger LOG = LoggerFactory.getLogger(AmbariLdapAuthenticationProvider.class); // exposed and mutable for "test"
+  private static final String SYSTEM_PROPERTY_DISABLE_ENDPOINT_IDENTIFICATION = "com.sun.jndi.ldap.object.disableEndpointIdentification";
+  private static Logger LOG = LoggerFactory.getLogger(AmbariLdapAuthenticationProvider.class);
 
   final AmbariLdapConfigurationProvider ldapConfigurationProvider;
 
@@ -169,6 +170,14 @@ public class AmbariLdapAuthenticationProvider extends AmbariAuthenticationProvid
       if (!ldapServerProperties.get().isAnonymousBind()) {
         springSecurityContextSource.setUserDn(ldapServerProperties.get().getManagerDn());
         springSecurityContextSource.setPassword(ldapServerProperties.get().getManagerPassword());
+      }
+
+      if (ldapServerProperties.get().isUseSsl() && ldapServerProperties.get().isDisableEndpointIdentification()) {
+        System.setProperty(SYSTEM_PROPERTY_DISABLE_ENDPOINT_IDENTIFICATION, "true");
+        LOG.info("Disabled endpoint identification");
+      } else {
+        System.clearProperty(SYSTEM_PROPERTY_DISABLE_ENDPOINT_IDENTIFICATION);
+        LOG.info("Removed endpoint identification disabling");
       }
 
       try {

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1764,6 +1764,9 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
     map.put(AmbariServerConfigurationKey.PAGINATION_ENABLED, "authentication.ldap.pagination.enabled");
     map.put(AmbariServerConfigurationKey.COLLISION_BEHAVIOR, "ldap.sync.username.collision.behavior");
 
+    // Added in the event a previous version of Ambari had AMBARI-24827 back-ported to it
+    map.put(AmbariServerConfigurationKey.DISABLE_ENDPOINT_IDENTIFICATION, "ldap.sync.disable.endpoint.identification");
+
     // SSO-related properties
     map.put(AmbariServerConfigurationKey.SSO_PROVIDER_URL, "authentication.jwt.providerUrl");
     map.put(AmbariServerConfigurationKey.SSO_PROVIDER_CERTIFICATE, "authentication.jwt.publicKey");


### PR DESCRIPTION
## What changes were proposed in this pull request?

LDAP users fail to authenticate using LDAPS due to `No subject alternative DNS name` exception:

```
2018-10-26 14:49:45,716  WARN [ambari-client-thread-37] AmbariLdapAuthenticationProvider:126 - Failed to communicate with the LDAP server: simple bind failed: ad.example.com:636; nested exception is javax.naming.CommunicationException: simple bind failed: ad.example.com:636 [Root exception is javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative DNS name matching ad.example.com found.]
```

This is the other half of the issue from AMBARI-24533 (which was related to the LDAP sync process).  

Note:  If LDAP sync is performed before a user attempts to log in, then the issue will not be seen since the system property, `com.sun.jndi.ldap.object.disableEndpointIdentification`, would have already been set to "true".   However, the logic path setting this value is not reached for an authentication attempt. 

Note: This occurs with OpenJDK 1.8.0.191 and maybe some earlier versions.
```
openjdk version "1.8.0_191"
OpenJDK Runtime Environment (build 1.8.0_191-b12)
OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)
```
This does not occur with Oracle JDK 1.8.0.112
```
java version "1.8.0_112"
Java(TM) SE Runtime Environment (build 1.8.0_112-b15)
Java HotSpot(TM) 64-Bit Server VM (build 25.112-b15, mixed mode)
```

This was cherry-picked from #2521.

## How was this patch tested?

Manually tested against a test AD.

```
mvn clean test package install  -pl ambari-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31:03 min
[INFO] Finished at: 2018-10-26T12:55:38-04:00
[INFO] Final Memory: 208M/977M
[INFO] ------------------------------------------------------------------------
```


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.