### PR TITLE
AMBARI-24958 Ambari YARN Queue Manager allows duplicate names when using rename functionality (asnaik)

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queue.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queue.js
@@ -503,8 +503,9 @@ App.QueueController = Ember.ObjectController.extend({
 
     queue.set('name',name);
 
+    //new queue name has to be unique  
     foundWithName = this.store.all('queue').find(function (q) {
-      return q.get('path') === [queue.get('parentPath'),queue.get('name')].join('.');
+      return q.get('name') === queue.get('name') && q.get('path') != queue.get('path');
     });
 
     if (!Em.isEmpty(foundWithName) && queue.changedAttributes().hasOwnProperty('name')) {


### PR DESCRIPTION
AMBARI-24958 Ambari YARN Queue Manager allows duplicate names when using rename functionality (asnaik)
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.