### PR TITLE
[AMBARI-24988] Support provision_action in complex Add Service request.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -17,6 +17,10 @@
  */
 package org.apache.ambari.server.controller.internal;
 
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_INITIAL_INSTALL;
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_INITIAL_START;
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_PROPERTY;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -385,7 +389,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     installProperties.put(DESIRED_STATE, "INSTALLED");
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Install components on host %s", hostname));
-    requestInfo.put("phase", "INITIAL_INSTALL");
+    requestInfo.put(CLUSTER_PHASE_PROPERTY, CLUSTER_PHASE_INITIAL_INSTALL);
     requestInfo.put(AmbariManagementControllerImpl.SKIP_INSTALL_FOR_COMPONENTS, StringUtils.join
       (skipInstallForComponents, ";"));
     requestInfo.put(AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS, StringUtils.join
@@ -436,7 +440,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Start components on host %s", hostName));
-    requestInfo.put("phase", "INITIAL_START");
+    requestInfo.put(CLUSTER_PHASE_PROPERTY, CLUSTER_PHASE_INITIAL_START);
     requestInfo.put(Setting.SETTING_NAME_SKIP_FAILURE, Boolean.toString(skipFailure));
 
     Predicate clusterPredicate = new EqualsPredicate<>(CLUSTER_NAME, cluster);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ProvisionAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ProvisionAction.java
@@ -18,9 +18,27 @@
 
 package org.apache.ambari.server.controller.internal;
 
-
 public enum ProvisionAction {
-  INSTALL_ONLY,     // Skip Start
-  START_ONLY,     // Skip Install
-  INSTALL_AND_START // Default action
+  INSTALL_ONLY {
+    @Override
+    public boolean skipStart() {
+      return true;
+    }
+  },
+  START_ONLY {
+    @Override
+    public boolean skipInstall() {
+      return true;
+    }
+  },
+  INSTALL_AND_START, // Default action
+  ;
+
+  public boolean skipInstall() {
+    return false;
+  }
+
+  public boolean skipStart() {
+    return false;
+  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceOrchestrator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceOrchestrator.java
@@ -130,7 +130,9 @@ public class AddServiceOrchestrator {
     resourceProviders.createComponents(request);
 
     resourceProviders.updateServiceDesiredState(request, State.INSTALLED);
-    resourceProviders.updateServiceDesiredState(request, State.STARTED);
+    if (!request.getRequest().getProvisionAction().skipStart()) {
+      resourceProviders.updateServiceDesiredState(request, State.STARTED);
+    }
     resourceProviders.createHostComponents(request);
 
     configureKerberos(request, cluster, existingServices);
@@ -164,10 +166,13 @@ public class AddServiceOrchestrator {
   }
 
   private void createHostTasks(AddServiceInfo request) {
-    LOG.info("Creating host tasks for {}", request);
+    LOG.info("Creating host tasks for {}: {}", request, request.getRequest().getProvisionAction());
 
     resourceProviders.updateHostComponentDesiredState(request, State.INSTALLED);
-    resourceProviders.updateHostComponentDesiredState(request, State.STARTED);
+    if (!request.getRequest().getProvisionAction().skipStart()) {
+      resourceProviders.updateHostComponentDesiredState(request, State.STARTED);
+    }
+
     try {
       request.getStages().persist();
     } catch (AmbariException e) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
@@ -32,12 +32,14 @@ import javax.inject.Singleton;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
 import org.apache.ambari.server.controller.ClusterRequest;
 import org.apache.ambari.server.controller.ConfigurationRequest;
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.ComponentResourceProvider;
 import org.apache.ambari.server.controller.internal.CredentialResourceProvider;
 import org.apache.ambari.server.controller.internal.HostComponentResourceProvider;
+import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.controller.internal.RequestImpl;
 import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.ServiceResourceProvider;
@@ -153,8 +155,12 @@ public class ResourceProviderAdapter {
       HostComponentResourceProvider.STATE, desiredState.name(),
       "context", String.format("Put new components to %s state", desiredState)
     ));
+
+    ImmutableMap.Builder<String, String> requestInfo = createRequestInfo(request.clusterName(), Resource.Type.HostComponent);
+    addProvisionProperties(requestInfo, desiredState, request.getRequest().getProvisionAction());
+
     HostComponentResourceProvider rp = (HostComponentResourceProvider) getClusterController().ensureResourceProvider(Resource.Type.HostComponent);
-    Request internalRequest = createRequest(request.clusterName(), properties, Resource.Type.HostComponent);
+    Request internalRequest = createRequest(properties, requestInfo.build());
     try {
       rp.doUpdateResources(request.getStages(), internalRequest, predicateForNewServices(request, HostComponentResourceProvider.HOST_ROLES), false, false, false);
     } catch (UnsupportedPropertyException | SystemException | NoSuchParentResourceException | NoSuchResourceException e) {
@@ -165,7 +171,7 @@ public class ResourceProviderAdapter {
   }
 
   private static void createResources(AddServiceInfo request, Set<Map<String, Object>> properties, Resource.Type resourceType, boolean okIfExists) {
-    Request internalRequest = new RequestImpl(null, properties, null, null);
+    Request internalRequest = createRequest(properties, null);
     ResourceProvider rp = getClusterController().ensureResourceProvider(resourceType);
     try {
       rp.createResources(internalRequest);
@@ -181,7 +187,7 @@ public class ResourceProviderAdapter {
   }
 
   private static void updateResources(AddServiceInfo request, Set<Map<String, Object>> properties, Resource.Type resourceType, Predicate predicate) {
-    Request internalRequest = createRequest(request.clusterName(), properties, resourceType);
+    Request internalRequest = createRequest(properties, createRequestInfo(request.clusterName(), resourceType).build());
     ResourceProvider rp = getClusterController().ensureResourceProvider(resourceType);
     try {
       rp.updateResources(internalRequest, predicate);
@@ -202,12 +208,21 @@ public class ResourceProviderAdapter {
     }
   }
 
-  private static Request createRequest(String clusterName, Set<Map<String, Object>> properties, Resource.Type resourceType) {
-    Map<String, String> requestInfoProperties = ImmutableMap.of(
-      RequestOperationLevel.OPERATION_LEVEL_ID, RequestOperationLevel.getExternalLevelName(resourceType.name()),
-      RequestOperationLevel.OPERATION_CLUSTER_ID, clusterName
-    );
+  private static Request createRequest(Set<Map<String, Object>> properties, Map<String, String> requestInfoProperties) {
     return new RequestImpl(null, properties, requestInfoProperties, null);
+  }
+
+  private static ImmutableMap.Builder<String, String> createRequestInfo(String clusterName, Resource.Type resourceType) {
+    return new ImmutableMap.Builder<String, String>()
+      .put(RequestOperationLevel.OPERATION_LEVEL_ID, RequestOperationLevel.getExternalLevelName(resourceType.name()))
+      .put(RequestOperationLevel.OPERATION_CLUSTER_ID, clusterName);
+  }
+
+  private static void addProvisionProperties(ImmutableMap.Builder<String, String> requestInfo, State desiredState, ProvisionAction requestAction) {
+    if (desiredState == State.INSTALLED && requestAction.skipInstall()) {
+      requestInfo.put(AmbariManagementControllerImpl.SKIP_INSTALL_FOR_COMPONENTS, "ALL");
+      requestInfo.put(AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS, "");
+    }
   }
 
   private static Map<String, Object> createServiceRequestProperties(AddServiceInfo request, String service) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
@@ -19,6 +19,9 @@ package org.apache.ambari.server.topology.addservice;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_PROPERTY;
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS;
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.SKIP_INSTALL_FOR_COMPONENTS;
 
 import java.util.List;
 import java.util.Map;
@@ -220,8 +223,9 @@ public class ResourceProviderAdapter {
 
   private static void addProvisionProperties(ImmutableMap.Builder<String, String> requestInfo, State desiredState, ProvisionAction requestAction) {
     if (desiredState == State.INSTALLED && requestAction.skipInstall()) {
-      requestInfo.put(AmbariManagementControllerImpl.SKIP_INSTALL_FOR_COMPONENTS, "ALL");
-      requestInfo.put(AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS, "");
+      requestInfo.put(SKIP_INSTALL_FOR_COMPONENTS, "ALL");
+      requestInfo.put(DONT_SKIP_INSTALL_FOR_COMPONENTS, "");
+      requestInfo.put(CLUSTER_PHASE_PROPERTY, AmbariManagementControllerImpl.CLUSTER_PHASE_INITIAL_INSTALL);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add request-level support for `provision_action` to the complex Add Service request.

Host component-level support will be added in a later change.

https://issues.apache.org/jira/browse/AMBARI-24988

## How was this patch tested?

Tested requests with each of the 3 provision action types, as well as request without specific provision action.  For start-only, manually pre-installed all required packages.

After the requests completed, queried the service, component, and host component states to verify they are as requested.

For start-only, also verified that no install tasks were created/executed for the services being added.