### PR TITLE
[AMBARI-25003] Starting JPA persistence service sometimes throws IllegalStateException

### DIFF
--- a/ambari-server/src/main/java/com/google/inject/persist/jpa/AmbariJpaPersistService.java
+++ b/ambari-server/src/main/java/com/google/inject/persist/jpa/AmbariJpaPersistService.java
@@ -18,6 +18,7 @@
 package com.google.inject.persist.jpa;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.inject.Inject;
 
@@ -26,10 +27,31 @@ import com.google.inject.Inject;
  */
 public class AmbariJpaPersistService extends JpaPersistService {
 
+  private final AtomicBoolean jpaStarted = new AtomicBoolean(false);
+
   @Inject
   public AmbariJpaPersistService(@Jpa String persistenceUnitName, @Jpa Map<?, ?> persistenceProperties) {
     super(persistenceUnitName, persistenceProperties);
   }
 
+  /**
+   * Starts the PersistService if it has not been previously started.
+   */
+  @Override
+  public synchronized void start() {
+    if (!jpaStarted.get()) {
+      super.start();
+      jpaStarted.set(true);
+    }
+  }
+
+  /**
+   * Returns whether JPA has been started or not
+   *
+   * @return <code>true</code> if JPA has been started; <code>false</code> if JPA has not been started
+   */
+  public boolean isStarted() {
+    return jpaStarted.get();
+  }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -1096,7 +1096,7 @@ public class AmbariServer {
 
       // Start and Initialize JPA
       GuiceJpaInitializer jpaInitializer = injector.getInstance(GuiceJpaInitializer.class);
-      jpaInitializer.setInitialized(injector.getInstance(AmbariEventPublisher.class)); // This must be called to alert Ambari that JPA is initialized.
+      jpaInitializer.setInitialized(); // This must be called to alert Ambari that JPA is initialized.
 
       DatabaseConsistencyCheckHelper.checkDBVersionCompatible();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/service/AmbariLdapConfigurationProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/service/AmbariLdapConfigurationProvider.java
@@ -24,11 +24,11 @@ import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationProvider;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
-import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.persist.jpa.AmbariJpaPersistService;
 
 /**
  * Provider implementation for LDAP configurations.
@@ -46,8 +46,8 @@ import com.google.inject.Singleton;
 public class AmbariLdapConfigurationProvider extends AmbariServerConfigurationProvider<AmbariLdapConfiguration> {
 
   @Inject
-  public AmbariLdapConfigurationProvider(AmbariEventPublisher publisher, GuiceJpaInitializer guiceJpaInitializer) {
-    super(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, publisher, guiceJpaInitializer);
+  public AmbariLdapConfigurationProvider(AmbariEventPublisher publisher, AmbariJpaPersistService persistService) {
+    super(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, publisher, persistService);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/GuiceJpaInitializer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/GuiceJpaInitializer.java
@@ -18,8 +18,6 @@
 
 package org.apache.ambari.server.orm;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.ambari.server.events.JpaInitializedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 
@@ -33,16 +31,20 @@ import com.google.inject.persist.PersistService;
 @Singleton
 public class GuiceJpaInitializer {
 
-  private final AtomicBoolean jpaInitialized = new AtomicBoolean(false);
+  private final AmbariEventPublisher publisher;
 
   /**
    * GuiceJpaInitializer constructor.
+   * <p>
+   * Starts the JPA service and holds on to an {@link AmbariEventPublisher} for future use.
+   *
+   * @param service   the persist service
+   * @param publisher the Ambari event publisher
    */
   @Inject
-  public GuiceJpaInitializer(PersistService persistService) {
-    if (persistService != null) {
-      persistService.start();
-    }
+  public GuiceJpaInitializer(PersistService service, AmbariEventPublisher publisher) {
+    this.publisher = publisher;
+    service.start();
   }
 
   /**
@@ -51,26 +53,11 @@ public class GuiceJpaInitializer {
    * This means that the schema for the underlying database matches the JPA entity objects expectations
    * and the PersistService has been started.
    * <p>
-   * If an {@link AmbariEventPublisher} is supplied, a {@link JpaInitializedEvent} is published so
-   * that subscribers can perform database-related tasks when the infrastructure is ready.
-   *
-   * @param publisher an {@link AmbariEventPublisher} to use for publishing the event, optional
+   * A {@link JpaInitializedEvent} is published so that subscribers can perform database-related tasks
+   * when the infrastructure is ready.
    */
-  public void setInitialized(AmbariEventPublisher publisher) {
-    jpaInitialized.set(true);
-
-    if (publisher != null) {
-      publisher.publish(new JpaInitializedEvent());
-    }
+  public void setInitialized() {
+    publisher.publish(new JpaInitializedEvent());
   }
 
-  /**
-   * Returns whether JPA has been initialized or not
-   *
-   * @return <code>true</code> if JPA has been initialized; <code>false</code> if JPA has not been initialized
-   * @see #setInitialized(AmbariEventPublisher)
-   */
-  public boolean isInitialized() {
-    return jpaInitialized.get();
-  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationPropertiesProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationPropertiesProvider.java
@@ -24,11 +24,11 @@ import java.util.Collection;
 
 import org.apache.ambari.server.configuration.AmbariServerConfigurationProvider;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
-import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.persist.jpa.AmbariJpaPersistService;
 
 /**
  * JwtAuthenticationPropertiesProvider manages a {@link JwtAuthenticationProperties} instance by
@@ -41,8 +41,8 @@ import com.google.inject.Singleton;
 public class JwtAuthenticationPropertiesProvider extends AmbariServerConfigurationProvider<JwtAuthenticationProperties> {
 
   @Inject
-  public JwtAuthenticationPropertiesProvider(AmbariEventPublisher ambariEventPublisher, GuiceJpaInitializer guiceJpaInitializer) {
-    super(SSO_CONFIGURATION, ambariEventPublisher, guiceJpaInitializer);
+  public JwtAuthenticationPropertiesProvider(AmbariEventPublisher ambariEventPublisher, AmbariJpaPersistService ambariJpaPersistService) {
+    super(SSO_CONFIGURATION, ambariEventPublisher, ambariJpaPersistService);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/tproxy/AmbariTProxyConfigurationProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/tproxy/AmbariTProxyConfigurationProvider.java
@@ -23,11 +23,11 @@ import java.util.Collection;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationProvider;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
-import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.persist.jpa.AmbariJpaPersistService;
 
 /**
  * Provider implementation for {@link AmbariTProxyConfiguration} objects.
@@ -45,8 +45,8 @@ import com.google.inject.Singleton;
 public class AmbariTProxyConfigurationProvider extends AmbariServerConfigurationProvider<AmbariTProxyConfiguration> {
 
   @Inject
-  public AmbariTProxyConfigurationProvider(AmbariEventPublisher ambariEventPublisher, GuiceJpaInitializer guiceJpaInitializer) {
-    super(AmbariServerConfigurationCategory.TPROXY_CONFIGURATION, ambariEventPublisher, guiceJpaInitializer);
+  public AmbariTProxyConfigurationProvider(AmbariEventPublisher ambariEventPublisher, AmbariJpaPersistService persistService) {
+    super(AmbariServerConfigurationCategory.TPROXY_CONFIGURATION, ambariEventPublisher, persistService);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
@@ -36,7 +36,6 @@ import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.audit.AuditLoggerModule;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.ControllerModule;
-import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.ldap.LdapModule;
 import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.GuiceJpaInitializer;
@@ -453,7 +452,7 @@ public class SchemaUpgradeHelper {
 
       // The DDL is expected to be updated, now send the JPA initialized event so Entity
       // implementations can be created.
-      jpaInitializer.setInitialized(injector.getInstance(AmbariEventPublisher.class));
+      jpaInitializer.setInitialized();
 
       schemaUpgradeHelper.executePreDMLUpdates(upgradeCatalogs);
 

--- a/ambari-server/src/test/java/com/google/inject/persist/jpa/AmbariJpaPersistServiceTest.java
+++ b/ambari-server/src/test/java/com/google/inject/persist/jpa/AmbariJpaPersistServiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.inject.persist.jpa;
+
+import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
+import org.junit.Test;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class AmbariJpaPersistServiceTest {
+
+  @Test
+  public void start() {
+    Injector injector = Guice.createInjector(
+        new InMemoryDefaultTestModule()
+    );
+
+    AmbariJpaPersistService persistService = injector.getInstance(AmbariJpaPersistService.class);
+
+    persistService.start();
+    // This should not fail...
+    persistService.start();
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -158,7 +158,7 @@ import org.springframework.security.crypto.password.StandardPasswordEncoder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.persist.PersistService;
+import com.google.inject.persist.jpa.AmbariJpaPersistService;
 
 
 @SuppressWarnings("unchecked")
@@ -243,7 +243,7 @@ public class KerberosHelperTest extends EasyMockSupport {
         PartialNiceMockBinder.newBuilder().addActionDBAccessorConfigsBindings().addFactoriesInstallBinding()
             .addPasswordEncryptorBindings().build().configure(binder());
 
-        bind(PersistService.class).toInstance(createNiceMock(PersistService.class));
+        bind(AmbariJpaPersistService.class).toInstance(createNiceMock(AmbariJpaPersistService.class));
         bind(ActionDBAccessor.class).to(ActionDBAccessorImpl.class);
         bind(ExecutionScheduler.class).to(ExecutionSchedulerImpl.class);
         bind(AbstractRootServiceResponseFactory.class).to(RootServiceResponseFactory.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Starting JPA persistence service sometimes throws IllegalStateException.  

For example:
```
Exception in thread "main" java.lang.IllegalStateException: Persistence service was already initialized.
	at com.google.common.base.Preconditions.checkState(Preconditions.java:173)
	at com.google.inject.persist.jpa.JpaPersistService.start(JpaPersistService.java:104)
	at com.google.inject.persist.jpa.AmbariJpaPersistService.start(AmbariJpaPersistService.java:27)
	at 
```

This occurs due to multiple calls to `com.google.inject.persist.jpa.JpaPersistService#start()`.  This can occur due to changes from AMBARI-24955 since the changes caused injected object to be reordered. 

## How was this patch tested?

Manually tested.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.