### PR TITLE
AMBARI-24888 fix SingleHostTopologyUpdater (benyoka)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -1892,7 +1892,7 @@ public class BlueprintConfigurationProcessor {
       if (!Objects.equals(origValue, replacedValue)) {
         return replacedValue;
       }
-      // localhost typlically means stack default values. If property is set to a concrete value such as an FQDN skip
+      // localhost typically means stack default values. If property is set to a concrete value such as an FQDN skip
       // validation and update
       else if (null != origValue && !origValue.contains(LOCALHOST)) {
         return origValue;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed {{SingleTopologyHostUpdater}}'s semantics to only do topology validation for potentially stack default property values (indicated by {{localhost}} in the property value). This allows for the {{BlueprintConfigurationProcessor}} to process topologies with required components missing (potentially external to the cluster). Properties pointing to the missing components may be set to an empty string or point to an external url/address, depending on the case.

## How was this patch tested?
- Wrote a new unit test
- Tested manual cluster installation with incomplete topology
