### PR TITLE
[AMBARI-24886] : Add stack feature constant to support Ranger admin use…

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/constants.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/constants.py
@@ -124,3 +124,4 @@ class StackFeature:
   OOZIE_EXTJS_INCLUDED = "oozie_extjs_included"
   MULTIPLE_ENV_SH_FILES_SUPPORT = "multiple_env_sh_files_support"
   AMS_LEGACY_HADOOP_SINK = "ams_legacy_hadoop_sink"
+  RANGER_ALL_ADMIN_CHANGE_DEFAULT_PASSWORD = 'ranger_all_admin_change_default_password'


### PR DESCRIPTION
…rs password change.

## What changes were proposed in this pull request?
Current Ambari stack for Ranger supports feature to change Ranger admin users passwords through multiple calls. Ranger now supports ability to change all admin users passwords in one call. Need to add stack feature support for the same.

## Changes proposed in this fix:
Adding required feature to the list of stack features.

## How was this patch tested?
Verified the changes with a fresh install on CentOS-6.

PS : This change will be dependent on [RANGER-2279](https://issues.apache.org/jira/browse/RANGER-2279), [review#69259](https://reviews.apache.org/r/69259/) for which is in progress as of now.