### PR TITLE
AMBARI-24877 Heatmap tab, metrics tab and QuickLinks section in summary tab should be hidden if service has only client service component

### DIFF
--- a/ambari-web/app/views/common/quick_view_link_view.js
+++ b/ambari-web/app/views/common/quick_view_link_view.js
@@ -109,7 +109,9 @@ App.QuickLinksView = Em.View.extend({
     if (App.get('router.clusterController.isServiceMetricsLoaded')) {
       this.setConfigProperties().done((configProperties) => {
         this.get('configProperties').pushObjects(configProperties);
-        this.getQuickLinksHosts();
+        this.getQuickLinksHosts().fail(() => {
+          this.set('showNoLinks', true);
+        });
       });
     }
   }.observes(

--- a/ambari-web/app/views/main/service/item.js
+++ b/ambari-web/app/views/main/service/item.js
@@ -382,16 +382,26 @@ App.MainServiceItemView = Em.View.extend(App.HiveInteractiveCheck, {
   hasConfigTab: function() {
     return App.havePermissions('CLUSTER.VIEW_CONFIGS') && !App.get('services.noConfigTypes').contains(this.get('controller.content.serviceName'));
   }.property('controller.content.serviceName','App.services.noConfigTypes'),
+  
+  hasMasterOrSlaveComponent: function() {
+    return App.SlaveComponent.find().toArray()
+    .concat(App.MasterComponent.find().toArray())
+    .filterProperty('service.serviceName', this.get('controller.content.serviceName'))
+    .mapProperty('totalCount')
+    .reduce((a, b) => a + b, 0) > 0;
+  }.property('controller.content.serviceName'),
 
   hasHeatmapTab: function() {
-    return App.get('services.servicesWithHeatmapTab').contains(this.get('controller.content.serviceName'));
-  }.property('controller.content.serviceName', 'App.services.servicesWithHeatmapTab'),
+    return App.StackService.find(this.get('controller.content.serviceName')).get('hasHeatmapSection')
+      && this.get('hasMasterOrSlaveComponent');
+  }.property('controller.content.serviceName', 'App.services.servicesWithHeatmapTab', 'hasMasterOrSlaveComponent'),
 
   hasMetricTab: function() {
     let serviceName = this.get('controller.content.serviceName');
     let graphs = require('data/service_graph_config')[serviceName.toLowerCase()];
-    return graphs || App.StackService.find(serviceName).get('isServiceWithWidgets');
-  }.property('controller.content.serviceName'),
+    return (graphs || App.StackService.find(serviceName).get('isServiceWithWidgets'))
+      && this.get('hasMasterOrSlaveComponent');
+  }.property('controller.content.serviceName', 'hasMasterOrSlaveComponent'),
 
   didInsertElement: function () {
     this.get('controller').setStartStopState();

--- a/ambari-web/test/views/common/quick_link_view_test.js
+++ b/ambari-web/test/views/common/quick_link_view_test.js
@@ -78,7 +78,7 @@ describe('App.QuickViewLinks', function () {
         done: Em.clb
       };
       sinon.stub(quickViewLinks, 'setConfigProperties').returns(mock);
-      sinon.stub(quickViewLinks, 'getQuickLinksHosts');
+      sinon.stub(quickViewLinks, 'getQuickLinksHosts').returns({fail: Em.clb});
       sinon.stub(App, 'get').returns(true);
     });
     afterEach(function () {
@@ -89,6 +89,12 @@ describe('App.QuickViewLinks', function () {
     it("getQuickLinksHosts should be called", function () {
       quickViewLinks.setQuickLinks();
       expect(quickViewLinks.getQuickLinksHosts.calledOnce).to.be.true;
+      expect(quickViewLinks.get('showNoLinks')).to.be.true;
+    });
+  
+    it("showNoLinks should be true when failed", function () {
+      quickViewLinks.setQuickLinks();
+      expect(quickViewLinks.get('showNoLinks')).to.be.true;
     });
   });
 

--- a/ambari-web/test/views/main/service/item_test.js
+++ b/ambari-web/test/views/main/service/item_test.js
@@ -664,18 +664,24 @@ describe('App.MainServiceItemView', function () {
 
   describe('#hasHeatmapTab', function() {
     beforeEach(function() {
-      sinon.stub(App, 'get').returns(['S1']);
+      sinon.stub(App.StackService, 'find').returns(Em.Object.create({
+        hasHeatmapSection: true
+      }));
     });
     afterEach(function() {
-      App.get.restore();
+      App.StackService.find.restore();
     });
 
     it('should return false when service does not have heatmaps', function() {
-      view.set('controller.content.serviceName', 'S2');
+      view.reopen({
+        hasMasterOrSlaveComponent: false
+      });
       expect(view.get('hasHeatmapTab')).to.be.false;
     });
     it('should return true when service has heatmaps', function() {
-      view.set('controller.content.serviceName', 'S1');
+      view.reopen({
+        hasMasterOrSlaveComponent: true
+      });
       expect(view.get('hasHeatmapTab')).to.be.true;
     });
   });


### PR DESCRIPTION
## How was this patch tested?
 21960 passing (30s)
  48 pending
