### PR TITLE
AMBARI-24921 If service does not have client service component created then "Run Service Check" option should be made hidden(second patch)

### DIFF
--- a/ambari-web/app/views/main/service/item.js
+++ b/ambari-web/app/views/main/service/item.js
@@ -158,11 +158,11 @@ App.MainServiceItemView = Em.View.extend(App.HiveInteractiveCheck, {
     var allMasters = service.get('hostComponents').filterProperty('isMaster').mapProperty('componentName').uniq();
     var allSlaves = service.get('slaveComponents').rejectProperty('totalCount', 0).mapProperty('componentName');
     var actionMap = App.HostComponentActionMap.getMap(this);
-    var serviceCheckSupported = App.get('services.supportsServiceCheck').contains(service.get('serviceName'))
-      && service.get('installedClients') > 0;
+    var serviceName = service.get('serviceName');
+    var hasClient = App.StackService.find(serviceName).get('hasClient') ? service.get('installedClients') > 0 : true;
+    var serviceCheckSupported = App.get('services.supportsServiceCheck').contains(serviceName) && hasClient;
     var hasConfigTab = this.get('hasConfigTab');
     var excludedCommands = this.get('mastersExcludedCommands');
-    var serviceName = service.get('serviceName');
     var hasMultipleMasterComponentGroups = this.get('service.hasMultipleMasterComponentGroups');
 
     if (App.isAuthorized('SERVICE.START_STOP')) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
If service does not have client service component created then "Run Service Check" option should be made hidden

## How was this patch tested?
 21966 passing (30s)
  48 pending
