### PR TITLE
[AMBARI-25008] Set unique version tag for config created by Add Service

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
@@ -344,7 +344,7 @@ public class ResourceProviderAdapter {
   ) {
     List<ConfigurationRequest> configRequests = configTypes
       .peek(configType -> LOG.info("Creating request for config type {} for {}", configType, addServiceRequest))
-      .map(configType -> new ConfigurationRequest(addServiceRequest.clusterName(), configType, "ADD_SERVICE",
+      .map(configType -> new ConfigurationRequest(addServiceRequest.clusterName(), configType, "ADD_SERVICE_" + System.currentTimeMillis(),
         fullProperties.getOrDefault(configType, ImmutableMap.of()),
         fullAttributes.getOrDefault(configType, ImmutableMap.of())))
       .collect(toList());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make version tag for configuration created by Add Service request unique by appending timestamp.  The goal is to allow add-delete-add-... cycle of the same service.  Currently these steps lead to exception when creating config with tag `ADD_SERVICE`.

## How was this patch tested?

Manually tested.