### PR TITLE
AMBARI-24966. Start Namenode failing during Move master NN wizard on non-HA cluster with custom hdfs service user.

### DIFF
--- a/ambari-web/app/controllers/wizard.js
+++ b/ambari-web/app/controllers/wizard.js
@@ -875,7 +875,10 @@ App.WizardController = Em.Controller.extend(App.LocalStorage, App.ThemesMappingM
     var interval = setInterval(function () {
       if (miscController.get('dataIsLoaded')) {
         if (self.get("content.hdfsUser")) {
-          self.set('content.hdfsUser', miscController.get('content.hdfsUser'));
+          var hdfsUser = miscController.get('users').filterProperty('filename', 'hadoop-env.xml').findProperty('name','hdfs_user');
+          if (hdfsUser) {
+            self.set('content.hdfsUser', hdfsUser.get('value'));
+          }
         }
         dfd.resolve();
         clearInterval(interval);

--- a/ambari-web/test/controllers/wizard_test.js
+++ b/ambari-web/test/controllers/wizard_test.js
@@ -836,11 +836,13 @@ describe('App.WizardController', function () {
           if (type === 'dataIsLoaded') {
             return true;
           }
-          return Em.Object.create({
-            hdfsUser: {
-              name: 'user'
-            }
-          });
+          return Em.A([
+            Em.Object.create({
+              name: 'hdfs_user',
+              filename: 'hadoop-env.xml',
+              value: 'cstm-hdfs'
+            })
+          ]);
         }
       });
     });


### PR DESCRIPTION
## How was this patch tested?
Tested on the cluster that had a repro and verified that it fixes the issue