### PR TITLE
AMBARI-24925. DFS Directory creation fails for Spark History

### DIFF
--- a/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Resource.java
+++ b/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Resource.java
@@ -312,8 +312,7 @@ public class Resource {
     if (fileStatus != null) {
       // Go through all resources in directory
       for (FileStatus fs : fileStatus) {
-        String pathToResource = path + "/" + fs.getPath().getName();
-
+        String pathToResource = fs.getPath().toString();
         resultSet.add(pathToResource);
 
         if (fs.isDir()) {


### PR DESCRIPTION
seems like

dfs.listStatus("s3a://cloudbreak-group/user/gruck/env/spark2-history") returns ["s3a://cloudhdp-dl-s3/user/gruck/env/spark2-history"].
But should return []

while

dfs.listStatus("s3a://cloudhdp-dl-s3/user/gruck/env/spark2-history") retuns []
as excepted.

So changes to handle that expected.