### PR TITLE
[AMBARI-24948] Test ordering issue in ExecutionCommandWrapperTest

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/actionmanager/ExecutionCommandWrapperTest.java
@@ -325,9 +325,9 @@ public class ExecutionCommandWrapperTest {
     Cluster cluster = clusters.getCluster(CLUSTER1);
 
     StackId stackId = cluster.getDesiredStackVersion();
-    RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(stackId, "0.1-0000");
+    RepositoryVersionEntity repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(new StackId("HDP", "0.2"), "0.2-0000");
     repositoryVersion.setResolved(true); // has build number
-    Service service = cluster.getService("HDFS");
+    Service service = cluster.addService("HIVE", repositoryVersion);
     service.setDesiredRepositoryVersion(repositoryVersion);
 
     repositoryVersion.addRepoOsEntities(new ArrayList<>());
@@ -342,10 +342,10 @@ public class ExecutionCommandWrapperTest {
     executionCommand.setTaskId(1);
     executionCommand.setRequestAndStage(1, 1);
     executionCommand.setHostname(HOST1);
-    executionCommand.setRole("NAMENODE");
+    executionCommand.setRole("HIVE_SERVER");
     executionCommand.setRoleParams(Collections.<String, String>emptyMap());
     executionCommand.setRoleCommand(RoleCommand.INSTALL);
-    executionCommand.setServiceName("HDFS");
+    executionCommand.setServiceName("HIVE");
     executionCommand.setCommandType(AgentCommandType.EXECUTION_COMMAND);
     executionCommand.setCommandParams(commandParams);
 
@@ -366,10 +366,10 @@ public class ExecutionCommandWrapperTest {
     executionCommand.setTaskId(1);
     executionCommand.setRequestAndStage(1, 1);
     executionCommand.setHostname(HOST1);
-    executionCommand.setRole("NAMENODE");
+    executionCommand.setRole("HIVE_SERVER");
     executionCommand.setRoleParams(Collections.<String, String> emptyMap());
     executionCommand.setRoleCommand(RoleCommand.START);
-    executionCommand.setServiceName("HDFS");
+    executionCommand.setServiceName("HIVE");
     executionCommand.setCommandType(AgentCommandType.EXECUTION_COMMAND);
     executionCommand.setCommandParams(commandParams);
 
@@ -379,7 +379,7 @@ public class ExecutionCommandWrapperTest {
 
     processedExecutionCommand = execCommWrap.getExecutionCommand();
     commandParams = processedExecutionCommand.getCommandParams();
-    Assert.assertEquals("0.1-0000", commandParams.get(KeyNames.VERSION));
+    Assert.assertEquals("0.2-0000", commandParams.get(KeyNames.VERSION));
   }
 
   @AfterClass


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix unit test failure that could happen if test methods are executed in particular order.

```
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 11.139 s <<< FAILURE! - in org.apache.ambari.server.actionmanager.ExecutionCommandWrapperTest
[ERROR] testGetExecutionCommand(org.apache.ambari.server.actionmanager.ExecutionCommandWrapperTest)  Time elapsed: 0.011 s  <<< FAILURE!
java.lang.AssertionError
	at org.apache.ambari.server.actionmanager.ExecutionCommandWrapperTest.testGetExecutionCommand(ExecutionCommandWrapperTest.java:203)
```

Change `testExecutionCommandNoRepositoryFile()` to use a different stack version (`HDP-0.2`) and another service (`HIVE`) to avoid conflict with `testGetExecutionCommand()`.

https://issues.apache.org/jira/browse/AMBARI-24948

## How was this patch tested?

Verified that these 2 test methods pass in both orders.  Also executed the complete test class.