### PR TITLE
[AMBARI-25051] Solved the problem of not being able to abort the request when a custom command request has a failed task.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -4128,6 +4128,12 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     Stage stage = createNewStage(requestStageContainer.getLastStageId(), cluster, requestId, requestContext,
         commandParamsForStage, jsons.getHostParamsForStage());
+    boolean skipFailure = false;
+    if (requestProperties.containsKey(Setting.SETTING_NAME_SKIP_FAILURE) && requestProperties.get(Setting.SETTING_NAME_SKIP_FAILURE).equalsIgnoreCase("true")) {
+        skipFailure = true;
+    }
+//    stage.setAutoSkipFailureSupported(skipFailure);
+    stage.setSkippable(skipFailure);
 
     if (actionRequest.isCommand()) {
       customCommandExecutionHelper.addExecutionCommandsToStage(actionExecContext, stage,

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -4061,13 +4061,17 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     String clusterName = actionRequest.getClusterName();
 
     String requestContext = "";
-
+    
+    boolean skipFailure = false;
     if (requestProperties != null) {
       requestContext = requestProperties.get(REQUEST_CONTEXT_PROPERTY);
       if (requestContext == null) {
         // guice needs a non-null value as there is no way to mark this parameter @Nullable
         requestContext = "";
       }
+      if (requestProperties.containsKey(Setting.SETTING_NAME_SKIP_FAILURE) && requestProperties.get(Setting.SETTING_NAME_SKIP_FAILURE).equalsIgnoreCase("true")) {
+        skipFailure = true;
+    }
     }
 
     Cluster cluster = null;
@@ -4128,12 +4132,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
 
     Stage stage = createNewStage(requestStageContainer.getLastStageId(), cluster, requestId, requestContext,
         commandParamsForStage, jsons.getHostParamsForStage());
-    boolean skipFailure = false;
-    if (requestProperties.containsKey(Setting.SETTING_NAME_SKIP_FAILURE) && requestProperties.get(Setting.SETTING_NAME_SKIP_FAILURE).equalsIgnoreCase("true")) {
-        skipFailure = true;
+    if (skipFailure) {
+        stage.setSkippable(skipFailure);
     }
-//    stage.setAutoSkipFailureSupported(skipFailure);
-    stage.setSkippable(skipFailure);
 
     if (actionRequest.isCommand()) {
       customCommandExecutionHelper.addExecutionCommandsToStage(actionExecContext, stage,


### PR DESCRIPTION


## What changes were proposed in this pull request?

When you call the request interface to execute a custom new request, you can choose to skip the failed task by specifying the skip_failure parameter to true in the RequestInfo parameter.

## How was this patch tested?

 manual tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.