### PR TITLE
AMBARI-24846. Ambari-agent stop hangs if ambari-server is stopped

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/main.py
+++ b/ambari-agent/src/main/python/ambari_agent/main.py
@@ -476,7 +476,7 @@ def main(initializer_module, heartbeat_stop_callback=None):
   stopped = False
 
   # Keep trying to connect to a server or bail out if ambari-agent was stopped
-  while not connected and not stopped:
+  while not connected and not stopped and not initializer_module.stop_event.is_set():
     for server_hostname in server_hostnames:
       server_url = config.get_api_url(server_hostname)
       try:


### PR DESCRIPTION
[root@gc7001 ~]# ambari-agent  stop
Verifying Python version compatibility...
Using python  /usr/bin/python
Found ambari-agent PID: 7391
Stopping ambari-agent
^C^C^X^Z
[2]+  Stopped                 ambari-agent stop
[root@gc7001 ~]# ^C
[root@gc7001 ~]# kill -9 7391