### PR TITLE
AMBARI-25034 Ambari is not updating core-site : "ha.zookeeper.quorum" once a zookeeper server is added or removed (asnaik)

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -133,6 +133,11 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
       typesToSave: ['hive-site', 'webhcat-site']
     },
     {
+      serviceName: 'HDFS',
+      typesToLoad: ['core-site'],
+      typesToSave: ['core-site']
+    }, 
+    {
       serviceName: 'YARN',
       typesToLoad: ['yarn-site', 'zoo.cfg'],
       typesToSave: ['yarn-site']


### PR DESCRIPTION
AMBARI-25034 Ambari is not updating core-site : "ha.zookeeper.quorum" once a zookeeper server is added or removed (asnaik)onece a zookeeper server is added or removed (asnaik)

## What changes were proposed in this pull request?

Tested in UI, the fix works fine.

[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ ambari-web ---
[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/ambari-web/target/.flattened-pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/ambari-web/3.0.0.0-SNAPSHOT/ambari-web-3.0.0.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:14 min
[INFO] Finished at: 2018-12-11T21:36:18+05:30
[INFO] Final Memory: 25M/228M
[INFO] ------------------------------------------------------------------------

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.