### PR TITLE
[AMBARI-25036] Update Stack Classloader Loading Pattern

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/UpgradeCheckRegistry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/UpgradeCheckRegistry.java
@@ -178,7 +178,6 @@ public class UpgradeCheckRegistry {
    * @param pluginChecks
    *          the collection to popoulate.
    */
-  @SuppressWarnings("unchecked")
   private void loadPluginUpgradeChecksFromStack(UpgradePack upgradePack,
       PluginUpgradeChecks pluginChecks) throws AmbariException {
     List<String> pluginCheckClassNames = upgradePack.getPrerequisiteChecks();
@@ -189,13 +188,11 @@ public class UpgradeCheckRegistry {
     if (null != classLoader) {
       for (String pluginCheckClassName : pluginCheckClassNames) {
         try {
-          Class<? extends UpgradeCheck> upgradeCheckClass = (Class<? extends UpgradeCheck>) classLoader.loadClass(
-              pluginCheckClassName);
+          UpgradeCheck upgradeCheck = stackInfo.getLibraryInstance(m_injector, pluginCheckClassName);
 
-          UpgradeCheck upgradeCheck = m_injector.getInstance(upgradeCheckClass);
           pluginChecks.m_loadedChecks.add(upgradeCheck);
 
-          LOG.info("Registered pre-upgrade check {} for stack {}", upgradeCheckClass, ownerStackId);
+          LOG.info("Registered pre-upgrade check {} for stack {}", pluginCheckClassName, ownerStackId);
         } catch (Exception exception) {
           LOG.error("Unable to load the upgrade check {}", pluginCheckClassName, exception);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/PluginUpgradeServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/PluginUpgradeServerAction.java
@@ -83,11 +83,7 @@ public class PluginUpgradeServerAction extends AbstractUpgradeServerAction {
     final String pluginClassName = getActionClassName();
 
     try {
-      @SuppressWarnings("unchecked")
-      Class<? extends UpgradeAction> upgradeActionClass = (Class<? extends UpgradeAction>) pluginClassLoader.loadClass(
-          pluginClassName);
-
-      upgradeAction = upgradeActionClass.newInstance();
+      upgradeAction = stackInfo.getLibraryInstance(pluginClassName);
     } catch (Exception exception) {
       LOG.error("Unable to load the upgrade action {}", pluginClassName, exception);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/UpgradeContext.java
@@ -1545,12 +1545,9 @@ public class UpgradeContext {
 
     try {
       StackInfo stack = metaInfo.getStack(stackId);
-      ClassLoader cl = stack.getLibraryClassLoader();
 
-      Class<?> clazz = (null == cl) ? Class.forName(className) :
-        cl.loadClass(className);
+      return stack.getLibraryInstance(className);
 
-      return (OrchestrationOptions) clazz.newInstance();
     } catch (Exception e) {
       LOG.error(String.format("Could not load orchestration options for stack {}: {}",
           stackId, e.getMessage()));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -102,6 +102,7 @@ import org.apache.ambari.spi.upgrade.UpgradeCheckStatus;
 import org.apache.ambari.spi.upgrade.UpgradeCheckType;
 import org.apache.ambari.spi.upgrade.UpgradeType;
 import org.apache.commons.lang3.StringUtils;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Test;
@@ -214,12 +215,11 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
     expect(serviceInfo.getChecksFolder()).andReturn(new File(checks));
 
     ClassLoader classLoader = createNiceMock(ClassLoader.class);
-    Class clazz = SampleServiceCheck.class;
-    expect(classLoader.loadClass(TEST_SERVICE_CHECK_CLASS_NAME)).andReturn(clazz).atLeastOnce();
-
     StackInfo stackInfo = createNiceMock(StackInfo.class);
     expect(ambariMetaInfo.getStack(targetStackId)).andReturn(stackInfo).atLeastOnce();
     expect(stackInfo.getLibraryClassLoader()).andReturn(classLoader).atLeastOnce();
+    expect(stackInfo.getLibraryInstance(EasyMock.anyObject(), EasyMock.eq(TEST_SERVICE_CHECK_CLASS_NAME)))
+      .andReturn(new SampleServiceCheck()).atLeastOnce();
 
     // replay
     replayAll();

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PluginUpgradeServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PluginUpgradeServerActionTest.java
@@ -49,6 +49,7 @@ import org.apache.ambari.spi.upgrade.UpgradeAction;
 import org.apache.ambari.spi.upgrade.UpgradeActionOperations;
 import org.apache.ambari.spi.upgrade.UpgradeActionOperations.ConfigurationChanges;
 import org.apache.ambari.spi.upgrade.UpgradeInformation;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
 import org.junit.Before;
@@ -128,12 +129,10 @@ public class PluginUpgradeServerActionTest extends EasyMockSupport {
     expect(m_mockUpgradePack.getOwnerStackId()).andReturn(m_stackId).atLeastOnce();
     expect(m_mockMetaInfo.getStack(m_stackId)).andReturn(m_mockStackInfo).atLeastOnce();
     expect(m_mockStackInfo.getLibraryClassLoader()).andReturn(m_mockClassLoader).atLeastOnce();
+    expect(m_mockStackInfo.getLibraryInstance(EasyMock.anyString())).andReturn(new MockUpgradeAction()).atLeastOnce();
 
     expect(m_action.getClusters()).andReturn(m_mockClusters).anyTimes();
     expect(m_action.getUpgradeContext(m_mockCluster)).andReturn(m_mockUpgradeContext).once();
-
-    Class clazz = MockUpgradeAction.class;
-    expect(m_mockClassLoader.loadClass(CLASS_NAME)).andReturn(clazz).atLeastOnce();
 
     m_action.agentConfigsHolder = m_mockAgentConfigsHolder;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the `StackInfo` to load an instance of a class with its own classloader.  This is to address a common pattern that emerging from usage.

## How was this patch tested?

Manual testing.  Automated (error not related - it's from the stack which was symlinked for dev environment):

```
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ServicePropertiesTest.validatePropertySchemaOfServiceXMLs:51 » Ambari File /Us...
[INFO]
[ERROR] Tests run: 5265, Failures: 0, Errors: 1, Skipped: 72
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 34:13 min
[INFO] Finished at: 2018-12-11T11:39:37-05:00
[INFO] ------------------------------------------------------------------------
```

