### PR TITLE
AMBARI-24927. Adding LDAP integration support information to service information via Ambari's REST API

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceResponse.java
@@ -43,13 +43,14 @@ public class ServiceResponse {
   private final boolean kerberosEnabled;
   private final boolean ldapIntegrationSupported;
   private final boolean ldapIntegrationEnabled;
+  private final boolean ldapIntegrationDesired;
 
   public ServiceResponse(Long clusterId, String clusterName, String serviceName,
                          StackId desiredStackId, String desiredRepositoryVersion,
                          RepositoryVersionState repositoryVersionState, String desiredState,
                          boolean credentialStoreSupported, boolean credentialStoreEnabled, boolean ssoIntegrationSupported,
                          boolean ssoIntegrationDesired, boolean ssoIntegrationEnabled, boolean ssoIntegrationRequiresKerberos,
-                         boolean kerberosEnabled, boolean ldapIntegrationSupported,  boolean ldapIntegrationEnabled) {
+                         boolean kerberosEnabled, boolean ldapIntegrationSupported,  boolean ldapIntegrationEnabled, boolean ldapIntegrationDesired) {
     this.clusterId = clusterId;
     this.clusterName = clusterName;
     this.serviceName = serviceName;
@@ -66,6 +67,7 @@ public class ServiceResponse {
     this.kerberosEnabled = kerberosEnabled;
     this.ldapIntegrationSupported = ldapIntegrationSupported;
     this.ldapIntegrationEnabled = ldapIntegrationEnabled;
+    this.ldapIntegrationDesired = ldapIntegrationDesired;
   }
 
   /**
@@ -298,7 +300,13 @@ public class ServiceResponse {
     return ldapIntegrationEnabled;
   }
 
-
+  /**
+   * Indicates whether the service is chosen for LDAP integration or not
+   */
+  @ApiModelProperty(name = "ldap_integration_desired")
+  public boolean isLdapIntegrationDesired() {
+    return ldapIntegrationDesired;
+  }
 
   /**
    * Interface to help correct Swagger documentation generation

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/StackServiceResponse.java
@@ -87,6 +87,7 @@ public class StackServiceResponse {
 
   private final boolean ssoIntegrationSupported;
   private final boolean ssoIntegrationRequiresKerberos;
+  private final boolean ldapIntegrationSupported;
 
   /**
    * Constructor.
@@ -126,6 +127,7 @@ public class StackServiceResponse {
     isSupportDeleteViaUI = service.isSupportDeleteViaUI();
     ssoIntegrationSupported = service.isSingleSignOnSupported();
     ssoIntegrationRequiresKerberos = service.isKerberosRequiredForSingleSignOnIntegration();
+    ldapIntegrationSupported = service.isLdapSupported();
     rollingRestartSupported = service.isRollingRestartSupported();
   }
 
@@ -364,6 +366,14 @@ public class StackServiceResponse {
   @ApiModelProperty(name = "sso_integration_requires_kerberos")
   public boolean isSsoIntegrationRequiresKerberos() {
     return ssoIntegrationRequiresKerberos;
+  }
+
+  /**
+   * Indicates if this service supports LDAP integration.
+   */
+  @ApiModelProperty(name = "ldap_integration_supported")
+  public boolean isLdapIntegrationSupported() {
+    return ldapIntegrationSupported;
   }
 
   @ApiModelProperty(name = "rolling_restart_supported")

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandler.java
@@ -21,10 +21,14 @@ package org.apache.ambari.server.controller.internal;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
@@ -171,6 +175,19 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
     }
 
     return properties;
+  }
+
+  protected Set<String> getEnabledServices(String categoryName, String manageServicesConfigurationPropertyName, String enabledServicesPropertyName) {
+    final Map<String, String> configurationProperties = getConfigurationProperties(categoryName);
+    final boolean manageConfigurations = StringUtils.isNotBlank(manageServicesConfigurationPropertyName)
+        && "true".equalsIgnoreCase(configurationProperties.get(manageServicesConfigurationPropertyName));
+    final String enabledServices = (manageConfigurations) ? configurationProperties.get(enabledServicesPropertyName) : null;
+
+    if (StringUtils.isEmpty(enabledServices)) {
+      return Collections.emptySet();
+    } else {
+      return Arrays.stream(enabledServices.split(",")).map(String::trim).map(String::toUpperCase).collect(Collectors.toSet());
+    }
   }
 
   private boolean updatePasswordIfNeeded(String categoryName, String propertyName, String newPassword) throws AmbariException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
@@ -19,6 +19,9 @@
 package org.apache.ambari.server.controller.internal;
 
 import static org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest.StackAdvisorRequestType.LDAP_CONFIGURATIONS;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.LDAP_CONFIGURATION;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.LDAP_ENABLED_SERVICES;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.AMBARI_MANAGES_LDAP_CONFIGURATION;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,6 +72,17 @@ public class AmbariServerLDAPConfigurationHandler extends AmbariServerStackAdvis
     if (ldapConfiguration.isAmbariManagesLdapConfiguration()) {
       processClusters(LDAP_CONFIGURATIONS);
     }
+  }
+
+  /**
+   * Gets the set of services for which the user declared  Ambari to enable LDAP integration.
+   * <p>
+   * If Ambari is not managing LDAP integration configuration for services the set of names will be empty.
+   *
+   * @return a set of service names
+   */
+  public Set<String> getLDAPEnabledServices() {
+    return getEnabledServices(LDAP_CONFIGURATION.getCategoryName(), AMBARI_MANAGES_LDAP_CONFIGURATION.key(), LDAP_ENABLED_SERVICES.key());
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerLDAPConfigurationHandler.java
@@ -20,8 +20,8 @@ package org.apache.ambari.server.controller.internal;
 
 import static org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest.StackAdvisorRequestType.LDAP_CONFIGURATIONS;
 import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.LDAP_CONFIGURATION;
-import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.LDAP_ENABLED_SERVICES;
 import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.AMBARI_MANAGES_LDAP_CONFIGURATION;
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.LDAP_ENABLED_SERVICES;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandler.java
@@ -19,11 +19,8 @@ import static org.apache.ambari.server.configuration.AmbariServerConfigurationCa
 import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_ENABLED_SERVICES;
 import static org.apache.ambari.server.configuration.AmbariServerConfigurationKey.SSO_MANAGE_SERVICES;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
@@ -33,7 +30,6 @@ import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ConfigHelper;
-import org.apache.commons.lang.StringUtils;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -76,18 +72,7 @@ public class AmbariServerSSOConfigurationHandler extends AmbariServerStackAdviso
    * @return a set of service names
    */
   public Set<String> getSSOEnabledServices() {
-    Map<String, String> ssoProperties = getConfigurationProperties(SSO_CONFIGURATION.getCategoryName());
-    boolean manageSSOConfigurations = (ssoProperties != null) && "true".equalsIgnoreCase(ssoProperties.get(SSO_MANAGE_SERVICES.key()));
-    String ssoEnabledServices = (manageSSOConfigurations) ? ssoProperties.get(SSO_ENABLED_SERVICES.key()) : null;
-
-    if (StringUtils.isEmpty(ssoEnabledServices)) {
-      return Collections.emptySet();
-    } else {
-      return Arrays.stream(ssoEnabledServices.split(","))
-          .map(String::trim)
-          .map(String::toUpperCase)
-          .collect(Collectors.toSet());
-    }
+    return getEnabledServices(SSO_CONFIGURATION.getCategoryName(), SSO_MANAGE_SERVICES.key(), SSO_ENABLED_SERVICES.key());
   }
   
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -145,6 +145,9 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   private static final String LDAP_INTEGRATION_ENABLED_PROPERTY_ID = PropertyHelper.getPropertyId(
       "ServiceInfo", "ldap_integration_enabled");
 
+  private static final String LDAP_INTEGRATION_DESIRED_PROPERTY_ID = PropertyHelper.getPropertyId(
+      "ServiceInfo", "ldap_integration_desired");
+
   public static final String OPERATION_TYPE = "operation_type";
 
   protected static final String SERVICE_REPOSITORY_STATE = "ServiceInfo/repository_state";
@@ -194,6 +197,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
 
     PROPERTY_IDS.add(LDAP_INTEGRATION_SUPPORTED_PROPERTY_ID);
     PROPERTY_IDS.add(LDAP_INTEGRATION_ENABLED_PROPERTY_ID);
+    PROPERTY_IDS.add(LDAP_INTEGRATION_DESIRED_PROPERTY_ID);
 
     PROPERTY_IDS.add(OPERATION_TYPE);
 
@@ -338,6 +342,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
 
       setResourceProperty(resource, LDAP_INTEGRATION_SUPPORTED_PROPERTY_ID, response.isLdapIntegrationSupported(), requestedIds);
       setResourceProperty(resource, LDAP_INTEGRATION_ENABLED_PROPERTY_ID, response.isLdapIntegrationEnabled(), requestedIds);
+      setResourceProperty(resource, LDAP_INTEGRATION_DESIRED_PROPERTY_ID, response.isLdapIntegrationDesired(), requestedIds);
       
 
       Map<String, Object> serviceSpecificProperties = getServiceSpecificProperties(

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackServiceResourceProvider.java
@@ -111,6 +111,9 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
   private static final String SSO_INTEGRATION_REQUIRES_KERBEROS_PROPERTY_ID = PropertyHelper.getPropertyId(
     "StackServices", "sso_integration_requires_kerberos");
 
+  private static final String LDAP_INTEGRATION_SUPPORTED_PROPERTY_ID = PropertyHelper.getPropertyId(
+      "StackServices", "ldap_integration_supported");
+
   private static final String ROLLING_RESTART_SUPPORTED_PROPERTY_ID = PropertyHelper.getPropertyId(
       "StackServices", "rolling_restart_supported");
 
@@ -148,6 +151,7 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
       SUPPORT_DELETE_VIA_UI,
       SSO_INTEGRATION_SUPPORTED_PROPERTY_ID,
       SSO_INTEGRATION_REQUIRES_KERBEROS_PROPERTY_ID,
+      LDAP_INTEGRATION_SUPPORTED_PROPERTY_ID,
       ROLLING_RESTART_SUPPORTED_PROPERTY_ID);
 
   /**
@@ -264,6 +268,7 @@ public class StackServiceResourceProvider extends ReadOnlyResourceProvider {
 
     setResourceProperty(resource, SSO_INTEGRATION_SUPPORTED_PROPERTY_ID, response.isSsoIntegrationSupported(), requestedIds);
     setResourceProperty(resource, SSO_INTEGRATION_REQUIRES_KERBEROS_PROPERTY_ID, response.isSsoIntegrationRequiresKerberos(), requestedIds);
+    setResourceProperty(resource, LDAP_INTEGRATION_SUPPORTED_PROPERTY_ID, response.isLdapIntegrationSupported(), requestedIds);
 
     return resource;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceImpl.java
@@ -40,6 +40,7 @@ import org.apache.ambari.server.collections.Predicate;
 import org.apache.ambari.server.collections.PredicateUtils;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.ServiceResponse;
+import org.apache.ambari.server.controller.internal.AmbariServerLDAPConfigurationHandler;
 import org.apache.ambari.server.controller.internal.AmbariServerSSOConfigurationHandler;
 import org.apache.ambari.server.controller.internal.DeleteHostComponentStatusMetaData;
 import org.apache.ambari.server.events.MaintenanceModeEvent;
@@ -104,7 +105,10 @@ public class ServiceImpl implements Service {
   private ConfigHelper configHelper;
 
   @Inject
-  private AmbariServerSSOConfigurationHandler ambariServerConfigurationHandler;
+  private AmbariServerSSOConfigurationHandler ambariServerSSOConfigurationHandler;
+
+  @Inject
+  private AmbariServerLDAPConfigurationHandler ambariServerLDAPConfigurationHandler;
 
   private final ClusterServiceDAO clusterServiceDAO;
   private final ServiceDesiredStateDAO serviceDesiredStateDAO;
@@ -422,7 +426,7 @@ public class ServiceImpl implements Service {
         getName(), desiredStackId, desiredRespositoryVersion.getVersion(), getRepositoryState(),
         getDesiredState().toString(), isCredentialStoreSupported(), isCredentialStoreEnabled(),
         ssoIntegrationSupported, isSsoIntegrationDesired(), isSsoIntegrationEnabled(existingConfigurations),
-        isKerberosRequiredForSsoIntegration(), isKerberosEnabled(existingConfigurations), ldapIntegrationSupported,isLdapIntegrationEnabeled(existingConfigurations));
+        isKerberosRequiredForSsoIntegration(), isKerberosEnabled(existingConfigurations), ldapIntegrationSupported,isLdapIntegrationEnabeled(existingConfigurations), isLdapIntegrationDesired());
 
     r.setDesiredRepositoryVersionId(desiredRespositoryVersion.getId());
 
@@ -795,7 +799,7 @@ public class ServiceImpl implements Service {
   }
 
   private boolean isSsoIntegrationDesired() {
-    return ambariServerConfigurationHandler.getSSOEnabledServices().contains(serviceName);
+    return ambariServerSSOConfigurationHandler.getSSOEnabledServices().contains(serviceName);
   }
 
   private boolean isSsoIntegrationEnabled(Map<String, Map<String, String>> existingConfigurations) {
@@ -808,5 +812,9 @@ public class ServiceImpl implements Service {
 
   private boolean isLdapIntegrationEnabeled(Map<String, Map<String, String>> existingConfigurations) {
     return ldapIntegrationSupported && ldapEnabledTest != null && ldapEnabledTest.evaluate(existingConfigurations);
+  }
+
+  private boolean isLdapIntegrationDesired() {
+    return ambariServerLDAPConfigurationHandler.getLDAPEnabledServices().contains(serviceName);
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/AgentResourceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/AgentResourceTest.java
@@ -50,6 +50,7 @@ import org.apache.ambari.server.hooks.HookService;
 import org.apache.ambari.server.hooks.users.PostUserCreationHookContext;
 import org.apache.ambari.server.hooks.users.UserCreatedEvent;
 import org.apache.ambari.server.hooks.users.UserHookService;
+import org.apache.ambari.server.ldap.service.LdapFacade;
 import org.apache.ambari.server.metadata.CachedRoleCommandOrderProvider;
 import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
 import org.apache.ambari.server.mpack.MpackManagerFactory;
@@ -360,6 +361,7 @@ public class AgentResourceTest extends RandomPortJerseyTest {
       bind(EncryptionService.class).to(AESEncryptionService.class);
       bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
       bind(new TypeLiteral<Encryptor<Config>>() {}).annotatedWith(Names.named("ConfigPropertiesEncryptor")).toInstance(Encryptor.NONE);
+      bind(LdapFacade.class).toInstance(createNiceMock(LdapFacade.class));
     }
 
     private void installDependencies() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/alerts/AgentHeartbeatAlertRunnableTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/alerts/AgentHeartbeatAlertRunnableTest.java
@@ -253,7 +253,7 @@ public class AgentHeartbeatAlertRunnableTest {
     @Override
     public void configure(Binder binder) {
       PartialNiceMockBinder.newBuilder().addConfigsBindings()
-          .addAlertDefinitionBinding().build().configure(binder);
+          .addAlertDefinitionBinding().addLdapBindings().build().configure(binder);
     }
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/alerts/AmbariPerformanceRunnableTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/alerts/AmbariPerformanceRunnableTest.java
@@ -259,7 +259,7 @@ public class AmbariPerformanceRunnableTest {
 
 
       PartialNiceMockBinder.newBuilder().addConfigsBindings()
-          .addAlertDefinitionBinding().build().configure(binder);
+          .addAlertDefinitionBinding().addLdapBindings().build().configure(binder);
 
       binder.bind(AlertsDAO.class).toInstance(createNiceMock(AlertsDAO.class));
       binder.bind(ActionManager.class).toInstance(createNiceMock(ActionManager.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/alerts/ComponentVersionAlertRunnableTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/alerts/ComponentVersionAlertRunnableTest.java
@@ -349,6 +349,7 @@ public class ComponentVersionAlertRunnableTest extends EasyMockSupport {
           .addDBAccessorBinding()
           .addFactoriesInstallBinding()
           .addAmbariMetaInfoBinding()
+          .addLdapBindings()
           .build().configure(binder);
 
       binder.bind(AmbariMetaInfo.class).toInstance(createNiceMock(AmbariMetaInfo.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/alerts/StaleAlertRunnableTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/alerts/StaleAlertRunnableTest.java
@@ -706,7 +706,7 @@ public class StaleAlertRunnableTest {
     @Override
     public void configure(Binder binder) {
       PartialNiceMockBinder.newBuilder().addConfigsBindings()
-          .addAlertDefinitionBinding().build().configure(binder);
+          .addAlertDefinitionBinding().addLdapBindings().build().configure(binder);
 
       binder.bind(AlertsDAO.class).toInstance(createNiceMock(AlertsDAO.class));
       binder.bind(HostRoleCommandDAO.class).toInstance(createNiceMock(HostRoleCommandDAO.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelperTest.java
@@ -860,7 +860,7 @@ public class DatabaseConsistencyCheckHelperTest {
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder().addAmbariMetaInfoBinding()
-            .addDBAccessorBinding(mockDBDbAccessor).build()
+            .addDBAccessorBinding(mockDBDbAccessor).addLdapBindings().build()
             .configure(binder());
 
         bind(AmbariMetaInfo.class).toInstance(mockAmbariMetainfo);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
@@ -217,7 +217,7 @@ public class KerberosAdminPersistedCredentialCheckTest extends EasyMockSupport {
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder().addActionDBAccessorConfigsBindings().addFactoriesInstallBinding()
-            .addPasswordEncryptorBindings().build().configure(binder());
+            .addPasswordEncryptorBindings().addLdapBindings().build().configure(binder());
 
         bind(ExecutionScheduler.class).toInstance(createNiceMock(ExecutionSchedulerImpl.class));
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariServerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariServerTest.java
@@ -350,7 +350,7 @@ public class AmbariServerTest {
     return Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
-        PartialNiceMockBinder.newBuilder().addClustersBinding().build().configure(binder());
+        PartialNiceMockBinder.newBuilder().addClustersBinding().addLdapBindings().build().configure(binder());
 
         bind(StackManagerFactory.class).toInstance(createNiceMock(StackManagerFactory.class));
         bind(MpackManagerFactory.class).toInstance(createNiceMock(MpackManagerFactory.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -80,6 +80,7 @@ import org.apache.ambari.server.controller.spi.ClusterController;
 import org.apache.ambari.server.controller.utilities.KerberosChecker;
 import org.apache.ambari.server.hooks.HookService;
 import org.apache.ambari.server.hooks.users.UserHookService;
+import org.apache.ambari.server.ldap.service.LdapFacade;
 import org.apache.ambari.server.metadata.CachedRoleCommandOrderProvider;
 import org.apache.ambari.server.metadata.RoleCommandOrder;
 import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
@@ -281,6 +282,7 @@ public class KerberosHelperTest extends EasyMockSupport {
         bind(RoleCommandOrderProvider.class).to(CachedRoleCommandOrderProvider.class);
         bind(HostRoleCommandFactory.class).to(HostRoleCommandFactoryImpl.class);
         bind(MpackManagerFactory.class).toInstance(createNiceMock(MpackManagerFactory.class));
+        bind(LdapFacade.class).toInstance(createNiceMock(LdapFacade.class));
         requestStaticInjection(KerberosChecker.class);
       }
     });

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostResourceProviderTest.java
@@ -1403,7 +1403,7 @@ public class HostResourceProviderTest extends EasyMockSupport {
     Injector injector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
-        PartialNiceMockBinder.newBuilder().addConfigsBindings().addFactoriesInstallBinding().addPasswordEncryptorBindings().build().configure(binder());
+        PartialNiceMockBinder.newBuilder().addConfigsBindings().addFactoriesInstallBinding().addPasswordEncryptorBindings().addLdapBindings().build().configure(binder());
 
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
         bind(DBAccessor.class).toInstance(createNiceMock(DBAccessor.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserAuthenticationSourceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserAuthenticationSourceResourceProviderTest.java
@@ -181,7 +181,7 @@ public class UserAuthenticationSourceResourceProviderTest extends EasyMockSuppor
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder(UserAuthenticationSourceResourceProviderTest.this)
-            .addAmbariMetaInfoBinding().build().configure(binder());
+            .addAmbariMetaInfoBinding().addLdapBindings().build().configure(binder());
 
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
         bind(DBAccessor.class).toInstance(createNiceMock(DBAccessor.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/dao/AlertsDAOCachedTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/dao/AlertsDAOCachedTest.java
@@ -278,7 +278,7 @@ public class AlertsDAOCachedTest {
 
       binder.bind(Configuration.class).toInstance(configuration);
 
-      PartialNiceMockBinder.newBuilder().addConfigsBindings().addAlertDefinitionBinding().build().configure(binder);
+      PartialNiceMockBinder.newBuilder().addConfigsBindings().addAlertDefinitionBinding().addLdapBindings().build().configure(binder);
     }
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/UpdateKerberosConfigsServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/UpdateKerberosConfigsServerActionTest.java
@@ -79,7 +79,7 @@ public class UpdateKerberosConfigsServerActionTest extends EasyMockSupport{
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder(UpdateKerberosConfigsServerActionTest.this)
-            .addClustersBinding().build().configure(binder());
+            .addClustersBinding().addLdapBindings().build().configure(binder());
 
         bind(ConfigHelper.class).toInstance(createNiceMock(ConfigHelper.class));
         bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/KerberosKeytabsActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/KerberosKeytabsActionTest.java
@@ -95,7 +95,7 @@ public class KerberosKeytabsActionTest {
 
       @Override
       protected void configure() {
-        PartialNiceMockBinder.newBuilder().addClustersBinding().build().configure(binder());
+        PartialNiceMockBinder.newBuilder().addClustersBinding().addLdapBindings().build().configure(binder());
 
         bind(Clusters.class).toInstance(m_clusters);
         bind(OsFamily.class).toInstance(EasyMock.createNiceMock(OsFamily.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
@@ -616,7 +616,7 @@ public class PreconfigureKerberosActionTest extends EasyMockSupport {
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder(PreconfigureKerberosActionTest.this)
-            .addActionDBAccessorConfigsBindings().build().configure(binder());
+            .addActionDBAccessorConfigsBindings().addLdapBindings().build().configure(binder());
 
         bind(EntityManager.class).toInstance(createMock(EntityManager.class));
         bind(DBAccessor.class).toInstance(createMock(DBAccessor.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ConfigHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ConfigHelperTest.java
@@ -1154,7 +1154,7 @@ public class ConfigHelperTest {
           final AmbariMetaInfo mockMetaInfo = createNiceMock(AmbariMetaInfo.class);
           final ClusterController clusterController = createStrictMock(ClusterController.class);
 
-          PartialNiceMockBinder.newBuilder().addAmbariMetaInfoBinding().addFactoriesInstallBinding().build().configure(binder());
+          PartialNiceMockBinder.newBuilder().addAmbariMetaInfoBinding().addFactoriesInstallBinding().addLdapBindings().build().configure(binder());
 
           bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
           bind(DBAccessor.class).toInstance(createNiceMock(DBAccessor.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/services/AlertNoticeDispatchServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/services/AlertNoticeDispatchServiceTest.java
@@ -787,7 +787,7 @@ public class AlertNoticeDispatchServiceTest extends AlertNoticeDispatchService {
     @Override
     public void configure(Binder binder) {
       Cluster cluster = EasyMock.createNiceMock(Cluster.class);
-      PartialNiceMockBinder.newBuilder().addDBAccessorBinding().addAmbariMetaInfoBinding().build().configure(binder);
+      PartialNiceMockBinder.newBuilder().addDBAccessorBinding().addAmbariMetaInfoBinding().addLdapBindings().build().configure(binder);
 
       binder.bind(AlertDispatchDAO.class).toInstance(m_dao);
       binder.bind(DispatchFactory.class).toInstance(m_dispatchFactory);

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/services/CachedAlertFlushServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/services/CachedAlertFlushServiceTest.java
@@ -128,7 +128,7 @@ public class CachedAlertFlushServiceTest extends EasyMockSupport {
 
       EasyMock.replay(configuration);
 
-      PartialNiceMockBinder.newBuilder().addDBAccessorBinding().addAlertDefinitionDAOBinding().build().configure(binder);
+      PartialNiceMockBinder.newBuilder().addDBAccessorBinding().addAlertDefinitionDAOBinding().addLdapBindings().build().configure(binder);
 
       binder.bind(Configuration.class).toInstance(configuration);
       binder.bind(Cluster.class).toInstance(cluster);

--- a/ambari-server/src/test/java/org/apache/ambari/server/testutils/PartialNiceMockBinder.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/testutils/PartialNiceMockBinder.java
@@ -46,6 +46,7 @@ import org.apache.ambari.server.hooks.HookService;
 import org.apache.ambari.server.hooks.users.PostUserCreationHookContext;
 import org.apache.ambari.server.hooks.users.UserCreatedEvent;
 import org.apache.ambari.server.hooks.users.UserHookService;
+import org.apache.ambari.server.ldap.service.LdapFacade;
 import org.apache.ambari.server.metadata.CachedRoleCommandOrderProvider;
 import org.apache.ambari.server.metadata.RoleCommandOrderProvider;
 import org.apache.ambari.server.mpack.MpackManagerFactory;
@@ -241,6 +242,11 @@ public class PartialNiceMockBinder implements Module {
       configurers.add((Binder binder) ->
           binder.bindConstant().annotatedWith(Names.named("executionCommandCacheSize")).to(10000L)
       );
+      return this;
+    }
+    
+    public Builder addLdapBindings() {
+      configurers.add((Binder binder) -> binder.bind(LdapFacade.class).toInstance(easyMockSupport.createNiceMock(LdapFacade.class)));
       return this;
     }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/update/HostUpdateHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/update/HostUpdateHelperTest.java
@@ -253,7 +253,7 @@ public class HostUpdateHelperTest {
     final Injector mockInjector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
-        PartialNiceMockBinder.newBuilder().addClustersBinding(mockAmbariManagementController).build().configure(binder());
+        PartialNiceMockBinder.newBuilder().addClustersBinding(mockAmbariManagementController).addLdapBindings().build().configure(binder());
         bind(StackManagerFactory.class).toInstance(easyMockSupport.createNiceMock(StackManagerFactory.class));
         bind(DBAccessor.class).toInstance(dbAccessor);
         bind(EntityManager.class).toInstance(entityManager);
@@ -496,7 +496,7 @@ public class HostUpdateHelperTest {
       protected void configure() {
 
         PartialNiceMockBinder.newBuilder().addConfigsBindings().addFactoriesInstallBinding().addPasswordEncryptorBindings()
-        .build().configure(binder());
+        .addLdapBindings().build().configure(binder());
 
         bind(DBAccessor.class).toInstance(dbAccessor);
         bind(EntityManager.class).toInstance(entityManager);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog251Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog251Test.java
@@ -293,7 +293,7 @@ public class UpgradeCatalog251Test {
       @Override
       public void configure(Binder binder) {
         PartialNiceMockBinder.newBuilder().addConfigsBindings().addFactoriesInstallBinding()
-        .addPasswordEncryptorBindings().build().configure(binder);
+        .addPasswordEncryptorBindings().addLdapBindings().build().configure(binder);
 
         binder.bind(DBAccessor.class).toInstance(dbAccessor);
         binder.bind(OsFamily.class).toInstance(osFamily);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog252Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog252Test.java
@@ -441,7 +441,7 @@ public class UpgradeCatalog252Test {
       @Override
       public void configure(Binder binder) {
         PartialNiceMockBinder.newBuilder().addConfigsBindings().addFactoriesInstallBinding()
-        .addPasswordEncryptorBindings().build().configure(binder);
+        .addPasswordEncryptorBindings().addLdapBindings().build().configure(binder);
 
         binder.bind(DBAccessor.class).toInstance(dbAccessor);
         binder.bind(OsFamily.class).toInstance(osFamily);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
@@ -1026,7 +1026,7 @@ public class UpgradeCatalog260Test {
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder().addConfigsBindings().addFactoriesInstallBinding()
-        .addPasswordEncryptorBindings().build().configure(binder());
+        .addPasswordEncryptorBindings().addLdapBindings().build().configure(binder());
 
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
         bind(AmbariManagementController.class).toInstance(controller);
@@ -1084,7 +1084,7 @@ public class UpgradeCatalog260Test {
     return Guice.createInjector(new Module() {
       @Override
       public void configure(Binder binder) {
-        PartialNiceMockBinder.newBuilder().addPasswordEncryptorBindings().build().configure(binder);
+        PartialNiceMockBinder.newBuilder().addPasswordEncryptorBindings().addLdapBindings().build().configure(binder);
         binder.bindConstant().annotatedWith(Names.named("actionTimeout")).to(600000L);
         binder.bindConstant().annotatedWith(Names.named("schedulerSleeptime")).to(1L);
         binder.bindConstant().annotatedWith(Names.named(HostRoleCommandDAO.HRC_STATUS_SUMMARY_CACHE_ENABLED)).to(true);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog270Test.java
@@ -600,7 +600,7 @@ public class UpgradeCatalog270Test {
     Module module = new AbstractModule() {
       @Override
       public void configure() {
-        PartialNiceMockBinder.newBuilder().addConfigsBindings().addPasswordEncryptorBindings().addFactoriesInstallBinding().build().configure(binder());
+        PartialNiceMockBinder.newBuilder().addConfigsBindings().addPasswordEncryptorBindings().addLdapBindings().addFactoriesInstallBinding().build().configure(binder());
 
         bind(DBAccessor.class).toInstance(dbAccessor);
         bind(OsFamily.class).toInstance(osFamily);

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -96,7 +96,7 @@ public class StageUtilsTest extends EasyMockSupport {
       protected void configure() {
 
         PartialNiceMockBinder.newBuilder(StageUtilsTest.this).addAmbariMetaInfoBinding()
-            .addDBAccessorBinding().build().configure(binder());
+            .addDBAccessorBinding().addLdapBindings().build().configure(binder());
 
         bind(AmbariMetaInfo.class).toInstance(createMock(AmbariMetaInfo.class));
         bind(TopologyManager.class).toInstance(createNiceMock(TopologyManager.class));


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following read-only information is available from now on using Ambari's REST API:

1. ) New read-only property for (stack) services is:
- ldap_integration_supported - Indicates whether the service supports LDAP integration or not

2.) New read-only properties for installed services are:
- ldap_integration_supported - Indicates whether the service supports LDAP integration or not
- ldap_integration_enabled - Indicates whether the service is configured for LDAP integration or not
- ldap_integration_desired - Indicates whether the service is chosen for LDAP integration or not

## How was this patch tested?

In addition to unit testing I deployed my changes in my local environment and tested if the new properties are available when querying them in my browser:

<img width="651" alt="screen shot 2018-11-21 at 2 57 53 pm" src="https://user-images.githubusercontent.com/34065904/48853969-f8dc1500-edb0-11e8-8add-e72a0e864b6d.png">

<img width="529" alt="screen shot 2018-11-21 at 2 58 09 pm" src="https://user-images.githubusercontent.com/34065904/48853985-ff6a8c80-edb0-11e8-96e3-e1d20ebc10bd.png">
