### PR TITLE
AMBARI-24921 If service does not have client service component created then "Run Service Check" option should be made hidden

### DIFF
--- a/ambari-web/app/views/main/service/item.js
+++ b/ambari-web/app/views/main/service/item.js
@@ -158,7 +158,8 @@ App.MainServiceItemView = Em.View.extend(App.HiveInteractiveCheck, {
     var allMasters = service.get('hostComponents').filterProperty('isMaster').mapProperty('componentName').uniq();
     var allSlaves = service.get('slaveComponents').rejectProperty('totalCount', 0).mapProperty('componentName');
     var actionMap = App.HostComponentActionMap.getMap(this);
-    var serviceCheckSupported = App.get('services.supportsServiceCheck').contains(service.get('serviceName'));
+    var serviceCheckSupported = App.get('services.supportsServiceCheck').contains(service.get('serviceName'))
+      && service.get('installedClients') > 0;
     var hasConfigTab = this.get('hasConfigTab');
     var excludedCommands = this.get('mastersExcludedCommands');
     var serviceName = service.get('serviceName');

--- a/ambari-web/test/views/main/service/item_test.js
+++ b/ambari-web/test/views/main/service/item_test.js
@@ -563,6 +563,7 @@ describe('App.MainServiceItemView', function () {
                 serviceName: testCase.serviceName,
                 displayName: testCase.displayName,
                 serviceTypes: testCase.serviceTypes,
+                installedClients: 1,
                 passiveState: 'OFF'
               }),
               isSeveralClients: false,


### PR DESCRIPTION
## How was this patch tested?
 21947 passing (31s)
  48 pending
