### PR TITLE
[AMBARI-24849] Add Information to the SPI to Support Upgrade Checks

### DIFF
--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -176,6 +176,10 @@
       <artifactId>guice</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>    
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/ambari-server-spi/src/main/java/org/apache/ambari/server/utils/VersionUtils.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/server/utils/VersionUtils.java
@@ -20,9 +20,6 @@ package org.apache.ambari.server.utils;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
-import org.apache.ambari.server.bootstrap.BootStrapImpl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 
@@ -32,6 +29,8 @@ import org.apache.commons.lang.math.NumberUtils;
  * in this class. Currently, exact match is required between all the three.
  */
 public class VersionUtils {
+  public static final String DEV_VERSION = "${ambariVersion}";
+
   /**
    * Compares two versions strings of the form N.N.N.N or even N.N.N.N-###
    * (which should ignore everything after the dash). If the user has a custom
@@ -39,7 +38,7 @@ public class VersionUtils {
    * letters should be ignored.
    *
    * @param version1
-   *          the first operand. If set to {@value BootStrapImpl#DEV_VERSION}
+   *          the first operand. If set to {@value #DEV_VERSION}
    *          then this will always return {@code 0)}
    * @param version2
    *          the second operand.
@@ -79,7 +78,7 @@ public class VersionUtils {
       throw new IllegalArgumentException("maxLengthToCompare cannot be less than 0");
     }
 
-    if(BootStrapImpl.DEV_VERSION.equals(version1.trim())) {
+    if (DEV_VERSION.equals(version1.trim())) {
       return 0;
     }
 
@@ -132,7 +131,7 @@ public class VersionUtils {
    * Compares two versions strings of the form N.N.N.N
    *
    * @param version1
-   *          the first operand. If set to {@value BootStrapImpl#DEV_VERSION}
+   *          the first operand. If set to {@value #DEV_VERSION}
    *          then this will always return {@code 0)}
    * @param version2
    *          the second operand.
@@ -143,7 +142,7 @@ public class VersionUtils {
    */
   public static int compareVersions(String version1, String version2, boolean allowEmptyVersions) {
     if (allowEmptyVersions) {
-      if (version1 != null && version1.equals(BootStrapImpl.DEV_VERSION)) {
+      if (version1 != null && version1.equals(DEV_VERSION)) {
         return 0;
       }
       if (version1 == null && version2 == null) {
@@ -176,7 +175,7 @@ public class VersionUtils {
    * Compares two versions strings of the form N.N.N.N
    *
    * @param version1
-   *          the first operand. If set to {@value BootStrapImpl#DEV_VERSION}
+   *          the first operand. If set to {@value #DEV_VERSION}
    *          then this will always return {@code 0)}
    * @param version2
    *          the second operand.
@@ -190,7 +189,7 @@ public class VersionUtils {
    * Compares two version for equality, allows empty versions
    *
    * @param version1
-   *          the first operand. If set to {@value BootStrapImpl#DEV_VERSION}
+   *          the first operand. If set to {@value #DEV_VERSION}
    *          then this will always return {@code 0)}
    * @param version2
    *          the second operand.
@@ -263,7 +262,7 @@ public class VersionUtils {
    * @param v2 The second version
    * @return 0 if both are equal, <0 if first one is lower, >0 otherwise
    */
-  public static int compareTo(@Nullable Comparable v1, @Nullable Comparable v2) {
+  public static int compareTo(Comparable v1, Comparable v2) {
     return v1 == null ? (v2 == null ? 0 : -1) : v2 == null ? 1 : v1.compareTo(v2);
   }
 }

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/ClusterInformation.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/ClusterInformation.java
@@ -57,6 +57,11 @@ public class ClusterInformation {
   private final Map<String, Set<String>> m_topology;
 
   /**
+   * The current version of every service in the cluster.
+   */
+  private final Map<String, RepositoryVersion> m_serviceVersions;
+
+  /**
    * Constructor.
    *
    * @param clusterName
@@ -70,13 +75,17 @@ public class ClusterInformation {
    *          a mapping of the cluster topology where the key is a combination
    *          of service / component and the value is the hosts where it is
    *          installed.
+   * @param serviceVersions
+   *          the current repository version for every service in the cluster.
    */
   public ClusterInformation(String clusterName, boolean isKerberosEnabled,
-      Map<String, Map<String, String>> configurations, Map<String, Set<String>> topology) {
+      Map<String, Map<String, String>> configurations, Map<String, Set<String>> topology,
+      Map<String, RepositoryVersion> serviceVersions) {
     m_configurations = configurations;
     m_clusterName = clusterName;
     m_isKerberosEnabled = isKerberosEnabled;
     m_topology = topology;
+    m_serviceVersions = serviceVersions;
   }
 
   /**
@@ -115,7 +124,7 @@ public class ClusterInformation {
     return hosts;
   }
 
-  public Map<String, String> getConfigruationProperties(String configurationType) {
+  public Map<String, String> getConfigurationProperties(String configurationType) {
     Map<String, String> properties = m_configurations.get(configurationType);
     if (null == properties) {
       return Maps.newHashMap();
@@ -134,7 +143,27 @@ public class ClusterInformation {
    * @return the property value, or {@code null} if it does not exist.
    */
   public String getConfigurationProperty(String configurationType, String propertyName) {
-    return getConfigruationProperties(configurationType).get(propertyName);
+    return getConfigurationProperties(configurationType).get(propertyName);
   }
 
+  /**
+   * Gets the {@link RepositoryVersion} for the given service which represents
+   * the service's current version in the cluster.
+   *
+   * @param serviceName
+   *          the service name.
+   * @return the repository version information for the given service.
+   */
+  public RepositoryVersion getServiceRepositoryVersion(String serviceName) {
+    return m_serviceVersions.get(serviceName);
+  }
+
+  /**
+   * Gets the services installed in the cluster.
+   *
+   * @return the services in the cluster.
+   */
+  public Set<String> getServices() {
+    return m_serviceVersions.keySet();
+  }
 }

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/RepositoryVersion.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/RepositoryVersion.java
@@ -24,6 +24,8 @@ public class RepositoryVersion {
 
   private final long m_id;
   private final String m_stackId;
+  private final String m_stackName;
+  private final String m_stackVersion;
   private final String m_version;
   private final RepositoryType m_repositoryType;
 
@@ -32,6 +34,12 @@ public class RepositoryVersion {
    *
    * @param id
    *          the internal ID of the repository stored in Ambari.
+   * @param stackName
+   *          the name of the stack, such as STACK (if the stack ID was
+   *          STACK-1.0.0).
+   * @param stackVersion
+   *          the version of the stack, such as 1.0.0 (if the stack ID was
+   *          STACK-1.0.0).
    * @param stackId
    *          the stack ID, such as STACK-1.0.0
    * @param version
@@ -39,8 +47,11 @@ public class RepositoryVersion {
    * @param repositoryType
    *          the type of repository.
    */
-  public RepositoryVersion(long id, String stackId, String version, RepositoryType repositoryType) {
+  public RepositoryVersion(long id, String stackName, String stackVersion, String stackId,
+      String version, RepositoryType repositoryType) {
     m_id = id;
+    m_stackName = stackName;
+    m_stackVersion = stackVersion;
     m_stackId = stackId;
     m_version = version;
     m_repositoryType = repositoryType;
@@ -56,12 +67,32 @@ public class RepositoryVersion {
   }
 
   /**
-   * Gets the ID of the stack, such as STACK-1.0.0
+   * Gets the ID of the stack, such as {@code STACK-1.0.0}.
    *
    * @return the stack id.
    */
   public String getStackId() {
     return m_stackId;
+  }
+
+  /**
+   * The name of the stack, such as {@code STACK} if the stack is
+   * {@code STACK-1.0.0}.
+   *
+   * @return the stack name.
+   */
+  public String getStackName() {
+    return m_stackName;
+  }
+
+  /**
+   * The version of the stack, such as {@code 1.0.0} if the stack is
+   * {@code STACK-1.0.0}.
+   *
+   * @return the stack version.
+   */
+  public String getStackVersion() {
+    return m_stackVersion;
   }
 
   /**

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheck.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheck.java
@@ -61,13 +61,6 @@ public interface UpgradeCheck {
       throws AmbariException;
 
   /**
-   * Gets the type of check.
-   *
-   * @return the type of check (not {@code null}).
-   */
-  UpgradeCheckType getType();
-
-  /**
    * The {@link UpgradeCheckDescription} which includes the name, description, and
    * success/failure messages for a {@link UpgradeCheck}.
    *

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheckDescription.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheckDescription.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * The {@link UpgradeCheckDescription} is used to provide information about an upgrade
@@ -48,6 +49,26 @@ public class UpgradeCheckDescription {
   private final UpgradeCheckType m_type;
   private final String m_description;
   private Map<String, String> m_fails;
+
+  /**
+   * Constructor.
+   *
+   * @param name
+   *          a unique identifier for the description container.
+   * @param type
+   *          the area which is being checked.
+   * @param description
+   *          a description of what this check is.
+   * @param failureReason
+   *          a description of the single failure reason associated with this
+   *          check. This will be associated with the {@link #DEFAULT} failure
+   *          key.
+   */
+  public UpgradeCheckDescription(String name, UpgradeCheckType type, String description,
+      String failureReason) {
+    this(name, type, description, new ImmutableMap.Builder<String, String>().put(
+        UpgradeCheckDescription.DEFAULT, failureReason).build());
+  }
 
   /**
    * Constructor.
@@ -114,7 +135,7 @@ public class UpgradeCheckDescription {
    * @param key the failure text key
    * @return the fail text template.  Never {@code null}
    */
-  public String getFail(String key) {
+  public String getFailureReason(String key) {
     return m_fails.containsKey(key) ? m_fails.get(key) : "";
   }
 
@@ -154,5 +175,22 @@ public class UpgradeCheckDescription {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("name", m_name).toString();
+  }
+
+  /**
+   * Gets the default failure reason associated with the {@link #DEFAULT} key.
+   *
+   * @return the default failure reason.
+   */
+  public String getDefaultFailureReason() {
+    if(null == m_fails) {
+      return null;
+    }
+
+    if(m_fails.size() == 1) {
+      return m_fails.values().stream().findFirst().get();
+    }
+
+    return m_fails.get(DEFAULT);
   }
 }

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheckResult.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheckResult.java
@@ -123,6 +123,6 @@ public class UpgradeCheckResult {
    * @return the type of check.
    */
   public UpgradeCheckType getType() {
-    return m_upgradeCheck.getType();
+    return m_upgradeCheck.getCheckDescription().getType();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BootStrapImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BootStrapImpl.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.bootstrap;
 
+import static org.apache.ambari.server.utils.VersionUtils.DEV_VERSION;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -35,7 +37,6 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class BootStrapImpl {
-  public static final String DEV_VERSION = "${ambariVersion}";
   private File bootStrapDir;
   private String bootScript;
   private String bootSetupAgentScript;
@@ -56,18 +57,18 @@ public class BootStrapImpl {
 
   @Inject
   public BootStrapImpl(Configuration conf, AmbariMetaInfo ambariMetaInfo) throws IOException {
-    this.bootStrapDir = conf.getBootStrapDir();
-    this.bootScript = conf.getBootStrapScript();
-    this.bootSetupAgentScript = conf.getBootSetupAgentScript();
-    this.bootSetupAgentPassword = conf.getBootSetupAgentPassword();
-    this.bsStatus = new FifoLinkedHashMap<>();
-    this.masterHostname = conf.getMasterHostname(
+    bootStrapDir = conf.getBootStrapDir();
+    bootScript = conf.getBootStrapScript();
+    bootSetupAgentScript = conf.getBootSetupAgentScript();
+    bootSetupAgentPassword = conf.getBootSetupAgentPassword();
+    bsStatus = new FifoLinkedHashMap<>();
+    masterHostname = conf.getMasterHostname(
         InetAddress.getLocalHost().getCanonicalHostName());
-    this.clusterOsType = conf.getServerOsType();
-    this.clusterOsFamily = conf.getServerOsFamily();
-    this.projectVersion = ambariMetaInfo.getServerVersion();
-    this.projectVersion = (this.projectVersion.equals(DEV_VERSION)) ? DEV_VERSION.replace("$", "") : this.projectVersion;
-    this.serverPort = (conf.getApiSSLAuthentication())? conf.getClientSSLApiPort() : conf.getClientApiPort();
+    clusterOsType = conf.getServerOsType();
+    clusterOsFamily = conf.getServerOsFamily();
+    projectVersion = ambariMetaInfo.getServerVersion();
+    projectVersion = (projectVersion.equals(DEV_VERSION)) ? DEV_VERSION.replace("$", "") : projectVersion;
+    serverPort = (conf.getApiSSLAuthentication())? conf.getClientSSLApiPort() : conf.getClientApiPort();
   }
 
   /**
@@ -96,8 +97,10 @@ public class BootStrapImpl {
   public synchronized void init() throws IOException {
     if (!bootStrapDir.exists()) {
       boolean mkdirs = bootStrapDir.mkdirs();
-      if (!mkdirs) throw new IOException("Unable to make directory for " +
-          "bootstrap " + bootStrapDir);
+      if (!mkdirs) {
+        throw new IOException("Unable to make directory for " +
+            "bootstrap " + bootStrapDir);
+      }
     }
   }
 
@@ -127,7 +130,7 @@ public class BootStrapImpl {
     } else {
       bsRunner = new BSRunner(this, info, bootStrapDir.toString(),
           bootScript, bootSetupAgentScript, bootSetupAgentPassword, requestId, 0L,
-          this.masterHostname, info.isVerbose(), this.clusterOsFamily, this.projectVersion, this.serverPort);
+          masterHostname, info.isVerbose(), clusterOsFamily, projectVersion, serverPort);
       bsRunner.start();
       response.setStatus(BSRunStat.OK);
       response.setLog("Running Bootstrap now.");
@@ -145,8 +148,9 @@ public class BootStrapImpl {
 
     if (null == hosts || 0 == hosts.size() || (hosts.size() == 1 && hosts.get(0).equals("*"))) {
       for (BootStrapStatus status : bsStatus.values()) {
-        if (null != status.getHostsStatus())
+        if (null != status.getHostsStatus()) {
           statuses.addAll(status.getHostsStatus());
+        }
       }
     } else {
       // TODO make bootstrapping a bit more robust then stop looping

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ClusterCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ClusterCheck.java
@@ -138,16 +138,6 @@ public abstract class ClusterCheck implements UpgradeCheck {
   }
 
   /**
-   * Gets the type of check.
-   *
-   * @return the type of check (not {@code null}).
-   */
-  @Override
-  public UpgradeCheckType getType() {
-    return m_description.getType();
-  }
-
-  /**
    * Gets the default fail reason
    * @param upgradeCheckResult the check being performed
    * @param request           the request
@@ -198,7 +188,7 @@ public abstract class ClusterCheck implements UpgradeCheck {
    */
   protected String getFailReason(String key, UpgradeCheckResult upgradeCheckResult,
       UpgradeCheckRequest request) throws AmbariException {
-    String fail = m_description.getFail(key);
+    String fail = m_description.getFailureReason(key);
 
     RepositoryVersion repositoryVersion = request.getTargetRepositoryVersion();
     if (fail.contains("{{version}}") && null != repositoryVersion) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/CheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/CheckHelper.java
@@ -38,6 +38,7 @@ import org.apache.ambari.spi.upgrade.UpgradeCheck;
 import org.apache.ambari.spi.upgrade.UpgradeCheckRequest;
 import org.apache.ambari.spi.upgrade.UpgradeCheckResult;
 import org.apache.ambari.spi.upgrade.UpgradeCheckStatus;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,10 @@ public class CheckHelper {
           new UpgradeTypeQualification(check.getClass()));
 
       // add any extras from the check
-      qualifications.addAll(check.getQualifications());
+      List<CheckQualification> checkQualifications = check.getQualifications();
+      if (CollectionUtils.isNotEmpty(checkQualifications)) {
+        qualifications.addAll(checkQualifications);
+      }
 
       // run the applicability check
       try {

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCheckTest.java
@@ -204,7 +204,7 @@ public class AmbariMetricsHadoopSinkVersionCheckTest {
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(MIN_HADOOP_SINK_VERSION_PROPERTY_NAME, "2.7.0.0");
 
-    ClusterInformation clusterInformation = new ClusterInformation("c1", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("c1", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -263,7 +263,7 @@ public class AmbariMetricsHadoopSinkVersionCheckTest {
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(MIN_HADOOP_SINK_VERSION_PROPERTY_NAME, "2.7.0.0");
 
-    ClusterInformation clusterInformation = new ClusterInformation("c1", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("c1", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ClusterCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ClusterCheckTest.java
@@ -77,7 +77,7 @@ public class ClusterCheckTest extends EasyMockSupport {
   private VersionDefinitionXml m_vdfXml;
 
   private static final UpgradeCheckDescription m_description = new UpgradeCheckDescription(
-      "Test Check", UpgradeCheckType.CLUSTER, "Test Check", null);
+      "Test Check", UpgradeCheckType.CLUSTER, "Test Check", "Test Failure Reason");
 
   private MockCheckHelper m_mockCheckHelper = new MockCheckHelper();
 
@@ -170,7 +170,7 @@ public class ClusterCheckTest extends EasyMockSupport {
       }
     };
 
-    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         repositoryVersion, null);
 
@@ -247,7 +247,7 @@ public class ClusterCheckTest extends EasyMockSupport {
       }
     };
 
-    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         repositoryVersion, null);
 
@@ -287,11 +287,6 @@ public class ClusterCheckTest extends EasyMockSupport {
     @Override
     public UpgradeCheckDescription getCheckDescription() {
       return m_description;
-    }
-
-    @Override
-    public UpgradeCheckType getType() {
-      return m_type;
     }
 
     @Override

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
@@ -75,7 +75,7 @@ public class ComponentExistsInRepoCheckTest extends EasyMockSupport {
 
     expect(cluster.getCurrentStackVersion()).andReturn(sourceStackId).anyTimes();
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, repoVersion(), null);
   }
 
@@ -106,7 +106,7 @@ public class ComponentExistsInRepoCheckTest extends EasyMockSupport {
   }
 
   private RepositoryVersion repoVersion() {
-    RepositoryVersion repositoryVersion = new RepositoryVersion(1,
+    RepositoryVersion repositoryVersion = new RepositoryVersion(1, STACK_NAME, STACK_VERSION,
         new StackId(STACK_NAME, STACK_VERSION).getStackId(), STACK_VERSION,
         RepositoryType.STANDARD);
     return repositoryVersion;

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
@@ -309,7 +309,7 @@ public class ComponentsInstallationCheckTest {
       Mockito.when(hcs.getCurrentState()).thenReturn(State.STARTED);
     }
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ConfigurationMergeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ConfigurationMergeCheckTest.java
@@ -163,7 +163,7 @@ public class ConfigurationMergeCheckTest {
 
     replay(ami);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HealthCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HealthCheckTest.java
@@ -81,7 +81,7 @@ public class HealthCheckTest {
   public void testWarningWhenNoAlertsExist() throws AmbariException {
     when(alertsDAO.findCurrentByCluster(eq(CLUSTER_ID))).thenReturn(Collections.emptyList());
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult result = healthCheck.perform(request);
@@ -114,7 +114,7 @@ public class HealthCheckTest {
 
     when(alertsDAO.findCurrentByCluster(eq(CLUSTER_ID))).thenReturn(asList(alertCurrentEntity));
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult result = healthCheck.perform(request);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostMaintenanceModeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostMaintenanceModeCheckTest.java
@@ -76,7 +76,7 @@ public class HostMaintenanceModeCheckTest {
 
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult check = hostMaintenanceModeCheck.perform(request);
@@ -122,7 +122,7 @@ public class HostMaintenanceModeCheckTest {
 
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult check = hostMaintenanceModeCheck.perform(request);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsHeartbeatCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsHeartbeatCheckTest.java
@@ -106,7 +106,7 @@ public class HostsHeartbeatCheckTest {
 
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult check = hostHeartbeatCheck.perform(request);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
@@ -125,7 +125,7 @@ public class HostsMasterMaintenanceCheckTest {
     Mockito.when(cluster.getDesiredStackVersion()).thenReturn(new StackId("HDP", "1.0"));
     Mockito.when(repositoryVersionHelper.getUpgradePackageName(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), (UpgradeType) Mockito.anyObject())).thenReturn(null);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest checkRequest = new UpgradeCheckRequest(clusterInformation,
         UpgradeType.ROLLING, m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheckTest.java
@@ -157,7 +157,7 @@ public class HostsRepositoryVersionCheckTest {
             Mockito.any(StackEntity.class), Mockito.anyString())).thenReturn(
         null);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 
@@ -245,7 +245,7 @@ public class HostsRepositoryVersionCheckTest {
               hve);
     }
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 
@@ -307,7 +307,7 @@ public class HostsRepositoryVersionCheckTest {
               hve);
     }
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/InstallPackagesCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/InstallPackagesCheckTest.java
@@ -157,7 +157,7 @@ public class InstallPackagesCheckTest {
     }
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
@@ -157,7 +157,7 @@ public class KerberosAdminPersistedCredentialCheckTest extends EasyMockSupport {
     Map<String, String> checkProperties = new HashMap<>();
     RepositoryVersion repositoryVersion = createNiceMock(RepositoryVersion.class);
 
-    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         repositoryVersion, checkProperties);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/LZOCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/LZOCheckTest.java
@@ -95,7 +95,7 @@ public class LZOCheckTest {
     Mockito.when(config.getProperties()).thenReturn(properties);
     Mockito.when(configuration.getGplLicenseAccepted()).thenReturn(false);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/MissingOsInRepoVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/MissingOsInRepoVersionCheckTest.java
@@ -144,7 +144,7 @@ public class MissingOsInRepoVersionCheckTest extends EasyMockSupport {
     expect(repositoryVersion.getRepositoryType()).andReturn(RepositoryType.STANDARD).anyTimes();
     expect(repositoryVersion.getStackId()).andReturn(SOURCE_STACK.getStackId()).anyTimes();
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/PreviousUpgradeCompletedTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/PreviousUpgradeCompletedTest.java
@@ -72,7 +72,7 @@ public class PreviousUpgradeCompletedTest {
     Mockito.when(toRepsitoryVersionEntity.getVersion()).thenReturn(destRepositoryVersion);
     Mockito.when(toRepsitoryVersionEntity.getStackId()).thenReturn(targetStackId);
 
-    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     checkRequest = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         null, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheckTest.java
@@ -120,7 +120,7 @@ public class RequiredServicesInRepositoryCheckTest {
    */
   @Test
   public void testNoMissingServices() throws Exception {
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 
@@ -138,7 +138,7 @@ public class RequiredServicesInRepositoryCheckTest {
   public void testMissingRequiredService() throws Exception {
     m_missingDependencies.add("BAR");
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
@@ -143,7 +143,7 @@ public class ServiceCheckValidityCheckTest {
     when(serviceConfigDAO.getLastServiceConfig(eq(CLUSTER_ID), eq(SERVICE_NAME))).thenReturn(serviceConfigEntity);
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(asList(lastServiceCheckDTO1, lastServiceCheckDTO2));
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     try {
@@ -171,7 +171,7 @@ public class ServiceCheckValidityCheckTest {
     when(serviceConfigDAO.getLastServiceConfig(eq(CLUSTER_ID), eq(SERVICE_NAME))).thenReturn(serviceConfigEntity);
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(singletonList(lastServiceCheckDTO));
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
@@ -194,7 +194,7 @@ public class ServiceCheckValidityCheckTest {
     when(serviceConfigDAO.getLastServiceConfig(eq(CLUSTER_ID), eq(SERVICE_NAME))).thenReturn(serviceConfigEntity);
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(Collections.<LastServiceCheckDTO>emptyList());
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
@@ -219,7 +219,7 @@ public class ServiceCheckValidityCheckTest {
     when(serviceConfigDAO.getLastServiceConfig(eq(CLUSTER_ID), eq(SERVICE_NAME))).thenReturn(serviceConfigEntity);
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(asList(lastServiceCheckDTO1, lastServiceCheckDTO2));
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
@@ -257,7 +257,7 @@ public class ServiceCheckValidityCheckTest {
     when(serviceConfigDAO.getLastServiceConfig(eq(CLUSTER_ID), eq(SERVICE_NAME))).thenReturn(serviceConfigEntity);
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(asList(lastServiceCheckDTO1, lastServiceCheckDTO2));
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicePresenceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicePresenceCheckTest.java
@@ -76,7 +76,7 @@ public class ServicePresenceCheckTest {
     checkProperties.put(ServicePresenceCheck.REPLACED_SERVICES_PROPERTY_NAME,"OldServiceOne, OldServiceTwo");
     checkProperties.put(ServicePresenceCheck.NEW_SERVICES_PROPERTY_NAME,"NewServiceOne, NewServiceTwo");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -97,7 +97,7 @@ public class ServicePresenceCheckTest {
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.NO_UPGRADE_SUPPORT_SERVICES_PROPERTY_NAME,"Atlas, MyService");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -120,7 +120,7 @@ public class ServicePresenceCheckTest {
     checkProperties.put(ServicePresenceCheck.REPLACED_SERVICES_PROPERTY_NAME, "Atlas, OldService");
     checkProperties.put(ServicePresenceCheck.NEW_SERVICES_PROPERTY_NAME, "Atlas2, NewService");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -142,7 +142,7 @@ public class ServicePresenceCheckTest {
     Map<String, String> checkProperties = new HashMap<>();
     checkProperties.put(ServicePresenceCheck.REMOVED_SERVICES_PROPERTY_NAME, "OldService");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -167,7 +167,7 @@ public class ServicePresenceCheckTest {
     checkProperties.put(ServicePresenceCheck.NEW_SERVICES_PROPERTY_NAME,"Atlas2, NewService");
     checkProperties.put(ServicePresenceCheck.REMOVED_SERVICES_PROPERTY_NAME, "RemovedService");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -190,7 +190,7 @@ public class ServicePresenceCheckTest {
     checkProperties.put(ServicePresenceCheck.REPLACED_SERVICES_PROPERTY_NAME, "OldService");
     checkProperties.put(ServicePresenceCheck.NEW_SERVICES_PROPERTY_NAME,"NewService");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 
@@ -216,7 +216,7 @@ public class ServicePresenceCheckTest {
     checkProperties.put(ServicePresenceCheck.REPLACED_SERVICES_PROPERTY_NAME, "Storm, Ranger");
     checkProperties.put(ServicePresenceCheck.NEW_SERVICES_PROPERTY_NAME,"Storm2, Ranger2");
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, checkProperties);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
@@ -136,7 +136,7 @@ public class ServicesMaintenanceModeCheckTest {
     // We don't bother checking service desired state as it's performed by a separate check
     Mockito.when(service.getDesiredState()).thenReturn(State.UNKNOWN);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
@@ -306,7 +306,7 @@ public class ServicesUpCheckTest {
       Mockito.when(hcs.getCurrentState()).thenReturn(State.STARTED);
     }
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         m_repositoryVersion, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/UpgradeTypeQualificationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/UpgradeTypeQualificationTest.java
@@ -28,7 +28,6 @@ import org.apache.ambari.spi.upgrade.UpgradeCheckDescription;
 import org.apache.ambari.spi.upgrade.UpgradeCheckGroup;
 import org.apache.ambari.spi.upgrade.UpgradeCheckRequest;
 import org.apache.ambari.spi.upgrade.UpgradeCheckResult;
-import org.apache.ambari.spi.upgrade.UpgradeCheckType;
 import org.apache.ambari.spi.upgrade.UpgradeType;
 import org.junit.Test;
 
@@ -80,11 +79,6 @@ public class UpgradeTypeQualificationTest {
     }
 
     @Override
-    public UpgradeCheckType getType() {
-      return null;
-    }
-
-    @Override
     public UpgradeCheckDescription getCheckDescription() {
       return null;
     }
@@ -104,11 +98,6 @@ public class UpgradeTypeQualificationTest {
 
     @Override
     public UpgradeCheckResult perform(UpgradeCheckRequest request) throws AmbariException {
-      return null;
-    }
-
-    @Override
-    public UpgradeCheckType getType() {
       return null;
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
@@ -84,7 +84,7 @@ public class VersionMismatchCheckTest {
   public void testWarningWhenHostWithVersionMismatchExists() throws Exception {
     when(firstServiceComponentHosts.get(FIRST_SERVICE_COMPONENT_HOST_NAME).getUpgradeState()).thenReturn(VERSION_MISMATCH);
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         null, null);
 
@@ -96,7 +96,7 @@ public class VersionMismatchCheckTest {
   public void testWarningWhenHostWithVersionMismatchDoesNotExist() throws Exception {
     when(firstServiceComponentHosts.get(FIRST_SERVICE_COMPONENT_HOST_NAME).getUpgradeState()).thenReturn(IN_PROGRESS);
 
-    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
         null, null);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -135,6 +135,8 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
     Service service = createNiceMock(Service.class);
     ServiceInfo serviceInfo = createNiceMock(ServiceInfo.class);
 
+    expect(service.getDesiredRepositoryVersion()).andReturn(repo).atLeastOnce();
+
     StackId currentStackId = createNiceMock(StackId.class);
     StackId targetStackId = createNiceMock(StackId.class);
     AmbariMetaInfo ambariMetaInfo = injector.getInstance(AmbariMetaInfo.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/CheckHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/CheckHelperTest.java
@@ -120,7 +120,7 @@ public class CheckHelperTest {
     EasyMock.replay(configuration);
     updateChecksRegistry.add(m_mockCheck);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
@@ -152,7 +152,7 @@ public class CheckHelperTest {
     EasyMock.replay(configuration);
     updateChecksRegistry.add(m_mockCheck);
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation,
         UpgradeType.NON_ROLLING, m_repositoryVersion, null);
 
@@ -182,7 +182,7 @@ public class CheckHelperTest {
     // this will cause an exception
     Mockito.when(m_mockPerform.toString()).thenThrow(new RuntimeException());
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
@@ -209,7 +209,7 @@ public class CheckHelperTest {
     // this will cause an exception, triggering the bypass
     Mockito.when(m_mockPerform.toString()).thenThrow(new RuntimeException());
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
@@ -252,7 +252,7 @@ public class CheckHelperTest {
     // this will cause an exception, triggering the fail
     Mockito.when(m_mockPerform.toString()).thenThrow(new RuntimeException());
 
-    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null);
+    ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/TestVersionUtils.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/TestVersionUtils.java
@@ -17,7 +17,8 @@
  */
 package org.apache.ambari.server.utils;
 
-import org.apache.ambari.server.bootstrap.BootStrapImpl;
+import static org.apache.ambari.server.utils.VersionUtils.DEV_VERSION;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -63,9 +64,9 @@ public class TestVersionUtils {
     Assert.assertTrue(VersionUtils.areVersionsEqual("1.2.3", "1.2.3", true));
     Assert.assertTrue(VersionUtils.areVersionsEqual("", "", true));
     Assert.assertTrue(VersionUtils.areVersionsEqual(null, null, true));
-    Assert.assertTrue(VersionUtils.areVersionsEqual(BootStrapImpl.DEV_VERSION, "1.2.3", false));
-    Assert.assertTrue(VersionUtils.areVersionsEqual(BootStrapImpl.DEV_VERSION, "", true));
-    Assert.assertTrue(VersionUtils.areVersionsEqual(BootStrapImpl.DEV_VERSION, null, true));
+    Assert.assertTrue(VersionUtils.areVersionsEqual(DEV_VERSION, "1.2.3", false));
+    Assert.assertTrue(VersionUtils.areVersionsEqual(DEV_VERSION, "", true));
+    Assert.assertTrue(VersionUtils.areVersionsEqual(DEV_VERSION, null, true));
 
     Assert.assertFalse(VersionUtils.areVersionsEqual("1.2.3.1", "1.2.3", false));
     Assert.assertFalse(VersionUtils.areVersionsEqual("2.1.3", "1.2.3", false));
@@ -109,9 +110,9 @@ public class TestVersionUtils {
     Assert.assertTrue(VersionUtils.areVersionsEqual("1.2.3_MYAMBARI_000000", "1.2.3_MYAMBARI_000000", true));
     Assert.assertTrue(VersionUtils.areVersionsEqual("", "", true));
     Assert.assertTrue(VersionUtils.areVersionsEqual(null, null, true));
-    Assert.assertTrue(VersionUtils.areVersionsEqual(BootStrapImpl.DEV_VERSION, "1.2.3_MYAMBARI_000000", false));
-    Assert.assertTrue(VersionUtils.areVersionsEqual(BootStrapImpl.DEV_VERSION, "", true));
-    Assert.assertTrue(VersionUtils.areVersionsEqual(BootStrapImpl.DEV_VERSION, null, true));
+    Assert.assertTrue(VersionUtils.areVersionsEqual(DEV_VERSION, "1.2.3_MYAMBARI_000000", false));
+    Assert.assertTrue(VersionUtils.areVersionsEqual(DEV_VERSION, "", true));
+    Assert.assertTrue(VersionUtils.areVersionsEqual(DEV_VERSION, null, true));
 
     Assert.assertFalse(VersionUtils.areVersionsEqual("1.2.3.1_MYAMBARI_000000", "1.2.3_MYAMBARI_000000", false));
     Assert.assertFalse(VersionUtils.areVersionsEqual("2.1.3_MYAMBARI_000000", "1.2.3_MYAMBARI_000000", false));


### PR DESCRIPTION
## What changes were proposed in this pull request?

While implementing some of the upgrade checks which were removed as part of AMBARI-24737, the SPI needed some extra information added.

- Some checks used `VersionUtils`, so this needed to be relocated to the SPI.
- Added service-level repository version information to `ClusterInformation`
- Simplified the `UpgradeCheckDescription` when there is only 1 failure message.
- Prevent NPE when `CheckQualifications` is `null` (even though Javadoc says it must return an empty iist.
- Fixed a spelling error in `getConfigurationProperties`

## How was this patch tested?

Revised unit tests for new signatures.