### PR TITLE
AMBARI-25005. Ambari hides information about cred_store generation failures. Resulting in confusing errors at later stages

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -30,11 +30,12 @@ import ambari_simplejson as json
 from collections import defaultdict
 from ConfigParser import NoOptionError
 
-from ambari_commons import shell, subprocess32
+from ambari_commons import shell
 from ambari_commons.constants import AGENT_TMP_DIR
 from resource_management.libraries.functions.log_process_information import log_process_information
 from resource_management.core.utils import PasswordString
 from resource_management.core.encryption import ensure_decrypted
+from resource_management.core import shell as rmf_shell
 
 from ambari_agent.models.commands import AgentCommand
 from ambari_agent.Utils import Utils
@@ -305,8 +306,7 @@ class CustomServiceOrchestrator(object):
         cmd = (java_bin, '-cp', cs_lib_path, self.credential_shell_cmd, 'create',
                alias, '-value', protected_pwd, '-provider', provider_path)
         logger.info(cmd)
-        cmd_result = subprocess32.call(cmd)
-        logger.info('cmd_result = {0}'.format(cmd_result))
+        rmf_shell.checked_call(cmd)
         os.chmod(file_path, 0644) # group and others should have read access so that the service user can read
       # Add JCEKS provider path instead
       config[self.CREDENTIAL_PROVIDER_PROPERTY_NAME] = provider_path


### PR DESCRIPTION
This is spawned from another jira
Component was failing to install due to:

Caught an exception while executing custom service command: <type 'exceptions.OSError'>: [Errno 2] No such file or directory: '/var/lib/ambari-agent/cred/conf/dp_profiler_agent/dpprofiler-config.jceks'; [Errno 2] No such file or directory: '/var/lib/ambari-agent/cred/conf/dp_profiler_agent/dpprofiler-config.jceks'

Command failed after 1 tries

The reason was an empty password provided in blueprint. However it took lots of time to debug this. Since ambari won't show any information regarding failures during cred_store generation.

The goal is too fail earlier and show output of failed generation command.
So with the patch it looks like this:

Caught an exception while executing custom service command: <class 'resource_management.core.exceptions.ExecutionFailed'>: Execution of '/usr/lib/jvm/java-openjdk/bin/java -cp '/var/lib/ambari-agent/cred/lib/*' org.apache.hadoop.security.alias.CredentialShell create dpprofiler.spnego.signature.secret -value '[PROTECTED]' -provider jceks://file/var/lib/ambari-agent/cred/conf/dp_profiler_agent/dpprofiler-config.jceks' returned 1. SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Dec 06, 2018 11:05:45 AM org.apache.hadoop.util.NativeCodeLoader <clinit>
WARNING: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
java.lang.IllegalArgumentException: Empty key
	at javax.crypto.spec.SecretKeySpec.<init>(SecretKeySpec.java:96)
	at org.apache.hadoop.security.alias.AbstractJavaKeyStoreProvider.innerSetCredential(AbstractJavaKeyStoreProvider.java:304)
	at org.apache.hadoop.security.alias.AbstractJavaKeyStoreProvider.createCredentialEntry(AbstractJavaKeyStoreProvider.java:269)
	at org.apache.hadoop.security.alias.CredentialShell$CreateCommand.execute(CredentialShell.java:365)
	at org.apache.hadoop.security.alias.CredentialShell.run(CredentialShell.java:68)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
	at org.apache.hadoop.security.alias.CredentialShell.main(CredentialShell.java:442); Execution of '/usr/lib/jvm/java-openjdk/bin/java -cp '/var/lib/ambari-agent/cred/lib/*' org.apache.hadoop.security.alias.CredentialShell create dpprofiler.spnego.signature.secret -value '[PROTECTED]' -provider jceks://file/var/lib/ambari-agent/cred/conf/dp_profiler_agent/dpprofiler-config.jceks' returned 1. SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Dec 06, 2018 11:05:45 AM org.apache.hadoop.util.NativeCodeLoader <clinit>
WARNING: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
java.lang.IllegalArgumentException: Empty key
	at javax.crypto.spec.SecretKeySpec.<init>(SecretKeySpec.java:96)
	at org.apache.hadoop.security.alias.AbstractJavaKeyStoreProvider.innerSetCredential(AbstractJavaKeyStoreProvider.java:304)
	at org.apache.hadoop.security.alias.AbstractJavaKeyStoreProvider.createCredentialEntry(AbstractJavaKeyStoreProvider.java:269)
	at org.apache.hadoop.security.alias.CredentialShell$CreateCommand.execute(CredentialShell.java:365)
	at org.apache.hadoop.security.alias.CredentialShell.run(CredentialShell.java:68)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
	at org.apache.hadoop.security.alias.CredentialShell.main(CredentialShell.java:442)