### PR TITLE
AMBARI-24942. Dir creation fails if webhdfs is enabled

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/hdfs_resource.py
@@ -70,6 +70,8 @@ EXCEPTIONS_TO_RETRY = {
   "RetriableException": ("", 20, 6),
 }
 
+DFS_WHICH_SUPPORT_WEBHDFS = ['hdfs']
+
 class HdfsResourceJar:
   """
   This is slower than HdfsResourceWebHDFS implementation of HdfsResouce, but it works in any cases on any DFS types.
@@ -92,16 +94,9 @@ class HdfsResourceJar:
     if not nameservices or len(nameservices) < 2:
       self.action_delayed_for_nameservice(None, action_name, main_resource)
     else:
-      default_fs_protocol = urlparse(main_resource.resource.default_fs).scheme
-
-      if not default_fs_protocol or default_fs_protocol == "viewfs":
-        protocol = dfs_type.lower()
-      else:
-        protocol = default_fs_protocol
-
       for nameservice in nameservices:
         try:
-          nameservice = protocol + "://" + nameservice
+          nameservice = main_resource.default_protocol + "://" + nameservice
           self.action_delayed_for_nameservice(nameservice, action_name, main_resource)
         except namenode_ha_utils.NoActiveNamenodeException as ex:
           # one of ns can be down (during initial start forexample) no need to worry for federated cluster
@@ -212,12 +207,17 @@ class WebHDFSUtil:
     self.run_user = run_user
     self.security_enabled = security_enabled
     self.logoutput = logoutput
+
+  @staticmethod
+  def get_default_protocol(default_fs, dfs_type):
+    default_fs_protocol = urlparse(default_fs).scheme.lower()
+    is_viewfs = default_fs_protocol == 'viewfs'
+    return dfs_type.lower() if is_viewfs else default_fs_protocol
     
   @staticmethod
-  def is_webhdfs_available(is_webhdfs_enabled, dfs_type):
-    # only hdfs seems to support webHDFS
-    return (is_webhdfs_enabled and dfs_type.lower() == 'hdfs')
-    
+  def is_webhdfs_available(is_webhdfs_enabled, default_protocol):
+    return (is_webhdfs_enabled and default_protocol in DFS_WHICH_SUPPORT_WEBHDFS)
+
   def run_command(self, *args, **kwargs):
     """
     This functions is a wrapper for self._run_command which does retry routine for it.
@@ -637,6 +637,8 @@ class HdfsResourceProvider(Provider):
 
     self.assert_parameter_is_set('dfs_type')
     self.fsType = getattr(resource, 'dfs_type').lower()
+
+    self.default_protocol = WebHDFSUtil.get_default_protocol(resource.default_fs, self.fsType)
     self.can_use_webhdfs = True
 
     if self.fsType == 'hdfs':
@@ -684,13 +686,12 @@ class HdfsResourceProvider(Provider):
     
     if self.has_core_configs:
       path_protocol = urlparse(self.resource.target).scheme.lower()
-      default_fs_protocol = urlparse(self.resource.default_fs).scheme.lower()
       
-      self.create_as_root = path_protocol == 'file' or default_fs_protocol == 'file' and not path_protocol
+      self.create_as_root = path_protocol == 'file' or self.default_protocol == 'file' and path_protocol == None
 
       # for protocols which are different that defaultFs webhdfs will not be able to create directories
       # so for them fast-hdfs-resource.jar should be used
-      if path_protocol and default_fs_protocol != "viewfs" and path_protocol != default_fs_protocol:
+      if path_protocol and path_protocol != self.default_protocol:
         self.can_use_webhdfs = False
         Logger.info("Cannot use webhdfs for {0} defaultFs = {1} has different protocol".format(self.resource.target, self.resource.default_fs))
     else:
@@ -723,7 +724,7 @@ class HdfsResourceProvider(Provider):
     HdfsResourceJar().action_execute(self, sudo=True)
     
   def get_hdfs_resource_executor(self):
-    if self.can_use_webhdfs and WebHDFSUtil.is_webhdfs_available(self.webhdfs_enabled, self.fsType):
+    if self.can_use_webhdfs and WebHDFSUtil.is_webhdfs_available(self.webhdfs_enabled, self.default_protocol):
       return HdfsResourceWebHDFS()
     else:
       return HdfsResourceJar()


### PR DESCRIPTION
The previous clusters had webhdfs disabled as a workaround.

With webHDFS turned back on, dir creation continues to fail.

Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_collector.py", line 90, in <module>
    AmsCollector().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 345, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_collector.py", line 48, in start
    self.configure(env, action = 'start') # for security
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/metrics_collector.py", line 43, in configure
    hbase('master', action)
  File "/usr/lib/ambari-agent/lib/ambari_commons/os_family_impl.py", line 89, in thunk
    return fn(*args, **kwargs)
  File "/var/lib/ambari-agent/cache/stacks/HDP/3.0/services/AMBARI_METRICS/package/scripts/hbase.py", line 228, in hbase
    dfs_type=params.dfs_type
  File "/usr/lib/ambari-agent/lib/resource_management/core/base.py", line 166, in __init__
    self.env.run()
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 160, in run
    self.run_action(resource, action)
  File "/usr/lib/ambari-agent/lib/resource_management/core/environment.py", line 124, in run_action
    provider_action()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 712, in action_create_on_execute
    self.action_delayed("create")
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 709, in action_delayed
    self.get_hdfs_resource_executor().action_delayed(action_name, self)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 385, in action_delayed
    self.action_delayed_for_nameservice(None, action_name, main_resource)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 407, in action_delayed_for_nameservice
    self._assert_valid()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 346, in _assert_valid
    self.target_status = self._get_file_status(target)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 509, in _get_file_status
    list_status = self.util.run_command(target, 'GETFILESTATUS', method='GET', ignore_status_codes=['404'], assertable_result=False)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 226, in run_command
    return self._run_command(*args, **kwargs)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/providers/hdfs_resource.py", line 294, in _run_command
    _, out, err = get_user_call_output(cmd, user=self.run_user, logoutput=self.logoutput, quiet=False)
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/functions/get_user_call_output.py", line 62, in get_user_call_output
    raise ExecutionFailed(err_msg, code, files_output[0], files_output[1])
resource_management.core.exceptions.ExecutionFailed: Execution of 'curl -sS -L -w '%{http_code}' -X GET -d '' -H 'Content-Length: 0' 'http://fakelocalhost:50070/webhdfs/v1s3a:/cloudhdp-dl-s3-2/c01/amshbase?op=GETFILESTATUS&user.name=hdfs' 1>/tmp/tmpsSkYRy 2>/tmp/tmpYQM8tv' returned 6. curl: (6) Could not resolve host: fakelocalhost; Unknown error
000