### PR TITLE
AMBARI-24951. Using Ambari CLI to specify which services should be setup for LDAP integration

### DIFF
--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -581,6 +581,10 @@ def init_ldap_setup_parser_options(parser):
   parser.add_option('--truststore-path', default=None, help="Path of TrustStore", dest="trust_store_path")
   parser.add_option('--truststore-password', default=None, help="Password for TrustStore", dest="trust_store_password")
   parser.add_option('--truststore-reconfigure', action="store_true", default=None, help="Force to reconfigure TrustStore if exits", dest="trust_store_reconfigure")
+  parser.add_option('--ldap-enabled-ambari', default=None, help="Indicates whether to enable/disable LDAP authentication for Ambari, itself", dest='ldap_enabled_ambari')
+  parser.add_option('--ldap-manage-services', default=None, help="Indicates whether Ambari should manage the LDAP configurations for specified services", dest='ldap_manage_services')
+  parser.add_option('--ldap-enabled-services', default=None, help="A comma separated list of services that are expected to be configured for LDAP (you are allowed to use '*' to indicate ALL services)", dest='ldap_enabled_services')
+
 
 @OsFamilyFuncImpl(OsFamilyImpl.DEFAULT)
 def init_setup_sso_options(parser):

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -1163,7 +1163,7 @@ def populate_service_management(options, properties, ambari_properties, admin_lo
     if manage_services:
       enabled_services = get_value_from_dictionary(properties, LDAP_ENABLED_SERVICES, "").upper().split(',')
 
-      all = "*" in enabled_services
+      all = WILDCARD_FOR_ALL_SERVICES in enabled_services
       configure_for_all_services = get_YN_input(" Manage LDAP for all services [y/n] ({0})? ".format('y' if all else 'n'), all)
       if configure_for_all_services:
         services = WILDCARD_FOR_ALL_SERVICES

--- a/ambari-server/src/main/python/ambari_server/setupSso.py
+++ b/ambari-server/src/main/python/ambari_server/setupSso.py
@@ -26,7 +26,8 @@ from ambari_commons.logging_utils import get_silent, print_info_msg
 
 from ambari_server.serverConfiguration import get_ambari_properties
 from ambari_server.serverUtils import is_server_runing, get_ambari_admin_username_password_pair, \
-  get_cluster_name, perform_changes_via_rest_api, get_json_via_rest_api
+  get_cluster_name, perform_changes_via_rest_api, get_json_via_rest_api, get_eligible_services, \
+  get_boolean_from_dictionary, get_value_from_dictionary
 from ambari_server.setupSecurity import REGEX_TRUE_FALSE
 from ambari_server.userInput import get_validated_string_input, get_YN_input, get_multi_line_input
 
@@ -134,31 +135,6 @@ def populate_ambari_requires_sso(options, properties):
 
   properties[AMBARI_SSO_AUTH_ENABLED] = 'true' if enabled else 'false'
 
-def eligible(service_info):
-  return service_info['sso_integration_supported'] \
-         and (not service_info['sso_integration_requires_kerberos'] or service_info['kerberos_enabled'])
-
-def get_eligible_services(properties, admin_login, admin_password, cluster_name):
-  print_info_msg("Fetching SSO enabled services")
-
-  safe_cluster_name = urllib2.quote(cluster_name)
-
-  response_code, json_data = get_json_via_rest_api(properties, admin_login, admin_password,
-                                                   FETCH_SERVICES_FOR_SSO_ENTRYPOINT % safe_cluster_name)
-
-  services = []
-
-  if json_data and 'items' in json_data:
-    services = [item['ServiceInfo']['service_name'] for item in json_data['items'] if eligible(item['ServiceInfo'])]
-
-    if len(services) > 0:
-      print_info_msg('Found SSO enabled services: %s' % ', '.join(services))
-    else:
-      print_info_msg('No SSO enabled services were found')
-
-  return services
-
-
 def populate_service_management(options, properties, ambari_properties, admin_login, admin_password):
   if not options.sso_enabled_services:
     if not options.sso_manage_services:
@@ -183,7 +159,7 @@ def populate_service_management(options, properties, ambari_properties, admin_lo
         cluster_name = get_cluster_name(ambari_properties, admin_login, admin_password)
 
         if cluster_name:
-          eligible_services = get_eligible_services(ambari_properties, admin_login, admin_password, cluster_name)
+          eligible_services = get_eligible_services(ambari_properties, admin_login, admin_password, cluster_name, FETCH_SERVICES_FOR_SSO_ENTRYPOINT, 'SSO')
 
           if eligible_services and len(eligible_services) > 0:
             service_list = []
@@ -318,11 +294,4 @@ def ensure_complete_cert(cert_string):
       cert_string = cert_string + '\n' + CERTIFICATE_FOOTER
 
   return cert_string
-
-def get_value_from_dictionary(properties, key, default_value=None):
-  return properties[key] if properties and key in properties else default_value
-
-def get_boolean_from_dictionary(properties, key, default_value=False):
-  value = get_value_from_dictionary(properties, key, None)
-  return 'true' == value.lower() if value else default_value
 

--- a/ambari-server/src/test/python/TestSetupSso.py
+++ b/ambari-server/src/test/python/TestSetupSso.py
@@ -482,6 +482,7 @@ class TestSetupSso(unittest.TestCase):
     self.assertEqual(ssoProperties[SSO_ENABLED_SERVICES], "*")
 
 
+  @patch("urllib2.urlopen")
   @patch("ambari_server.setupSso.perform_changes_via_rest_api")
   @patch("ambari_server.setupSso.get_cluster_name")
   @patch("ambari_server.setupSso.get_YN_input")
@@ -497,7 +498,8 @@ class TestSetupSso(unittest.TestCase):
                                                              get_ambari_properties_mock,
                                                              get_YN_input_mock,
                                                              get_cluster_name_mock,
-                                                             perform_changes_via_rest_api_mock):
+                                                             perform_changes_via_rest_api_mock,
+                                                             urlopen_mock):
     out = StringIO.StringIO()
     sys.stdout = out
 
@@ -582,6 +584,7 @@ class TestSetupSso(unittest.TestCase):
     response = MagicMock()
     response.getcode.return_value = 200
     response.read.return_value = eligible_services
+    urlopen_mock.return_value = response
 
     options = self._create_empty_options_mock()
     options.sso_enabled = 'true'


### PR DESCRIPTION
## What changes were proposed in this pull request?

New questions and CLI options have been added to support LDAP integration in Ambari:

1. Indicating whether to enable/disable LDAP authentication for Ambari itself
2. Indicating whether Ambari should manage the LDAP configurations for specified services
3. A comma separated list of services that are expected to be configured for LDAP (it is allowed to use `*` to indicate ALL services)

## How was this patch tested?

By extending existing unit tests with the new scenarios:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25:51 min
[INFO] Finished at: 2018-11-26T19:08:08+01:00
[INFO] Final Memory: 162M/874M
[INFO] ------------------------------------------------------------------------
```

In addition to this I executed `ambari-server setup-ldap` with and without the following CLI options; the tool behaved as expected in all cases and the new data has been saved in the DB:
`--ldap-enabled-ambari`
`--ldap-manage-services`
`--ldap-enabled-services`

**Important note:** the [JIRA](https://issues.apache.org/jira/browse/AMBARI-24951) indicated that we have to add a new question and CLI option to populate `User group member attribute (memberOf)` field; this change will come in a separate PR (I did not want to mix it with the service management)