### PR TITLE
AMBARI-24961 Ambari is unable to parse {{hostname}} in {hdfs-site/dfsdatanode.address} and is triggering alert for datanode process (asnaik)

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/alerts/port_alert.py
+++ b/ambari-agent/src/main/python/ambari_agent/alerts/port_alert.py
@@ -113,7 +113,7 @@ class PortAlert(BaseAlert):
 
 
     host = get_host_from_url(uri_value)
-    if host is None or host == "localhost" or host == "0.0.0.0":
+    if host is None or host == "localhost" or host == "0.0.0.0" or host == "{{hostname}}":
       host = self.host_name
       host_not_specified = True
 


### PR DESCRIPTION
AMBARI-24961 Ambari is unable to parse {{hostname}} in {hdfs-site/dfsdatanode.address} and is triggering alert for datanode process (asnaik)
## What changes were proposed in this pull request?
Ambari should parse {{hostname}} also as localhost becuase datanode accepts it .currenyly ambari is only parsing localhost and 0.0.0.0 as localhost.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.