### PR TITLE
[AMBARI-24852] NPE in default host group replacement

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -1767,6 +1767,11 @@ public class BlueprintConfigurationProcessor {
                                          Map<String, Map<String, String>> properties,
                                          ClusterTopology topology) {
 
+      if (origValue == null) {
+        LOG.info("Property {} is null, skipping search for host group placeholder", propertyName);
+        return null;
+      }
+
       HostGroups hostGroups = new HostGroups(topology, propertyName);
 
       //todo: getHostStrings (?)
@@ -1807,6 +1812,11 @@ public class BlueprintConfigurationProcessor {
                                                     String origValue,
                                                     Map<String, Map<String, String>> properties,
                                                     ClusterTopology topology) {
+      if (origValue == null) {
+        LOG.info("Property {} is null, skipping search for host group placeholder", propertyName);
+        return Collections.emptyList();
+      }
+
       //todo: getHostStrings
       Matcher m = HostGroup.HOSTGROUP_REGEX.matcher(origValue);
       Set<String> hostGroups = new HashSet<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -2249,6 +2249,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
         "dfs.https.address", "testhost3")),
       "myservice-site", new HashMap<>(ImmutableMap.of(
         "myservice_slave_address", "%HOSTGROUP::group1%:8080"))));
+    hostGroupProperties.get("hdfs-site").put("null_property", null);
 
     Configuration clusterConfig = new Configuration(new HashMap<>(), new HashMap<>());
     clusterConfig.setParentConfiguration(new Configuration(stackProperties, emptyMap()));
@@ -2387,6 +2388,9 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
           "%HOSTGROUP::master3%:8080",
           clusterConfig.getProperties(),
           topology)));
+
+    assertEquals(emptyList(),
+      updater.getRequiredHostGroups("mycomponent.urls", null, clusterConfig.getProperties(), topology));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2567, for `trunk`.

Avoid searching for host group placeholder in `null` string.

## How was this patch tested?

Added test case in unit test.