### PR TITLE
[AMBARI-24971] HDFS datanode process fails with class not found exception when installed with OZONE 

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -112,6 +112,10 @@ hadoop_home = stack_select.get_hadoop_dir("home")
 hadoop_libexec_dir = stack_select.get_hadoop_dir("libexec")
 hadoop_lib_home = stack_select.get_hadoop_dir("lib")
 
+ozone_manager_hosts = default("/clusterHostInfo/ozone_manager_hosts", [])
+has_ozone = not len(ozone_manager_hosts) == 0
+hadoop_ozone_home = os.path.join(stack_root, version, "hadoop-ozone")
+
 hadoop_dir = "/etc/hadoop"
 hadoop_java_io_tmpdir = os.path.join(tmp_dir, "hadoop_java_io_tmpdir")
 datanode_max_locked_memory = config['configurations']['hdfs-site']['dfs.datanode.max.locked.memory']

--- a/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/before-ANY/scripts/params.py
@@ -114,7 +114,10 @@ hadoop_lib_home = stack_select.get_hadoop_dir("lib")
 
 ozone_manager_hosts = default("/clusterHostInfo/ozone_manager_hosts", [])
 has_ozone = not len(ozone_manager_hosts) == 0
-hadoop_ozone_home = os.path.join(stack_root, version, "hadoop-ozone")
+if version:
+  hadoop_ozone_home = os.path.join(stack_root, version, "hadoop-ozone")
+else:
+  hadoop_ozone_home = os.path.join(stack_root, "current", "hadoop-ozone")
 
 hadoop_dir = "/etc/hadoop"
 hadoop_java_io_tmpdir = os.path.join(tmp_dir, "hadoop_java_io_tmpdir")

--- a/ambari-server/src/test/python/stacks/configs/default.json
+++ b/ambari-server/src/test/python/stacks/configs/default.json
@@ -32,8 +32,7 @@
         "xml_configs_list":[{"hdfs-site.xml":"hdfs-site"}],
         "env_configs_list":[{"hadoop-env.sh":"hadoop-env"},{"log4j.properties":"hdfs-log4j,yarn-log4j"}],
         "properties_configs_list":[{"runtime.properties":"falcon-runtime.properties"},{"startup.properties":"falcon-startup.properties"}],
-        "output_file":"HDFS_CLIENT-configs.tar.gz",
-        "version":"3.0.100.0-75"
+        "output_file":"HDFS_CLIENT-configs.tar.gz"
     }, 
     "clusterLevelParams": {
         "stack_version": "2.0", 

--- a/ambari-server/src/test/python/stacks/configs/default.json
+++ b/ambari-server/src/test/python/stacks/configs/default.json
@@ -32,7 +32,8 @@
         "xml_configs_list":[{"hdfs-site.xml":"hdfs-site"}],
         "env_configs_list":[{"hadoop-env.sh":"hadoop-env"},{"log4j.properties":"hdfs-log4j,yarn-log4j"}],
         "properties_configs_list":[{"runtime.properties":"falcon-runtime.properties"},{"startup.properties":"falcon-startup.properties"}],
-        "output_file":"HDFS_CLIENT-configs.tar.gz"
+        "output_file":"HDFS_CLIENT-configs.tar.gz",
+        "version":"3.0.100.0-75"
     }, 
     "clusterLevelParams": {
         "stack_version": "2.0", 


### PR DESCRIPTION
## What changes were proposed in this pull request?
added the oozone_home env variable initialization
## How was this patch tested?
manually