### PR TITLE
AMBARI-24977 Loading on Dashboard stuck

### DIFF
--- a/ambari-web/app/app.js
+++ b/ambari-web/app/app.js
@@ -241,7 +241,9 @@ module.exports = Em.Application.create({
    * @type {bool}
    */
   isHaEnabled: function () {
-    return App.Service.find('HDFS').get('isLoaded') && !App.HostComponent.find().someProperty('componentName', 'SECONDARY_NAMENODE');
+    return App.Service.find('HDFS').get('isLoaded')
+      && App.MasterComponent.find('SECONDARY_NAMENODE').get('totalCount') === 0
+      && App.MasterComponent.find('NAMENODE').get('totalCount') > 1;
   }.property('router.clusterController.dataLoadList.services', 'router.clusterController.isServiceContentFullyLoaded'),
 
   hasNameNodeFederation: function () {

--- a/ambari-web/test/app_test.js
+++ b/ambari-web/test/app_test.js
@@ -160,22 +160,30 @@ describe('App', function () {
 
     beforeEach(function () {
       sinon.stub(App.Service, 'find').returns(Em.Object.create({'isLoaded': true}));
-      this.mock = sinon.stub(App.HostComponent, 'find');
+      this.mock = sinon.stub(App.MasterComponent, 'find');
     });
     afterEach(function () {
       App.Service.find.restore();
       this.mock.restore();
     });
 
-    it('if hadoop stack version higher than 2 then isHaEnabled should be true', function () {
-      this.mock.returns([]);
+    it('if one SECONDARY_NAMENODE and one NAMENODE then isHaEnabled should be false', function () {
+      this.mock.withArgs('SECONDARY_NAMENODE').returns(Em.Object.create({totalCount: 1}));
+      this.mock.withArgs('NAMENODE').returns(Em.Object.create({totalCount: 1}));
       App.propertyDidChange('isHaEnabled');
-      expect(App.get('isHaEnabled')).to.equal(true);
+      expect(App.get('isHaEnabled')).to.be.false;
     });
-    it('if cluster has SECONDARY_NAMENODE then isHaEnabled should be false', function () {
-      this.mock.returns([Em.Object.create({componentName: 'SECONDARY_NAMENODE'})]);
+    it('if no SECONDARY_NAMENODE and two NAMENODE then isHaEnabled should be true', function () {
+      this.mock.withArgs('SECONDARY_NAMENODE').returns(Em.Object.create({totalCount: 0}));
+      this.mock.withArgs('NAMENODE').returns(Em.Object.create({totalCount: 2}));
       App.propertyDidChange('isHaEnabled');
-      expect(App.get('isHaEnabled')).to.equal(false);
+      expect(App.get('isHaEnabled')).to.be.true;
+    });
+    it('if no SECONDARY_NAMENODE and no NAMENODE then isHaEnabled should be false', function () {
+      this.mock.withArgs('SECONDARY_NAMENODE').returns(Em.Object.create({totalCount: 0}));
+      this.mock.withArgs('NAMENODE').returns(Em.Object.create({totalCount: 0}));
+      App.propertyDidChange('isHaEnabled');
+      expect(App.get('isHaEnabled')).to.be.false;
     });
   });
 

--- a/ambari-web/test/controllers/main/host/details_test.js
+++ b/ambari-web/test/controllers/main/host/details_test.js
@@ -1028,14 +1028,9 @@ describe('App.MainHostDetailsController', function () {
 
     it('isHaEnabled = true', function () {
       loadService('HDFS');
-
-      App.HostComponent.find().clear();
-      App.propertyDidChange('isHaEnabled');
+      sinon.stub(App, 'get').returns(true);
       expect(controller.constructZookeeperConfigUrlParams(data)).to.eql(['(type=core-site&tag=1)']);
-      App.store.safeLoad(App.HostComponent, {
-        id: 'SECONDARY_NAMENODE_host1',
-        component_name: 'SECONDARY_NAMENODE'
-      });
+      App.get.restore();
     });
 
     it('HBASE is installed', function () {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Dashboard doesn't load, spinner keeps spinning infinitely due to incorrect work of App.get('isHaEnabled') property in a cluster which has only HDFS_CLIENT from HDFS service.

## How was this patch tested?
 21971 passing (30s)
  48 pending
