### PR TITLE
[AMBARI-24869] Request configurations when needed during server-side actions rather than rely on configuration data from the execution command

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
@@ -173,29 +173,6 @@ public abstract class AbstractServerAction implements ServerAction {
     return (commandParameters == null) ? null : commandParameters.get(propertyName);
   }
 
-  /**
-   * Returns the configurations value from the ExecutionCommand
-   * <p/>
-   * The returned map should be assumed to be read-only.
-   *
-   * @return the (assumed read-only) configurations value from the ExecutionCommand
-   */
-  protected Map<String, Map<String, String>> getConfigurations() {
-    return (executionCommand == null) ? Collections.emptyMap() : executionCommand.getConfigurations();
-  }
-
-  /**
-   * Returns the requested configuration Map from the ExecutionCommand
-   * <p/>
-   * The returned map should be assumed to be read-only.
-   *
-   * @param configurationName a String indicating the name of the configuration data to retrieve
-   * @return the (assumed read-only) configuration Map from the ExecutionCommand, or null if not available
-   */
-  protected Map<String, String> getConfiguration(String configurationName) {
-    return getConfigurations().get(configurationName);
-  }
-
   protected void auditLog(AuditEvent ae) {
     auditLogger.log(ae);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/DestroyPrincipalsServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/DestroyPrincipalsServerAction.java
@@ -110,7 +110,7 @@ public class DestroyPrincipalsServerAction extends KerberosServerAction {
     String defaultRealm = getDefaultRealm(commandParameters);
 
     KerberosOperationHandler operationHandler = kerberosOperationHandlerFactory.getKerberosOperationHandler(kdcType);
-    Map<String, String> kerberosConfiguration = getConfiguration("kerberos-env");
+    Map<String, String> kerberosConfiguration = getConfigurationProperties("kerberos-env");
 
     try {
       operationHandler.open(administratorCredential, defaultRealm, kerberosConfiguration);

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
@@ -41,8 +41,10 @@ import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerbero
 import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerberosPrincipal;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.utils.StageUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -435,7 +437,7 @@ public abstract class KerberosServerAction extends AbstractServerAction {
       String defaultRealm = getDefaultRealm(commandParameters);
 
       KerberosOperationHandler handler = kerberosOperationHandlerFactory.getKerberosOperationHandler(kdcType);
-      Map<String, String> kerberosConfiguration = getConfiguration("kerberos-env");
+      Map<String, String> kerberosConfiguration = getConfigurationProperties("kerberos-env");
 
       try {
         handler.open(administratorCredential, defaultRealm, kerberosConfiguration);
@@ -603,6 +605,34 @@ public abstract class KerberosServerAction extends AbstractServerAction {
     return (ambariServerHostEntity == null)
         ? null
         : ambariServerHostEntity.getHostId();
+  }
+
+  /**
+   * Retrieve the current set of properties for the requested config type for the relevant cluster.
+   *
+   * @return a Map of property names to property values for the requested config type; or null if no data is found
+   * @throws AmbariException if an error occurs retrieving the relevant cluster details
+   */
+  protected Map<String, String> getConfigurationProperties(String configType) throws AmbariException {
+    if (StringUtils.isNotEmpty(configType)) {
+      Cluster cluster = getCluster();
+      Config config = (cluster == null) ? null : cluster.getDesiredConfigByType(configType);
+      Map<String, String> properties = (config == null) ? null : config.getProperties();
+
+      if (properties == null) {
+        LOG.warn("The '{}' configuration data is not available:" +
+                "\n\tcluster: {}" +
+                "\n\tconfig: {}" +
+                "\n\tproperties: null",
+            configType,
+            (cluster == null) ? "null" : "not null",
+            (config == null) ? "null" : "not null");
+      }
+
+      return properties;
+    } else {
+      return null;
+    }
   }
 
   public static class KerberosCommandParameters {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
@@ -44,7 +44,6 @@ import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.utils.StageUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerbero
 import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerberosPrincipal;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
@@ -63,6 +64,8 @@ import junit.framework.Assert;
 
 public class KerberosServerActionTest extends EasyMockSupport {
 
+  private  static final Map<String, String> KERBEROS_ENV_PROPERTIES = Collections.singletonMap("admin_server_host", "kdc.example.com");
+
   Map<String, String> commandParams = new HashMap<>();
   File temporaryDirectory;
   private Injector injector;
@@ -72,7 +75,12 @@ public class KerberosServerActionTest extends EasyMockSupport {
 
   @Before
   public void setUp() throws Exception {
+
+    Config kerberosEnvConfig = createMock(Config.class);
+    expect(kerberosEnvConfig.getProperties()).andReturn(KERBEROS_ENV_PROPERTIES).anyTimes();
+
     cluster = createMock(Cluster.class);
+    expect(cluster.getDesiredConfigByType("kerberos-env")).andReturn(kerberosEnvConfig).anyTimes();
 
     Clusters clusters = createMock(Clusters.class);
     expect(clusters.getCluster(anyString())).andReturn(cluster).anyTimes();
@@ -278,6 +286,29 @@ public class KerberosServerActionTest extends EasyMockSupport {
     CommandReport report = action.processIdentities(sharedMap);
     Assert.assertNotNull(report);
     Assert.assertEquals(HostRoleStatus.FAILED.toString(), report.getStatus());
+
+    verifyAll();
+  }
+
+  @Test
+  public void testGetConfigurationProperties() throws AmbariException {
+    Config emptyConfig = createMock(Config.class);
+    expect(emptyConfig.getProperties()).andReturn(Collections.emptyMap()).once();
+
+    Config missingPropertiesConfig = createMock(Config.class);
+    expect(missingPropertiesConfig.getProperties()).andReturn(null).once();
+
+    expect(cluster.getDesiredConfigByType("invalid-type")).andReturn(null).once();
+    expect(cluster.getDesiredConfigByType("missing-properties-type")).andReturn(missingPropertiesConfig).once();
+    expect(cluster.getDesiredConfigByType("empty-type")).andReturn(emptyConfig).once();
+
+    replayAll();
+
+    Assert.assertNull(action.getConfigurationProperties(null));
+    Assert.assertNull(action.getConfigurationProperties("invalid-type"));
+    Assert.assertNull(action.getConfigurationProperties("missing-properties-type"));
+    Assert.assertEquals(Collections.emptyMap(), action.getConfigurationProperties("empty-type"));
+    Assert.assertEquals(KERBEROS_ENV_PROPERTIES, action.getConfigurationProperties("kerberos-env"));
 
     verifyAll();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to a recent change (AMBARI-24722), which appeared to remove configuration data from the execution command JSON document, data needed for Kerberos-related service-side actions is missing.  This data may be requested when needed from the cluster data at the time of execution rather than when setting up the stages.

This breaks enabling Kerberos.  Since configurations are no longer set in ExecutionCommand at https://github.com/apache/ambari/blob/trunk/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java#L2468, the kerberos-env command data is not available to the task creation process starting at https://github.com/apache/ambari/blob/trunk/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java#L4128.

Therefore when the initial Kerberos service check is invoked, the needed data is not available and the processes fails.

```
Failed to process the identities, could not properly open the KDC operation handler: Failed to kinit as the KDC administrator user, admin/admin:
ExitCode: 1
STDOUT: 
STDERR: kinit: Server not found in Kerberos database while getting initial credentials
```

From the krb5kdc.log
```
Nov 07 21:46:39 c7401.ambari.apache.org krb5kdc[14431](info): AS_REQ (8 etypes {18 17 20 19 16 23 25 26}) 192.168.74.101: SERVER_NOT_FOUND: admin/admin@EXAMPLE.COM for kadmin/null@EXAMPLE.COM, Server not found in Kerberos database
The null in kadmin/null@EXAMPLE.COM is coming from the missing kerberos-env/admin_server_host property when running the server-side task to create the test identity.
```

## How was this patch tested?

Manually tested

Added new unit tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.