### PR TITLE
[AMBARI-23478] YARN Cluster CPU Usage Graph Always Shows High CPU Usage

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsDataTransferMethodFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsDataTransferMethodFactory.java
@@ -40,7 +40,9 @@ public class MetricsDataTransferMethodFactory {
     Set<String> metricsWithAggregateFunctionIds = new HashSet<>();
     for (String metric : percentMetrics) {
       for (String aggregateFunctionId : AGGREGATE_FUNCTION_IDENTIFIERS) {
-        metricsWithAggregateFunctionIds.add(metric + aggregateFunctionId);
+        if (!"._sum".equals(aggregateFunctionId)) {
+          metricsWithAggregateFunctionIds.add(metric + aggregateFunctionId);
+        }
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix bug in Ambari Server post processing of metrics. Sum of percentage values can be > 100 and need not be normalized.

## How was this patch tested?
Manually tested.