### PR TITLE
AMBARI-25069 - Ambari wrties Empty baseurl values written to Repo Files when using a local repository causing stack installation failure

### DIFF
--- a/ambari-web/app/controllers/wizard/step1_controller.js
+++ b/ambari-web/app/controllers/wizard/step1_controller.js
@@ -193,14 +193,14 @@ App.WizardStep1Controller = Em.Controller.extend({
    */
   onNetworkIssuesExist: function() {
     if (this.get('networkIssuesExist')) {
-      this.get('content.stacks').forEach(function (stack) {
-       if(stack.get('useLocalRepo') != true){
+      this.get('content.stacks').forEach(function(stack) {
+        if (stack.get('useLocalRepo') !== true) {
           stack.setProperties({
             usePublicRepo: false,
             useLocalRepo: true
           });
           stack.cleanReposBaseUrls();
-        } 
+        }
       });
     }
   }.observes('networkIssuesExist'),

--- a/ambari-web/app/controllers/wizard/step1_controller.js
+++ b/ambari-web/app/controllers/wizard/step1_controller.js
@@ -194,11 +194,13 @@ App.WizardStep1Controller = Em.Controller.extend({
   onNetworkIssuesExist: function() {
     if (this.get('networkIssuesExist')) {
       this.get('content.stacks').forEach(function (stack) {
-        stack.setProperties({
-          usePublicRepo: false,
-          useLocalRepo: true
-        });
-        stack.cleanReposBaseUrls();
+       if(stack.get('useLocalRepo') != true){
+          stack.setProperties({
+            usePublicRepo: false,
+            useLocalRepo: true
+          });
+          stack.cleanReposBaseUrls();
+        } 
       });
     }
   }.observes('networkIssuesExist'),


### PR DESCRIPTION

## What changes were proposed in this pull request?
AMBARI-25069 - Ambari wrties Empty baseurl values written to Repo Files when using a local repository causing stack installation failure

## How was this patch tested?
Tested in UI
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.