### PR TITLE
[AMBARI-24865] Build error at Findbugs with Maven 3.6.

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -661,7 +661,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <configuration>
           <failOnError>false</failOnError>
           <threshold>Low</threshold>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2581, for `branch-2.7`.

## How was this patch tested?

Build with Maven 3.6:

```
$ mvn -version
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T20:41:47+02:00)
...
$ mvn -am -pl ambari-server -DskipTests clean verify
...
[INFO] Ambari Server 2.7.3.0.0 ............................ SUCCESS [02:08 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

Build with Maven 3.5:

```
$ mvn -version
Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T20:33:14+02:00)
...
$ mvn -am -pl ambari-server -DskipTests clean verify
...
[INFO] Ambari Server 2.7.3.0.0 ............................ SUCCESS [02:06 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```