### PR TITLE
AMBARI-24904. JAR does not exist: /var/lib/ambari-agent/lib/fast-hdfs.jar

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
@@ -206,7 +206,7 @@ class WebHDFSUtil:
   @staticmethod
   def is_webhdfs_available(is_webhdfs_enabled, dfs_type):
     # only hdfs seems to support webHDFS
-    return (is_webhdfs_enabled and dfs_type == 'HDFS')
+    return (is_webhdfs_enabled and dfs_type == 'hdfs')
     
   def run_command(self, *args, **kwargs):
     """
@@ -625,10 +625,10 @@ class HdfsResourceProvider(Provider):
       return
 
     self.assert_parameter_is_set('dfs_type')
-    self.fsType = getattr(resource, 'dfs_type')
+    self.fsType = getattr(resource, 'dfs_type').lower()
     self.can_use_webhdfs = True
 
-    if self.fsType == 'HDFS':
+    if self.fsType == 'hdfs':
       self.assert_parameter_is_set('hdfs_site')
       self.webhdfs_enabled = self.resource.hdfs_site['dfs.webhdfs.enabled']
     else:


### PR DESCRIPTION
Noticed this in HdfsResource tried to use fast-hdfs-resource.jar, but it was missing.

2018-11-13 17:29:20,335 - Audit directory creation in HDFS for KNOX Ranger plugin failed with error:
Execution of 'hadoop --config /usr/hdp/3.0.100.0-38/hadoop/conf jar /var/lib/ambari-agent/lib/fast-hdfs-resource.jar /var/lib/ambari-agent/tmp/hdfs_resources_1542130158.84.json' returned 255. ######## Hortonworks #############
This is MOTD message, added for testing in qe infra
JAR does not exist or is not a normal file: /var/lib/ambari-agent/lib/fast-hdfs-resource.jar
However, it looks like webhdfs should have been used.


        "dfs_type": "HDFS", 
            "dfs.webhdfs.enabled": "true", 
            "sysprep_skip_copy_fast_jar_hdfs": "false"
