### PR TITLE
[AMBARI-25023] Admin View cannot be Deployed Due to META-INF Ordering

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/view/ViewExtractor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/ViewExtractor.java
@@ -95,7 +95,14 @@ public class ViewExtractor {
             view.setStatusDetail(msg);
             LOG.info(msg);
 
-            // create the META-INF directory
+            // pre-create the META-INF directory since JAR compression ordering
+            // can sometimes cause problems with creation of the files inside of
+            // META-INF if the directory appears after
+            //
+            // 473 12-07-2018 11:37   META-INF/MANIFEST.MF
+            // 0   12-07-2018 11:37   META-INF/
+            // 0   12-07-2018 11:37   META-INF/maven/
+            //
             File metaInfDir = archiveUtility.getFile(archivePath + File.separator + "META-INF");
             if (!metaInfDir.mkdir()) {
               msg = "Could not create archive META-INF directory.";
@@ -116,14 +123,18 @@ public class ViewExtractor {
 
                 if (jarEntry.isDirectory()) {
 
-                  LOG.debug("Making directory {}", entryPath);
+                  // only try to create the directory if it doesn't already
+                  // exist (like META-INFO might)
+                  if (!entryFile.exists()) {
+                    LOG.debug("Making directory {}", entryPath);
 
-                  if (!entryFile.mkdir()) {
-                    msg = "Could not create archive entry directory " + entryPath + ".";
+                    if (!entryFile.mkdir()) {
+                      msg = "Could not create archive entry directory " + entryPath + ".";
 
-                    view.setStatusDetail(msg);
-                    LOG.error(msg);
-                    throw new ExtractionException(msg);
+                      view.setStatusDetail(msg);
+                      LOG.error(msg);
+                      throw new ExtractionException(msg);
+                    }
                   }
                 } else {
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/view/ViewExtractorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/view/ViewExtractorTest.java
@@ -19,8 +19,6 @@
 package org.apache.ambari.server.view;
 
 import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -49,6 +47,7 @@ import org.apache.ambari.server.orm.entities.ResourceTypeEntity;
 import org.apache.ambari.server.orm.entities.ViewEntity;
 import org.apache.ambari.server.orm.entities.ViewEntityTest;
 import org.apache.ambari.server.view.configuration.ViewConfig;
+import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,27 +55,27 @@ import org.junit.Test;
 /**
  * ViewExtractor tests.
  */
-public class ViewExtractorTest {
+public class ViewExtractorTest extends EasyMockSupport {
 
-  private static final File extractedArchiveDir = createNiceMock(File.class);
-  private static final File viewArchive = createNiceMock(File.class);
-  private static final File archiveDir = createNiceMock(File.class);
-  private static final File entryFile  = createNiceMock(File.class);
-  private static final File classesDir = createNiceMock(File.class);
-  private static final File libDir = createNiceMock(File.class);
-  private static final File metaInfDir = createNiceMock(File.class);
-  private static final JarInputStream viewJarFile = createNiceMock(JarInputStream.class);
-  private static final JarEntry jarEntry = createNiceMock(JarEntry.class);
-  private static final FileOutputStream fos = createMock(FileOutputStream.class);
-  private static final Configuration configuration = createNiceMock(Configuration.class);
-  private static final File viewDir = createNiceMock(File.class);
-  private static final File fileEntry = createNiceMock(File.class);
-  private static final ViewDAO viewDAO = createMock(ViewDAO.class);
+  private final File extractedArchiveDir = createNiceMock(File.class);
+  private final File viewArchive = createNiceMock(File.class);
+  private final File archiveDir = createNiceMock(File.class);
+  private final File entryFile = createNiceMock(File.class);
+  private final File classesDir = createNiceMock(File.class);
+  private final File libDir = createNiceMock(File.class);
+  private final File metaInfDir = createNiceMock(File.class);
+  private final File metaInfManifest = createNiceMock(File.class);
+  private final JarInputStream viewJarFile = createNiceMock(JarInputStream.class);
+  private final JarEntry jarEntry = createNiceMock(JarEntry.class);
+  private final FileOutputStream fos = createMock(FileOutputStream.class);
+  private final Configuration configuration = createNiceMock(Configuration.class);
+  private final File viewDir = createNiceMock(File.class);
+  private final File fileEntry = createNiceMock(File.class);
+  private final ViewDAO viewDAO = createMock(ViewDAO.class);
 
   @Before
   public void resetGlobalMocks() {
-    reset(extractedArchiveDir, viewArchive,archiveDir,entryFile, classesDir, libDir, metaInfDir, viewJarFile,
-        jarEntry, fos, configuration, viewDir, fileEntry, viewDAO);
+    resetAll();
   }
 
   @Test
@@ -100,20 +99,20 @@ public class ViewExtractorTest {
     expect(configuration.getViewExtractionThreadPoolCoreSize()).andReturn(2).anyTimes();
     expect(configuration.getViewExtractionThreadPoolMaxSize()).andReturn(3).anyTimes();
     expect(configuration.getViewExtractionThreadPoolTimeout()).andReturn(10000L).anyTimes();
+
     if (System.getProperty("os.name").contains("Windows")) {
       expect(viewArchive.getAbsolutePath()).andReturn("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}").anyTimes();
-    }
-    else {
-      expect(viewArchive.getAbsolutePath()).andReturn("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}").anyTimes();
-    }
-
-    expect(archiveDir.exists()).andReturn(false);
-    if (System.getProperty("os.name").contains("Windows")) {
+      expect(metaInfManifest.getAbsolutePath()).andReturn("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\META-INF\\MANIFEST.MF").anyTimes();
       expect(archiveDir.getAbsolutePath()).andReturn("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}").anyTimes();
     }
     else {
+      expect(viewArchive.getAbsolutePath()).andReturn("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}").anyTimes();
+      expect(metaInfManifest.getAbsolutePath()).andReturn("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/META-INF/MANIFEST.MF").anyTimes();
       expect(archiveDir.getAbsolutePath()).andReturn("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}").anyTimes();
     }
+
+    expect(archiveDir.exists()).andReturn(false);
+        
     expect(archiveDir.mkdir()).andReturn(true);
     expect(archiveDir.toURI()).andReturn(new URI("file:./"));
 
@@ -157,16 +156,12 @@ public class ViewExtractorTest {
     expect(addFilePath.isFile()).andReturn(true);
     expect(addFilePath.toURI()).andReturn(new URI("file://file3"));
 
-    replay(extractedArchiveDir, viewArchive, archiveDir, entryFile, classesDir, libDir, metaInfDir, viewJarFile,
-        jarEntry, fos, configuration, viewDir, fileEntry, viewDAO,
-            addDirPath, addDirPathFile1, addDirPathFile2, addDirPath2, addFilePath);
+    replayAll();
 
     ViewExtractor viewExtractor = getViewExtractor(viewDefinition);
     viewExtractor.extractViewArchive(viewDefinition, viewArchive, archiveDir, viewsAdditionalClasspath);
 
-    verify(extractedArchiveDir, viewArchive, archiveDir, entryFile, classesDir, libDir, metaInfDir, viewJarFile,
-        jarEntry, fos, configuration, viewDir, fileEntry, viewDAO,
-            addDirPath, addDirPathFile1, addDirPathFile2, addDirPath2, addFilePath);
+    verifyAll();
   }
 
   @Test
@@ -181,8 +176,7 @@ public class ViewExtractorTest {
 
     expect(extractedArchiveDir.exists()).andReturn(true);
 
-    replay(extractedArchiveDir, viewArchive, archiveDir, entryFile, classesDir, libDir, metaInfDir, viewJarFile,
-        jarEntry, fos, configuration, viewDir, fileEntry, viewDAO);
+    replayAll();
 
     ViewExtractor viewExtractor = getViewExtractor(viewDefinition);
 
@@ -193,8 +187,7 @@ public class ViewExtractorTest {
       Assert.assertTrue(viewExtractor.ensureExtractedArchiveDirectory("/var/lib/ambari-server/resources/views/work"));
     }
 
-    verify(extractedArchiveDir, viewArchive, archiveDir, entryFile, classesDir, libDir, metaInfDir, viewJarFile,
-        jarEntry, fos, configuration, viewDir, fileEntry, viewDAO);
+    verifyAll();
 
     reset(extractedArchiveDir);
 
@@ -240,20 +233,24 @@ public class ViewExtractorTest {
     Map<String, File> files = new HashMap<>();
 
     if (System.getProperty("os.name").contains("Windows")) {
+      // sometimes JARs have odd orderings for the MANIFEST.MF, so put it before the META-INF directory
+      files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\META-INF\\MANIFEST.MF", metaInfManifest);
+      files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\META-INF", metaInfDir);
       files.put("\\var\\lib\\ambari-server\\resources\\views\\work", extractedArchiveDir);
       files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}", archiveDir);
       files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\view.xml", entryFile);
       files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\WEB-INF/classes", classesDir);
       files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\WEB-INF/lib", libDir);
-      files.put("\\var\\lib\\ambari-server\\resources\\views\\work\\MY_VIEW{1.0.0}\\META-INF", metaInfDir);
     }
     else {
+      // sometimes JARs have odd orderings for the MANIFEST.MF, so put it before the META-INF directory
+      files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/META-INF/MANIFEST.MF", metaInfManifest);
+      files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/META-INF", metaInfDir);
       files.put("/var/lib/ambari-server/resources/views/work", extractedArchiveDir);
       files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}", archiveDir);
       files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/view.xml", entryFile);
       files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/WEB-INF/classes", classesDir);
       files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/WEB-INF/lib", libDir);
-      files.put("/var/lib/ambari-server/resources/views/work/MY_VIEW{1.0.0}/META-INF", metaInfDir);
     }
 
     Map<File, FileOutputStream> outputStreams = new HashMap<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new build process which was changed in #2488 is causing JARs to be built slightly differently:

#### unzip -l ambari-admin-2.7.3.0.0.jar | grep META-INF
```
        0  12-07-2018 10:53   META-INF/
      133  12-07-2018 10:53   META-INF/MANIFEST.MF
        0  12-07-2018 10:53   META-INF/maven/
        0  12-07-2018 10:53   META-INF/maven/org.apache.ambari/
        0  12-07-2018 10:53   META-INF/maven/org.apache.ambari/ambari-admin/
    11110  12-05-2018 14:31   META-INF/maven/org.apache.ambari/ambari-admin/pom.xml
      118  12-07-2018 10:53   META-INF/maven/org.apache.ambari/ambari-admin/pom.properties
```

#### unzip -l ambari-admin-3.0.0.0-SNAPSHOT.jar | grep META-INF
```
    473  12-07-2018 11:37   META-INF/MANIFEST.MF
        0  12-07-2018 11:37   META-INF/
        0  12-07-2018 11:37   META-INF/maven/
        0  12-07-2018 11:37   META-INF/maven/org.apache.ambari/
        0  12-07-2018 11:37   META-INF/maven/org.apache.ambari/ambari-admin/
      106  12-07-2018 11:37   META-INF/maven/org.apache.ambari/ambari-admin/pom.properties
    11358  12-07-2018 11:37   META-INF/LICENSE
     5060  12-07-2018 11:37   META-INF/maven/org.apache.ambari/ambari-admin/pom.xml
      267  12-07-2018 11:37   META-INF/DEPENDENCIES
      165  12-07-2018 11:37   META-INF/NOTICE
```

Since the file `META-INF/MANIFEST.MF` appears before `META-INF`, it exposes a bug in the `ViewExtractor`

## How was this patch tested?

- Manually tested deployed of previously failing `ambari-admin-3.0.0.0-SNAPSHOT.jar`
- Updated unit tests for ordering