### PR TITLE
[AMBARI-22643] Trying to create some duplicate resources leads to HTTP 500 error

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CredentialResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/CredentialResourceProvider.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.DuplicateResourceException;
 import org.apache.ambari.server.StaticallyInject;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
@@ -368,7 +369,7 @@ public class CredentialResourceProvider extends AbstractControllerResourceProvid
       String alias = getAlias(properties);
 
       if (credentialStoreService.containsCredential(clusterName, alias)) {
-        throw new AmbariException("A credential with the alias of " + alias + " already exists");
+        throw new DuplicateResourceException("A credential with the alias of " + alias + " already exists");
       }
 
       credentialStoreService.setCredential(clusterName, alias, createCredential(properties), credentialStoreType);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RepositoryVersionResourceProvider.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.DuplicateResourceException;
 import org.apache.ambari.server.ObjectNotFoundException;
 import org.apache.ambari.server.api.resources.OperatingSystemResourceDefinition;
 import org.apache.ambari.server.api.resources.RepositoryResourceDefinition;
@@ -201,10 +202,10 @@ public class RepositoryVersionResourceProvider extends AbstractAuthorizedResourc
           RepositoryVersionEntity entity = toRepositoryVersionEntity(properties);
 
           if (repositoryVersionDAO.findByDisplayName(entity.getDisplayName()) != null) {
-            throw new AmbariException("Repository version with name " + entity.getDisplayName() + " already exists");
+            throw new DuplicateResourceException("Repository version with name " + entity.getDisplayName() + " already exists");
           }
           if (repositoryVersionDAO.findByStackAndVersion(entity.getStack(), entity.getVersion()) != null) {
-            throw new AmbariException("Repository version for stack " + entity.getStack() + " and version " + entity.getVersion() + " already exists");
+            throw new DuplicateResourceException("Repository version for stack " + entity.getStack() + " and version " + entity.getVersion() + " already exists");
           }
 
           validateRepositoryVersion(repositoryVersionDAO, ambariMetaInfo, entity);
@@ -479,7 +480,7 @@ public class RepositoryVersionResourceProvider extends AbstractAuthorizedResourc
       for (RepoDefinitionEntity repositoryEntity : os.getRepoDefinitionEntities()) {
         String baseUrl = repositoryEntity.getBaseUrl();
         if (!skipUrlCheck && os.isAmbariManaged() && existingRepoUrls.contains(baseUrl)) {
-          throw new AmbariException("Base url " + baseUrl + " is already defined for another repository version. " +
+          throw new DuplicateResourceException("Base url " + baseUrl + " is already defined for another repository version. " +
                   "Setting up base urls that contain the same versions of components will cause stack upgrade to fail.");
         }
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserResourceProvider.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.DuplicateResourceException;
 import org.apache.ambari.server.ObjectNotFoundException;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.UserRequest;
@@ -170,7 +171,7 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
       public Void invoke() throws AmbariException {
         try {
           createUsers(requests);
-        } catch (ResourceAlreadyExistsException | AuthorizationException e) {
+        } catch (AuthorizationException e) {
           throw new AmbariException(e.getMessage(), e);
         }
         return null;
@@ -354,7 +355,7 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
    * @param requests the request objects which define the user.
    * @throws AmbariException when the user cannot be created.
    */
-  private void createUsers(Set<UserRequest> requests) throws AmbariException, ResourceAlreadyExistsException, AuthorizationException {
+  private void createUsers(Set<UserRequest> requests) throws AmbariException, AuthorizationException {
     // First check for obvious issues... then try to create the accounts.  This will help to avoid
     // some accounts being created and some not due to an issue with one or more of the users.
     for (UserRequest request : requests) {
@@ -371,7 +372,7 @@ public class UserResourceProvider extends AbstractControllerResourceProvider imp
         } else {
           message = "One or more of the requested usernames already exists.";
         }
-        throw new ResourceAlreadyExistsException(message);
+        throw new DuplicateResourceException(message);
       }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
@@ -296,7 +296,7 @@ public class VersionDefinitionResourceProvider extends AbstractAuthorizedResourc
       if (dryRun) {
         validations.add(err);
       } else {
-        throw new IllegalArgumentException(err);
+        throw new ResourceAlreadyExistsException(err);
       }
     }
 
@@ -307,7 +307,7 @@ public class VersionDefinitionResourceProvider extends AbstractAuthorizedResourc
       if (dryRun) {
         validations.add(err);
       } else {
-        throw new IllegalArgumentException(err);
+        throw new ResourceAlreadyExistsException(err);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Trying to create duplicate resources of some kind (users, version definitions, credentials) results in the wrong HTTP response (`HTTP 500 Internal Server Error` or `HTTP 400 Bad Request`).  For most other resources, eg. services, the response is `HTTP 409 Conflict`.  This PR changes HTTP response for duplicate credentials, users and version definitions to be consistent with the rest of Ambari Server.

```
$ curl -X POST "http://${AMBARI_SERVER}:8080/api/v1/users/admin"
HTTP/1.1 500 Internal Server Error
{
  "status" : 500,
  "message" : "An internal system exception occurred: The requested username already exists."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/credentials/kdc.admin.principal" <<EOF
{
  "Credential": {
    "type": "TEMPORARY",
    "principal": "admin/admin",
    "key": "k"
  }
}
EOF
HTTP/1.1 500 Internal Server Error
{
  "status" : 500,
  "message" : "An internal system exception occurred: A credential with the alias of kdc.admin.principal already exists"
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "file:///tmp/duplicate_url.xml"
  }
}
EOF
HTTP/1.1 500 Internal Server Error
{
  "status" : 500,
  "message" : "An internal system exception occurred: Base url http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.0.0.0 is already defined for another repository version. Setting up base urls that contain the same versions of components will cause stack upgrade to fail."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "file:///tmp/duplicate_stack_version.xml"
  }
}
EOF
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Repository version for stack HDP-3.0 and version 3.0.0.0-1634 already exists."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "file:///tmp/duplicate_display_name.xml"
  }
}
EOF
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Repository version with name HDP-3.0.0.0 already exists."
}
```

https://issues.apache.org/jira/browse/AMBARI-22643

## How was this patch tested?

Tested the affected API to verify that the requests are still rejected, but with the correct response code.

```
$ curl -X POST "http://${AMBARI_SERVER}:8080/api/v1/users/admin"
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "The requested username already exists."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/users" <<EOF
[
  {
    "Users": {
      "user_name": "xy"
    }
  },
  {
    "Users": {
      "user_name": "admin"
    }
  }
]
EOF
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "One or more of the requested usernames already exists."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/credentials/kdc.admin.principal" <<EOF
{
  "Credential": {
    "type": "TEMPORARY",
    "principal": "admin/admin",
    "key": "k"
  }
}
EOF
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "A credential with the alias of kdc.admin.principal already exists"
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "file:///tmp/duplicate_url.xml"
  }
}
EOF
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "Base url http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.0.0.0 is already defined for another repository version. Setting up base urls that contain the same versions of components will cause stack upgrade to fail."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "file:///tmp/duplicate_stack_version.xml"
  }
}
EOF
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "Repository version for stack HDP-3.0 and version 3.0.0.0-1634 already exists."
}

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "file:///tmp/duplicate_display_name.xml"
  }
}
EOF
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "Repository version with name HDP-3.0.0.0 already exists."
}
```

Also tested regular, non-error case:

```
$ curl -X POST "http://${AMBARI_SERVER}:8080/api/v1/users/xy"
HTTP/1.1 201 Created

$ curl -X POST -d '{ "Users": { "user_name": "asdf" } }' "http://${AMBARI_SERVER}:8080/api/v1/users"
HTTP/1.1 201 Created

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/credentials/some.principal" <<EOF
{
  "Credential": {
    "type": "TEMPORARY",
    "principal": "admin/admin",
    "key": "k"
  }
}
EOF
HTTP/1.1 201 Created

$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/version_definitions" <<EOF
{
  "VersionDefinition": {
    "version_url": "http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml"
  }
}
EOF
HTTP/1.1 201 Created
{
  "resources" : [
    {
      "VersionDefinition" : {
        "id" : 52,
        "stack_name" : "HDP",
        "stack_version" : "2.6"
      }
    }
  ]
}
```