### PR TITLE
[AMBARI-24870] Allow blueprint install without HISTORYMANAGER, APP_TIMELINE_SERVER (benyoka)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -2951,10 +2951,10 @@ public class BlueprintConfigurationProcessor {
     mapredSiteMap.put("mapreduce.job.hdfs-servers", new SingleHostTopologyUpdater("NAMENODE"));
 
 
-    // HISTORY_SERVER
-    yarnSiteMap.put("yarn.log.server.url", new SingleHostTopologyUpdater("HISTORYSERVER"));
-    mapredSiteMap.put("mapreduce.jobhistory.webapp.address", new SingleHostTopologyUpdater("HISTORYSERVER"));
-    mapredSiteMap.put("mapreduce.jobhistory.address", new SingleHostTopologyUpdater("HISTORYSERVER"));
+    // HISTORYSERVER
+    yarnSiteMap.put("yarn.log.server.url", new OptionalSingleHostTopologyUpdater("HISTORYSERVER"));
+    mapredSiteMap.put("mapreduce.jobhistory.webapp.address", new OptionalSingleHostTopologyUpdater("HISTORYSERVER"));
+    mapredSiteMap.put("mapreduce.jobhistory.address", new OptionalSingleHostTopologyUpdater("HISTORYSERVER"));
 
     // RESOURCEMANAGER
     yarnSiteMap.put("yarn.resourcemanager.hostname", new OptionalSingleHostTopologyUpdater("RESOURCEMANAGER"));
@@ -2966,10 +2966,10 @@ public class BlueprintConfigurationProcessor {
     yarnSiteMap.put("yarn.resourcemanager.webapp.https.address", new OptionalSingleHostTopologyUpdater("RESOURCEMANAGER"));
 
     // APP_TIMELINE_SERVER
-    yarnSiteMap.put("yarn.timeline-service.address", new SingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
-    yarnSiteMap.put("yarn.timeline-service.webapp.address", new SingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
-    yarnSiteMap.put("yarn.timeline-service.webapp.https.address", new SingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
-    yarnSiteMap.put("yarn.log.server.web-service.url", new SingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
+    yarnSiteMap.put("yarn.timeline-service.address", new OptionalSingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
+    yarnSiteMap.put("yarn.timeline-service.webapp.address", new OptionalSingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
+    yarnSiteMap.put("yarn.timeline-service.webapp.https.address", new OptionalSingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
+    yarnSiteMap.put("yarn.log.server.web-service.url", new OptionalSingleHostTopologyUpdater("APP_TIMELINE_SERVER"));
 
     // TIMELINE_READER
     yarnSiteMap.put("yarn.timeline-service.reader.webapp.address", new MultipleHostTopologyUpdater("TIMELINE_READER"));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -2561,15 +2561,11 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
   @Test
   public void testDoUpdateForClusterCreate_SingleHostProperty__MissingComponent() throws Exception {
     Map<String, Map<String, String>> properties = new HashMap<>();
-    Map<String, String> typeProps = new HashMap<>();
-    typeProps.put("yarn.resourcemanager.hostname", "localhost");
-    typeProps.put("yarn.timeline-service.address", "localhost");
-    properties.put("yarn-site", typeProps);
-
+    properties.put("mapred-site",
+      new HashMap<>(ImmutableMap.of("mapreduce.job.hdfs-servers", "localhost")));
     Configuration clusterConfig = new Configuration(properties, emptyMap());
 
     Collection<String> group1Components = new HashSet<>();
-    group1Components.add("NAMENODE");
     group1Components.add("SECONDARY_NAMENODE");
     group1Components.add("RESOURCEMANAGER");
     TestHostGroup group1 = new TestHostGroup("group1", group1Components, Collections.singleton("testhost"));
@@ -2583,8 +2579,7 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     hostGroups.add(group1);
     hostGroups.add(group2);
 
-    expect(stack.getCardinality("APP_TIMELINE_SERVER")).andReturn(new Cardinality("1")).anyTimes();
-    expect(stack.getCardinality("TIMELINE_READER")).andReturn(new Cardinality("1")).anyTimes();
+    expect(stack.getCardinality("NAMENODE")).andReturn(new Cardinality("1")).anyTimes();
 
     ClusterTopology topology = createClusterTopology(bp, clusterConfig, hostGroups);
     BlueprintConfigurationProcessor updater = new BlueprintConfigurationProcessor(topology);
@@ -2603,9 +2598,8 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
 
     Map<String, Map<String, String>> properties = new HashMap<>();
     Map<String, String> typeProps = new HashMap<>();
-    typeProps.put("yarn.resourcemanager.hostname", "localhost");
-    typeProps.put("yarn.timeline-service.address", "localhost");
-    properties.put("yarn-site", typeProps);
+    properties.put("mapred-site",
+      new HashMap<>(ImmutableMap.of("mapreduce.job.hdfs-servers", "localhost")));
 
     Configuration clusterConfig = new Configuration(properties, emptyMap());
 
@@ -2618,19 +2612,16 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     TestHostGroup group1 = new TestHostGroup("group1", group1Components, Collections.singleton("testhost"));
 
     Collection<String> group2Components = new HashSet<>();
+    group2Components.add("NAMENODE");
     group2Components.add("DATANODE");
     group2Components.add("HDFS_CLIENT");
-    group2Components.add("APP_TIMELINE_SERVER");
-    group2Components.add("TIMELINE_READER");
     TestHostGroup group2 = new TestHostGroup("group2", group2Components, Collections.singleton("testhost2"));
 
     Collection<TestHostGroup> hostGroups = new HashSet<>();
     hostGroups.add(group1);
     hostGroups.add(group2);
 
-    expect(stack.getCardinality("APP_TIMELINE_SERVER")).andReturn(new Cardinality("0-1")).anyTimes();
-    expect(stack.getCardinality("TIMELINE_READER")).andReturn(new Cardinality("0-1")).anyTimes();
-
+    expect(stack.getCardinality("NAMENODE")).andReturn(new Cardinality("0-1")).anyTimes();
 
     ClusterTopology topology = createClusterTopology(bp, clusterConfig, hostGroups);
     BlueprintConfigurationProcessor updater = new BlueprintConfigurationProcessor(topology);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaced HISTORYSERVER's and APPTIMELINESERVER's SingleHostTopologyUpdater's to OptionalSingleHostTopologyUpdater's. This way the _BlueprintConfigurationProcessor_ doesn't throw Exception when these components are missing from the cluster.

## How was this patch tested?

- Tested installation manually. Blueprint install processed through the configuration and installation phases.
- Updated _BlueprintConfigurationProcessor_ unit tests.