### PR TITLE
[AMBARI-25030] Improve component-host association syntax in Add Service request

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AddServiceRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AddServiceRequest.java
@@ -284,7 +284,7 @@ public class AddServiceRequest {
     @JsonCreator
     public Component(@JsonProperty(COMPONENT_NAME) String name, @JsonProperty(HOSTS) Set<Host> hosts) {
       this.name = name;
-      this.hosts = hosts != null ? ImmutableSet.copyOf(hosts) : null;
+      this.hosts = hosts != null ? ImmutableSet.copyOf(hosts) : ImmutableSet.of();
     }
 
     public static Component of(String name, String... hosts) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AddServiceRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AddServiceRequest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.controller;
 
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.ambari.server.controller.internal.BaseClusterRequest.PROVISION_ACTION_PROPERTY;
 import static org.apache.ambari.server.controller.internal.ClusterResourceProvider.CREDENTIALS;
 import static org.apache.ambari.server.controller.internal.ClusterResourceProvider.SECURITY;
@@ -29,6 +30,7 @@ import static org.apache.ambari.server.topology.Configurable.CONFIGURATIONS;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,6 +53,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -64,10 +67,10 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class AddServiceRequest {
 
-  static final String STACK_NAME = "stack_name";
-  static final String STACK_VERSION = "stack_version";
-  static final String SERVICES = "services";
-  static final String COMPONENTS = "components";
+  private static final String STACK_NAME = "stack_name";
+  private static final String STACK_VERSION = "stack_version";
+  private static final String SERVICES = "services";
+  private static final String COMPONENTS = "components";
 
   public static final Set<String> TOP_LEVEL_PROPERTIES = ImmutableSet.of(
     OPERATION_TYPE, CONFIG_RECOMMENDATION_STRATEGY, PROVISION_ACTION_PROPERTY,
@@ -103,7 +106,6 @@ public class AddServiceRequest {
       ConfigurableHelper.parseConfigs(configs)
     );
   }
-
 
   private AddServiceRequest(
     OperationType operationType,
@@ -219,25 +221,74 @@ public class AddServiceRequest {
     return security;
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
 
-// ------- inner classes -------
+    AddServiceRequest other = (AddServiceRequest) obj;
+
+    return Objects.equals(operationType, other.operationType) &&
+      Objects.equals(recommendationStrategy, other.recommendationStrategy) &&
+      Objects.equals(provisionAction, other.provisionAction) &&
+      Objects.equals(stackName, other.stackName) &&
+      Objects.equals(stackVersion, other.stackVersion) &&
+      Objects.equals(services, other.services) &&
+      Objects.equals(components, other.components) &&
+      Objects.equals(security, other.security) &&
+      Objects.equals(configuration, other.configuration);
+    // credentials is ignored for equality, since it's not serialized
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(operationType, recommendationStrategy, provisionAction, stackName, stackVersion,
+      services, components, configuration, security);
+    // credentials is ignored for hashcode, since it's not serialized
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+      .add(OPERATION_TYPE, operationType)
+      .add(CONFIG_RECOMMENDATION_STRATEGY, recommendationStrategy)
+      .add(PROVISION_ACTION_PROPERTY, provisionAction)
+      .add(STACK_NAME, stackName)
+      .add(STACK_VERSION, stackVersion)
+      .add(SERVICES, services)
+      .add(COMPONENTS, components)
+      .add(CONFIGURATIONS, configuration)
+      .add(SECURITY, security)
+      // credentials is not part of string output
+      .toString();
+  }
+
+  // ------- inner classes -------
 
   public enum OperationType {
     ADD_SERVICE, DELETE_SERVICE, MOVE_SERVICE
   }
 
   public static final class Component {
-    static final String COMPONENT_NAME = "component_name";
-    static final String FQDN = "fqdn";
 
-    private String name;
-    private String fqdn;
+    static final String COMPONENT_NAME = "name";
+    static final String HOSTS = "hosts";
 
-    public static Component of(String name, String fqdn) {
-      Component component = new Component();
-      component.setName(name);
-      component.setFqdn(fqdn);
-      return component;
+    private final String name;
+    private final Set<Host> hosts;
+
+    @JsonCreator
+    public Component(@JsonProperty(COMPONENT_NAME) String name, @JsonProperty(HOSTS) Set<Host> hosts) {
+      this.name = name;
+      this.hosts = hosts != null ? ImmutableSet.copyOf(hosts) : null;
+    }
+
+    public static Component of(String name, String... hosts) {
+      return new Component(name, Arrays.stream(hosts).map(Host::new).collect(toSet()));
     }
 
     @JsonProperty(COMPONENT_NAME)
@@ -246,34 +297,30 @@ public class AddServiceRequest {
       return name;
     }
 
-    @JsonProperty(COMPONENT_NAME)
-    public void setName(String name) {
-      this.name = name;
-    }
-
-    @JsonProperty(FQDN)
-    @ApiModelProperty(name = FQDN)
-    public String getFqdn() {
-      return fqdn;
-    }
-
-    @JsonProperty(FQDN)
-    public void setFqdn(String fqdn) {
-      this.fqdn = fqdn;
+    @JsonProperty(HOSTS)
+    @ApiModelProperty(name = HOSTS)
+    public Set<Host> getHosts() {
+      return hosts;
     }
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      Component component = (Component) o;
-      return Objects.equals(name, component.name) &&
-        Objects.equals(fqdn, component.fqdn);
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Component other = (Component) o;
+
+      return Objects.equals(name, other.name) &&
+        Objects.equals(hosts, other.hosts);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, fqdn);
+      return Objects.hash(name, hosts);
     }
 
     @Override
@@ -282,27 +329,69 @@ public class AddServiceRequest {
     }
   }
 
+  public static final class Host {
+
+    static final String FQDN = "fqdn";
+
+    private final String fqdn;
+
+    @JsonCreator
+    public Host(@JsonProperty(FQDN) String fqdn) {
+      this.fqdn = fqdn;
+    }
+
+    @JsonProperty(FQDN)
+    @ApiModelProperty(name = FQDN)
+    public String getFqdn() {
+      return fqdn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Host other = (Host) o;
+
+      return Objects.equals(fqdn, other.fqdn);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(fqdn);
+    }
+
+    @Override
+    public String toString() {
+      return "host: " + fqdn;
+    }
+
+  }
+
   @ApiModel
   public static final class Service {
+
     static final String NAME = "name";
 
-    private String name;
+    private final String name;
+
+    @JsonCreator
+    public Service(@JsonProperty(NAME) String name) {
+      this.name = name;
+    }
 
     public static Service of(String name) {
-      Service service = new Service();
-      service.setName(name);
-      return service;
+      return new Service(name);
     }
 
     @JsonProperty(NAME)
     @ApiModelProperty(name = NAME)
     public String getName() {
       return name;
-    }
-
-    @JsonProperty(NAME)
-    public void setName(String name) {
-      this.name = name;
     }
 
     @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/Configuration.java
@@ -489,4 +489,20 @@ public class Configuration {
   public Pair<Map<String, Map<String, String>>, Map<String, Map<String, Map<String, String>>>> asPair() {
     return Pair.of(properties, attributes);
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    Configuration other = (Configuration) obj;
+
+    return Objects.equals(properties, other.properties) &&
+      Objects.equals(attributes, other.attributes) &&
+      Objects.equals(parentConfiguration, other.parentConfiguration);
+  }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
@@ -21,7 +21,6 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -227,8 +226,7 @@ public class RequestValidator {
         "Service %s (for component %s) already exists in cluster %s", serviceName, componentName, cluster.getClusterName());
 
       newServices.computeIfAbsent(serviceName, __ -> new HashMap<>())
-        .computeIfAbsent(componentName, __ -> new HashSet<>())
-        .add(requestedComponent.getFqdn());
+        .put(componentName, requestedComponent.getHosts().stream().map(AddServiceRequest.Host::getFqdn).collect(toSet()));
     }
 
     CHECK.checkArgument(!newServices.isEmpty(), "Request should have at least one new service or component to be added");

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AddServiceRequestTest.java
@@ -18,22 +18,14 @@
 
 package org.apache.ambari.server.controller;
 
-import static org.apache.ambari.server.controller.AddServiceRequest.COMPONENTS;
 import static org.apache.ambari.server.controller.AddServiceRequest.Component;
 import static org.apache.ambari.server.controller.AddServiceRequest.OperationType.ADD_SERVICE;
-import static org.apache.ambari.server.controller.AddServiceRequest.SERVICES;
-import static org.apache.ambari.server.controller.AddServiceRequest.STACK_NAME;
-import static org.apache.ambari.server.controller.AddServiceRequest.STACK_VERSION;
 import static org.apache.ambari.server.controller.AddServiceRequest.Service;
-import static org.apache.ambari.server.controller.internal.BaseClusterRequest.PROVISION_ACTION_PROPERTY;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_AND_START;
 import static org.apache.ambari.server.controller.internal.ProvisionAction.INSTALL_ONLY;
-import static org.apache.ambari.server.controller.internal.ProvisionClusterRequest.CONFIG_RECOMMENDATION_STRATEGY;
-import static org.apache.ambari.server.controller.internal.ServiceResourceProvider.OPERATION_TYPE;
 import static org.apache.ambari.server.topology.ConfigRecommendationStrategy.ALWAYS_APPLY;
 import static org.apache.ambari.server.topology.ConfigRecommendationStrategy.NEVER_APPLY;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -44,21 +36,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
-import org.apache.ambari.server.controller.internal.ProvisionAction;
 import org.apache.ambari.server.security.encryption.CredentialStoreType;
 import org.apache.ambari.server.state.SecurityType;
-import org.apache.ambari.server.topology.ConfigRecommendationStrategy;
-import org.apache.ambari.server.topology.Configurable;
 import org.apache.ambari.server.topology.Configuration;
 import org.apache.ambari.server.topology.Credential;
 import org.apache.ambari.server.topology.SecurityConfiguration;
-import org.apache.ambari.server.topology.SecurityConfigurationFactory;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -112,7 +98,7 @@ public class AddServiceRequestTest {
       configuration.getProperties());
 
     assertEquals(
-      ImmutableSet.of(Component.of("NIMBUS", "c7401.ambari.apache.org"), Component.of("BEACON_SERVER", "c7402.ambari.apache.org")),
+      ImmutableSet.of(Component.of("NIMBUS", "c7401.ambari.apache.org", "c7402.ambari.apache.org"), Component.of("BEACON_SERVER", "c7402.ambari.apache.org", "c7403.ambari.apache.org")),
       request.getComponents());
 
     assertEquals(
@@ -137,7 +123,7 @@ public class AddServiceRequestTest {
 
     // filled-out values
     assertEquals(
-      ImmutableSet.of(Component.of("NIMBUS", "c7401.ambari.apache.org"), Component.of("BEACON_SERVER", "c7402.ambari.apache.org")),
+      ImmutableSet.of(Component.of("NIMBUS", "c7401.ambari.apache.org", "c7402.ambari.apache.org"), Component.of("BEACON_SERVER", "c7402.ambari.apache.org", "c7403.ambari.apache.org")),
       request.getComponents());
 
     assertEquals(
@@ -187,7 +173,7 @@ public class AddServiceRequestTest {
 
     // filled-out values
     assertEquals(
-      ImmutableSet.of(Component.of("NIMBUS", "c7401.ambari.apache.org"), Component.of("BEACON_SERVER", "c7402.ambari.apache.org")),
+      ImmutableSet.of(Component.of("NIMBUS", "c7401.ambari.apache.org", "c7402.ambari.apache.org"), Component.of("BEACON_SERVER", "c7402.ambari.apache.org", "c7403.ambari.apache.org")),
       request.getComponents());
 
     // default / empty values
@@ -223,78 +209,27 @@ public class AddServiceRequestTest {
   @Test
   public void testSerialize_basic() throws Exception {
     AddServiceRequest request = mapper.readValue(REQUEST_ALL_FIELDS_SET, AddServiceRequest.class);
-
-    Map<String, ?> serialized = serialize(request);
-
-    assertEquals(AddServiceRequest.OperationType.ADD_SERVICE.name(), serialized.get(OPERATION_TYPE));
-    assertEquals(ConfigRecommendationStrategy.ALWAYS_APPLY.name(), serialized.get(CONFIG_RECOMMENDATION_STRATEGY));
-    assertEquals(ProvisionAction.INSTALL_ONLY.name(), serialized.get(PROVISION_ACTION_PROPERTY));
-    assertEquals("HDP", serialized.get(STACK_NAME));
-    assertEquals("3.0", serialized.get(STACK_VERSION));
-
-    assertEquals(
-      ImmutableSet.of(ImmutableMap.of(Service.NAME, "BEACON"), ImmutableMap.of(Service.NAME, "STORM")),
-      ImmutableSet.copyOf((List<String>) serialized.get(SERVICES)) );
-
-    assertEquals(
-      ImmutableSet.of(
-        ImmutableMap.of(Component.COMPONENT_NAME, "NIMBUS", Component.FQDN, "c7401.ambari.apache.org"),
-        ImmutableMap.of(Component.COMPONENT_NAME, "BEACON_SERVER", Component.FQDN, "c7402.ambari.apache.org")),
-      ImmutableSet.copyOf((List<String>) serialized.get(COMPONENTS)) );
-
-    assertEquals(
-      ImmutableList.of(
-        ImmutableMap.of(
-          "storm-site",
-          ImmutableMap.of(
-            "properties", ImmutableMap.of("ipc.client.connect.max.retries", "50"),
-            "properties_attributes", ImmutableMap.of("final", ImmutableMap.of("fs.defaultFS", "true"))
-          )
-        )
-      ),
-      serialized.get(Configurable.CONFIGURATIONS)
-    );
-
-    assertEquals(
-      ImmutableMap.of(
-        SecurityConfigurationFactory.TYPE_PROPERTY_ID, SecurityType.KERBEROS.name(),
-        SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_PROPERTY_ID, KERBEROS_DESCRIPTOR1,
-        SecurityConfigurationFactory.KERBEROS_DESCRIPTOR_REFERENCE_PROPERTY_ID, "ref_to_kerb_desc"
-      ),
-      serialized.get(ClusterResourceProvider.SECURITY)
-    );
-
-    assertNull(serialized.get(ClusterResourceProvider.CREDENTIALS));
+    AddServiceRequest serialized = serialize(request);
+    assertEquals(request, serialized);
+    assertEquals(ImmutableMap.of(), serialized.getCredentials());
   }
 
   @Test
   public void testSerialize_EmptyOmitted() throws Exception {
     AddServiceRequest request = mapper.readValue(REQUEST_MINIMAL_SERVICES_ONLY, AddServiceRequest.class);
-    Map<String, ?> serialized = serialize(request);
-
-    assertEquals(AddServiceRequest.OperationType.ADD_SERVICE.name(), serialized.get(OPERATION_TYPE));
-    assertEquals(ProvisionAction.INSTALL_AND_START.name(), serialized.get(PROVISION_ACTION_PROPERTY));
-    assertEquals(
-      ImmutableSet.of(ImmutableMap.of(Service.NAME, "BEACON"), ImmutableMap.of(Service.NAME, "STORM")),
-      ImmutableSet.copyOf((List<String>) serialized.get(SERVICES)) );
-
-    assertFalse(serialized.containsKey(STACK_NAME));
-    assertFalse(serialized.containsKey(STACK_VERSION));
-    assertFalse(serialized.containsKey(Configurable.CONFIGURATIONS));
-    assertFalse(serialized.containsKey(COMPONENTS));
-
+    AddServiceRequest serialized = serialize(request);
+    assertEquals(request, serialized);
   }
 
-  private Map<String, ?> serialize(AddServiceRequest request) throws IOException {
+  private AddServiceRequest serialize(AddServiceRequest request) throws IOException {
     String serialized = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
-    return mapper.readValue(serialized, new TypeReference<Map<String, ?>>() {});
+    return mapper.readValue(serialized, AddServiceRequest.class);
   }
 
   private static String read(String resourceName) {
     try {
       return Resources.toString(Resources.getResource(resourceName), StandardCharsets.UTF_8);
-    }
-    catch (IOException e) {
+    } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
   }

--- a/ambari-server/src/test/resources/add_service_api/request1.json
+++ b/ambari-server/src/test/resources/add_service_api/request1.json
@@ -12,12 +12,18 @@
 
   "components" : [
     {
-      "component_name" : "NIMBUS",
-      "fqdn" : "c7401.ambari.apache.org"
+      "name" : "NIMBUS",
+      "hosts": [
+        { "fqdn" : "c7401.ambari.apache.org" },
+        { "fqdn" : "c7402.ambari.apache.org" }
+      ]
     },
     {
-      "component_name" : "BEACON_SERVER",
-      "fqdn" : "c7402.ambari.apache.org"
+      "name" : "BEACON_SERVER",
+      "hosts": [
+        { "fqdn" : "c7402.ambari.apache.org" },
+        { "fqdn" : "c7403.ambari.apache.org" }
+      ]
     }
   ],
 

--- a/ambari-server/src/test/resources/add_service_api/request2.json
+++ b/ambari-server/src/test/resources/add_service_api/request2.json
@@ -6,12 +6,18 @@
 
   "components" : [
     {
-      "component_name" : "NIMBUS",
-      "fqdn" : "c7401.ambari.apache.org"
+      "name" : "NIMBUS",
+      "hosts": [
+        { "fqdn" : "c7401.ambari.apache.org" },
+        { "fqdn" : "c7402.ambari.apache.org" }
+      ]
     },
     {
-      "component_name" : "BEACON_SERVER",
-      "fqdn" : "c7402.ambari.apache.org"
+      "name" : "BEACON_SERVER",
+      "hosts": [
+        { "fqdn" : "c7402.ambari.apache.org" },
+        { "fqdn" : "c7403.ambari.apache.org" }
+      ]
     }
   ]
 

--- a/ambari-server/src/test/resources/add_service_api/request4.json
+++ b/ambari-server/src/test/resources/add_service_api/request4.json
@@ -1,12 +1,18 @@
 {
   "components" : [
     {
-      "component_name" : "NIMBUS",
-      "fqdn" : "c7401.ambari.apache.org"
+      "name" : "NIMBUS",
+      "hosts": [
+        { "fqdn" : "c7401.ambari.apache.org" },
+        { "fqdn" : "c7402.ambari.apache.org" }
+      ]
     },
     {
-      "component_name" : "BEACON_SERVER",
-      "fqdn" : "c7402.ambari.apache.org"
+      "name" : "BEACON_SERVER",
+      "hosts": [
+        { "fqdn" : "c7402.ambari.apache.org" },
+        { "fqdn" : "c7403.ambari.apache.org" }
+      ]
     }
   ]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change syntax of the Add Service request:

 * allow multiple hosts per component
 * simplify `component_name` to `name` to be more consistent with blueprints

https://issues.apache.org/jira/browse/AMBARI-25030

## How was this patch tested?

Unit tests are updated.  Tested manually using new syntax:

```
$ curl -X POST -d @- "http://${AMBARI_SERVER_NAME}:8080/api/v1/clusters/TEST/services" <<-EOF
{
  "operation_type": "ADD_SERVICE",
  "components": [
    { "name": "KAFKA_BROKER",
      "hosts": [
        { "fqdn": "c7401.ambari.apache.org" },
        { "fqdn": "c7402.ambari.apache.org" }
      ]
    },
    { "name": "INFRA_SOLR",
      "hosts": [
        { "fqdn": "c7402.ambari.apache.org" }
      ]
    },
    { "name": "INFRA_SOLR_CLIENT",
      "hosts": [
        { "fqdn": "c7401.ambari.apache.org" },
        { "fqdn": "c7402.ambari.apache.org" }
      ]
    }
  ],
  ...
}
EOF

HTTP/1.1 202 Accepted
{
  "Requests" : {
    "id" : 7,
    "status" : "Accepted"
  }
}
```