### PR TITLE
[AMBARI-25007] Process Kerberos descriptor for Add Service request

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/ClusterBlueprintRenderer.java
@@ -55,7 +55,6 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceProvider;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
-import org.apache.ambari.server.controller.utilities.PredicateBuilder;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.topology.AmbariContext;
@@ -68,6 +67,7 @@ import org.apache.ambari.server.topology.HostGroupInfo;
 import org.apache.ambari.server.topology.InvalidTopologyException;
 import org.apache.ambari.server.topology.InvalidTopologyTemplateException;
 import org.apache.ambari.server.topology.SecurityConfigurationFactory;
+import org.apache.ambari.server.topology.addservice.ResourceProviderAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -331,11 +331,8 @@ public class ClusterBlueprintRenderer extends BaseRenderer implements Renderer {
     return blueprintSetting;
   }
 
-  private Map<String, Object> getKerberosDescriptor(ClusterController clusterController, String clusterName) throws AmbariException {
-    PredicateBuilder pb = new PredicateBuilder();
-    Predicate predicate = pb.begin().property("Artifacts/cluster_name").equals(clusterName).and().
-      property(ArtifactResourceProvider.ARTIFACT_NAME_PROPERTY).equals("kerberos_descriptor").
-      end().toPredicate();
+  private static Map<String, Object> getKerberosDescriptor(ClusterController clusterController, String clusterName) throws AmbariException {
+    Predicate predicate = ResourceProviderAdapter.predicateForKerberosDescriptorArtifact(clusterName);
 
     ResourceProvider artifactProvider =
        clusterController.ensureResourceProvider(Resource.Type.Artifact);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ArtifactResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ArtifactResourceProvider.java
@@ -75,6 +75,9 @@ public class ArtifactResourceProvider extends AbstractResourceProvider {
   public static final String CLUSTER_NAME_PROPERTY = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + CLUSTER_NAME;
   public static final String SERVICE_NAME_PROPERTY = RESPONSE_KEY + PropertyHelper.EXTERNAL_PATH_SEP + SERVICE_NAME;
 
+  // artifact names
+  public static final String KERBEROS_DESCRIPTOR = "kerberos_descriptor";
+
   /**
    * primary key fields
    */
@@ -545,6 +548,10 @@ public class ArtifactResourceProvider extends AbstractResourceProvider {
   private boolean isInstanceRequest(Set<Map<String, Object>> requestProps) {
     return requestProps.size() == 1 &&
         requestProps.iterator().next().get(ARTIFACT_NAME_PROPERTY) != null;
+  }
+
+  public static String toArtifactDataJson(Map<?,?> properties) {
+    return String.format("{ \"%s\": %s }", ARTIFACT_DATA_PROPERTY, jsonSerializer.toJson(properties));
   }
 
   //todo: when static registration is changed to external registration, this interface

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosDescriptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosDescriptor.java
@@ -90,8 +90,8 @@ import org.apache.commons.lang.StringUtils;
  */
 public class KerberosDescriptor extends AbstractKerberosDescriptorContainer {
 
-  static final String KEY_PROPERTIES = "properties";
-  static final String KEY_SERVICES = Type.SERVICE.getDescriptorPluralName();
+  public static final String KEY_PROPERTIES = "properties";
+  public static final String KEY_SERVICES = Type.SERVICE.getDescriptorPluralName();
 
   /**
    * A Map of the "global" properties contained within this KerberosDescriptor
@@ -271,8 +271,9 @@ public class KerberosDescriptor extends AbstractKerberosDescriptorContainer {
    * Properties will be updated if the relevant updated values are not null.
    *
    * @param updates the KerberosDescriptor containing the updated values
+   * @return this {@code KerberosDescriptor} for convenience
    */
-  public void update(KerberosDescriptor updates) {
+  public KerberosDescriptor update(KerberosDescriptor updates) {
     if (updates != null) {
       Map<String, KerberosServiceDescriptor> updatedServiceDescriptors = updates.getServices();
       if (updatedServiceDescriptors != null) {
@@ -290,6 +291,8 @@ public class KerberosDescriptor extends AbstractKerberosDescriptorContainer {
     }
 
     super.update(updates);
+
+    return this;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosServiceDescriptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosServiceDescriptor.java
@@ -86,6 +86,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
  */
 public class KerberosServiceDescriptor extends AbstractKerberosDescriptorContainer {
 
+  public static final String KEY_NAME = "name";
   static final String KEY_PRECONFIGURE = "preconfigure";
   static final String KEY_COMPONENTS = Type.COMPONENT.getDescriptorPluralName();
 
@@ -111,7 +112,7 @@ public class KerberosServiceDescriptor extends AbstractKerberosDescriptorContain
   KerberosServiceDescriptor(Map<?, ?> data) {
     // The name for this KerberosServiceDescriptor is stored in the "name" entry in the map
     // This is not automatically set by the super classes.
-    this(getStringValue(data, "name"), data);
+    this(getStringValue(data, KEY_NAME), data);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/BlueprintImpl.java
@@ -64,8 +64,7 @@ public class BlueprintImpl implements Blueprint {
   public BlueprintImpl(BlueprintEntity entity) throws NoSuchStackException {
     this.name = entity.getBlueprintName();
     if (entity.getSecurityType() != null) {
-      this.security = new SecurityConfiguration(entity.getSecurityType(), entity.getSecurityDescriptorReference(),
-        null);
+      this.security = SecurityConfiguration.of(entity.getSecurityType(), entity.getSecurityDescriptorReference(), null);
     }
 
     parseStack(entity.getStack());

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
@@ -80,14 +80,14 @@ public class SecurityConfiguration {
     return type;
   }
 
-  @JsonProperty(KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)
-  @ApiModelProperty(name = KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)
+  @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID)
+  @ApiModelProperty(name = KERBEROS_DESCRIPTOR_PROPERTY_ID)
   public String getDescriptor() {
     return descriptor;
   }
 
-  @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID)
-  @ApiModelProperty(name = KERBEROS_DESCRIPTOR_PROPERTY_ID)
+  @JsonProperty(KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)
+  @ApiModelProperty(name = KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)
   public String getDescriptorReference() {
     return descriptorReference;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfiguration.java
@@ -22,13 +22,18 @@ import static org.apache.ambari.server.topology.SecurityConfigurationFactory.KER
 import static org.apache.ambari.server.topology.SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID;
 import static org.apache.ambari.server.topology.SecurityConfigurationFactory.TYPE_PROPERTY_ID;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
+import org.apache.ambari.annotations.ApiIgnore;
 import org.apache.ambari.server.state.SecurityType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -42,36 +47,61 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SecurityConfiguration {
 
-  public static final SecurityConfiguration NONE = new SecurityConfiguration(SecurityType.NONE);
+  public static final SecurityConfiguration NONE = new SecurityConfiguration(SecurityType.NONE, null, null);
+  public static final SecurityConfiguration KERBEROS = new SecurityConfiguration(SecurityType.KERBEROS, null, null);
 
   /**
    * Security Type
    */
-  private SecurityType type;
+  private final SecurityType type;
 
   /**
    * Holds a reference to a kerberos_descriptor resource.
    */
-  private String descriptorReference;
+  private final String descriptorReference;
 
   /**
-   * Content of a kerberos_descriptor as String.
+   * Content of a kerberos_descriptor as Map.
    */
-  private String descriptor;
+  private final Map<?,?> descriptor;
 
-  public SecurityConfiguration(SecurityType type) {
-    this.type = type;
+  public static SecurityConfiguration of(SecurityType type, String reference, Map<?,?> descriptorMap) {
+    if (type == SecurityType.NONE) {
+      return NONE;
+    }
+    if (type != SecurityType.KERBEROS) {
+      throw new IllegalArgumentException("Unexpected SecurityType: " + type);
+    }
+    if (reference == null && descriptorMap == null) {
+      return KERBEROS;
+    }
+    if (reference != null && descriptorMap != null) {
+      throw new IllegalArgumentException("Cannot set both descriptor and reference");
+    }
+    return reference != null ? withReference(reference) : withDescriptor(descriptorMap);
+  }
+
+  public static SecurityConfiguration withReference(String reference) {
+    return new SecurityConfiguration(SecurityType.KERBEROS, reference, null);
+  }
+
+  public static SecurityConfiguration withDescriptor(Map<?, ?> descriptorMap) {
+    return new SecurityConfiguration(SecurityType.KERBEROS, null, descriptorMap);
+  }
+
+  public static SecurityConfiguration forTest(SecurityType type, String reference, Map<?, ?> descriptorMap) {
+    return new SecurityConfiguration(type, reference, descriptorMap);
   }
 
   @JsonCreator
-  public SecurityConfiguration(
+  SecurityConfiguration(
     @JsonProperty(TYPE_PROPERTY_ID) SecurityType type,
     @JsonProperty(KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID) String descriptorReference,
-    @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID) String descriptor
+    @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID) Map<?, ?> descriptorMap
   ) {
     this.type = type;
     this.descriptorReference = descriptorReference;
-    this.descriptor = descriptor;
+    this.descriptor = descriptorMap != null ? ImmutableMap.copyOf(descriptorMap) : null;
   }
 
   @JsonProperty(TYPE_PROPERTY_ID)
@@ -82,8 +112,14 @@ public class SecurityConfiguration {
 
   @JsonProperty(KERBEROS_DESCRIPTOR_PROPERTY_ID)
   @ApiModelProperty(name = KERBEROS_DESCRIPTOR_PROPERTY_ID)
-  public String getDescriptor() {
-    return descriptor;
+  public Map<?,?> _getDescriptor() {
+    return getDescriptor().isPresent() ? descriptor : ImmutableMap.of();
+  }
+
+  @ApiIgnore
+  @JsonIgnore
+  public Optional<Map<?,?>> getDescriptor() {
+    return Optional.ofNullable(descriptor);
   }
 
   @JsonProperty(KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID)

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfigurationFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/SecurityConfigurationFactory.java
@@ -104,11 +104,9 @@ public class SecurityConfigurationFactory {
             + KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID + " at the same time, is not allowed.");
       }
 
-      String descriptorText;
-
       if (descriptorJsonMap != null) { // this means the reference is null
         LOGGER.debug("Found embedded descriptor: {}", descriptorJsonMap);
-        descriptorText = jsonSerializer.toJson(descriptorJsonMap, Map.class);
+        String descriptorText = jsonSerializer.toJson(descriptorJsonMap, Map.class);
         if (persistEmbeddedDescriptor) {
           descriptorReference = persistKerberosDescriptor(descriptorText);
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/TopologyManager.java
@@ -313,8 +313,8 @@ public class TopologyManager {
     // create resources
     ambariContext.createAmbariResources(topology, clusterName, securityType, repoVersion, repoVersionID);
 
-    if (securityConfiguration != null && securityConfiguration.getDescriptor() != null) {
-      submitKerberosDescriptorAsArtifact(clusterName, securityConfiguration.getDescriptor());
+    if (securityConfiguration != null) {
+      securityConfiguration.getDescriptor().ifPresent(descriptor -> submitKerberosDescriptorAsArtifact(clusterName, descriptor));
     }
 
     if (credential != null) {
@@ -440,21 +440,16 @@ public class TopologyManager {
     return securityConfiguration;
   }
 
-  private void submitKerberosDescriptorAsArtifact(String clusterName, String descriptor) {
+  private void submitKerberosDescriptorAsArtifact(String clusterName, Map<?,?> descriptor) {
 
     ResourceProvider artifactProvider =
         ambariContext.getClusterController().ensureResourceProvider(Resource.Type.Artifact);
 
-    Map<String, Object> properties = new HashMap<>();
-    properties.put(ArtifactResourceProvider.ARTIFACT_NAME_PROPERTY, "kerberos_descriptor");
-    properties.put("Artifacts/cluster_name", clusterName);
-
-    Map<String, String> requestInfoProps = new HashMap<>();
-    requestInfoProps.put(org.apache.ambari.server.controller.spi.Request.REQUEST_INFO_BODY_PROPERTY,
-            "{\"" + ArtifactResourceProvider.ARTIFACT_DATA_PROPERTY + "\": " + descriptor + "}");
-
-    org.apache.ambari.server.controller.spi.Request request = new RequestImpl(Collections.emptySet(),
-        Collections.singleton(properties), requestInfoProps, null);
+    Map<String, Object> properties = ResourceProviderAdapter.createKerberosDescriptorRequestProperties(clusterName);
+    Map<String, String> requestInfoProps = ImmutableMap.of(
+      Request.REQUEST_INFO_BODY_PROPERTY, ArtifactResourceProvider.toArtifactDataJson(descriptor)
+    );
+    Request request = new RequestImpl(Collections.emptySet(), Collections.singleton(properties), requestInfoProps, null);
 
     try {
       RequestStatus status = artifactProvider.createResources(request);

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
@@ -20,11 +20,13 @@ package org.apache.ambari.server.topology.addservice;
 import static java.util.stream.Collectors.joining;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.ambari.server.controller.AddServiceRequest;
 import org.apache.ambari.server.controller.internal.RequestStageContainer;
 import org.apache.ambari.server.controller.internal.Stack;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.topology.Configuration;
 
 /**
@@ -35,21 +37,31 @@ public final class AddServiceInfo {
   private final AddServiceRequest request;
   private final String clusterName;
   private final Stack stack;
+  private final KerberosDescriptor kerberosDescriptor;
   private final Map<String, Map<String, Set<String>>> newServices;
   private final RequestStageContainer stages;
   private final Configuration config;
 
-  public AddServiceInfo(AddServiceRequest request, String clusterName, Stack stack, Configuration config, RequestStageContainer stages, Map<String, Map<String, Set<String>>> newServices) {
+  public AddServiceInfo(
+    AddServiceRequest request,
+    String clusterName,
+    Stack stack,
+    Configuration config,
+    KerberosDescriptor kerberosDescriptor,
+    RequestStageContainer stages,
+    Map<String, Map<String, Set<String>>> newServices
+  ) {
     this.request = request;
     this.clusterName = clusterName;
     this.stack = stack;
+    this.kerberosDescriptor = kerberosDescriptor;
     this.newServices = newServices;
     this.stages = stages;
     this.config = config;
   }
 
   public AddServiceInfo withNewServices(Map<String, Map<String, Set<String>>> services) {
-    return new AddServiceInfo(request, clusterName, stack, config, stages, services);
+    return new AddServiceInfo(request, clusterName, stack, config, kerberosDescriptor, stages, services);
   }
 
   @Override
@@ -83,6 +95,10 @@ public final class AddServiceInfo {
 
   public Configuration getConfig() {
     return config;
+  }
+
+  public Optional<KerberosDescriptor> getKerberosDescriptor() {
+    return Optional.ofNullable(kerberosDescriptor);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceOrchestrator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceOrchestrator.java
@@ -19,6 +19,7 @@ package org.apache.ambari.server.topology.addservice;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -31,12 +32,16 @@ import org.apache.ambari.server.controller.AddServiceRequest;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.RequestStatusResponse;
+import org.apache.ambari.server.serveraction.kerberos.KerberosAdminAuthenticationException;
 import org.apache.ambari.server.serveraction.kerberos.KerberosInvalidConfigurationException;
+import org.apache.ambari.server.serveraction.kerberos.KerberosMissingAdminCredentialsException;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.Service;
 import org.apache.ambari.server.state.State;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.utils.LoggingPreconditions;
 import org.apache.ambari.server.utils.StageUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +53,7 @@ import com.google.common.collect.Sets;
 public class AddServiceOrchestrator {
 
   private static final Logger LOG = LoggerFactory.getLogger(AddServiceOrchestrator.class);
+  private static final LoggingPreconditions CHECK = new LoggingPreconditions(LOG);
 
   @Inject
   private ResourceProviderAdapter resourceProviders;
@@ -71,6 +77,7 @@ public class AddServiceOrchestrator {
     LOG.info("Received {} request for {}: {}", request.getOperationType(), cluster.getClusterName(), request);
 
     AddServiceInfo validatedRequest = validate(cluster, request);
+    ensureCredentials(cluster, validatedRequest);
     AddServiceInfo requestWithLayout = recommendLayout(validatedRequest);
     AddServiceInfo requestWithConfig = recommendConfiguration(requestWithLayout);
 
@@ -93,6 +100,25 @@ public class AddServiceOrchestrator {
     validator.validate();
 
     return validator.createValidServiceInfo(actionManager, requestFactory);
+  }
+
+  /**
+   * Stores any credentials provided in the request, and
+   * validates KDC credentials if the cluster has Kerberos enabled.
+   * The goal is to make sure that no resources (services, components, etc.) get created
+   * (except the credentials) if the request as a whole would fail due to missing credentials.
+   */
+  private void ensureCredentials(Cluster cluster, AddServiceInfo validatedRequest) {
+    resourceProviders.createCredentials(validatedRequest);
+    if (cluster.getSecurityType() == SecurityType.KERBEROS) {
+      try {
+        controller.getKerberosHelper().validateKDCCredentials(cluster);
+      } catch (KerberosMissingAdminCredentialsException | KerberosAdminAuthenticationException | KerberosInvalidConfigurationException e) {
+        CHECK.wrapInUnchecked(e, IllegalArgumentException::new, "KDC credentials validation failed: %s", e);
+      } catch (AmbariException e) {
+        CHECK.wrapInUnchecked(e, IllegalStateException::new, "Error occurred while validating KDC credentials: %s", e);
+      }
+    }
   }
 
   /**
@@ -124,7 +150,7 @@ public class AddServiceOrchestrator {
 
     Set<String> existingServices = cluster.getServices().keySet();
 
-    resourceProviders.createCredentials(request);
+    updateKerberosDescriptor(request);
 
     resourceProviders.createServices(request);
     resourceProviders.createComponents(request);
@@ -159,8 +185,7 @@ public class AddServiceOrchestrator {
           )
         );
       } catch (AmbariException | KerberosInvalidConfigurationException e) {
-        LOG.error("Error configuring Kerberos: {}", e, e);
-        throw new RuntimeException(e);
+        CHECK.wrapInUnchecked(e, RuntimeException::new, "Error configuring Kerberos for %s: %s", request, e);
       }
     }
   }
@@ -176,10 +201,20 @@ public class AddServiceOrchestrator {
     try {
       request.getStages().persist();
     } catch (AmbariException e) {
-      String msg = String.format("Error creating host tasks for %s", request);
-      LOG.error(msg, e);
-      throw new IllegalStateException(msg, e);
+      CHECK.wrapInUnchecked(e, IllegalStateException::new, "Error creating host tasks for %s", request);
     }
+  }
+
+  private void updateKerberosDescriptor(AddServiceInfo request) {
+    request.getKerberosDescriptor().ifPresent(descriptorInRequest -> {
+      Optional<KerberosDescriptor> existingDescriptor = resourceProviders.getKerberosDescriptor(request);
+      if (existingDescriptor.isPresent()) {
+        KerberosDescriptor newDescriptor = existingDescriptor.get().update(descriptorInRequest);
+        resourceProviders.updateKerberosDescriptor(request, newDescriptor);
+      } else {
+        resourceProviders.createKerberosDescriptor(request, descriptorInRequest);
+      }
+    });
   }
 
   private static Map<String, String> createComponentHostMap(Cluster cluster) {
@@ -194,8 +229,7 @@ public class AddServiceOrchestrator {
     try {
       return cluster.getService(service).getServiceComponent(component).getServiceComponentsHosts();
     } catch (AmbariException e) {
-      LOG.error("Error getting components of service {}: {}", service, e, e);
-      throw new RuntimeException(e);
+      return CHECK.wrapInUnchecked(e, IllegalStateException::new, "Error getting hosts for service %s component %: %s", service, component, e, e);
     }
   }
 
@@ -203,8 +237,7 @@ public class AddServiceOrchestrator {
     try {
       return cluster.getService(service).getServiceComponents().keySet();
     } catch (AmbariException e) {
-      LOG.error("Error getting components of service {}: {}", service, e, e);
-      throw new RuntimeException(e);
+      return CHECK.wrapInUnchecked(e, IllegalStateException::new, "Error getting components of service %s: %s", service, e, e);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import javax.inject.Inject;
 
@@ -41,9 +40,14 @@ import org.apache.ambari.server.controller.internal.RequestStageContainer;
 import org.apache.ambari.server.controller.internal.Stack;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.ConfigHelper;
+import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.StackId;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptorFactory;
 import org.apache.ambari.server.topology.Configuration;
+import org.apache.ambari.server.topology.SecurityConfigurationFactory;
 import org.apache.ambari.server.topology.StackFactory;
+import org.apache.ambari.server.utils.LoggingPreconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +62,7 @@ import com.google.inject.assistedinject.Assisted;
 public class RequestValidator {
 
   private static final Logger LOG = LoggerFactory.getLogger(RequestValidator.class);
+  private static final LoggingPreconditions CHECK = new LoggingPreconditions(LOG);
 
   private static final Set<String> NOT_ALLOWED_CONFIG_TYPES = ImmutableSet.of("kerberos-env", "krb5-conf");
 
@@ -66,7 +71,9 @@ public class RequestValidator {
   private final AmbariManagementController controller;
   private final ConfigHelper configHelper;
   private final StackFactory stackFactory;
+  private final KerberosDescriptorFactory kerberosDescriptorFactory;
   private final AtomicBoolean serviceInfoCreated = new AtomicBoolean();
+  private final SecurityConfigurationFactory securityConfigurationFactory;
 
   private State state;
 
@@ -74,7 +81,8 @@ public class RequestValidator {
   public RequestValidator(
     @Assisted AddServiceRequest request, @Assisted Cluster cluster,
     AmbariManagementController controller, ConfigHelper configHelper,
-    StackFactory stackFactory
+    StackFactory stackFactory, KerberosDescriptorFactory kerberosDescriptorFactory,
+    SecurityConfigurationFactory securityConfigurationFactory
   ) {
     this.state = State.INITIAL;
     this.request = request;
@@ -82,15 +90,17 @@ public class RequestValidator {
     this.controller = controller;
     this.configHelper = configHelper;
     this.stackFactory = stackFactory;
+    this.kerberosDescriptorFactory = kerberosDescriptorFactory;
+    this.securityConfigurationFactory = securityConfigurationFactory;
   }
 
   /**
    * Perform validation of the request.
    */
   void validate() {
-    validateSecurity();
     validateStack();
     validateServicesAndComponents();
+    validateSecurity();
     validateHosts();
     validateConfiguration();
   }
@@ -101,11 +111,13 @@ public class RequestValidator {
   AddServiceInfo createValidServiceInfo(ActionManager actionManager, RequestFactory requestFactory) {
     final State state = this.state;
 
-    checkState(state.isValid(), "The request needs to be validated first");
-    checkState(!serviceInfoCreated.getAndSet(true), "Can create only one instance for each validated add service request");
+    CHECK.checkState(state.isValid(), "The request needs to be validated first");
+    CHECK.checkState(!serviceInfoCreated.getAndSet(true), "Can create only one instance for each validated add service request");
 
     RequestStageContainer stages = new RequestStageContainer(actionManager.getNextRequestId(), null, requestFactory, actionManager);
-    AddServiceInfo validatedRequest = new AddServiceInfo(request, cluster.getClusterName(), state.getStack(), state.getConfig(), stages, state.getNewServices());
+    AddServiceInfo validatedRequest = new AddServiceInfo(request, cluster.getClusterName(),
+      state.getStack(), state.getConfig(), state.getKerberosDescriptor(),
+      stages, state.getNewServices());
     stages.setRequestContext(validatedRequest.describe());
     return validatedRequest;
   }
@@ -122,12 +134,52 @@ public class RequestValidator {
 
   @VisibleForTesting
   void validateSecurity() {
-    request.getSecurity().ifPresent(requestSecurity ->
-      checkArgument(requestSecurity.getType() == cluster.getSecurityType(),
+    request.getSecurity().ifPresent(requestSecurity -> {
+      CHECK.checkArgument(requestSecurity.getType() == cluster.getSecurityType(),
         "Security type in the request (%s), if specified, should match cluster's security type (%s)",
         requestSecurity.getType(), cluster.getSecurityType()
-      )
-    );
+      );
+
+      boolean hasDescriptor = requestSecurity.getDescriptor().isPresent();
+      boolean hasDescriptorReference = requestSecurity.getDescriptorReference() != null;
+      boolean secureCluster = cluster.getSecurityType() == SecurityType.KERBEROS;
+
+      CHECK.checkArgument(secureCluster || !hasDescriptor,
+        "Kerberos descriptor cannot be set for security type %s", cluster.getSecurityType());
+      CHECK.checkArgument(secureCluster || !hasDescriptorReference,
+        "Kerberos descriptor reference cannot be set for security type %s", cluster.getSecurityType());
+      CHECK.checkArgument(!hasDescriptor || !hasDescriptorReference,
+        "Kerberos descriptor and reference cannot be both set");
+
+      Optional<Map<?,?>> kerberosDescriptor = hasDescriptor
+        ? requestSecurity.getDescriptor()
+        : hasDescriptorReference
+          ? loadKerberosDescriptor(requestSecurity.getDescriptorReference())
+          : Optional.empty();
+
+      kerberosDescriptor.ifPresent(descriptorMap -> {
+        CHECK.checkState(state.getNewServices() != null,
+          "Services need to be validated before security settings");
+
+        KerberosDescriptor descriptor = kerberosDescriptorFactory.createInstance(descriptorMap);
+
+        Set<String> servicesWithNewDescriptor = descriptor.getServices().keySet();
+        Set<String> newServices = state.getNewServices().keySet();
+        Set<String> nonNewServices = ImmutableSet.copyOf(Sets.difference(servicesWithNewDescriptor, newServices));
+
+        CHECK.checkArgument(nonNewServices.isEmpty(),
+          "Kerberos descriptor should be provided only for new services, but found other services: %s",
+          nonNewServices);
+
+        try {
+          descriptor.toMap();
+        } catch (Exception e) {
+          CHECK.wrapInUnchecked(e, IllegalArgumentException::new, "Error validating Kerberos descriptor: %s", e);
+        }
+
+        state = state.with(descriptor);
+      });
+    });
   }
 
   @VisibleForTesting
@@ -138,9 +190,8 @@ public class RequestValidator {
       Stack stack = stackFactory.createStack(stackId.getStackName(), stackId.getStackVersion(), controller);
       state = state.with(stack);
     } catch (AmbariException e) {
-      logAndThrow(requestStackId.isPresent()
-        ? msg -> new IllegalArgumentException(msg, e)
-        : IllegalStateException::new,
+      CHECK.wrapInUnchecked(e,
+        requestStackId.isPresent() ? IllegalArgumentException::new : IllegalStateException::new,
         "Stack %s not found", stackId
       );
     }
@@ -157,9 +208,9 @@ public class RequestValidator {
     for (AddServiceRequest.Service service : request.getServices()) {
       String serviceName = service.getName();
 
-      checkArgument(stack.getServices().contains(serviceName),
+      CHECK.checkArgument(stack.getServices().contains(serviceName),
         "Unknown service %s in %s", service, stack);
-      checkArgument(!existingServices.contains(serviceName),
+      CHECK.checkArgument(!existingServices.contains(serviceName),
         "Service %s already exists in cluster %s", serviceName, cluster.getClusterName());
 
       newServices.computeIfAbsent(serviceName, __ -> new HashMap<>());
@@ -170,9 +221,9 @@ public class RequestValidator {
       String componentName = requestedComponent.getName();
       String serviceName = stack.getServiceForComponent(componentName);
 
-      checkArgument(serviceName != null,
+      CHECK.checkArgument(serviceName != null,
         "No service found for component %s in %s", componentName, stack);
-      checkArgument(!existingServices.contains(serviceName),
+      CHECK.checkArgument(!existingServices.contains(serviceName),
         "Service %s (for component %s) already exists in cluster %s", serviceName, componentName, cluster.getClusterName());
 
       newServices.computeIfAbsent(serviceName, __ -> new HashMap<>())
@@ -180,7 +231,7 @@ public class RequestValidator {
         .add(requestedComponent.getFqdn());
     }
 
-    checkArgument(!newServices.isEmpty(), "Request should have at least one new service or component to be added");
+    CHECK.checkArgument(!newServices.isEmpty(), "Request should have at least one new service or component to be added");
 
     state = state.withNewServices(newServices);
   }
@@ -190,7 +241,7 @@ public class RequestValidator {
     Configuration config = request.getConfiguration();
 
     for (String type : NOT_ALLOWED_CONFIG_TYPES) {
-      checkArgument(!config.getProperties().containsKey(type), "Cannot change '%s' configuration in Add Service request", type);
+      CHECK.checkArgument(!config.getProperties().containsKey(type), "Cannot change '%s' configuration in Add Service request", type);
     }
 
     Configuration clusterConfig = getClusterDesiredConfigs();
@@ -209,7 +260,7 @@ public class RequestValidator {
       .collect(toSet());
     Set<String> unknownHosts = new TreeSet<>(Sets.difference(requestHosts, clusterHosts));
 
-    checkArgument(unknownHosts.isEmpty(),
+    CHECK.checkArgument(unknownHosts.isEmpty(),
       "Requested host not associated with cluster %s: %s", cluster.getClusterName(), unknownHosts);
   }
 
@@ -217,42 +268,29 @@ public class RequestValidator {
     try {
       return Configuration.of(configHelper.calculateExistingConfigs(cluster));
     } catch (AmbariException e) {
-      logAndThrow(msg -> new IllegalStateException(msg, e), "Error getting effective configuration of cluster %s", cluster.getClusterName());
-      return Configuration.newEmpty(); // unreachable
+      return CHECK.wrapInUnchecked(e, IllegalStateException::new, "Error getting effective configuration of cluster %s", cluster.getClusterName());
     }
   }
 
-  private static void checkArgument(boolean expression, String errorMessage, Object... messageParams) {
-    if (!expression) {
-      logAndThrow(IllegalArgumentException::new, errorMessage, messageParams);
-    }
-  }
-
-  private static void checkState(boolean expression, String errorMessage, Object... messageParams) {
-    if (!expression) {
-      logAndThrow(IllegalStateException::new, errorMessage, messageParams);
-    }
-  }
-
-  private static void logAndThrow(Function<String, RuntimeException> exceptionCreator, String errorMessage, Object... messageParams) {
-    String msg = String.format(errorMessage, messageParams);
-    LOG.error(msg);
-    throw exceptionCreator.apply(msg);
+  private Optional<Map<?,?>> loadKerberosDescriptor(String descriptorReference) {
+    return securityConfigurationFactory.loadSecurityConfigurationByReference(descriptorReference).getDescriptor();
   }
 
   @VisibleForTesting
   static class State {
 
-    static final State INITIAL = new State(null, null, null);
+    static final State INITIAL = new State(null, null, null, null);
 
     private final Stack stack;
     private final Map<String, Map<String, Set<String>>> newServices;
     private final Configuration config;
+    private final KerberosDescriptor kerberosDescriptor;
 
-    State(Stack stack, Map<String, Map<String, Set<String>>> newServices, Configuration config) {
+    State(Stack stack, Map<String, Map<String, Set<String>>> newServices, Configuration config, KerberosDescriptor kerberosDescriptor) {
       this.stack = stack;
       this.newServices = newServices;
       this.config = config;
+      this.kerberosDescriptor = kerberosDescriptor;
     }
 
     boolean isValid() {
@@ -260,15 +298,19 @@ public class RequestValidator {
     }
 
     State with(Stack stack) {
-      return new State(stack, newServices, config);
+      return new State(stack, newServices, config, kerberosDescriptor);
     }
 
     State withNewServices(Map<String, Map<String, Set<String>>> newServices) {
-      return new State(stack, newServices, config);
+      return new State(stack, newServices, config, kerberosDescriptor);
     }
 
     State with(Configuration config) {
-      return new State(stack, newServices, config);
+      return new State(stack, newServices, config, kerberosDescriptor);
+    }
+
+    State with(KerberosDescriptor kerberosDescriptor) {
+      return new State(stack, newServices, config, kerberosDescriptor);
     }
 
     Stack getStack() {
@@ -281,6 +323,10 @@ public class RequestValidator {
 
     Configuration getConfig() {
       return config;
+    }
+
+    KerberosDescriptor getKerberosDescriptor() {
+      return kerberosDescriptor;
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/LoggingPreconditions.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/LoggingPreconditions.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.utils;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+
+public class LoggingPreconditions {
+
+  private final Logger logger;
+
+  public LoggingPreconditions(Logger logger) {
+    this.logger = logger;
+  }
+
+  public void checkNotNull(Object o, String errorMessage, Object... messageParams) {
+    if (o == null) {
+      logAndThrow(NullPointerException::new, errorMessage, messageParams);
+    }
+  }
+
+  public void checkArgument(boolean expression, String errorMessage, Object... messageParams) {
+    if (!expression) {
+      logAndThrow(IllegalArgumentException::new, errorMessage, messageParams);
+    }
+  }
+
+  public void checkState(boolean expression, String errorMessage, Object... messageParams) {
+    if (!expression) {
+      logAndThrow(IllegalStateException::new, errorMessage, messageParams);
+    }
+  }
+
+  /**
+   * Wraps {@code exception} in an unchecked exception created by {@code uncheckedWrapper}, and always throws the unchecked exception.
+   * @return null to make the compiler happy
+   */
+  public <T> T wrapInUnchecked(Exception exception, BiFunction<String, Exception, RuntimeException> uncheckedWrapper, String errorMessage, Object... messageParams) {
+    logAndThrow(msg -> uncheckedWrapper.apply(msg, exception), errorMessage, messageParams);
+    return null; // unreachable
+  }
+
+  /**
+   * Formats an error message with parameters using {@code String.format}, logs it using {@code logger},
+   * and throws an unchecked exception with the same message created by {@code exceptionCreator}.
+   */
+  public void logAndThrow(Function<String, RuntimeException> exceptionCreator, String errorMessage, Object... messageParams) {
+    String msg = String.format(errorMessage, messageParams);
+    logger.error(msg);
+    throw exceptionCreator.apply(msg);
+  }
+
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
@@ -77,6 +77,8 @@ public class AddServiceRequestTest {
   private static String REQUEST_INVALID_NO_SERVICES_AND_COMPONENTS;
   private static String REQUEST_INVALID_INVALID_FIELD;
   private static String REQUEST_INVALID_INVALID_CONFIG;
+  private static final Map<String, List<Map<String, String>>> KERBEROS_DESCRIPTOR1 =
+    ImmutableMap.of("services", ImmutableList.of(ImmutableMap.of("name", "ZOOKEEPER")));
 
   private ObjectMapper mapper = new ObjectMapper();
 
@@ -118,7 +120,7 @@ public class AddServiceRequestTest {
       request.getServices());
 
     assertEquals(
-      Optional.of(new SecurityConfiguration(SecurityType.KERBEROS, "ref_to_kerb_desc", "kerb_desc")),
+      Optional.of(SecurityConfiguration.forTest(SecurityType.KERBEROS, "ref_to_kerb_desc", KERBEROS_DESCRIPTOR1)),
       request.getSecurity());
 
     assertEquals(
@@ -256,7 +258,7 @@ public class AddServiceRequestTest {
     assertEquals(
       ImmutableMap.of(
         SecurityConfigurationFactory.TYPE_PROPERTY_ID, SecurityType.KERBEROS.name(),
-        SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_PROPERTY_ID, "kerb_desc",
+        SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_PROPERTY_ID, KERBEROS_DESCRIPTOR1,
         SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID, "ref_to_kerb_desc"
       ),
       serialized.get(ClusterResourceProvider.SECURITY)

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.security.encryption.CredentialStoreType;
 import org.apache.ambari.server.state.SecurityType;
@@ -52,6 +53,7 @@ import org.apache.ambari.server.topology.Configurable;
 import org.apache.ambari.server.topology.Configuration;
 import org.apache.ambari.server.topology.Credential;
 import org.apache.ambari.server.topology.SecurityConfiguration;
+import org.apache.ambari.server.topology.SecurityConfigurationFactory;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -116,7 +118,7 @@ public class AddServiceRequestTest {
       request.getServices());
 
     assertEquals(
-      Optional.of(new SecurityConfiguration(SecurityType.KERBEROS, "ref_to_kerb_desc", null)),
+      Optional.of(new SecurityConfiguration(SecurityType.KERBEROS, "ref_to_kerb_desc", "kerb_desc")),
       request.getSecurity());
 
     assertEquals(
@@ -250,6 +252,17 @@ public class AddServiceRequestTest {
       ),
       serialized.get(Configurable.CONFIGURATIONS)
     );
+
+    assertEquals(
+      ImmutableMap.of(
+        SecurityConfigurationFactory.TYPE_PROPERTY_ID, SecurityType.KERBEROS.name(),
+        SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_PROPERTY_ID, "kerb_desc",
+        SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID, "ref_to_kerb_desc"
+      ),
+      serialized.get(ClusterResourceProvider.SECURITY)
+    );
+
+    assertNull(serialized.get(ClusterResourceProvider.CREDENTIALS));
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintResourceProviderTest.java
@@ -73,7 +73,6 @@ import org.apache.ambari.server.orm.entities.HostGroupEntity;
 import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.orm.entities.TopologyRequestEntity;
 import org.apache.ambari.server.state.PropertyInfo;
-import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.StackInfo;
 import org.apache.ambari.server.topology.Blueprint;
 import org.apache.ambari.server.topology.BlueprintFactory;
@@ -384,7 +383,7 @@ public class BlueprintResourceProviderTest {
     Set<Map<String, Object>> setProperties = getBlueprintTestProperties();
     Map<String, String> requestInfoProperties = getTestRequestInfoProperties();
     Map<String, Set<HashMap<String, String>>> settingProperties = getSettingProperties();
-    SecurityConfiguration securityConfiguration = new SecurityConfiguration(SecurityType.KERBEROS, "testRef", null);
+    SecurityConfiguration securityConfiguration = SecurityConfiguration.withReference("testRef");
 
     // set expectations
     expect(securityFactory.createSecurityConfigurationFromRequest(EasyMock.anyObject(), anyBoolean())).andReturn

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClusterResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ClusterResourceProviderTest.java
@@ -177,9 +177,8 @@ public class ClusterResourceProviderTest {
     Map<String, String> requestInfoProperties = new HashMap<>();
     requestInfoProperties.put(Request.REQUEST_INFO_BODY_PROPERTY, "{\"security\" : {\n\"type\" : \"NONE\"," +
       "\n\"kerberos_descriptor_reference\" : " + "\"testRef\"\n}}");
-    SecurityConfiguration blueprintSecurityConfiguration = new SecurityConfiguration(SecurityType.KERBEROS, "testRef",
-      null);
-    SecurityConfiguration securityConfiguration = new SecurityConfiguration(SecurityType.NONE, null, null);
+    SecurityConfiguration blueprintSecurityConfiguration = SecurityConfiguration.withReference("testRef");
+    SecurityConfiguration securityConfiguration = SecurityConfiguration.NONE;
 
     // set expectations
     expect(request.getProperties()).andReturn(requestProperties).anyTimes();
@@ -201,7 +200,7 @@ public class ClusterResourceProviderTest {
   public void testCreateResource_blueprint_withSecurityConfiguration() throws Exception {
     Set<Map<String, Object>> requestProperties = createBlueprintRequestProperties(CLUSTER_NAME, BLUEPRINT_NAME);
     Map<String, Object> properties = requestProperties.iterator().next();
-    SecurityConfiguration securityConfiguration = new SecurityConfiguration(SecurityType.KERBEROS, "testRef", null);
+    SecurityConfiguration securityConfiguration = SecurityConfiguration.withReference("testRef");
 
     Map<String, String> requestInfoProperties = new HashMap<>();
     requestInfoProperties.put(Request.REQUEST_INFO_BODY_PROPERTY, "{\"security\" : {\n\"type\" : \"KERBEROS\",\n\"kerberos_descriptor_reference\" : " +

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/BlueprintImplTest.java
@@ -123,7 +123,7 @@ public class BlueprintImplTest {
     properties.put("category2", category2Props);
     category2Props.put("prop2", "val");
 
-    SecurityConfiguration securityConfiguration = new SecurityConfiguration(SecurityType.KERBEROS, "testRef", null);
+    SecurityConfiguration securityConfiguration = SecurityConfiguration.withReference("testRef");
     Blueprint blueprint = new BlueprintImpl("test", hostGroups, stack, configuration, securityConfiguration);
     blueprint.validateRequiredProperties();
     BlueprintEntity entity = blueprint.toEntity();

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/StackAdvisorAdapterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/StackAdvisorAdapterTest.java
@@ -252,7 +252,7 @@ public class StackAdvisorAdapterTest {
       "KAFKA",
       ImmutableMap.of("KAFKA_BROKER", emptySet()));
 
-    AddServiceInfo info = new AddServiceInfo(null, "c1", stack, org.apache.ambari.server.topology.Configuration.newEmpty(), null, newServices);
+    AddServiceInfo info = new AddServiceInfo(null, "c1", stack, org.apache.ambari.server.topology.Configuration.newEmpty(), null, null, newServices);
     AddServiceInfo infoWithRecommendations = adapter.recommendLayout(info);
 
     Map<String, Map<String, Set<String>>> expectedNewLayout = ImmutableMap.of(

--- a/ambari-server/src/test/resources/add_service_api/request1.json
+++ b/ambari-server/src/test/resources/add_service_api/request1.json
@@ -23,7 +23,9 @@
 
   "security": {
     "type": "KERBEROS",
-    "kerberos_descriptor": "kerb_desc",
+    "kerberos_descriptor": {
+      "services": [ { "name": "ZOOKEEPER" } ]
+    },
     "kerberos_descriptor_reference": "ref_to_kerb_desc"
   },
 

--- a/ambari-server/src/test/resources/add_service_api/request1.json
+++ b/ambari-server/src/test/resources/add_service_api/request1.json
@@ -23,6 +23,7 @@
 
   "security": {
     "type": "KERBEROS",
+    "kerberos_descriptor": "kerb_desc",
     "kerberos_descriptor_reference": "ref_to_kerb_desc"
   },
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Service request already has Kerberos descriptor/reference, but it was being ignored until this change.

 * `kerberos_descriptor` in the request was a string, which requires the actual descriptor to be escaped.  Changed it to a Map, so that it can be specified as part of the main JSON.  This is how it works in blueprints, too.
 * Load Kerberos descriptor if provided by reference
 * Validate the descriptor, including a check that it should not include any services not being added in the request (ie. existing or unknown ones)
 * Merge overrides given in the request into the user-specified Kerberos descriptor (if already exists)
 * Save the (possibly updated) descriptor as artifact

Misc. fixes/improvements:

 * fixed bug in serialization of `SecurityConfiguration` due to interchanged field names for `kerberos_descriptor` and `kerberos_descriptor_reference`
 * extracted check-and-log methods to `LoggingPreconditions` (suggestions for a better name welcome!)
 * verify KDC credentials before creating any resources

https://issues.apache.org/jira/browse/AMBARI-25007

## How was this patch tested?

Tested add service request with valid kerberos descriptor, both with and without previous user-specified descriptor.  Verified that user-specified descriptor is applied (eg. custom configs and keytab filename).

```
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/artifacts/kerberos_descriptor"
HTTP/1.1 404 Not Found
{
  "status" : 404,
  "message" : "The requested resource doesn't exist: Artifact not found, Artifacts/cluster_name=TEST AND Artifacts/artifact_name=kerberos_descriptor"
}

$ curl -X POST -d @kafka.json "http://${AMBARI_SERVER_NAME}:8080/api/v1/clusters/TEST/services"
...
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/artifacts/kerberos_descriptor"
{
  "artifact_data" : {
    "services" : [
      {
        "configurations" : [
          {
            "kafka-broker" : {
              "listeners" : "PLAINTEXT://localhost:6668",
              "port" : "6668"
            }
          }
        ],
        "name" : "KAFKA"
      }
    ]
  }
}

$ curl -X POST -d @infra_solr.json "http://${AMBARI_SERVER_NAME}:8080/api/v1/clusters/TEST/services"
...
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/artifacts/kerberos_descriptor"
{
  "artifact_data" : {
    "services" : [
      {
        "components" : [
          {
            "identities" : [
              {
                "keytab" : {
                  "file" : "${keytab_dir}/custom-infra-solr.keytab"
                },
                "name" : "infra-solr"
              }
            ],
            "name" : "INFRA_SOLR"
          }
        ],
        "name" : "AMBARI_INFRA_SOLR"
      },
      {
        "configurations" : [
          {
            "kafka-broker" : {
              "listeners" : "PLAINTEXT://localhost:6668",
              "port" : "6668"
            }
          }
        ],
        "name" : "KAFKA"
      }
    ]
  }
}
```

Tested request with `kerberos_descriptor_reference`:

```
$ curl -X POST -d @metrics_descriptor.json "http://${AMBARI_SERVER}:8080/api/v1/kerberos_descriptors/metrics_descriptor"
$ curl -X POST -d @add_metrics_with_ref.json "http://${AMBARI_SERVER_NAME}:8080/api/v1/clusters/TEST/services"
...
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/artifacts/kerberos_descriptor"
{
  "artifact_data" : {
    "services" : [
      ...,
      {
        "components" : [
          {
            "identities" : [
              {
                "name" : "ams_monitor",
                "principal" : {
                  "value" : "mm/_HOST@${realm}"
                }
              }
            ],
            "name" : "METRICS_MONITOR"
          }
        ],
        "name" : "AMBARI_METRICS"
      }
    ]
  }
}
```

Request without `credentials`, if credentials from cluster creation request already expired:

```
HTTP/1.1 400 Bad Request

{
  "status" : 400,
  "message" : "KDC credentials validation failed: org.apache.ambari.server.serveraction.kerberos.KerberosMissingAdminCredentialsException: Missing KDC administrator credentials.\nThe KDC administrator credentials must be set as a persisted or temporary credential resource.This may be done by issuing a POST to the /api/v1/clusters/:clusterName/credentials/kdc.admin.credential API entry point with the following payload:\n{\n  \"Credential\" : {\n    \"principal\" : \"(PRINCIPAL)\", \"key\" : \"(PASSWORD)\", \"type\" : \"(persisted|temporary)\"}\n  }\n}"
}
```

Request with Kerberos descriptor for existing service:

```
HTTP/1.1 400 Bad Request

{
  "status" : 400,
  "message" : "Kerberos descriptor should be provided only for new services, but found other services: [ZOOKEEPER]"
}
```

Request with invalid Kerberos descriptor:

```
HTTP/1.1 400 Bad Request

{
  "status" : 400,
  "message" : "Error validating Kerberos descriptor: java.lang.NullPointerException"
}
```

Request with reference to non-existent Kerberos descriptor:

```
HTTP/1.1 400 Bad Request

{
  "status" : 400,
  "message" : "No security configuration found for the reference: no_such_kerberos_descriptor"
}
```

Also tested blueprint deployment with custom Kerberos descriptor for any regression, both with `kerberos_descriptor` and with `kerberos_descriptor_reference`.