### PR TITLE
[AMBARI-25002] Allow Stack To Define Custom Rolling Orchestration Logic

### DIFF
--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/OrchestrationOptions.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/OrchestrationOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.spi.upgrade;
+
+import org.apache.ambari.spi.ClusterInformation;
+
+/**
+ * A provider may specify the orchestration options for parts of the upgrade.
+ */
+public interface OrchestrationOptions {
+
+  /**
+   * Gets the count of components that may be run in parallel for groupings.
+   * 
+   * @param cluster
+   *          the cluster information containing topology and configurations
+   * @param service
+   *          the name of the service containing the component
+   * @param component
+   *          the name of the component
+   *          
+   * @return the number of slaves that may be run in parallel.  Returning a
+   *          value less than 1 results in non-parallel behavior
+   */
+  int getConcurrencyCount(ClusterInformation cluster, String service, String component);
+  
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/Grouping.java
@@ -229,15 +229,8 @@ public class Grouping {
       for (TaskWrapper tw : tasks) {
         List<Set<String>> hostSets = null;
 
-        if (m_grouping.parallelScheduler != null) {
-          int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
-          if (taskParallelism == Integer.MAX_VALUE) {
-            taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
-          }
-          hostSets = SetUtils.split(tw.getHosts(), taskParallelism);
-        } else {
-          hostSets = SetUtils.split(tw.getHosts(), 1);
-        }
+        int parallel = getParallelHostCount(ctx, 1);
+        hostSets = SetUtils.split(tw.getHosts(), parallel);
 
         int numBatchesNeeded = hostSets.size();
         int batchNum = 0;

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/UpgradePack.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/UpgradePack.java
@@ -82,6 +82,9 @@ public class UpgradePack {
   @XmlElement(name="prerequisite-checks")
   private PrerequisiteChecks prerequisiteChecks;
 
+  @XmlElement(name="orchestration-options-class")
+  private String orchestrationOptionsClass;
+
   /**
    * In the case of a rolling upgrade, will specify processing logic for a particular component.
    * NonRolling upgrades are simpler so the "processing" is embedded into the  group's "type", which is a function like
@@ -882,4 +885,13 @@ public class UpgradePack {
   public StackId getOwnerStackId() {
     return ownerStackId;
   }
+
+  /**
+   * @return
+   *      the class name used for orchestration options
+   */
+  public String getOrchestrationOptions() {
+    return orchestrationOptionsClass;
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.ambari.server.serveraction.upgrades.AutoSkipFailedSummaryAction;
 import org.apache.ambari.server.stack.HostsType;
 import org.apache.ambari.server.stack.upgrade.Grouping;
+import org.apache.ambari.server.stack.upgrade.ParallelScheduler;
 import org.apache.ambari.server.stack.upgrade.ServerActionTask;
 import org.apache.ambari.server.stack.upgrade.ServiceCheckGrouping;
 import org.apache.ambari.server.stack.upgrade.Task;
@@ -199,7 +200,7 @@ public abstract class StageWrapperBuilder {
   }
 
   /**
-   * Determine the list of tasks given these rules
+   * Determine the list of pre- or post-tasks given these rules
    * <ul>
    *   <li>When performing an upgrade, only use upgrade tasks</li>
    *   <li>When performing a downgrade, use the downgrade tasks if they are defined</li>
@@ -263,4 +264,27 @@ public abstract class StageWrapperBuilder {
 
     return null;
   }
+
+  /**
+   * Gets the parallel setting for a grouping, if defined.
+   *
+   * @param ctx
+   *          the upgrade context
+   * @param defaultValue
+   *          if the parallel scheduler is not found, return this value instead
+   * @return
+   *          the count of hosts to run in parallel
+   */
+  protected int getParallelHostCount(UpgradeContext ctx, int defaultValue) {
+
+    if (m_grouping.parallelScheduler != null) {
+      int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
+      if (taskParallelism == ParallelScheduler.DEFAULT_MAX_DEGREE_OF_PARALLELISM) {
+        taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
+      }
+    }
+
+    return defaultValue;
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
@@ -282,6 +282,7 @@ public abstract class StageWrapperBuilder {
       if (taskParallelism == ParallelScheduler.DEFAULT_MAX_DEGREE_OF_PARALLELISM) {
         taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
       }
+      return taskParallelism;
     }
 
     return defaultValue;

--- a/ambari-server/src/main/resources/upgrade-pack.xsd
+++ b/ambari-server/src/main/resources/upgrade-pack.xsd
@@ -478,6 +478,7 @@
           <xs:element name="source-stack" type="xs:string" />
           <xs:element name="target-stack" type="xs:string" />
         </xs:choice>
+        <xs:element name="orchestration-options-class" minOccurs="0" type="xs:string" />
         <xs:element name="skip-failures" minOccurs="0" type="xs:boolean" />
         <xs:element name="skip-service-check-failures" minOccurs="0" type="xs:boolean" />
         <xs:element name="downgrade-allowed" minOccurs="0" type="xs:boolean" />


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows a stack to provide it's own class to change how orchestration is handled.  The first iteration is to allow a stack to set the parallelism for slaves to run.

## How was this patch tested?

Manual cluster upgrade.  Unit tests:

```
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 35:51 min
[INFO] Finished at: 2018-12-04T15:15:59-05:00
[INFO] ------------------------------------------------------------------------
```