### PR TITLE
[AMBARI-25039] Parse error should be reported as Bad Request

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ServiceResourceProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ambari.server.controller.internal;
 
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -79,6 +80,7 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.topology.STOMPComponentsDeleteHandler;
 import org.apache.ambari.server.topology.addservice.AddServiceOrchestrator;
+import org.apache.ambari.server.utils.LoggingPreconditions;
 import org.apache.ambari.spi.RepositoryType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -96,6 +98,7 @@ import com.google.inject.assistedinject.AssistedInject;
 public class ServiceResourceProvider extends AbstractControllerResourceProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceResourceProvider.class);
+  private static final LoggingPreconditions CHECK = new LoggingPreconditions(LOG);
 
   public static final String SERVICE_CLUSTER_NAME_PROPERTY_ID = PropertyHelper.getPropertyId(
       "ServiceInfo", "cluster_name");
@@ -1246,7 +1249,11 @@ public class ServiceResourceProvider extends AbstractControllerResourceProvider 
   }
 
   private static AddServiceRequest createAddServiceRequest(Map<String, String> requestInfoProperties) {
-    return AddServiceRequest.of(requestInfoProperties.get(Request.REQUEST_INFO_BODY_PROPERTY));
+    try {
+      return AddServiceRequest.of(requestInfoProperties.get(Request.REQUEST_INFO_BODY_PROPERTY));
+    } catch (UncheckedIOException e) {
+      return CHECK.wrapInUnchecked(e, IllegalArgumentException::new, "Could not parse input as valid Add Service request: " + e.getCause().getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Report JSON errors encountered while parsing Add Service request as HTTP 400 Bad Request instead of HTTP 500 Server Error.

https://issues.apache.org/jira/browse/AMBARI-25039

Note that invalid JSON syntax (eg. dangling `,` at the end of a list) is already caught earlier at:

```
$ curl -X POST -d @invalid_syntax.json http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Invalid Request: Malformed Request Body.  An exception occurred parsing the request body: Unexpected character ('}' (code 125)): was expecting double-quote to start field name\n at [Source: java.io.StringReader@78a9b9d4; line: 1, column: 57]"
}
```

## How was this patch tested?

```
$ curl -X POST -d @invalid_data_type.json http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services
HTTP/1.1 400 Bad Request
{
  "status" : 400,
  "message" : "Could not parse input as valid Add Service request: Cannot deserialize instance of `java.util.HashSet` out of VALUE_STRING token\n at [Source: (String)\"{  \"operation_type\": \"ADD_SERVICE\",  \"components\": \"asdf\"}\"; line: 1, column: 52] (through reference chain: org.apache.ambari.server.controller.AddServiceRequest[\"components\"])"
}

$ curl -X POST -d @valid.json http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/services
HTTP/1.1 202 Accepted
{
  "Requests" : {
    "id" : 8,
    "status" : "Accepted"
  }
}
```