### PR TITLE
[AMBARI-25040] Handle blueprint/VDF stack version mismatch

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/AmbariContextTest.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.topology;
 
 import static java.util.Collections.singletonList;
+import static org.apache.ambari.server.utils.Assertions.assertThrows;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
@@ -103,7 +104,7 @@ public class AmbariContextTest {
   private static final String HOST_GROUP_2 = "group2";
   private static final String HOST1 = "host1";
   private static final String HOST2 = "host2";
-  StackId stackId = new StackId(STACK_NAME, STACK_VERSION);
+  private static final StackId STACK_ID = new StackId(STACK_NAME, STACK_VERSION);
 
   private static final AmbariContext context = new AmbariContext();
   private static final AmbariManagementController controller = createNiceMock(AmbariManagementController.class);
@@ -735,22 +736,29 @@ public class AmbariContextTest {
 
     context.repositoryVersionDAO = repositoryVersionDAO;
 
-    controller.createCluster(capture(Capture.<ClusterRequest>newInstance()));
-    expectLastCall().once();
-    expect(cluster.getServices()).andReturn(clusterServices).anyTimes();
-
-    serviceResourceProvider.createServices(capture(Capture.<Set<ServiceRequest>>newInstance()));
-    expectLastCall().once();
-    componentResourceProvider.createComponents(capture(Capture.<Set<ServiceComponentRequest>>newInstance()));
-    expectLastCall().once();
-
-    expect(serviceResourceProvider.updateResources(
-        capture(Capture.<Request>newInstance()), capture(Capture.<Predicate>newInstance()))).andReturn(null).atLeastOnce();
+    expectAmbariResourceCreation();
 
     replayAll();
 
     // test
     context.createAmbariResources(topology, CLUSTER_NAME, null, null, null);
+  }
+
+  private void expectAmbariResourceCreation() {
+    try {
+      controller.createCluster(capture(Capture.newInstance()));
+      expectLastCall().once();
+      expect(cluster.getServices()).andReturn(clusterServices).anyTimes();
+
+      serviceResourceProvider.createServices(capture(Capture.newInstance()));
+      expectLastCall().once();
+      componentResourceProvider.createComponents(capture(Capture.newInstance()));
+      expectLastCall().once();
+
+      expect(serviceResourceProvider.updateResources(capture(Capture.newInstance()), capture(Capture.newInstance()))).andReturn(null).atLeastOnce();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test
@@ -805,6 +813,58 @@ public class AmbariContextTest {
           "Could not identify repository version with stack testStack-testVersion and version xyz for installing services. Specify a valid version with 'repository_version'",
           e.getMessage());
     }
+  }
+
+  @Test
+  public void testCreateAmbariResourcesVersionOK() {
+    RepositoryVersionEntity repoVersion = repositoryInClusterCreationRequest(1L, "3.0.1.2-345", STACK_ID);
+    expectAmbariResourceCreation();
+    replayAll();
+
+    context.createAmbariResources(topology, CLUSTER_NAME, null, repoVersion.getVersion(), null);
+  }
+
+  @Test
+  public void testCreateAmbariResourcesVersionByIdOK() {
+    RepositoryVersionEntity repoVersion = repositoryInClusterCreationRequest(1L, "3.0.1.2-345", STACK_ID);
+    expectAmbariResourceCreation();
+    replayAll();
+
+    context.createAmbariResources(topology, CLUSTER_NAME, null, null, repoVersion.getId());
+  }
+
+  @Test
+  public void testCreateAmbariResourcesVersionMismatch() {
+    RepositoryVersionEntity repoVersion = repositoryInClusterCreationRequest(1L, "3.0.1.2-345", new StackId("HDP", "3.0"));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+      () -> context.createAmbariResources(topology, CLUSTER_NAME, null, repoVersion.getVersion(), null));
+    assertTrue(e.getMessage(), e.getMessage().contains("should match"));
+  }
+
+  @Test
+  public void testCreateAmbariResourcesVersionMismatchById() {
+    RepositoryVersionEntity repoVersion = repositoryInClusterCreationRequest(1L, "3.0.1.2-345", new StackId("HDP", "3.0"));
+    replayAll();
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+      () -> context.createAmbariResources(topology, CLUSTER_NAME, null, null, repoVersion.getId()));
+    assertTrue(e.getMessage(), e.getMessage().contains("should match"));
+  }
+
+  private RepositoryVersionEntity repositoryInClusterCreationRequest(Long id, String version, StackId stackId) {
+    RepositoryVersionEntity repoEntity = createNiceMock(RepositoryVersionEntity.class);
+    expect(repoEntity.getStackId()).andStubReturn(stackId);
+    expect(repoEntity.getId()).andStubReturn(id);
+    expect(repoEntity.getType()).andStubReturn(RepositoryType.STANDARD);
+    expect(repoEntity.getVersion()).andStubReturn(version);
+    RepositoryVersionDAO repositoryVersionDAO = createNiceMock(RepositoryVersionDAO.class);
+    expect(repositoryVersionDAO.findByPK(1L)).andStubReturn(repoEntity);
+    expect(repositoryVersionDAO.findByStackAndVersion(EasyMock.anyObject(StackId.class), EasyMock.anyString())).andStubReturn(repoEntity);
+    replay(repositoryVersionDAO, repoEntity);
+    context.repositoryVersionDAO = repositoryVersionDAO;
+    return repoEntity;
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/RequestValidatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/RequestValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.topology.addservice;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.ambari.server.utils.Assertions.assertThrows;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -602,19 +603,6 @@ public class RequestValidatorTest extends EasyMockSupport {
         .map(each -> ImmutableMap.of(KerberosServiceDescriptor.KEY_NAME, each))
         .collect(toList())
     ));
-  }
-
-  private static <T extends Throwable> T assertThrows(Class<T> expectedException, Runnable code) {
-    try {
-      code.run();
-    } catch (Throwable t) {
-      if (expectedException.isInstance(t)) {
-        return expectedException.cast(t);
-      }
-      throw new AssertionError("Expected exception: " + expectedException + " but " + t.getClass() + " was thrown instead");
-    }
-
-    throw new AssertionError("Expected exception: " + expectedException + ", but was not thrown");
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/Assertions.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/Assertions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.utils;
+
+public class Assertions {
+
+  public static <T extends Exception> T assertThrows(Class<T> expectedException, Runnable code) {
+    try {
+      code.run();
+    } catch (Exception e) {
+      if (expectedException.isInstance(e)) {
+        return expectedException.cast(e);
+      }
+      throw new AssertionError("Expected exception: " + expectedException + " but " + e.getClass() + " was thrown instead", e);
+    }
+
+    throw new AssertionError("Expected exception: " + expectedException + ", but was not thrown");
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reject cluster creation request if the stacks in the blueprint and the VDF are different (eg. HDP 2.6 vs HDP 3.0).

https://issues.apache.org/jira/browse/AMBARI-25040

## How was this patch tested?

Added test case in unit test.

Manually tested both reject and accept scenarios.

#### Mismatch

```
"Blueprints" : {
  "stack_name" : "HDP",
  "stack_version" : "2.6",
  ...
}

"VersionDefinition" : {
  "id" : 1,
  "stack_name" : "HDP",
  "stack_version" : "3.0"
}
```

By `repository_version_id`:

```
$ curl -X POST -d @wrong_id/cluster.json http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST
{
  "status": 500,
  "message": "An exception occurred during cluster provisioning: The stack specified in the blueprint (HDP-2.6) and the repository version (HDP-3.0 for 'repository_version_id' = 1) should match"
}
```

By `repository_version`:

```
$ curl -X POST -d @wrong_version/cluster.json http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST
{
  "status": 500,
  "message": "An exception occurred during cluster provisioning: The stack specified in the blueprint (HDP-2.6) and the repository version (HDP-3.0 for 'repository_version' = '3.0.0.0-1634') should match"
}
```

#### Match

```
"Blueprints" : {
  "stack_name" : "HDP",
  "stack_version" : "3.0",
  ...
}

"VersionDefinition" : {
  "id" : 1,
  "stack_name" : "HDP",
  "stack_version" : "3.0"
}
```

Request with correct `repository_version_id` / `repository_version`, or no repo version at all:

```
{
  "Requests": {
    "id": 1,
    "status": "Accepted"
  }
}
...
"Clusters" : {
  "cluster_name" : "TEST",
  "version" : "HDP-3.0"
}
```