### PR TITLE
AMBARI-25013. New kerberos-env property to allow populating auth_to_local rules for non installed service components

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
@@ -135,6 +135,10 @@ public interface KerberosHelper {
    */
   String MANAGE_AUTH_TO_LOCAL_RULES = "manage_auth_to_local";
   /**
+   * The kerberos-env property name declaring whether the Hadoop auth_to_local rules should be included for all components of an installed service even if the component itself is not installed
+   */
+  String INCLUDE_ALL_COMPONENTS_IN_AUTH_TO_LOCAL_RULES = "include_all_components_in_auth_to_local_rules";
+  /**
    * The kerberos-env property name declaring whether auth-to-local rules should be case-insensitive or not
    */
   String CASE_INSENSITIVE_USERNAME_RULES = "case_insensitive_username_rules";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -1183,6 +1183,7 @@ public class KerberosHelperImpl implements KerberosHelper {
       // or marked to be preconfigured, add the relevant data to the auth-to-local rules.
       Map<String, KerberosServiceDescriptor> serviceDescriptors = kerberosDescriptor.getServices();
       if (serviceDescriptors != null) {
+        final boolean includeAllComponents = Boolean.valueOf(kerberosEnvProperties.get(INCLUDE_ALL_COMPONENTS_IN_AUTH_TO_LOCAL_RULES));
         for (KerberosServiceDescriptor serviceDescriptor : serviceDescriptors.values()) {
           String serviceName = serviceDescriptor.getName();
           boolean preconfigure = includePreconfigureData && serviceDescriptor.shouldPreconfigure();
@@ -1217,7 +1218,7 @@ public class KerberosHelperImpl implements KerberosHelper {
 
                 // Add this component's identities if we are implicitly preconfiguring the parent
                 // service or if the component has been explicitly added to the cluster
-                if (preconfigure || (installedServiceComponents.contains(componentName))) {
+                if (preconfigure || includeAllComponents || installedServiceComponents.contains(componentName)) {
                   LOG.info("Adding identities for component {} to auth to local mapping", componentName);
                   addIdentities(authToLocalBuilder, componentDescriptor.getIdentities(true, filterContext), null, replacements);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari should optionally generate auth-to-local rules for the Kerberos identities of all components of installed services.

Currently Ambari will generate auth-to-local rules for the installed components of installed services. This is generally the accepted behavior. However, there may be cases where identities from remote clusters (using the same Kerberos realm) need to be translated to local names.

A use case may be that some slave component for a service is installed on a remote cluster, but that component is not installed on the local cluster. However a master component of that service is installed on the local cluster and the slave component from the remote cluster needs to communicate with it.

The solution is to add a new property to kerberos-env, maybe named `include_all_components_in_auth_to_local_rules`, where the default value is `false`. If set to `true`, when building the auth-to-local rules, Ambari should add the rules for all components of installed services, not just the installed components (which is what it does today).

## How was this patch tested?

Added new unit test to cover this case:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 27:55 min
[INFO] Finished at: 2018-12-13T11:14:26+01:00
[INFO] Final Memory: 170M/1724M
[INFO] ------------------------------------------------------------------------
```

Additionally the following E2E test has been executed:

1. installed a cluster with HDFS (and Kafka, but it's irrelevant now since Kafka does not support our `auth to local` feature) without `NFSGateway`
<img width="793" alt="screen shot 2018-12-13 at 10 34 14 am" src="https://user-images.githubusercontent.com/34065904/49933551-33c2fb80-fecc-11e8-9117-01c1037b7347.png">

2. applied my changes (replaced the server JAR with the new one and edited the `kerberos-env.xml` to have the new property)
3. Kerberized the cluster
<img width="1204" alt="screen shot 2018-12-11 at 2 27 44 pm" src="https://user-images.githubusercontent.com/34065904/49933812-f4e17580-fecc-11e8-9514-925753eadb5f.png">

4. checked `hadoop.security.auth_to_local` within `HDFS / Configs / Advanced / Advanced core-site`. As expected the `auth to local` rules contained the rule for not installed components (NFSGatwway, JournalNode) too
<img width="1352" alt="screen shot 2018-12-13 at 10 34 43 am" src="https://user-images.githubusercontent.com/34065904/49933570-45a49e80-fecc-11e8-9b6c-51208c90ba93.png">

5. Successfully installed and started an instance of `NFSGateway` on c7402
<img width="849" alt="screen shot 2018-12-13 at 11 51 58 am" src="https://user-images.githubusercontent.com/34065904/49934043-9c5ea800-fecd-11e8-9f92-8f50998e0d68.png">
