### PR TITLE
fix the bug of widget duplication

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -5323,6 +5323,9 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
             List<WidgetLayoutInfo> layoutInfoList = widgetLayout.getWidgetLayoutInfoList();
             if (layoutInfoList != null && !layoutInfoList.isEmpty()) {
               for (WidgetLayoutInfo layoutInfo : layoutInfoList) {
+                if (layoutInfo.getDefaultSectionName() == null) {
+                  layoutInfo.setDefaultSectionName(existingLayoutEntity.getSectionName());
+                }
                 WidgetEntity widgetEntity = addIfNotExistsWidgetEntity(layoutInfo, clusterEntity, user, now);
                 if (widgetEntity != null && layoutInfo.isVisible()) {
                   WidgetLayoutUserWidgetEntity widgetLayoutUserWidgetEntity = new WidgetLayoutUserWidgetEntity();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The data of widget in the database will not be deleted when the service (for example YARN) uninstalling. And when installing,will check if the widget exists by clusterId,widget_name,user and default_section_name. The focus is on default_section_name. In the `if` statement, the default value will be set by `SECTION_NAME`. But in the `else` statement, no default value will be set. Then the widget created in the first installation can not be find in the next installation, and another widget (same with the previous) will be created repeatedly.

## How was this patch tested?
Manual tests.
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.