### PR TITLE
AMBARI-25004. Directory/File creation hangs if relative path is supplied

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/providers/system.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/system.py
@@ -101,7 +101,7 @@ def _ensure_metadata(path, user, group, mode=None, cd_access=None, recursive_own
       raise Fail("'cd_acess' value '%s' is not valid" % (cd_access))
     
     dir_path = re.sub('/+', '/', path)
-    while dir_path != os.sep:
+    while dir_path and dir_path != os.sep:
       if sudo.path_isdir(dir_path):
         sudo.chmod_extended(dir_path, cd_access+"+rx")
         


### PR DESCRIPTION

Directory('hadoofs/fs1/ams-hbase-wal', owner='root', group='root', create_parents=True, recursive_ownership=True, cd_access='a')


Hangs as seen on s3a clusters when one of paths was set to relative by an accident.