### PR TITLE
[AMBARI-24922] No need to create test jar if tests are skipped.

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -91,6 +91,7 @@
       </activation>
       <properties>
         <skipPythonTests>true</skipPythonTests>
+        <skipSurefireTests>true</skipSurefireTests>
       </properties>
     </profile>
   </profiles>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -192,6 +192,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipSurefireTests}</skip>
               <target>
                 <mkdir dir="target/test-classes/extensions/EXT/0.1/services/OOZIE2/checks/tmp"/>
               </target>
@@ -204,6 +205,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipSurefireTests}</skip>
               <target>
                 <mkdir dir="target/test-classes/extensions/EXT/0.1/services/OOZIE2/server_actions/tmp"/>
               </target>
@@ -720,6 +722,7 @@
               <goal>test-jar</goal>
             </goals>
             <configuration>
+              <skip>${skipSurefireTests}</skip>
               <outputDirectory>target/test-classes/checks</outputDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid running the following tasks if Java tests are skipped, to save some time during dev build:

 * `generate-test-oozie2-checks-dir`
 * `generate-test-oozie2-server-actions-dir`
 * `create-sample-upgrade-check-jar`

https://issues.apache.org/jira/browse/AMBARI-24922

## How was this patch tested?

Verified that the tasks are executed by default:

```
$ mvn -am -pl ambari-server -DfailIfNoTests=false -Dtest=StackManagerExtensionTest clean test
...
[INFO] --- maven-antrun-plugin:1.7:run (clean-sample-upgrade-check-jar) @ ambari-server ---
[INFO] Executing tasks

main:
[INFO] Executed tasks
[INFO]
[INFO] --- maven-antrun-plugin:1.7:run (generate-test-oozie2-checks-dir) @ ambari-server ---
[INFO] Executing tasks

main:
    [mkdir] Created dir: ambari-server/target/test-classes/extensions/EXT/0.1/services/OOZIE2/checks/tmp
[INFO] Executed tasks
[INFO]
[INFO] --- maven-antrun-plugin:1.7:run (generate-test-oozie2-server-actions-dir) @ ambari-server ---
[INFO] Executing tasks

main:
    [mkdir] Created dir: ambari-server/target/test-classes/extensions/EXT/0.1/services/OOZIE2/server_actions/tmp
[INFO] Executed tasks
[INFO]
[INFO] --- maven-jar-plugin:3.0.2:test-jar (create-sample-upgrade-check-jar) @ ambari-server ---
[INFO] Building jar: ambari-server/target/test-classes/checks/ambari-server-3.0.0.0-SNAPSHOT-tests.jar
[INFO]
[INFO] --- maven-surefire-plugin:2.20:test (default-test) @ ambari-server ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ambari.server.stack.StackManagerExtensionTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.889 s - in org.apache.ambari.server.stack.StackManagerExtensionTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] BUILD SUCCESS
```

Verified that the tasks are not run if Java tests are skipped:

```
$ mvn -am -pl ambari-server -DskipSurefireTests clean test
...
[INFO] --- maven-antrun-plugin:1.7:run (clean-sample-upgrade-check-jar) @ ambari-server ---
[INFO] Executing tasks

main:
[INFO] Executed tasks
[INFO]
[INFO] --- maven-antrun-plugin:1.7:run (generate-test-oozie2-checks-dir) @ ambari-server ---
[INFO] Skipping Antrun execution
[INFO]
[INFO] --- maven-antrun-plugin:1.7:run (generate-test-oozie2-server-actions-dir) @ ambari-server ---
[INFO] Skipping Antrun execution
[INFO]
[INFO] --- maven-jar-plugin:3.0.2:test-jar (create-sample-upgrade-check-jar) @ ambari-server ---
[INFO] Skipping packaging of the test-jar
[INFO]
[INFO] --- maven-surefire-plugin:2.20:test (default-test) @ ambari-server ---
[INFO] Tests are skipped.
...
[INFO] BUILD SUCCESS
```

Same with skipping all tests (`-DskipTests`).