### PR TITLE
AMBARI-24885 Ambari Files view not working when User doesnt have access to any group and just have access to Filesview

### DIFF
--- a/ambari-web/app/routes/main.js
+++ b/ambari-web/app/routes/main.js
@@ -51,7 +51,7 @@ module.exports = Em.Route.extend(App.RouterRedirections, {
                     });
                   } else {
                     // Don't transit to Views when user already on View page
-                    if (App.router.currentState.name !== 'viewDetails') {
+                    if (App.router.currentState.name !== 'viewDetails' && App.router.currentState.name !== 'shortViewDetails') {
                       App.router.transitionTo('main.views.index');
                     }
                     clusterController.set('isLoaded', true); // hide loading bar


### PR DESCRIPTION
AMBARI-24885 Ambari Files view not working when User doesnt have access to any group and just have access to Filesviewss to any group and just have access to Filesview

## What changes were proposed in this pull request?
Fix of AMBARI-24885
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.