### PR TITLE
[AMBARI-24999] Disallow changing Kerberos-related configs in Add Service request

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/RequestValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/RequestValidatorTest.java
@@ -375,6 +375,26 @@ public class RequestValidatorTest extends EasyMockSupport {
     verifyConfigOverrides(requestConfig, clusterConfig, stackConfig, config);
   }
 
+  @Test
+  public void rejectsKerberosEnvChange() {
+    Configuration requestConfig = Configuration.newEmpty();
+    requestConfig.setProperty("kerberos-env", "some-property", "some-value");
+    expect(request.getConfiguration()).andReturn(requestConfig.copy()).anyTimes();
+    replayAll();
+
+    assertThrows(IllegalArgumentException.class, validator::validateConfiguration);
+  }
+
+  @Test
+  public void rejectsKrb5ConfChange() {
+    Configuration requestConfig = Configuration.newEmpty();
+    requestConfig.setProperty("krb5-conf", "some-property", "some-value");
+    expect(request.getConfiguration()).andReturn(requestConfig.copy()).anyTimes();
+    replayAll();
+
+    assertThrows(IllegalArgumentException.class, validator::validateConfiguration);
+  }
+
   private static void verifyConfigOverrides(Configuration requestConfig, Configuration clusterConfig, Configuration stackConfig, Configuration actualConfig) {
     requestConfig.getProperties().forEach(
       (type, properties) -> properties.forEach(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Complex Add Service request allows changing configuration of existing services.  This change disallows the request to update Kerberos-related configs.

https://issues.apache.org/jira/browse/AMBARI-24999

## How was this patch tested?

Tested that request with one or both of the Kerberos-related configs (`kerberos-env`, `krb5-conf`) are rejected, but request without these is accepted.

Added unit test for the same.