### PR TITLE
AMBARI-25034 Ambari is not updating core-site : "ha.zookeeper.quorum"once a zookeeper server is added or removed (asnaik)

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1730,15 +1730,15 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
   constructZookeeperConfigUrlParams: function (data) {
     var urlParams = [];
     var services = App.Service.find();
+    var zooKeeperRelatedServices = this.get('zooKeeperRelatedServices').slice(0);
     if (App.get('isHaEnabled')) {
-      var zooKeeperRelatedServices = this.get('zooKeeperRelatedServices');
       zooKeeperRelatedServices.push({
         serviceName: 'HDFS',
         typesToLoad: ['core-site'],
         typesToSave: ['core-site']
       });
     }
-    this.get('zooKeeperRelatedServices').forEach(function (service) {
+    zooKeeperRelatedServices.forEach(function (service) {
       if (services.someProperty('serviceName', service.serviceName)) {
         service.typesToLoad.forEach(function (type) {
           if (data.Clusters.desired_configs[type]) {
@@ -1767,7 +1767,15 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
     this.updateZkConfigs(configs);
     var groups = [];
     var installedServiceNames = App.Service.find().mapProperty('serviceName');
-    this.get('zooKeeperRelatedServices').forEach(function (service) {
+    var zooKeeperRelatedServices = this.get('zooKeeperRelatedServices').slice(0);
+    if (App.get('isHaEnabled')) {
+      zooKeeperRelatedServices.push({
+        serviceName: 'HDFS',
+        typesToLoad: ['core-site'],
+        typesToSave: ['core-site']
+      });
+    }
+    zooKeeperRelatedServices.forEach(function (service) {
       if (installedServiceNames.contains(service.serviceName)) {
         var group = {
           properties: {},

--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1731,7 +1731,12 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
     var urlParams = [];
     var services = App.Service.find();
     if (App.get('isHaEnabled')) {
-      urlParams.push('(type=core-site&tag=' + data.Clusters.desired_configs['core-site'].tag + ')');
+      var zooKeeperRelatedServices = this.get('zooKeeperRelatedServices');
+      zooKeeperRelatedServices.push({
+        serviceName: 'HDFS',
+        typesToLoad: ['core-site'],
+        typesToSave: ['core-site']
+      });
     }
     this.get('zooKeeperRelatedServices').forEach(function (service) {
       if (services.someProperty('serviceName', service.serviceName)) {
@@ -1775,16 +1780,6 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
         groups.push(group);
       }
     });
-    if (App.get('isHaEnabled') && installedServiceNames.contains('HDFS')) {
-      var group = {
-          properties: {},
-          properties_attributes: {}
-        };
-      var type= 'core-site';
-      group.properties[type] = configs[type];
-      group.properties_attributes[type] = attributes[type];
-      groups.push(group);
-    }
     this.setConfigsChanges(groups);
   },
 

--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1775,6 +1775,16 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
         groups.push(group);
       }
     });
+    if (App.get('isHaEnabled') && installedServiceNames.contains('HDFS')) {
+      var group = {
+          properties: {},
+          properties_attributes: {}
+        };
+      var type= 'core-site';
+      group.properties[type] = configs[type];
+      group.properties_attributes[type] = attributes[type];
+      groups.push(group);
+    }
     this.setConfigsChanges(groups);
   },
 


### PR DESCRIPTION
AMBARI-25034 Ambari is not updating core-site : "ha.zookeeper.quorum"once a zookeeper server is added or removed (asnaik)
## What changes were proposed in this pull request?
Fix for AMBARI-25034

## How was this patch tested?

- Tested the UI as per defect description 
- UT Test successful in the local run 

  22064 passing (34s)
  48 pending

JQMIGRATE: jQuery.support.boxModel is deprecated

JQMIGRATE: jQuery.event.handle is undocumented and deprecated


[INFO]
[INFO] --- apache-rat-plugin:0.12:check (default) @ ambari-web ---
[INFO] RAT will not execute since it is configured to be skipped via system property 'rat.skip'.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:06 min
[INFO] Finished at: 2018-12-11T23:33:17+05:30
[INFO] Final Memory: 17M/225M
[INFO] ------------------------------------------------------------------------


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.