### PR TITLE
AMBARI-25063. Restarting Ambari Server Fails Due to Recursive Injection of STOMPUpdatePublisher.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/BufferedUpdateEventPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/BufferedUpdateEventPublisher.java
@@ -20,21 +20,28 @@ package org.apache.ambari.server.events.publishers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.eventbus.EventBus;
-import com.google.inject.Singleton;
+import org.apache.ambari.server.events.STOMPEvent;
 
-@Singleton
+import com.google.common.eventbus.EventBus;
+
 public abstract class BufferedUpdateEventPublisher<T> {
 
   private static final long TIMEOUT = 1000L;
   private final ConcurrentLinkedQueue<T> buffer = new ConcurrentLinkedQueue<>();
 
+  public abstract STOMPEvent.Type getType();
+
   private ScheduledExecutorService scheduledExecutorService;
+
+  public BufferedUpdateEventPublisher(STOMPUpdatePublisher stompUpdatePublisher) {
+    stompUpdatePublisher.registerPublisher(this);
+  }
 
   public void publish(T event, EventBus m_eventBus) {
     if (scheduledExecutorService == null) {
@@ -76,5 +83,18 @@ public abstract class BufferedUpdateEventPublisher<T> {
       }
       mergeBufferAndPost(events, m_eventBus);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BufferedUpdateEventPublisher<?> that = (BufferedUpdateEventPublisher<?>) o;
+    return Objects.equals(getType(), that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getType());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/HostComponentUpdateEventPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/HostComponentUpdateEventPublisher.java
@@ -21,14 +21,26 @@ package org.apache.ambari.server.events.publishers;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.ambari.server.EagerSingleton;
 import org.apache.ambari.server.events.HostComponentUpdate;
 import org.apache.ambari.server.events.HostComponentsUpdateEvent;
+import org.apache.ambari.server.events.STOMPEvent;
 
 import com.google.common.eventbus.EventBus;
-import com.google.inject.Singleton;
+import com.google.inject.Inject;
 
-@Singleton
+@EagerSingleton
 public class HostComponentUpdateEventPublisher extends BufferedUpdateEventPublisher<HostComponentsUpdateEvent> {
+
+  @Inject
+  public HostComponentUpdateEventPublisher(STOMPUpdatePublisher stompUpdatePublisher) {
+    super(stompUpdatePublisher);
+  }
+
+  @Override
+  public STOMPEvent.Type getType() {
+    return STOMPEvent.Type.HOSTCOMPONENT;
+  }
 
   @Override
   public void mergeBufferAndPost(List<HostComponentsUpdateEvent> events, EventBus m_eventBus) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/RequestUpdateEventPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/RequestUpdateEventPublisher.java
@@ -22,8 +22,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ambari.server.EagerSingleton;
 import org.apache.ambari.server.controller.internal.CalculatedStatus;
 import org.apache.ambari.server.events.RequestUpdateEvent;
+import org.apache.ambari.server.events.STOMPEvent;
 import org.apache.ambari.server.orm.dao.ClusterDAO;
 import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
 import org.apache.ambari.server.orm.dao.RequestDAO;
@@ -32,9 +34,8 @@ import org.apache.ambari.server.topology.TopologyManager;
 
 import com.google.common.eventbus.EventBus;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 
-@Singleton
+@EagerSingleton
 public class RequestUpdateEventPublisher extends BufferedUpdateEventPublisher<RequestUpdateEvent> {
 
   @Inject
@@ -48,6 +49,16 @@ public class RequestUpdateEventPublisher extends BufferedUpdateEventPublisher<Re
 
   @Inject
   private ClusterDAO clusterDAO;
+
+  @Inject
+  public RequestUpdateEventPublisher(STOMPUpdatePublisher stompUpdatePublisher) {
+    super(stompUpdatePublisher);
+  }
+
+  @Override
+  public STOMPEvent.Type getType() {
+    return STOMPEvent.Type.REQUEST;
+  }
 
   @Override
   public void mergeBufferAndPost(List<RequestUpdateEvent> events, EventBus m_eventBus) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/ServiceUpdateEventPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/ServiceUpdateEventPublisher.java
@@ -23,18 +23,30 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ambari.server.EagerSingleton;
 import org.apache.ambari.server.controller.utilities.ServiceCalculatedStateFactory;
 import org.apache.ambari.server.controller.utilities.state.ServiceCalculatedState;
+import org.apache.ambari.server.events.STOMPEvent;
 import org.apache.ambari.server.events.ServiceUpdateEvent;
 import org.apache.ambari.server.state.State;
 
 import com.google.common.eventbus.EventBus;
-import com.google.inject.Singleton;
+import com.google.inject.Inject;
 
-@Singleton
+@EagerSingleton
 public class ServiceUpdateEventPublisher extends BufferedUpdateEventPublisher<ServiceUpdateEvent> {
   private Map<String, Map<String, State>> states = new HashMap<>();
 
+  @Inject
+  public ServiceUpdateEventPublisher(STOMPUpdatePublisher stompUpdatePublisher) {
+    super(stompUpdatePublisher);
+  }
+
+
+  @Override
+  public STOMPEvent.Type getType() {
+    return STOMPEvent.Type.SERVICE;
+  }
 
   @Override
   public void mergeBufferAndPost(List<ServiceUpdateEvent> events, EventBus eventBus) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cyclic injection was eliminated by inverting buffered publishers usage.

## How was this patch tested?

Manual testing.