### PR TITLE
AMBARI-24850 Use the proper stack root for Hive pre upgrade

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
@@ -93,8 +93,8 @@ class HivePreUpgrade(Script):
     source_version = upgrade_summary.get_source_version(service_name = "HIVE")
     target_version = upgrade_summary.get_target_version(service_name = "HIVE")
     
-    source_dir = format("/usr/hdp/{source_version}");
-    target_dir = format("/usr/hdp/{target_version}")
+    source_dir = format("{stack_root}/{source_version}")
+    target_dir = format("{stack_root}/{target_version}")
     
     if params.security_enabled:
       hive_kinit_cmd = format("{kinit_path_local} -kt {hive_server2_keytab} {hive_principal}; ")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the proper stack root acquired by Script.get_stack_root() instead of hard coded /usr/hdp for Hive pre upgrade.

## How was this patch tested?

Tested by running an actual upgrade with the modified version.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.