### PR TITLE
[AMBARI-24917] Implement complex Add Service request using default configs

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/handlers/CreateHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/handlers/CreateHandler.java
@@ -77,7 +77,7 @@ public class CreateHandler extends BaseManagementHandler {
     } catch (ResourceAlreadyExistsException e) {
       result = new ResultImpl(new ResultStatus(ResultStatus.STATUS.CONFLICT, e.getMessage()));
     } catch(IllegalArgumentException e) {
-      LOG.error("Bad request received: " + e.getMessage());
+      LOG.error("Bad request received: " + e.getMessage(), e);
       result = new ResultImpl(new ResultStatus(ResultStatus.STATUS.BAD_REQUEST, e.getMessage()));
     } catch (RuntimeException e) {
       if (LOG.isErrorEnabled()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -799,7 +799,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
    * @throws NoSuchResourceException        the query didn't match any resources
    * @throws NoSuchParentResourceException  a specified parent resource doesn't exist
    */
-  private RequestStageContainer doUpdateResources(final RequestStageContainer stages, final Request request,
+  public RequestStageContainer doUpdateResources(final RequestStageContainer stages, final Request request,
                                                   Predicate predicate, boolean performQueryEvaluation,
                                                   boolean useGeneratedConfigs, boolean useClusterHostInfo)
                                                   throws UnsupportedPropertyException,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -244,9 +244,9 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     if (request.getProperties().size() == 1) {
       Map<String, Object> requestProperties = request.getProperties().iterator().next();
       if (isAddServiceRequest(requestProperties)) {
-        processAddServiceRequest(requestProperties, request.getRequestInfoProperties());
+        RequestStatusResponse response = processAddServiceRequest(requestProperties, request.getRequestInfoProperties());
         notifyCreate(Resource.Type.Service, request);
-        return getRequestStatus(null);
+        return getRequestStatus(response);
       }
     }
 
@@ -1214,11 +1214,11 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     return OperationType.ADD_SERVICE.name().equals(properties.get(OPERATION_TYPE));
   }
 
-  private void processAddServiceRequest(Map<String, Object> requestProperties, Map<String, String> requestInfoProperties) throws NoSuchParentResourceException {
+  private RequestStatusResponse processAddServiceRequest(Map<String, Object> requestProperties, Map<String, String> requestInfoProperties) throws NoSuchParentResourceException {
     AddServiceRequest request = createAddServiceRequest(requestProperties, requestInfoProperties);
     String clusterName = String.valueOf(requestProperties.get(SERVICE_CLUSTER_NAME_PROPERTY_ID));
     try {
-      addServiceOrchestrator.processAddServiceRequest(getManagementController().getClusters().getCluster(clusterName), request);
+      return addServiceOrchestrator.processAddServiceRequest(getManagementController().getClusters().getCluster(clusterName), request);
     } catch (AmbariException e) {
       throw new NoSuchParentResourceException(e.getMessage(), e);
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UnitUpdater.java
@@ -49,15 +49,20 @@ public class UnitUpdater implements BlueprintConfigurationProcessor.PropertyUpda
                                        String origValue,
                                        Map<String, Map<String, String>> properties,
                                        ClusterTopology topology) {
-      PropertyUnit stackUnit = PropertyUnit.of(topology.getBlueprint().getStack(), serviceName, configType, propertyName);
-      PropertyValue value = PropertyValue.of(propertyName, origValue);
-      if (value.hasUnit(stackUnit)) {
-        return value.toString();
-      } else if (!value.hasAnyUnit()) {
-        return value.withUnit(stackUnit);
-      } else { // should not happen because of pre-validation in UnitValidator
-        throw new IllegalArgumentException("Property " + propertyName + "=" + origValue + " has an unsupported unit. Stack supported unit is: " + stackUnit + " or no unit");
-      }
+    Stack stack = topology.getBlueprint().getStack();
+    return updateForClusterCreate(stack, serviceName, configType, propertyName, origValue);
+  }
+
+  public static String updateForClusterCreate(Stack stack, String serviceName, String configType, String propertyName, String origValue) {
+    PropertyUnit stackUnit = PropertyUnit.of(stack, serviceName, configType, propertyName);
+    PropertyValue value = PropertyValue.of(propertyName, origValue);
+    if (value.hasUnit(stackUnit)) {
+      return value.toString();
+    } else if (!value.hasAnyUnit()) {
+      return value.withUnit(stackUnit);
+    } else { // should not happen because of pre-validation in UnitValidator
+      throw new IllegalArgumentException("Property " + propertyName + "=" + origValue + " has an unsupported unit. Stack supported unit is: " + stackUnit + " or no unit");
+    }
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
@@ -17,8 +17,14 @@
  */
 package org.apache.ambari.server.topology.addservice;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.ambari.server.controller.internal.RequestStageContainer;
+import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.topology.Configuration;
 
 /**
  * Processed info for adding new services/components to an existing cluster.
@@ -26,15 +32,30 @@ import java.util.Set;
 public final class AddServiceInfo {
 
   private final String clusterName;
+  private final Stack stack;
   private final Map<String, Map<String, Set<String>>> newServices;
+  private final RequestStageContainer stages;
+  private final Configuration config;
 
-  public AddServiceInfo(String clusterName, Map<String, Map<String, Set<String>>> newServices) {
+  public AddServiceInfo(String clusterName, Stack stack, Configuration config, RequestStageContainer stages, Map<String, Map<String, Set<String>>> newServices) {
     this.clusterName = clusterName;
+    this.stack = stack;
     this.newServices = newServices;
+    this.stages = stages;
+    this.config = config;
+  }
+
+  @Override
+  public String toString() {
+    return "AddServiceRequest(" + stages.getId() + ")";
   }
 
   public String clusterName() {
     return clusterName;
+  }
+
+  public RequestStageContainer getStages() {
+    return stages;
   }
 
   /**
@@ -44,4 +65,27 @@ public final class AddServiceInfo {
   public Map<String, Map<String, Set<String>>> newServices() {
     return newServices;
   }
+
+  public Stack getStack() {
+    return stack;
+  }
+
+  public Configuration getConfig() {
+    return config;
+  }
+
+  /**
+   * Creates a descriptive label to be displayed in the UI.
+   */
+  public String describe() {
+    int maxServicesToShow = 3;
+    StringBuilder sb = new StringBuilder("Add Services: ")
+      .append(newServices.keySet().stream().sorted().limit(maxServicesToShow).collect(joining(", ")));
+    if (newServices.size() > maxServicesToShow) {
+      sb.append(" and ").append(newServices.size() - maxServicesToShow).append(" more");
+    }
+    sb.append(" to cluster ").append(clusterName);
+    return sb.toString();
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
@@ -17,15 +17,36 @@
  */
 package org.apache.ambari.server.topology.addservice;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.ClusterRequest;
+import org.apache.ambari.server.controller.ConfigurationRequest;
+import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
+import org.apache.ambari.server.controller.internal.ComponentResourceProvider;
+import org.apache.ambari.server.controller.internal.HostComponentResourceProvider;
 import org.apache.ambari.server.controller.internal.RequestImpl;
+import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.ServiceResourceProvider;
+import org.apache.ambari.server.controller.predicate.AndPredicate;
+import org.apache.ambari.server.controller.predicate.EqualsPredicate;
+import org.apache.ambari.server.controller.predicate.OrPredicate;
 import org.apache.ambari.server.controller.spi.ClusterController;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
+import org.apache.ambari.server.controller.spi.NoSuchResourceException;
+import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
@@ -33,19 +54,27 @@ import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.ClusterControllerHelper;
+import org.apache.ambari.server.controller.utilities.PropertyHelper;
+import org.apache.ambari.server.security.authorization.AuthorizationException;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Creates resources using the resource providers.
  * Translates {@link AddServiceInfo} to internal requests accepted by those.
  */
+@Singleton
 public class ResourceProviderAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ResourceProviderAdapter.class);
+
+  @Inject
+  private AmbariManagementController controller;
 
   public void createServices(AddServiceInfo request) {
     LOG.info("Creating service resources for {}", request);
@@ -54,14 +83,113 @@ public class ResourceProviderAdapter {
       .map(service -> createServiceRequestProperties(request, service))
       .collect(toSet());
 
+    createResources(properties, Resource.Type.Service);
+  }
+
+  public void createComponents(AddServiceInfo request) {
+    LOG.info("Creating component resources for {}", request);
+
+    Set<Map<String, Object>> properties = request.newServices().entrySet().stream()
+      .flatMap(componentsOfService -> componentsOfService.getValue().keySet().stream()
+        .map(component -> createComponentRequestProperties(request, componentsOfService.getKey(), component)))
+      .collect(toSet());
+
+    createResources(properties, Resource.Type.Component);
+  }
+
+  public void createHostComponents(AddServiceInfo request) {
+    LOG.info("Creating host component resources for {}", request);
+
+    Set<Map<String, Object>> properties = request.newServices().entrySet().stream()
+      .flatMap(componentsOfService -> componentsOfService.getValue().entrySet().stream()
+        .flatMap(hostsOfComponent -> hostsOfComponent.getValue().stream()
+          .map(host -> createHostComponentRequestProperties(request, componentsOfService.getKey(), hostsOfComponent.getKey(), host))))
+      .collect(toSet());
+
+    createResources(properties, Resource.Type.HostComponent);
+  }
+
+  public void createConfigs(AddServiceInfo request) {
+    LOG.info("Creating configurations for {}", request);
+
+    Set<ClusterRequest> requests = new HashSet<>();
+    for (String service : request.newServices().keySet()) {
+      List<ConfigurationRequest> configRequests = request.getStack().getConfigurationTypes(service).stream()
+        .filter(configType -> !Objects.equals(configType, ConfigHelper.CLUSTER_ENV))
+        .map(configType -> createClusterConfigRequestProperties(request, service, configType))
+        .collect(toList());
+      ClusterRequest internalRequest = new ClusterRequest(null, request.clusterName(), null, null);
+      internalRequest.setDesiredConfig(configRequests);
+      requests.add(internalRequest);
+    }
+
+    try {
+      controller.updateClusters(requests, null);
+    } catch (AmbariException | AuthorizationException e) {
+      String msg = String.format("Error creating configurations for %s", request);
+      LOG.error(msg, e);
+      throw new RuntimeException(msg, e);
+    }
+  }
+
+  public void updateServiceDesiredState(AddServiceInfo request, State desiredState) {
+    LOG.info("Updating service desired state to {} for {}", desiredState, request);
+
+    Set<Map<String, Object>> properties = ImmutableSet.of(ImmutableMap.of(
+      ServiceResourceProvider.SERVICE_SERVICE_STATE_PROPERTY_ID, desiredState.name()
+    ));
+    updateResources(request, properties, Resource.Type.Service, predicateForNewServices(request, "ServiceInfo"));
+  }
+
+  public void updateHostComponentDesiredState(AddServiceInfo request, State desiredState) {
+    LOG.info("Updating host component desired state to {} for {}", desiredState, request);
+
+    Set<Map<String, Object>> properties = ImmutableSet.of(ImmutableMap.of(
+      HostComponentResourceProvider.STATE, desiredState.name(),
+      "context", String.format("Put new components to %s state", desiredState)
+    ));
+    HostComponentResourceProvider rp = (HostComponentResourceProvider) getClusterController().ensureResourceProvider(Resource.Type.HostComponent);
+    Request internalRequest = createRequest(request, properties, Resource.Type.HostComponent);
+    try {
+      rp.doUpdateResources(request.getStages(), internalRequest, predicateForNewServices(request, HostComponentResourceProvider.HOST_ROLES), false, false, false);
+    } catch (UnsupportedPropertyException | SystemException | NoSuchParentResourceException | NoSuchResourceException e) {
+      String msg = String.format("Error updating host component desired state for %s", request);
+      LOG.error(msg, e);
+      throw new RuntimeException(msg, e);
+    }
+  }
+
+  private static void createResources(Set<Map<String, Object>> properties, Resource.Type resourceType) {
     Request internalRequest = new RequestImpl(null, properties, null, null);
-    ResourceProvider rp = getClusterController().ensureResourceProvider(Resource.Type.Service);
+    ResourceProvider rp = getClusterController().ensureResourceProvider(resourceType);
     try {
       rp.createResources(internalRequest);
     } catch (UnsupportedPropertyException | SystemException | ResourceAlreadyExistsException | NoSuchParentResourceException e) {
-      LOG.error("Error creating services", e);
-      throw new RuntimeException("Error creating services", e);
+      String msg = String.format("Error creating resources: %s", resourceType);
+      LOG.error(msg, e);
+      throw new RuntimeException(msg, e);
     }
+  }
+
+  private static void updateResources(AddServiceInfo request, Set<Map<String, Object>> properties, Resource.Type resourceType, Predicate predicate) {
+    Request internalRequest = createRequest(request, properties, resourceType);
+    ResourceProvider rp = getClusterController().ensureResourceProvider(resourceType);
+    try {
+      rp.updateResources(internalRequest, predicate);
+    } catch (UnsupportedPropertyException | SystemException | NoSuchParentResourceException | NoSuchResourceException e) {
+      String msg = String.format("Error updating resources: %s", resourceType);
+      LOG.error(msg, e);
+      throw new RuntimeException(msg, e);
+    }
+  }
+
+  private static Request createRequest(AddServiceInfo request, Set<Map<String, Object>> properties, Resource.Type resourceType) {
+    Map<String, String> requestInfoProperties = ImmutableMap.of(
+
+      RequestOperationLevel.OPERATION_LEVEL_ID, RequestOperationLevel.getExternalLevelName(resourceType.name()),
+      RequestOperationLevel.OPERATION_CLUSTER_ID, request.clusterName()
+    );
+    return new RequestImpl(null, properties, requestInfoProperties, null);
   }
 
   private static Map<String, Object> createServiceRequestProperties(AddServiceInfo request, String service) {
@@ -74,22 +202,49 @@ public class ResourceProviderAdapter {
     return properties.build();
   }
 
-  private ClusterController getClusterController() {
+  private static Map<String, Object> createComponentRequestProperties(AddServiceInfo request, String service, String component) {
+    ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+
+    properties.put(ComponentResourceProvider.CLUSTER_NAME, request.clusterName());
+    properties.put(ComponentResourceProvider.SERVICE_NAME, service);
+    properties.put(ComponentResourceProvider.COMPONENT_NAME, component);
+    properties.put(ComponentResourceProvider.STATE, State.INIT.name());
+
+    return properties.build();
+  }
+
+  private static Map<String, Object> createHostComponentRequestProperties(AddServiceInfo request, String service, String component, String host) {
+    ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+
+    properties.put(HostComponentResourceProvider.CLUSTER_NAME, request.clusterName());
+    properties.put(HostComponentResourceProvider.SERVICE_NAME, service);
+    properties.put(HostComponentResourceProvider.COMPONENT_NAME, component);
+    properties.put(HostComponentResourceProvider.HOST_NAME, host);
+    properties.put(HostComponentResourceProvider.STATE, State.INIT.name());
+
+    return properties.build();
+  }
+
+  private static ConfigurationRequest createClusterConfigRequestProperties(AddServiceInfo request, String service, String configType) {
+    LOG.debug("Creating config type {} for service {}", configType, service);
+
+    return new ConfigurationRequest(request.clusterName(), configType, "ADD_SERVICE",
+      request.getConfig().getProperties().getOrDefault(configType, new HashMap<>(0)),
+      request.getConfig().getAttributes().getOrDefault(configType, new HashMap<>(0)));
+  }
+
+  private static Predicate predicateForNewServices(AddServiceInfo request, String category) {
+    return new AndPredicate(
+      new EqualsPredicate<>(PropertyHelper.getPropertyId(category, ClusterResourceProvider.CLUSTER_NAME), request.clusterName()),
+      new OrPredicate(
+        request.newServices().keySet().stream()
+          .map(service -> new EqualsPredicate<>(PropertyHelper.getPropertyId(category, "service_name"), service))
+          .toArray(Predicate[]::new)
+      )
+    );
+  }
+
+  private static ClusterController getClusterController() {
     return ClusterControllerHelper.getClusterController();
-  }
-
-  public void createComponents(AddServiceInfo request) {
-    LOG.info("Creating component resources for {}", request);
-    // TODO implement
-  }
-
-  public void createHostComponents(AddServiceInfo request) {
-    LOG.info("Creating host component resources for {}", request);
-    // TODO implement
-  }
-
-  public void updateServiceDesiredState(AddServiceInfo request, State desiredState) {
-    LOG.info("Updating service desired state to {} for {}", desiredState, request);
-    // TODO implement, reuse parts of AmbariContext#createAmbariServiceAndComponentResources
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement the following for complex "Add Service" request:

 * create components
 * create host components
 * create configs for the new services based on stack defaults
 * trigger install/start of host components
 * return request status for monitoring

Custom configs (user-defined and advisor-recommended) will be implemented separately.

## How was this patch tested?

Performed initial blueprint deployment.  Tested the new request using API call:

```
$ curl -X POST -d @- http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/services
{
  "operation_type": "ADD_SERVICE",
  "stack_name": "HDP",
  "stack_version": "3.0",
  "components": [
    { "component_name": "DATANODE", "fqdn": "c7401.ambari.apache.org" },
    { "component_name": "HDFS_CLIENT", "fqdn": "c7401.ambari.apache.org" },
    { "component_name": "KAFKA_BROKER", "fqdn": "c7402.ambari.apache.org" },
    { "component_name": "METRICS_COLLECTOR", "fqdn": "c7402.ambari.apache.org" },
    { "component_name": "METRICS_MONITOR", "fqdn": "c7401.ambari.apache.org" },
    { "component_name": "METRICS_MONITOR", "fqdn": "c7402.ambari.apache.org" },
    { "component_name": "NAMENODE", "fqdn": "c7401.ambari.apache.org" },
    { "component_name": "SECONDARY_NAMENODE", "fqdn": "c7402.ambari.apache.org" }
  ]
}

HTTP/1.1 202 Accepted
...
{
  "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/requests/12",
  "Requests" : {
    "id" : 12,
    "status" : "Accepted"
  }
}
```

Monitored the request on Ambari UI.

After successful completion:

```
$ curl "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/requests/12?fields=Requests/request_status,Requests/request_context"
{
  "href" : "http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/requests/12",
  "Requests" : {
    "cluster_name" : "TEST",
    "id" : 12,
    "request_context" : "Add Services: AMBARI_METRICS, HDFS, KAFKA to cluster TEST",
    "request_status" : "COMPLETED"
  }
}
```