### PR TITLE
AMBARI-24919 external Namenode HA (benyoka)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.topology;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.ambari.server.controller.RequestStatusResponse;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
@@ -67,6 +68,10 @@ public interface ClusterTopology {
    */
   Map<String, HostGroupInfo> getHostGroupInfo();
 
+  /**
+   * @return all hosts in the topology
+   */
+  Set<String> getAllHosts();
   /**
    * Get the names of  all of host groups which contain the specified component.
    *

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/NameNodeHaValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/NameNodeHaValidator.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.topology.validators;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.topology.ClusterTopology;
+import org.apache.ambari.server.topology.HostGroup;
+import org.apache.ambari.server.topology.InvalidTopologyException;
+import org.apache.ambari.server.topology.TopologyValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+
+/**
+ * Validates NAMENODE HA setup correctness.
+ */
+public class NameNodeHaValidator implements TopologyValidator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NameNodeHaValidator.class);
+  private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
+
+  @Override
+  public void validate(ClusterTopology topology) throws InvalidTopologyException {
+    if( topology.isNameNodeHAEnabled() ) {
+
+      if (!allHostNamesAreKnown(topology)) {
+        LOG.warn("Provision cluster template contains hostgroup(s) without explicit hostnames. Cannot validate NAMENODE HA setup in this case.");
+        return;
+      }
+
+      Collection<String> nnHosts = topology.getHostAssignmentsForComponent("NAMENODE");
+
+      if (nnHosts.isEmpty()) {
+        LOG.info("NAMENODE HA is enabled but there are no NAMENODE components in the cluster. Assuming external name nodes.");
+        validateExternalNamenodeHa(topology);
+      }
+      else if (nnHosts.size() == 1) {
+        throw new InvalidTopologyException("NAMENODE HA requires at least two hosts running NAMENODE but there is only one: " +
+          nnHosts.iterator().next());
+      }
+
+      Map<String, String> hadoopEnvConfig = topology.getConfiguration().getFullProperties().get("hadoop-env");
+      if(hadoopEnvConfig != null && !hadoopEnvConfig.isEmpty() && hadoopEnvConfig.containsKey("dfs_ha_initial_namenode_active") && hadoopEnvConfig.containsKey("dfs_ha_initial_namenode_standby")) {
+        if((!HostGroup.HOSTGROUP_REGEX.matcher(hadoopEnvConfig.get("dfs_ha_initial_namenode_active")).matches() && !nnHosts.contains(hadoopEnvConfig.get("dfs_ha_initial_namenode_active")))
+          || (!HostGroup.HOSTGROUP_REGEX.matcher(hadoopEnvConfig.get("dfs_ha_initial_namenode_standby")).matches() && !nnHosts.contains(hadoopEnvConfig.get("dfs_ha_initial_namenode_standby")))){
+          throw new InvalidTopologyException("NAMENODE HA hosts mapped incorrectly for properties 'dfs_ha_initial_namenode_active' and 'dfs_ha_initial_namenode_standby'. Expected hosts are: " + nnHosts);
+        }
+      }
+    }
+
+  }
+
+  private boolean allHostNamesAreKnown(ClusterTopology topology) {
+    return topology.getHostGroupInfo().values().stream().allMatch(
+      hg -> !hg.getHostNames().isEmpty());
+  }
+
+  /**
+   * Verifies that all respective properties are set for an external NANENODE HA setup
+   */
+  public void validateExternalNamenodeHa(ClusterTopology topology) throws InvalidTopologyException {
+    Map<String, String> hdfsSite = topology.getConfiguration().getFullProperties().get("hdfs-site");
+    Set<String> hosts = topology.getAllHosts();
+
+    for (Map.Entry<String, List<String>> entry: getNameServicesToNameNodes(hdfsSite).entrySet()) {
+      String nameService = entry.getKey();
+      List<String> nameNodes = entry.getValue();
+      for (String nameNode: nameNodes) {
+        String address = hdfsSite.get("dfs.namenode.rpc-address." + nameService + "." + nameNode);
+        checkValidExternalNameNodeAddress(nameService, nameNode, address, hosts);
+      }
+    }
+  }
+
+  private void checkValidExternalNameNodeAddress(String nameService, String nameNode, String address, Set<String> hosts) throws InvalidTopologyException {
+    final String errorMessage = "Illegal external HA NAMENODE address for name service [%s], namenode [%s]: [%s]. Address " +
+      "must be in <host>:<port> format where host is external to the cluster.";
+
+    checkInvalidTopology(
+      Strings.isNullOrEmpty(address) || address.contains("localhost") || address.contains("%HOSTGROUP") || !address.contains(":"),
+      errorMessage, nameService, nameNode, address);
+
+    String hostName = address.substring(0, address.indexOf(':'));
+
+    checkInvalidTopology(hostName.isEmpty() || hosts.contains(hostName),
+      errorMessage, nameService, nameNode, address);
+  }
+
+  Map<String, List<String>> getNameServicesToNameNodes(Map<String, String> hdfsSite) throws InvalidTopologyException {
+    String nameServices = null != hdfsSite.get("dfs.internal.nameservices") ?
+      hdfsSite.get("dfs.internal.nameservices") : hdfsSite.get("dfs.nameservices");
+    Map<String, List<String>> nameServicesToNameNodes = new HashMap<>();
+
+    for (String ns: SPLITTER.splitToList(nameServices)) {
+      String nameNodes = hdfsSite.get("dfs.ha.namenodes." + ns);
+      checkInvalidTopology(Strings.isNullOrEmpty(nameNodes),
+        "No namenodes specified for nameservice %s.", ns);
+      nameServicesToNameNodes.put(ns, SPLITTER.splitToList(nameNodes));
+    }
+
+    return nameServicesToNameNodes;
+  }
+
+
+  private void checkInvalidTopology(boolean errorCondition, String errorMessageTemplate, Object... errorMessageParams) throws InvalidTopologyException {
+    if (errorCondition) throw new InvalidTopologyException(String.format(errorMessageTemplate, errorMessageParams));
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidatorFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/validators/TopologyValidatorFactory.java
@@ -24,8 +24,13 @@ public class TopologyValidatorFactory {
   List<TopologyValidator> validators;
 
   public TopologyValidatorFactory() {
-    validators = ImmutableList.of(new RequiredConfigPropertiesValidator(), new RequiredPasswordValidator(), new HiveServiceValidator(),
-      new StackConfigTypeValidator(), new UnitValidator(UnitValidatedProperty.ALL));
+    validators = ImmutableList.of(
+      new RequiredConfigPropertiesValidator(),
+      new RequiredPasswordValidator(),
+      new HiveServiceValidator(),
+      new StackConfigTypeValidator(),
+      new UnitValidator(UnitValidatedProperty.ALL),
+      new NameNodeHaValidator());
   }
 
   public TopologyValidator createConfigurationValidatorChain() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterTopologyImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterTopologyImplTest.java
@@ -49,11 +49,11 @@ public class ClusterTopologyImplTest {
   private static final String CLUSTER_NAME = "cluster_name";
   private static final long CLUSTER_ID = 1L;
   private static final String predicate = "Hosts/host_name=foo";
-  private static final Blueprint blueprint = createNiceMock(Blueprint.class);
-  private static final HostGroup group1 = createNiceMock(HostGroup.class);
-  private static final HostGroup group2 = createNiceMock(HostGroup.class);
-  private static final HostGroup group3 = createNiceMock(HostGroup.class);
-  private static final HostGroup group4 = createNiceMock(HostGroup.class);
+  private final Blueprint blueprint = createNiceMock(Blueprint.class);
+  private final HostGroup group1 = createNiceMock(HostGroup.class);
+  private final HostGroup group2 = createNiceMock(HostGroup.class);
+  private final HostGroup group3 = createNiceMock(HostGroup.class);
+  private final HostGroup group4 = createNiceMock(HostGroup.class);
   private final Map<String, HostGroupInfo> hostGroupInfoMap = new HashMap<>();
   private final Map<String, HostGroup> hostGroupMap = new HashMap<>();
 
@@ -148,7 +148,6 @@ public class ClusterTopologyImplTest {
     verify(blueprint, group1, group2, group3, group4);
     reset(blueprint, group1, group2, group3, group4);
 
-
     hostGroupInfoMap.clear();
     hostGroupMap.clear();
   }
@@ -178,50 +177,6 @@ public class ClusterTopologyImplTest {
     replayAll();
 
     new ClusterTopologyImpl(null, request).getHostAssignmentsForComponent("component1");
-  }
-
-  @Test(expected = InvalidTopologyException.class)
-  public void testCreate_NNHAInvaid() throws Exception {
-    bpconfiguration.setProperty("hdfs-site", "dfs.nameservices", "val");
-    expect(group4.getName()).andReturn("group4");
-    hostGroupInfoMap.get("group4").removeHost("host5");
-    TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
-    replayAll();
-    new ClusterTopologyImpl(null, request);
-    hostGroupInfoMap.get("group4").addHost("host5");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCreate_NNHAHostNameNotCorrectForStandby() throws Exception {
-    expect(group4.getName()).andReturn("group4");
-    bpconfiguration.setProperty("hdfs-site", "dfs.nameservices", "val");
-    bpconfiguration.setProperty("hadoop-env", "dfs_ha_initial_namenode_active", "host4");
-    bpconfiguration.setProperty("hadoop-env", "dfs_ha_initial_namenode_standby", "val");
-    TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
-    replayAll();
-    new ClusterTopologyImpl(null, request);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCreate_NNHAHostNameNotCorrectForActive() throws Exception {
-    expect(group4.getName()).andReturn("group4");
-    bpconfiguration.setProperty("hdfs-site", "dfs.nameservices", "val");
-    bpconfiguration.setProperty("hadoop-env", "dfs_ha_initial_namenode_active", "val");
-    bpconfiguration.setProperty("hadoop-env", "dfs_ha_initial_namenode_standby", "host5");
-    TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
-    replayAll();
-    new ClusterTopologyImpl(null, request);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCreate_NNHAHostNameNotCorrectForStandbyWithActiveAsVariable() throws Exception {
-    expect(group4.getName()).andReturn("group4");
-    bpconfiguration.setProperty("hdfs-site", "dfs.nameservices", "val");
-    bpconfiguration.setProperty("hadoop-env", "dfs_ha_initial_namenode_active", "%HOSTGROUP::group4%");
-    bpconfiguration.setProperty("hadoop-env", "dfs_ha_initial_namenode_standby", "host6");
-    TestTopologyRequest request = new TestTopologyRequest(TopologyRequest.Type.PROVISION);
-    replayAll();
-    new ClusterTopologyImpl(null, request);
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/NameNodeHaValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/validators/NameNodeHaValidatorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ambari.server.topology.validators;
+
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.topology.ClusterTopology;
+import org.apache.ambari.server.topology.ClusterTopologyImpl;
+import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.topology.HostGroupInfo;
+import org.apache.ambari.server.topology.InvalidTopologyException;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+@RunWith(EasyMockRunner.class)
+public class NameNodeHaValidatorTest {
+
+  Set<String> hosts = new HashSet<>();
+  Set<String> nameNodes = new HashSet<>();
+  Map<String, HostGroupInfo> hostGroupInfos = new HashMap<>();
+  Map<String, String> hdfsSite = new HashMap<>();
+  Map<String, String> hadoopEnv = new HashMap<>();
+  Map<String, Map<String, String>> fullProperties = ImmutableMap.of("hdfs-site", hdfsSite, "hadoop-env", hadoopEnv);
+  NameNodeHaValidator validator = new NameNodeHaValidator();
+
+  @Mock
+  Configuration clusterConfig;
+
+  @Mock
+  ClusterTopology clusterTopology;
+
+  @Before
+  public void setUp() {
+    expect(clusterTopology.getConfiguration()).andReturn(clusterConfig).anyTimes();
+    expect(clusterTopology.getAllHosts()).andReturn(hosts).anyTimes();
+    expect(clusterTopology.getHostAssignmentsForComponent("NAMENODE")).andReturn(nameNodes).anyTimes();
+    expect(clusterTopology.isNameNodeHAEnabled())
+      .andAnswer(() -> ClusterTopologyImpl.isNameNodeHAEnabled(fullProperties))
+      .anyTimes();
+    expect(clusterTopology.getHostGroupInfo()).andReturn(hostGroupInfos).anyTimes();
+    expect(clusterConfig.getFullProperties()).andReturn(fullProperties).anyTimes();
+    replay(clusterTopology, clusterConfig);
+    createDefaultHdfsSite();
+    hosts.addAll(ImmutableSet.of("internalhost1", "internalhost2"));
+  }
+
+  private void createDefaultHdfsSite() {
+    hdfsSite.put("dfs.nameservices", "demo1, demo2");
+    hdfsSite.put("dfs.ha.namenodes.demo1", "nn1, nn2");
+    hdfsSite.put("dfs.ha.namenodes.demo2", "nn1, nn2");
+  }
+
+  private void addExternalNameNodesToHdfsSite() {
+    hdfsSite.put("dfs.namenode.rpc-address.demo1.nn1", "demohost1:8020");
+    hdfsSite.put("dfs.namenode.rpc-address.demo1.nn2", "demohost2:8020");
+    hdfsSite.put("dfs.namenode.rpc-address.demo2.nn1", "demohost3:8020");
+    hdfsSite.put("dfs.namenode.rpc-address.demo2.nn2", "demohost4:8020");
+  }
+
+  @Test
+  public void nonHA() throws Exception {
+     hdfsSite.clear();
+     validator.validate(clusterTopology);
+  }
+
+  @Test
+  public void externalNameNodes_properConfig1() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    validator.validate(clusterTopology);
+  }
+
+  @Test
+  public void externalNameNodes_properConfig2() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.remove("dfs.nameservices");
+    hdfsSite.put("dfs.internal.nameservices", "demo1, demo2");
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void externalNameNodes_missingNameNodes() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.remove("dfs.ha.namenodes.demo2");
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void externalNameNodes_missingRpcAddress() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.remove("dfs.namenode.rpc-address.demo2.nn1");
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void externalNameNodes_localhost() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.put("dfs.namenode.rpc-address.demo2.nn1", "localhost:8020");
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void externalNameNodes_hostGroupToken() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.put("dfs.namenode.rpc-address.demo2.nn1", "%HOSTGROUP::group1%:8020");
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void externalNameNodes_missingPort() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.put("dfs.namenode.rpc-address.demo2.nn1", "demohost3");
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void externalNameNodes_internalHost() throws Exception {
+    addExternalNameNodesToHdfsSite();
+    hdfsSite.put("dfs.namenode.rpc-address.demo2.nn1", "internalhost1:8020");
+    validator.validate(clusterTopology);
+  }
+
+  @Test
+  public void validationSkippedDueToMissingHostInformation() throws Exception {
+    // this is an invalid HA topology as there is only one namenode
+    nameNodes.add(hosts.iterator().next());
+
+    // adding a host group without hosts prohibits validation
+    HostGroupInfo groupInfo = new HostGroupInfo("group1");
+    hostGroupInfos.put(groupInfo.getHostGroupName(), groupInfo);
+
+    // yet this call should not throw exception as validation should be skipped
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void notEnoughNameNodesForHa() throws Exception {
+    nameNodes.add(hosts.iterator().next());
+    validator.validate(clusterTopology);
+  }
+
+  @Test
+  public void haNoInitialSetup() throws Exception {
+    List<String> nameNodeHosts = ImmutableList.copyOf(hosts).subList(0, 2);
+    nameNodes.addAll(nameNodeHosts);
+    validator.validate(clusterTopology);
+  }
+
+  @Test
+  public void haProperInitialSetup() throws Exception {
+    List<String> nameNodeHosts = ImmutableList.copyOf(hosts).subList(0, 2);
+    nameNodes.addAll(nameNodeHosts);
+
+    hadoopEnv.put("dfs_ha_initial_namenode_active", nameNodeHosts.get(0));
+    hadoopEnv.put("dfs_ha_initial_namenode_active", nameNodeHosts.get(1));
+
+    validator.validate(clusterTopology);
+  }
+
+  @Test
+  public void haProperInitialSetupWithHostGroups() throws Exception {
+    List<String> nameNodeHosts = ImmutableList.copyOf(hosts).subList(0, 2);
+    nameNodes.addAll(nameNodeHosts);
+
+    hadoopEnv.put("dfs_ha_initial_namenode_active", "%HOSTGROUP::group1%");
+    hadoopEnv.put("dfs_ha_initial_namenode_standby", "%HOSTGROUP::group2%");
+
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void haInvalidInitialActive() throws Exception {
+    List<String> nameNodeHosts = ImmutableList.copyOf(hosts).subList(0, 2);
+    nameNodes.addAll(nameNodeHosts);
+
+    hadoopEnv.put("dfs_ha_initial_namenode_active", "externalhost");
+    hadoopEnv.put("dfs_ha_initial_namenode_standby", nameNodeHosts.get(0));
+
+    validator.validate(clusterTopology);
+  }
+
+  @Test(expected = InvalidTopologyException.class)
+  public void haInvalidInitialStandby() throws Exception {
+    List<String> nameNodeHosts = ImmutableList.copyOf(hosts).subList(0, 2);
+    nameNodes.addAll(nameNodeHosts);
+
+    hadoopEnv.put("dfs_ha_initial_namenode_active", nameNodeHosts.get(0));
+    hadoopEnv.put("dfs_ha_initial_namenode_standby", "externalhost");
+
+    validator.validate(clusterTopology);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Refactored Namenode HA validation to be part of the topology validation chain.
- Changed Namenode HA validation to accept the following setup:
  - There are zero namenodes
  - All namenode rpc addresses point to an external fqdn.
- The setup above indicates that namenodes are intentionally omitted and HDFS client points to external namenodes 

## How was this patch tested?
- Tested namenode HA installation manually with external namenodes, also with missing namenode
 - Wrote unit tests for Namenode HA validation and blueprint configuration processing.
