### PR TITLE
[AMBARI-25025] Duplicate kerberos_descriptor name reported as HTTP 500.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/KerberosDescriptorResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/KerberosDescriptorResourceProvider.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ambari.server.controller.internal;
 
 import java.util.Collections;
@@ -26,32 +43,16 @@ import org.apache.ambari.server.topology.KerberosDescriptorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 public class KerberosDescriptorResourceProvider extends AbstractControllerResourceProvider {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KerberosDescriptorResourceProvider.class);
 
-  private static final String KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID =
+  static final String KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID =
       PropertyHelper.getPropertyId("KerberosDescriptors", "kerberos_descriptor_name");
 
   private static final String KERBEROS_DESCRIPTOR_TEXT_PROPERTY_ID =
@@ -60,16 +61,12 @@ public class KerberosDescriptorResourceProvider extends AbstractControllerResour
   /**
    * The key property ids for a KerberosDescriptor resource.
    */
-  private static final Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
-      .put(Resource.Type.KerberosDescriptor, KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID)
-      .build();
+  private static final Map<Resource.Type, String> KEY_PROPERTY_IDS = ImmutableMap.of(Resource.Type.KerberosDescriptor, KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID);
 
   /**
    * The property ids for a KerberosDescriptor resource.
    */
-  private static final Set<String> propertyIds = Sets.newHashSet(
-      KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID,
-      KERBEROS_DESCRIPTOR_TEXT_PROPERTY_ID);
+  private static final Set<String> PROPERTY_IDS = ImmutableSet.of(KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID, KERBEROS_DESCRIPTOR_TEXT_PROPERTY_ID);
 
   private KerberosDescriptorDAO kerberosDescriptorDAO;
 
@@ -80,7 +77,7 @@ public class KerberosDescriptorResourceProvider extends AbstractControllerResour
   KerberosDescriptorResourceProvider(KerberosDescriptorDAO kerberosDescriptorDAO,
                                      KerberosDescriptorFactory kerberosDescriptorFactory,
                                      @Assisted AmbariManagementController managementController) {
-    super(Resource.Type.KerberosDescriptor, propertyIds, keyPropertyIds, managementController);
+    super(Resource.Type.KerberosDescriptor, PROPERTY_IDS, KEY_PROPERTY_IDS, managementController);
     this.kerberosDescriptorDAO = kerberosDescriptorDAO;
     this.kerberosDescriptorFactory = kerberosDescriptorFactory;
   }
@@ -92,11 +89,15 @@ public class KerberosDescriptorResourceProvider extends AbstractControllerResour
   }
 
   @Override
-  public RequestStatus createResources(Request request) throws SystemException, UnsupportedPropertyException,
-      ResourceAlreadyExistsException, NoSuchParentResourceException {
-
+  public RequestStatus createResources(Request request) throws ResourceAlreadyExistsException {
     String name = getNameFromRequest(request);
     String descriptor = getRawKerberosDescriptorFromRequest(request);
+
+    if (kerberosDescriptorDAO.findByName(name) != null) {
+      String msg = String.format("Kerberos descriptor named %s already exists", name);
+      LOGGER.info(msg);
+      throw new ResourceAlreadyExistsException(msg);
+    }
 
     KerberosDescriptor kerberosDescriptor = kerberosDescriptorFactory.createKerberosDescriptor(name, descriptor);
     kerberosDescriptorDAO.create(kerberosDescriptor.toEntity());
@@ -104,10 +105,8 @@ public class KerberosDescriptorResourceProvider extends AbstractControllerResour
     return getRequestStatus(null);
   }
 
-
   @Override
-  public Set<Resource> getResources(Request request, Predicate predicate) throws SystemException,
-      UnsupportedPropertyException, NoSuchResourceException, NoSuchParentResourceException {
+  public Set<Resource> getResources(Request request, Predicate predicate) throws NoSuchResourceException, NoSuchParentResourceException {
 
     List<KerberosDescriptorEntity> results = null;
     boolean applyPredicate = false;
@@ -150,7 +149,7 @@ public class KerberosDescriptorResourceProvider extends AbstractControllerResour
     return resources;
   }
 
-  private void toResource(Resource resource, KerberosDescriptorEntity entity, Set<String> requestPropertyIds) {
+  private static void toResource(Resource resource, KerberosDescriptorEntity entity, Set<String> requestPropertyIds) {
     setResourceProperty(resource, KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID, entity.getName(), requestPropertyIds);
     setResourceProperty(resource, KERBEROS_DESCRIPTOR_TEXT_PROPERTY_ID, entity.getKerberosDescriptorText(), requestPropertyIds);
   }
@@ -179,26 +178,41 @@ public class KerberosDescriptorResourceProvider extends AbstractControllerResour
 
   @Override
   protected Set<String> getPKPropertyIds() {
-    return Collections.emptySet();
+    return ImmutableSet.copyOf(KEY_PROPERTY_IDS.values());
   }
 
-  private String getRawKerberosDescriptorFromRequest(Request request) throws UnsupportedPropertyException {
-    if (request.getRequestInfoProperties() == null ||
-        !request.getRequestInfoProperties().containsKey(Request.REQUEST_INFO_BODY_PROPERTY)) {
-      LOGGER.error("Could not find the raw request body in the request: {}", request);
-      throw new UnsupportedPropertyException(Resource.Type.KerberosDescriptor,
-          Collections.singleton(Request.REQUEST_INFO_BODY_PROPERTY));
+  /**
+   * @throws IllegalArgumentException if descriptor text is not found or is empty
+   */
+  private static String getRawKerberosDescriptorFromRequest(Request request) {
+    Map<String, String> requestInfoProperties = request.getRequestInfoProperties();
+    if (requestInfoProperties != null) {
+      String descriptorText = requestInfoProperties.get(Request.REQUEST_INFO_BODY_PROPERTY);
+      if (!Strings.isNullOrEmpty(descriptorText)) {
+        return descriptorText;
+      }
     }
-    return request.getRequestInfoProperties().get(Request.REQUEST_INFO_BODY_PROPERTY);
+
+    String msg = "No Kerberos descriptor found in the request body";
+    LOGGER.error(msg);
+    throw new IllegalArgumentException(msg);
   }
 
-  private String getNameFromRequest(Request request) throws UnsupportedPropertyException {
-    if (request.getProperties() == null || !request.getProperties().iterator().hasNext()) {
-      LOGGER.error("There is no {} property id in the request {}", KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID, request);
-      throw new UnsupportedPropertyException(Resource.Type.KerberosDescriptor,
-          Collections.singleton(KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID));
+  /**
+   * @throws IllegalArgumentException if name is not found or is empty
+   */
+  private static String getNameFromRequest(Request request) {
+    if (request.getProperties() != null && !request.getProperties().isEmpty()) {
+      Map<String, Object> properties = request.getProperties().iterator().next();
+      Object name = properties.get(KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID);
+      if (name != null) {
+        return String.valueOf(name);
+      }
     }
-    return (String) request.getProperties().iterator().next().get(KERBEROS_DESCRIPTOR_NAME_PROPERTY_ID);
+
+    String msg = "No name provided for the Kerberos descriptor";
+    LOGGER.error(msg);
+    throw new IllegalArgumentException(msg);
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/KerberosDescriptorEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/KerberosDescriptorEntity.java
@@ -1,5 +1,7 @@
 package org.apache.ambari.server.orm.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -52,5 +54,23 @@ public class KerberosDescriptorEntity {
 
   public void setKerberosDescriptorText(String kerberosDescriptorText) {
     this.kerberosDescriptorText = kerberosDescriptorText;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    KerberosDescriptorEntity other = (KerberosDescriptorEntity) obj;
+    return Objects.equals(name, other.name) &&
+      Objects.equals(kerberosDescriptorText, other.kerberosDescriptorText);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, kerberosDescriptorText);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve `KerberosDescriptorResourceProvider`:

 * Return HTTP 409 if trying to create duplicate `kerberos_descriptor` instead of HTTP 500 with ugly stack trace
 * Clarify message for incomplete request
 * Clean up the unit test
 * Minor clean-up in `KerberosDescriptorResourceProvider`

https://issues.apache.org/jira/browse/AMBARI-25025

## How was this patch tested?

Added test case in unit test.

Tested manually:

```
$ curl -X POST -d @descriptor.json http://${AMBARI_SERVER}:8080/api/v1/kerberos_descriptors/metrics_descriptor
HTTP/1.1 201 Created

$ curl -X POST -d @descriptor.json http://${AMBARI_SERVER}:8080/api/v1/kerberos_descriptors/metrics_descriptor
HTTP/1.1 409 Conflict
{
  "status" : 409,
  "message" : "Kerberos descriptor named metrics_descriptor already exists"
}

$ curl -X POST -d @descriptor.json http://${AMBARI_SERVER}:8080/api/v1/kerberos_descriptors/other_name
HTTP/1.1 201 Created

$ curl -X DELETE http://${AMBARI_SERVER}:8080/api/v1/kerberos_descriptors/metrics_descriptor
HTTP/1.1 200 OK

$ curl -X POST -d @descriptor.json http://${AMBARI_SERVER}:8080/api/v1/kerberos_descriptors/metrics_descriptor
HTTP/1.1 201 Created

$ curl -X POST http://c7401.ambari.apache.org:8080/api/v1/kerberos_descriptors/invalid
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "No Kerberos descriptor found in the request body"
}
```