### PR TITLE
[AMBARI-24844] Improve copy of atlas.war

### DIFF
--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
@@ -89,6 +89,7 @@ def metadata(type='server'):
       war_source = format('{metadata_home}/server/webapp/atlas.war')
       war_target = format("{expanded_war_dir}/atlas.war")
       Execute(('cp', war_source, war_target),
+              sudo = True,
               not_if = war_source == war_target)
 
       File(format("{conf_dir}/atlas-log4j.xml"),

--- a/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
+++ b/ambari-server/src/main/resources/common-services/ATLAS/0.1.0.2.3/package/scripts/metadata.py
@@ -85,9 +85,12 @@ def metadata(type='server'):
                 group=params.user_group,
                 create_parents = True
       )
-      File(format("{expanded_war_dir}/atlas.war"),
-           content = StaticFile(format('{metadata_home}/server/webapp/atlas.war'))
-      )
+
+      war_source = format('{metadata_home}/server/webapp/atlas.war')
+      war_target = format("{expanded_war_dir}/atlas.war")
+      Execute(('cp', war_source, war_target),
+              not_if = war_source == war_target)
+
       File(format("{conf_dir}/atlas-log4j.xml"),
            mode=0644,
            owner=params.metadata_user,

--- a/ambari-server/src/test/python/stacks/2.3/ATLAS/test_metadata_server.py
+++ b/ambari-server/src/test/python/stacks/2.3/ATLAS/test_metadata_server.py
@@ -83,6 +83,7 @@ class TestMetadataServer(RMFTestCase):
                                 mode=0644
       )
       self.assertResourceCalled('Execute', ('cp', '/usr/hdp/current/atlas-server/server/webapp/atlas.war', '/usr/hdp/current/atlas-server/server/webapp/atlas.war'),
+                                sudo = True,
                                 not_if = True,
       )
       host_name = u"c6401.ambari.apache.org"
@@ -218,6 +219,7 @@ class TestMetadataServer(RMFTestCase):
                               mode=0644
     )
     self.assertResourceCalled('Execute', ('cp', self.stack_root+'/current/atlas-server/server/webapp/atlas.war', self.stack_root+'/current/atlas-server/server/webapp/atlas.war'),
+                              sudo = True,
                               not_if = True,
     )
     host_name = u"c6401.ambari.apache.org"

--- a/ambari-server/src/test/python/stacks/2.3/ATLAS/test_metadata_server.py
+++ b/ambari-server/src/test/python/stacks/2.3/ATLAS/test_metadata_server.py
@@ -82,8 +82,8 @@ class TestMetadataServer(RMFTestCase):
                                 cd_access='a',
                                 mode=0644
       )
-      self.assertResourceCalled('File', self.stack_root+'/current/atlas-server/server/webapp/atlas.war',
-          content = StaticFile(self.stack_root+'/current/atlas-server/server/webapp/atlas.war'),
+      self.assertResourceCalled('Execute', ('cp', '/usr/hdp/current/atlas-server/server/webapp/atlas.war', '/usr/hdp/current/atlas-server/server/webapp/atlas.war'),
+                                not_if = True,
       )
       host_name = u"c6401.ambari.apache.org"
       app_props =  dict(self.getConfig()['configurations']['application-properties'])
@@ -217,9 +217,9 @@ class TestMetadataServer(RMFTestCase):
                               cd_access='a',
                               mode=0644
     )
-    self.assertResourceCalled('File', self.stack_root+'/current/atlas-server/server/webapp/atlas.war',
-                              content = StaticFile(self.stack_root+'/current/atlas-server/server/webapp/atlas.war'),
-                              )
+    self.assertResourceCalled('Execute', ('cp', self.stack_root+'/current/atlas-server/server/webapp/atlas.war', self.stack_root+'/current/atlas-server/server/webapp/atlas.war'),
+                              not_if = True,
+    )
     host_name = u"c6401.ambari.apache.org"
     app_props =  dict(self.getConfig()['configurations']['application-properties'])
     app_props['atlas.server.bind.address'] = host_name

--- a/ambari-server/src/test/python/stacks/2.5/ATLAS/test_atlas_server.py
+++ b/ambari-server/src/test/python/stacks/2.5/ATLAS/test_atlas_server.py
@@ -77,8 +77,8 @@ class TestAtlasServer(RMFTestCase):
                               cd_access='a',
                               mode=0644
     )
-    self.assertResourceCalled('File', '/usr/hdp/current/atlas-server/server/webapp/atlas.war',
-                              content = StaticFile('/usr/hdp/current/atlas-server/server/webapp/atlas.war'),
+    self.assertResourceCalled('Execute', ('cp', '/usr/hdp/current/atlas-server/server/webapp/atlas.war', '/usr/hdp/current/atlas-server/server/webapp/atlas.war'),
+                              not_if = True,
     )
     host_name = u"c6401.ambari.apache.org"
     app_props =  dict(self.getConfig()['configurations'][

--- a/ambari-server/src/test/python/stacks/2.5/ATLAS/test_atlas_server.py
+++ b/ambari-server/src/test/python/stacks/2.5/ATLAS/test_atlas_server.py
@@ -78,6 +78,7 @@ class TestAtlasServer(RMFTestCase):
                               mode=0644
     )
     self.assertResourceCalled('Execute', ('cp', '/usr/hdp/current/atlas-server/server/webapp/atlas.war', '/usr/hdp/current/atlas-server/server/webapp/atlas.war'),
+                              sudo = True,
                               not_if = True,
     )
     host_name = u"c6401.ambari.apache.org"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Save a bit of time during Atlas Metadata Server start by:

 * copying `atlas.war` using `cp` instead of `File`
 * skip copying if source and target are the same

https://issues.apache.org/jira/browse/AMBARI-24844

## How was this patch tested?

Tested blueprint deployment of Atlas with default settings.  Verified that copy is skipped, since paths are the same:

```
2018-10-29 20:16:46,901 - Execute[('cp', u'/usr/hdp/current/atlas-server/server/webapp/atlas.war', u'/usr/hdp/current/atlas-server/server/webapp/atlas.war')] {'not_if': True}
2018-10-29 20:16:46,901 - Skipping Execute[('cp', u'/usr/hdp/current/atlas-server/server/webapp/atlas.war', u'/usr/hdp/current/atlas-server/server/webapp/atlas.war')] due to not_if
```

Changed `expanded_war_dir` in `params.py`, restarted Atlas.  Verified that copy is not skipped:

```
2018-10-29 20:33:39,072 - Execute[('cp', u'/usr/hdp/current/atlas-server/server/webapp/atlas.war', u'/usr/hdp/current/atlas-server/server/custom_webapp/atlas.war')] {'not_if': False}
2018-10-29 20:33:39,411 - ...
```