### PR TITLE
AMBARI-25084. Delete identities fails when removing service in reverse order (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ClusterDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/ClusterDAO.java
@@ -19,6 +19,7 @@
 package org.apache.ambari.server.orm.dao;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -223,6 +224,9 @@ public class ClusterDAO {
   @RequiresSession
   public List<ClusterConfigEntity> getLatestConfigurationsWithTypes(long clusterId, StackId stackId, Collection<String> configTypes) {
     StackEntity stackEntity = stackDAO.find(stackId.getStackName(), stackId.getStackVersion());
+    if (configTypes.isEmpty()) {
+      return Collections.emptyList();
+    }
     return daoUtils.selectList(
       entityManagerProvider.get()
       .createNamedQuery("ClusterConfigEntity.findLatestConfigsByStackWithTypes", ClusterConfigEntity.class)

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/dao/ServiceConfigDAOTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/dao/ServiceConfigDAOTest.java
@@ -22,6 +22,7 @@ import static java.util.Arrays.asList;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -491,6 +492,8 @@ public class ServiceConfigDAOTest {
     List<ClusterConfigEntity> entities = clusterDAO.getLatestConfigurationsWithTypes(clusterEntity.getClusterId(), HDP_01, asList("oozie-site"));
     Assert.assertEquals(1, entities.size());
     entities = clusterDAO.getLatestConfigurationsWithTypes(clusterEntity.getClusterId(), HDP_01, asList("no-such-type"));
+    Assert.assertTrue(entities.isEmpty());
+    entities = clusterDAO.getLatestConfigurationsWithTypes(clusterEntity.getClusterId(), HDP_01, Collections.emptyList());
     Assert.assertTrue(entities.isEmpty());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After deleting a service the principal removal operation might fail with an error saying:

>  Internal Exception: org.postgresql.util.PSQLException: ERROR: syntax error at or near ")"

which is caused by an empty list parameter of a named query

## How was this patch tested?

* Install ZooKeeper + Kafka + Kerberos
* Stop Kafka
* curl -X DELETE http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/hosts/c7401.ambari.apache.org/host_components/KAFKA_BROKER
* curl -X DELETE http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/services/KAFKA/components/KAFKA_BROKER
* curl -X DELETE http://c7401.ambari.apache.org:8080/api/v1/clusters/TEST/services/KAFKA
* checked that there was no PersistenceException during principal removal