### PR TITLE
[AMBARI-24835] Fix javadoc errors in ambari-utility

### DIFF
--- a/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java
+++ b/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 
 /**
  * The {@link SwaggerOverwriteNestedAPI} is used to overwrite default values of
- * {@link org.apache.ambari.swagger.NestedApiRecord} when {@link org.apache.ambari.swagger.AmbariSwaggerReader}
+ * {@code NestedApiRecord} when {@link org.apache.ambari.swagger.AmbariSwaggerReader}
  * processes nested API classes for Swagger annotations.
  *
  * It can be useful to overcome the limitations of multi-nested service endpoints or endpoints without Path
@@ -38,26 +38,22 @@ import java.lang.annotation.Target;
 public @interface SwaggerOverwriteNestedAPI {
 
     /**
-     * Class name of parent object
-     * @return
+     * @return class name of parent object
      */
-    Class parentApi();
+    Class<?> parentApi();
 
     /**
-     * Parent API path, usually top-level API path starting with slash.
-     * @return
+     * @return parent API path, usually top-level API path starting with slash.
      */
     String parentApiPath();
 
     /**
-     * Path annotation value of the method in parent class.
-     * @return
+     * @return path annotation value of the method in parent class.
      */
     String parentMethodPath();
 
     /**
-     * Array of Strings to provide path parameters. Only string types are supported as of now.
-     * @return
+     * @return array of Strings to provide path parameters. Only string types are supported as of now.
      */
     String[] pathParameters();
 }

--- a/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java
+++ b/ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java
@@ -33,8 +33,7 @@ import java.lang.annotation.Target;
 public @interface SwaggerPreferredParent {
 
     /**
-     * Class name of preferred parent object
-     * @return
+     * @return class name of preferred parent object
      */
-    Class preferredParent();
+    Class<?> preferredParent();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following `javadoc` errors in `ambari-utility`:

```
$ mvn -am -pl ambari-utility -Pjavadoc clean package
...
[INFO] BUILD FAILURE
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project ambari-utility: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java:28: error: reference not found
[ERROR]  * {@link org.apache.ambari.swagger.NestedApiRecord} when {@link org.apache.ambari.swagger.AmbariSwaggerReader}
[ERROR]           ^
[ERROR] ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java:42: warning: no description for @return
[ERROR]      * @return
[ERROR]        ^
[ERROR] ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java:48: warning: no description for @return
[ERROR]      * @return
[ERROR]        ^
[ERROR] ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java:54: warning: no description for @return
[ERROR]      * @return
[ERROR]        ^
[ERROR] ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerOverwriteNestedAPI.java:60: warning: no description for @return
[ERROR]      * @return
[ERROR]        ^
[ERROR] ambari-utility/src/main/java/org/apache/ambari/annotations/SwaggerPreferredParent.java:37: warning: no description for @return
[ERROR]      * @return
[ERROR]        ^
```

https://issues.apache.org/jira/browse/AMBARI-24835

## How was this patch tested?

```
$ mvn -am -pl ambari-utility -Pjavadoc clean package
...
[INFO] BUILD SUCCESS
```