### PR TITLE
AMBARI-25043. Make sure we mask password properties when fetching sensitive Ambari configuration via the API (just like we do it for service configs)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProvider.java
@@ -40,6 +40,7 @@ import org.apache.ambari.server.controller.spi.UnsupportedPropertyException;
 import org.apache.ambari.server.controller.utilities.PredicateHelper;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
 import org.apache.ambari.server.security.authorization.RoleAuthorization;
+import org.apache.ambari.server.utils.SecretReference;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -210,7 +211,7 @@ public class RootServiceComponentConfigurationResourceProvider extends AbstractA
     setResourceProperty(resource, CONFIGURATION_SERVICE_NAME_PROPERTY_ID, serviceName, requestedIds);
     setResourceProperty(resource, CONFIGURATION_COMPONENT_NAME_PROPERTY_ID, componentName, requestedIds);
     setResourceProperty(resource, CONFIGURATION_CATEGORY_PROPERTY_ID, categoryName, requestedIds);
-    setResourceProperty(resource, CONFIGURATION_PROPERTIES_PROPERTY_ID, properties, requestedIds);
+    setResourceProperty(resource, CONFIGURATION_PROPERTIES_PROPERTY_ID, SecretReference.maskPasswordInPropertyMap(properties), requestedIds);
     setResourceProperty(resource, CONFIGURATION_PROPERTY_TYPES_PROPERTY_ID, propertyTypes, requestedIds);
     return resource;
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/SecretReference.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/SecretReference.java
@@ -112,11 +112,14 @@ public class SecretReference {
     }
     final Map<String, String> maskedMap = new HashMap<>();
     for (Map.Entry<String, String> property : propertyMap.entrySet()) {
-      String value = property.getKey().toLowerCase().contains(PASSWORD_TEXT) || property.getKey().toLowerCase().contains(PASSWD_TEXT) ? secretPrefix
-          : property.getValue();
+      String value = isPassword(property.getKey()) ? secretPrefix : property.getValue();
       maskedMap.put(property.getKey(), value);
     }
     return maskedMap;
+  }
+
+  private final static boolean isPassword(String propertyName) {
+    return propertyName.toLowerCase().contains(PASSWORD_TEXT) || propertyName.toLowerCase().contains(PASSWD_TEXT);
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/SecretReference.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/SecretReference.java
@@ -94,17 +94,29 @@ public class SecretReference {
    * @return New string with the passwords masked, or null if the property map is null.
    */
   public static String maskPasswordInPropertyMap(String propertyMap) {
-    if (null == propertyMap) return null;
-    Map<String, String> maskedMap = new HashMap<>();
-    Map<String, String> map = gson.fromJson(propertyMap, new TypeToken<Map<String, String>>() {}.getType());
-    for (Map.Entry<String, String> e : map.entrySet()) {
-      String value = e.getValue();
-      if (e.getKey().toLowerCase().contains(PASSWORD_TEXT) || e.getKey().toLowerCase().contains(PASSWD_TEXT)) {
-        value = secretPrefix;
-      }
-      maskedMap.put(e.getKey(), value);
+    if (null == propertyMap) {
+      return null;
     }
-    return gson.toJson(maskedMap);
+    final Map<String, String> map = gson.fromJson(propertyMap, new TypeToken<Map<String, String>>() {}.getType());
+    return gson.toJson(maskPasswordInPropertyMap(map));
+  }
+
+  /**
+   * Helper function to mask a string of properties that may contain a property with a password.
+   * @param propertyMap Property map to mask by replacing any passwords with the text "SECRET"
+   * @return a new map with the passwords masked, or null if the <code>propertyMap</code> is null.
+   */
+  public static Map<String, String> maskPasswordInPropertyMap(Map<String, String> propertyMap) {
+    if (null == propertyMap) {
+      return null;
+    }
+    final Map<String, String> maskedMap = new HashMap<>();
+    for (Map.Entry<String, String> property : propertyMap.entrySet()) {
+      String value = property.getKey().toLowerCase().contains(PASSWORD_TEXT) || property.getKey().toLowerCase().contains(PASSWD_TEXT) ? secretPrefix
+          : property.getValue();
+      maskedMap.put(property.getKey(), value);
+    }
+    return maskedMap;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Like I indicated in #2742 the API returned the encrypted form instead of a secret reference (this is what we do for service configs). From now on we are in synch with service configurations.

## How was this patch tested?

Running JUnit tests in `ambari-server`:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 28:27 min
[INFO] Finished at: 2019-01-14T12:52:47+01:00
[INFO] Final Memory: 163M/1047M
[INFO] ------------------------------------------------------------------------
```

Additionally I executed some E2E tests and found that passwords are masked by `SECRET`:

![screen shot 2019-01-14 at 12 13 17 pm](https://user-images.githubusercontent.com/34065904/51111682-0f28af00-17fd-11e9-9b89-bed941b81b13.png)
