### PR TITLE
[AMBARI-24982] APT/DPKG existence check broken for packages with long names

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
+++ b/ambari-common/src/main/python/ambari_commons/repo_manager/apt_manager.py
@@ -49,7 +49,7 @@ class AptManagerProperties(GenericManagerProperties):
   repo_update_cmd = [repo_manager_bin, 'update', '-qq']
 
   available_packages_cmd = [repo_cache_bin, "dump"]
-  installed_packages_cmd = [pkg_manager_bin, "-l"]
+  installed_packages_cmd = ['COLUMNS=999', pkg_manager_bin, "-l"]
 
   repo_definition_location = "/etc/apt/sources.list.d"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`dpkg` may cut the output to fit package name, description etc. on the screen:

```
$ COLUMNS=80 dpkg -l zookeeper-3-0-1-0-187
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-=================================
ii  zookeeper-3-0- 3.4.6.3.0.1. all          A high-performance coordination s
```

which results in multiple attempts to install the same package:

```
output-2.txt: Package['zookeeper-3-0-1-0-187'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-2.txt: Installing package zookeeper-3-0-1-0-187 ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187')
output-2.txt: Package['zookeeper-3-0-1-0-187-server'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-2.txt: Installing package zookeeper-3-0-1-0-187-server ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187-server')
output-3.txt: Package['zookeeper-3-0-1-0-187'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-3.txt: Installing package zookeeper-3-0-1-0-187 ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187')
output-3.txt: Package['zookeeper-3-0-1-0-187-server'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-3.txt: Installing package zookeeper-3-0-1-0-187-server ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187-server')
```

since Ambari compares full package name to truncated one:

```
Package['zookeeper-3-0-1-0-187'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
Checking if zookeeper-3-0-1-0-187 is installed
zookeeper-3-0-1-0-187 == zookeeper-3-0- => False
Installing package zookeeper-3-0-1-0-187 ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187')
```

This change makes it more likely that `dpkg` prints full package name when listing existing packages.

https://issues.apache.org/jira/browse/AMBARI-24982

## How was this patch tested?

Tested package install on cluster.  Verified that all packages are installed only once:

```
output-2.txt: Package['zookeeper-3-0-1-0-187'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-2.txt: Installing package zookeeper-3-0-1-0-187 ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187')
output-2.txt: Package['zookeeper-3-0-1-0-187-server'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-2.txt: Installing package zookeeper-3-0-1-0-187-server ('/usr/bin/apt-get -o Dpkg::Options::=--force-confdef --allow-unauthenticated --assume-yes install zookeeper-3-0-1-0-187-server')
output-3.txt: Package['zookeeper-3-0-1-0-187'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-3.txt: Skipping installation of existing package zookeeper-3-0-1-0-187
output-3.txt: Package['zookeeper-3-0-1-0-187-server'] {'retry_on_repo_unavailability': False, 'retry_count': 1}
output-3.txt: Skipping installation of existing package zookeeper-3-0-1-0-187-server
```