### PR TITLE
[AMBARI-24843] Make Ambaripreupload.py more configurable

### DIFF
--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -88,6 +88,10 @@ with Environment() as env:
                     help="flag to indicate script is being run for upgrade", default=False)
   (options, args) = parser.parse_args()
 
+  if not os.path.exists(options.sql_driver_path):
+    Logger.error("SQL driver file {} does not exist".format(options.sql_driver_path))
+    sys.exit(1)
+
   Logger.info("Using SQL driver from {}".format(options.sql_driver_path))
   sql_driver_filename = os.path.basename(options.sql_driver_path)
 

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -326,6 +326,7 @@ with Environment() as env:
             tar.add(os.path.realpath(filepath), arcname=os.path.basename(filepath))
           else:
             Logger.warning(format("Skipping broken link {filepath}"))
+    Execute(("chmod", "0644", params.yarn_service_tarball))
 
   env.set_params(params)
   hadoop_conf_dir = params.hadoop_conf_dir

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -32,6 +32,9 @@ import time
 import functools
 from xml.dom import minidom
 
+from ambari_server.serverClassPath import JDBC_DRIVER_PATH_PROPERTY
+from ambari_server.serverConfiguration import get_value_from_properties, get_ambari_properties
+
 from resource_management.core import File
 from resource_management.core import shell
 from resource_management.core.environment import Environment
@@ -45,13 +48,16 @@ from resource_management.libraries.functions.oozie_prepare_war import prepare_wa
 from resource_management.libraries.resources.hdfs_resource import HdfsResource
 
 
-SQL_DRIVER_PATH = "/var/lib/ambari-server/resources/sqljdbc41.jar"
- 
+ambari_properties = get_ambari_properties()
+DEFAULT_SQL_DRIVER_PATH = "/var/lib/ambari-server/resources/sqljdbc41.jar"
+SQL_DRIVER_PATH = get_value_from_properties(ambari_properties, JDBC_DRIVER_PATH_PROPERTY, DEFAULT_SQL_DRIVER_PATH) if ambari_properties != -1 else DEFAULT_SQL_DRIVER_PATH
+print("Using SQL driver from {}".format(SQL_DRIVER_PATH))
+
 """
 This file provides helper methods needed for the versioning of RPMs. Specifically, it does dynamic variable
 interpretation to replace strings like {{ stack_version_formatted }}  where the value of the
 variables cannot be determined ahead of time, but rather, depends on what files are found.
- 
+
 It assumes that {{ stack_version_formatted }} is constructed as ${major.minor.patch.rev}-${build_number}
 E.g., 998.2.2.1.0-998
 Please note that "-${build_number}" is optional.

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -17,20 +17,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """
+import functools
+import glob
 import os
+import re
 import sys
 import tarfile
-from contextlib import closing
-from optparse import OptionParser
-os.environ["PATH"] += os.pathsep + "/var/lib/ambari-agent"
-sys.path.append("/usr/lib/ambari-server/lib")
-
-import glob
-import re
 import tempfile
 import time
-import functools
+
+from contextlib import closing
+from optparse import OptionParser
 from xml.dom import minidom
+
+os.environ["PATH"] += os.pathsep + "/var/lib/ambari-agent"
+sys.path.append("/usr/lib/ambari-server/lib")
 
 from ambari_server.serverClassPath import JDBC_DRIVER_PATH_PROPERTY
 from ambari_server.serverConfiguration import get_value_from_properties, get_ambari_properties

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -321,7 +321,11 @@ with Environment() as env:
     with closing(tarfile.open(params.yarn_service_tarball, "w:gz")) as tar:
       for folder in folders:
         for filepath in glob.glob(format("{folder}/*.jar")):
-          tar.add(os.path.realpath(filepath), arcname=os.path.basename(filepath))
+          if os.path.exists(filepath):
+            Logger.debug(format("Adding {filepath}"))
+            tar.add(os.path.realpath(filepath), arcname=os.path.basename(filepath))
+          else:
+            Logger.warning(format("Skipping broken link {filepath}"))
 
   env.set_params(params)
   hadoop_conf_dir = params.hadoop_conf_dir

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -478,7 +478,7 @@ with Environment() as env:
   copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/pig/pig.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/pig/", params.mapred_user, params.hdfs_user, params.user_group)
   copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-mapreduce/hadoop-streaming.jar"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/mapreduce/", params.mapred_user, params.hdfs_user, params.user_group)
   copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/sqoop/sqoop.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/sqoop/", params.mapred_user, params.hdfs_user, params.user_group)
-  copy_tarballs_to_hdfs(format("/usr/hdp/{stack_version}/hadoop-yarn/lib/service-dep.tar.gz"), hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/yarn/", params.hdfs_user, params.hdfs_user, params.user_group)
+  copy_tarballs_to_hdfs(params.yarn_service_tarball, hdfs_path_prefix+"/hdp/apps/{{ stack_version_formatted }}/yarn/", params.hdfs_user, params.hdfs_user, params.user_group)
 
   createHdfsResources()
   copy_zeppelin_dependencies_to_hdfs(format("/usr/hdp/{stack_version}/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies*.jar"))

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -91,6 +91,8 @@ with Environment() as env:
     return stack_version
 
   parser = OptionParser()
+  parser.add_option("-f", "--fs-type", dest="fs_type", default="wasb",
+                    help="Expected protocol of fs.defaultFS")
   parser.add_option("-v", "--hdp-version", dest="hdp_version", default="",
                     help="hdp-version used in path of tarballs")
   parser.add_option("-u", "--upgrade", dest="upgrade", action="store_true",
@@ -120,11 +122,12 @@ with Environment() as env:
 
   def get_fs_root(fsdefaultName=None):
     fsdefaultName = "fake"
+    expected_fs_protocol = options.fs_type + '://'
 
     while True:
       fsdefaultName =  getPropertyValueFromConfigXMLFile("/etc/hadoop/conf/core-site.xml", "fs.defaultFS")
 
-      if fsdefaultName and fsdefaultName.startswith("wasb://"):
+      if fsdefaultName and fsdefaultName.startswith(expected_fs_protocol):
         break
 
       print "Waiting to read appropriate value of fs.defaultFS from /etc/hadoop/conf/core-site.xml ..."
@@ -151,7 +154,7 @@ with Environment() as env:
     ambari_libs_dir = "/var/lib/ambari-agent/lib"
     hdfs_site = ConfigDictionary({'dfs.webhdfs.enabled':False,})
     fs_default = get_fs_root()
-    dfs_type = "WASB"
+    dfs_type = options.fs_type.upper()
     yarn_home_dir = '/usr/hdp/' + stack_version + '/hadoop-yarn'
     yarn_lib_dir = yarn_home_dir + '/lib'
     yarn_service_tarball = yarn_lib_dir + '/service-dep.tar.gz'

--- a/ambari-server/src/main/resources/scripts/Ambaripreupload.py
+++ b/ambari-server/src/main/resources/scripts/Ambaripreupload.py
@@ -54,16 +54,6 @@ DEFAULT_SQL_DRIVER_PATH = "/var/lib/ambari-server/resources/sqljdbc41.jar"
 SQL_DRIVER_PATH = get_value_from_properties(ambari_properties, JDBC_DRIVER_PATH_PROPERTY, DEFAULT_SQL_DRIVER_PATH) if ambari_properties != -1 else DEFAULT_SQL_DRIVER_PATH
 print("Using SQL driver from {}".format(SQL_DRIVER_PATH))
 
-"""
-This file provides helper methods needed for the versioning of RPMs. Specifically, it does dynamic variable
-interpretation to replace strings like {{ stack_version_formatted }}  where the value of the
-variables cannot be determined ahead of time, but rather, depends on what files are found.
-
-It assumes that {{ stack_version_formatted }} is constructed as ${major.minor.patch.rev}-${build_number}
-E.g., 998.2.2.1.0-998
-Please note that "-${build_number}" is optional.
-"""
-
 with Environment() as env:
   def get_stack_version():
     if not options.hdp_version:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve `Ambaripreupload.py` script:

 * add command-line parameters for DFS type and JDBC driver path (keep previous values as defaults)
 * take JDBC driver path from `server.jdbc.driver.path` property if set (can be overridden via command-line parameter)
 * skip broken symlinks during creation of YARN tarball
 * make sure YARN tarball is readable by `hdfs` user (could be unreadable due to restrictive umask)
 * use `Logger` everywhere, instead of `print`

## How was this patch tested?

Default settings, for backward compatibility:

```bash
$ Ambaripreupload.py
2018-10-29 17:13:05,341 - Using SQL driver from /var/lib/ambari-server/resources/sqljdbc41.jar
...
2018-10-29 17:13:05,379 - Waiting to read appropriate value of fs.defaultFS from /etc/hadoop/conf/core-site.xml ...
2018-10-29 17:13:15,392 - Waiting to read appropriate value of fs.defaultFS from /etc/hadoop/conf/core-site.xml ...
...
```

Nonexistent JDBC driver (error logged both to stdout and stderr):

```bash
$ Ambaripreupload.py -d /usr/share/java/no-such-file.jar
2018-10-29 17:14:15,191 - SQL driver file /usr/share/java/no-such-file.jar does not exist
2018-10-29 17:14:15,191 - SQL driver file /usr/share/java/no-such-file.jar does not exist
```

JDBC driver taken from `ambari.properties`:

```bash
$ touch /usr/share/java/driver-from-properties.jar
$ echo 'server.jdbc.driver.path=/usr/share/java/driver-from-properties.jar' >> /etc/ambari-server/conf/ambari.properties
$ Ambaripreupload.py -f hdfs
2018-10-29 17:16:15,971 - Using SQL driver from /usr/share/java/driver-from-properties.jar
...
2018-10-29 17:16:16,018 - Returning fs.defaultFS -> hdfs://...:8020
...
2018-10-29 17:16:45,870 - Ambari preupload script completed.
```

JDBC driver and DFS type given on command-line:

```bash
$ touch /usr/share/java/driver-from-cmd-line.jar
$ Ambaripreupload.py -d /usr/share/java/driver-from-cmd-line.jar -f hdfs
2018-10-29 17:18:09,188 - Using SQL driver from /usr/share/java/driver-from-cmd-line.jar
...
2018-10-29 17:18:09,232 - Returning fs.defaultFS -> hdfs://...:8020
...
2018-10-29 17:18:39,026 - Ambari preupload script completed.
```