### PR TITLE
AMBARI-24845. Sometimes host status still in heartbeat lost after agent become heartbeating.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/host/HostImpl.java
@@ -360,6 +360,8 @@ public class HostImpl implements Host {
 
       host.topologyManager.onHostRegistered(host, associatedWithCluster);
 
+      host.setHealthStatus(new HostHealthStatus(HealthStatus.HEALTHY,
+          host.getHealthStatus().getHealthReport()));
       // initialize agent times in the last time to prevent setting registering/heartbeat times for failed registration.
       host.updateHostTimestamps(e);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server sets HEALTHY health status to host with registration instead with first heartbeat.

## How was this patch tested?

Manual testing.