### PR TITLE
Ambari 24970 branch 2.7

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
@@ -101,7 +101,7 @@ class HivePreUpgrade(Script):
       Execute(hive_kinit_cmd, user = params.hive_user)
     
     # in the M10 release PreUpgradeTool was fixed to use Hive1 instead of Hive2 
-    if target_version >= "3.0.3":
+    if target_version >= "3.1":
       hive_lib_dir = format("{source_dir}/hive/lib")
     else:
       hive_lib_dir = format("{source_dir}/hive2/lib")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set Hive pre-upgrade threshold for using Hive 1 jars to 3.1

## How was this patch tested?

Tested on local cluster.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.