### PR TITLE
[AMBARI-25088] Enable Kerberos fails when Ambari server is not on a registered host

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelperImpl.java
@@ -1763,6 +1763,7 @@ public class KerberosHelperImpl implements KerberosHelper {
     } else {
       Collection<String> hosts;
       String ambariServerHostname = StageUtils.getHostName();
+      boolean ambariServerHostnameIsForced = false;
 
       if (hostName == null) {
         Map<String, Host> hostMap = clusters.getHostsForCluster(clusterName);
@@ -1777,6 +1778,7 @@ public class KerberosHelperImpl implements KerberosHelper {
           extendedHosts.addAll(hosts);
           extendedHosts.add(ambariServerHostname);
           hosts = extendedHosts;
+          ambariServerHostnameIsForced = true;
         }
       } else {
         hosts = Collections.singleton(hostName);
@@ -1788,14 +1790,14 @@ public class KerberosHelperImpl implements KerberosHelper {
         if (kerberosDescriptor != null) {
           Set<String> existingServices = cluster.getServices().keySet();
 
-          for (String hostname : hosts) {
+          for (String host : hosts) {
             // Calculate the current host-specific configurations. These will be used to replace
             // variables within the Kerberos descriptor data
             Map<String, Map<String, String>> configurations = calculateConfigurations(cluster,
-              hostname,
-              kerberosDescriptor,
-              false,
-              false);
+                (ambariServerHostnameIsForced && ambariServerHostname.equals(host)) ? null : host,
+                kerberosDescriptor,
+                false,
+                false);
 
             // Create the context to use for filtering Kerberos Identities based on the state of the cluster
             Map<String, Object> filterContext = new HashMap<>();
@@ -1804,10 +1806,10 @@ public class KerberosHelperImpl implements KerberosHelper {
 
 
             Map<String, KerberosIdentityDescriptor> hostActiveIdentities = new HashMap<>();
-            List<KerberosIdentityDescriptor> identities = getActiveIdentities(cluster, hostname,
+            List<KerberosIdentityDescriptor> identities = getActiveIdentities(cluster, host,
               serviceName, componentName, kerberosDescriptor, filterContext);
 
-            if (hostname.equals(ambariServerHostname)) {
+            if (host.equals(ambariServerHostname)) {
               // Determine if we should _calculate_ the Ambari service identities.
               // If kerberos-env/create_ambari_principal is not set to false the identity should be calculated.
               if (createAmbariIdentities(kerberosEnvConfig.getProperties())) {
@@ -1836,7 +1838,7 @@ public class KerberosHelperImpl implements KerberosHelper {
                   }
 
                   if (replaceHostNames) {
-                    principal = principal.replace("_HOST", hostname);
+                    principal = principal.replace("_HOST", host);
                   }
 
                   String uniqueKey = String.format("%s|%s", principal, (keytabFile == null) ? "" : keytabFile);
@@ -1883,7 +1885,7 @@ public class KerberosHelperImpl implements KerberosHelper {
               }
             }
 
-            activeIdentities.put(hostname, hostActiveIdentities.values());
+            activeIdentities.put(host, hostActiveIdentities.values());
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable Kerberos fails when Ambari server is not on a registered host.  

The following error is seen in /var/log/ambari-server.log

```
2019-01-03 15:28:34,238  WARN [Server Action Executor Worker 39] ServerActionExecutor:471 - Task #39 failed to complete execution due to thrown exception: org.apache.ambari.server.HostNotFoundException:Host not found, hostname=c7401.ambari.apache.org
org.apache.ambari.server.HostNotFoundException: Host not found, hostname=c7401.ambari.apache.org
        at org.apache.ambari.server.state.cluster.ClustersImpl.getHost(ClustersImpl.java:456)
        at org.apache.ambari.server.state.ConfigHelper.getEffectiveDesiredTags(ConfigHelper.java:190)
        at org.apache.ambari.server.state.ConfigHelper.getEffectiveDesiredTags(ConfigHelper.java:174)
        at org.apache.ambari.server.controller.AmbariManagementControllerImpl.findConfigurationTagsWithOverrides(AmbariManagementControllerImpl.java:2431)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.google.inject.internal.DelegatingInvocationHandler.invoke(DelegatingInvocationHandler.java:50)
        at com.sun.proxy.$Proxy134.findConfigurationTagsWithOverrides(Unknown Source)
        at org.apache.ambari.server.state.ConfigHelper.calculateExistingConfigurations(ConfigHelper.java:2158)
        at org.apache.ambari.server.controller.KerberosHelperImpl.calculateConfigurations(KerberosHelperImpl.java:1722)
        at org.apache.ambari.server.controller.KerberosHelperImpl.getActiveIdentities(KerberosHelperImpl.java:1797)
        at org.apache.ambari.server.serveraction.kerberos.KerberosServerAction.calculateServiceIdentities(KerberosServerAction.java:512)
        at org.apache.ambari.server.serveraction.kerberos.KerberosServerAction.processIdentities(KerberosServerAction.java:456)
        at org.apache.ambari.server.serveraction.kerberos.CreatePrincipalsServerAction.execute(CreatePrincipalsServerAction.java:92)
        at org.apache.ambari.server.serveraction.ServerActionExecutor$Worker.execute(ServerActionExecutor.java:550)
        at org.apache.ambari.server.serveraction.ServerActionExecutor$Worker.run(ServerActionExecutor.java:466)
        at java.lang.Thread.run(Thread.java:745)
```
This is caused when Ambari tried to find the host-specific configuration values when processing the Kerberos identities and the host is not registered for the relevant cluster. This can happen when the Ambari server Kerberos identity is being processed when the Ambari server host is not registered with the cluster. 

To solve this, host specific configuration values should not be obtained for the non-registered Ambari server host. 

## How was this patch tested?

Manually tested.

All unit tests passed.


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.