### PR TITLE
[AMBARI-25041] Scale hosts does not install component if service is in maintenance mode.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -396,6 +396,8 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Install components on host %s", hostname));
     requestInfo.put(CLUSTER_PHASE_PROPERTY, CLUSTER_PHASE_INITIAL_INSTALL);
+    // although the operation is really for a specific host, the level needs to be set to HostComponent
+    // to make sure that any service in maintenance mode does not prevent install/start on the new host during scale-up
     requestInfo.putAll(RequestOperationLevel.propertiesFor(Resource.Type.HostComponent, cluster));
     addProvisionActionProperties(skipInstallForComponents, dontSkipInstallForComponents, requestInfo);
 
@@ -470,6 +472,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Start components on host %s", hostName));
     requestInfo.put(CLUSTER_PHASE_PROPERTY, CLUSTER_PHASE_INITIAL_START);
+    // see rationale for marking the operation as HostComponent-level at "Install components on host"
     requestInfo.putAll(RequestOperationLevel.propertiesFor(Resource.Type.HostComponent, cluster));
     requestInfo.put(Setting.SETTING_NAME_SKIP_FAILURE, Boolean.toString(skipFailure));
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostComponentResourceProvider.java
@@ -396,6 +396,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Install components on host %s", hostname));
     requestInfo.put(CLUSTER_PHASE_PROPERTY, CLUSTER_PHASE_INITIAL_INSTALL);
+    requestInfo.putAll(RequestOperationLevel.propertiesFor(Resource.Type.HostComponent, cluster));
     addProvisionActionProperties(skipInstallForComponents, dontSkipInstallForComponents, requestInfo);
 
     Request installRequest = PropertyHelper.getUpdateRequest(installProperties, requestInfo);
@@ -469,6 +470,7 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
     Map<String, String> requestInfo = new HashMap<>();
     requestInfo.put("context", String.format("Start components on host %s", hostName));
     requestInfo.put(CLUSTER_PHASE_PROPERTY, CLUSTER_PHASE_INITIAL_START);
+    requestInfo.putAll(RequestOperationLevel.propertiesFor(Resource.Type.HostComponent, cluster));
     requestInfo.put(Setting.SETTING_NAME_SKIP_FAILURE, Boolean.toString(skipFailure));
 
     Predicate clusterPredicate = new EqualsPredicate<>(CLUSTER_NAME, cluster);
@@ -531,7 +533,6 @@ public class HostComponentResourceProvider extends AbstractControllerResourcePro
 
     return requestStages.getRequestStatusResponse();
   }
-
 
   /**
    * Update the host component identified by the given request object with the

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestOperationLevel.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestOperationLevel.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import org.apache.ambari.server.controller.spi.Resource;
 
+import com.google.common.collect.ImmutableMap;
+
 /**
  * Operation level is specified along with some requests. It identifies
  * the logical level, at which the operation is executed.
@@ -183,4 +185,12 @@ public class RequestOperationLevel {
             ", hostName='" + hostName + '\'' +
             '}';
   }
+
+  public static Map<String, String> propertiesFor(Resource.Type type, String clusterName) {
+    return ImmutableMap.of(
+      OPERATION_LEVEL_ID, getExternalLevelName(type.name()),
+      OPERATION_CLUSTER_ID, clusterName
+    );
+  }
+
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestOperationLevel.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestOperationLevel.java
@@ -186,6 +186,17 @@ public class RequestOperationLevel {
             '}';
   }
 
+  /**
+   * Create a map of required properties to be added to a request info map which is
+   * then used to create a {@link RequestOperationLevel} object.
+   * Other properties (service name, host name, host component name) can be set on
+   * the request info map itself as needed.
+   *
+   * @param type resource type for which to calculate the operation level
+   * @param clusterName cluster name
+   * @return immutable map with required properties: operation level and cluster name
+   * @throws IllegalArgumentException if the given resource {@code type} is not mapped to any operation level
+   */
   public static Map<String, String> propertiesFor(Resource.Type type, String clusterName) {
     return ImmutableMap.of(
       OPERATION_LEVEL_ID, getExternalLevelName(type.name()),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow scaling up the cluster even if some service is in maintenance mode, without having to manually install/start the service's components on the new host.

https://issues.apache.org/jira/browse/AMBARI-25041

## How was this patch tested?

Tested blueprint install and scale operations.