### PR TITLE
AMBARI-24968. Apply QosFilter on ambari-server's api interface.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -149,6 +149,7 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.GzipFilter;
+import org.eclipse.jetty.servlets.QoSFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
@@ -424,6 +425,11 @@ public class AmbariServer {
       root.addEventListener(new RequestContextListener());
       root.addFilter(new FilterHolder(springSecurityFilter), "/api/*", DISPATCHER_TYPES);
       root.addFilter(new FilterHolder(new UserNameOverrideFilter()), "/api/v1/users/*", DISPATCHER_TYPES);
+
+      // Apply the QoSFilter for api
+      QoSFilter qosFilter = new QoSFilter();
+      qosFilter.setMaxRequests(configs.getClientThreadPoolSize());
+      root.addFilter(new FilterHolder(qosFilter), "/api/*", DISPATCHER_TYPES);
 
       // session-per-request strategy for agents
       agentroot.addFilter(new FilterHolder(injector.getInstance(AmbariPersistFilter.class)), "/agent/*", DISPATCHER_TYPES);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apply QoSFilter on ambari-server's api interface.

## How was this patch tested?

Manually tested in a cluster. Also tested upgrade scenarios.

```bash
mvn -pl ambari-server test -DskipPythonTests

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ViewRegistryTest.testReadViewArchives:260->testReadViewArchives:488 expected:<DEPLOYED> but was:<ERROR>
[ERROR]   ViewRegistryTest.testReadViewArchives_removeUndeployed:265->testReadViewArchives:488 expected:<DEPLOYED> but was:<ERROR>
[ERROR] Errors: 
[ERROR]   AmbariManagementControllerTest.testCreateActionsFailures:4363 » Ambari Action ...
[ERROR]   AlertsDAOTest.setup:123 » ClusterNotFound Cluster not found, clusterName=clust...
[INFO] 
[ERROR] Tests run: 5232, Failures: 2, Errors: 2, Skipped: 72
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

The above failure may have something to do with my environment, this change shouldn't cause this failure.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.