### PR TITLE
AMBARI-24979 Redirect Hive Pre-upgrade log to a logfile

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/pre_upgrade.py
@@ -111,7 +111,7 @@ class HivePreUpgrade(Script):
     derby_jars = glob.glob(source_dir + "/hive2/lib/*derby-*.jar")
     if len(derby_jars) == 1:
       classpath = derby_jars[0] + ":" + classpath
-    cmd = format("{java64_home}/bin/java -Djavax.security.auth.useSubjectCredsOnly=false -cp {classpath} org.apache.hadoop.hive.upgrade.acid.PreUpgradeTool -execute")
+    cmd = format("{java64_home}/bin/java -Djavax.security.auth.useSubjectCredsOnly=false -cp {classpath} org.apache.hadoop.hive.upgrade.acid.PreUpgradeTool -execute &> {hive_log_dir}/pre_upgrade_{target_version}.log")
     Execute(cmd, user = params.hive_user)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes were proposed in this pull request?

Redirects the output of the Hive pre upgrade step to a logfile.

## How was this patch tested?

Tested on local cluster.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.