### PR TITLE
Revert "AMBARI-24966 Start Namenode failing during Move master NN wizard on non-HA cluster with custom hdfs service user"

### DIFF
--- a/ambari-web/app/controllers/main/admin/highAvailability/nameNode/wizard_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability/nameNode/wizard_controller.js
@@ -198,14 +198,20 @@ App.HighAvailabilityWizardController = App.WizardController.extend({
         type: 'async',
         callback: function () {
           var dfd = $.Deferred(),
-            self = this;
-            
-          this.loadHdfsUserFromServer().done(function (data) {
-            self.set('content.hdfsUser', Em.get(data, '0.properties.hdfs_user'));
-            self.saveHdfsUser();
-            self.load('cluster');
-            dfd.resolve();
-          });
+            self = this,
+            usersLoadingCallback = function () {
+              self.saveHdfsUser();
+              self.load('cluster');
+              dfd.resolve();
+            };
+          if (App.db.getHighAvailabilityWizardHdfsUser()) {
+            usersLoadingCallback();
+          } else {
+            this.loadHdfsUserFromServer().done(function (data) {
+              self.set('content.hdfsUser', Em.get(data, '0.properties.hdfs_user'));
+              usersLoadingCallback();
+            });
+          }
           return dfd.promise();
         }
       }

--- a/ambari-web/app/controllers/main/service/reassign_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign_controller.js
@@ -144,15 +144,14 @@ App.ReassignMasterController = App.WizardController.extend({
         type: 'sync',
         callback: function () {
           this.loadComponentDir();
-          this.updateUserConfigs();
         }
       }
     ]
   },
 
   serviceToConfigSiteMap: {
-    'NAMENODE': ['hdfs-site', 'core-site', 'hadoop-env', 'cluster-env'],
-    'SECONDARY_NAMENODE': ['hdfs-site', 'core-site', 'hadoop-env', 'cluster-env'],
+    'NAMENODE': ['hdfs-site', 'core-site'],
+    'SECONDARY_NAMENODE': ['hdfs-site', 'core-site'],
     'JOBTRACKER': ['mapred-site'],
     'RESOURCEMANAGER': ['yarn-site'],
     'WEBHCAT_SERVER': ['hive-env', 'webhcat-site', 'core-site'],
@@ -201,14 +200,6 @@ App.ReassignMasterController = App.WizardController.extend({
   loadTasksStatuses: function () {
     var statuses = App.db.getReassignTasksStatuses();
     this.set('content.tasksStatuses', statuses);
-  },
-  
-  /**
-   * Update hdfs-user and group with actual value from configs
-   */
-  updateUserConfigs: function() {
-    this.set('content.hdfsUser', this.get('content.configs')['hadoop-env']['hdfs_user']);
-    this.set('content.group', this.get('content.configs')['cluster-env']['user_group']);
   },
 
   /**

--- a/ambari-web/test/controllers/main/service/reassign_controller_test.js
+++ b/ambari-web/test/controllers/main/service/reassign_controller_test.js
@@ -130,23 +130,5 @@ describe('App.ReassignMasterController', function () {
     });
 
   });
-  
-  describe('#updateUserConfigs', function() {
-    
-    it('should update user and group from configs', function() {
-      reassignMasterController.set('content.configs', {
-        'hadoop-env': {
-          'hdfs_user': 'u1'
-        },
-        'cluster-env': {
-          'user_group': 'g1'
-        }
-      });
-      reassignMasterController.updateUserConfigs();
-      expect(reassignMasterController.get('content.hdfsUser')).to.be.equal('u1');
-      expect(reassignMasterController.get('content.group')).to.be.equal('g1');
-      
-    });
-  });
 
 });


### PR DESCRIPTION
Reverts apache/ambari#2664
Need to revert this patch for following reasons:

1. It does not fix the original issue
2. It introduces a new issue where refreshing browser on "Manual Commands" page results in JS error and empty page