### PR TITLE
AMBARI-25076 Select Service page: Show Yarn and MR2 as separate services for selection instead of single selection (Yarn+MapReduce2)

### DIFF
--- a/ambari-web/app/models/stack_service.js
+++ b/ambari-web/app/models/stack_service.js
@@ -221,9 +221,8 @@ App.StackService = DS.Model.extend({
   }.property('coSelectedServices', 'serviceName'),
 
   isHiddenOnSelectServicePage: function () {
-    var hiddenServices = ['MAPREDUCE2'];
-    return hiddenServices.contains(this.get('serviceName')) || !this.get('isInstallable') || this.get('doNotShowAndInstall');
-  }.property('serviceName', 'isInstallable'),
+    return !this.get('isInstallable') || this.get('doNotShowAndInstall');
+  }.property('isInstallable', 'doNotShowAndInstall'),
 
   doNotShowAndInstall: function () {
     var skipServices = [];
@@ -351,9 +350,7 @@ App.StackService.componentsOrderForService = {
 };
 
 //@TODO: Write unit test for no two keys in the object should have any intersecting elements in their values
-App.StackService.coSelected = {
-  'YARN': ['MAPREDUCE2']
-};
+App.StackService.coSelected = {};
 
 
 App.StackService.reviewPageHandlers = {

--- a/ambari-web/app/models/stack_version/service_simple.js
+++ b/ambari-web/app/models/stack_version/service_simple.js
@@ -25,10 +25,7 @@ App.ServiceSimple = DS.Model.extend({
   latestVersion: DS.attr('string'),
   isAvailable: DS.attr('boolean'),
   isUpgradable: DS.attr('boolean'),
-  isHidden: function () {
-    var hiddenServices = ['MAPREDUCE2'];
-    return hiddenServices.contains(this.get('name')) || this.get('doNotShowAndInstall');
-  }.property('name'),
+  isHidden: Em.computed.alias('doNotShowAndInstall'),
 
   doNotShowAndInstall: function () {
     var skipServices = ['KERBEROS'];

--- a/ambari-web/test/controllers/wizard/step4_test.js
+++ b/ambari-web/test/controllers/wizard/step4_test.js
@@ -190,13 +190,16 @@ describe('App.WizardStep4Controller', function () {
         beforeEach(function () {
           controller.clear();
           Object.keys(testCase.condition).forEach(function (id) {
-            controller.pushObject(App.StackService.createRecord({
+            controller.pushObject(Em.Object.create({
               serviceName: id,
               isSelected: testCase.condition[id],
               canBeSelected: true,
               isInstalled: false,
               coSelectedServices: function() {
-                return App.StackService.coSelected[this.get('serviceName')] || [];
+                var coSelected = {
+                  'YARN': ['MAPREDUCE2']
+                };
+                return coSelected[this.get('serviceName')] || [];
               }.property('serviceName')
             }));
           });

--- a/ambari-web/test/models/stack_service_test.js
+++ b/ambari-web/test/models/stack_service_test.js
@@ -98,6 +98,9 @@ describe('App.StackService', function () {
       expect(ss.get('displayNameOnSelectServicePage')).to.equal('HDFS');
     });
     it('Present coSelectedServices', function () {
+      ss.reopen({
+        coSelectedServices: ['MAPREDUCE2']
+      });
       ss.set('serviceName', 'YARN');
       ss.set('displayName', 'YARN');
       ss.propertyDidChange('displayNameOnSelectServicePage');
@@ -111,11 +114,6 @@ describe('App.StackService', function () {
         serviceName: 'HDFS',
         isInstallable: true,
         result: false
-      },
-      {
-        serviceName: 'MAPREDUCE2',
-        isInstallable: true,
-        result: true
       },
       {
         serviceName: 'KERBEROS',

--- a/ambari-web/test/models/stack_version/service_simple_test.js
+++ b/ambari-web/test/models/stack_version/service_simple_test.js
@@ -31,12 +31,6 @@ describe('App.ServiceSimple', function () {
 
     var cases = [
       {
-        name: 'MAPREDUCE2',
-        doNotShowAndInstall: false,
-        isHidden: true,
-        title: 'MapReduce2 isn\'t displayed in wizard as separate service'
-      },
-      {
         name: 'KERBEROS',
         doNotShowAndInstall: true,
         isHidden: true,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This needs to be done so that user can select YARN without MR2 using UI installer wizard

## How was this patch tested?
  22099 passing (30s)
  48 pending
