### PR TITLE
[AMBARI-25000] START_ONLY provision action may be applied to the wrong component

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -295,8 +295,6 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
   private static final String PASSWORD = "password";
 
-  public static final String SKIP_INSTALL_FOR_COMPONENTS = "skipInstallForComponents";
-  public static final String DONT_SKIP_INSTALL_FOR_COMPONENTS = "dontSkipInstallForComponents";
   public static final String CLUSTER_NAME_VALIDATION_REGEXP = "^[a-zA-Z0-9_-]{1,100}$";
   public static final Pattern CLUSTER_NAME_PTRN = Pattern.compile(CLUSTER_NAME_VALIDATION_REGEXP);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -124,6 +124,7 @@ import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.configuration.Configuration.DatabaseType;
 import org.apache.ambari.server.controller.internal.DeleteHostComponentStatusMetaData;
 import org.apache.ambari.server.controller.internal.DeleteStatusMetaData;
+import org.apache.ambari.server.controller.internal.HostComponentResourceProvider;
 import org.apache.ambari.server.controller.internal.RequestOperationLevel;
 import org.apache.ambari.server.controller.internal.RequestResourceFilter;
 import org.apache.ambari.server.controller.internal.RequestStageContainer;
@@ -3355,15 +3356,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         isClientComponent = serviceComponent.isClientComponent();
       }
     }
-    // Skip INSTALL for service components if START_ONLY is set for component, or if START_ONLY is set on cluster
-    // level and no other provsion action is specified for component
-    String skipInstallForComponents = requestProperties.get(SKIP_INSTALL_FOR_COMPONENTS);
-    return !isClientComponent &&
-      CLUSTER_PHASE_INITIAL_INSTALL.equals(requestProperties.get(CLUSTER_PHASE_PROPERTY)) &&
-      skipInstallForComponents != null &&
-      (skipInstallForComponents.contains(componentName) ||
-        (skipInstallForComponents.equals("ALL") && !requestProperties.get(DONT_SKIP_INSTALL_FOR_COMPONENTS).contains(componentName))
-      );
+    return HostComponentResourceProvider.shouldSkipInstallTaskForComponent(componentName, isClientComponent, requestProperties);
 
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -173,6 +173,9 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
       UPGRADE_STATE,
       QUERY_PARAMETERS_RUN_SMOKE_TEST_ID);
 
+  public static final String ALL_COMPONENTS = "ALL";
+  public static final String SKIP_INSTALL_FOR_ALL_COMPONENTS = joinComponentList(ImmutableSet.of(ALL_COMPONENTS));
+
   /**
    * maintenance state helper
    */
@@ -430,7 +433,9 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
   }
 
   private static String joinComponentList(Collection<String> components) {
-    return components != null ? String.join(";", components) : "";
+    return components != null
+      ? ";" + String.join(";", components) + ";"
+      : "";
   }
 
 
@@ -935,11 +940,13 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     // Skip INSTALL for service components if START_ONLY is set for component, or if START_ONLY is set on cluster
     // level and no other provision action is specified for component
     String skipInstallForComponents = requestProperties.get(AmbariManagementControllerImpl.SKIP_INSTALL_FOR_COMPONENTS);
+    String searchString = joinComponentList(ImmutableSet.of(componentName));
     return !isClientComponent &&
       CLUSTER_PHASE_INITIAL_INSTALL.equals(requestProperties.get(CLUSTER_PHASE_PROPERTY)) &&
       skipInstallForComponents != null &&
-      (skipInstallForComponents.contains(componentName) ||
-        (skipInstallForComponents.equals("ALL") && !requestProperties.get(AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS).contains(componentName))
+      (skipInstallForComponents.contains(searchString) ||
+        (skipInstallForComponents.equals(SKIP_INSTALL_FOR_ALL_COMPONENTS) &&
+        !requestProperties.get(AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS).contains(searchString))
       );
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.topology;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.ALL_COMPONENTS;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_AND_START;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_ONLY;
 import static org.apache.ambari.server.state.ServiceInfo.HADOOP_COMPATIBLE_FS;
@@ -221,7 +222,7 @@ public class ClusterTopologyImpl implements ClusterTopology {
 
       Collection<String> skipInstallForComponents = new ArrayList<>();
       if (skipInstallTaskCreate) {
-        skipInstallForComponents.add("ALL");
+        skipInstallForComponents.add(ALL_COMPONENTS);
       } else {
         // get the set of components that are marked as START_ONLY for this hostgroup
         skipInstallForComponents.addAll(hostGroup.getComponentNames(ProvisionAction.START_ONLY));

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
@@ -20,8 +20,8 @@ package org.apache.ambari.server.topology.addservice;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_PROPERTY;
-import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.DO_NOT_SKIP_INSTALL_FOR_COMPONENTS;
 import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.DO_NOT_SKIP_INSTALL_FOR_ANY_COMPONENTS;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.DO_NOT_SKIP_INSTALL_FOR_COMPONENTS;
 import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.SKIP_INSTALL_FOR_ALL_COMPONENTS;
 import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.SKIP_INSTALL_FOR_COMPONENTS;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/ResourceProviderAdapter.java
@@ -20,8 +20,10 @@ package org.apache.ambari.server.topology.addservice;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_PROPERTY;
-import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.DONT_SKIP_INSTALL_FOR_COMPONENTS;
-import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.SKIP_INSTALL_FOR_COMPONENTS;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.DO_NOT_SKIP_INSTALL_FOR_COMPONENTS;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.DO_NOT_SKIP_INSTALL_FOR_ANY_COMPONENTS;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.SKIP_INSTALL_FOR_ALL_COMPONENTS;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.SKIP_INSTALL_FOR_COMPONENTS;
 
 import java.util.List;
 import java.util.Map;
@@ -223,8 +225,8 @@ public class ResourceProviderAdapter {
 
   private static void addProvisionProperties(ImmutableMap.Builder<String, String> requestInfo, State desiredState, ProvisionAction requestAction) {
     if (desiredState == State.INSTALLED && requestAction.skipInstall()) {
-      requestInfo.put(SKIP_INSTALL_FOR_COMPONENTS, "ALL");
-      requestInfo.put(DONT_SKIP_INSTALL_FOR_COMPONENTS, "");
+      requestInfo.put(SKIP_INSTALL_FOR_COMPONENTS, SKIP_INSTALL_FOR_ALL_COMPONENTS);
+      requestInfo.put(DO_NOT_SKIP_INSTALL_FOR_COMPONENTS, DO_NOT_SKIP_INSTALL_FOR_ANY_COMPONENTS);
       requestInfo.put(CLUSTER_PHASE_PROPERTY, AmbariManagementControllerImpl.CLUSTER_PHASE_INITIAL_INSTALL);
     }
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.ambari.server.controller.internal;
 
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_INITIAL_INSTALL;
+import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_PROPERTY;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.shouldSkipInstallTaskForComponent;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.eq;
@@ -25,16 +28,20 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -597,6 +604,82 @@ public class HostComponentResourceProviderTest {
 
     // verify
     verify(managementController, resourceProviderFactory, stageContainer);
+  }
+
+  @Test
+  public void doesNotSkipInstallTaskForClient() {
+    String component = "SOME_COMPONENT";
+    assertFalse(shouldSkipInstallTaskForComponent(component, true, new RequestInfoBuilder().skipInstall(component).build()));
+    assertFalse(shouldSkipInstallTaskForComponent(component, true, new RequestInfoBuilder().skipInstall("ALL").build()));
+  }
+
+  @Test
+  public void doesNotSkipInstallTaskForOtherPhase() {
+    String component = "SOME_COMPONENT";
+    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().phase("INSTALL");
+    assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.skipInstall(component).build()));
+    assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.skipInstall("ALL").build()));
+  }
+
+  @Test
+  public void doesNotSkipInstallTaskForExplicitException() {
+    String component = "SOME_COMPONENT";
+    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall("ALL").doNotSkipInstall(component);
+    assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.build()));
+  }
+
+  @Test
+  public void skipsInstallTaskIfRequested() {
+    String component = "SOME_COMPONENT";
+    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall(component);
+    assertTrue(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.build()));
+  }
+
+  @Test
+  public void skipsInstallTaskForAll() {
+    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall("ALL");
+    assertTrue(shouldSkipInstallTaskForComponent("ANY_COMPONENT", false, requestInfoBuilder.build()));
+  }
+
+  @Test
+  public void doesNotSkipInstallOfPrefixedComponent() {
+    String prefix = "HIVE_SERVER", component = prefix + "_INTERACTIVE";
+    Map<String, String> requestInfo = new RequestInfoBuilder().skipInstall(component).build();
+    assertTrue(shouldSkipInstallTaskForComponent(component, false, requestInfo));
+    assertFalse(shouldSkipInstallTaskForComponent(prefix, false, requestInfo));
+  }
+
+  private static class RequestInfoBuilder {
+
+    private String phase = CLUSTER_PHASE_INITIAL_INSTALL;
+    private final Collection<String> skipInstall = new LinkedList<>();
+    private final Collection<String> doNotSkipInstall = new LinkedList<>();
+
+    public RequestInfoBuilder skipInstall(String... components) {
+      skipInstall.clear();
+      skipInstall.addAll(Arrays.asList(components));
+      return this;
+    }
+
+    public RequestInfoBuilder doNotSkipInstall(String... components) {
+      doNotSkipInstall.clear();
+      doNotSkipInstall.addAll(Arrays.asList(components));
+      return this;
+    }
+
+    public RequestInfoBuilder phase(String phase) {
+      this.phase = phase;
+      return this;
+    }
+
+    public Map<String, String> build() {
+      Map<String, String> info = new HashMap<>();
+      if (phase != null) {
+        info.put(CLUSTER_PHASE_PROPERTY, phase);
+      }
+      HostComponentResourceProvider.addProvisionActionProperties(skipInstall, doNotSkipInstall, info);
+      return info;
+    }
   }
 
   // Used to directly call updateHostComponents on the resource provider.

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostComponentResourceProviderTest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.controller.internal;
 
 import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_INITIAL_INSTALL;
 import static org.apache.ambari.server.controller.AmbariManagementControllerImpl.CLUSTER_PHASE_PROPERTY;
+import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.ALL_COMPONENTS;
 import static org.apache.ambari.server.controller.internal.HostComponentResourceProvider.shouldSkipInstallTaskForComponent;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
@@ -610,7 +611,7 @@ public class HostComponentResourceProviderTest {
   public void doesNotSkipInstallTaskForClient() {
     String component = "SOME_COMPONENT";
     assertFalse(shouldSkipInstallTaskForComponent(component, true, new RequestInfoBuilder().skipInstall(component).build()));
-    assertFalse(shouldSkipInstallTaskForComponent(component, true, new RequestInfoBuilder().skipInstall("ALL").build()));
+    assertFalse(shouldSkipInstallTaskForComponent(component, true, new RequestInfoBuilder().skipInstall(ALL_COMPONENTS).build()));
   }
 
   @Test
@@ -618,13 +619,13 @@ public class HostComponentResourceProviderTest {
     String component = "SOME_COMPONENT";
     RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().phase("INSTALL");
     assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.skipInstall(component).build()));
-    assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.skipInstall("ALL").build()));
+    assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.skipInstall(ALL_COMPONENTS).build()));
   }
 
   @Test
   public void doesNotSkipInstallTaskForExplicitException() {
     String component = "SOME_COMPONENT";
-    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall("ALL").doNotSkipInstall(component);
+    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall(ALL_COMPONENTS).doNotSkipInstall(component);
     assertFalse(shouldSkipInstallTaskForComponent(component, false, requestInfoBuilder.build()));
   }
 
@@ -637,7 +638,7 @@ public class HostComponentResourceProviderTest {
 
   @Test
   public void skipsInstallTaskForAll() {
-    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall("ALL");
+    RequestInfoBuilder requestInfoBuilder = new RequestInfoBuilder().skipInstall(ALL_COMPONENTS);
     assertTrue(shouldSkipInstallTaskForComponent("ANY_COMPONENT", false, requestInfoBuilder.build()));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the bug that if component XY is provisioned with `START_ONLY`, and component X is a prefix of XY, then the provision action is applied to both X and XY.

In addition, refactor related code to reduce clutter in `AmbariManagementControllerImpl` a tiny bit.

https://issues.apache.org/jira/browse/AMBARI-25000

## How was this patch tested?

Added test cases in unit test.

Tested cluster deployment via blueprint, verified that only the correct component is provisioned with `START_ONLY`:

```
2018-12-10 14:22:00,642  INFO [pool-33-thread-1] AmbariManagementControllerImpl:3226 - Skipping create of INSTALL task for HIVE_SERVER_INTERACTIVE on c7401.ambari.apache.org.
```