### PR TITLE
[AMBARI-25058] Ambari Admin doesn't redirect user to login page if auth session becomes invalidated

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/app.js
@@ -64,21 +64,14 @@ angular.module('ambariAdminConsole', [
   }]);
 
   $httpProvider.interceptors.push(['$rootScope', '$q', function (scope, $q) {
-    function success(response) {
-      return response;
-    }
-
-    function error(response) {
-      if (response.status == 403) {
-        window.location = Settings.siteRoot;
-        return;
+    return {
+      responseError: function (response) {
+        if (response.status === 403) {
+          window.location = Settings.siteRoot;
+        }
+        return $q.reject(response);
       }
-      return $q.reject(response);
-    }
-
-    return function (promise) {
-      return promise.then(success, error);
-    }
+    };
   }]);
 
   $provide.factory('TimestampHttpInterceptor', [function($q) {

--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/services/Cluster.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/services/Cluster.js
@@ -100,14 +100,13 @@ angular.module('ambariAdminConsole')
       var deferred = $q.defer();
       var url = '/services/AMBARI/components/AMBARI_SERVER?fields=RootServiceComponents/properties/user.inactivity.timeout.default';
       $http.get(Settings.baseUrl + url)
-      .then(function(data) {
-        var properties = data.data.RootServiceComponents.properties;
-        var timeout = properties? properties['user.inactivity.timeout.default'] : 0;
-        deferred.resolve(timeout);
-      })
-      .catch(function(data) {
-        deferred.reject(data);
-      });
+        .then(function(data) {
+          var properties = data.data.RootServiceComponents.properties;
+          var timeout = properties ? properties['user.inactivity.timeout.default'] : 0;
+          deferred.resolve(timeout);
+        }, function (data) {
+          deferred.reject(data);
+        });
 
       return deferred.promise;
     },


### PR DESCRIPTION
## What changes were proposed in this pull request?

When auth session becomes invalid, nothing happens (instead of redirection to login page)

## How was this patch tested?

Tested manually