### PR TITLE
[AMBARI-25062] Optionally execute the post user creation hook on existing users during LDAP sync

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -5153,7 +5153,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         postProcessExistingUsers = userRequest.getPostProcessExistingUsers();
 
         if(postProcessExistingUsers && !configs.isUserHookEnabled()) {
-          LOG.info("Post processing existing users is requested while processing users; however, the user post creation hook is turned off.");
+          LOG.warn("Post processing existing users is requested while processing users; however, the user post creation hook is turned off.");
           postProcessExistingUsers = false;
         }
 
@@ -5173,7 +5173,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
         postProcessExistingUsersInGroups = groupRequest.getPostProcessExistingUsers();
 
         if(postProcessExistingUsersInGroups && !configs.isUserHookEnabled()) {
-          LOG.info("Post processing existing users is requested while processing groups; however, the user post creation hook is turned off.");
+          LOG.warn("Post processing existing users is requested while processing groups; however, the user post creation hook is turned off.");
           postProcessExistingUsersInGroups = false;
         }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/LdapSyncRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/LdapSyncRequest.java
@@ -38,18 +38,26 @@ public class LdapSyncRequest {
    */
   private final LdapSyncSpecEntity.SyncType type;
 
+  /**
+   * A Boolean value indicating whether to execute the post user creation hook on previously
+   * existing users (if the post user creation hook feature has been enabled)
+   */
+  private final boolean postProcessExistingUsers;
+
 
   // ----- Constructors ------------------------------------------------------
 
   /**
    * Construct an LdapSyncRequest.
    *
-   * @param type            the request type
-   * @param principalNames  the principal names
+   * @param type                     the request type
+   * @param principalNames           the principal names
+   * @param postProcessExistingUsers true, to process existing users; false, otherwise
    */
-  public LdapSyncRequest(LdapSyncSpecEntity.SyncType type, Set<String> principalNames) {
-    this.type  = type;
+  public LdapSyncRequest(LdapSyncSpecEntity.SyncType type, Set<String> principalNames, boolean postProcessExistingUsers) {
+    this.type = type;
     this.principalNames = principalNames == null ? new HashSet<>() : principalNames;
+    this.postProcessExistingUsers = postProcessExistingUsers;
   }
 
   /**
@@ -57,9 +65,8 @@ public class LdapSyncRequest {
    *
    * @param type  the request type
    */
-  public LdapSyncRequest(LdapSyncSpecEntity.SyncType type) {
-    this.principalNames = new HashSet<>();
-    this.type  = type;
+  public LdapSyncRequest(LdapSyncSpecEntity.SyncType type, boolean postProcessExistingUsers) {
+    this(type, null, postProcessExistingUsers);
   }
 
 
@@ -90,5 +97,15 @@ public class LdapSyncRequest {
    */
   public LdapSyncSpecEntity.SyncType getType() {
     return type;
+  }
+
+  /**
+   * Gets whether to (re)exectue the post user creation hook on previously existing users
+   * (if the post user creation hook feature has been enabled), on not.
+   *
+   * @return true, to process existing users; false, otherwise
+   */
+  public boolean getPostProcessExistingUsers() {
+    return postProcessExistingUsers;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/LdapSyncSpecEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/LdapSyncSpecEntity.java
@@ -40,20 +40,27 @@ public class LdapSyncSpecEntity {
    */
   private List<String> principalNames;
 
+  /**
+   * A Boolean value indicating whether to (re)exectue the post user creation hook on previously
+   * existing users (if the post user creation hook feature has been enabled)
+   */
+  private boolean postProcessExistingUsers;
 
   // ----- Constructors ------------------------------------------------------
 
   /**
    * Construct an LdapSyncSpecEntity.
    *
-   * @param principalType   the principal type
-   * @param syncType        the sync type
-   * @param principalNames  the list of principal names; may not be null
+   * @param principalType            the principal type
+   * @param syncType                 the sync type
+   * @param principalNames           the list of principal names; may not be null
+   * @param postProcessExistingUsers true, to process existing users; false, otherwise
    */
-  public LdapSyncSpecEntity(PrincipalType principalType, SyncType syncType, List<String> principalNames) {
+  public LdapSyncSpecEntity(PrincipalType principalType, SyncType syncType, List<String> principalNames, boolean postProcessExistingUsers) {
     this.principalType  = principalType;
     this.syncType       = syncType;
     this.principalNames = principalNames;
+    this.postProcessExistingUsers = postProcessExistingUsers;
 
     assert principalNames != null;
 
@@ -96,6 +103,16 @@ public class LdapSyncSpecEntity {
    */
   public List<String> getPrincipalNames() {
     return principalNames;
+  }
+
+  /**
+   * Gets whether to execute the post user creation hook on previously existing users
+   * (if the post user creation hook feature has been enabled), on not.
+   *
+   * @return true, to process existing users; false, otherwise
+   */
+  public boolean getPostProcessExistingUsers() {
+    return postProcessExistingUsers;
   }
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/Users.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authorization/Users.java
@@ -310,11 +310,28 @@ public class Users {
     userDAO.create(userEntity);
 
     // execute user initialization hook if required ()
-    hookServiceProvider.get().execute(hookContextFactory.createUserHookContext(validatedUserName));
+    executeUserHook(validatedUserName);
 
     return userEntity;
   }
 
+  /**
+   * Triggers the post user creation hook, if enabled
+   *
+   * @param username the username of the user to process
+   */
+  public void executeUserHook(String username) {
+    hookServiceProvider.get().execute(hookContextFactory.createUserHookContext(username));
+  }
+
+  /**
+   * Triggers the post user creation hook, if enabled
+   *
+   * @param userGroupsMap a map of user names to relevant groups
+   */
+  public void executeUserHook(Map<String, Set<String>> userGroupsMap) {
+    hookServiceProvider.get().execute(hookContextFactory.createBatchUserHookContext(userGroupsMap));
+  }
 
   /**
    * Removes a user from the Ambari database.

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/ldap/LdapBatchDto.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/ldap/LdapBatchDto.java
@@ -29,6 +29,7 @@ public class LdapBatchDto {
   private final Set<LdapGroupDto> groupsToBeRemoved = new HashSet<>();
   private final Set<LdapGroupDto> groupsProcessedInternal = new HashSet<>();
   private final Set<LdapUserDto> usersSkipped = new HashSet<>();
+  private final Set<LdapUserDto> usersIgnored = new HashSet<>();
   private final Set<LdapUserDto> usersToBecomeLdap = new HashSet<>();
   private final Set<LdapUserDto> usersToBeCreated = new HashSet<>();
   private final Set<LdapUserDto> usersToBeRemoved = new HashSet<>();
@@ -37,6 +38,10 @@ public class LdapBatchDto {
 
   public Set<LdapUserDto> getUsersSkipped() {
     return usersSkipped;
+  }
+
+  public Set<LdapUserDto> getUsersIgnored() {
+    return usersIgnored;
   }
 
   public Set<LdapGroupDto> getGroupsToBecomeLdap() {

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -539,6 +539,8 @@ def init_ldap_sync_parser_options(parser):
                     dest="ldap_sync_users")
   parser.add_option('--groups', default=None, help="LDAP sync groups option.  Specifies the path to a CSV file of group names to be synchronized.",
                     dest="ldap_sync_groups")
+  parser.add_option('--post-process-existing-users', action="store_true", default=False, help="While performing an LDAP sync, reprocess existing users by executing the post creation hook on them, if the feature is enabled",
+                    dest="ldap_sync_post_process_existing_users")
   parser.add_option('--ldap-sync-admin-name', default=None, help="Username for LDAP sync", dest="ldap_sync_admin_name")
   parser.add_option('--ldap-sync-admin-password', default=None, help="Password for LDAP sync", dest="ldap_sync_admin_password")
 

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -291,6 +291,11 @@ class LdapSyncOptions:
     except AttributeError:
       self.ldap_sync_admin_password = None
 
+    try:
+      self.ldap_sync_post_process_existing_users = options.ldap_sync_post_process_existing_users
+    except AttributeError:
+      self.ldap_sync_post_process_existing_users = False
+
   def no_ldap_sync_options_set(self):
     return not self.ldap_sync_all and not self.ldap_sync_existing and self.ldap_sync_users is None and self.ldap_sync_groups is None
 
@@ -416,6 +421,10 @@ def sync_ldap(options):
     if ldap_sync_options.ldap_sync_groups is not None:
       new_specs = [{"principal_type":"groups","sync_type":"specific","names":""}]
       get_ldap_event_spec_names(ldap_sync_options.ldap_sync_groups, specs, new_specs)
+
+  if ldap_sync_options.ldap_sync_post_process_existing_users:
+    for spec in bodies[0]["Event"]["specs"]:
+      spec["post_process_existing_users"] = "true"
 
   if get_verbose():
     sys.stdout.write('\nCalling API ' + url + ' : ' + str(bodies) + '\n')

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/LdapSyncRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/LdapSyncRequestTest.java
@@ -34,7 +34,7 @@ public class LdapSyncRequestTest {
     Set<String> names = new HashSet<>();
     names.add("name1");
 
-    LdapSyncRequest request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC,names);
+    LdapSyncRequest request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC,names, false);
 
     names = new HashSet<>();
     names.add("name2");
@@ -56,7 +56,7 @@ public class LdapSyncRequestTest {
     names.add("name2");
     names.add("name3");
 
-    LdapSyncRequest request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC,names);
+    LdapSyncRequest request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC,names, false);
 
     Set<String> principalNames = request.getPrincipalNames();
     Assert.assertEquals(3, principalNames.size());
@@ -69,16 +69,46 @@ public class LdapSyncRequestTest {
   public void testGetType() throws Exception {
     Set<String> names = new HashSet<>();
 
-    LdapSyncRequest request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC, names);
+    LdapSyncRequest request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC, names, false);
 
     Assert.assertEquals(LdapSyncSpecEntity.SyncType.SPECIFIC, request.getType());
 
-    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.ALL);
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.ALL, false);
 
     Assert.assertEquals(LdapSyncSpecEntity.SyncType.ALL, request.getType());
 
-    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.EXISTING);
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.EXISTING, false);
 
     Assert.assertEquals(LdapSyncSpecEntity.SyncType.EXISTING, request.getType());
   }
-}
+
+  @Test
+  public void testGetPostProcessExistingUsers() throws Exception {
+    Set<String> names = new HashSet<>();
+
+    LdapSyncRequest request;
+
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC, names, false);
+
+    Assert.assertFalse(request.getPostProcessExistingUsers());
+
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.SPECIFIC, names, true);
+
+    Assert.assertTrue(request.getPostProcessExistingUsers());
+
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.ALL, false);
+
+    Assert.assertFalse(request.getPostProcessExistingUsers());
+
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.ALL, true);
+
+    Assert.assertTrue(request.getPostProcessExistingUsers());
+
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.EXISTING, false);
+
+    Assert.assertFalse(request.getPostProcessExistingUsers());
+
+    request = new LdapSyncRequest(LdapSyncSpecEntity.SyncType.EXISTING, true);
+
+    Assert.assertTrue(request.getPostProcessExistingUsers());
+  }}

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/entities/LdapSyncEventEntityTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/entities/LdapSyncEventEntityTest.java
@@ -63,7 +63,7 @@ public class LdapSyncEventEntityTest {
   public void testSetGetSpecs() throws Exception {
     LdapSyncEventEntity event = new LdapSyncEventEntity(1L);
     LdapSyncSpecEntity spec = new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.GROUPS,
-        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList());
+        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList(), false);
 
     event.setSpecs(Collections.singletonList(spec));
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/entities/LdapSyncSpecEntityTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/entities/LdapSyncSpecEntityTest.java
@@ -32,22 +32,22 @@ public class LdapSyncSpecEntityTest {
   @Test
   public void testGetPrincipalType() throws Exception {
     LdapSyncSpecEntity entity = new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList());
+        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList(), false);
     Assert.assertEquals(LdapSyncSpecEntity.PrincipalType.USERS, entity.getPrincipalType());
 
     entity = new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.GROUPS,
-        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList());
+        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList(), false);
     Assert.assertEquals(LdapSyncSpecEntity.PrincipalType.GROUPS, entity.getPrincipalType());
   }
 
   @Test
   public void testGetSyncType() throws Exception {
     LdapSyncSpecEntity entity = new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList());
+        LdapSyncSpecEntity.SyncType.ALL, Collections.emptyList(), false);
     Assert.assertEquals(LdapSyncSpecEntity.SyncType.ALL, entity.getSyncType());
 
     entity = new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-        LdapSyncSpecEntity.SyncType.EXISTING, Collections.emptyList());
+        LdapSyncSpecEntity.SyncType.EXISTING, Collections.emptyList(), false);
     Assert.assertEquals(LdapSyncSpecEntity.SyncType.EXISTING, entity.getSyncType());
   }
 
@@ -58,7 +58,7 @@ public class LdapSyncSpecEntityTest {
     names.add("fred");
 
     LdapSyncSpecEntity entity = new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-        LdapSyncSpecEntity.SyncType.SPECIFIC, names);
+        LdapSyncSpecEntity.SyncType.SPECIFIC, names, false);
     Assert.assertEquals(names, entity.getPrincipalNames());
   }
 
@@ -66,7 +66,7 @@ public class LdapSyncSpecEntityTest {
   public void testIllegalConstruction() throws Exception {
     try {
       new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-          LdapSyncSpecEntity.SyncType.SPECIFIC, Collections.emptyList());
+          LdapSyncSpecEntity.SyncType.SPECIFIC, Collections.emptyList(), false);
       Assert.fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // expected
@@ -78,7 +78,7 @@ public class LdapSyncSpecEntityTest {
 
     try {
       new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-          LdapSyncSpecEntity.SyncType.ALL, names);
+          LdapSyncSpecEntity.SyncType.ALL, names, false);
       Assert.fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // expected
@@ -86,7 +86,7 @@ public class LdapSyncSpecEntityTest {
 
     try {
       new LdapSyncSpecEntity(LdapSyncSpecEntity.PrincipalType.USERS,
-          LdapSyncSpecEntity.SyncType.EXISTING, names);
+          LdapSyncSpecEntity.SyncType.EXISTING, names, false);
       Assert.fail("expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       // expected

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/AmbariLdapDataPopulatorTest.java
@@ -292,7 +292,7 @@ public class AmbariLdapDataPopulatorTest {
     expect(populator.getLdapGroups("group2")).andReturn(Collections.emptySet());
     LdapGroupDto externalGroup1 = createNiceMock(LdapGroupDto.class);
     LdapBatchDto batchInfo = new LdapBatchDto();
-    populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+    populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup1), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
     expectLastCall();
     expect(populator.getLdapGroups("group4")).andReturn(Collections.singleton(externalGroup1));
     expect(populator.getLdapGroups("group5")).andReturn(Collections.emptySet());
@@ -301,7 +301,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeExistingLdapGroups(batchInfo);
+    LdapBatchDto result = populator.synchronizeExistingLdapGroups(batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBeRemoved(), Sets.newHashSet("group2", "group5"));
     assertTrue(result.getGroupsToBecomeLdap().isEmpty());
@@ -364,7 +364,7 @@ public class AmbariLdapDataPopulatorTest {
 
     replay(dataPopulator);
     // WHEN
-    dataPopulator.synchronizeExistingLdapGroups(batchInfo);
+    dataPopulator.synchronizeExistingLdapGroups(batchInfo, false);
     // THEN
     verify(dataPopulator, group1, group2);
 
@@ -421,14 +421,14 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup3, externalGroup4);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup),
-          EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
     populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup1),
-        EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+        EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
     expectLastCall();
     populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup2), EasyMock.anyObject(),
-        EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+        EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
     expectLastCall();
     expect(populator.getLdapGroups("x*")).andReturn(externalGroups);
     expect(populator.getLdapGroups("group1")).andReturn(Collections.singleton(externalGroup1));
@@ -438,7 +438,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeLdapGroups(createSet("x*", "group1", "group2"), batchInfo);
+    LdapBatchDto result = populator.synchronizeLdapGroups(createSet("x*", "group1", "group2"), batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBecomeLdap(), Sets.newHashSet("group1"));
     verifyGroupsInSet(result.getGroupsToBeCreated(), Sets.newHashSet("xgroup1", "xgroup2"));
@@ -504,11 +504,11 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup3, externalGroup4);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup), EasyMock.anyObject(), EasyMock.anyObject(),
-          EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
     populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup2), EasyMock.anyObject(),
-        EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+        EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
     expectLastCall();
     expect(populator.getLdapGroups("x*")).andReturn(externalGroups);
     expect(populator.getLdapGroups("group2")).andReturn(Collections.singleton(externalGroup2));
@@ -517,7 +517,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeLdapGroups(createSet("x*", "group2"), batchInfo);
+    LdapBatchDto result = populator.synchronizeLdapGroups(createSet("x*", "group2"), batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBeCreated(), Sets.newHashSet("xgroup1", "xgroup2"));
     assertTrue(result.getGroupsToBeRemoved().isEmpty());
@@ -581,7 +581,7 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup1, externalGroup2, externalGroup3, externalGroup4);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup), EasyMock.anyObject(),
-          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
     expect(populator.getLdapGroups("group*")).andReturn(externalGroups);
@@ -590,7 +590,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeLdapGroups(createSet("group*"), batchInfo);
+    LdapBatchDto result = populator.synchronizeLdapGroups(createSet("group*"), batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBecomeLdap(), Sets.newHashSet("group1", "group4"));
     assertTrue(result.getGroupsToBeCreated().isEmpty());
@@ -660,7 +660,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    populator.synchronizeLdapGroups(createSet("x*", "group1", "group2"), batchInfo);
+    populator.synchronizeLdapGroups(createSet("x*", "group1", "group2"), batchInfo, false);
   }
 
   @SuppressWarnings("unchecked")
@@ -716,7 +716,7 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup1, externalGroup2, externalGroup3, externalGroup4);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup), EasyMock.anyObject(),
-          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
 
@@ -727,7 +727,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo);
+    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBeRemoved(), Sets.newHashSet("group2"));
     verifyGroupsInSet(result.getGroupsToBecomeLdap(), Sets.newHashSet("group3"));
@@ -777,7 +777,7 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup1, externalGroup2);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup), EasyMock.anyObject(),
-          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
     expect(populator.getExternalLdapGroupInfo()).andReturn(externalGroups);
@@ -787,7 +787,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo);
+    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBeCreated(), Sets.newHashSet("group3", "group4"));
     assertTrue(result.getGroupsToBecomeLdap().isEmpty());
@@ -843,7 +843,7 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup1);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup), EasyMock.anyObject(),
-          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
     expect(populator.getExternalLdapGroupInfo()).andReturn(externalGroups);
@@ -853,7 +853,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo);
+    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBeRemoved(), Sets.newHashSet("group2", "group4"));
     assertTrue(result.getGroupsToBeCreated().isEmpty());
@@ -908,7 +908,7 @@ public class AmbariLdapDataPopulatorTest {
     Set<LdapGroupDto> externalGroups = createSet(externalGroup1, externalGroup2);
     for (LdapGroupDto externalGroup : externalGroups) {
       populator.refreshGroupMembers(eq(batchInfo), eq(externalGroup), EasyMock.anyObject(),
-          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean());
+          EasyMock.anyObject(), EasyMock.anyObject(), anyBoolean(), eq(false));
       expectLastCall();
     }
     expect(populator.getExternalLdapGroupInfo()).andReturn(externalGroups);
@@ -918,7 +918,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo);
+    LdapBatchDto result = populator.synchronizeAllLdapGroups(batchInfo, false);
 
     verifyGroupsInSet(result.getGroupsToBecomeLdap(), Sets.newHashSet("group2", "group3"));
     assertTrue(result.getGroupsToBeCreated().isEmpty());
@@ -983,7 +983,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBeRemoved(), Sets.newHashSet("synced_user1"));
     verifyUsersInSet(result.getUsersToBeCreated(), Sets.newHashSet("external_user1", "external_user2"));
@@ -1044,7 +1044,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersSkipped(), Sets.newHashSet("local1", "local2"));
     assertTrue(result.getUsersToBeCreated().isEmpty());
@@ -1098,7 +1098,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBeCreated(), Sets.newHashSet("user3", "user4"));
     assertTrue(result.getUsersToBecomeLdap().isEmpty());
@@ -1150,7 +1150,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBeRemoved(), Sets.newHashSet("user3", "user1"));
     assertTrue(result.getUsersToBecomeLdap().isEmpty());
@@ -1210,7 +1210,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeAllLdapUsers(new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBecomeLdap(), Sets.newHashSet("user3"));
     assertTrue(result.getUsersToBeRemoved().isEmpty());
@@ -1265,7 +1265,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeExistingLdapUsers(new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeExistingLdapUsers(new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBeRemoved(), Sets.newHashSet("synced_user1"));
     assertTrue(result.getUsersToBeCreated().isEmpty());
@@ -1332,7 +1332,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeLdapUsers(createSet("user1", "user2", "xuser*"), new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeLdapUsers(createSet("user1", "user2", "xuser*"), new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBeCreated(), Sets.newHashSet("xuser3", "xuser4"));
     verifyUsersInSet(result.getUsersToBecomeLdap(), Sets.newHashSet("user1"));
@@ -1396,7 +1396,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeLdapUsers(createSet("user2", "xuser*"), new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeLdapUsers(createSet("user2", "xuser*"), new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBeCreated(), Sets.newHashSet("xuser3", "xuser4"));
     assertTrue(result.getUsersToBecomeLdap().isEmpty());
@@ -1461,7 +1461,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    LdapBatchDto result = populator.synchronizeLdapUsers(createSet("user2", "user1", "user6"), new LdapBatchDto());
+    LdapBatchDto result = populator.synchronizeLdapUsers(createSet("user2", "user1", "user6"), new LdapBatchDto(), false);
 
     verifyUsersInSet(result.getUsersToBecomeLdap(), Sets.newHashSet("user1", "user6"));
     assertTrue(result.getUsersToBeCreated().isEmpty());
@@ -1510,7 +1510,7 @@ public class AmbariLdapDataPopulatorTest {
     populator.setLdapTemplate(ldapTemplate);
     populator.setLdapServerProperties(ldapServerProperties);
 
-    populator.synchronizeLdapUsers(createSet("user1", "user2", "xuser*"), new LdapBatchDto());
+    populator.synchronizeLdapUsers(createSet("user1", "user2", "xuser*"), new LdapBatchDto(), false);
   }
 
   @SuppressWarnings("unchecked")
@@ -1593,7 +1593,7 @@ public class AmbariLdapDataPopulatorTest {
     Map<String, Group> internalGroups = new HashMap<>();
     internalGroups.put("group2", group2);
 
-    populator.refreshGroupMembers(batchInfo, externalGroup, internalUsers, internalGroups, null, true);
+    populator.refreshGroupMembers(batchInfo, externalGroup, internalUsers, internalGroups, null, true, false);
 
     verifyMembershipInSet(batchInfo.getMembershipToAdd(), Sets.newHashSet("user1", "user2", "user6"));
     verifyMembershipInSet(batchInfo.getMembershipToRemove(), Sets.newHashSet("user3", "user4"));

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/LdapPerformanceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/ldap/LdapPerformanceTest.java
@@ -104,14 +104,14 @@ public class LdapPerformanceTest {
     System.out.println("Data fetch: " + (System.currentTimeMillis() - time));
     time = System.currentTimeMillis();
     LdapBatchDto batchDto = new LdapBatchDto();
-    populator.synchronizeLdapUsers(userNames, batchDto);
-    populator.synchronizeLdapGroups(groupNames, batchDto);
+    populator.synchronizeLdapUsers(userNames, batchDto, false);
+    populator.synchronizeLdapGroups(groupNames, batchDto, false);
     this.users.processLdapSync(batchDto);
     System.out.println("Initial sync: " + (System.currentTimeMillis() - time));
     time = System.currentTimeMillis();
     batchDto = new LdapBatchDto();
-    populator.synchronizeLdapUsers(userNames, batchDto);
-    populator.synchronizeLdapGroups(groupNames, batchDto);
+    populator.synchronizeLdapUsers(userNames, batchDto, false);
+    populator.synchronizeLdapGroups(groupNames, batchDto, false);
     this.users.processLdapSync(batchDto);
     System.out.println("Subsequent sync: " + (System.currentTimeMillis() - time));
   }

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -7769,6 +7769,7 @@ class TestAmbariServer(TestCase):
     options = self._create_empty_options_mock()
     options.ldap_sync_all = True
     options.ldap_sync_existing = False
+    options.ldap_sync_post_process_existing_users = False
 
     sync_ldap(options)
 
@@ -7777,6 +7778,49 @@ class TestAmbariServer(TestCase):
 
     self.assertEquals(url, str(request.get_full_url()))
     self.assertEquals('[{"Event": {"specs": [{"principal_type": "users", "sync_type": "all"}, {"principal_type": "groups", "sync_type": "all"}]}}]', request.data)
+
+    self.assertTrue(response.getcode.called)
+    self.assertTrue(response.read.called)
+    pass
+
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
+  @patch("ambari_server.setupSecurity.is_ldap_enabled")
+  @patch("ambari_server.setupSecurity.is_server_runing")
+  @patch("ambari_server.setupSecurity.is_root")
+  @patch("ambari_server.setupSecurity.logger")
+  def test_ldap_sync_all_post_process_existing_users(self, logger_mock, is_root_method, is_server_runing_mock, is_ldap_enabled_mock, get_ambari_properties_mock,
+      get_validated_string_input_mock, urlopen_mock):
+
+    is_root_method.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
+    is_ldap_enabled_mock.return_value = 'true'
+    properties = Properties()
+    properties.process_pair(CLIENT_API_PORT_PROPERTY, '8080')
+    get_ambari_properties_mock.return_value = properties
+    get_validated_string_input_mock.side_effect = ['admin', 'admin']
+
+    response = MagicMock()
+    response.getcode.side_effect = [201, 200, 200]
+    response.read.side_effect = ['{"resources" : [{"href" : "http://c6401.ambari.apache.org:8080/api/v1/ldap_sync_events/16","Event" : {"id" : 16}}]}',
+                          '{"Event":{"status" : "RUNNING","summary" : {"groups" : {"created" : 0,"removed" : 0,"updated" : 0},"memberships" : {"created" : 0,"removed" : 0},"users" : {"created" : 0,"removed" : 0,"updated" : 0}}}}',
+                          '{"Event":{"status" : "COMPLETE","summary" : {"groups" : {"created" : 1,"removed" : 0,"updated" : 0},"memberships" : {"created" : 5,"removed" : 0},"users" : {"created" : 5,"removed" : 0,"updated" : 0}}}}']
+
+    urlopen_mock.return_value = response
+
+    options = self._create_empty_options_mock()
+    options.ldap_sync_all = True
+    options.ldap_sync_existing = False
+    options.ldap_sync_post_process_existing_users = True
+
+    sync_ldap(options)
+
+    url = '{0}://{1}:{2!s}{3}'.format('http', '127.0.0.1', '8080', '/api/v1/ldap_sync_events')
+    request = urlopen_mock.call_args_list[0][0][0]
+
+    self.assertEquals(url, str(request.get_full_url()))
+    self.assertEquals('[{"Event": {"specs": [{"post_process_existing_users": "true", "principal_type": "users", "sync_type": "all"}, {"post_process_existing_users": "true", "principal_type": "groups", "sync_type": "all"}]}}]', request.data)
 
     self.assertTrue(response.getcode.called)
     self.assertTrue(response.read.called)
@@ -7817,12 +7861,60 @@ class TestAmbariServer(TestCase):
     options.ldap_sync_existing = False
     options.ldap_sync_users = 'users.txt'
     options.ldap_sync_groups = None
+    options.ldap_sync_post_process_existing_users = False
 
     sync_ldap(options)
 
     request = urlopen_mock.call_args_list[0][0][0]
 
     self.assertEquals('[{"Event": {"specs": [{"principal_type": "users", "sync_type": "specific", "names": "bob, tom"}]}}]', request.data)
+
+    self.assertTrue(response.getcode.called)
+    self.assertTrue(response.read.called)
+    pass
+
+  @patch("__builtin__.open")
+  @patch("os.path.exists")
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
+  @patch("ambari_server.setupSecurity.is_ldap_enabled")
+  @patch("ambari_server.setupSecurity.is_server_runing")
+  @patch("ambari_server.setupSecurity.is_root")
+  @patch("ambari_server.setupSecurity.logger")
+  def test_ldap_sync_users_post_process_existing_users(self, logger_mock, is_root_method, is_server_runing_mock, is_ldap_enabled_mock, get_ambari_properties_mock,
+                         get_validated_string_input_mock, urlopen_mock, os_path_exists_mock, open_mock):
+
+    os_path_exists_mock.return_value = 1
+    f = MagicMock()
+    f.__enter__().read.return_value = "bob, tom"
+
+    open_mock.return_value = f
+    is_root_method.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
+    is_ldap_enabled_mock.return_value = 'true'
+    get_validated_string_input_mock.side_effect = ['admin', 'admin']
+
+    response = MagicMock()
+    response.getcode.side_effect = [201, 200, 200]
+    response.read.side_effect = ['{"resources" : [{"href" : "http://c6401.ambari.apache.org:8080/api/v1/ldap_sync_events/16","Event" : {"id" : 16}}]}',
+                                 '{"Event":{"status" : "RUNNING","summary" : {"groups" : {"created" : 0,"removed" : 0,"updated" : 0},"memberships" : {"created" : 0,"removed" : 0},"users" : {"created" : 0,"removed" : 0,"updated" : 0}}}}',
+                                 '{"Event":{"status" : "COMPLETE","summary" : {"groups" : {"created" : 1,"removed" : 0,"updated" : 0},"memberships" : {"created" : 5,"removed" : 0},"users" : {"created" : 5,"removed" : 0,"updated" : 0}}}}']
+
+    urlopen_mock.return_value = response
+
+    options = self._create_empty_options_mock()
+    options.ldap_sync_all = False
+    options.ldap_sync_existing = False
+    options.ldap_sync_users = 'users.txt'
+    options.ldap_sync_groups = None
+    options.ldap_sync_post_process_existing_users = True
+
+    sync_ldap(options)
+
+    request = urlopen_mock.call_args_list[0][0][0]
+
+    self.assertEquals('[{"Event": {"specs": [{"post_process_existing_users": "true", "principal_type": "users", "sync_type": "specific", "names": "bob, tom"}]}}]', request.data)
 
     self.assertTrue(response.getcode.called)
     self.assertTrue(response.read.called)
@@ -7863,12 +7955,60 @@ class TestAmbariServer(TestCase):
     options.ldap_sync_existing = False
     options.ldap_sync_users = None
     options.ldap_sync_groups = 'groups.txt'
+    options.ldap_sync_post_process_existing_users = False
 
     sync_ldap(options)
 
     request = urlopen_mock.call_args_list[0][0][0]
 
     self.assertEquals('[{"Event": {"specs": [{"principal_type": "groups", "sync_type": "specific", "names": "group1, group2"}]}}]', request.data)
+
+    self.assertTrue(response.getcode.called)
+    self.assertTrue(response.read.called)
+    pass
+
+  @patch("__builtin__.open")
+  @patch("os.path.exists")
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
+  @patch("ambari_server.setupSecurity.is_ldap_enabled")
+  @patch("ambari_server.setupSecurity.is_server_runing")
+  @patch("ambari_server.setupSecurity.is_root")
+  @patch("ambari_server.setupSecurity.logger")
+  def test_ldap_sync_groups_post_process_existing_users(self, logger_mock, is_root_method, is_server_runing_mock, is_ldap_enabled_mock, get_ambari_properties_mock,
+                           get_validated_string_input_mock, urlopen_mock, os_path_exists_mock, open_mock):
+
+    os_path_exists_mock.return_value = 1
+    f = MagicMock()
+    f.__enter__().read.return_value = "group1, group2"
+
+    open_mock.return_value = f
+    is_root_method.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
+    is_ldap_enabled_mock.return_value = 'true'
+    get_validated_string_input_mock.side_effect = ['admin', 'admin']
+
+    response = MagicMock()
+    response.getcode.side_effect = [201, 200, 200]
+    response.read.side_effect = ['{"resources" : [{"href" : "http://c6401.ambari.apache.org:8080/api/v1/ldap_sync_events/16","Event" : {"id" : 16}}]}',
+                                 '{"Event":{"status" : "RUNNING","summary" : {"groups" : {"created" : 0,"removed" : 0,"updated" : 0},"memberships" : {"created" : 0,"removed" : 0},"users" : {"created" : 0,"removed" : 0,"updated" : 0}}}}',
+                                 '{"Event":{"status" : "COMPLETE","summary" : {"groups" : {"created" : 1,"removed" : 0,"updated" : 0},"memberships" : {"created" : 5,"removed" : 0},"users" : {"created" : 5,"removed" : 0,"updated" : 0}}}}']
+
+    urlopen_mock.return_value = response
+
+    options = self._create_empty_options_mock()
+    options.ldap_sync_all = False
+    options.ldap_sync_existing = False
+    options.ldap_sync_users = None
+    options.ldap_sync_groups = 'groups.txt'
+    options.ldap_sync_post_process_existing_users = True
+
+    sync_ldap(options)
+
+    request = urlopen_mock.call_args_list[0][0][0]
+
+    self.assertEquals('[{"Event": {"specs": [{"post_process_existing_users": "true", "principal_type": "groups", "sync_type": "specific", "names": "group1, group2"}]}}]', request.data)
 
     self.assertTrue(response.getcode.called)
     self.assertTrue(response.read.called)
@@ -7948,8 +8088,54 @@ class TestAmbariServer(TestCase):
     options.ldap_sync_existing = True
     options.ldap_sync_users = None
     options.ldap_sync_groups = None
+    options.ldap_sync_post_process_existing_users = False
 
     sync_ldap(options)
+
+    request = urlopen_mock.call_args_list[0][0][0]
+
+    self.assertEquals('[{"Event": {"specs": [{"principal_type": "users", "sync_type": "existing"}, {"principal_type": "groups", "sync_type": "existing"}]}}]', request.data)
+
+    self.assertTrue(response.getcode.called)
+    self.assertTrue(response.read.called)
+    pass
+
+  @patch("urllib2.urlopen")
+  @patch("ambari_server.setupSecurity.get_validated_string_input")
+  @patch("ambari_server.setupSecurity.get_ambari_properties")
+  @patch("ambari_server.setupSecurity.is_ldap_enabled")
+  @patch("ambari_server.setupSecurity.is_server_runing")
+  @patch("ambari_server.setupSecurity.is_root")
+  @patch("ambari_server.setupSecurity.logger")
+  def test_ldap_sync_existing_post_process_existing_users(self, logger_mock, is_root_method, is_server_runing_mock, is_ldap_enabled_mock, get_ambari_properties_mock,
+                         get_validated_string_input_mock, urlopen_mock):
+
+    is_root_method.return_value = True
+    is_server_runing_mock.return_value = (True, 0)
+    is_ldap_enabled_mock.return_value = 'true'
+    get_ambari_properties_mock.return_value = Properties()
+    get_validated_string_input_mock.side_effect = ['admin', 'admin']
+
+    response = MagicMock()
+    response.getcode.side_effect = [201, 200, 200]
+    response.read.side_effect = ['{"resources" : [{"href" : "http://c6401.ambari.apache.org:8080/api/v1/ldap_sync_events/16","Event" : {"id" : 16}}]}',
+                                 '{"Event":{"status" : "RUNNING","summary" : {"groups" : {"created" : 0,"removed" : 0,"updated" : 0},"memberships" : {"created" : 0,"removed" : 0},"users" : {"created" : 0,"removed" : 0,"updated" : 0}}}}',
+                                 '{"Event":{"status" : "COMPLETE","summary" : {"groups" : {"created" : 1,"removed" : 0,"updated" : 0},"memberships" : {"created" : 5,"removed" : 0},"users" : {"created" : 5,"removed" : 0,"updated" : 0}}}}']
+
+    urlopen_mock.return_value = response
+
+    options = self._create_empty_options_mock()
+    options.ldap_sync_all = False
+    options.ldap_sync_existing = True
+    options.ldap_sync_users = None
+    options.ldap_sync_groups = None
+    options.ldap_sync_post_process_existing_users = True
+
+    sync_ldap(options)
+
+    request = urlopen_mock.call_args_list[0][0][0]
+
+    self.assertEquals('[{"Event": {"specs": [{"post_process_existing_users": "true", "principal_type": "users", "sync_type": "existing"}, {"post_process_existing_users": "true", "principal_type": "groups", "sync_type": "existing"}]}}]', request.data)
 
     self.assertTrue(response.getcode.called)
     self.assertTrue(response.read.called)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optionally execute the post user creation hook on existing users during LDAP sync.

The post user creation hook is executed on users when created or imported into Ambari. This hook is executed given the following criteria is met:

1. The post user creation hook is enabled (ambari.properties - `ambari.post.user.creation.hook.enabled = true,` default: `false`)
2. The post user creation hook is set and available (ambari.properties - `ambari.post.user.creation.hook = <path to script>`, default: `/var/lib/ambari-server/resources/scripts/post-user-creation-hook.sh`)
3. HDFS is installed and running.

It is possible to have executed the LDAP sync process before all of the criteria has been met. Therefore, it would be beneficial to trigger the post user creation hook to be executed on these users when the criteria has been met.

To do this, an optional property should be set on the LDAP sync request - post_process_existing_users. The post_process_existing_users property is part of a "spec" object and should be set to either "true" or "false", if set at all. If set to "true", the post user creation hook will be executed on all user's that come back from the LDAP query that also exist in the Ambari database as LDAP users.

Example REST API calls:
**Sync All Users and Groups**
```
POST /api/v1/ldap_sync_events
[
  {
    "Event": {
      "specs": [
        {
          "principal_type": "users",
          "sync_type": "all",
          "post_process_existing_users" : "true"
        },
        {
          "principal_type": "groups",
          "sync_type": "all",
          "post_process_existing_users" : "true"
        }
      ]
    }
  }
]
```
**Sync Specific Users**
```
POST /api/v1/ldap_sync_events
[
  {
    "Event": {
      "specs": [
        {
          "principal_type": "users",
          "sync_type": "specific",
          "names" : "user1, user2, user3",
          "post_process_existing_users" : "true"
        }
      ]
    }
  }
]
```
**Sync Specific Groups**
```
POST /api/v1/ldap_sync_events
[
  {
    "Event": {
      "specs": [
        {
          "principal_type": "groups",
          "sync_type": "specific",
          "names" : "hadoop_users, hadoop_admins",
          "post_process_existing_users" : "true"
        }
      ]
    }
  }
]
```

Using the Ambari sync-ldap CLI, an optional argument named "--post-process-existing-users" may be added to enable this feature.

Example CLI calls:
**Sync All Users and Groups**
```
ambari-server sync-ldap --all --post-process-existing-users
```
**Sync Specific Users**
```
ambari-server sync-ldap --users users.txt --post-process-existing-users
```
**Sync Specific Groups**
```
ambari-server sync-ldap --groups groups.txt --post-process-existing-users
```

## How was this patch tested?

Manually tested various scenarios.

Unit tests updated and passed. 


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.