### PR TITLE
[AMBARI-25059] SPI Upgrade Improvements For Web Calls And Required Plugins

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -242,7 +242,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>20.0</version>
+        <version>24.1.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -242,7 +242,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>18.0</version>
+        <version>20.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/net/HttpURLConnectionProvider.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/net/HttpURLConnectionProvider.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.spi.net;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The {@link HttpURLConnectionProvider} is used as a way to provide
+ * {@link HttpURLConnection} instances which are backed by Ambari's truststore,
+ * cookie store, and timeout configurations.
+ */
+public interface HttpURLConnectionProvider {
+
+  /**
+   * Gets a {@link HttpURLConnection} which is initialized and ready to read.
+   *
+   * @param url
+   *          the URL to retrieve information from.
+   * @param headers
+   *          the HTTP headers to use in the request.
+   *
+   * @return an iniitalized HTTP connection which is ready to read.
+   * @throws IOException
+   *           if the URL could not be opened.
+   */
+  HttpURLConnection getConnection(String url, Map<String, List<String>> headers) throws IOException;
+
+}

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/net/package-info.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/net/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Provides classes for working with network connections and streaming.
+ */
+package org.apache.ambari.spi.net;

--- a/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheckRequest.java
+++ b/ambari-server-spi/src/main/java/org/apache/ambari/spi/upgrade/UpgradeCheckRequest.java
@@ -17,11 +17,13 @@
  */
 package org.apache.ambari.spi.upgrade;
 
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.ambari.spi.ClusterInformation;
 import org.apache.ambari.spi.RepositoryVersion;
+import org.apache.ambari.spi.net.HttpURLConnectionProvider;
 
 /**
  * Represents a request to run the upgrade checks before an upgrade begins.
@@ -32,6 +34,7 @@ public class UpgradeCheckRequest {
   private boolean m_revert = false;
   private final RepositoryVersion m_targetRepositoryVersion;
   private final Map<String,String> m_checkConfigurations;
+  private final HttpURLConnectionProvider m_httpURLConnectionProvider;
 
   /**
    * Used for tracking results during a check request.
@@ -51,13 +54,19 @@ public class UpgradeCheckRequest {
    * @param checkConfigurations
    *          any configurations specified in the upgrade pack which can be used
    *          to when
+   * @param httpURLConnectionProvider
+   *          provides a mechanism for an {@link UpgradeCheck} to make URL
+   *          requests while using Ambari's truststore and configured stream
+   *          timeout settings.
    */
   public UpgradeCheckRequest(ClusterInformation clusterInformation, UpgradeType upgradeType,
-      RepositoryVersion targetRepositoryVersion, Map<String,String> checkConfigurations) {
+      RepositoryVersion targetRepositoryVersion, Map<String, String> checkConfigurations,
+      HttpURLConnectionProvider httpURLConnectionProvider) {
     m_clusterInformation = clusterInformation;
     m_upgradeType = upgradeType;
     m_targetRepositoryVersion = targetRepositoryVersion;
     m_checkConfigurations = checkConfigurations;
+    m_httpURLConnectionProvider = httpURLConnectionProvider;
   }
 
   /**
@@ -132,5 +141,15 @@ public class UpgradeCheckRequest {
    */
   public UpgradeCheckStatus getResult(UpgradeCheckDescription description) {
     return m_results.get(description);
+  }
+
+  /**
+   * Gets a class which can construct {@link HttpURLConnection} instances which
+   * are backed by Ambari's cookie store, truststore, and timeout settings.
+   *
+   * @return the httpURLConnectionProvider an instance of the provider.
+   */
+  public HttpURLConnectionProvider getHttpURLConnectionProvider() {
+    return m_httpURLConnectionProvider;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProvider.java
@@ -28,6 +28,7 @@ import org.apache.ambari.server.StaticallyInject;
 import org.apache.ambari.server.checks.UpgradeCheckRegistry;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
+import org.apache.ambari.server.controller.internal.URLStreamProvider.AmbariHttpUrlConnectionProvider;
 import org.apache.ambari.server.controller.spi.NoSuchParentResourceException;
 import org.apache.ambari.server.controller.spi.NoSuchResourceException;
 import org.apache.ambari.server.controller.spi.Predicate;
@@ -215,7 +216,8 @@ public class PreUpgradeCheckResourceProvider extends ReadOnlyResourceProvider {
 
       final UpgradeCheckRequest upgradeCheckRequest = new UpgradeCheckRequest(clusterInformation,
           upgradeType, targetRepositoryVersion,
-          upgradePack.getPrerequisiteCheckConfig().getAllProperties());
+          upgradePack.getPrerequisiteCheckConfig().getAllProperties(),
+          new AmbariHttpUrlConnectionProvider());
 
       if (propertyMap.containsKey(UPGRADE_CHECK_FOR_REVERT_PROPERTY_ID)) {
         Boolean forRevert = BooleanUtils.toBooleanObject(propertyMap.get(UPGRADE_CHECK_FOR_REVERT_PROPERTY_ID).toString());

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ClusterConfigEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ClusterConfigEntity.java
@@ -42,6 +42,8 @@ import javax.persistence.UniqueConstraint;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 
+import com.google.common.base.MoreObjects;
+
 @Entity
 @Table(name = "clusterconfig",
   uniqueConstraints = {@UniqueConstraint(name = "UQ_config_type_tag", columnNames = {"cluster_id", "type_name", "version_tag"}),
@@ -303,7 +305,7 @@ public class ClusterConfigEntity {
    */
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("clusterId", clusterId)
       .add("type", type)
       .add("version", version)

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentDesiredStateEntity.java
@@ -41,6 +41,7 @@ import org.apache.ambari.server.state.HostComponentAdminState;
 import org.apache.ambari.server.state.MaintenanceState;
 import org.apache.ambari.server.state.State;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 
@@ -278,7 +279,7 @@ public class HostComponentDesiredStateEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
+    return MoreObjects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
         componentName).add("hostId", hostId).add("desiredState", desiredState).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -36,7 +36,7 @@ import javax.persistence.TableGenerator;
 import org.apache.ambari.server.state.State;
 import org.apache.ambari.server.state.UpgradeState;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 @Entity
 @Table(name = "hostcomponentstate")
@@ -260,7 +260,7 @@ public class HostComponentStateEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
+    return MoreObjects.toStringHelper(this).add("serviceName", serviceName).add("componentName",
         componentName).add("hostId", hostId).add("state", currentState).toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeHistoryEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/UpgradeHistoryEntity.java
@@ -32,6 +32,7 @@ import javax.persistence.UniqueConstraint;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -222,7 +223,7 @@ public class UpgradeHistoryEntity {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("id", id)
         .add("upgradeId", upgradeId)
         .add("serviceName", serviceName)

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FinalizeUpgradeAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/upgrades/FinalizeUpgradeAction.java
@@ -59,6 +59,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.text.StrBuilder;
 
+import com.google.common.base.MoreObjects;
 import com.google.inject.Inject;
 
 /**
@@ -552,7 +553,7 @@ public class FinalizeUpgradeAction extends AbstractUpgradeServerAction {
      */
     @Override
     public String toString() {
-      return com.google.common.base.Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("host", hostName)
           .add("component", componentName)
           .add("current", currentVersion)

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackDirectory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackDirectory.java
@@ -303,7 +303,7 @@ public class StackDirectory extends StackDefinitionDirectory {
    * @return the class loader for 3rd party JARs supplied by the stack or
    *         {@code null} if there are no libraries for this stack.
    */
-  public @Nullable ClassLoader getLibraryClassLoader() {
+  public @Nullable URLClassLoader getLibraryClassLoader() {
     return libraryClassLoader;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/ConfigurationCondition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/ConfigurationCondition.java
@@ -31,7 +31,7 @@ import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Config;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * The {@link ConfigurationCondition} class is used to represent a condition on
@@ -119,7 +119,7 @@ public final class ConfigurationCondition extends Condition {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", type).add("property", property).add("value",
+    return MoreObjects.toStringHelper(this).add("type", type).add("property", property).add("value",
         value).add("comparison", comparisonType).omitNullValues().toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/Grouping.java
@@ -42,7 +42,7 @@ import org.apache.ambari.server.stack.upgrade.orchestrate.UpgradeContext;
 import org.apache.ambari.server.utils.SetUtils;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  *
@@ -417,6 +417,6 @@ public class Grouping {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("name", name).toString();
+    return MoreObjects.toStringHelper(this).add("name", name).toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/HostOrderItem.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/HostOrderItem.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.ambari.spi.upgrade.UpgradeType;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * The {@link HostOrderItem} class represents the orchestration order of hosts
@@ -96,7 +96,7 @@ public class HostOrderItem {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", m_type).add("items",
+    return MoreObjects.toStringHelper(this).add("type", m_type).add("items",
         StringUtils.join(m_actionItems, ", ")).omitNullValues().toString();
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.state;
 
 import java.io.File;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -91,7 +92,7 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
    * A {@link ClassLoader} for any JARs discovered in the stack's library
    * folder.
    */
-  private ClassLoader libraryClassLoader = null;
+  private URLClassLoader libraryClassLoader = null;
 
   /**
    * List of services removed from current stack
@@ -673,7 +674,7 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
    * @return the class loader for 3rd party JARs supplied by the stack or
    *         {@code null} if there are no libraries for this stack.
    */
-  public @Nullable ClassLoader getLibraryClassLoader() {
+  public @Nullable URLClassLoader getLibraryClassLoader() {
     return libraryClassLoader;
   }
 
@@ -684,7 +685,7 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
    * @param libraryClassLoader
    *          the class loader.
    */
-  public void setLibraryClassLoader(ClassLoader libraryClassLoader) {
+  public void setLibraryClassLoader(URLClassLoader libraryClassLoader) {
     this.libraryClassLoader = libraryClassLoader;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog270.java
@@ -1662,7 +1662,7 @@ public class UpgradeCatalog270 extends AbstractUpgradeCatalog {
           final HostAndPort hostAndPort = HostAndPort.fromString(propertyValue);
           AmbariServerConfigurationKey keyToBesaved = AmbariServerConfigurationKey.SERVER_HOST == key ? AmbariServerConfigurationKey.SERVER_HOST
               : AmbariServerConfigurationKey.SECONDARY_SERVER_HOST;
-          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, hostAndPort.getHostText());
+          populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, hostAndPort.getHost());
 
           keyToBesaved = AmbariServerConfigurationKey.SERVER_HOST == key ? AmbariServerConfigurationKey.SERVER_PORT : AmbariServerConfigurationKey.SECONDARY_SERVER_PORT;
           populateConfigurationToBeMoved(propertiesToBeMoved, oldPropertyName, keyToBesaved, String.valueOf(hostAndPort.getPort()));

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AmbariMetricsHadoopSinkVersionCheckTest.java
@@ -206,7 +206,7 @@ public class AmbariMetricsHadoopSinkVersionCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("c1", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult check = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());
@@ -265,7 +265,7 @@ public class AmbariMetricsHadoopSinkVersionCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("c1", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult check = m_check.perform(request);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/AutoStartDisabledCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/AutoStartDisabledCheckTest.java
@@ -98,7 +98,7 @@ public class AutoStartDisabledCheckTest {
   @Test
   public void testIsApplicable() throws Exception {
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, m_configMap);
+        repositoryVersion, m_configMap, null);
 
     CheckHelper checkHelper = new CheckHelper();
     List<UpgradeCheck> applicableChecks = checkHelper.getApplicableChecks(request,
@@ -110,7 +110,7 @@ public class AutoStartDisabledCheckTest {
   @Test
   public void testNoAutoStart() throws Exception {
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, null);
+        repositoryVersion, null, null);
 
     UpgradeCheckResult check = m_check.perform(request);
 
@@ -121,7 +121,7 @@ public class AutoStartDisabledCheckTest {
   @Test
   public void testAutoStartFalse() throws Exception {
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, null);
+        repositoryVersion, null, null);
 
     m_configMap.put(AutoStartDisabledCheck.RECOVERY_ENABLED_KEY, "false");
 
@@ -134,7 +134,7 @@ public class AutoStartDisabledCheckTest {
   @Test
   public void testAutoStartTrue() throws Exception {
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, null);
+        repositoryVersion, null, null);
 
     m_configMap.put(AutoStartDisabledCheck.RECOVERY_ENABLED_KEY, "true");
     m_configMap.put(AutoStartDisabledCheck.RECOVERY_TYPE_KEY, AutoStartDisabledCheck.RECOVERY_AUTO_START);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ClusterCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ClusterCheckTest.java
@@ -172,7 +172,7 @@ public class ClusterCheckTest extends EasyMockSupport {
 
     ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, null);
+        repositoryVersion, null, null);
 
     // case, where we need at least one service to be present
     check.setApplicableServices(oneServiceList);
@@ -249,7 +249,7 @@ public class ClusterCheckTest extends EasyMockSupport {
 
     ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, null);
+        repositoryVersion, null, null);
 
     // since the check is for SERVICE2, it should not match even though its
     // installed since the repository is only for SERVICE1

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentExistsInRepoCheckTest.java
@@ -76,7 +76,7 @@ public class ComponentExistsInRepoCheckTest extends EasyMockSupport {
     expect(cluster.getCurrentStackVersion()).andReturn(sourceStackId).anyTimes();
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, repoVersion(), null);
+    request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, repoVersion(), null, null);
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ComponentsInstallationCheckTest.java
@@ -311,7 +311,7 @@ public class ComponentsInstallationCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     Mockito.when(hcsTezClient.getCurrentState()).thenReturn(State.INSTALLED);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ConfigurationMergeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ConfigurationMergeCheckTest.java
@@ -165,7 +165,7 @@ public class ConfigurationMergeCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = cmc.perform(request);
     Assert.assertEquals("Expect no warnings", 0, check.getFailedOn().size());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HealthCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HealthCheckTest.java
@@ -82,7 +82,7 @@ public class HealthCheckTest {
     when(alertsDAO.findCurrentByCluster(eq(CLUSTER_ID))).thenReturn(Collections.emptyList());
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult result = healthCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, result.getStatus());
@@ -115,7 +115,7 @@ public class HealthCheckTest {
     when(alertsDAO.findCurrentByCluster(eq(CLUSTER_ID))).thenReturn(asList(alertCurrentEntity));
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult result = healthCheck.perform(request);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostMaintenanceModeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostMaintenanceModeCheckTest.java
@@ -77,7 +77,7 @@ public class HostMaintenanceModeCheckTest {
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult check = hostMaintenanceModeCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());
@@ -123,7 +123,7 @@ public class HostMaintenanceModeCheckTest {
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult check = hostMaintenanceModeCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());
@@ -132,7 +132,7 @@ public class HostMaintenanceModeCheckTest {
     // put a host into MM in order to trigger the warning
     Mockito.when(host3.getMaintenanceState(1L)).thenReturn(MaintenanceState.ON);
 
-    request = new UpgradeCheckRequest(clusterInformation, UpgradeType.HOST_ORDERED, null, null);
+    request = new UpgradeCheckRequest(clusterInformation, UpgradeType.HOST_ORDERED, null, null, null);
     check = hostMaintenanceModeCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, check.getStatus());
     Assert.assertFalse(check.getFailedDetail().isEmpty());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsHeartbeatCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsHeartbeatCheckTest.java
@@ -107,7 +107,7 @@ public class HostsHeartbeatCheckTest {
     Mockito.when(cluster.getHosts()).thenReturn(hosts);
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult check = hostHeartbeatCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsMasterMaintenanceCheckTest.java
@@ -127,7 +127,7 @@ public class HostsMasterMaintenanceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest checkRequest = new UpgradeCheckRequest(clusterInformation,
-        UpgradeType.ROLLING, m_repositoryVersion, null);
+        UpgradeType.ROLLING, m_repositoryVersion, null, null);
 
     UpgradeCheckResult result = hostsMasterMaintenanceCheck.perform(checkRequest);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/HostsRepositoryVersionCheckTest.java
@@ -159,7 +159,7 @@ public class HostsRepositoryVersionCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = hostsRepositoryVersionCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, check.getStatus());
@@ -247,7 +247,7 @@ public class HostsRepositoryVersionCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = hostsRepositoryVersionCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());
@@ -309,7 +309,7 @@ public class HostsRepositoryVersionCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = hostsRepositoryVersionCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/InstallPackagesCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/InstallPackagesCheckTest.java
@@ -159,7 +159,7 @@ public class InstallPackagesCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     // Case 1. Initialize with good values
     UpgradeCheckResult check = installPackagesCheck.perform(request);

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/KerberosAdminPersistedCredentialCheckTest.java
@@ -159,7 +159,7 @@ public class KerberosAdminPersistedCredentialCheckTest extends EasyMockSupport {
 
     ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, checkProperties);
+        repositoryVersion, checkProperties, null);
 
     expect(upgradeHelper.suggestUpgradePack(eq(clusterName), anyObject(), anyObject(), eq(Direction.UPGRADE), eq(UpgradeType.ROLLING), anyObject()))
       .andReturn(upgradePackWithRegenKeytab()).anyTimes();

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/LZOCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/LZOCheckTest.java
@@ -97,7 +97,7 @@ public class LZOCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult result = lZOCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, result.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/MissingOsInRepoVersionCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/MissingOsInRepoVersionCheckTest.java
@@ -146,7 +146,7 @@ public class MissingOsInRepoVersionCheckTest extends EasyMockSupport {
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        repositoryVersion, null);
+        repositoryVersion, null, null);
 
     return request;
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/PluginChecksLoadedCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/PluginChecksLoadedCheckTest.java
@@ -69,7 +69,7 @@ public class PluginChecksLoadedCheckTest extends EasyMockSupport {
 
     replayAll();
 
-    UpgradeCheckRequest request = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null, null);
     UpgradeCheckResult check = m_check.perform(request);
 
     Assert.assertEquals(UpgradeCheckStatus.WARNING, check.getStatus());
@@ -90,7 +90,7 @@ public class PluginChecksLoadedCheckTest extends EasyMockSupport {
         new HashSet<>()).atLeastOnce();
     replayAll();
 
-    UpgradeCheckRequest request = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null, null);
     UpgradeCheckResult check = m_check.perform(request);
 
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/PreviousUpgradeCompletedTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/PreviousUpgradeCompletedTest.java
@@ -74,7 +74,7 @@ public class PreviousUpgradeCompletedTest {
 
     ClusterInformation clusterInformation = new ClusterInformation(clusterName, false, null, null, null);
     checkRequest = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        null, null);
+        null, null, null);
 
     puc.clustersProvider = new Provider<Clusters>() {
       @Override

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/RequiredServicesInRepositoryCheckTest.java
@@ -122,7 +122,7 @@ public class RequiredServicesInRepositoryCheckTest {
   public void testNoMissingServices() throws Exception {
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = m_requiredServicesCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());
@@ -140,7 +140,7 @@ public class RequiredServicesInRepositoryCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = m_requiredServicesCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServiceCheckValidityCheckTest.java
@@ -144,7 +144,7 @@ public class ServiceCheckValidityCheckTest {
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(asList(lastServiceCheckDTO1, lastServiceCheckDTO2));
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     try {
       UpgradeCheckResult result = serviceCheckValidityCheck.perform(request);
@@ -172,7 +172,7 @@ public class ServiceCheckValidityCheckTest {
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(singletonList(lastServiceCheckDTO));
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -195,7 +195,7 @@ public class ServiceCheckValidityCheckTest {
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(Collections.<LastServiceCheckDTO>emptyList());
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -220,7 +220,7 @@ public class ServiceCheckValidityCheckTest {
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(asList(lastServiceCheckDTO1, lastServiceCheckDTO2));
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -258,7 +258,7 @@ public class ServiceCheckValidityCheckTest {
     when(hostRoleCommandDAO.getLatestServiceChecksByRole(any(Long.class))).thenReturn(asList(lastServiceCheckDTO1, lastServiceCheckDTO2));
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, null, null, null);
 
     UpgradeCheckResult result =  serviceCheckValidityCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());  }

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicePresenceCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicePresenceCheckTest.java
@@ -78,7 +78,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, result.getStatus());
@@ -99,7 +99,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -122,7 +122,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -144,7 +144,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -169,7 +169,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -192,7 +192,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());
@@ -218,7 +218,7 @@ public class ServicePresenceCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, checkProperties);
+        m_repositoryVersion, checkProperties, null);
 
     UpgradeCheckResult result = m_check.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.FAIL, result.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMaintenanceModeCheckTest.java
@@ -138,7 +138,7 @@ public class ServicesMaintenanceModeCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = servicesMaintenanceModeCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesUpCheckTest.java
@@ -308,7 +308,7 @@ public class ServicesUpCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        m_repositoryVersion, null);
+        m_repositoryVersion, null, null);
 
     UpgradeCheckResult check = servicesUpCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/UpgradeTypeQualificationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/UpgradeTypeQualificationTest.java
@@ -44,8 +44,8 @@ public class UpgradeTypeQualificationTest {
    */
   @Test
   public void testRequired() throws Exception {
-    UpgradeCheckRequest rolling = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null);
-    UpgradeCheckRequest express = new UpgradeCheckRequest(null, UpgradeType.NON_ROLLING, null, null);
+    UpgradeCheckRequest rolling = new UpgradeCheckRequest(null, UpgradeType.ROLLING, null, null, null);
+    UpgradeCheckRequest express = new UpgradeCheckRequest(null, UpgradeType.NON_ROLLING, null, null, null);
 
     UpgradeTypeQualification rollingQualification = new UpgradeTypeQualification(RollingTestCheckImpl.class);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/VersionMismatchCheckTest.java
@@ -86,7 +86,7 @@ public class VersionMismatchCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        null, null);
+        null, null, null);
 
     UpgradeCheckResult check = versionMismatchCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.WARNING, check.getStatus());
@@ -98,7 +98,7 @@ public class VersionMismatchCheckTest {
 
     ClusterInformation clusterInformation = new ClusterInformation(CLUSTER_NAME, false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING,
-        null, null);
+        null, null, null);
 
     UpgradeCheckResult check = versionMismatchCheck.perform(request);
     Assert.assertEquals(UpgradeCheckStatus.PASS, check.getStatus());

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -109,7 +109,9 @@ import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.reflections.Configuration;
@@ -130,8 +132,7 @@ import com.google.inject.name.Names;
  * PreUpgradeCheckResourceProvider tests.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ UpgradeCheckRegistry.class, Reflections.class, Configuration.class,
-    ConfigurationBuilder.class })
+@PrepareForTest({ UpgradeCheckRegistry.class })
 public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
 
   private static final String TEST_SERVICE_CHECK_CLASS_NAME = "org.apache.ambari.server.sample.checks.SampleServiceCheck";
@@ -238,8 +239,10 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
 
     // mock out plugin check loading
     Reflections reflectionsMock = createNiceMock(Reflections.class);
-    Configuration configurationBuilder = EasyMock.anyObject(Configuration.class);
-    PowerMock.expectNew(Reflections.class, configurationBuilder).andReturn(reflectionsMock).once();
+
+    PowerMockito.whenNew(Reflections.class).withParameterTypes(
+        Configuration.class).withArguments(Matchers.any(ConfigurationBuilder.class)).thenReturn(
+            reflectionsMock);
 
     PowerMock.replay(Reflections.class);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -23,6 +23,8 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,6 +108,12 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.google.common.collect.Lists;
@@ -120,6 +128,8 @@ import com.google.inject.name.Names;
 /**
  * PreUpgradeCheckResourceProvider tests.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ UpgradeCheckRegistry.class, Reflections.class })
 public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
 
   private static final String TEST_SERVICE_CHECK_CLASS_NAME = "org.apache.ambari.server.sample.checks.SampleServiceCheck";
@@ -214,12 +224,20 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
     String checks = ClassLoader.getSystemClassLoader().getResource("checks").getPath();
     expect(serviceInfo.getChecksFolder()).andReturn(new File(checks));
 
-    ClassLoader classLoader = createNiceMock(ClassLoader.class);
+    URL url = new URL("file://foo");
+    URLClassLoader classLoader = createNiceMock(URLClassLoader.class);
+    expect(classLoader.getURLs()).andReturn(new URL[] { url }).once();
+
     StackInfo stackInfo = createNiceMock(StackInfo.class);
     expect(ambariMetaInfo.getStack(targetStackId)).andReturn(stackInfo).atLeastOnce();
     expect(stackInfo.getLibraryClassLoader()).andReturn(classLoader).atLeastOnce();
     expect(stackInfo.getLibraryInstance(EasyMock.anyObject(), EasyMock.eq(TEST_SERVICE_CHECK_CLASS_NAME)))
       .andReturn(new SampleServiceCheck()).atLeastOnce();
+
+    // mock out plugin check loading
+    Reflections reflectionsMock = createNiceMock(Reflections.class);
+    PowerMock.expectNew(Reflections.class, EasyMock.anyObject(ConfigurationBuilder.class)).andReturn(reflectionsMock).once();
+    PowerMock.replay(Reflections.class);
 
     // replay
     replayAll();
@@ -267,6 +285,8 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
     Assert.assertEquals(CLUSTER_NAME, clusterName);
     UpgradeType upgradeType = (UpgradeType) customUpgradeCheck.getPropertyValue(PreUpgradeCheckResourceProvider.UPGRADE_CHECK_UPGRADE_TYPE_PROPERTY_ID);
     Assert.assertEquals(UpgradeType.NON_ROLLING, upgradeType);
+
+    PowerMock.verifyAll();
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -112,6 +112,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.reflections.Configuration;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -129,7 +130,8 @@ import com.google.inject.name.Names;
  * PreUpgradeCheckResourceProvider tests.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ UpgradeCheckRegistry.class, Reflections.class })
+@PrepareForTest({ UpgradeCheckRegistry.class, Reflections.class, Configuration.class,
+    ConfigurationBuilder.class })
 public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
 
   private static final String TEST_SERVICE_CHECK_CLASS_NAME = "org.apache.ambari.server.sample.checks.SampleServiceCheck";
@@ -236,7 +238,9 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
 
     // mock out plugin check loading
     Reflections reflectionsMock = createNiceMock(Reflections.class);
-    PowerMock.expectNew(Reflections.class, EasyMock.anyObject(ConfigurationBuilder.class)).andReturn(reflectionsMock).once();
+    Configuration configurationBuilder = EasyMock.anyObject(Configuration.class);
+    PowerMock.expectNew(Reflections.class, configurationBuilder).andReturn(reflectionsMock).once();
+
     PowerMock.replay(Reflections.class);
 
     // replay

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PluginUpgradeServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PluginUpgradeServerActionTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,7 +83,7 @@ public class PluginUpgradeServerActionTest extends EasyMockSupport {
 
   private final UpgradeContext m_mockUpgradeContext = createNiceMock(UpgradeContext.class);
   private final UpgradePack m_mockUpgradePack = createNiceMock(UpgradePack.class);
-  private final ClassLoader m_mockClassLoader = createNiceMock(ClassLoader.class);
+  private final URLClassLoader m_mockClassLoader = createNiceMock(URLClassLoader.class);
   private final AmbariMetaInfo m_mockMetaInfo = createNiceMock(AmbariMetaInfo.class);
   private final AmbariManagementController m_mockController = createNiceMock(AmbariManagementController.class);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/CheckHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/CheckHelperTest.java
@@ -121,7 +121,7 @@ public class CheckHelperTest {
     updateChecksRegistry.add(m_mockCheck);
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
 
@@ -154,13 +154,13 @@ public class CheckHelperTest {
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
     UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation,
-        UpgradeType.NON_ROLLING, m_repositoryVersion, null);
+        UpgradeType.NON_ROLLING, m_repositoryVersion, null, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
 
     Assert.assertEquals(null, request.getResult(m_mockUpgradeCheckDescription));
 
-    request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
+    request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null, null);
   }
 
   /**
@@ -183,7 +183,7 @@ public class CheckHelperTest {
     Mockito.when(m_mockPerform.toString()).thenThrow(new RuntimeException());
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
 
@@ -210,7 +210,7 @@ public class CheckHelperTest {
     Mockito.when(m_mockPerform.toString()).thenThrow(new RuntimeException());
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
 
@@ -253,7 +253,7 @@ public class CheckHelperTest {
     Mockito.when(m_mockPerform.toString()).thenThrow(new RuntimeException());
 
     ClusterInformation clusterInformation = new ClusterInformation("cluster", false, null, null, null);
-    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null);
+    UpgradeCheckRequest request = new UpgradeCheckRequest(clusterInformation, UpgradeType.ROLLING, m_repositoryVersion, null, null);
 
     helper.performChecks(request, updateChecksRegistry, configuration);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This issue is to track two changes to the SPI and to Ambari:

- The SPI should provide a mechanism where 'UpgradeCheck' classes can make web requests using a connection factory that is able to leverage Ambari's cookie store, truststore, and timeout values. This is now done through the `HttpURLConnectionProvider` which is backed by a `URLStreamProvider` and can provide ready-to-go `HttpURLConnection` instances.

- Upgrade checks provided by a stack can be marked as 'required' in the 'UpgradeCheckInfo'. This prevents them from being explicitly defined in the upgrade pack XML. However, since Ambari loads 100's of 1000's of classes, a `ClassLoader` scan can take too long. Using the 'Reflections' library, we're able to pass in the URLs of the JARs which comprise the plugin `ClassLoader` and are able to perform the scan very quickly.

- The `pom.xml` needed to be updated to include a version of `guava` which was compatible with the version of `reflections`.

## How was this patch tested?

- Unit tests updated
- Tested using the old `RangerPasswordCheck` which makes several calls to Ranger in order to determine if the password Ambari stores is the correct one for logging in via the UI.