### PR TITLE
[AMBARI-24972] Improve Add Service request validation.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AddServiceRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AddServiceRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.ambari.server.controller;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.ambari.server.controller.internal.BaseClusterRequest.PROVISION_ACTION_PROPERTY;
@@ -63,7 +62,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public final class AddServiceRequest {
+public class AddServiceRequest {
 
   static final String STACK_NAME = "stack_name";
   static final String STACK_VERSION = "stack_version";
@@ -130,8 +129,6 @@ public final class AddServiceRequest {
     this.credentials = null != credentials
       ? credentials.stream().collect(toMap(Credential::getAlias, Function.identity()))
       : ImmutableMap.of();
-
-    checkArgument(!this.services.isEmpty() || !this.components.isEmpty(), "Either services or components must be specified");
   }
 
   // TODO move to JsonUtils -- pick part of 0252c08d86f
@@ -278,6 +275,11 @@ public final class AddServiceRequest {
     public int hashCode() {
       return Objects.hash(name, fqdn);
     }
+
+    @Override
+    public String toString() {
+      return name;
+    }
   }
 
   @ApiModel
@@ -314,6 +316,11 @@ public final class AddServiceRequest {
     @Override
     public int hashCode() {
       return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+      return name;
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
@@ -520,9 +520,11 @@ public class ControllerModule extends AbstractModule {
     install(new FactoryModuleBuilder().build(MetricPropertyProviderFactory.class));
     install(new FactoryModuleBuilder().build(UpgradeContextFactory.class));
     install(new FactoryModuleBuilder().build(MpackManagerFactory.class));
+    install(new FactoryModuleBuilder().build(org.apache.ambari.server.topology.addservice.RequestValidatorFactory.class));
 
     bind(HostRoleCommandFactory.class).to(HostRoleCommandFactoryImpl.class);
     bind(SecurityHelper.class).toInstance(SecurityHelperImpl.getInstance());
+    bind(org.apache.ambari.server.topology.StackFactory.class).to(org.apache.ambari.server.topology.DefaultStackFactory.class);
     bind(BlueprintFactory.class);
 
     install(new FactoryModuleBuilder().implement(AmbariEvent.class, Names.named("userCreated"), UserCreatedEvent.class).build(AmbariEventFactory.class));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/Stack.java
@@ -210,6 +210,11 @@ public class Stack {
     return new StackId(name, version);
   }
 
+  @Override
+  public String toString() {
+    return "stack " + getStackId();
+  }
+
   Map<DependencyInfo, String> getDependencyConditionalServiceMap() {
     return dependencyConditionalServiceMap;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -59,6 +59,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2147,7 +2148,6 @@ public class ConfigHelper {
    * @param cluster  the cluster
    * @param hostname a hostname
    * @return a map of the existing configurations
-   * @throws AmbariException
    */
   public Map<String, Map<String, String>> calculateExistingConfigurations(AmbariManagementController ambariManagementController, Cluster cluster, String hostname) throws AmbariException {
     // For a configuration type, both tag and an actual configuration can be stored
@@ -2177,6 +2177,17 @@ public class ConfigHelper {
     }
 
     return configurations;
+  }
+
+  /**
+   * Determines the existing configurations for the cluster, both properties and attributes.
+   */
+  public Pair<Map<String, Map<String, String>>, Map<String, Map<String, Map<String, String>>>> calculateExistingConfigs(Cluster cluster) throws AmbariException {
+    Map<String, Map<String, String>> desiredConfigTags = getEffectiveDesiredTags(cluster, null);
+    return Pair.of(
+      getEffectiveConfigProperties(cluster, desiredConfigTags),
+      getEffectiveConfigAttributes(cluster, desiredConfigTags)
+    );
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintFactory.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.ObjectNotFoundException;
-import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariServer;
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
@@ -221,26 +220,4 @@ public class BlueprintFactory {
     blueprintDAO   = dao;
   }
 
-  /**
-   * Internal interface used to abstract out the process of creating the Stack object.
-   *
-   * This is used to simplify unit testing, since a new Factory can be provided to
-   * simulate various Stack or error conditions.
-   */
-  interface StackFactory {
-      Stack createStack(String stackName, String stackVersion, AmbariManagementController managementController) throws AmbariException;
-  }
-
-  /**
-   * Default implementation of StackFactory.
-   *
-   * Calls the Stack constructor to create the Stack instance.
-   *
-   */
-  private static class DefaultStackFactory implements StackFactory {
-    @Override
-    public Stack createStack(String stackName, String stackVersion, AmbariManagementController managementController) throws AmbariException {
-      return new Stack(stackName, stackVersion, managementController);
-    }
-  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -471,5 +472,21 @@ public class Configuration {
     if (parentConfiguration != null) {
       parentConfiguration.removeConfigType(configType);
     }
+  }
+
+  /**
+   * Create a new {@code Configuration} based on a pair of maps.
+   * (This is just a convenience method to be able to avoid local variables in a few places.)
+   */
+  public static Configuration of(Pair<Map<String, Map<String, String>>, Map<String, Map<String, Map<String, String>>>> propertiesAndAttributes) {
+    return new Configuration(propertiesAndAttributes.getLeft(), propertiesAndAttributes.getRight());
+  }
+
+  /**
+   * @return this configuration's properties and attributes as a pair of maps,
+   * in order to be able to pass around more easily without polluting non-topology code with the Configuration object
+   */
+  public Pair<Map<String, Map<String, String>>, Map<String, Map<String, Map<String, String>>>> asPair() {
+    return Pair.of(properties, attributes);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/DefaultStackFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/DefaultStackFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.internal.Stack;
+
+/**
+ * Default implementation of StackFactory.
+ *
+ * Calls the Stack constructor to create the Stack instance.
+ */
+public class DefaultStackFactory implements StackFactory {
+  @Override
+  public Stack createStack(String stackName, String stackVersion, AmbariManagementController managementController) throws AmbariException {
+    return new Stack(stackName, stackVersion, managementController);
+  }
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/StackFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/StackFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.internal.Stack;
+
+public interface StackFactory {
+  Stack createStack(String stackName, String stackVersion, AmbariManagementController managementController) throws AmbariException;
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology.addservice;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.actionmanager.ActionManager;
+import org.apache.ambari.server.actionmanager.RequestFactory;
+import org.apache.ambari.server.controller.AddServiceRequest;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.internal.RequestStageContainer;
+import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.topology.StackFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import com.google.inject.assistedinject.Assisted;
+
+/**
+ * Validates a specific {@link AddServiceRequest}.
+ */
+public class RequestValidator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestValidator.class);
+
+  private final AddServiceRequest request;
+  private final Cluster cluster;
+  private final AmbariManagementController controller;
+  private final ConfigHelper configHelper;
+  private final StackFactory stackFactory;
+  private final AtomicBoolean serviceInfoCreated = new AtomicBoolean();
+
+  private State state;
+
+  @Inject
+  public RequestValidator(
+    @Assisted AddServiceRequest request, @Assisted Cluster cluster,
+    AmbariManagementController controller, ConfigHelper configHelper,
+    StackFactory stackFactory
+  ) {
+    this.state = State.INITIAL;
+    this.request = request;
+    this.cluster = cluster;
+    this.controller = controller;
+    this.configHelper = configHelper;
+    this.stackFactory = stackFactory;
+  }
+
+  /**
+   * Perform validation of the request.
+   */
+  void validate() {
+    validateSecurity();
+    validateStack();
+    validateServicesAndComponents();
+    validateHosts();
+    validateConfiguration();
+  }
+
+  /**
+   * Create an {@link AddServiceInfo} based on the validated request.
+   */
+  AddServiceInfo createValidServiceInfo(ActionManager actionManager, RequestFactory requestFactory) {
+    final State state = this.state;
+
+    checkState(state.isValid(), "The request needs to be validated first");
+    checkState(!serviceInfoCreated.getAndSet(true), "Can create only one instance for each validated add service request");
+
+    RequestStageContainer stages = new RequestStageContainer(actionManager.getNextRequestId(), null, requestFactory, actionManager);
+    AddServiceInfo validatedRequest = new AddServiceInfo(request, cluster.getClusterName(), state.getStack(), state.getConfig(), stages, state.getNewServices());
+    stages.setRequestContext(validatedRequest.describe());
+    return validatedRequest;
+  }
+
+  @VisibleForTesting
+  State getState() {
+    return state;
+  }
+
+  @VisibleForTesting
+  void setState(State state) {
+    this.state = state;
+  }
+
+  @VisibleForTesting
+  void validateSecurity() {
+    request.getSecurity().ifPresent(requestSecurity ->
+      checkArgument(requestSecurity.getType() == cluster.getSecurityType(),
+        "Security type in the request (%s), if specified, should match cluster's security type (%s)",
+        requestSecurity.getType(), cluster.getSecurityType()
+      )
+    );
+  }
+
+  @VisibleForTesting
+  void validateStack() {
+    Optional<StackId> requestStackId = request.getStackId();
+    StackId stackId = requestStackId.orElseGet(cluster::getCurrentStackVersion);
+    try {
+      Stack stack = stackFactory.createStack(stackId.getStackName(), stackId.getStackVersion(), controller);
+      state = state.with(stack);
+    } catch (AmbariException e) {
+      logAndThrow(requestStackId.isPresent()
+        ? msg -> new IllegalArgumentException(msg, e)
+        : IllegalStateException::new,
+        "Stack %s not found", stackId
+      );
+    }
+  }
+
+  @VisibleForTesting
+  void validateServicesAndComponents() {
+    Stack stack = state.getStack();
+    Map<String, Map<String, Set<String>>> newServices = new LinkedHashMap<>();
+
+    Set<String> existingServices = cluster.getServices().keySet();
+
+    // process service declarations
+    for (AddServiceRequest.Service service : request.getServices()) {
+      String serviceName = service.getName();
+
+      checkArgument(stack.getServices().contains(serviceName),
+        "Unknown service %s in %s", service, stack);
+      checkArgument(!existingServices.contains(serviceName),
+        "Service %s already exists in cluster %s", serviceName, cluster.getClusterName());
+
+      newServices.computeIfAbsent(serviceName, __ -> new HashMap<>());
+    }
+
+    // process component declarations
+    for (AddServiceRequest.Component requestedComponent : request.getComponents()) {
+      String componentName = requestedComponent.getName();
+      String serviceName = stack.getServiceForComponent(componentName);
+
+      checkArgument(serviceName != null,
+        "No service found for component %s in %s", componentName, stack);
+      checkArgument(!existingServices.contains(serviceName),
+        "Service %s (for component %s) already exists in cluster %s", serviceName, componentName, cluster.getClusterName());
+
+      newServices.computeIfAbsent(serviceName, __ -> new HashMap<>())
+        .computeIfAbsent(componentName, __ -> new HashSet<>())
+        .add(requestedComponent.getFqdn());
+    }
+
+    checkArgument(!newServices.isEmpty(), "Request should have at least one new service or component to be added");
+
+    state = state.withNewServices(newServices);
+  }
+
+  @VisibleForTesting
+  void validateConfiguration() {
+    Configuration config = request.getConfiguration();
+    Configuration clusterConfig = getClusterDesiredConfigs();
+    clusterConfig.setParentConfiguration(state.getStack().getValidDefaultConfig());
+    config.setParentConfiguration(clusterConfig);
+
+    // no validation here so far
+
+    state = state.with(config);
+  }
+
+  @VisibleForTesting
+  void validateHosts() {
+    Set<String> clusterHosts = cluster.getHostNames();
+    Set<String> requestHosts = state.getNewServices().values().stream()
+      .flatMap(componentHosts -> componentHosts.values().stream())
+      .flatMap(Collection::stream)
+      .collect(toSet());
+    Set<String> unknownHosts = new TreeSet<>(Sets.difference(requestHosts, clusterHosts));
+
+    checkArgument(unknownHosts.isEmpty(),
+      "Requested host not associated with cluster %s: %s", cluster.getClusterName(), unknownHosts);
+  }
+
+  private Configuration getClusterDesiredConfigs() {
+    try {
+      return Configuration.of(configHelper.calculateExistingConfigs(cluster));
+    } catch (AmbariException e) {
+      logAndThrow(msg -> new IllegalStateException(msg, e), "Error getting effective configuration of cluster %s", cluster.getClusterName());
+      return Configuration.newEmpty(); // unreachable
+    }
+  }
+
+  private static void checkArgument(boolean expression, String errorMessage, Object... messageParams) {
+    if (!expression) {
+      logAndThrow(IllegalArgumentException::new, errorMessage, messageParams);
+    }
+  }
+
+  private static void checkState(boolean expression, String errorMessage, Object... messageParams) {
+    if (!expression) {
+      logAndThrow(IllegalStateException::new, errorMessage, messageParams);
+    }
+  }
+
+  private static void logAndThrow(Function<String, RuntimeException> exceptionCreator, String errorMessage, Object... messageParams) {
+    String msg = String.format(errorMessage, messageParams);
+    LOG.error(msg);
+    throw exceptionCreator.apply(msg);
+  }
+
+  @VisibleForTesting
+  static class State {
+
+    static final State INITIAL = new State(null, null, null);
+
+    private final Stack stack;
+    private final Map<String, Map<String, Set<String>>> newServices;
+    private final Configuration config;
+
+    State(Stack stack, Map<String, Map<String, Set<String>>> newServices, Configuration config) {
+      this.stack = stack;
+      this.newServices = newServices;
+      this.config = config;
+    }
+
+    boolean isValid() {
+      return stack != null && newServices != null && config != null;
+    }
+
+    State with(Stack stack) {
+      return new State(stack, newServices, config);
+    }
+
+    State withNewServices(Map<String, Map<String, Set<String>>> newServices) {
+      return new State(stack, newServices, config);
+    }
+
+    State with(Configuration config) {
+      return new State(stack, newServices, config);
+    }
+
+    Stack getStack() {
+      return stack;
+    }
+
+    Map<String, Map<String, Set<String>>> getNewServices() {
+      return newServices;
+    }
+
+    Configuration getConfig() {
+      return config;
+    }
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidatorFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidatorFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology.addservice;
+
+import org.apache.ambari.server.controller.AddServiceRequest;
+import org.apache.ambari.server.state.Cluster;
+
+/**
+ * Factory for {@link RequestValidator} objects.
+ * Implemented by Guice, needed for {@code Assisted} injection.
+ */
+public interface RequestValidatorFactory {
+
+  RequestValidator create(AddServiceRequest request, Cluster cluster);
+
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
@@ -200,8 +200,9 @@ public class AddServiceRequestTest {
     assertTrue(request.getServices().isEmpty());
   }
 
-  @Test(expected = JsonProcessingException.class)
+  @Test
   public void testDeserialize_invalid_noServicesAndComponents() throws Exception {
+    // empty service/component list should be accepted at the JSON level, will be rejected by the request handler
     mapper.readValue(REQUEST_INVALID_NO_SERVICES_AND_COMPONENTS, AddServiceRequest.class);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintFactoryTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintFactoryTest.java
@@ -166,8 +166,8 @@ public class BlueprintFactoryTest {
   @Test(expected=NoSuchStackException.class)
   public void testCreateInvalidStack() throws Exception {
     EasyMockSupport mockSupport = new EasyMockSupport();
-    BlueprintFactory.StackFactory mockStackFactory =
-      mockSupport.createMock(BlueprintFactory.StackFactory.class);
+    StackFactory mockStackFactory =
+      mockSupport.createMock(StackFactory.class);
 
     // setup mock to throw exception, to simulate invalid stack request
     expect(mockStackFactory.createStack("null", "null", null)).andThrow(new ObjectNotFoundException("Invalid Stack"));

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/RequestValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/RequestValidatorTest.java
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.topology.addservice;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.actionmanager.ActionManager;
+import org.apache.ambari.server.actionmanager.RequestFactory;
+import org.apache.ambari.server.controller.AddServiceRequest;
+import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.SecurityType;
+import org.apache.ambari.server.state.Service;
+import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.topology.SecurityConfiguration;
+import org.apache.ambari.server.topology.StackFactory;
+import org.easymock.EasyMockSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+public class RequestValidatorTest extends EasyMockSupport {
+
+  private final AddServiceRequest request = createNiceMock(AddServiceRequest.class);
+  private final Cluster cluster = createMock(Cluster.class);
+  private final AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
+  private final ConfigHelper configHelper = createMock(ConfigHelper.class);
+  private final StackFactory stackFactory = createNiceMock(StackFactory.class);
+  private final RequestValidator validator = new RequestValidator(request, cluster, controller, configHelper, stackFactory);
+
+  @Before
+  public void setUp() {
+    validator.setState(RequestValidator.State.INITIAL);
+    expect(cluster.getClusterName()).andReturn("TEST").anyTimes();
+    expect(cluster.getServices()).andStubReturn(ImmutableMap.of());
+    expect(request.getServices()).andStubReturn(ImmutableSet.of());
+    expect(request.getComponents()).andStubReturn(ImmutableSet.of());
+  }
+
+  @After
+  public void tearDown() {
+    resetAll();
+  }
+
+  @Test
+  public void cannotConstructInvalidRequestInfo() {
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+
+    Stack stack = simpleMockStack();
+    Map<String, Map<String, Set<String>>> newServices = someNewServices();
+    Configuration config = Configuration.newEmpty();
+
+    validator.setState(RequestValidator.State.INITIAL.with(stack));
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+    validator.setState(validator.getState().with(config));
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+
+    validator.setState(RequestValidator.State.INITIAL.withNewServices(newServices));
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+    validator.setState(validator.getState().with(stack));
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+
+    validator.setState(RequestValidator.State.INITIAL.with(config));
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+    validator.setState(validator.getState().withNewServices(newServices));
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(null, null));
+  }
+
+  @Test
+  public void canConstructValidRequestInfo() {
+    validator.setState(
+      RequestValidator.State.INITIAL
+        .withNewServices(someNewServices())
+        .with(simpleMockStack())
+        .with(Configuration.newEmpty())
+    );
+    ActionManager actionManager = createNiceMock(ActionManager.class);
+    RequestFactory requestFactory = createNiceMock(RequestFactory.class);
+    replayAll();
+
+    AddServiceInfo addServiceInfo = validator.createValidServiceInfo(actionManager, requestFactory);
+    assertNotNull(addServiceInfo);
+    assertSame(request, addServiceInfo.getRequest());
+    assertEquals(cluster.getClusterName(), addServiceInfo.clusterName());
+    assertSame(validator.getState().getConfig(), addServiceInfo.getConfig());
+    assertSame(validator.getState().getStack(), addServiceInfo.getStack());
+    assertEquals(validator.getState().getNewServices(), addServiceInfo.newServices());
+  }
+
+  @Test
+  public void cannotConstructTwice() {
+    ActionManager actionManager = createNiceMock(ActionManager.class);
+    RequestFactory requestFactory = createNiceMock(RequestFactory.class);
+    replayAll();
+
+    validator.setState(
+      RequestValidator.State.INITIAL
+        .withNewServices(someNewServices())
+        .with(simpleMockStack())
+        .with(Configuration.newEmpty())
+    );
+    validator.createValidServiceInfo(actionManager, requestFactory);
+    assertThrows(IllegalStateException.class, () -> validator.createValidServiceInfo(actionManager, requestFactory));
+  }
+
+  @Test
+  public void reportsUnknownStackFromRequest() throws Exception {
+    StackId requestStackId = new StackId("HDP", "123");
+    expect(request.getStackId()).andReturn(Optional.of(requestStackId)).anyTimes();
+    expect(stackFactory.createStack(requestStackId.getStackName(), requestStackId.getStackVersion(), controller)).andThrow(new AmbariException("Stack not found"));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateStack);
+    assertTrue(e.getMessage().contains(requestStackId.toString()));
+    assertNull(validator.getState().getStack());
+  }
+
+  @Test
+  public void reportsUnknownStackFromCluster() throws Exception {
+    StackId clusterStackId = new StackId("CLUSTER", "555");
+    expect(request.getStackId()).andReturn(Optional.empty()).anyTimes();
+    expect(cluster.getCurrentStackVersion()).andReturn(clusterStackId);
+    expect(stackFactory.createStack(clusterStackId.getStackName(), clusterStackId.getStackVersion(), controller)).andThrow(new AmbariException("Stack not found"));
+    replayAll();
+
+    IllegalStateException e = assertThrows(IllegalStateException.class, validator::validateStack);
+    assertTrue(e.getMessage().contains(clusterStackId.toString()));
+    assertNull(validator.getState().getStack());
+  }
+
+  @Test
+  public void useClusterStackIfAbsentInRequest() throws Exception {
+    StackId clusterStackId = new StackId("CLUSTER", "123");
+    Stack expectedStack = createNiceMock(Stack.class);
+    expect(request.getStackId()).andReturn(Optional.empty()).anyTimes();
+    expect(cluster.getCurrentStackVersion()).andReturn(clusterStackId);
+    expect(stackFactory.createStack(clusterStackId.getStackName(), clusterStackId.getStackVersion(), controller)).andReturn(expectedStack);
+    replayAll();
+
+    validator.validateStack();
+
+    assertSame(expectedStack, validator.getState().getStack());
+  }
+
+  @Test
+  public void acceptsKnownServices() {
+    expect(request.getServices()).andReturn(ImmutableSet.of(AddServiceRequest.Service.of("KAFKA")));
+    validator.setState(RequestValidator.State.INITIAL.with(simpleMockStack()));
+    replayAll();
+
+    validator.validateServicesAndComponents();
+
+    Map<String, Map<String, Set<String>>> expectedNewServices = ImmutableMap.of(
+      "KAFKA", ImmutableMap.of()
+    );
+    assertEquals(expectedNewServices, validator.getState().getNewServices());
+  }
+
+  @Test
+  public void acceptsKnownComponents() {
+    expect(request.getComponents()).andReturn(ImmutableSet.of(AddServiceRequest.Component.of("KAFKA_BROKER", "c7401.ambari.apache.org")));
+    validator.setState(RequestValidator.State.INITIAL.with(simpleMockStack()));
+    replayAll();
+
+    validator.validateServicesAndComponents();
+
+    Map<String, Map<String, Set<String>>> expectedNewServices = ImmutableMap.of(
+      "KAFKA", ImmutableMap.of("KAFKA_BROKER", ImmutableSet.of("c7401.ambari.apache.org"))
+    );
+    assertEquals(expectedNewServices, validator.getState().getNewServices());
+  }
+
+  @Test
+  public void rejectsUnknownService() {
+    String serviceName = "UNKNOWN_SERVICE";
+    expect(request.getServices()).andReturn(ImmutableSet.of(AddServiceRequest.Service.of(serviceName)));
+    validator.setState(RequestValidator.State.INITIAL.with(simpleMockStack()));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateServicesAndComponents);
+    assertTrue(e.getMessage().contains(serviceName));
+    assertNull(validator.getState().getNewServices());
+  }
+
+  @Test
+  public void rejectsUnknownComponent() {
+    String componentName = "UNKNOWN_COMPONENT";
+    expect(request.getComponents()).andReturn(ImmutableSet.of(AddServiceRequest.Component.of(componentName, "c7401.ambari.apache.org")));
+    validator.setState(RequestValidator.State.INITIAL.with(simpleMockStack()));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateServicesAndComponents);
+    assertTrue(e.getMessage().contains(componentName));
+    assertNull(validator.getState().getNewServices());
+  }
+
+  @Test
+  public void rejectsExistingServiceForService() {
+    String serviceName = "KAFKA";
+    expect(cluster.getServices()).andReturn(ImmutableMap.of(serviceName, createNiceMock(Service.class))).anyTimes();
+    expect(request.getServices()).andReturn(ImmutableSet.of(AddServiceRequest.Service.of(serviceName)));
+    validator.setState(RequestValidator.State.INITIAL.with(simpleMockStack()));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateServicesAndComponents);
+    assertTrue(e.getMessage().contains(serviceName));
+    assertNull(validator.getState().getNewServices());
+  }
+
+  @Test
+  public void rejectsExistingServiceForComponent() {
+    String serviceName = "KAFKA";
+    String componentName = "KAFKA_BROKER";
+    expect(cluster.getServices()).andReturn(ImmutableMap.of(serviceName, createNiceMock(Service.class))).anyTimes();
+    expect(request.getComponents()).andReturn(ImmutableSet.of(AddServiceRequest.Component.of(componentName, "c7401.ambari.apache.org")));
+    validator.setState(RequestValidator.State.INITIAL.with(simpleMockStack()));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateServicesAndComponents);
+    assertTrue(e.getMessage().contains(serviceName));
+    assertTrue(e.getMessage().contains(componentName));
+    assertNull(validator.getState().getNewServices());
+  }
+
+  @Test
+  public void rejectsEmptyServiceAndComponentList() {
+    replayAll();
+
+    assertThrows(IllegalArgumentException.class, validator::validateServicesAndComponents);
+    assertNull(validator.getState().getNewServices());
+  }
+
+  @Test
+  public void acceptsKnownHosts() {
+    Set<String> requestHosts = ImmutableSet.of("c7401.ambari.apache.org", "c7402.ambari.apache.org");
+    Set<String> otherHosts = ImmutableSet.of("c7403.ambari.apache.org", "c7404.ambari.apache.org");
+    Set<String> clusterHosts = Sets.union(requestHosts, otherHosts);
+    expect(cluster.getHostNames()).andReturn(clusterHosts).anyTimes();
+    validator.setState(RequestValidator.State.INITIAL.withNewServices(ImmutableMap.of(
+      "KAFKA", ImmutableMap.of("KAFKA_BROKER", requestHosts)
+    )));
+    replayAll();
+
+    validator.validateHosts();
+  }
+
+  @Test
+  public void rejectsUnknownHosts() {
+    Set<String> clusterHosts = ImmutableSet.of("c7401.ambari.apache.org", "c7402.ambari.apache.org");
+    Set<String> otherHosts = ImmutableSet.of("c7403.ambari.apache.org", "c7404.ambari.apache.org");
+    Set<String> requestHosts = ImmutableSet.copyOf(Sets.union(clusterHosts, otherHosts));
+    expect(cluster.getHostNames()).andReturn(clusterHosts).anyTimes();
+    validator.setState(RequestValidator.State.INITIAL.withNewServices(ImmutableMap.of(
+      "KAFKA", ImmutableMap.of("KAFKA_BROKER", requestHosts)
+    )));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateHosts);
+    assertTrue(e.getMessage(), e.getMessage().contains("host"));
+  }
+
+  @Test
+  public void acceptsAbsentSecurityWhenClusterHasKerberos() {
+    expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
+    expect(request.getSecurity()).andReturn(Optional.empty()).anyTimes();
+    replayAll();
+
+    validator.validateSecurity();
+  }
+
+  @Test
+  public void acceptsAbsentSecurityWhenClusterHasNone() {
+    expect(cluster.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
+    expect(request.getSecurity()).andReturn(Optional.empty()).anyTimes();
+    replayAll();
+
+    validator.validateSecurity();
+  }
+
+  @Test
+  public void acceptsMatchingKerberosSecurity() {
+    expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
+    expect(request.getSecurity()).andReturn(Optional.of(new SecurityConfiguration(SecurityType.KERBEROS))).anyTimes();
+    replayAll();
+
+    validator.validateSecurity();
+  }
+
+  @Test
+  public void acceptsMatchingNoneSecurity() {
+    expect(cluster.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
+    expect(request.getSecurity()).andReturn(Optional.of(SecurityConfiguration.NONE)).anyTimes();
+    replayAll();
+
+    validator.validateSecurity();
+  }
+
+  @Test
+  public void rejectsNoneSecurityWhenClusterHasKerberos() {
+    expect(cluster.getSecurityType()).andReturn(SecurityType.KERBEROS).anyTimes();
+    expect(request.getSecurity()).andReturn(Optional.of(SecurityConfiguration.NONE)).anyTimes();
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateSecurity);
+    assertTrue(e.getMessage().contains("KERBEROS"));
+  }
+
+  @Test
+  public void rejectsKerberosSecurityWhenClusterHasNone() {
+    expect(cluster.getSecurityType()).andReturn(SecurityType.NONE).anyTimes();
+    expect(request.getSecurity()).andReturn(Optional.of(new SecurityConfiguration(SecurityType.KERBEROS))).anyTimes();
+    replayAll();
+
+    assertThrows(IllegalArgumentException.class, validator::validateSecurity);
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, validator::validateSecurity);
+    assertTrue(e.getMessage().contains("KERBEROS"));
+  }
+
+  @Test
+  public void combinesRequestConfigWithClusterAndStack() throws AmbariException {
+    Configuration requestConfig = Configuration.newEmpty();
+    requestConfig.setProperty("kafka-broker", "zookeeper.connect", "zookeeper.connect:request");
+    requestConfig.setProperty("kafka-env", "custom_property", "custom_property:request");
+    expect(request.getConfiguration()).andReturn(requestConfig.copy()).anyTimes();
+
+    Configuration clusterConfig = Configuration.newEmpty();
+    clusterConfig.setProperty("zookeeper-env", "zk_user", "zk_user:cluster_level");
+    expect(configHelper.calculateExistingConfigs(cluster)).andReturn(clusterConfig.asPair()).anyTimes();
+
+    Stack stack = simpleMockStack();
+    Configuration stackConfig = Configuration.newEmpty();
+    stackConfig.setProperty("zookeeper-env", "zk_user", "zk_user:stack_default");
+    stackConfig.setProperty("zookeeper-env", "zk_log_dir", "zk_log_dir:stack_default");
+    stackConfig.setProperty("kafka-broker", "zookeeper.connect", "zookeeper.connect:stack_default");
+    expect(stack.getValidDefaultConfig()).andReturn(stackConfig).anyTimes();
+
+    replayAll();
+
+    validator.setState(RequestValidator.State.INITIAL.with(stack));
+    validator.validateConfiguration();
+
+    Configuration config = validator.getState().getConfig();
+    verifyConfigOverrides(requestConfig, clusterConfig, stackConfig, config);
+  }
+
+  private static void verifyConfigOverrides(Configuration requestConfig, Configuration clusterConfig, Configuration stackConfig, Configuration actualConfig) {
+    requestConfig.getProperties().forEach(
+      (type, properties) -> properties.forEach(
+        (propertyName, propertyValue) -> assertEquals(type + "/" + propertyName, propertyValue, actualConfig.getPropertyValue(type, propertyName))
+      )
+    );
+    clusterConfig.getProperties().forEach(
+      (type, properties) -> properties.forEach(
+        (propertyName, propertyValue) -> {
+          if (!requestConfig.isPropertySet(type, propertyName)) {
+            assertEquals(type + "/" + propertyName, propertyValue, actualConfig.getPropertyValue(type, propertyName));
+          }
+        }
+      )
+    );
+    stackConfig.getProperties().forEach(
+      (type, properties) -> properties.forEach(
+        (propertyName, propertyValue) -> {
+          if (!requestConfig.isPropertySet(type, propertyName) && !clusterConfig.isPropertySet(type, propertyName)) {
+            assertEquals(type + "/" + propertyName, propertyValue, actualConfig.getPropertyValue(type, propertyName));
+          }
+        }
+      )
+    );
+  }
+
+  private Stack simpleMockStack() {
+    Stack stack = createNiceMock(Stack.class);
+    Set<String> stackServices = ImmutableSet.of("KAFKA", "ZOOKEEPER");
+    expect(stack.getServices()).andReturn(stackServices).anyTimes();
+    expect(stack.getServiceForComponent("KAFKA_BROKER")).andReturn("KAFKA").anyTimes();
+    expect(stack.getServiceForComponent("ZOOKEEPER_SERVER")).andReturn("ZOOKEEPER").anyTimes();
+    expect(stack.getServiceForComponent("ZOOKEEPER_CLIENT")).andReturn("ZOOKEEPER").anyTimes();
+    return stack;
+  }
+
+  private static Map<String, Map<String, Set<String>>> someNewServices() {
+    return ImmutableMap.of(
+      "KAFKA", ImmutableMap.of("KAFKA_BROKER", ImmutableSet.of("c7401.ambari.apache.org"))
+    );
+  }
+
+  private static <T extends Throwable> T assertThrows(Class<T> expectedException, Runnable code) {
+    try {
+      code.run();
+    } catch (Throwable t) {
+      if (expectedException.isInstance(t)) {
+        return expectedException.cast(t);
+      }
+      throw new AssertionError("Expected exception: " + expectedException + " but " + t.getClass() + " was thrown instead");
+    }
+
+    throw new AssertionError("Expected exception: " + expectedException + ", but was not thrown");
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improved validation of the complex Add Service request.

 * check for existing services being added (previously only components were checked for the same)
 * check if all referenced hosts are associated with the cluster
 * allow omitting stack name and version, use cluster's current stack in this case
 * move the check that handled the "no services and no components" case (previously it resulted in JSON parse exceptions)

Refactored validation code to a separate class.

Added unit test for request validation.

https://issues.apache.org/jira/browse/AMBARI-24972

## How was this patch tested?

In addition to new unit tests, tested the API manually:

```
$ curl -X POST -d @- http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "stack_name": "PHD",
  "stack_version": "3.0",
  "components": [
    { "component_name": "KAFKA_BROKER", "fqdn": "c7401.ambari.apache.org" }
  ]
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Stack PHD-3.0 not found"
}


$ curl -X POST -d @- http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "services": [
    { "name": "UNKNOWN_SERVICE" }
  ]
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Unknown service UNKNOWN_SERVICE in stack HDP-3.0"
}


$ curl -X POST -d @- http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "components": [
    { "component_name": "UNKNOWN_COMPONENT", "fqdn": "c7401.ambari.apache.org" }
  ]
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "No service found for component UNKNOWN_COMPONENT in stack HDP-3.0"
}


$ curl -X POST -d @- http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "components": [
    { "component_name": "KAFKA_BROKER", "fqdn": "unknown.ambari.apache.org" }
  ]
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Requested host not associated with cluster TEST: [unknown.ambari.apache.org]"
}


$ curl -X POST -d { "operation_type": "ADD_SERVICE", "services": [] } http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Request should have at least one new service or component to be added"
}


$ curl -X POST -d { "operation_type": "ADD_SERVICE", "components": [] } http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Request should have at least one new service or component to be added"
}


$ curl -X POST -d { "operation_type": "ADD_SERVICE" } http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Request should have at least one new service or component to be added"
}


$ curl -X POST -d @- http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "services": [
    { "name": "ZOOKEEPER" }
  ]
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Service ZOOKEEPER already exists in cluster TEST"
}


$ curl -X POST -d @- http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "components": [
    { "component_name": "ZOOKEEPER_SERVER", "fqdn": "c7401.ambari.apache.org" }
  ]
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Service ZOOKEEPER (for component ZOOKEEPER_SERVER) already exists in cluster TEST"
}


$ curl -X POST -d @- "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services" <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "components": [
    { "component_name": "KAFKA_BROKER", "fqdn": "c7401.ambari.apache.org" }
  ],
  "security": {
    "type": "NONE"
  }
}
EOF

HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Security type in the request (NONE), if specified, should match cluster's security type (KERBEROS)"
}
```