### PR TITLE
[AMBARI-25086] Upgrading Using a Modified Default Version Repository Fails on Some Services

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -245,7 +245,7 @@ public class ServiceInfo implements Validable {
 
   @Override
   public void addErrors(Collection<String> errors) {
-    this.errorSet.addAll(errors);
+    errorSet.addAll(errors);
   }
 
   /**
@@ -363,11 +363,11 @@ public class ServiceInfo implements Validable {
     }
     // If set to null and has a parent, then the value would have already been resolved and set.
     // Otherwise, return the default value (true).
-    return this.supportDeleteViaUIInternal;
+    return supportDeleteViaUIInternal;
   }
 
   public void setSupportDeleteViaUI(boolean supportDeleteViaUI) {
-    this.supportDeleteViaUIInternal = supportDeleteViaUI;
+    supportDeleteViaUIInternal = supportDeleteViaUI;
   }
 
   public String getName() {
@@ -395,7 +395,7 @@ public class ServiceInfo implements Validable {
   }
 
   public void setServiceAdvisorType(ServiceAdvisorType type) {
-    this.serviceAdvisorType = type;
+    serviceAdvisorType = type;
   }
 
   public ServiceAdvisorType getServiceAdvisorType() {
@@ -711,6 +711,7 @@ public class ServiceInfo implements Validable {
   /**
    * @deprecated Use {@link #getSingleSignOnEnabledTest()} instead
    */
+  @Deprecated
   public String getSingleSignOnEnabledConfiguration() {
     return singleSignOnInfo != null ? singleSignOnInfo.getEnabledConfiguration() : null;
   }
@@ -725,7 +726,7 @@ public class ServiceInfo implements Validable {
   public boolean isKerberosRequiredForSingleSignOnIntegration() {
     return singleSignOnInfo != null && singleSignOnInfo.isKerberosRequired();
   }
-  
+
   /**
    * Gets a new value for LDAP integration support
    */
@@ -735,7 +736,7 @@ public class ServiceInfo implements Validable {
 
   /**
    * Sets a new value for LDAP integration support
-   * 
+   *
    * @param ldapInfo
    *          a {@link ServiceLdapInfo}
    */
@@ -812,7 +813,7 @@ public class ServiceInfo implements Validable {
    * @param typeAttributes attributes associated with the type
    */
   public synchronized void setTypeAttributes(String type, Map<String, Map<String, String>> typeAttributes) {
-    if (this.configTypes == null) {
+    if (configTypes == null) {
       configTypes = new HashMap<>();
     }
     configTypes.put(type, typeAttributes);
@@ -1373,8 +1374,29 @@ public class ServiceInfo implements Validable {
 
     if (ldapInfo != null && ldapInfo.isSupported() && StringUtils.isBlank(ldapInfo.getLdapEnabledTest())) {
       setValid(false);
-      addError("LDAP support is indicated for service " + getName() + " but no test configuration has been set by ldapEnabledTest."); 
+      addError("LDAP support is indicated for service " + getName() + " but no test configuration has been set by ldapEnabledTest.");
     }
+  }
+
+  /**
+   * Gets whether this service advertises a version based on whether at least
+   * one of its components advertises a version.
+   *
+   * @return {@code true} if at least 1 component of this service advertises a
+   *         version, {@code false} otherwise.
+   */
+  public boolean isVersionAdvertised() {
+    if (null == components) {
+      return false;
+    }
+
+    for (ComponentInfo componentInfo : components) {
+      if (componentInfo.isVersionAdvertised()) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public enum Selection {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/VersionDefinitionXml.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/VersionDefinitionXml.java
@@ -200,9 +200,14 @@ public class VersionDefinitionXml {
   }
 
   /**
-   * Gets the list of stack services, applying information from the version definition.
-   * @param stack the stack for which to get the information
-   * @return the list of {@code ManifestServiceInfo} instances for each service in the stack
+   * Gets the list of stack services, applying information from the version
+   * definition. This will include both services which advertise a version and
+   * those which do not.
+   * 
+   * @param stack
+   *          the stack for which to get the information
+   * @return the list of {@code ManifestServiceInfo} instances for each service
+   *         in the stack
    */
   public synchronized List<ManifestServiceInfo> getStackServices(StackInfo stack) {
 
@@ -610,7 +615,12 @@ public class VersionDefinitionXml {
   }
 
   /**
-   * Builds a Version Definition that is the default for the stack
+   * Builds a Version Definition that is the default for the stack.
+   * <p>
+   * This will use all of the services defined on the stack, excluding those
+   * which do not advertise a version. If a service doesn't advertise a version,
+   * we cannot include it in a generated VDF.
+   *
    * @return the version definition
    */
   public static VersionDefinitionXml build(StackInfo stackInfo) {
@@ -630,6 +640,13 @@ public class VersionDefinitionXml {
     xml.release.display = stackId.toString();
 
     for (ServiceInfo si : stackInfo.getServices()) {
+      // do NOT build a manifest entry for services on the stack which cannot be
+      // a part of an upgrade - this is to prevent services like KERBEROS from
+      // preventing an upgrade if it's in Maintenance Mode
+      if (!si.isVersionAdvertised()) {
+        continue;
+      }
+
       ManifestService ms = new ManifestService();
       ms.serviceName = si.getName();
       ms.version = StringUtils.trimToEmpty(si.getVersion());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When performing a stack upgrade, if the user chooses the "Default Version Definition" option and just modifies the default URLs, the backing VDF which is created and stored in the database contains services which do not support upgrading. 

Before the upgrade, if any of these services are in maintenance mode (such as Ambari Infra), they will prevent the upgrade from starting.

During the actual upgrade, this will cause problems on finalization as those services/components have not participated, yet the VDF indicates that they should have.

## How was this patch tested?

- Verified that the STR would cause a VDF stored in `repo_version` to include services which did not advertise a version (such as `AMBARI_INFRA` and `KERBEROS`).

- After changes were applied, the same STR produce a VDF with only those services which advertise a version.

- Unit test written to cover changed functionality in `VersionDefiniionXml`