### PR TITLE
AMBARI-25018. End users should be able to execute setup-ldap tool without manual intervention

### DIFF
--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -8135,7 +8135,7 @@ class TestAmbariServer(TestCase):
     sys.stdout = out
     read_password_method.return_value = "blah"
     options = self._create_empty_options_mock()
-    configure_ldap_password(options)
+    configure_ldap_password(options, True)
 
     self.assertTrue(read_password_method.called)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should provide a way to our end user to execute `ambari-server setup-ldap` in a non-interactive way (i.e. all answers are provided by command line options).

This was not the case when we wanted to setup a secure LDAP (SSL is set to true) but we did not want to use a custom trust store. In this case the following question(s) were being asked:
1. Do you want to provide custom TrustStore for Ambari?
2. Optionally: if custom trust store was set previously the tool displays the earlier configuration and asks the following: Do you want to remove these properties?

To address this issue I modified the tool to find out whether it's being executed in non-interactive mode or not. Non-interactive mode, in this respect, means that all properties which require a non-empty answer have their answers provided via CLI options.

## How was this patch tested?

In addition to running unit tests I've executed several E2E tests within my vagrant environment; see test results in this file: [setup_ldap_in_ambari_2.7.100.0-171.txt](https://github.com/apache/ambari/files/2662189/setup_ldap_in_ambari_2.7.100.0-171.txt)
