### PR TITLE
[AMBARI-24934] Accept legacy JSON configuration in Add Service request

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ConfigurableHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ConfigurableHelper.java
@@ -44,7 +44,7 @@ import com.google.common.collect.Sets;
  */
 public class ConfigurableHelper {
 
-  static final ImmutableSet<String> PERMITTED_CONFIG_FIELDS = ImmutableSet.of(PROPERTIES_PROPERTY_ID, PROPERTIES_ATTRIBUTES_PROPERTY_ID);
+  private static final ImmutableSet<String> PERMITTED_CONFIG_FIELDS = ImmutableSet.of(PROPERTIES_PROPERTY_ID, PROPERTIES_ATTRIBUTES_PROPERTY_ID);
 
   /**
    * Parses configuration maps The configs can be in fully structured JSON, e.g.
@@ -65,8 +65,6 @@ public class ConfigurableHelper {
    * }]
    * </code>
    * In the latter case it calls {@link ConfigurationFactory#getConfiguration(Collection)}
-   * @param configs
-   * @return
    */
   public static Configuration parseConfigs(@Nullable Collection<? extends Map<String, ?>> configs) {
     Configuration configuration;
@@ -74,7 +72,7 @@ public class ConfigurableHelper {
     if (null == configs || configs.isEmpty()) {
       configuration = Configuration.newEmpty();
     }
-    else if (!configs.isEmpty() && configs.iterator().next().keySet().iterator().next().contains("/")) {
+    else if (configs.iterator().next().keySet().iterator().next().contains("/")) {
       // Configuration has keys with slashes like "zk.cfg/properties/dataDir" means it is coming through
       // the resource framework and must be parsed with configuration factories
       checkFlattenedConfig(configs);
@@ -117,7 +115,7 @@ public class ConfigurableHelper {
             checkMap(PROPERTIES_ATTRIBUTES_PROPERTY_ID, configData.get(PROPERTIES_ATTRIBUTES_PROPERTY_ID), Map.class);
             Map<String, Map<String, String>> attributes =
               (Map<String, Map<String, String>>) configData.get(PROPERTIES_ATTRIBUTES_PROPERTY_ID);
-            attributes.entrySet().forEach(entry -> checkMap(entry.getKey(), entry.getValue(), String.class));
+            attributes.forEach((key, value) -> checkMap(key, value, String.class));
 
             allAttributes.put(configName, attributes);
           }
@@ -138,7 +136,7 @@ public class ConfigurableHelper {
     Collection<Map<String, Map<String, ?>>> configurations = new ArrayList<>();
     Set<String> allConfigTypes = Sets.union(configuration.getProperties().keySet(), configuration.getAttributes().keySet());
     for (String configType: allConfigTypes) {
-      Map<String, Map<String, ? extends Object>> configData = new HashMap<>();
+      Map<String, Map<String, ?>> configData = new HashMap<>();
       if (configuration.getProperties().containsKey(configType)) {
         configData.put(PROPERTIES_PROPERTY_ID, configuration.getProperties().get(configType));
       }
@@ -174,10 +172,10 @@ public class ConfigurableHelper {
   private static void checkMap(String fieldName, Object mapObj, Class<?> valueType) {
     checkArgument(mapObj instanceof Map, "'%s' needs to be a JSON object. Found: %s", fieldName, getClassName(mapObj));
     Map<?, ?> map = (Map<?, ?>)mapObj;
-    map.forEach( (__, value) -> {
-      checkArgument(valueType.isInstance(value), "Expected %s as value type, found %s, type: %s",
-        valueType.getName(), value, getClassName(value));
-    });
+    map.forEach( (__, value) ->
+      checkArgument(valueType.isInstance(value),
+        "Expected %s as value type, found %s, type: %s",
+        valueType.getName(), value, getClassName(value)));
   }
 
   private static String getClassName(Object object) {

--- a/ambari-server/src/test/resources/add_service_api/configurable3.json
+++ b/ambari-server/src/test/resources/add_service_api/configurable3.json
@@ -1,0 +1,10 @@
+{
+  "configurations" : [
+    {
+      "cluster-env" : {
+        "dataDir" : "/zookeeper1",
+        "custom-property": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Accept configuration in the legacy format in the Add Service request.  This format omits the `"properties"` map, all properties are directly under the config type.

Example:

```json
  "configurations": [
    {
      "cluster-env": {
        "custom-property": "whatever"
      }
    },
    {
      "zoo.cfg": {
        "syncLimit": "7"
      }
    }
  ]
```

Rationale for supporting this format:

1. compatibility: configuration can be easily migrated from blueprints with such structure
2. simplicity: even new configurations benefit because this format is a bit less verbose

https://issues.apache.org/jira/browse/AMBARI-24934

## How was this patch tested?

Added unit test case.

```
[INFO] Running org.apache.ambari.server.topology.ConfigurableTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.605 s - in org.apache.ambari.server.topology.ConfigurableTest
```

Tested Add Service request with both formats.

```
$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services" <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "stack_name": "HDP",
  "stack_version": "3.0",
  "components": [
    { "component_name": "KAFKA_BROKER", "fqdn": "c7402.ambari.apache.org" }
  ],
  "configurations": [
    {
      "kafka-broker": {
        "zookeeper.connect": "c7401.ambari.apache.org:2181,c7402.ambari.apache.org:2181"
      }
    }
  ]
}
EOF

HTTP/1.1 202 Accepted
```

```
$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services" <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "stack_name": "HDP",
  "stack_version": "3.0",
  "components": [
    { "component_name": "METRICS_COLLECTOR", "fqdn": "c7402.ambari.apache.org" },
    { "component_name": "METRICS_MONITOR", "fqdn": "c7401.ambari.apache.org" },
    { "component_name": "METRICS_MONITOR", "fqdn": "c7402.ambari.apache.org" }
  ],
  "configurations": [
    {
      "ams-site": {
        "properties": {
          "timeline.metrics.hbase.init.check.enabled": "false"
        }
      }
    }
  ]
}
EOF

HTTP/1.1 202 Accepted
```