### PR TITLE
[AMBARI-24997] fix the service has no configuration file suspended

### DIFF
--- a/ambari-web/app/mixins/common/configs/enhanced_configs.js
+++ b/ambari-web/app/mixins/common/configs/enhanced_configs.js
@@ -651,6 +651,7 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
     this.prepareSectionsConfigProperties(serviceName);
     const service = this.get('stepConfigs').findProperty('serviceName', serviceName);
     if (service) {
+      try{
       const serviceConfigs = service.get('configs'),
         configConditions = App.ThemeCondition.find().filter(condition => {
           const dependentConfigName = condition.get('configName'),
@@ -667,6 +668,9 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
           });
         });
       this.updateAttributesFromConditions(configConditions, serviceConfigs, serviceName);
+    }catch(err){
+      return;
+    }
     }
   },
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip the get config when the custom service  has not configuration directory

## How was this patch tested?

 manual tests
![image](https://user-images.githubusercontent.com/7973761/49503629-dc60d200-f8b2-11e8-8cf3-6f6954d1f069.png)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.