### PR TITLE
[WIP] AMBARI-25043. Sensitive Ambari configuration values are encrypted in Ambari Server DB

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfiguration.java
@@ -75,16 +75,23 @@ public abstract class AmbariServerConfiguration {
   }
   
   /**
-   * @return
+   * @return this configuration represented as a map
    */
   public Map<String, String> toMap() {
     return new HashMap<>(configurationMap);
   }
-  
+
   /**
+   * Sets the given value for the given configuration
    * 
    * @param configName
+   *          the name of the configuration to set the value for
    * @param value
+   *          the new value
+   *
+   * @throws IllegalArgumentException
+   *           in case the supplied configuration does not belong to the
+   *           configuration category of this instance
    */
   public void setValueFor(String configName, String value) {
     AmbariServerConfigurationKey ambariServerConfigurationKey = AmbariServerConfigurationKey.translate(getCategory(), configName);
@@ -94,9 +101,16 @@ public abstract class AmbariServerConfiguration {
   }
 
   /**
+   * Sets the given value for the given configuration
    * 
    * @param ambariServerConfigurationKey
+   *          the configuration key to set the value for
    * @param value
+   *          the new value
+   *
+   * @throws IllegalArgumentException
+   *           in case the supplied configuration does not belong to the
+   *           configuration category of this instance
    */
   public void setValueFor(AmbariServerConfigurationKey ambariServerConfigurationKey, String value) {
     if (ambariServerConfigurationKey.getConfigurationCategory() != getCategory()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfiguration.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ambari.server.configuration;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -32,6 +33,14 @@ import org.slf4j.LoggerFactory;
 public abstract class AmbariServerConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AmbariServerConfiguration.class);
+  
+  protected final Map<String, String> configurationMap = new HashMap<>();
+
+  protected AmbariServerConfiguration(Map<String, String> configurationMap) {
+    if (configurationMap != null) {
+      this.configurationMap.putAll(configurationMap);
+    }
+  }
 
   /**
    * Gets the configuration value for given {@link AmbariServerConfigurationKey}.
@@ -64,5 +73,38 @@ public abstract class AmbariServerConfiguration {
       return defaultValue;
     }
   }
+  
+  /**
+   * @return
+   */
+  public Map<String, String> toMap() {
+    return new HashMap<>(configurationMap);
+  }
+  
+  /**
+   * 
+   * @param configName
+   * @param value
+   */
+  public void setValueFor(String configName, String value) {
+    AmbariServerConfigurationKey ambariServerConfigurationKey = AmbariServerConfigurationKey.translate(getCategory(), configName);
+    if (ambariServerConfigurationKey != null) {
+      setValueFor(ambariServerConfigurationKey, value);
+    }
+  }
+
+  /**
+   * 
+   * @param ambariServerConfigurationKey
+   * @param value
+   */
+  public void setValueFor(AmbariServerConfigurationKey ambariServerConfigurationKey, String value) {
+    if (ambariServerConfigurationKey.getConfigurationCategory() != getCategory()) {
+      throw new IllegalArgumentException(ambariServerConfigurationKey.key() + " is not a valid " + getCategory().getCategoryName());
+    }
+    configurationMap.put(ambariServerConfigurationKey.key(), value);
+  }
+  
+  protected abstract AmbariServerConfigurationCategory getCategory();
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKey.java
@@ -17,6 +17,10 @@ package org.apache.ambari.server.configuration;
 import static org.apache.ambari.server.configuration.ConfigurationPropertyType.PASSWORD;
 import static org.apache.ambari.server.configuration.ConfigurationPropertyType.PLAINTEXT;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,5 +165,9 @@ public enum AmbariServerConfigurationKey {
     String categoryName = (category == null) ? "null" : category.getCategoryName();
     LOG.warn("Invalid Ambari server configuration key: {}:{}", categoryName, keyName);
     return null;
+  }
+  
+  public static Set<String> findPasswordConfigurations() {
+      return Stream.of(AmbariServerConfigurationKey.values()).filter(k -> PASSWORD == k.getConfigurationPropertyType()).map(f -> f.propertyName).collect(Collectors.toSet());
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/AmbariServerConfigurationProvider.java
@@ -28,12 +28,14 @@ import org.apache.ambari.server.events.JpaInitializedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.name.Named;
 import com.google.inject.persist.jpa.AmbariJpaPersistService;
 
 /**
@@ -53,6 +55,9 @@ public abstract class AmbariServerConfigurationProvider<T extends AmbariServerCo
 
   @Inject
   private Provider<AmbariConfigurationDAO> ambariConfigurationDAOProvider;
+
+  @Inject @Named("AmbariServerConfigurationEncryptor")
+  private Encryptor<AmbariServerConfiguration> encryptor;
 
   private final AtomicBoolean jpaStarted = new AtomicBoolean(false);
 
@@ -84,6 +89,7 @@ public abstract class AmbariServerConfigurationProvider<T extends AmbariServerCo
     if (configurationCategory.getCategoryName().equalsIgnoreCase(event.getCategoryName())) {
       LOGGER.info("Ambari configuration changed event received: {}", event);
       instance = loadInstance();
+      
     }
   }
 
@@ -120,7 +126,9 @@ public abstract class AmbariServerConfigurationProvider<T extends AmbariServerCo
   private T loadInstance() {
     if (jpaStarted.get()) {
       LOGGER.info("Loading {} configuration data", configurationCategory.getCategoryName());
-      return loadInstance(ambariConfigurationDAOProvider.get().findByCategory(configurationCategory.getCategoryName()));
+      T instance = loadInstance(ambariConfigurationDAOProvider.get().findByCategory(configurationCategory.getCategoryName()));
+      encryptor.decryptSensitiveData(instance);
+      return instance;
     } else {
       LOGGER.info("Cannot load {} configuration data since JPA is not initialized", configurationCategory.getCategoryName());
       if (instance == null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
@@ -59,6 +59,7 @@ import org.apache.ambari.server.checks.DatabaseConsistencyCheckHelper;
 import org.apache.ambari.server.checks.UpgradeCheckRegistry;
 import org.apache.ambari.server.checks.UpgradeCheckRegistryProvider;
 import org.apache.ambari.server.cleanup.ClasspathScannerUtils;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.configuration.Configuration.ConnectionPoolType;
 import org.apache.ambari.server.configuration.Configuration.DatabaseType;
@@ -117,6 +118,7 @@ import org.apache.ambari.server.security.authorization.internal.InternalAuthenti
 import org.apache.ambari.server.security.authorization.internal.RunWithInternalSecurityContext;
 import org.apache.ambari.server.security.encryption.AESEncryptionService;
 import org.apache.ambari.server.security.encryption.AgentConfigUpdateEncryptor;
+import org.apache.ambari.server.security.encryption.AmbariServerConfigurationEncryptor;
 import org.apache.ambari.server.security.encryption.ConfigPropertiesEncryptor;
 import org.apache.ambari.server.security.encryption.CredentialStoreService;
 import org.apache.ambari.server.security.encryption.CredentialStoreServiceImpl;
@@ -341,9 +343,11 @@ public class ControllerModule extends AbstractModule {
     if (configuration.shouldEncryptSensitiveData()) {
       bind(new TypeLiteral<Encryptor<Config>>() {}).annotatedWith(Names.named("ConfigPropertiesEncryptor")).to(ConfigPropertiesEncryptor.class);
       bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).to(AgentConfigUpdateEncryptor.class);
+      bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).to(AmbariServerConfigurationEncryptor.class);
     } else {
       bind(new TypeLiteral<Encryptor<Config>>() {}).annotatedWith(Names.named("ConfigPropertiesEncryptor")).toInstance(Encryptor.NONE);
       bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
+      bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
     }
 
     bind(Configuration.class).toInstance(configuration);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandler.java
@@ -18,13 +18,9 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,15 +28,11 @@ import java.util.stream.Collectors;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
-import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
-import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.events.AmbariConfigurationChangedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
-import org.apache.ambari.server.security.encryption.CredentialProvider;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,15 +50,11 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
 
   private final AmbariConfigurationDAO ambariConfigurationDAO;
   private final AmbariEventPublisher publisher;
-  private final Configuration ambariConfiguration;
-
-  private CredentialProvider credentialProvider;
 
   @Inject
-  AmbariServerConfigurationHandler(AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher, Configuration ambariConfiguration) {
+  AmbariServerConfigurationHandler(AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher) {
     this.ambariConfigurationDAO = ambariConfigurationDAO;
     this.publisher = publisher;
-    this.ambariConfiguration = ambariConfiguration;
   }
 
   @Override
@@ -111,35 +99,20 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
 
   @Override
   public void updateComponentCategory(String categoryName, Map<String, String> properties, boolean removePropertiesIfNotSpecified) throws AmbariException {
-    boolean toBePublished = false;
-    final Iterator<Map.Entry<String, String>> propertiesIterator = properties.entrySet().iterator();
-    while (propertiesIterator.hasNext()) {
-      Map.Entry<String, String> property = propertiesIterator.next();
-
-      // Ensure the incoming property is valid
-      AmbariServerConfigurationKey key = AmbariServerConfigurationUtils.getConfigurationKey(categoryName, property.getKey());
-      if(key == null) {
-        throw new IllegalArgumentException(String.format("Invalid Ambari server configuration key: %s:%s", categoryName, property.getKey()));
-      }
-
-      if (AmbariServerConfigurationUtils.isPassword(key)) {
-        final String passwordFileOrCredentialStoreAlias = fetchPasswordFileNameOrCredentialStoreAlias(categoryName, property.getKey());
-        if (StringUtils.isNotBlank(passwordFileOrCredentialStoreAlias)) { //if blank -> this is the first time setup; we simply need to store the alias/file name
-          if (updatePasswordIfNeeded(categoryName, property.getKey(), property.getValue())) {
-            toBePublished = true;
-          }
-          propertiesIterator.remove(); //we do not need to change the any PASSWORD type configuration going forward
-        }
-      }
-    }
-
-    if (!properties.isEmpty()) {
-      toBePublished = ambariConfigurationDAO.reconcileCategory(categoryName, properties, removePropertiesIfNotSpecified) || toBePublished;
-    }
+    validateProperties(categoryName, properties);
+    final boolean toBePublished = properties.isEmpty() ? false : ambariConfigurationDAO.reconcileCategory(categoryName, properties, removePropertiesIfNotSpecified);
 
     if (toBePublished) {
       // notify subscribers about the configuration changes
       publisher.publish(new AmbariConfigurationChangedEvent(categoryName));
+    }
+  }
+
+  private void validateProperties(String categoryName, Map<String, String> properties) {
+    for (String key : properties.keySet()) {
+      if (AmbariServerConfigurationUtils.getConfigurationKey(categoryName, key) == null) {
+        throw new IllegalArgumentException(String.format("Invalid Ambari server configuration key: %s:%s", categoryName, key));
+      }
     }
   }
 
@@ -195,52 +168,6 @@ public class AmbariServerConfigurationHandler extends RootServiceComponentConfig
       return Collections.emptySet();
     } else {
       return Arrays.stream(enabledServices.split(",")).map(String::trim).map(String::toUpperCase).collect(Collectors.toSet());
-    }
-  }
-
-  private boolean updatePasswordIfNeeded(String categoryName, String propertyName, String newPassword) throws AmbariException {
-    if (newPassword != null) {
-      final String passwordFileOrCredentailStoreAlias = fetchPasswordFileNameOrCredentialStoreAlias(categoryName, propertyName);
-      if (!newPassword.equals(passwordFileOrCredentailStoreAlias)) { //we only need to do anything if the user-supplied password is a 'real' password
-        if (ambariConfiguration.isSecurityPasswordEncryptionEnabled()) {
-          getCredentialProvider().addAliasToCredentialStore(passwordFileOrCredentailStoreAlias, newPassword);
-        } else {
-          savePasswordInFile(passwordFileOrCredentailStoreAlias, newPassword);
-        }
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /*
-   * If the configuration element is actually a PASSWORD type element then we either have a password file name stored in the DB
-   * or - in case security password encryption is enabled - a Credential Store alias.
-   */
-  private String fetchPasswordFileNameOrCredentialStoreAlias(String categoryName, String propertyName) {
-    for (AmbariConfigurationEntity entity : ambariConfigurationDAO.findByCategory(categoryName)) {
-      if (entity.getPropertyName().equals(propertyName)) {
-        return entity.getPropertyValue();
-      }
-    }
-
-    return null;
-  }
-
-  private CredentialProvider getCredentialProvider() throws AmbariException {
-    if (credentialProvider == null) {
-      credentialProvider = new CredentialProvider(null, ambariConfiguration);
-    }
-    return credentialProvider;
-  }
-
-  private void savePasswordInFile(String passwordFileName, String newPassword) throws AmbariException {
-    try {
-      if (StringUtils.isNotBlank(passwordFileName)) {
-        FileUtils.writeStringToFile(new File(passwordFileName), newPassword, Charset.defaultCharset());
-      }
-    } catch (IOException e) {
-      throw new AmbariException("Error while updating password file [" + passwordFileName + "]", e);
     }
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandler.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
-import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
@@ -43,8 +42,8 @@ public class AmbariServerSSOConfigurationHandler extends AmbariServerStackAdviso
 
   @Inject
   public AmbariServerSSOConfigurationHandler(Clusters clusters, ConfigHelper configHelper, AmbariManagementController managementController,
-      StackAdvisorHelper stackAdvisorHelper, AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher, Configuration ambariConfiguration) {
-    super(ambariConfigurationDAO, publisher, ambariConfiguration, clusters, configHelper, managementController, stackAdvisorHelper);
+      StackAdvisorHelper stackAdvisorHelper, AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher) {
+    super(ambariConfigurationDAO, publisher, clusters, configHelper, managementController, stackAdvisorHelper);
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerStackAdvisorAwareConfigurationHandler.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariServerStackAdvisorAwareConfigurationHandler.java
@@ -32,7 +32,6 @@ import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorException;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest;
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
-import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
@@ -58,9 +57,9 @@ class AmbariServerStackAdvisorAwareConfigurationHandler extends AmbariServerConf
   private final AmbariManagementController managementController;
   private final StackAdvisorHelper stackAdvisorHelper;
 
-  AmbariServerStackAdvisorAwareConfigurationHandler(AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher, Configuration ambariConfiguration,
+  AmbariServerStackAdvisorAwareConfigurationHandler(AmbariConfigurationDAO ambariConfigurationDAO, AmbariEventPublisher publisher,
       Clusters clusters, ConfigHelper configHelper, AmbariManagementController managementController, StackAdvisorHelper stackAdvisorHelper) {
-    super(ambariConfigurationDAO, publisher, ambariConfiguration);
+    super(ambariConfigurationDAO, publisher);
     this.clusters = clusters;
     this.configHelper = configHelper;
     this.managementController = managementController;

--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/domain/AmbariLdapConfiguration.java
@@ -24,7 +24,6 @@ import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
 import org.apache.ambari.server.configuration.LdapUsernameCollisionHandlingBehavior;
 import org.apache.ambari.server.security.authorization.LdapServerProperties;
-import org.apache.ambari.server.utils.PasswordUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -38,23 +37,17 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
  */
 public class AmbariLdapConfiguration extends AmbariServerConfiguration {
 
-  private final Map<String, String> configurationMap = new HashMap<>();
-
-  public void setValueFor(AmbariServerConfigurationKey ambariServerConfigurationKey, String value) {
-    if (ambariServerConfigurationKey.getConfigurationCategory() != AmbariServerConfigurationCategory.LDAP_CONFIGURATION) {
-      throw new IllegalArgumentException(ambariServerConfigurationKey.name() + " is not an LDAP configuration");
-    }
-    configurationMap.put(ambariServerConfigurationKey.key(), value);
-  }
-
   public AmbariLdapConfiguration() {
     this(null);
   }
 
   public AmbariLdapConfiguration(Map<String, String> configurationMap) {
-    if (configurationMap != null) {
-      this.configurationMap.putAll(configurationMap);
-    }
+    super(configurationMap);
+  }
+  
+  @Override
+  protected AmbariServerConfigurationCategory getCategory() {
+    return AmbariServerConfigurationCategory.LDAP_CONFIGURATION;
   }
 
   public boolean isAmbariManagesLdapConfiguration() {
@@ -249,7 +242,7 @@ public class AmbariLdapConfiguration extends AmbariServerConfiguration {
     ldapServerProperties.setUseSsl(parseBoolean(configValue(AmbariServerConfigurationKey.USE_SSL)));
     ldapServerProperties.setAnonymousBind(parseBoolean(configValue(AmbariServerConfigurationKey.ANONYMOUS_BIND)));
     ldapServerProperties.setManagerDn(configValue(AmbariServerConfigurationKey.BIND_DN));
-    ldapServerProperties.setManagerPassword(PasswordUtils.getInstance().readPassword(configValue(AmbariServerConfigurationKey.BIND_PASSWORD), AmbariServerConfigurationKey.BIND_PASSWORD.getDefaultValue()));
+    ldapServerProperties.setManagerPassword(configValue(AmbariServerConfigurationKey.BIND_PASSWORD));
     ldapServerProperties.setBaseDN(configValue(AmbariServerConfigurationKey.USER_SEARCH_BASE));
     ldapServerProperties.setUsernameAttribute(configValue(AmbariServerConfigurationKey.USER_NAME_ATTRIBUTE));
     ldapServerProperties.setForceUsernameToLowercase(parseBoolean(configValue(AmbariServerConfigurationKey.FORCE_LOWERCASE_USERNAMES)));

--- a/ambari-server/src/main/java/org/apache/ambari/server/ldap/service/ads/DefaultLdapAttributeDetectionService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/ldap/service/ads/DefaultLdapAttributeDetectionService.java
@@ -14,13 +14,14 @@
 
 package org.apache.ambari.server.ldap.service.ads;
 
+import static org.apache.ambari.server.configuration.AmbariServerConfigurationCategory.LDAP_CONFIGURATION;
+
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
 import org.apache.ambari.server.ldap.service.AmbariLdapException;
@@ -155,7 +156,7 @@ public class DefaultLdapAttributeDetectionService implements LdapAttributeDetect
 
     for (Map.Entry<String, String> detecteMapEntry : detectedAttributes.entrySet()) {
       LOG.info("Setting detected configuration value: [{}] - > [{}]", detecteMapEntry.getKey(), detecteMapEntry.getValue());
-      AmbariServerConfigurationKey key = AmbariServerConfigurationKey.translate(AmbariServerConfigurationCategory.LDAP_CONFIGURATION, detecteMapEntry.getKey());
+      AmbariServerConfigurationKey key = AmbariServerConfigurationKey.translate(LDAP_CONFIGURATION, detecteMapEntry.getKey());
       if(key != null) {
         ambariLdapConfiguration.setValueFor(key, detecteMapEntry.getValue());
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationProperties.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationProperties.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ambari.server.configuration.AmbariServerConfiguration;
+import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.security.encryption.CertificateUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -47,51 +48,40 @@ public class JwtAuthenticationProperties extends AmbariServerConfiguration {
   private static final String PEM_CERTIFICATE_HEADER = "-----BEGIN CERTIFICATE-----";
   private static final String PEM_CERTIFICATE_FOOTER = "-----END CERTIFICATE-----";
 
-  private String authenticationProviderUrl = null;
   private RSAPublicKey publicKey = null;
-  private List<String> audiences = null;
-  private String cookieName = "hadoop-jwt";
-  private String originalUrlQueryParam = null;
-  private boolean enabledForAmbari;
 
   JwtAuthenticationProperties(Map<String, String> configurationMap) {
-    setEnabledForAmbari(Boolean.valueOf(getValue(SSO_AUTHENTICATION_ENABLED, configurationMap)));
-    setAudiencesString(getValue(SSO_JWT_AUDIENCES, configurationMap));
-    setAuthenticationProviderUrl(getValue(SSO_PROVIDER_URL, configurationMap));
-    setCookieName(getValue(SSO_JWT_COOKIE_NAME, configurationMap));
-    setOriginalUrlQueryParam(getValue(SSO_PROVIDER_ORIGINAL_URL_PARAM_NAME, configurationMap));
-    setPublicKey(getValue(SSO_PROVIDER_CERTIFICATE, configurationMap));
+    super(configurationMap);
+  }
+  
+  @Override
+  protected AmbariServerConfigurationCategory getCategory() {
+    return AmbariServerConfigurationCategory.SSO_CONFIGURATION;
   }
 
   public String getAuthenticationProviderUrl() {
-    return authenticationProviderUrl;
+    return getValue(SSO_PROVIDER_URL, configurationMap);
   }
 
-  public void setAuthenticationProviderUrl(String authenticationProviderUrl) {
-    this.authenticationProviderUrl = authenticationProviderUrl;
+  public String getCertification() {
+    return getValue(SSO_PROVIDER_CERTIFICATE, configurationMap);
   }
 
   public RSAPublicKey getPublicKey() {
+    if (publicKey == null) {
+      publicKey = createPublicKey(getCertification());
+    }
     return publicKey;
   }
 
-  public void setPublicKey(String publicKey) {
-    setPublicKey(createPublicKey(publicKey));
-  }
-
-  public void setPublicKey(RSAPublicKey publicKey) {
+  //used by unit tests only to make JWT related filter test easier to setup
+  void setPublicKey(RSAPublicKey publicKey) {
     this.publicKey = publicKey;
   }
 
   public List<String> getAudiences() {
-    return audiences;
-  }
-
-  public void setAudiences(List<String> audiences) {
-    this.audiences = audiences;
-  }
-
-  public void setAudiencesString(String audiencesString) {
+    final String audiencesString = getValue(SSO_JWT_AUDIENCES, configurationMap);
+    final List<String> audiences;
     if (StringUtils.isNotEmpty(audiencesString)) {
       // parse into the list
       String[] audArray = audiencesString.split(",");
@@ -100,30 +90,20 @@ public class JwtAuthenticationProperties extends AmbariServerConfiguration {
     } else {
       audiences = null;
     }
+    
+    return audiences;
   }
 
   public String getCookieName() {
-    return cookieName;
-  }
-
-  public void setCookieName(String cookieName) {
-    this.cookieName = cookieName;
+    return getValue(SSO_JWT_COOKIE_NAME, configurationMap);
   }
 
   public String getOriginalUrlQueryParam() {
-    return originalUrlQueryParam;
-  }
-
-  public void setOriginalUrlQueryParam(String originalUrlQueryParam) {
-    this.originalUrlQueryParam = originalUrlQueryParam;
+    return getValue(SSO_PROVIDER_ORIGINAL_URL_PARAM_NAME, configurationMap);
   }
 
   public boolean isEnabledForAmbari() {
-    return enabledForAmbari;
-  }
-
-  public void setEnabledForAmbari(boolean enabledForAmbari) {
-    this.enabledForAmbari = enabledForAmbari;
+    return Boolean.valueOf(getValue(SSO_AUTHENTICATION_ENABLED, configurationMap));
   }
 
   /**
@@ -158,5 +138,10 @@ public class JwtAuthenticationProperties extends AmbariServerConfiguration {
     }
 
     return publicKey;
+  }
+  
+  @Override
+  public Map<String, String> toMap() {
+    return configurationMap;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/tproxy/AmbariTProxyConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/tproxy/AmbariTProxyConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.security.authentication.tproxy;
 import java.util.Map;
 
 import org.apache.ambari.server.configuration.AmbariServerConfiguration;
+import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -36,8 +37,6 @@ public class AmbariTProxyConfiguration extends AmbariServerConfiguration {
   private static final String TEMPLATE_PROXY_USER_ALLOWED_USERS = "ambari.tproxy.proxyuser.%s.users";
   private static final String TEMPLATE_PROXY_USER_ALLOWED_GROUPS = "ambari.tproxy.proxyuser.%s.groups";
 
-  private final ImmutableMap<String, String> configurationMap;
-
   /**
    * Constructor
    * <p>
@@ -47,28 +46,18 @@ public class AmbariTProxyConfiguration extends AmbariServerConfiguration {
    * @param configurationMap a map of property names to values
    */
   AmbariTProxyConfiguration(Map<String, String> configurationMap) {
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-
-    if (configurationMap != null) {
-      builder.putAll(configurationMap);
-    }
-
-    this.configurationMap = builder.build();
+    super(configurationMap);
+  }
+  
+  @Override
+  protected AmbariServerConfigurationCategory getCategory() {
+    return AmbariServerConfigurationCategory.TPROXY_CONFIGURATION;
   }
 
   /**
-   * Returns an immutable map of the contained properties
+   * Determines of trusted proxy support is enabled based on the configuration data.
    *
-   * @return an immutable map property names to values
-   */
-  public Map<String, String> toMap() {
-    return configurationMap;
-  }
-
-  /**
-   * Determines of tristed proxy support is enabled based on the configuration data.
-   *
-   * @return <code>true</code> if trusted proxy support is enabed; <code>false</code> otherwise
+   * @return <code>true</code> if trusted proxy support is enabled; <code>false</code> otherwise
    * @see AmbariServerConfigurationKey#TPROXY_AUTHENTICATION_ENABLED
    */
   public boolean isEnabled() {
@@ -95,14 +84,6 @@ public class AmbariTProxyConfiguration extends AmbariServerConfiguration {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
     return new EqualsBuilder()
         .append(configurationMap, ((AmbariTProxyConfiguration) o).configurationMap)
         .isEquals();

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/AmbariServerConfigurationEncryptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/AmbariServerConfigurationEncryptor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.security.encryption;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
+import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
+import org.apache.ambari.server.utils.TextEncoding;
+
+import com.google.inject.Inject;
+
+public class AmbariServerConfigurationEncryptor implements Encryptor<AmbariServerConfiguration> {
+
+  private final Set<String> passwordConfigurations = AmbariServerConfigurationKey.findPasswordConfigurations();
+  private final EncryptionService encryptionService;
+
+  @Inject
+  public AmbariServerConfigurationEncryptor(EncryptionService encryptionService) {
+    this.encryptionService = encryptionService;
+  }
+
+  @Override
+  public void encryptSensitiveData(AmbariServerConfiguration encryptible) {
+    encryptible.toMap().entrySet().stream().filter(f -> shouldEncrypt(f)).forEach(entry -> encryptible.setValueFor(entry.getKey(), encryptAndDecorateConfigValue(entry.getValue())));
+  }
+
+  private boolean shouldEncrypt(Map.Entry<String, String> config) {
+    return passwordConfigurations.contains(config.getKey()) && !isEncryptedPassword(config.getValue());
+  }
+
+  private String encryptAndDecorateConfigValue(String propertyValue) {
+    final String encrypted = encryptionService.encrypt(propertyValue, TextEncoding.BIN_HEX);
+    return String.format(ENCRYPTED_PROPERTY_SCHEME, encrypted);
+  }
+
+  @Override
+  public void decryptSensitiveData(AmbariServerConfiguration decryptible) {
+    decryptible.toMap().entrySet().stream().filter(f -> passwordConfigurations.contains(f.getKey())).filter(f -> isEncryptedPassword(f.getValue()))
+        .forEach(entry -> decryptible.setValueFor(entry.getKey(), decryptConfig(entry.getValue())));
+  }
+
+  private boolean isEncryptedPassword(String password) {
+    return password != null && password.startsWith(Encryptor.ENCRYPTED_PROPERTY_PREFIX); // assuming previous encryption by this class
+  }
+
+  private String decryptConfig(String property) {
+    // sample value: ${enc=aes256_hex, value=5248...303d}
+    final String encrypted = property.substring(ENCRYPTED_PROPERTY_PREFIX.length(), property.indexOf('}'));
+    return encryptionService.decrypt(encrypted, TextEncoding.BIN_HEX);
+  }
+
+  @Override
+  public String getEncryptionKey() {
+    return null;
+  }
+
+}

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/AmbariServerConfigurationEncryptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/AmbariServerConfigurationEncryptor.java
@@ -38,7 +38,9 @@ public class AmbariServerConfigurationEncryptor implements Encryptor<AmbariServe
 
   @Override
   public void encryptSensitiveData(AmbariServerConfiguration encryptible) {
-    encryptible.toMap().entrySet().stream().filter(f -> shouldEncrypt(f)).forEach(entry -> encryptible.setValueFor(entry.getKey(), encryptAndDecorateConfigValue(entry.getValue())));
+    encryptible.toMap().entrySet().stream()
+        .filter(f -> shouldEncrypt(f))
+        .forEach(entry -> encryptible.setValueFor(entry.getKey(), encryptAndDecorateConfigValue(entry.getValue())));
   }
 
   private boolean shouldEncrypt(Map.Entry<String, String> config) {
@@ -52,7 +54,9 @@ public class AmbariServerConfigurationEncryptor implements Encryptor<AmbariServe
 
   @Override
   public void decryptSensitiveData(AmbariServerConfiguration decryptible) {
-    decryptible.toMap().entrySet().stream().filter(f -> passwordConfigurations.contains(f.getKey())).filter(f -> isEncryptedPassword(f.getValue()))
+    decryptible.toMap().entrySet().stream()
+        .filter(f -> passwordConfigurations.contains(f.getKey()))
+        .filter(f -> isEncryptedPassword(f.getValue()))
         .forEach(entry -> decryptible.setValueFor(entry.getKey(), decryptConfig(entry.getValue())));
   }
 
@@ -68,7 +72,7 @@ public class AmbariServerConfigurationEncryptor implements Encryptor<AmbariServe
 
   @Override
   public String getEncryptionKey() {
-    return null;
+    return encryptionService.getAmbariMasterKey();
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/Encryptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/Encryptor.java
@@ -21,6 +21,9 @@ package org.apache.ambari.server.security.encryption;
  * Defines a generic contract on encrypting/decrypting sensitive data
  */
 public interface Encryptor<T> {
+  
+  static final String ENCRYPTED_PROPERTY_PREFIX = "${enc=aes256_hex, value=";
+  static final String ENCRYPTED_PROPERTY_SCHEME = ENCRYPTED_PROPERTY_PREFIX + "%s}";
 
   /**
    * Encrypts the given encryptible object
@@ -43,7 +46,7 @@ public interface Encryptor<T> {
    */
   String getEncryptionKey();
 
-  Encryptor NONE = new Encryptor() {
+  Encryptor NONE = new Encryptor<Object>() {
     @Override
     public void encryptSensitiveData(Object data) { }
     @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/PropertiesEncryptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/PropertiesEncryptor.java
@@ -36,8 +36,6 @@ import org.apache.commons.collections.CollectionUtils;
  * A common base class for various encryptor implementations
  */
 public class PropertiesEncryptor {
-  private static final String ENCRYPTED_PROPERTY_PREFIX = "${enc=aes256_hex, value=";
-  private static final String ENCRYPTED_PROPERTY_SCHEME = ENCRYPTED_PROPERTY_PREFIX + "%s}";
   private final Map<Long, Map<StackId, Map<String, Set<String>>>> clusterPasswordProperties = new ConcurrentHashMap<>(); //Map<clusterId, <Map<stackId, Map<configType, Set<passwordPropertyKeys>>>>;
   protected final EncryptionService encryptionService;
 
@@ -69,7 +67,7 @@ public class PropertiesEncryptor {
   }
 
   private boolean isEncryptedPassword(String password) {
-    return password != null && password.startsWith(ENCRYPTED_PROPERTY_PREFIX); // assuming previous encryption by this class
+    return password != null && password.startsWith(Encryptor.ENCRYPTED_PROPERTY_PREFIX); // assuming previous encryption by this class
   }
 
   private Set<String> getPasswordProperties(Cluster cluster, String configType) {
@@ -91,12 +89,12 @@ public class PropertiesEncryptor {
 
   private String encryptAndDecoratePropertyValue(String propertyValue) {
     final String encrypted = encryptionService.encrypt(propertyValue, TextEncoding.BIN_HEX);
-    return String.format(ENCRYPTED_PROPERTY_SCHEME, encrypted);
+    return String.format(Encryptor.ENCRYPTED_PROPERTY_SCHEME, encrypted);
   }
 
   private String encryptAndDecoratePropertyValue(String propertyValue, String encryptionKey) {
     final String encrypted = encryptionService.encrypt(propertyValue, encryptionKey, TextEncoding.BIN_HEX);
-    return String.format(ENCRYPTED_PROPERTY_SCHEME, encrypted);
+    return String.format(Encryptor.ENCRYPTED_PROPERTY_SCHEME, encrypted);
   }
 
   protected void decrypt(Map<String, String> configProperties) {
@@ -109,7 +107,7 @@ public class PropertiesEncryptor {
 
   private String decryptProperty(String property) {
     // sample value: ${enc=aes256_hex, value=5248...303d}
-    final String encrypted = property.substring(ENCRYPTED_PROPERTY_PREFIX.length(), property.indexOf('}'));
+    final String encrypted = property.substring(Encryptor.ENCRYPTED_PROPERTY_PREFIX.length(), property.indexOf('}'));
     return encryptionService.decrypt(encrypted, TextEncoding.BIN_HEX);
   }
 }

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -514,13 +514,6 @@ def setup_master_key(options):
     with open(db_password, 'r') as passwdfile:
       db_password = passwdfile.read()
 
-  ldap_password = properties.get_property(LDAP_MGR_PASSWORD_PROPERTY)
-  if ldap_password:
-    # Read clear text LDAP password from file
-    if not is_alias_string(ldap_password) and os.path.isfile(ldap_password):
-      with open(ldap_password, 'r') as passwdfile:
-        ldap_password = passwdfile.read()
-
   ts_password = properties.get_property(SSL_TRUSTSTORE_PASSWORD_PROPERTY)
   resetKey = False
   masterKey = None
@@ -550,8 +543,6 @@ def setup_master_key(options):
               " password and call 'encrypt-passwords' again."
         if db_sql_auth and db_password and is_alias_string(db_password):
           print err.format('- Database password', "'" + SETUP_ACTION + "'")
-        if ldap_password and is_alias_string(ldap_password):
-          print err.format('- LDAP manager password', "'" + LDAP_SETUP_ACTION + "'")
         if ts_password and is_alias_string(ts_password):
           print err.format('TrustStore password', "'" + LDAP_SETUP_ACTION + "'")
 
@@ -563,8 +554,6 @@ def setup_master_key(options):
   # Read back any encrypted passwords
   if db_sql_auth  and db_password and is_alias_string(db_password):
     db_password = read_passwd_for_alias(JDBC_RCA_PASSWORD_ALIAS, masterKey)
-  if ldap_password and is_alias_string(ldap_password):
-    ldap_password = read_passwd_for_alias(LDAP_MGR_PASSWORD_ALIAS, masterKey)
   if ts_password and is_alias_string(ts_password):
     ts_password = read_passwd_for_alias(SSL_TRUSTSTORE_PASSWORD_ALIAS, masterKey)
   # Read master key, if non-secure or reset is true
@@ -608,15 +597,6 @@ def setup_master_key(options):
       remove_password_file(JDBC_PASSWORD_FILENAME)
       if properties.get_property(JDBC_RCA_PASSWORD_FILE_PROPERTY):
         propertyMap[JDBC_RCA_PASSWORD_FILE_PROPERTY] = get_alias_string(JDBC_RCA_PASSWORD_ALIAS)
-  pass
-
-  if ldap_password and not is_alias_string(ldap_password):
-    retCode = save_passwd_for_alias(LDAP_MGR_PASSWORD_ALIAS, ldap_password, masterKey)
-    if retCode != 0:
-      print 'Failed to save secure LDAP password.'
-    else:
-      propertyMap[LDAP_MGR_PASSWORD_PROPERTY] = get_alias_string(LDAP_MGR_PASSWORD_ALIAS)
-      remove_password_file(LDAP_MGR_PASSWORD_FILENAME)
   pass
 
   if ts_password and not is_alias_string(ts_password):
@@ -948,21 +928,10 @@ def setup_ldap(options):
 
   if save_settings:
     if isSecure:
-      if mgr_password:
-        encrypted_passwd = encrypt_password(LDAP_MGR_PASSWORD_ALIAS, mgr_password, options)
-        if mgr_password != encrypted_passwd:
-          ldap_property_value_map[LDAP_MGR_PASSWORD_PROPERTY] = encrypted_passwd
-      pass
       if ts_password:
         encrypted_passwd = encrypt_password(SSL_TRUSTSTORE_PASSWORD_ALIAS, ts_password, options)
         if ts_password != encrypted_passwd:
           ldap_property_values_in_ambari_properties[SSL_TRUSTSTORE_PASSWORD_PROPERTY] = encrypted_passwd
-      pass
-    pass
-
-    # Persisting values
-    if mgr_password:
-      ldap_property_value_map[LDAP_MGR_PASSWORD_PROPERTY] = store_password_file(mgr_password, LDAP_MGR_PASSWORD_FILENAME)
 
     print 'Saving LDAP properties...'
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/AgentResourceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/AgentResourceTest.java
@@ -36,6 +36,7 @@ import org.apache.ambari.server.actionmanager.RequestFactory;
 import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.agent.rest.AgentResource;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
@@ -362,6 +363,7 @@ public class AgentResourceTest extends RandomPortJerseyTest {
       bind(EncryptionService.class).to(AESEncryptionService.class);
       bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
       bind(new TypeLiteral<Encryptor<Config>>() {}).annotatedWith(Names.named("ConfigPropertiesEncryptor")).toInstance(Encryptor.NONE);
+      bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
       bind(LdapFacade.class).toInstance(createNiceMock(LdapFacade.class));
       bind(AmbariLdapConfigurationProvider.class).toInstance(createNiceMock(AmbariLdapConfigurationProvider.class));
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/alerts/AgentHeartbeatAlertRunnableTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/alerts/AgentHeartbeatAlertRunnableTest.java
@@ -247,9 +247,6 @@ public class AgentHeartbeatAlertRunnableTest {
    *
    */
   private class MockModule implements Module {
-    /**
-     *
-     */
     @Override
     public void configure(Binder binder) {
       PartialNiceMockBinder.newBuilder().addConfigsBindings()

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKeyTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/AmbariServerConfigurationKeyTest.java
@@ -14,6 +14,8 @@
 
 package org.apache.ambari.server.configuration;
 
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,6 +57,14 @@ public class AmbariServerConfigurationKeyTest {
     Assert.assertNotSame(keyWithRegex, translatedKey);
 
     Assert.assertNull(AmbariServerConfigurationKey.translate(keyWithRegex.getConfigurationCategory(), "ambari.tproxy.proxyuser.not.knox.invalid"));
+  }
+  
+  @Test
+  public void testFindPasswordConfigurations() throws Exception {
+    final Set<String> passwordConfigurations = AmbariServerConfigurationKey.findPasswordConfigurations();
+    Assert.assertEquals(2, passwordConfigurations.size());
+    Assert.assertTrue(passwordConfigurations.contains(AmbariServerConfigurationKey.BIND_PASSWORD.key()));
+    Assert.assertTrue(passwordConfigurations.contains(AmbariServerConfigurationKey.TRUST_STORE_PASSWORD.key()));
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/AmbariServerConfigurationProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/AmbariServerConfigurationProviderTest.java
@@ -35,6 +35,7 @@ import org.apache.ambari.server.events.JpaInitializedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.Assert;
@@ -43,6 +44,8 @@ import org.junit.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 import com.google.inject.persist.jpa.AmbariJpaPersistService;
 
 public class AmbariServerConfigurationProviderTest extends EasyMockSupport {
@@ -164,6 +167,7 @@ public class AmbariServerConfigurationProviderTest extends EasyMockSupport {
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
         bind(AmbariJpaPersistService.class).toInstance(persistService);
         bind(AmbariConfigurationDAO.class).toInstance(createNiceMock(AmbariConfigurationDAO.class));
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
       }
     });
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/AmbariServerConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/AmbariServerConfigurationTest.java
@@ -31,11 +31,14 @@ public class AmbariServerConfigurationTest {
 
   @Test
   public void testGetValue() {
-    AmbariServerConfiguration ambariServerConfiguration = new AmbariServerConfiguration() {
+    final Map<String, String> configurationMap = Collections.singletonMap(TPROXY_AUTHENTICATION_ENABLED.key(), "true");
 
+    final AmbariServerConfiguration ambariServerConfiguration = new AmbariServerConfiguration(configurationMap) {
+      @Override
+      protected AmbariServerConfigurationCategory getCategory() {
+        return null;
+      }
     };
-
-    Map<String, String> configurationMap = Collections.singletonMap(TPROXY_AUTHENTICATION_ENABLED.key(), "true");
 
     // Get the value specified in the configuration map
     Assert.assertEquals("true", ambariServerConfiguration.getValue(TPROXY_AUTHENTICATION_ENABLED, configurationMap));
@@ -48,5 +51,8 @@ public class AmbariServerConfigurationTest {
     Assert.assertEquals("defaultValue", ambariServerConfiguration.getValue(null, configurationMap, "defaultValue"));
     Assert.assertEquals("defaultValue", ambariServerConfiguration.getValue("property.name", null, "defaultValue"));
     Assert.assertNull(ambariServerConfiguration.getValue("property.name", Collections.emptyMap(), null));
+
+    // check toMap()
+    Assert.assertEquals(configurationMap, ambariServerConfiguration.toMap());
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerConfigurationHandlerTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.api.services.RootServiceComponentConfiguration;
-import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.events.AmbariConfigurationChangedEvent;
 import org.apache.ambari.server.events.publishers.AmbariEventPublisher;
 import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
@@ -81,9 +80,8 @@ public class AmbariServerConfigurationHandlerTest extends EasyMockSupport {
     expect(ambariConfigurationDAO.findByCategory("invalid category")).andReturn(null).once();
 
     AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
-    Configuration configuration = createMock(Configuration.class);
 
-    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher, configuration);
+    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher);
 
     replayAll();
 
@@ -121,9 +119,7 @@ public class AmbariServerConfigurationHandlerTest extends EasyMockSupport {
     publisher.publish(anyObject(AmbariConfigurationChangedEvent.class));
     expectLastCall().once();
 
-    Configuration configuration = createMock(Configuration.class);
-
-    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher, configuration);
+    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher);
 
     replayAll();
 
@@ -149,9 +145,7 @@ public class AmbariServerConfigurationHandlerTest extends EasyMockSupport {
     publisher.publish(anyObject(AmbariConfigurationChangedEvent.class));
     expectLastCall().times(2);
 
-    Configuration configuration = createMock(Configuration.class);
-
-    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher, configuration);
+    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher);
 
     replayAll();
 
@@ -183,9 +177,8 @@ public class AmbariServerConfigurationHandlerTest extends EasyMockSupport {
     expect(ambariConfigurationDAO.findAll()).andReturn(allEntities).once();
 
     AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
-    Configuration configuration = createMock(Configuration.class);
 
-    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher, configuration);
+    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher);
 
     replayAll();
 
@@ -212,9 +205,8 @@ public class AmbariServerConfigurationHandlerTest extends EasyMockSupport {
     expect(ambariConfigurationDAO.findByCategory("invalid category")).andReturn(null).once();
 
     AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
-    Configuration configuration = createMock(Configuration.class);
 
-    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher, configuration);
+    AmbariServerConfigurationHandler handler = new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher);
 
     replayAll();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AmbariServerSSOConfigurationHandlerTest.java
@@ -37,7 +37,6 @@ import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorException;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRequest;
 import org.apache.ambari.server.api.services.stackadvisor.recommendations.RecommendationResponse;
-import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.events.AmbariConfigurationChangedEvent;
 import org.apache.ambari.server.events.AmbariEvent;
@@ -75,7 +74,6 @@ public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
     expect(ambariConfigurationDAO.findByCategory(SSO_CONFIGURATION.getCategoryName())).andReturn(entities).once();
 
     AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
-    Configuration configuration = createMock(Configuration.class);
     Clusters clusters = createMock(Clusters.class);
     ConfigHelper configHelper = createMock(ConfigHelper.class);
     AmbariManagementController managementController = createMock(AmbariManagementController.class);
@@ -83,7 +81,7 @@ public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration);
+    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher);
     handler.updateComponentCategory(SSO_CONFIGURATION.getCategoryName(), ssoConfigurationProperties, true);
 
     verifyAll();
@@ -134,7 +132,6 @@ public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
     Capture<Map<String, String>> capturedUpdates = newCapture();
     Capture<Collection<String>> capturedRemovals = newCapture();
 
-    Configuration configuration = createMock(Configuration.class);
     AmbariManagementController managementController = createMock(AmbariManagementController.class);
 
     AmbariConfigurationDAO ambariConfigurationDAO = createMock(AmbariConfigurationDAO.class);
@@ -167,7 +164,7 @@ public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration);
+    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher);
     handler.updateComponentCategory(SSO_CONFIGURATION.getCategoryName(), ssoConfigurationProperties, true);
 
     verifyAll();
@@ -193,7 +190,6 @@ public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
     AmbariManagementController managementController = createMock(AmbariManagementController.class);
     StackAdvisorHelper stackAdvisorHelper = createMock(StackAdvisorHelper.class);
     AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
-    Configuration configuration = createMock(Configuration.class);
 
     List<AmbariConfigurationEntity> entities = new ArrayList<>();
     AmbariConfigurationEntity entity;
@@ -215,7 +211,7 @@ public class AmbariServerSSOConfigurationHandlerTest extends EasyMockSupport {
 
     replayAll();
 
-    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration);
+    AmbariServerSSOConfigurationHandler handler = new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher);
 
     Assert.assertTrue(handler.getSSOEnabledServices().contains("SERVICE1"));
     Assert.assertTrue(handler.getSSOEnabledServices().contains("SERVICE2"));

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/GroupPrivilegeResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/GroupPrivilegeResourceProviderTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import javax.persistence.EntityManager;
 
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.GroupPrivilegeResponse;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Request;
@@ -58,6 +59,7 @@ import org.apache.ambari.server.security.TestAuthenticationFactory;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.security.authorization.ResourceType;
 import org.apache.ambari.server.security.authorization.Users;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
@@ -68,6 +70,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 
 import junit.framework.Assert;
 
@@ -350,6 +354,7 @@ public class GroupPrivilegeResourceProviderTest extends EasyMockSupport{
                                                        bind(PasswordEncoder.class).toInstance(createNiceMock(PasswordEncoder.class));
                                                        bind(HookService.class).toInstance(createMock(HookService.class));
                                                        bind(HookContextFactory.class).toInstance(createMock(HookContextFactory.class));
+                                                       bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
                                                        bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
 
                                                        bind(GroupDAO.class).toInstance(groupDAO);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/PreUpgradeCheckResourceProviderTest.java
@@ -43,6 +43,7 @@ import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.checks.UpgradeCheckRegistry;
 import org.apache.ambari.server.checks.UpgradeCheckRegistryProvider;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
@@ -335,6 +336,7 @@ public class PreUpgradeCheckResourceProviderTest extends EasyMockSupport {
         Provider<EntityManager> entityManagerProvider = createNiceMock(Provider.class);
         bind(EntityManager.class).toProvider(entityManagerProvider);
         bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
 
         requestStaticInjection(PreUpgradeCheckResourceProvider.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProviderTest.java
@@ -25,8 +25,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.newCapture;
 
-import java.io.File;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,9 +38,9 @@ import javax.persistence.EntityManager;
 
 import org.apache.ambari.server.api.services.RootServiceComponentConfigurationService;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorHelper;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationCategory;
 import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
-import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.RootComponent;
 import org.apache.ambari.server.controller.RootService;
@@ -60,7 +58,8 @@ import org.apache.ambari.server.orm.dao.AmbariConfigurationDAO;
 import org.apache.ambari.server.orm.entities.AmbariConfigurationEntity;
 import org.apache.ambari.server.security.TestAuthenticationFactory;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
-import org.apache.ambari.server.security.encryption.CredentialProvider;
+import org.apache.ambari.server.security.encryption.AmbariServerConfigurationEncryptor;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.stack.OsFamily;
@@ -71,7 +70,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.security.core.Authentication;
@@ -82,7 +80,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 
 import junit.framework.Assert;
-import junit.framework.AssertionFailedError;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FileUtils.class, AmbariServerConfigurationHandler.class})
@@ -96,7 +93,6 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
   private RootServiceComponentConfigurationHandlerFactory factory;
   private Request request;
   private AmbariConfigurationDAO dao;
-  private Configuration configuration;
   private AmbariEventPublisher publisher;
   private AmbariServerLDAPConfigurationHandler ambariServerLDAPConfigurationHandler;
   private AmbariServerSSOConfigurationHandler ambariServerSSOConfigurationHandler;
@@ -108,7 +104,6 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
     predicate = createPredicate(RootService.AMBARI.name(), RootComponent.AMBARI_SERVER.name(), LDAP_CONFIG_CATEGORY);
     request = createMock(Request.class);
     dao = injector.getInstance(AmbariConfigurationDAO.class);
-    configuration = injector.getInstance(Configuration.class);
     factory = injector.getInstance(RootServiceComponentConfigurationHandlerFactory.class);
     publisher = injector.getInstance(AmbariEventPublisher.class);
     ambariServerLDAPConfigurationHandler = injector.getInstance(AmbariServerLDAPConfigurationHandler.class);
@@ -204,7 +199,6 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
       expect(dao.reconcileCategory(eq(SSO_CONFIG_CATEGORY), capture(capturedProperties2), eq(true)))
           .andReturn(true)
           .once();
-      expect(dao.findByCategory(LDAP_CONFIG_CATEGORY)).andReturn(Collections.emptyList());
       expect(dao.findByCategory(eq(SSO_CONFIG_CATEGORY)))
           .andReturn(Collections.emptyList())
           .once();
@@ -438,7 +432,6 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
       expect(dao.reconcileCategory(eq(LDAP_CONFIG_CATEGORY), capture(capturedProperties1), eq(false)))
           .andReturn(true)
           .once();
-      expect(dao.findByCategory(LDAP_CONFIG_CATEGORY)).andReturn(Collections.emptyList());
       publisher.publish(anyObject(AmbariConfigurationChangedEvent.class));
       expectLastCall().times(1);
     }
@@ -474,79 +467,6 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
     } else {
       Assert.assertFalse(capturedProperties1.hasCaptured());
     }
-  }
-
-  @Test
-  public void shouldNotUpdatePasswordIfItHasNotBeenChanged() throws Exception {
-    SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
-    Set<Map<String, Object>> propertySets = new HashSet<>();
-    Map<String, String> properties = new HashMap<>();
-    properties.put(AmbariServerConfigurationKey.BIND_PASSWORD.key(), "passwd");
-    propertySets.add(toRequestProperties(LDAP_CONFIG_CATEGORY, properties));
-    setupBasicExpectations(properties, propertySets);
-    expect(configuration.isSecurityPasswordEncryptionEnabled()).andThrow(new AssertionFailedError()).anyTimes(); //this call should never have never been hit
-    replayAll();
-    resourceProvider.updateResources(request, predicate);
-    verifyAll();
-  }
-
-  @Test
-  public void shouldUpdatePasswordFileIfSecurityPasswordEncryptionIsDisabled() throws Exception {
-    SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
-    Map<String, String> properties = new HashMap<>();
-    Set<Map<String, Object>> propertySets = new HashSet<>();
-    properties.put(AmbariServerConfigurationKey.BIND_PASSWORD.key(), "newPasswd");
-    propertySets.add(toRequestProperties(LDAP_CONFIG_CATEGORY, properties));
-    Map<String, String> expectedProperties = new HashMap<>();
-    expectedProperties.put(AmbariServerConfigurationKey.BIND_PASSWORD.key(), "currentPasswd");
-    setupBasicExpectations(expectedProperties, propertySets);
-    expect(configuration.isSecurityPasswordEncryptionEnabled()).andReturn(false).once();
-    PowerMock.mockStatic(FileUtils.class);
-    FileUtils.writeStringToFile(new File("currentPasswd"), "newPasswd", Charset.defaultCharset());
-    PowerMock.expectLastCall().once();
-    PowerMock.replay(FileUtils.class);
-    publisher.publish(anyObject(AmbariConfigurationChangedEvent.class));
-    expectLastCall().once();
-
-    replayAll();
-    resourceProvider.updateResources(request, predicate);
-    verifyAll();
-  }
-
-  @Test
-  public void shouldUpdatePasswordInCredentialStoreIfSecurityPasswordEncryptionIsEnabled() throws Exception {
-    SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
-    Map<String, String> properties = new HashMap<>();
-    Set<Map<String, Object>> propertySets = new HashSet<>();
-    properties.put(AmbariServerConfigurationKey.BIND_PASSWORD.key(), "newPasswd");
-    propertySets.add(toRequestProperties(LDAP_CONFIG_CATEGORY, properties));
-    Map<String, String> expectedProperties = new HashMap<>();
-    expectedProperties.put(AmbariServerConfigurationKey.BIND_PASSWORD.key(), "currentPasswd");
-    setupBasicExpectations(expectedProperties, propertySets);
-    expect(configuration.isSecurityPasswordEncryptionEnabled()).andReturn(true).once();
-
-    File masterKeyLocation = createNiceMock(File.class);
-    File masterKeyStoreLocation = createNiceMock(File.class);
-    CredentialProvider credentialProvider = PowerMock.createMock(CredentialProvider.class);
-    PowerMock.expectNew(CredentialProvider.class, null, null, configuration).andReturn(credentialProvider);
-    credentialProvider.addAliasToCredentialStore("currentPasswd", "newPasswd");
-    PowerMock.expectLastCall().once();
-    PowerMock.replay(credentialProvider, CredentialProvider.class);
-
-    publisher.publish(anyObject(AmbariConfigurationChangedEvent.class));
-    expectLastCall().once();
-
-    replayAll();
-    resourceProvider.updateResources(request, predicate);
-    verifyAll();
-    PowerMock.verify(credentialProvider, CredentialProvider.class);
-  }
-
-  private void setupBasicExpectations(Map<String, String> expectedProperties, Set<Map<String, Object>> propertySets) {
-    expect(request.getProperties()).andReturn(propertySets).once();
-    expect(request.getRequestInfoProperties()).andReturn(new HashMap<>());
-    expect(dao.findByCategory(LDAP_CONFIG_CATEGORY)).andReturn(createEntities(AmbariServerConfigurationCategory.LDAP_CONFIGURATION.getCategoryName(), expectedProperties)).times(3);
-    expect(factory.getInstance(RootService.AMBARI.name(), RootComponent.AMBARI_SERVER.name(), LDAP_CONFIG_CATEGORY)).andReturn(ambariServerLDAPConfigurationHandler).once();
   }
 
   private Predicate createPredicate(String serviceName, String componentName, String categoryName) {
@@ -608,23 +528,22 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
       protected void configure() {
         AmbariEventPublisher publisher = createMock(AmbariEventPublisher.class);
         AmbariConfigurationDAO ambariConfigurationDAO = createMock(AmbariConfigurationDAO.class);
-        Configuration configuration = createNiceMock(Configuration.class);
         Clusters clusters = createNiceMock(Clusters.class);
         ConfigHelper configHelper = createNiceMock(ConfigHelper.class);
         AmbariManagementController managementController = createNiceMock(AmbariManagementController.class);
         StackAdvisorHelper stackAdvisorHelper = createNiceMock(StackAdvisorHelper.class);
         LdapFacade ldapFacade = createNiceMock(LdapFacade.class);
+        Encryptor<AmbariServerConfiguration> encryptor = createNiceMock(AmbariServerConfigurationEncryptor.class);
 
         bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));
-        bind(Configuration.class).toInstance(configuration);
         bind(EntityManager.class).toInstance(createNiceMock(EntityManager.class));
         bind(AmbariConfigurationDAO.class).toInstance(ambariConfigurationDAO);
         bind(AmbariEventPublisher.class).toInstance(publisher);
 
-        bind(AmbariServerConfigurationHandler.class).toInstance(new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher, configuration));
-        bind(AmbariServerSSOConfigurationHandler.class).toInstance(new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration));
+        bind(AmbariServerConfigurationHandler.class).toInstance(new AmbariServerConfigurationHandler(ambariConfigurationDAO, publisher));
+        bind(AmbariServerSSOConfigurationHandler.class).toInstance(new AmbariServerSSOConfigurationHandler(clusters, configHelper, managementController, stackAdvisorHelper, ambariConfigurationDAO, publisher));
         bind(AmbariServerLDAPConfigurationHandler.class).toInstance(new AmbariServerLDAPConfigurationHandler(clusters, configHelper, managementController,
-            stackAdvisorHelper, ambariConfigurationDAO, publisher, configuration, ldapFacade));
+            stackAdvisorHelper, ambariConfigurationDAO, publisher, ldapFacade, encryptor));
         bind(RootServiceComponentConfigurationHandlerFactory.class).toInstance(createMock(RootServiceComponentConfigurationHandlerFactory.class));
       }
     });

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackUpgradeConfigurationMergeTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/StackUpgradeConfigurationMergeTest.java
@@ -445,7 +445,7 @@ public class StackUpgradeConfigurationMergeTest extends EasyMockSupport {
     public void configure(Binder binder) {
       StageDAO stageDAO = createNiceMock(StageDAO.class);
       PartialNiceMockBinder.newBuilder(StackUpgradeConfigurationMergeTest.this)
-          .addActionDBAccessorConfigsBindings().build().configure(binder);
+          .addActionDBAccessorConfigsBindings().addPasswordEncryptorBindings().build().configure(binder);
 
       binder.bind(Clusters.class).toInstance(createNiceMock(Clusters.class));
       binder.bind(StageDAO.class).toInstance(stageDAO);

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserAuthorizationResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserAuthorizationResourceProviderTest.java
@@ -36,6 +36,7 @@ import org.apache.ambari.server.actionmanager.HostRoleCommandFactory;
 import org.apache.ambari.server.actionmanager.HostRoleCommandFactoryImpl;
 import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.AmbariManagementControllerImpl;
@@ -438,6 +439,7 @@ public class UserAuthorizationResourceProviderTest extends EasyMockSupport {
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
 
         bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
       }
     });
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserPrivilegeResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserPrivilegeResourceProviderTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import javax.persistence.EntityManager;
 
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.UserPrivilegeResponse;
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Request;
@@ -61,6 +62,7 @@ import org.apache.ambari.server.security.TestAuthenticationFactory;
 import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.security.authorization.ResourceType;
 import org.apache.ambari.server.security.authorization.Users;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
@@ -71,6 +73,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 
 import junit.framework.Assert;
 
@@ -549,6 +553,7 @@ public class UserPrivilegeResourceProviderTest extends EasyMockSupport {
         bind(ViewInstanceDAO.class).toInstance(createNiceMock(ViewInstanceDAO.class));
         bind(PrivilegeDAO.class).toInstance(createMock(PrivilegeDAO.class));
         bind(MemberDAO.class).toInstance(createMock(MemberDAO.class));
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
       }
     });

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/UserResourceProviderTest.java
@@ -45,6 +45,7 @@ import org.apache.ambari.server.actionmanager.HostRoleCommandFactoryImpl;
 import org.apache.ambari.server.actionmanager.RequestFactory;
 import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
@@ -440,6 +441,7 @@ public class UserResourceProviderTest extends EasyMockSupport {
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
 
         bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
       }
     });
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/ldap/AmbariLdapConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/ldap/AmbariLdapConfigurationTest.java
@@ -20,19 +20,13 @@ package org.apache.ambari.server.ldap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.nio.charset.Charset;
 
 import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
 import org.apache.ambari.server.ldap.domain.AmbariLdapConfiguration;
 import org.apache.ambari.server.security.authorization.LdapServerProperties;
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class AmbariLdapConfigurationTest {
 
@@ -85,20 +79,8 @@ public class AmbariLdapConfigurationTest {
   }
 
   @Test
-  public void testGetLdapServerProperties_WrongManagerPassword() throws Exception {
-    configuration.setValueFor(AmbariServerConfigurationKey.BIND_PASSWORD, "somePassword");
-    // if it's not a store alias and is not a file, the default manager PW should be returned (which is null)
-    assertNull(configuration.getLdapServerProperties().getManagerPassword());
-  }
-
-  @Test
   public void testGetLdapServerProperties() throws Exception {
     final String managerPw = "ambariTest";
-    final TemporaryFolder tempFolder = new TemporaryFolder();
-    tempFolder.create();
-    final File passwordFile = tempFolder.newFile();
-    passwordFile.deleteOnExit();
-    FileUtils.writeStringToFile(passwordFile, managerPw, Charset.defaultCharset());
 
     configuration.setValueFor(AmbariServerConfigurationKey.SERVER_HOST, "host");
     configuration.setValueFor(AmbariServerConfigurationKey.SERVER_PORT, "1");
@@ -107,7 +89,7 @@ public class AmbariLdapConfigurationTest {
     configuration.setValueFor(AmbariServerConfigurationKey.USE_SSL, "true");
     configuration.setValueFor(AmbariServerConfigurationKey.ANONYMOUS_BIND, "true");
     configuration.setValueFor(AmbariServerConfigurationKey.BIND_DN, "5");
-    configuration.setValueFor(AmbariServerConfigurationKey.BIND_PASSWORD, passwordFile.getAbsolutePath());
+    configuration.setValueFor(AmbariServerConfigurationKey.BIND_PASSWORD, managerPw);
     configuration.setValueFor(AmbariServerConfigurationKey.USER_SEARCH_BASE, "7");
     configuration.setValueFor(AmbariServerConfigurationKey.USER_NAME_ATTRIBUTE, "8");
     configuration.setValueFor(AmbariServerConfigurationKey.USER_BASE, "9");
@@ -137,7 +119,6 @@ public class AmbariLdapConfigurationTest {
     assertEquals("14", ldapProperties.getGroupNamingAttr());
     assertEquals("15", ldapProperties.getAdminGroupMappingRules());
     assertEquals("16", ldapProperties.getGroupSearchFilter());
-    tempFolder.delete();
   }
 
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/AbstractAuthenticationProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/AbstractAuthenticationProviderTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 import javax.persistence.EntityManager;
 
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.hooks.HookContextFactory;
 import org.apache.ambari.server.hooks.HookService;
@@ -33,6 +34,7 @@ import org.apache.ambari.server.ldap.service.AmbariLdapConfigurationProvider;
 import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.entities.UserEntity;
 import org.apache.ambari.server.security.authorization.Users;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
@@ -46,6 +48,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 
 public abstract class AbstractAuthenticationProviderTest extends EasyMockSupport {
 
@@ -197,6 +201,7 @@ public abstract class AbstractAuthenticationProviderTest extends EasyMockSupport
         bind(OsFamily.class).toInstance(createNiceMock(OsFamily.class));
         bind(HookService.class).toInstance(createMock(HookService.class));
         bind(HookContextFactory.class).toInstance(createMock(HookContextFactory.class));
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
 
         bind(Users.class).toInstance(users);

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/AmbariJwtAuthenticationFilterTest.java
@@ -38,13 +38,16 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.orm.entities.UserAuthenticationEntity;
 import org.apache.ambari.server.orm.entities.UserEntity;
@@ -55,6 +58,7 @@ import org.apache.ambari.server.security.authentication.AmbariAuthenticationFilt
 import org.apache.ambari.server.security.authorization.User;
 import org.apache.ambari.server.security.authorization.UserAuthenticationType;
 import org.apache.ambari.server.security.authorization.Users;
+import org.apache.commons.lang.StringUtils;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMockSupport;
@@ -100,11 +104,12 @@ public class AmbariJwtAuthenticationFilterTest extends EasyMockSupport {
   }
 
   private JwtAuthenticationProperties createTestProperties(List<String> audiences) {
-    JwtAuthenticationProperties properties = new JwtAuthenticationProperties(Collections.emptyMap());
-    properties.setCookieName("non-default");
+    final Map<String, String> configurationMap = new HashMap<>();
+    configurationMap.put(AmbariServerConfigurationKey.SSO_JWT_COOKIE_NAME.key(), "non-default");
+    configurationMap.put(AmbariServerConfigurationKey.SSO_JWT_AUDIENCES.key(), audiences == null || audiences.isEmpty() ? "" : StringUtils.join(audiences, ","));
+    configurationMap.put(AmbariServerConfigurationKey.SSO_AUTHENTICATION_ENABLED.key(), "true");
+    JwtAuthenticationProperties properties = new JwtAuthenticationProperties(configurationMap);
     properties.setPublicKey(publicKey);
-    properties.setAudiences(audiences);
-    properties.setEnabledForAmbari(true);
 
     return properties;
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationPropertiesTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/jwt/JwtAuthenticationPropertiesTest.java
@@ -23,30 +23,32 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.ambari.server.configuration.AmbariServerConfigurationKey;
 import org.junit.Test;
 
 public class JwtAuthenticationPropertiesTest {
 
   @Test
   public void testSetNullAudiences() {
-    JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties(Collections.emptyMap());
-    jwtAuthenticationProperties.setAudiencesString(null);
-    assertNull(jwtAuthenticationProperties.getAudiences());
+    assertNull(new JwtAuthenticationProperties(Collections.emptyMap()).getAudiences());
   }
 
   @Test
   public void testSetEmptyAudiences() {
-    JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties(Collections.emptyMap());
-    jwtAuthenticationProperties.setAudiencesString("");
-    assertNull(jwtAuthenticationProperties.getAudiences());
+    final Map<String, String> configurationMap = new HashMap<>();
+    configurationMap.put(AmbariServerConfigurationKey.SSO_JWT_AUDIENCES.key(), "");
+    assertNull(new JwtAuthenticationProperties(configurationMap).getAudiences());
   }
 
   @Test
   public void testSetValidAudiences() {
-    String[] expectedAudiences = {"first", "second", "third"};
-    JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties(Collections.emptyMap());
-    jwtAuthenticationProperties.setAudiencesString("first,second,third");
+    final String[] expectedAudiences = {"first", "second", "third"};
+    final Map<String, String> configurationMap = new HashMap<>();
+    configurationMap.put(AmbariServerConfigurationKey.SSO_JWT_AUDIENCES.key(), "first,second,third");
+    final JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties(configurationMap);
     assertNotNull(jwtAuthenticationProperties.getAudiences());
     assertArrayEquals(expectedAudiences, jwtAuthenticationProperties.getAudiences().toArray(new String[]{}));
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/pam/AmbariPamAuthenticationProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authentication/pam/AmbariPamAuthenticationProviderTest.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 import javax.persistence.EntityManager;
 
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.hooks.HookContextFactory;
 import org.apache.ambari.server.hooks.HookService;
@@ -42,6 +43,7 @@ import org.apache.ambari.server.security.authorization.User;
 import org.apache.ambari.server.security.authorization.UserAuthenticationType;
 import org.apache.ambari.server.security.authorization.UserName;
 import org.apache.ambari.server.security.authorization.Users;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.Before;
@@ -58,6 +60,8 @@ import org.springframework.security.crypto.password.StandardPasswordEncoder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 
 import junit.framework.Assert;
 
@@ -100,6 +104,7 @@ public class AmbariPamAuthenticationProviderTest extends EasyMockSupport {
         bind(PasswordEncoder.class).toInstance(new StandardPasswordEncoder());
         bind(Users.class).toInstance(users);
         bind(Configuration.class).toInstance(configuration);
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
       }
     });

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariAuthorizationFilterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/AmbariAuthorizationFilterTest.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.ambari.server.audit.AuditLogger;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.hooks.HookContextFactory;
 import org.apache.ambari.server.hooks.HookService;
@@ -41,6 +42,7 @@ import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.dao.UserDAO;
 import org.apache.ambari.server.security.AmbariEntryPoint;
 import org.apache.ambari.server.security.TestAuthenticationFactory;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.apache.ambari.server.view.ViewRegistry;
 import org.easymock.EasyMock;
@@ -56,6 +58,8 @@ import com.google.common.collect.Table.Cell;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 
 import junit.framework.Assert;
 
@@ -338,6 +342,7 @@ public class AmbariAuthorizationFilterTest {
         bind(AuditLogger.class).toInstance(EasyMock.createNiceMock(AuditLogger.class));
         bind(HookService.class).toInstance(EasyMock.createMock(HookService.class));
         bind(HookContextFactory.class).toInstance(EasyMock.createMock(HookContextFactory.class));
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
         bind(AmbariLdapConfigurationProvider.class).toInstance(EasyMock.createMock(AmbariLdapConfigurationProvider.class));
       }
     });

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/UsersTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/authorization/UsersTest.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.hooks.HookContextFactory;
 import org.apache.ambari.server.hooks.HookService;
@@ -50,6 +51,7 @@ import org.apache.ambari.server.orm.entities.PermissionEntity;
 import org.apache.ambari.server.orm.entities.PrincipalEntity;
 import org.apache.ambari.server.orm.entities.PrivilegeEntity;
 import org.apache.ambari.server.orm.entities.UserEntity;
+import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -60,6 +62,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 
 import junit.framework.Assert;
 
@@ -205,6 +209,7 @@ public class UsersTest extends EasyMockSupport {
         bind(HookContextFactory.class).toInstance(createMock(HookContextFactory.class));
         bind(PrincipalDAO.class).toInstance(createMock(PrincipalDAO.class));
         bind(Configuration.class).toInstance(createNiceMock(Configuration.class));
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
       }
     });

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/AbstractPrepareKerberosServerActionTest.java
@@ -47,6 +47,7 @@ import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.audit.AuditLogger;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
@@ -234,6 +235,7 @@ public class AbstractPrepareKerberosServerActionTest extends EasyMockSupport {
         bind(MpackManagerFactory.class).toInstance(createNiceMock(MpackManagerFactory.class));
         bind(AmbariLdapConfigurationProvider.class).toInstance(createMock(AmbariLdapConfigurationProvider.class));
         bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
+        bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
       }
     });
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/upgrades/PreconfigureKerberosActionTest.java
@@ -71,7 +71,6 @@ import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
 import org.apache.ambari.server.controller.KerberosHelperImpl;
 import org.apache.ambari.server.controller.RootServiceResponseFactory;
-import org.apache.ambari.server.events.AgentConfigsUpdateEvent;
 import org.apache.ambari.server.events.AmbariEvent;
 import org.apache.ambari.server.hooks.AmbariEventFactory;
 import org.apache.ambari.server.hooks.HookContext;
@@ -96,7 +95,6 @@ import org.apache.ambari.server.orm.entities.UpgradeEntity;
 import org.apache.ambari.server.scheduler.ExecutionScheduler;
 import org.apache.ambari.server.scheduler.ExecutionSchedulerImpl;
 import org.apache.ambari.server.security.encryption.CredentialStoreService;
-import org.apache.ambari.server.security.encryption.Encryptor;
 import org.apache.ambari.server.stack.StackManagerFactory;
 import org.apache.ambari.server.stack.upgrade.Direction;
 import org.apache.ambari.server.stack.upgrade.orchestrate.UpgradeContext;
@@ -154,7 +152,6 @@ import com.google.gson.reflect.TypeToken;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
 
@@ -616,7 +613,7 @@ public class PreconfigureKerberosActionTest extends EasyMockSupport {
       @Override
       protected void configure() {
         PartialNiceMockBinder.newBuilder(PreconfigureKerberosActionTest.this)
-            .addActionDBAccessorConfigsBindings().addLdapBindings().build().configure(binder());
+            .addActionDBAccessorConfigsBindings().addLdapBindings().addPasswordEncryptorBindings().build().configure(binder());
 
         bind(EntityManager.class).toInstance(createMock(EntityManager.class));
         bind(DBAccessor.class).toInstance(createMock(DBAccessor.class));
@@ -657,7 +654,6 @@ public class PreconfigureKerberosActionTest extends EasyMockSupport {
         bind(HostDAO.class).toInstance(createMock(HostDAO.class));
         bind(ExecutionScheduler.class).to(ExecutionSchedulerImpl.class);
         bind(ActionDBAccessor.class).to(ActionDBAccessorImpl.class);
-        bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
 
         install(new FactoryModuleBuilder().implement(HookContext.class, PostUserCreationHookContext.class)
             .build(HookContextFactory.class));

--- a/ambari-server/src/test/java/org/apache/ambari/server/testutils/PartialNiceMockBinder.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/testutils/PartialNiceMockBinder.java
@@ -33,6 +33,7 @@ import org.apache.ambari.server.actionmanager.StageFactory;
 import org.apache.ambari.server.actionmanager.StageFactoryImpl;
 import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.audit.AuditLoggerDefaultImpl;
+import org.apache.ambari.server.configuration.AmbariServerConfiguration;
 import org.apache.ambari.server.controller.AbstractRootServiceResponseFactory;
 import org.apache.ambari.server.controller.AmbariManagementController;
 import org.apache.ambari.server.controller.KerberosHelper;
@@ -218,6 +219,7 @@ public class PartialNiceMockBinder implements Module {
         binder.bind(EncryptionService.class).toInstance(easyMockSupport.createNiceMock(EncryptionService.class));
         binder.bind(new TypeLiteral<Encryptor<Config>>() {}).annotatedWith(Names.named("ConfigPropertiesEncryptor")).toInstance(Encryptor.NONE);
         binder.bind(new TypeLiteral<Encryptor<AgentConfigsUpdateEvent>>() {}).annotatedWith(Names.named("AgentConfigEncryptor")).toInstance(Encryptor.NONE);
+        binder.bind(new TypeLiteral<Encryptor<AmbariServerConfiguration>>() {}).annotatedWith(Names.named("AmbariServerConfigurationEncryptor")).toInstance(Encryptor.NONE);
       });
       return this;
     }

--- a/ambari-server/src/test/python/TestAmbariServer.py
+++ b/ambari-server/src/test/python/TestAmbariServer.py
@@ -6751,7 +6751,6 @@ class TestAmbariServer(TestCase):
     p = Properties()
     FAKE_PWD_STRING = "fakepasswd"
     p.process_pair(JDBC_PASSWORD_PROPERTY, FAKE_PWD_STRING)
-    p.process_pair(LDAP_MGR_PASSWORD_PROPERTY, FAKE_PWD_STRING)
     p.process_pair(SSL_TRUSTSTORE_PASSWORD_PROPERTY, FAKE_PWD_STRING)
     p.process_pair(JDBC_RCA_PASSWORD_FILE_PROPERTY, FAKE_PWD_STRING)
     get_ambari_properties_method.return_value = p
@@ -6773,15 +6772,13 @@ class TestAmbariServer(TestCase):
     self.assertTrue(update_properties_method.called)
     self.assertFalse(save_master_key_method.called)
     self.assertTrue(save_passwd_for_alias_method.called)
-    self.assertEquals(3, save_passwd_for_alias_method.call_count)
+    self.assertEquals(2, save_passwd_for_alias_method.call_count)
     self.assertTrue(remove_password_file_method.called)
 
     result_expected = {JDBC_PASSWORD_PROPERTY:
                          get_alias_string(JDBC_RCA_PASSWORD_ALIAS),
                        JDBC_RCA_PASSWORD_FILE_PROPERTY:
                          get_alias_string(JDBC_RCA_PASSWORD_ALIAS),
-                       LDAP_MGR_PASSWORD_PROPERTY:
-                         get_alias_string(LDAP_MGR_PASSWORD_ALIAS),
                        SSL_TRUSTSTORE_PASSWORD_PROPERTY:
                          get_alias_string(SSL_TRUSTSTORE_PASSWORD_ALIAS),
                        SECURITY_IS_ENCRYPTION_ENABLED: 'true'}
@@ -6882,7 +6879,6 @@ class TestAmbariServer(TestCase):
     p = Properties()
     FAKE_PWD_STRING = '${alias=fakealias}'
     p.process_pair(JDBC_PASSWORD_PROPERTY, FAKE_PWD_STRING)
-    p.process_pair(LDAP_MGR_PASSWORD_PROPERTY, FAKE_PWD_STRING)
     p.process_pair(SSL_TRUSTSTORE_PASSWORD_PROPERTY, FAKE_PWD_STRING)
     p.process_pair(JDBC_RCA_PASSWORD_FILE_PROPERTY, FAKE_PWD_STRING)
     get_ambari_properties_method.return_value = p
@@ -6902,15 +6898,13 @@ class TestAmbariServer(TestCase):
     self.assertTrue(read_master_key_method.called)
     self.assertTrue(update_properties_method.called)
     self.assertTrue(read_passwd_for_alias_method.called)
-    self.assertTrue(3, read_passwd_for_alias_method.call_count)
-    self.assertTrue(3, save_passwd_for_alias_method.call_count)
+    self.assertTrue(2, read_passwd_for_alias_method.call_count)
+    self.assertTrue(2, save_passwd_for_alias_method.call_count)
 
     result_expected = {JDBC_PASSWORD_PROPERTY:
                          get_alias_string(JDBC_RCA_PASSWORD_ALIAS),
                        JDBC_RCA_PASSWORD_FILE_PROPERTY:
                          get_alias_string(JDBC_RCA_PASSWORD_ALIAS),
-                       LDAP_MGR_PASSWORD_PROPERTY:
-                         get_alias_string(LDAP_MGR_PASSWORD_ALIAS),
                        SSL_TRUSTSTORE_PASSWORD_PROPERTY:
                          get_alias_string(SSL_TRUSTSTORE_PASSWORD_ALIAS),
                        SECURITY_IS_ENCRYPTION_ENABLED: 'true'}
@@ -6991,7 +6985,6 @@ class TestAmbariServer(TestCase):
     p = Properties()
     FAKE_PWD_STRING = '${alias=fakealias}'
     p.process_pair(JDBC_PASSWORD_PROPERTY, FAKE_PWD_STRING)
-    p.process_pair(LDAP_MGR_PASSWORD_PROPERTY, FAKE_PWD_STRING)
     p.process_pair(SSL_TRUSTSTORE_PASSWORD_PROPERTY, FAKE_PWD_STRING)
     p.process_pair(JDBC_RCA_PASSWORD_FILE_PROPERTY, FAKE_PWD_STRING)
     get_ambari_properties_method.return_value = p
@@ -7012,16 +7005,14 @@ class TestAmbariServer(TestCase):
     self.assertTrue(get_validated_string_input_method.called)
     self.assertTrue(update_properties_method.called)
     self.assertTrue(read_passwd_for_alias_method.called)
-    self.assertTrue(3, read_passwd_for_alias_method.call_count)
-    self.assertTrue(3, save_passwd_for_alias_method.call_count)
+    self.assertTrue(2, read_passwd_for_alias_method.call_count)
+    self.assertTrue(2, save_passwd_for_alias_method.call_count)
     self.assertFalse(save_master_key_method.called)
 
     result_expected = {JDBC_PASSWORD_PROPERTY:
                          get_alias_string(JDBC_RCA_PASSWORD_ALIAS),
                        JDBC_RCA_PASSWORD_FILE_PROPERTY:
                          get_alias_string(JDBC_RCA_PASSWORD_ALIAS),
-                       LDAP_MGR_PASSWORD_PROPERTY:
-                         get_alias_string(LDAP_MGR_PASSWORD_ALIAS),
                        SSL_TRUSTSTORE_PASSWORD_PROPERTY:
                          get_alias_string(SSL_TRUSTSTORE_PASSWORD_ALIAS),
                        SECURITY_IS_ENCRYPTION_ENABLED: 'true'}
@@ -7261,7 +7252,7 @@ class TestAmbariServer(TestCase):
         "ambari.ldap.connectivity.bind_dn": "test",
         "ambari.ldap.advanced.referrals": "test",
         "client.security": "ldap",
-        LDAP_MGR_PASSWORD_PROPERTY: "ldap-password.dat",
+        LDAP_MGR_PASSWORD_PROPERTY: "dummyPassword",
         "ambari.ldap.authentication.enabled": "true"
       }
     return ldap_properties_map
@@ -7290,7 +7281,7 @@ class TestAmbariServer(TestCase):
         "ambari.ldap.attributes.group.name_attr": "test",
         "ambari.ldap.attributes.dn_attr": "test",
         "ambari.ldap.advanced.referrals": "test",
-        LDAP_MGR_PASSWORD_PROPERTY: "ldap-password.dat",
+        LDAP_MGR_PASSWORD_PROPERTY: "dummyPassword",
         "ambari.ldap.authentication.enabled": "true",
         "ambari.ldap.manage_services": "true",
         "ambari.ldap.enabled_services":"ZOOKEEPER",
@@ -7343,7 +7334,7 @@ class TestAmbariServer(TestCase):
     properties.process_pair(CLIENT_API_PORT_PROPERTY, '8080')
 
     get_ambari_properties_method.return_value = properties
-    configure_ldap_password_method.return_value = "password"
+    configure_ldap_password_method.return_value = "dummyPassword"
     save_passwd_for_alias_method.return_value = 0
     encrypt_password_method.return_value = get_alias_string(LDAP_MGR_PASSWORD_ALIAS)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari configuration value types are defined in `org.apache.ambari.server.configuration.AmbariServerConfigurationKey.` Sensitive properties have property type of `org.apache.ambari.server.configuration.ConfigurationPropertyType#PASSWORD`.

Using this information, if this feature is enabled, the Ambari server should encrypt sensitive values before storing them in the`ambari_configuration` table in the Ambari DB.

The Ambari server should encrypt sensitive configuration values if the following has been met:
1. A master key has been setup using the `ambari-server setup-security` CLI (using option # 2 - Encrypt passwords stored in ambari.properties file)
2. The Ambari server configuration property named `security.server.encrypt_sensitive_data` is set to `true`

WIP: the API still return the encrypted form; I'm not sure if this needs to be changed...

## How was this patch tested?

Updated unit tests and they passed:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 24:50 min
[INFO] Finished at: 2018-12-21T14:31:01+01:00
[INFO] Final Memory: 103M/1814M
[INFO] ------------------------------------------------------------------------
```

In addition to uni tests the following steps have been done to check if everything works as expected:

1. installed the latest Ambari and replaced the `setupSecurity.py` and the generated JAR then restarted the server and the agents
2. configured LDAP by running `ambari-server setup-ldap` (some attributes are changed in the below sample such as server name, etc...)
3. checked the database: the manager password was stored in encrypted form
4. synced LDAP users successfully

```
[root@c7401 ~]# ambari-server setup-ldap --ambari-admin-username=admin --ambari-admin-password=admin --ldap-url=TEST_LDAP_SERVER --ldap-user-class=user --ldap-user-attr=sAMAccountName --ldap-group-class=group --ldap-group-attr=cn --ldap-member-attr=member --ldap-dn=distinguishedName --ldap-base-dn=TEST_BASE_DN --ldap-bind-anonym=false --ldap-manager-dn=cn=manager,cn=Users,dc=TEST_DC,dc=hortonworks,dc=com --ldap-manager-password=TEST_PASSWORD --ldap-referral=follow --ldap-sync-username-collisions-behavior=convert --ldap-force-lowercase-usernames=false --ldap-pagination-enabled=false --ldap-ssl=false --ldap-force-setup --ldap-save-settings --ldap-enabled-ambari=true --ldap-manage-services=true --ldap-enabled-services=* --ldap-user-group-member-attr=myMemberOf
Using python  /usr/bin/python

Fetching LDAP configuration from DB.
====================
Review Settings
====================
...
Saving LDAP properties...
Saving LDAP properties finished
Ambari Server 'setup-ldap' completed successfully.


[root@c7401 ~]# ambari-server sync-ldap --all --ldap-sync-admin-name admin --ldap-sync-admin-password admin
Using python  /usr/bin/python
Syncing with LDAP...

Fetching LDAP configuration from DB.
Syncing all.................

Completed LDAP Sync.
Summary:
  memberships:
    removed = 0
    created = 9
  users:
    skipped = 0
    removed = 0
    updated = 0
    created = 1006
  groups:
    updated = 0
    removed = 0
    created = 22

Ambari Server 'sync-ldap' completed successfully.
```