### PR TITLE
AMBARI-24962 Summary panel should not have any information if only client component is installed in a cluster

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -3123,6 +3123,8 @@ Em.I18n.translations = {
   'dashboard.services.yarn.nodes.heapUsedPercent':'{0}%',
   'dashboard.services.yarn.clients':'YARN Clients',
   'dashboard.services.yarn.client':'YARN Client',
+  'dashboard.services.hdfs.clients':'HDFS Clients',
+  'dashboard.services.hdfs.client':'HDFS Client',
   'dashboard.services.yarn.resourceManager.uptime':'ResourceManager Uptime',
   'dashboard.services.yarn.resourceManager.active':'Active ResourceManager',
   'dashboard.services.yarn.resourceManager.standby':'Standby ResourceManager',

--- a/ambari-web/app/templates/main/service/info/summary/hdfs/slaves.hbs
+++ b/ambari-web/app/templates/main/service/info/summary/hdfs/slaves.hbs
@@ -84,6 +84,19 @@
         </div>
       </div>
     {{/if}}
+    {{! HDFS Clients }}
+    {{#if view.isHDFSClientCreated}}
+      <div {{bindAttr class=":row :component :col-md-3 view.hdfsClientComponent.componentName"}}>
+        <div class="summary-value main-info">
+          <span>{{view.service.installedClients}} {{t common.installed}} </span>
+        </div>
+        <div class="summary-label">
+          <a {{action filterHosts view.hdfsClientComponent}} href="javascript:void(null)">
+            {{pluralize view.service.installedClients singular="t:dashboard.services.hdfs.client" plural="t:dashboard.services.hdfs.clients"}}
+          </a>
+        </div>
+      </div>
+    {{/if}}
     {{! indent next row}}
     <div class="row"></div>
     <div class="summary-label col-md-12">{{t dashboard.services.hdfs.datanodecounts}}</div>

--- a/ambari-web/app/templates/main/service/info/summary/master_components.hbs
+++ b/ambari-web/app/templates/main/service/info/summary/master_components.hbs
@@ -64,6 +64,20 @@
     {{/if}}
   {{/if}}
 {{/each}}
-{{#if view.componentCommonWidgetsView}}
-  {{view view.componentCommonWidgetsView}}
+{{#unless view.mastersComp.length}}
+  <div class="col-md-12">
+    <div class="col-md-2">
+      {{#if view.parentView.parentView.hasComponents}}
+        {{t dashboard.services.hdfs.summary.components}}
+      {{/if}}
+    </div>
+    <div class="col-md-10">
+      {{view App.SummaryClientComponentsView clientsObjBinding="view.parentView.parentView.clientObj"}}
+    </div>
+  </div>
+{{/unless}}
+{{#if view.parentView.parentView.service.hasMasterOrSlaveComponent}}
+  {{#if view.componentCommonWidgetsView}}
+    {{view view.componentCommonWidgetsView}}
+  {{/if}}
 {{/if}}

--- a/ambari-web/app/templates/main/service/services/yarn.hbs
+++ b/ambari-web/app/templates/main/service/services/yarn.hbs
@@ -22,7 +22,7 @@
     {{view view.dashboardMasterComponentView}}
     <div class="col-md-12">
       <div class="col-md-2">
-        {{#if view.hasMultipleMasterGroups}}
+        {{#if view.parentView.hasComponents}}
           {{t dashboard.services.hdfs.summary.components}}
         {{/if}}
       </div>
@@ -57,72 +57,75 @@
             </a>
           </div>
         </div>
-        {{! indent next row}}
-        <div class="row"></div>
-        {{! ResourceManager Uptime }}
-        <div class="row col-md-3 resourcemanager-uptime">
-          <div class="summary-value main-info">{{view.nodeUptime}}</div>
-          <div class="summary-label">{{t dashboard.services.yarn.resourceManager.uptime}}</div>
-        </div>
-        {{! indent next row}}
-        <div class="row"></div>
-        <div class="summary-label col-md-12">{{t dashboard.services.yarn.nodeManagers.status}}</div>
-        {{! NodeManagers active }}
-        <div class="row col-md-3 nodemanager-active">
-        <span class="summary-value main-info"
-          {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.active"}}
+        {{#if view.parentView.service.hasMasterOrSlaveComponent}}
+          {{! indent next row}}
+          <div class="row"></div>
+          {{! ResourceManager Uptime }}
+          <div class="row col-md-3 resourcemanager-uptime">
+            <div class="summary-value main-info">{{view.nodeUptime}}</div>
+            <div class="summary-label">{{t dashboard.services.yarn.resourceManager.uptime}}</div>
+          </div>
+          {{! indent next row}}
+          <div class="row"></div>
+          <div class="summary-label col-md-12">{{t dashboard.services.yarn.nodeManagers.status}}</div>
+          {{! NodeManagers active }}
+          <div class="row col-md-3 nodemanager-active">
+          <span class="summary-value main-info"
+            {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.active"}}
               rel="tooltip">
-          {{view._nmActive}}
-        </span>
-          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.active}}</div>
-        </div>
-        {{! NodeManagers lost }}
-        <div class="row col-md-3 nodemanager-lost">
-        <span class="summary-value main-info"
-          {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.lost"}}
+            {{view._nmActive}}
+          </span>
+            <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.active}}</div>
+          </div>
+          {{! NodeManagers lost }}
+          <div class="row col-md-3 nodemanager-lost">
+          <span class="summary-value main-info"
+            {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.lost"}}
               rel="tooltip">
-          {{view._nmLost}}
-        </span>
-          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.lost}}</div>
-        </div>
-        {{! NodeManagers unhealthy }}
-        <div class="row col-md-3 nodemanager-unhealthy">
-        <span class="summary-value main-info"
-          {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.unhealthy"}}
+            {{view._nmLost}}
+          </span>
+            <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.lost}}</div>
+          </div>
+          {{! NodeManagers unhealthy }}
+          <div class="row col-md-3 nodemanager-unhealthy">
+          <span class="summary-value main-info"
+            {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.unhealthy"}}
               rel="tooltip">
-          {{view._nmUnhealthy}}
-        </span>
-          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.unhealthy}}</div>
-        </div>
-        {{! NodeManagers rebooted }}
-        <div class="row col-md-3 nodemanager-rebooted">
-        <span class="summary-value main-info"
+            {{view._nmUnhealthy}}
+          </span>
+            <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.unhealthy}}</div>
+          </div>
+          {{! NodeManagers rebooted }}
+          <div class="row col-md-3 nodemanager-rebooted">
+          <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.rebooted"}}
               rel="tooltip">
           {{view._nmRebooted}}
-        </span>
-          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.rebooted}}</div>
-        </div>
-        {{! NodeManagers decommissioned }}
-        <div class="row col-md-3 nodemanager-decommissioned">
-        <span class="summary-value main-info"
+          </span>
+            <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.rebooted}}</div>
+          </div>
+          {{! NodeManagers decommissioned }}
+          <div class="row col-md-3 nodemanager-decommissioned">
+          <span class="summary-value main-info"
           {{translateAttr data-original-title="dashboard.services.yarn.nodeManagers.status.tooltip.decommissioned"}}
               rel="tooltip">
           {{view._nmDecom}}
-        </span>
-          <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.decommissioned}}</div>
-        </div>
-        {{! indent next row}}
-        <div class="row"></div>
-        {{! ResourceManager Heap }}
-        <div class="row col-md-3 resourcemanager-heap">
-          <div class="summary-value main-info">{{view.nodeHeap}}</div>
-          <div class="summary-label">{{t dashboard.services.resourceManager.nodes.heap}}</div>
-        </div>
+          </span>
+            <div class="info-desc">{{t dashboard.services.yarn.nodeManagers.status.decommissioned}}</div>
+          </div>
+          {{! indent next row}}
+          <div class="row"></div>
+          {{! ResourceManager Heap }}
+          <div class="row col-md-3 resourcemanager-heap">
+            <div class="summary-value main-info">{{view.nodeHeap}}</div>
+            <div class="summary-label">{{t dashboard.services.resourceManager.nodes.heap}}</div>
+          </div>
+        {{/if}}
       </div>
     </div>
   </div>
 
+  {{#if view.parentView.service.hasMasterOrSlaveComponent}}
   {{! Service Metrics Section }}
   <div class="col-md-12 metrics-summary">
     <div class="col-md-2">{{t dashboard.services.hdfs.summary.service-metrics}}</div>
@@ -232,5 +235,6 @@
       </div>
     </div>
   </div>
+  {{/if}}
   {{! right column end }}
 </div>

--- a/ambari-web/app/views/main/service/info/summary.js
+++ b/ambari-web/app/views/main/service/info/summary.js
@@ -51,6 +51,11 @@ App.MainServiceInfoSummaryView = Em.View.extend({
    */
   clientObj: [],
   clientsLength: 0,
+  
+  /**
+   * @type {boolean}
+   */
+  hasComponents: Em.computed.or('mastersLength', 'slavesLength', 'clientsLength'),
 
   /**
    *  @property {String} templatePathPrefix - base path for custom templates

--- a/ambari-web/app/views/main/service/info/summary/hdfs/slaves.js
+++ b/ambari-web/app/views/main/service/info/summary/hdfs/slaves.js
@@ -35,6 +35,10 @@ App.HDFSSlaveComponentsView = Em.View.extend({
   nfsGatewayComponent: Em.Object.create({
     componentName: 'NFS_GATEWAY'
   }),
+  
+  hdfsClientComponent: Em.Object.create({
+    componentName: 'HDFS_CLIENT'
+  }),
 
   service: Em.computed.alias('summaryView.service'),
 
@@ -44,6 +48,10 @@ App.HDFSSlaveComponentsView = Em.View.extend({
 
   isJournalNodeCreated: function () {
     return this.get('summaryView') ? this.get('summaryView').isServiceComponentCreated('JOURNALNODE') : false;
+  }.property('App.router.clusterController.isComponentsStateLoaded'),
+  
+  isHDFSClientCreated: function () {
+    return this.get('summaryView') ? this.get('summaryView').isServiceComponentCreated('HDFS_CLIENT') : false;
   }.property('App.router.clusterController.isComponentsStateLoaded'),
 
   journalNodesLive: function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Service Summary does not list number of HDFS clients installed
2. Other data in summary panel fetched from ambari metrics api should be made hidden (like Disk usage etc)
3. Same needs to be done for Yarn client service

## How was this patch tested?
21969 passing (29s)
  48 pending
