### PR TITLE
AMBARI-24908 OneFS mpack should have dfs.webhdfs.enabled = true

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
@@ -19,6 +19,13 @@
 <!-- Put site-specific property overrides in this file. -->
 <configuration supports_final="true">
   <property>
+    <name>dfs.webhdfs.enabled</name>
+    <value>true</value>
+    <display-name>WebHDFS enabled</display-name>
+    <description>Whether to enable WebHDFS feature</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>dfs.namenode.http-address</name>
     <value>localhost:8082</value>
     <description>The name of the default file system.  Either the


### PR DESCRIPTION
Update the OneFS mpack to include default setting for dfs.webhdfs.enabled in the hdfs-site.xml. This setting was removed recently, however, rather than removing it we should have changed the value of the setting from "false" to "true". 

In addition this change allows the setting to be overridden.

(Please fill in changes proposed in this fix)

## How was this patch tested?

The management pack was built with the updated hdfs-site.xml file and installed to a fresh hdp deployment. The services came up correctly and did not complain that they were unable to find "dfs.webhdfs.enabled" in the dictionary.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.