### PR TITLE
AMBARI-24879. kAdmin principal name is set on the GUI when enabling Kerberos with MIT KDC using a new variable replacement function

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/IPAKerberosOperationHandler.java
@@ -254,7 +254,7 @@ public class IPAKerberosOperationHandler extends KDCKerberosOperationHandler {
   }
 
   @Override
-  protected String[] getKinitCommand(String executableKinit, PrincipalKeyCredential credentials, String credentialsCache) {
+  protected String[] getKinitCommand(String executableKinit, PrincipalKeyCredential credentials, String credentialsCache, Map<String, String> kerberosConfiguration) {
     return new String[]{
         executableKinit,
         "-c",

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KDCKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KDCKerberosOperationHandler.java
@@ -111,7 +111,7 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
     // Pre-determine the paths to relevant Kerberos executables
     executableKinit = getExecutable("kinit");
 
-    setOpen(init());
+    setOpen(init(kerberosConfiguration));
   }
 
   @Override
@@ -269,9 +269,11 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
    * @param executableKinit  the absolute path to the kinit executable
    * @param credentials      the KDC adminisrator's credentials
    * @param credentialsCache the absolute path to the expected location of the Kerberos ticket/credential cache file
+   * @param kerberosConfigurations  a Map of key/value pairs containing data from the kerberos-env configuration set
+   * @throws KerberosOperationException in case there was any error during kinit command creation
    * @return an array of Strings containing the command to execute
    */
-  protected abstract String[] getKinitCommand(String executableKinit, PrincipalKeyCredential credentials, String credentialsCache);
+  protected abstract String[] getKinitCommand(String executableKinit, PrincipalKeyCredential credentials, String credentialsCache, Map<String, String> kerberosConfigurations) throws KerberosOperationException;
 
   /**
    * Export the requested keytab entries for a given principal into the specified file.
@@ -294,7 +296,7 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
    * @return
    * @throws KerberosOperationException
    */
-  protected boolean init() throws KerberosOperationException {
+  protected boolean init(Map<String, String> kerberosConfiguration) throws KerberosOperationException {
     if (credentialsCacheFile != null) {
       if (!credentialsCacheFile.delete()) {
         LOG.debug("Failed to remove the orphaned cache file, {}", credentialsCacheFile.getAbsolutePath());
@@ -317,7 +319,7 @@ abstract class KDCKerberosOperationHandler extends KerberosOperationHandler {
 
     PrincipalKeyCredential credentials = getAdministratorCredential();
 
-    ShellCommandUtil.Result result = executeCommand(getKinitCommand(executableKinit, credentials, credentialsCache),
+    ShellCommandUtil.Result result = executeCommand(getKinitCommand(executableKinit, credentials, credentialsCache, kerberosConfiguration),
         environmentMap,
         new InteractivePasswordHandler(String.valueOf(credentials.getKey()), null));
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosOperationHandler.java
@@ -95,6 +95,11 @@ public abstract class KerberosOperationHandler {
   public final static String KERBEROS_ENV_ADMIN_SERVER_HOST = "admin_server_host";
 
   /**
+   * Kerberos-env configuration property name: kadmin_principal_name
+   */
+  public final static String KERBEROS_ENV_KADMIN_PRINCIPAL_NAME = "kadmin_principal_name";
+
+  /**
    * Kerberos-env configuration property name: executable_search_paths
    */
   public final static String KERBEROS_ENV_EXECUTABLE_SEARCH_PATHS = "executable_search_paths";

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandler.java
@@ -19,12 +19,15 @@
 package org.apache.ambari.server.serveraction.kerberos;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.security.credential.PrincipalKeyCredential;
+import org.apache.ambari.server.state.kerberos.VariableReplacementHelper;
 import org.apache.ambari.server.utils.ShellCommandUtil;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -47,6 +50,9 @@ public class MITKerberosOperationHandler extends KDCKerberosOperationHandler {
 
   @Inject
   private Configuration configuration;
+  
+  @Inject
+  private VariableReplacementHelper variableReplacementHelper;
 
   /**
    * A String containing user-specified attributes used when creating principals
@@ -333,16 +339,27 @@ public class MITKerberosOperationHandler extends KDCKerberosOperationHandler {
   }
 
   @Override
-  protected String[] getKinitCommand(String executableKinit, PrincipalKeyCredential credentials, String credentialsCache) {
+  protected String[] getKinitCommand(String executableKinit, PrincipalKeyCredential credentials, String credentialsCache, Map<String, String> kerberosConfiguration) throws KerberosOperationException {
     // kinit -c <path> -S kadmin/`hostname -f` <principal>
-    return new String[]{
-        executableKinit,
-        "-c",
-        credentialsCache,
-        "-S",
-        String.format("kadmin/%s", getAdminServerHost(false)),
-        credentials.getPrincipal()
-    };
+    try {
+      final String kadminPrincipalName = variableReplacementHelper.replaceVariables(kerberosConfiguration.get(KERBEROS_ENV_KADMIN_PRINCIPAL_NAME), buildReplacementsMap(kerberosConfiguration));
+      return new String[]{
+          executableKinit,
+          "-c",
+          credentialsCache,
+          "-S",
+          kadminPrincipalName,
+          credentials.getPrincipal()
+      };
+    } catch (AmbariException e) {
+      throw new KerberosOperationException("Error while getting 'kinit' command", e);
+    }
+  }
+
+  private Map<String, Map<String, String>> buildReplacementsMap(Map<String, String> kerberosConfiguration) {
+    final Map<String, Map<String, String>> replacementsMap = new HashMap<>();
+    replacementsMap.put("", kerberosConfiguration);
+    return replacementsMap;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/VariableReplacementHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/VariableReplacementHelper.java
@@ -60,6 +60,7 @@ public class VariableReplacementHelper {
       put("replace", new ReplaceValue());
       put("append", new AppendFunction());
       put("principalPrimary", new PrincipalPrimary());
+      put("stripPort", new StripPort());
     }
   };
 
@@ -430,6 +431,21 @@ public class VariableReplacementHelper {
       } else {
         return data;
       }
+    }
+  }
+
+  /**
+   * Strips out the port (if any) from a URL assuming the following input data layout
+   * <code>host[:port]</code>
+   */
+  private static class StripPort implements Function {
+    @Override
+    public String perform(String[] args, String data, Map<String, Map<String, String>> replacementsMap) {
+      if (data == null) {
+        return null;
+      }
+      final int semicolonIndex = data.indexOf(":");
+      return semicolonIndex == -1 ? data : data.substring(0, semicolonIndex);
     }
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/MITKerberosOperationHandlerTest.java
@@ -265,6 +265,7 @@ public class MITKerberosOperationHandlerTest extends KDCKerberosOperationHandler
 
     Map<String,String> config = new HashMap<>();
     config.put("encryption_types", "aes des3-cbc-sha1 rc4 des-cbc-md5");
+    config.put(MITKerberosOperationHandler.KERBEROS_ENV_KADMIN_PRINCIPAL_NAME, "kadmin/kdc.example.com");
 
     replayAll();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/kerberos/VariableReplacementHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/kerberos/VariableReplacementHelperTest.java
@@ -196,6 +196,8 @@ public class VariableReplacementHelperTest {
         put("", new HashMap<String, String>() {{
           put("delimited.data", "one,two,three,four");
           put("realm", "UNIT.TEST");
+          put("admin_server_host", "c7401.ambari.apache.org");
+          put("admin_server_host_port", "c7401.ambari.apache.org:8080");
         }});
 
         put("kafka-broker", new HashMap<String, String>() {{
@@ -259,6 +261,9 @@ public class VariableReplacementHelperTest {
     assertEquals("test=unit.test", helper.replaceVariables("test=${realm|toLower()}", configurations));
 
     assertEquals("PLAINTEXTSASL://localhost:6667", helper.replaceVariables("${kafka-broker/listeners|replace(\\bPLAINTEXT\\b,PLAINTEXTSASL)}", configurations));
+
+    assertEquals("kadmin/c7401.ambari.apache.org", helper.replaceVariables("kadmin/${admin_server_host|stripPort()}", configurations));
+    assertEquals("kadmin/c7401.ambari.apache.org", helper.replaceVariables("kadmin/${admin_server_host_port|stripPort()}", configurations));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

The kadmin service principal name should be configurable for MIT KDC interactions. The current process assumes the kadmin service principal is `kadmin/FQDN_KADMIN_HOST`, but this could be different on some installations. For example, `kadmin/admin`.

A new `kerberos-env` property should be added to allow a user to change the kadmin principal name - `kerberos-env/kadmin_principal_name`

The default value for the new property should be `kadmin/${admin_server_host|stripPort()}`.  To be able to do this, we have to create a new variable replacement function. For example, `stripPort`.

**Note**: related stack change is going to be submitted separately.

## How was this patch tested?

Executing JUnit tests locally in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 26:12 min
[INFO] Finished at: 2018-11-12T16:43:44+01:00
[INFO] Final Memory: 163M/1033M
[INFO] ------------------------------------------------------------------------
```

In addition to this I did an E2E testing within my vagrant environment where Kerberos was enabled using the new property (leave as the default and changing it to a custom value).

<img width="1549" alt="screen shot 2018-11-12 at 5 11 54 pm" src="https://user-images.githubusercontent.com/34065904/48359834-1963eb00-e69e-11e8-9b05-38f5eb94a2d2.png">
