### PR TITLE
[AMBARI-25061] Refactor AddServiceInfo to use a builder

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/AddServiceInfo.java
@@ -42,18 +42,7 @@ public final class AddServiceInfo {
   private final Configuration config;
   private final LayoutRecommendationInfo recommendationInfo;
 
-  public AddServiceInfo(
-    AddServiceRequest request,
-    String clusterName,
-    RequestStageContainer stages,
-    Stack stack,
-    Configuration config,
-    Map<String, Map<String, Set<String>>> newServices
-  ) {
-    this(request, clusterName, stages, stack, config, newServices, null, null);
-  }
-
-  AddServiceInfo(
+  private AddServiceInfo(
     AddServiceRequest request,
     String clusterName,
     RequestStageContainer stages,
@@ -73,13 +62,26 @@ public final class AddServiceInfo {
     this.recommendationInfo = recommendationInfo;
   }
 
+  public Builder toBuilder() {
+    return new Builder()
+      .setRequest(request)
+      .setClusterName(clusterName)
+      .setStack(stack)
+      .setKerberosDescriptor(kerberosDescriptor)
+      .setNewServices(newServices)
+      .setStages(stages)
+      .setConfig(config)
+      .setRecommendationInfo(recommendationInfo)
+      ;
+  }
+
   public AddServiceInfo withLayoutRecommendation(Map<String, Map<String, Set<String>>> services,
                                                  LayoutRecommendationInfo recommendation) {
-    return new AddServiceInfo(request, clusterName, stages, stack, config, services, kerberosDescriptor, recommendation);
+    return toBuilder().setNewServices(services).setRecommendationInfo(recommendation).build();
   }
 
   public AddServiceInfo withConfig(Configuration newConfig) {
-    return new AddServiceInfo(request, clusterName, stages, stack, newConfig, newServices, kerberosDescriptor, recommendationInfo);
+    return toBuilder().setConfig(newConfig).build();
   }
 
   @Override
@@ -139,6 +141,63 @@ public final class AddServiceInfo {
 
   public boolean requiresLayoutRecommendation() {
     return !request.getServices().isEmpty();
+  }
+
+  public static class Builder {
+
+    private AddServiceRequest request;
+    private String clusterName;
+    private Stack stack;
+    private KerberosDescriptor kerberosDescriptor;
+    private Map<String, Map<String, Set<String>>> newServices;
+    private RequestStageContainer stages;
+    private Configuration config;
+    private LayoutRecommendationInfo recommendationInfo;
+
+    public AddServiceInfo build() {
+      return new AddServiceInfo(request, clusterName, stages, stack, config, newServices, kerberosDescriptor, recommendationInfo);
+    }
+
+    public Builder setRequest(AddServiceRequest request) {
+      this.request = request;
+      return this;
+    }
+
+    public Builder setClusterName(String clusterName) {
+      this.clusterName = clusterName;
+      return this;
+    }
+
+    public Builder setStages(RequestStageContainer stages) {
+      this.stages = stages;
+      return this;
+    }
+
+    public Builder setStack(Stack stack) {
+      this.stack = stack;
+      return this;
+    }
+
+    public Builder setConfig(Configuration config) {
+      this.config = config;
+      return this;
+    }
+
+    public Builder setNewServices(Map<String, Map<String, Set<String>>> newServices) {
+      this.newServices = newServices;
+      return this;
+    }
+
+    public Builder setKerberosDescriptor(KerberosDescriptor kerberosDescriptor) {
+      this.kerberosDescriptor = kerberosDescriptor;
+      return this;
+    }
+
+    public Builder setRecommendationInfo(LayoutRecommendationInfo recommendationInfo) {
+      this.recommendationInfo = recommendationInfo;
+      return this;
+    }
+
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/addservice/RequestValidator.java
@@ -121,10 +121,15 @@ public class RequestValidator {
     CHECK.checkState(!serviceInfoCreated.getAndSet(true), "Can create only one instance for each validated add service request");
 
     RequestStageContainer stages = new RequestStageContainer(actionManager.getNextRequestId(), null, requestFactory, actionManager);
-    AddServiceInfo validatedRequest = new AddServiceInfo(request, cluster.getClusterName(), stages,
-      state.getStack(), state.getConfig(), state.getNewServices(), state.getKerberosDescriptor(),
-      null
-    );
+    AddServiceInfo validatedRequest = new AddServiceInfo.Builder()
+      .setRequest(request)
+      .setClusterName(cluster.getClusterName())
+      .setStages(stages)
+      .setStack(state.getStack())
+      .setConfig(state.getConfig())
+      .setNewServices(state.getNewServices())
+      .setKerberosDescriptor(state.getKerberosDescriptor())
+      .build();
     stages.setRequestContext(validatedRequest.describe());
     return validatedRequest;
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/ProvisionActionPredicateBuilderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/ProvisionActionPredicateBuilderTest.java
@@ -57,11 +57,13 @@ public class ProvisionActionPredicateBuilderTest {
     )
   );
   private static final RequestStageContainer STAGES = new RequestStageContainer(42L, null, null, null, null);
+  private static final AddServiceInfo.Builder ADD_SERVICE_INFO_BUILDER = new AddServiceInfo.Builder()
+    .setClusterName(CLUSTER_NAME).setStages(STAGES).setNewServices(NEW_SERVICES);
 
   @Test
   public void noCustomProvisionAction() {
     AddServiceRequest request = createRequest(null, null, null);
-    AddServiceInfo info = new AddServiceInfo(request, CLUSTER_NAME, STAGES, null, null, NEW_SERVICES);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER.setRequest(request).build();
     ProvisionActionPredicateBuilder builder = new ProvisionActionPredicateBuilder(info);
 
     assertTrue(builder.getPredicate(ProvisionStep.INSTALL).isPresent());
@@ -81,7 +83,7 @@ public class ProvisionActionPredicateBuilderTest {
   @Test
   public void requestLevelStartOnly() {
     AddServiceRequest request = createRequest(ProvisionAction.START_ONLY, null, null);
-    AddServiceInfo info = new AddServiceInfo(request, CLUSTER_NAME, STAGES, null, null, NEW_SERVICES);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER.setRequest(request).build();
     ProvisionActionPredicateBuilder builder = new ProvisionActionPredicateBuilder(info);
 
     assertEquals(Optional.empty(), builder.getPredicate(ProvisionStep.INSTALL));
@@ -115,7 +117,7 @@ public class ProvisionActionPredicateBuilderTest {
         Component.of("METRICS_MONITOR", ProvisionAction.INSTALL_ONLY, "c7404", "c7405") // overrides service-level
       )
     );
-    AddServiceInfo info = new AddServiceInfo(request, CLUSTER_NAME, STAGES, null, null, NEW_SERVICES);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER.setRequest(request).build();
     ProvisionActionPredicateBuilder builder = new ProvisionActionPredicateBuilder(info);
 
     assertTrue(builder.getPredicate(ProvisionStep.INSTALL).isPresent());

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/StackAdvisorAdapterTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/addservice/StackAdvisorAdapterTest.java
@@ -117,6 +117,9 @@ public class StackAdvisorAdapterTest {
     .put("c7406", ImmutableSet.of("DATANODE", "HDFS_CLIENT", "ZOOKEEPER_CLIENT"))
     .build();
 
+  private static final AddServiceInfo.Builder ADD_SERVICE_INFO_BUILDER = new AddServiceInfo.Builder()
+    .setClusterName("c1");
+
   @Test
   public void getHostComponentMap() {
     assertEquals(HOST_COMPONENT_MAP, StackAdvisorAdapter.getHostComponentMap(COMPONENT_HOST_MAP));
@@ -178,7 +181,12 @@ public class StackAdvisorAdapterTest {
         "OOZIE_CLIENT", ImmutableSet.of("c7403", "c7404")));
 
     AddServiceRequest request = request(ConfigRecommendationStrategy.ALWAYS_APPLY);
-    AddServiceInfo info = new AddServiceInfo(request, "c1", null, stack, Configuration.newEmpty(), newServices); // No LayoutReommendationInfo -> needs to be calculated
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setRequest(request)
+      .setStack(stack)
+      .setConfig(Configuration.newEmpty())
+      .setNewServices(newServices)
+      .build(); // No LayoutReommendationInfo -> needs to be calculated
 
     LayoutRecommendationInfo layoutRecommendationInfo = adapter.getLayoutRecommendationInfo(info);
     layoutRecommendationInfo.getAllServiceLayouts();
@@ -360,7 +368,11 @@ public class StackAdvisorAdapterTest {
       "KAFKA",
       ImmutableMap.of("KAFKA_BROKER", emptySet()));
 
-    AddServiceInfo info = new AddServiceInfo(null, "c1", null, stack, org.apache.ambari.server.topology.Configuration.newEmpty(), newServices);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setStack(stack)
+      .setConfig(Configuration.newEmpty())
+      .setNewServices(newServices)
+      .build();
     AddServiceInfo infoWithRecommendations = adapter.recommendLayout(info);
 
     Map<String, Map<String, Set<String>>> expectedNewLayout = ImmutableMap.of(
@@ -392,7 +404,12 @@ public class StackAdvisorAdapterTest {
     clusterConfig.setParentConfiguration(stackConfig);
 
     AddServiceRequest request = request(ConfigRecommendationStrategy.ALWAYS_APPLY);
-    AddServiceInfo info = new AddServiceInfo(request, "c1", null, stack, userConfig, newServices); // No LayoutRecommendationInfo
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setRequest(request)
+      .setStack(stack)
+      .setConfig(userConfig)
+      .setNewServices(newServices)
+      .build(); // No LayoutRecommendationInfo
     AddServiceInfo infoWithConfig = adapter.recommendConfigurations(info);
 
     Configuration recommendedConfig = infoWithConfig.getConfig();
@@ -442,8 +459,13 @@ public class StackAdvisorAdapterTest {
 
     LayoutRecommendationInfo layoutRecommendationInfo = new LayoutRecommendationInfo(new HashMap<>(), new HashMap<>()); // contents doesn't matter for the test
     AddServiceRequest request = request(ConfigRecommendationStrategy.ALWAYS_APPLY);
-    AddServiceInfo info = new AddServiceInfo(request, "c1", null, stack, userConfig, newServices)
-      .withLayoutRecommendation(newServices, layoutRecommendationInfo);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setRequest(request)
+      .setStack(stack)
+      .setConfig(userConfig)
+      .setNewServices(newServices)
+      .setRecommendationInfo(layoutRecommendationInfo)
+      .build();
     AddServiceInfo infoWithConfig = adapter.recommendConfigurations(info);
 
     Configuration recommendedConfig = infoWithConfig.getConfig();
@@ -493,8 +515,13 @@ public class StackAdvisorAdapterTest {
 
     LayoutRecommendationInfo layoutRecommendationInfo = new LayoutRecommendationInfo(new HashMap<>(), new HashMap<>()); // contents doesn't matter for the test
     AddServiceRequest request = request(ConfigRecommendationStrategy.ALWAYS_APPLY_DONT_OVERRIDE_CUSTOM_VALUES);
-    AddServiceInfo info = new AddServiceInfo(request, "c1", null, stack, userConfig, newServices)
-      .withLayoutRecommendation(newServices, layoutRecommendationInfo);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setRequest(request)
+      .setStack(stack)
+      .setConfig(userConfig)
+      .setNewServices(newServices)
+      .setRecommendationInfo(layoutRecommendationInfo)
+      .build();
     AddServiceInfo infoWithConfig = adapter.recommendConfigurations(info);
 
     assertSame(userConfig, infoWithConfig.getConfig()); // user config stays top priority
@@ -549,8 +576,13 @@ public class StackAdvisorAdapterTest {
 
     LayoutRecommendationInfo layoutRecommendationInfo = new LayoutRecommendationInfo(new HashMap<>(), new HashMap<>()); // contents doesn't matter for the test
     AddServiceRequest request = request(ConfigRecommendationStrategy.NEVER_APPLY);
-    AddServiceInfo info = new AddServiceInfo(request, "c1", null, stack, userConfig, newServices)
-      .withLayoutRecommendation(newServices, layoutRecommendationInfo);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setRequest(request)
+      .setStack(stack)
+      .setConfig(userConfig)
+      .setNewServices(newServices)
+      .setRecommendationInfo(layoutRecommendationInfo)
+      .build();
     AddServiceInfo infoWithConfig = adapter.recommendConfigurations(info);
 
     // No recommended config, no stack config
@@ -591,8 +623,13 @@ public class StackAdvisorAdapterTest {
 
     LayoutRecommendationInfo layoutRecommendationInfo = new LayoutRecommendationInfo(new HashMap<>(), new HashMap<>()); // contents doesn't matter for the test
     AddServiceRequest request = request(ConfigRecommendationStrategy.ONLY_STACK_DEFAULTS_APPLY);
-    AddServiceInfo info = new AddServiceInfo(request, "c1", null, stack, userConfig, newServices)
-      .withLayoutRecommendation(newServices, layoutRecommendationInfo);
+    AddServiceInfo info = ADD_SERVICE_INFO_BUILDER
+      .setRequest(request)
+      .setStack(stack)
+      .setConfig(userConfig)
+      .setNewServices(newServices)
+      .setRecommendationInfo(layoutRecommendationInfo)
+      .build();
     AddServiceInfo infoWithConfig = adapter.recommendConfigurations(info);
     Configuration recommendedConfig = infoWithConfig.getConfig().getParentConfiguration();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Clean up `AddServiceInfo` creation by adding a builder class.

https://github.com/apache/ambari/pull/2725#discussion_r243259847
https://issues.apache.org/jira/browse/AMBARI-25061

## How was this patch tested?

Existing unit tests (no functional change) pass.

Tested for regression manually via API call.