### PR TITLE
[AMBARI-24947] Support for complex Add Service request in secure cluster

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
@@ -155,6 +155,11 @@ public interface KerberosHelper {
   String ALLOW_RETRY = "allow_retry_on_failure";
 
   /**
+   * Used as key in config maps to store component to host assignment mapping.
+   */
+  String CLUSTER_HOST_INFO = "clusterHostInfo";
+
+  /**
    * Toggles Kerberos security to enable it or remove it depending on the state of the cluster.
    * <p/>
    * The cluster "security_type" property is used to determine the security state of the cluster.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -605,12 +605,8 @@ public class KerberosHelperImpl implements KerberosHelper {
           }
         }
 
-        // Get (and created if needed) the clusterHostInfo map
-        Map<String, String> clusterHostInfoMap = configurations.get("clusterHostInfo");
-        if (clusterHostInfoMap == null) {
-          clusterHostInfoMap = new HashMap<>();
-          configurations.put("clusterHostInfo", clusterHostInfoMap);
-        }
+        // Get (and create if needed) the clusterHostInfo map
+        Map<String, String> clusterHostInfoMap = configurations.computeIfAbsent(CLUSTER_HOST_INFO, __ -> new HashMap<>());
 
         // Iterate through the recommendations to find the recommended host assignments
         for (RecommendationResponse.HostGroup hostGroup : hostGroups) {
@@ -2955,7 +2951,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     generalProperties.put("short_date", new SimpleDateFormat("MMddyy").format(new Date()));
 
     // add clusterHostInfo config
-    if (configurations.get("clusterHostInfo") == null) {
+    if (configurations.get(CLUSTER_HOST_INFO) == null) {
       Map<String, Set<String>> clusterHostInfo = StageUtils.getClusterHostInfo(cluster);
 
       if (clusterHostInfo != null) {
@@ -2967,7 +2963,7 @@ public class KerberosHelperImpl implements KerberosHelper {
           componentHosts.put(entry.getKey(), StringUtils.join(entry.getValue(), ","));
         }
 
-        configurations.put("clusterHostInfo", componentHosts);
+        configurations.put(CLUSTER_HOST_INFO, componentHosts);
       }
     }
     configurations.put("principals", principalNames(cluster, configurations));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
@@ -100,8 +100,8 @@ public class ClusterResourceProvider extends AbstractControllerResourceProvider 
   public static final String CLUSTER_STATE_PROPERTY_ID = PropertyHelper.getPropertyId("Clusters","state");
 
   static final String BLUEPRINT = "blueprint";
-  private static final String SECURITY = "security";
-  static final String CREDENTIALS = "credentials";
+  public static final String SECURITY = "security";
+  public static final String CREDENTIALS = "credentials";
   private static final String QUICKLINKS_PROFILE = "quicklinks_profile";
   private static final String SESSION_ATTRIBUTES = "session_attributes";
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ProvisionClusterRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ProvisionClusterRequest.java
@@ -119,6 +119,11 @@ public class ProvisionClusterRequest extends BaseClusterRequest {
    */
   public static final String QUICKLINKS_PROFILE_SERVICES_PROPERTY = "quicklinks_profile/services";
 
+  public static final String ALIAS = "alias";
+  public static final String PRINCIPAL = "principal";
+  public static final String KEY = "key";
+  public static final String TYPE = "type";
+
 
   /**
    * configuration factory
@@ -217,19 +222,19 @@ public class ProvisionClusterRequest extends BaseClusterRequest {
     Set<Map<String, String>> credentialsSet = (Set<Map<String, String>>) properties.get(ClusterResourceProvider.CREDENTIALS);
     if (credentialsSet != null) {
       for (Map<String, String> credentialMap : credentialsSet) {
-        String alias = Strings.emptyToNull(credentialMap.get("alias"));
+        String alias = Strings.emptyToNull(credentialMap.get(ALIAS));
         if (alias == null) {
           throw new InvalidTopologyTemplateException("credential.alias property is missing.");
         }
-        String principal = Strings.emptyToNull(credentialMap.get("principal"));
+        String principal = Strings.emptyToNull(credentialMap.get(PRINCIPAL));
         if (principal == null) {
           throw new InvalidTopologyTemplateException("credential.principal property is missing.");
         }
-        String key = Strings.emptyToNull(credentialMap.get("key"));
+        String key = Strings.emptyToNull(credentialMap.get(KEY));
         if (key == null) {
           throw new InvalidTopologyTemplateException("credential.key is missing.");
         }
-        String typeString = Strings.emptyToNull(credentialMap.get("type"));
+        String typeString = Strings.emptyToNull(credentialMap.get(TYPE));
         if (typeString == null) {
           throw new InvalidTopologyTemplateException("credential.type is missing.");
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -200,6 +200,8 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     PROPERTY_IDS.add(LDAP_INTEGRATION_DESIRED_PROPERTY_ID);
 
     PROPERTY_IDS.add(OPERATION_TYPE);
+    PROPERTY_IDS.add(ClusterResourceProvider.SECURITY);
+    PROPERTY_IDS.add(ClusterResourceProvider.CREDENTIALS);
 
     // keys
     KEY_PROPERTY_IDS.put(Resource.Type.Service, SERVICE_SERVICE_NAME_PROPERTY_ID);
@@ -1234,7 +1236,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   }
 
   private RequestStatusResponse processAddServiceRequest(Map<String, Object> requestProperties, Map<String, String> requestInfoProperties) throws NoSuchParentResourceException {
-    AddServiceRequest request = createAddServiceRequest(requestProperties, requestInfoProperties);
+    AddServiceRequest request = createAddServiceRequest(requestInfoProperties);
     String clusterName = String.valueOf(requestProperties.get(SERVICE_CLUSTER_NAME_PROPERTY_ID));
     try {
       return addServiceOrchestrator.processAddServiceRequest(getManagementController().getClusters().getCluster(clusterName), request);
@@ -1243,7 +1245,7 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
     }
   }
 
-  private static AddServiceRequest createAddServiceRequest(Map<String, Object> requestProperties, Map<String, String> requestInfoProperties) {
+  private static AddServiceRequest createAddServiceRequest(Map<String, String> requestInfoProperties) {
     return AddServiceRequest.of(requestInfoProperties.get(Request.REQUEST_INFO_BODY_PROPERTY));
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterConfigurationRequest.java
@@ -33,18 +33,21 @@ import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorBlueprintProcessor;
 import org.apache.ambari.server.controller.ClusterRequest;
 import org.apache.ambari.server.controller.ConfigurationRequest;
+import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.internal.BlueprintConfigurationProcessor;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.ConfigurationTopologyException;
 import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.serveraction.kerberos.KerberosInvalidConfigurationException;
 import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Responsible for cluster configuration.
@@ -57,7 +60,6 @@ public class ClusterConfigurationRequest {
    * a regular expression Pattern used to find "clusterHostInfo.(component_name)_host" placeholders in strings
    */
   private static final Pattern CLUSTER_HOST_INFO_PATTERN_VARIABLE = Pattern.compile("\\$\\{clusterHostInfo/?([\\w\\-\\.]+)_host(?:\\s*\\|\\s*(.+?))?\\}");
-  public static final String CLUSTER_HOST_INFO = "clusterHostInfo";
 
   private AmbariContext ambariContext;
   private ClusterTopology clusterTopology;
@@ -159,70 +161,41 @@ public class ClusterConfigurationRequest {
   }
 
   private Set<String> configureKerberos(Configuration clusterConfiguration, Map<String, Map<String, String>> existingConfigurations) throws AmbariException {
-    Set<String> updatedConfigTypes = new HashSet<>();
-
     Cluster cluster = getCluster();
     Blueprint blueprint = clusterTopology.getBlueprint();
-
-    Configuration stackDefaults = blueprint.getStack().getConfiguration(blueprint.getServices());
-    Map<String, Map<String, String>> stackDefaultProps = stackDefaults.getProperties();
+    Set<String> services = ImmutableSet.copyOf(blueprint.getServices());
+    Configuration stackDefaults = blueprint.getStack().getConfiguration(services);
 
     // add clusterHostInfo containing components to hosts map, based on Topology, to use this one instead of
     // StageUtils.getClusterInfo()
     Map<String, String> componentHostsMap = createComponentHostMap(blueprint);
-    existingConfigurations.put("clusterHostInfo", componentHostsMap);
+    existingConfigurations.put(KerberosHelper.CLUSTER_HOST_INFO, componentHostsMap);
 
     try {
+      KerberosHelper kerberosHelper = AmbariContext.getController().getKerberosHelper();
+
       // generate principals & keytabs for headless identities
-      AmbariContext.getController().getKerberosHelper()
-        .ensureHeadlessIdentities(cluster, existingConfigurations,
-          new HashSet<>(blueprint.getServices()));
+      kerberosHelper.ensureHeadlessIdentities(cluster, existingConfigurations, services);
 
-      // apply Kerberos specific configurations
-      Map<String, Map<String, String>> updatedConfigs = AmbariContext.getController().getKerberosHelper()
-        .getServiceConfigurationUpdates(cluster, existingConfigurations,
-            createServiceComponentMap(blueprint), null, null, true, false);
+      // get Kerberos specific configurations
+      Map<String, Map<String, String>> updatedConfigs = kerberosHelper.getServiceConfigurationUpdates(
+        cluster, existingConfigurations, createServiceComponentMap(blueprint), null, null, true, false);
 
-      // ******************************************************************************************
       // Since Kerberos is being enabled, make sure the cluster-env/security_enabled property is
       // set to "true"
-      Map<String, String> clusterEnv = updatedConfigs.get("cluster-env");
+      updatedConfigs
+        .computeIfAbsent(ConfigHelper.CLUSTER_ENV, __ -> new HashMap<>())
+        .put("security_enabled", "true");
 
-      if(clusterEnv == null) {
-        clusterEnv = new HashMap<>();
-        updatedConfigs.put("cluster-env", clusterEnv);
-      }
+      updatedConfigs.keySet().removeIf(configType -> !blueprint.isValidConfigType(configType));
 
-      clusterEnv.put("security_enabled", "true");
-      // ******************************************************************************************
-
-      for (String configType : updatedConfigs.keySet()) {
-        // apply only if config type has related services in Blueprint
-        if (blueprint.isValidConfigType(configType)) {
-          Map<String, String> propertyMap = updatedConfigs.get(configType);
-          Map<String, String> clusterConfigProperties = existingConfigurations.get(configType);
-          Map<String, String> stackDefaultConfigProperties = stackDefaultProps.get(configType);
-          for (String property : propertyMap.keySet()) {
-            // update value only if property value configured in Blueprint / ClusterTemplate is not a custom one
-            String currentValue = clusterConfiguration.getPropertyValue(configType, property);
-            String newValue = propertyMap.get(property);
-            if (!propertyHasCustomValue(clusterConfigProperties, stackDefaultConfigProperties, property) &&
-              (currentValue == null || !currentValue.equals(newValue))) {
-
-              LOG.debug("Update Kerberos related config property: {} {} {}", configType, property, propertyMap.get
-                (property));
-              clusterConfiguration.setProperty(configType, property, newValue);
-              updatedConfigTypes.add(configType);
-            }
-          }
-        }
-      }
-
+      // apply Kerberos specific configurations
+      return clusterConfiguration.applyUpdatesToStackDefaultProperties(stackDefaults, existingConfigurations, updatedConfigs);
     } catch (KerberosInvalidConfigurationException e) {
       LOG.error("An exception occurred while doing Kerberos related configuration update: " + e, e);
     }
 
-    return updatedConfigTypes;
+    return ImmutableSet.of();
   }
 
   /**
@@ -238,58 +211,20 @@ public class ClusterConfigurationRequest {
     if(services != null) {
       for (String service : services) {
         Collection<String> components = blueprint.getComponents(service);
-        serviceComponents.put(service,
-            (components == null)
-                ? Collections.emptySet()
-                : new HashSet<>(blueprint.getComponents(service)));
+        Set<String> componentSet = components == null ? ImmutableSet.of() : ImmutableSet.copyOf(components);
+        serviceComponents.put(service, componentSet);
       }
     }
 
     return serviceComponents;
   }
 
-  /**
-   * Returns true if the property exists in clusterConfigProperties and has a custom user defined value. Property has
-   * custom value in case we there's no stack default value for it or it's not equal to stack default value.
-   * @param clusterConfigProperties
-   * @param stackDefaultConfigProperties
-   * @param property
-   * @return
-   */
-  private boolean propertyHasCustomValue(Map<String, String> clusterConfigProperties, Map<String, String>
-    stackDefaultConfigProperties, String property) {
-
-    boolean propertyHasCustomValue = false;
-    if (clusterConfigProperties != null) {
-      String propertyValue = clusterConfigProperties.get(property);
-      if (propertyValue != null) {
-        if (stackDefaultConfigProperties != null) {
-          String stackDefaultValue = stackDefaultConfigProperties.get(property);
-          if (stackDefaultValue != null) {
-            propertyHasCustomValue = !propertyValue.equals(stackDefaultValue);
-          } else {
-            propertyHasCustomValue = true;
-          }
-        } else {
-          propertyHasCustomValue = true;
-        }
-      }
-    }
-    return propertyHasCustomValue;
-  }
-
   private Map<String, String> createComponentHostMap(Blueprint blueprint) {
-    Map<String, String> componentHostsMap = new HashMap<>();
-    for (String service : blueprint.getServices()) {
-      Collection<String> components = blueprint.getComponents(service);
-      for (String component : components) {
-        Collection<String> componentHost = clusterTopology.getHostAssignmentsForComponent(component);
-        // retrieve corresponding clusterInfoKey for component using StageUtils
-        String clusterInfoKey = StageUtils.getClusterHostInfoKey(component);
-        componentHostsMap.put(clusterInfoKey, StringUtils.join(componentHost, ","));
-      }
-    }
-    return componentHostsMap;
+    return StageUtils.createComponentHostMap(
+      blueprint.getServices(),
+      blueprint::getComponents,
+      (service, component) -> clusterTopology.getHostAssignmentsForComponent(component)
+    );
   }
 
   private Collection<String> getRequiredHostgroupsForKerberosConfiguration() {
@@ -301,7 +236,7 @@ public class ClusterConfigurationRequest {
 
       Configuration clusterConfiguration = clusterTopology.getConfiguration();
       Map<String, Map<String, String>> existingConfigurations = clusterConfiguration.getFullProperties();
-      existingConfigurations.put(CLUSTER_HOST_INFO, new HashMap<>());
+      existingConfigurations.put(KerberosHelper.CLUSTER_HOST_INFO, new HashMap<>());
 
       // apply Kerberos specific configurations
       Map<String, Map<String, String>> updatedConfigs = AmbariContext.getController().getKerberosHelper()
@@ -398,7 +333,7 @@ public class ClusterConfigurationRequest {
    */
   private void setConfigurationsOnCluster(List<BlueprintServiceConfigRequest> configurationRequests,
                                          String tag, Set<String> updatedConfigTypes)  {
-    String clusterName = null;
+    String clusterName;
     try {
       clusterName = ambariContext.getClusterName(clusterTopology.getClusterId());
     } catch (AmbariException e) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Credential.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Credential.java
@@ -18,53 +18,108 @@
 
 package org.apache.ambari.server.topology;
 
+import static org.apache.ambari.server.controller.internal.ProvisionClusterRequest.ALIAS;
+import static org.apache.ambari.server.controller.internal.ProvisionClusterRequest.KEY;
+import static org.apache.ambari.server.controller.internal.ProvisionClusterRequest.PRINCIPAL;
+import static org.apache.ambari.server.controller.internal.ProvisionClusterRequest.TYPE;
+
+import java.util.Objects;
+
 import org.apache.ambari.server.security.encryption.CredentialStoreType;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Holds credential info submitted in a cluster create template.
  */
+@ApiModel
 public class Credential {
 
   /**
    * Credential alias like kdc.admin.credential.
    */
-  private String alias;
+  private final String alias;
 
   /**
    * Name of a principal.
    */
-  private String principal;
+  private final String principal;
 
   /**
    * Key of credential.
    */
-  private String key;
+  private final String key;
 
   /**
    * Type of credential store.
    */
-  private CredentialStoreType type;
+  private final CredentialStoreType type;
 
-  public Credential(String alias, String principal, String key, CredentialStoreType type) {
+  @JsonCreator
+  public Credential(
+    @JsonProperty(ALIAS) String alias,
+    @JsonProperty(PRINCIPAL) String principal,
+    @JsonProperty(KEY) String key,
+    @JsonProperty(TYPE) CredentialStoreType type
+  ) {
     this.alias = alias;
     this.principal = principal;
     this.key = key;
     this.type = type;
   }
 
+  @JsonProperty(ALIAS)
+  @ApiModelProperty(name = ALIAS)
   public String getAlias() {
     return alias;
   }
 
+  @JsonProperty(PRINCIPAL)
+  @ApiModelProperty(name = PRINCIPAL)
   public String getPrincipal() {
     return principal;
   }
 
+  @JsonProperty(KEY)
+  @ApiModelProperty(name = KEY)
   public String getKey() {
     return key;
   }
 
+  @JsonProperty(TYPE)
+  @ApiModelProperty(name = TYPE)
   public CredentialStoreType getType() {
     return type;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+
+    Credential other = (Credential) obj;
+
+    return Objects.equals(alias, other.alias) &&
+      Objects.equals(principal, other.principal) &&
+      Objects.equals(key, other.key) &&
+      Objects.equals(type, other.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(alias, principal, key, type);
+  }
+
+  @Override
+  public String toString() {
+    return alias;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
@@ -18,14 +18,31 @@
 
 package org.apache.ambari.server.topology;
 
+import static org.apache.ambari.server.topology.SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_PROPERTY_ID;
+import static org.apache.ambari.server.topology.SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID;
+import static org.apache.ambari.server.topology.SecurityConfigurationFactory.TYPE_PROPERTY_ID;
+
+import java.util.Objects;
+
 import org.apache.ambari.server.state.SecurityType;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Holds security related properties, the securityType and security descriptor (in case of KERBEROS
  * kerberos_descriptor) either contains the whole descriptor or just the reference to it.
  *
  */
+@ApiModel
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SecurityConfiguration {
+
+  public static final SecurityConfiguration NONE = new SecurityConfiguration(SecurityType.NONE);
 
   /**
    * Security Type
@@ -46,21 +63,54 @@ public class SecurityConfiguration {
     this.type = type;
   }
 
-  public SecurityConfiguration(SecurityType type, String descriptorReference, String descriptor) {
+  @JsonCreator
+  public SecurityConfiguration(
+    @JsonProperty(TYPE_PROPERTY_ID) SecurityType type,
+    @JsonProperty(KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID) String descriptorReference,
+    @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID) String descriptor
+  ) {
     this.type = type;
     this.descriptorReference = descriptorReference;
     this.descriptor = descriptor;
   }
 
+  @JsonProperty(TYPE_PROPERTY_ID)
+  @ApiModelProperty(name = TYPE_PROPERTY_ID)
   public SecurityType getType() {
     return type;
   }
 
+  @JsonProperty(KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)
+  @ApiModelProperty(name = KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)
   public String getDescriptor() {
     return descriptor;
   }
 
+  @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID)
+  @ApiModelProperty(name = KERBEROS_DESCRIPTOR_PROPERTY_ID)
   public String getDescriptorReference() {
     return descriptorReference;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+
+    SecurityConfiguration other = (SecurityConfiguration) obj;
+
+    return Objects.equals(type, other.type) &&
+      Objects.equals(descriptor, other.descriptor) &&
+      Objects.equals(descriptorReference, other.descriptorReference);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, descriptor, descriptorReference);
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.joining;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ambari.server.controller.AddServiceRequest;
 import org.apache.ambari.server.controller.internal.RequestStageContainer;
 import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.topology.Configuration;
@@ -31,13 +32,15 @@ import org.apache.ambari.server.topology.Configuration;
  */
 public final class AddServiceInfo {
 
+  private final AddServiceRequest request;
   private final String clusterName;
   private final Stack stack;
   private final Map<String, Map<String, Set<String>>> newServices;
   private final RequestStageContainer stages;
   private final Configuration config;
 
-  public AddServiceInfo(String clusterName, Stack stack, Configuration config, RequestStageContainer stages, Map<String, Map<String, Set<String>>> newServices) {
+  public AddServiceInfo(AddServiceRequest request, String clusterName, Stack stack, Configuration config, RequestStageContainer stages, Map<String, Map<String, Set<String>>> newServices) {
+    this.request = request;
     this.clusterName = clusterName;
     this.stack = stack;
     this.newServices = newServices;
@@ -48,6 +51,10 @@ public final class AddServiceInfo {
   @Override
   public String toString() {
     return "AddServiceRequest(" + stages.getId() + ")";
+  }
+
+  public AddServiceRequest getRequest() {
+    return request;
   }
 
   public String clusterName() {

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/ShellCommandUtil.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/ShellCommandUtil.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -442,6 +443,8 @@ public class ShellCommandUtil {
       Map<String, String> env = builder.environment();
       env.putAll(vars);
     }
+
+    LOG.debug("Executing the command {}", Arrays.toString(processArgs));
 
     Process process;
     if (WINDOWS) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -45,6 +45,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import javax.xml.bind.JAXBException;
 
@@ -616,5 +618,27 @@ public class StageUtils {
         hostLevelParams.put(JCE_NAME, null); // custom jdk for stack
       }
     }
+  }
+
+  /**
+   * Create a component -> hosts mapping that can be used for clusterHostInfo.
+   * Component names are transformed to clusterHostInfo keys ("_hosts" is appended).
+   * List of hosts is comma-separated.
+   *
+   * @param services collection of services to create the mapping for
+   * @param componentsLookup function to find components of a given service
+   * @param hostAssignmentLookup function to find hosts of a given (service, component) pair
+   * @return component names
+   */
+  public static Map<String, String> createComponentHostMap(Collection<String> services, Function<String, Collection<String>> componentsLookup, BiFunction<String, String, Collection<String>> hostAssignmentLookup) {
+    Map<String, String> componentHostsMap = new HashMap<>();
+    for (String service : services) {
+      Collection<String> components = componentsLookup.apply(service);
+      for (String component : components) {
+        Collection<String> hosts = hostAssignmentLookup.apply(service, component);
+        componentHostsMap.put(getClusterHostInfoKey(component), StringUtils.join(hosts, ","));
+      }
+    }
+    return componentHostsMap;
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
@@ -42,11 +42,16 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.ambari.server.controller.internal.ProvisionAction;
+import org.apache.ambari.server.security.encryption.CredentialStoreType;
+import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.topology.ConfigRecommendationStrategy;
 import org.apache.ambari.server.topology.Configurable;
 import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.topology.Credential;
+import org.apache.ambari.server.topology.SecurityConfiguration;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -110,6 +115,16 @@ public class AddServiceRequestTest {
       ImmutableSet.of(Service.of("STORM"), Service.of("BEACON")),
       request.getServices());
 
+    assertEquals(
+      Optional.of(new SecurityConfiguration(SecurityType.KERBEROS, "ref_to_kerb_desc", null)),
+      request.getSecurity());
+
+    assertEquals(
+      ImmutableMap.of(
+        "kdc.admin.credential", new Credential( "kdc.admin.credential", "admin/admin@EXAMPLE.COM", "k", CredentialStoreType.TEMPORARY)
+      ),
+      request.getCredentials()
+    );
   }
 
   @Test
@@ -131,6 +146,8 @@ public class AddServiceRequestTest {
     assertEquals(INSTALL_AND_START, request.getProvisionAction());
     assertNull(request.getStackName());
     assertNull(request.getStackVersion());
+    assertEquals(Optional.empty(), request.getSecurity());
+    assertEquals(ImmutableMap.of(), request.getCredentials());
 
     Configuration configuration = request.getConfiguration();
     assertTrue(configuration.getFullAttributes().isEmpty());

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterConfigurationRequestTest.java
@@ -230,7 +230,7 @@ public class ClusterConfigurationRequestTest {
     expectLastCall().andReturn(controller).anyTimes();
 
     expect(controller.getClusters()).andReturn(clusters).anyTimes();
-    expect(controller.getKerberosHelper()).andReturn(kerberosHelper).times(2);
+    expect(controller.getKerberosHelper()).andReturn(kerberosHelper).times(1);
 
     expect(clusters.getCluster("testCluster")).andReturn(cluster).anyTimes();
 

--- a/ambari-server/src/test/resources/add_service_api/request1.json
+++ b/ambari-server/src/test/resources/add_service_api/request1.json
@@ -21,6 +21,20 @@
     }
   ],
 
+  "security": {
+    "type": "KERBEROS",
+    "kerberos_descriptor_reference": "ref_to_kerb_desc"
+  },
+
+  "credentials": [
+    {
+      "alias": "kdc.admin.credential",
+      "principal": "admin/admin@EXAMPLE.COM",
+      "key": "k",
+      "type": "TEMPORARY"
+    }
+  ],
+
   "configurations" : [
     {
       "storm-site" : {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow using Add Service request in clusters with Kerberos.

 * Add `security` and `credentials` to the request syntax
 * Store credentials from the request, but allow the case when credential is already available (eg. from initial cluster install)
 * `security/type` is optional, but validated if specified

Kerberos descriptor is not stored yet.

## How was this patch tested?

Deployed secure cluster with ZooKeeper and Infra Solr via blueprint.  Added Kafka and Ambari Metrics via Add Service request.