### PR TITLE
AMBARI-24913. New LDAP related properties to indicate if Ambari should manage LDAP configuration for certain services

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
@@ -25,6 +25,9 @@ public enum AmbariServerConfigurationKey {
   /* ********************************************************
    * LDAP Configuration Keys
    * ******************************************************** */
+  AMBARI_MANAGES_LDAP_CONFIGURATION(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, "ambari.ldap.manage_services", PLAINTEXT, "false", "A Boolean value indicating whether Ambari is to manage the LDAP configuration for services or not."),
+  LDAP_ENABLED_SERVICES(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, "ambari.ldap.enabled_services", PLAINTEXT, null, "A comma-delimited list of services that are expected to be configured for LDAP.  A \"*\" indicates all services."),
+
   LDAP_ENABLED(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, "ambari.ldap.authentication.enabled", PLAINTEXT, "false", "An internal property used for unit testing and development purposes."),
   SERVER_HOST(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, "ambari.ldap.connectivity.server.host", PLAINTEXT, "localhost", "The LDAP URL host used for connecting to an LDAP server when authenticating users."),
   SERVER_PORT(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, "ambari.ldap.connectivity.server.port", PLAINTEXT, "33389", "The LDAP URL port used for connecting to an LDAP server when authenticating users."),

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
@@ -66,7 +66,7 @@ public class AmbariServerLDAPConfigurationHandler extends AmbariServerStackAdvis
   public void updateComponentCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException {
     super.updateComponentCategory(categoryName, properties, removePropertiesIfNotSpecified);
     final AmbariLdapConfiguration ldapConfiguration = new AmbariLdapConfiguration(getConfigurationProperties(AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName()));
-    if (ldapConfiguration.ldapEnabled()) {
+    if (ldapConfiguration.isAmbariManagesLdapConfiguration()) {
       processClusters(LDAP_CONFIGURATIONS);
     }
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfiguration.java
@@ -71,6 +71,14 @@ public class AmbariLdapConfiguration {
     this.configurationMap = configuration;
   }
 
+  public boolean isAmbariManagesLdapConfiguration() {
+    return Boolean.valueOf(configValue(AmbariServerConfigurationKey.AMBARI_MANAGES_LDAP_CONFIGURATION));
+  }
+
+  public String getLdapEnabledServices() {
+    return configValue(AmbariServerConfigurationKey.LDAP_ENABLED_SERVICES);
+  }
+
   public boolean ldapEnabled() {
     return Boolean.valueOf(configValue(AmbariServerConfigurationKey.LDAP_ENABLED));
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1683,6 +1683,14 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
             populateConfigurationToBeMoved(propertiesToBeMoved, null, AmbariServerConfigurationKey.SSO_MANAGE_SERVICES, "true");
             populateConfigurationToBeMoved(propertiesToBeMoved, null, AmbariServerConfigurationKey.SSO_ENABLED_SERVICES, "AMBARI");
           }
+        } else if (AmbariServerConfigurationKey.LDAP_ENABLED == key) {
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, key, propertyValue);
+
+          if ("true".equalsIgnoreCase(propertyValue)) {
+            // Add the new properties to tell Ambari that LDAP is enabled:
+            populateConfigurationToBeMoved(propertiesToBeMoved, null, AmbariServerConfigurationKey.AMBARI_MANAGES_LDAP_CONFIGURATION, "true");
+            populateConfigurationToBeMoved(propertiesToBeMoved, null, AmbariServerConfigurationKey.LDAP_ENABLED_SERVICES, "AMBARI");
+          }
         } else {
           populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, key, propertyValue);
         }

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -1267,6 +1267,9 @@ public class UpgradeCatalog270Test {
     expect(entityManager.find(anyObject(), anyObject())).andReturn(null).anyTimes();
     final Map<String, String> properties = new HashMap<>();
     properties.put(AmbariServerConfigurationKey.LDAP_ENABLED.key(), "true");
+    properties.put(AmbariServerConfigurationKey.AMBARI_MANAGES_LDAP_CONFIGURATION.key(), "true");
+    properties.put(AmbariServerConfigurationKey.LDAP_ENABLED_SERVICES.key(), "AMBARI");
+
     expect(ambariConfigurationDao.reconcileCategory(AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName(), properties, false)).andReturn(true).once();
     replay(entityManager, ambariConfigurationDao);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated `ldap-configuration` category in Ambari Configurations data to contain properties to aid in automated LDAP configuration:

- `ambari.ldap.manage_services` - This property is used to indicate whether Ambari is to manage relevant services' LDAP configurations or not ("true" | "false")
- `ambari.ldap.enabled_services` -This property is used to declare what services are expected to be configured for LDAP and is expected to be a comma-delimited list of services or "*" to indicate all services.

## How was this patch tested?

Added new unit tests and updated existing ones in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 30:40 min
[INFO] Finished at: 2018-11-19T13:14:02+01:00
[INFO] Final Memory: 162M/959M
[INFO] ------------------------------------------------------------------------
```

In addition to this I issued a PUT request using Ambari's API with the two new preoprties and then queried ldap-configurations in my browser:
![screen shot 2018-11-19 at 12 40 25 pm](https://user-images.githubusercontent.com/34065904/48707376-8b3cb700-ebff-11e8-8bf2-5d7d0d1653ca.png)
