### PR TITLE
[AMBARI-25094] Remove Flume Live widget from Ambari, alongside the Flume service during upgrade to HDP3.

### DIFF
--- a/ambari-web/app/views/main/dashboard/widgets.js
+++ b/ambari-web/app/views/main/dashboard/widgets.js
@@ -539,7 +539,7 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
   },
 
   /**
-   * check if stack has upgraded from HDP 1.0 to 2.0 OR add/delete services.
+   * Check if any services with widgets were added or deleted.
    * Update the value on server if true.
    */
   checkServicesChange: function () {
@@ -558,6 +558,12 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
         if (!userPreferences.visible.contains(id) && !userPreferences.hidden.contains(id)) {
           isChanged = true;
           newValue[state].push(id);
+        }
+      });
+      userPreferences[state].forEach(id => {
+        if (!defaultPreferences.visible.contains(id) && !defaultPreferences.hidden.contains(id)) {
+          isChanged = true;
+          newValue[state] = newValue[state].without(id);
         }
       });
       Object.keys(defaultPreferences.groups).forEach(groupName => {


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the ambari-managed upgrade from HDP 2.6 -> HDP 3.0, the flume service is removed (as it is no longer supported in the new stack). 

The "Flume Live" widget is still displayed on the Ambari home page.  

Let's remove this widget as well, when the flume service is removed. 

## How was this patch tested?

Tested manually
UI unit tests:
```
  22131 passing (27s)
  48 pending
```