### PR TITLE
[AMBARI-24865] Build error at Findbugs with Maven 3.6.

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -640,7 +640,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <configuration>
           <failOnError>false</failOnError>
           <threshold>Low</threshold>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build error observable with recently released Maven 3.6:

```
$ mvn -am -pl ambari-server clean verify
...
[INFO] Ambari Server 3.0.0.0-SNAPSHOT ..................... FAILURE [01:16 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
...
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs (findbugs) on project ambari-server: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]
```

The bug was [fixed](https://github.com/gleclaire/findbugs-maven-plugin/commit/7954b94eff5c6b0524e7fe26d8f114b3c5450b86) in `findbugs-maven-plugin` 3.0.4.

Upgrade `findbugs-maven-plugin` to latest release (3.0.5).

## How was this patch tested?

Build with Maven 3.6:

```
$ mvn -version
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T20:41:47+02:00)
...
$ mvn -am -pl ambari-server clean verify
...
[INFO] Ambari Server 3.0.0.0-SNAPSHOT ..................... SUCCESS [02:32 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

Build with Maven 3.5:

```
$ mvn -version
Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T20:33:14+02:00)
...
$ mvn -am -pl ambari-server clean verify
...
[INFO] Ambari Server 3.0.0.0-SNAPSHOT ..................... SUCCESS [02:47 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```