### PR TITLE
[AMBARI-24836] Service Auto start is enabled after page refresh

### DIFF
--- a/ambari-web/app/controllers/main/admin/service_auto_start.js
+++ b/ambari-web/app/controllers/main/admin/service_auto_start.js
@@ -113,14 +113,19 @@ App.MainAdminServiceAutoStartController = Em.Controller.extend({
   },
 
   load: function() {
-    App.router.get('configurationController').getCurrentConfigsBySites(['cluster-env']).done((data) => {
-      this.set('clusterConfigs', data[0].properties);
-      this.set('isGeneralRecoveryEnabled', data[0].properties.recovery_enabled === 'true');
-      this.set('isGeneralRecoveryEnabledCached', this.get('isGeneralRecoveryEnabled'));
-      this.loadComponentsConfigs().then(() => {
-        this.set('isLoaded', true);
+    const self = this;
+    const clusterConfigController = App.router.get('configurationController');
+    clusterConfigController.updateConfigTags().always(function () {
+      clusterConfigController.getCurrentConfigsBySites(['cluster-env']).done((data) => {
+        self.set('clusterConfigs', data[0].properties);
+        self.set('isGeneralRecoveryEnabled', data[0].properties.recovery_enabled === 'true');
+        self.set('isGeneralRecoveryEnabledCached', self.get('isGeneralRecoveryEnabled'));
+        self.loadComponentsConfigs().then(() => {
+          self.set('isLoaded', true);
+        });
       });
     });
+
   },
 
   loadComponentsConfigs: function () {

--- a/ambari-web/test/controllers/main/admin/service_auto_start_test.js
+++ b/ambari-web/test/controllers/main/admin/service_auto_start_test.js
@@ -80,6 +80,9 @@ describe('App.MainAdminServiceAutoStartController', function() {
           ]);
         }
       });
+      sinon.stub(App.router.get('configurationController'), 'updateConfigTags').returns({
+        always: Em.clb
+      });
       sinon.stub(controller, 'loadComponentsConfigs').returns({
         then: Em.clb
       });
@@ -87,6 +90,7 @@ describe('App.MainAdminServiceAutoStartController', function() {
     });
     afterEach(function() {
       App.router.get('configurationController').getCurrentConfigsBySites.restore();
+      App.router.get('configurationController').updateConfigTags.restore();
       controller.loadComponentsConfigs.restore();
     });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reload config tags from server when auto service start page is loaded.

## How was this patch tested?
Modified existing test cases. 
21754 passing (23s)
  48 pending