### PR TITLE
AMBARI-24989 Knox: Reorder of query parameters breaks Ambari logic for retrieving configs

### DIFF
--- a/ambari-web/app/mixins/common/configs/configs_loader.js
+++ b/ambari-web/app/mixins/common/configs/configs_loader.js
@@ -179,7 +179,7 @@ App.ConfigsLoader = Em.Mixin.create(App.GroupsMappingMixin, {
       data: {
         serviceName: this.get('content.serviceName'),
         serviceConfigVersions: versions,
-        additionalParams: this.get('dependentServiceNames.length') ? '|service_name.in(' + this.get('dependentServiceNames') + ')&is_current=true' : ''
+        additionalParams: this.get('dependentServiceNames.length') ? '|(service_name.in(' + this.get('dependentServiceNames') + ')%26is_current=true)' : ''
       },
       success: 'loadSelectedVersionsSuccess'
     }));

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -2913,7 +2913,7 @@ var urls = {
     mock: '/data/configurations/service_version.json'
   },
   'service.serviceConfigVersions.get.multiple': {
-    real: '/clusters/{clusterName}/configurations/service_config_versions?service_name={serviceName}&service_config_version.in({serviceConfigVersions}){additionalParams}',
+    real: '/clusters/{clusterName}/configurations/service_config_versions?(service_name={serviceName}%26service_config_version.in({serviceConfigVersions})){additionalParams}',
     mock: '/data/configurations/service_version.json',
     format: function (data) {
       return {

--- a/ambari-web/test/mixins/common/configs/configs_loader_test.js
+++ b/ambari-web/test/mixins/common/configs/configs_loader_test.js
@@ -342,7 +342,7 @@ describe('App.ConfigsLoader', function() {
         data: {
           serviceName: 'S1',
           serviceConfigVersions: ['v1'],
-          additionalParams: '|service_name.in(S2)&is_current=true'
+          additionalParams: '|(service_name.in(S2)%26is_current=true)'
         },
         success: 'loadSelectedVersionsSuccess'
       });


### PR DESCRIPTION
## How was this patch tested?
21982 passing (29s)
  48 pending