### PR TITLE
[AMBARI-24857] UI Changes for supporting Ozone deployment.

### DIFF
--- a/ambari-web/app/controllers/wizard/step4_controller.js
+++ b/ambari-web/app/controllers/wizard/step4_controller.js
@@ -59,11 +59,27 @@ App.WizardStep4Controller = Em.ArrayController.extend({
    */
   errorStack: [],
 
+  isAddServiceWizard: Em.computed.equal('content.controllerName', 'addServiceController'),
+
+  isOzoneInstalled: function() {
+    let isOzone = this.findProperty('serviceName', 'OZONE');
+    return isOzone && isOzone.get('isInstalled');
+  }.property('@each.isInstalled'),
+
   /**
    * Services which are HDFS compatible
    */
   fileSystems: function() {
-    var fileSystems = this.filterProperty('isDFS', true);;
+    let fileSystems = [];
+    const self = this;
+    this.filterProperty('isDFS', true).forEach((fs) => {
+      if (self.get('isAddServiceWizard') && self.get('isOzoneInstalled') &&
+        fs.get('serviceName') === 'HDFS') {
+        return;
+      }
+      fileSystems.push(fs);
+    });
+
     return fileSystems.map(function(fs) {
       return App.FileSystem.create({content: fs, services: fileSystems});
     });
@@ -318,7 +334,7 @@ App.WizardStep4Controller = Em.ArrayController.extend({
    */
   isDFSStack: function () {
 	  var bDFSStack = false;
-    var dfsServices = ['HDFS', 'GLUSTERFS'];
+    var dfsServices = ['HDFS', 'GLUSTERFS', 'OZONE'];
     var availableServices = this.filterProperty('isInstalled',false);
     availableServices.forEach(function(service){
       if (dfsServices.contains(service.get('serviceName')) || service.get('serviceType') == 'HCFS' ) {
@@ -335,12 +351,26 @@ App.WizardStep4Controller = Em.ArrayController.extend({
    */
   fileSystemServiceValidation: function(callback) {
     if(this.isDFSStack()){
+      const self = this;
       var primaryDFS = this.findProperty('isPrimaryDFS',true);
       if (primaryDFS) {
         var primaryDfsDisplayName = primaryDFS.get('displayNameOnSelectServicePage');
         var primaryDfsServiceName = primaryDFS.get('serviceName');
+        //if multiple DFS are not selected, remove the related error from the error array
+        let removeFsError = function () {
+          var fsError = self.get('errorStack').filterProperty('id',"multipleDFS");
+          if(fsError)
+          {
+            self.get('errorStack').removeObject(fsError[0]);
+          }
+        };
         if (this.multipleDFSs()) {
           var dfsServices = this.filterProperty('isDFS',true).filterProperty('isSelected',true).mapProperty('serviceName');
+          //special case for HDFS and OZONE
+          if (dfsServices.length === 2 && dfsServices.includes('HDFS') && dfsServices.includes('OZONE')) {
+            removeFsError();
+            return;
+          }
           var services = dfsServices.map(function (item){
             return {
               serviceName: item,
@@ -355,12 +385,7 @@ App.WizardStep4Controller = Em.ArrayController.extend({
         }
         else
         {
-          //if multiple DFS are not selected, remove the related error from the error array
-          var fsError = this.get('errorStack').filterProperty('id',"multipleDFS");
-          if(fsError)
-          {
-             this.get('errorStack').removeObject(fsError[0]);
-          }
+          removeFsError();
         }
       }
     }

--- a/ambari-web/app/controllers/wizard/step4_controller.js
+++ b/ambari-web/app/controllers/wizard/step4_controller.js
@@ -358,10 +358,10 @@ App.WizardStep4Controller = Em.ArrayController.extend({
         var primaryDfsServiceName = primaryDFS.get('serviceName');
         //if multiple DFS are not selected, remove the related error from the error array
         let removeFsError = function () {
-          var fsError = self.get('errorStack').filterProperty('id',"multipleDFS");
+          let fsError = self.get('errorStack').findProperty('id',"multipleDFS");
           if(fsError)
           {
-            self.get('errorStack').removeObject(fsError[0]);
+            self.get('errorStack').removeObject(fsError);
           }
         };
         if (this.multipleDFSs()) {

--- a/ambari-web/app/controllers/wizard/step6_controller.js
+++ b/ambari-web/app/controllers/wizard/step6_controller.js
@@ -302,9 +302,11 @@ App.WizardStep6Controller = Em.Controller.extend(App.HostComponentValidationMixi
     else if (this.get('isAddServiceWizard')) services = installedServices.concat(selectedServices);
 
     var headers = Em.A([]);
+    let doHideOzoneDataNodes = !!services.findProperty('serviceName', 'HDFS');
     services.forEach(function (stackService) {
       stackService.get('serviceComponents').forEach(function (serviceComponent) {
-        if (serviceComponent.get('isShownOnInstallerSlaveClientPage')) {
+        let hideComponent = serviceComponent.get('componentName') === 'OZONE_DATANODE' ? doHideOzoneDataNodes : false;
+        if (serviceComponent.get('isShownOnInstallerSlaveClientPage') && !hideComponent) {
           headers.pushObject(Em.Object.create({
             name: serviceComponent.get('componentName'),
             label: App.format.role(serviceComponent.get('componentName'), false),
@@ -338,6 +340,7 @@ App.WizardStep6Controller = Em.Controller.extend(App.HostComponentValidationMixi
       this.callValidation();
     }
   },
+
 
   /**
    * Returns list of new hosts

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -80,7 +80,7 @@ App.FileSystem = Ember.ObjectProxy.extend({
     const dfsNames = this.get('services').mapProperty('serviceName');
     const coExistingDfs = ['HDFS', 'OZONE'],
       selectedServices = this.get('services').filterProperty('isSelected');
-    for (let i = 0; selectedServices && i < selectedServices.length; i++) {
+    for (let i = 0; i < selectedServices.length; i++) {
       if (!coExistingDfs.includes(selectedServices[i].get('serviceName'))) {
         return true;
       }

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -85,7 +85,7 @@ App.FileSystem = Ember.ObjectProxy.extend({
         return true;
       }
     }
-    return dfsNames.includes('HDFS') && dfsNames.includes('OZONE') && coExistingDfs.includes(this.get('content.serviceName'));
+    return !(dfsNames.includes('HDFS') && dfsNames.includes('OZONE') && coExistingDfs.includes(this.get('content.serviceName')));
   },
 
   isSelected: function(key, aBoolean) {

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -75,9 +75,27 @@ App.FileSystem = Ember.ObjectProxy.extend({
   content: null,
   services: [],
 
+  //special case for HDFS and OZONE. They can be selected together
+  shouldAllSelectionBeCleared: function () {
+    const dfsNames = this.get('services').mapProperty('serviceName');
+    const coExistingDfs = ['HDFS', 'OZONE'];
+    this.get('services').filterProperty('isSelected').forEach((s) => {
+      if (!coExistingDfs.includes(s.get('serviceName'))) {
+        return true;
+      }
+    });
+
+    if (dfsNames.includes('HDFS') && dfsNames.includes('OZONE') && coExistingDfs.includes(this.get('content.serviceName'))) {
+      return false;
+    }
+    return true;
+  },
+
   isSelected: function(key, aBoolean) {
     if (arguments.length > 1) {
-      this.clearAllSelection();
+      if (this.shouldAllSelectionBeCleared()) {
+        this.clearAllSelection();
+      }
       this.get('content').set('isSelected', aBoolean);
     }
     return this.get('content.isSelected');

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -80,7 +80,7 @@ App.FileSystem = Ember.ObjectProxy.extend({
     const dfsNames = this.get('services').mapProperty('serviceName');
     const coExistingDfs = ['HDFS', 'OZONE'],
       selectedServices = this.get('services').filterProperty('isSelected');
-    for (let i = 0; i < selectedServices.length; i++) {
+    for (let i = 0; selectedServices && i < selectedServices.length; i++) {
       if (!coExistingDfs.includes(selectedServices[i].get('serviceName'))) {
         return true;
       }

--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -78,17 +78,14 @@ App.FileSystem = Ember.ObjectProxy.extend({
   //special case for HDFS and OZONE. They can be selected together
   shouldAllSelectionBeCleared: function () {
     const dfsNames = this.get('services').mapProperty('serviceName');
-    const coExistingDfs = ['HDFS', 'OZONE'];
-    this.get('services').filterProperty('isSelected').forEach((s) => {
-      if (!coExistingDfs.includes(s.get('serviceName'))) {
+    const coExistingDfs = ['HDFS', 'OZONE'],
+      selectedServices = this.get('services').filterProperty('isSelected');
+    for (let i = 0; i < selectedServices.length; i++) {
+      if (!coExistingDfs.includes(selectedServices[i].get('serviceName'))) {
         return true;
       }
-    });
-
-    if (dfsNames.includes('HDFS') && dfsNames.includes('OZONE') && coExistingDfs.includes(this.get('content.serviceName'))) {
-      return false;
     }
-    return true;
+    return dfsNames.includes('HDFS') && dfsNames.includes('OZONE') && coExistingDfs.includes(this.get('content.serviceName'));
   },
 
   isSelected: function(key, aBoolean) {

--- a/ambari-web/app/views/main/host/summary.js
+++ b/ambari-web/app/views/main/host/summary.js
@@ -229,6 +229,9 @@ App.MainHostSummaryView = Em.View.extend(App.HiveInteractiveCheck, App.TimeRange
             addableComponent.get('componentName') === 'HIVE_SERVER_INTERACTIVE' && !self.get('enableHiveInteractive')) {
             return;
           }
+          if (installedServices.includes('HDFS') && addableComponent.get('componentName') === 'OZONE_DATANODE') {
+            return;
+          }
           components.pushObject(self.addableComponentObject.create({
             'componentName': addableComponent.get('componentName'),
             'serviceName': addableComponent.get('serviceName')


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Allow multi file system for cases where only HDFS and Ozone are being deployed together. (Currently only single file system is allowed during installer) 
2. If user selects HDFS and Ozone, allow only HDFS Datanodes to be deployed (Install wizard as well as Add Service Wizard)
3. If user select Ozone as only service, allow Ozone-Datanodes to be deployed (cardinality: 1+)
4. Do not allow HDFS installation via Add Service Wizard if Ozone is deployed.
5. If Hdfs is already installed don't allow ozone-datanodes during Add Host Wizard. 
6. Do not allow host component Ozone-Datanodes to be added if HDFS Datanodes are already added.

## How was this patch tested?
21959 passing (23s)
  48 pending