### PR TITLE
[AMBARI-24897] Reduce Visible Artifacts from the SPI

### DIFF
--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -21,10 +21,12 @@
     <version>${revision}</version>
     <relativePath>../ambari-project</relativePath>
   </parent>
+  
   <artifactId>ambari-server-spi</artifactId>
   <url>http://ambari.apache.org</url>
   <name>Ambari Server SPI</name>
   <description>A client library which is used for providing plugins for the Ambari Server framework.</description>  
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <xlint>none</xlint>
@@ -35,7 +37,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>
@@ -163,22 +164,30 @@
   </build>  
   
   <dependencies>
+    <!-- not exposed for SPI consumers -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>provided</scope>
     </dependency>
+    
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-    </dependency>
+    
+    <!-- provides consumers of the SPI some basic string manipulations -->
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-    </dependency>    
+    </dependency>
+    
+    <!-- provides consumers of the SPI the ability to use Jackson annotations for object serialization --> 
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/ambari-server-spi/src/main/java/org/apache/ambari/annotations/UpgradeCheckInfo.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/annotations/UpgradeCheckInfo.java
@@ -28,13 +28,11 @@ import org.apache.ambari.spi.upgrade.UpgradeCheck;
 import org.apache.ambari.spi.upgrade.UpgradeCheckGroup;
 import org.apache.ambari.spi.upgrade.UpgradeType;
 
-import com.google.inject.Singleton;
-
 /**
  * The {@link UpgradeCheckInfo} annotation is used to provide ordering and
  * grouping to any {@link UpgradeCheck} instance.
  * <p>
- * Classes marked with this annotation should also be {@link Singleton}. They
+ * Classes marked with this annotation will be instantiated as singletons. They
  * will be discovered on the classpath and then registered with the
  * {@code UpgradeCheckRegistry}.
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?

The SPI exposes too many internal dependencies to its consumers. Some dependencies, such as `commons-lang` might be useful and should still be provided. Others, such as `gson` should be hidden.

- Remove non-essential dependencies from being seen by consumers of the SPI
- Prevent consumers of the SPI from double-copying dependencies which Ambari Server already has

## How was this patch tested?

Performed a full build and dry run deploy:
```
mvn release:prepare -DdryRun=true

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 58.877 s
[INFO] Finished at: 2018-11-14T12:15:31-05:00
[INFO] Final Memory: 22M/618M
[INFO] ------------------------------------------------------------------------
```
Verified dependencies are no longer transitive to consumers.