### PR TITLE
[AMBARI-24892] Warn During Upgrade When Plugin ClassLoader is not Found

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/UpgradeCheckRegistry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/UpgradeCheckRegistry.java
@@ -207,6 +207,8 @@ public class UpgradeCheckRegistry {
       LOG.error(
           "Unable to perform the following upgrade checks because no libraries could be loaded for the {} stack: {}",
           ownerStackId, StringUtils.join(pluginCheckClassNames, ","));
+
+      pluginChecks.m_failedChecks.addAll(pluginCheckClassNames);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog280.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog280.java
@@ -75,19 +75,18 @@ public class UpgradeCatalog280 extends AbstractUpgradeCatalog {
   }
 
   protected void addColumnsToRequestScheduleTable() throws SQLException {
-    dbAccessor.addColumn(UPGRADE_TABLE,
-        new DBAccessor.DBColumnInfo(UPGRADE_PACK_STACK_ID, String.class, 255,
-            "", false));
-  }
-
-  protected void addColumnsToUpgradeTable() throws SQLException {
     dbAccessor.addColumn(REQUEST_SCHEDULE_TABLE_NAME,
         new DBAccessor.DBColumnInfo(REQUEST_SCHEDULE_BATCH_TOLERATION_LIMIT_PER_BATCH_COLUMN_NAME, Short.class, null,
             null, true));
     dbAccessor.addColumn(REQUEST_SCHEDULE_TABLE_NAME,
         new DBAccessor.DBColumnInfo(REQUEST_SCHEDULE_PAUSE_AFTER_FIRST_BATCH_COLUMN_NAME, Boolean.class, null,
-            null, true));
+            null, true));    
+  }
 
+  protected void addColumnsToUpgradeTable() throws SQLException {
+    dbAccessor.addColumn(UPGRADE_TABLE,
+        new DBAccessor.DBColumnInfo(UPGRADE_PACK_STACK_ID, String.class, 255,
+            "", false));
   }
 
   protected void removeLastValidState() throws SQLException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a stack's plugin classloader is not found, all plugin classes should be added to the set of failed plugins.

## How was this patch tested?

Manual verification using a stack without a `lib` directory.