### PR TITLE
[AMBARI-25033] Layout recommendation adds unwanted components

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
@@ -115,4 +115,8 @@ public final class AddServiceInfo {
     return sb.toString();
   }
 
+  public boolean requiresLayoutRecommendation() {
+    return !request.getServices().isEmpty();
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceOrchestrator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceOrchestrator.java
@@ -127,6 +127,11 @@ public class AddServiceOrchestrator {
    * @throws IllegalArgumentException if the request cannot be satisfied
    */
   private AddServiceInfo recommendLayout(AddServiceInfo request) {
+    if (!request.requiresLayoutRecommendation()) {
+      LOG.info("Using layout specified in request for {}", request);
+      return request;
+    }
+
     LOG.info("Recommending layout for {}", request);
     return stackAdvisorAdapter.recommendLayout(request);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Service request can list `"services"` and/or `"components"`:

 * only `"services"`: use layout recommended by stack advisor
 * both `"services"` and `"components"`: use layout recommended by stack advisor, but pass "partial" layout as input to the advisor
 * only `"components"`: use explicit layout specified in the request

The last one currently doesn't work, recommendation is always called, and possibly adds unwanted components.

This change skips the call to layout recommendation if `"services"` section is not present in the request, ie. if it's an explicit layout.

https://issues.apache.org/jira/browse/AMBARI-25033

## How was this patch tested?

Tested install with explicit layout, excluding Metrics Grafana:

```
{
  "operation_type": "ADD_SERVICE",
  "components": [
    { "component_name": "METRICS_COLLECTOR", "fqdn": "c7401.ambari.apache.org" },
    { "component_name": "METRICS_MONITOR", "fqdn": "c7401.ambari.apache.org" }
  ],
  "configurations": [
    {
      "ams-site": {
        "timeline.metrics.hbase.init.check.enabled": "false"
      }
    }
  ]
}
$ cat /var/lib/ambari-agent/data/command-[56]?.json | jq -r '.role, .roleCommand' | xargs -n2
METRICS_COLLECTOR INSTALL
METRICS_MONITOR INSTALL
KERBEROS_CLIENT CUSTOM_COMMAND
KERBEROS_CLIENT CUSTOM_COMMAND
METRICS_COLLECTOR START
METRICS_MONITOR START
```

Also tested install with layout recommended by stack advisor:

```
{
  "operation_type": "ADD_SERVICE",
  "services": [
    { "name": "AMBARI_METRICS" }
  ],
  "configurations": [
    {
      "ams-site": {
        "timeline.metrics.hbase.init.check.enabled": "false"
      }
    },
    {
      "ams-grafana-env": {
        "metrics_grafana_password": "............"
      }
    }
  ]
}
$ cat /var/lib/ambari-agent/data/command-[56]?.json | jq -r '.role, .roleCommand' | xargs -n2
METRICS_COLLECTOR INSTALL
METRICS_GRAFANA INSTALL
METRICS_MONITOR INSTALL
KERBEROS_CLIENT CUSTOM_COMMAND
KERBEROS_CLIENT CUSTOM_COMMAND
METRICS_COLLECTOR START
METRICS_MONITOR START
METRICS_GRAFANA START
```