### PR TITLE
AMBARI-24905 Service display name on left navigation bar should be suffixed with "Client" if only client service component is present for a service

### DIFF
--- a/ambari-web/app/templates/main/service/menu_item.hbs
+++ b/ambari-web/app/templates/main/service/menu_item.hbs
@@ -33,6 +33,6 @@
     <i {{bindAttr class="view.content.isStarted:started:stopped :icon-circle :status-icon"}}></i>
   {{/unless}}
   <span {{bindAttr class="view.isClientOnlyService:client-only-service :menu-item-name view.content.workStatus view.isMasterDown:master-down" data-original-title="view.content.toolTipContent"}} rel="serviceHealthTooltip">
-      {{unbound view.displayName}}
+      {{view.content.displayName}}
   </span>
 </a>


### PR DESCRIPTION
## How was this patch tested?
 21947 passing (31s)
  48 pending
