### PR TITLE
AMBARI-24991. Commands timeouts if stdout has non-unicode symbols

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -336,8 +336,8 @@ class ActionQueue(threading.Thread):
 
     role_result = self.commandStatuses.generate_report_template(command)
     role_result.update({
-      'stdout': command_result['stdout'],
-      'stderr': command_result['stderr'],
+      'stdout': unicode(command_result['stdout'], errors='replace'),
+      'stderr': unicode(command_result['stderr'], errors='replace'),
       'exitCode': command_result['exitcode'],
       'status': status,
     })


### PR DESCRIPTION
in this case stdout had latin1 characters output by one of knox commands.







ERROR 2018-12-03 18:08:08,694 ActionQueue.py:198 - Exception while processing EXECUTION_COMMAND command
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/ambari_agent/ActionQueue.py", line 191, in process_command
    self.execute_command(command)
  File "/usr/lib/ambari-agent/lib/ambari_agent/ActionQueue.py", line 379, in execute_command
    self.commandStatuses.put_command_status(command, role_result)
  File "/usr/lib/ambari-agent/lib/ambari_agent/CommandStatusDict.py", line 77, in put_command_status
    is_sent, correlation_id = self.force_update_to_server({command['clusterId']: [report]})
  File "/usr/lib/ambari-agent/lib/ambari_agent/CommandStatusDict.py", line 95, in force_update_to_server
    correlation_id = self.initializer_module.connection.send(message={'clusters':reports_dict}, destination=Constants.COMMANDS_STATUS_REPORTS_ENDPOINT, log_message_function=CommandStatusDict.log_sending)
  File "/usr/lib/ambari-agent/lib/ambari_agent/security.py", line 137, in send
    body = json.dumps(message)
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 202, in encode
    chunks = list(chunks)
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 426, in _iterencode
    for chunk in iterencode_dict(o, current_indent_level):
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 400, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 400, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 323, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 382, in _iterencode_dict
    yield _encoder(value)
  File "/usr/lib/ambari-agent/lib/ambari_simplejson/encoder.py", line 48, in py_encode_basestring_ascii
    s = s.decode('utf-8')
  File "/usr/lib64/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xea in position 90211: invalid continuation byte