### PR TITLE
[AMBARI-24837] Make Grafana connection attempts and retry delay configurable

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-grafana-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-grafana-env.xml
@@ -95,6 +95,10 @@ export AMS_GRAFANA_PID_DIR={{ams_grafana_pid_dir}}
     <value>20</value>
     <display-name>Grafana connect retry delay</display-name>
     <description>The time in seconds after which connection to Grafana is retried in case of failure</description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+    </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>
   <property>
@@ -102,6 +106,10 @@ export AMS_GRAFANA_PID_DIR={{ams_grafana_pid_dir}}
     <value>15</value>
     <display-name>Grafana connect attempts</display-name>
     <description>The number of attempts for connection to Grafana</description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+    </value-attributes>
     <on-ambari-upgrade add="false"/>
   </property>
 </configuration>

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-grafana-env.xml
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/configuration/ams-grafana-env.xml
@@ -90,4 +90,18 @@ export AMS_GRAFANA_PID_DIR={{ams_grafana_pid_dir}}
     </value>
     <on-ambari-upgrade add="true"/>
   </property>
+  <property>
+    <name>metrics_grafana_connect_retry_delay</name>
+    <value>20</value>
+    <display-name>Grafana connect retry delay</display-name>
+    <description>The time in seconds after which connection to Grafana is retried in case of failure</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>metrics_grafana_connect_attempts</name>
+    <value>15</value>
+    <display-name>Grafana connect attempts</display-name>
+    <description>The number of attempts for connection to Grafana</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
 </configuration>

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/metrics_grafana.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/metrics_grafana.py
@@ -22,7 +22,6 @@ from resource_management import Script, Execute
 from resource_management.libraries.functions import format
 from status import check_service_status
 from ams import ams
-from metrics_grafana_util import create_ams_datasource, create_ams_dashboards, create_grafana_admin_pwd
 from resource_management.core.logger import Logger
 from resource_management.core import sudo
 
@@ -53,6 +52,8 @@ class AmsGrafana(Script):
       Logger.warning("Pid file doesn't exist after starting of the component.")
     else:
       Logger.info("Grafana Server has started with pid: {0}".format(sudo.read_file(pidfile).strip()))
+
+    from metrics_grafana_util import create_ams_datasource, create_ams_dashboards, create_grafana_admin_pwd
 
     #Set Grafana admin pwd
     create_grafana_admin_pwd()

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/scripts/params.py
@@ -177,6 +177,9 @@ ams_grafana_cert_file = default("/configurations/ams-grafana-ini/cert_file", '/e
 ams_grafana_cert_key = default("/configurations/ams-grafana-ini/cert_key", '/etc/ambari-metrics/conf/ams-grafana.key')
 ams_grafana_ca_cert = default("/configurations/ams-grafana-ini/ca_cert", None)
 
+grafana_connect_attempts = max(int(default('/configurations/ams-grafana-env/metrics_grafana_connect_attempts', 15)), 1)
+grafana_connect_retry_delay = max(int(default('/configurations/ams-grafana-env/metrics_grafana_connect_retry_delay', 20)), 1)
+
 ams_hbase_home_dir = "/usr/lib/ams-hbase/"
 
 ams_hbase_init_check_enabled = default("/configurations/ams-site/timeline.metrics.hbase.init.check.enabled", True)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make the number of attempts and length of the delay for Metrics Grafana HTTP requests configurable.  Shorter retry delay could be useful to reduce overall startup time.  The default values for number of attempts and retry period are kept for backwards compatibility.

Also, log "Connection failed. Next retry in ... seconds" after the failure, before waiting for next attempt, instead of after `sleep`.

https://issues.apache.org/jira/browse/AMBARI-24837

## How was this patch tested?

Tested blueprint deployment with various config values (absent, valid, invalid) with simulated connection failure.

Example with custom number of attempts (n=3) and retry period (t=5 seconds):

```
2018-10-26 21:43:29,124 - Pid file doesn't exist after starting of the component.
2018-10-26 21:43:29,148 - Connecting (GET) to c7401.ambari.apache.org:3000/api/user
2018-10-26 21:43:29,156 - Connection to Grafana failed. Next retry in 5 seconds.
2018-10-26 21:43:34,159 - Connecting (GET) to c7401.ambari.apache.org:3000/api/user
2018-10-26 21:43:34,160 - Connection to Grafana failed. Next retry in 5 seconds.
2018-10-26 21:43:39,164 - Connecting (GET) to c7401.ambari.apache.org:3000/api/user
2018-10-26 21:43:39,173 - Skipping stack-select on AMBARI_METRICS because it does not exist in the stack-select package structure.
```