### PR TITLE
[AMBARI-25103] Duplicate title on YARN summary page

### DIFF
--- a/ambari-web/app/templates/main/service/info/summary/master_components.hbs
+++ b/ambari-web/app/templates/main/service/info/summary/master_components.hbs
@@ -64,18 +64,6 @@
     {{/if}}
   {{/if}}
 {{/each}}
-{{#unless view.mastersComp.length}}
-  <div class="col-md-12">
-    <div class="col-md-2">
-      {{#if view.parentView.parentView.hasComponents}}
-        {{t dashboard.services.hdfs.summary.components}}
-      {{/if}}
-    </div>
-    <div class="col-md-10">
-      {{view App.SummaryClientComponentsView clientsObjBinding="view.parentView.parentView.clientObj"}}
-    </div>
-  </div>
-{{/unless}}
 {{#if view.parentView.parentView.service.hasMasterOrSlaveComponent}}
   {{#if view.componentCommonWidgetsView}}
     {{view view.componentCommonWidgetsView}}

--- a/ambari-web/app/templates/main/service/services/hbase.hbs
+++ b/ambari-web/app/templates/main/service/services/hbase.hbs
@@ -22,7 +22,7 @@
     {{view view.dashboardMasterComponentView}}
     <div class="col-md-12">
       <div class="col-md-2">
-        {{#if view.hasMultipleMasterGroups}}
+        {{#if view.showComponentsTitleForNonMasters}}
           {{t dashboard.services.hdfs.summary.components}}
         {{/if}}
       </div>

--- a/ambari-web/app/templates/main/service/services/hdfs.hbs
+++ b/ambari-web/app/templates/main/service/services/hdfs.hbs
@@ -25,5 +25,17 @@
       {{view view.slaveComponentsView slaveComponentsViewBinding="view.slaveComponentsView" summaryViewBinding="view"
         showTitle=true}}
     {{/if}}
+    {{#unless view.parentView.service.hasMasterOrSlaveComponent}}
+      <div class="col-md-12">
+        <div class="col-md-2">
+          {{#if view.parentView.hasComponents}}
+            {{t dashboard.services.hdfs.summary.components}}
+          {{/if}}
+        </div>
+        <div class="col-md-10">
+          {{view App.SummaryClientComponentsView clientsObjBinding="view.parentView.clientObj"}}
+        </div>
+      </div>
+    {{/unless}}
   </div>
 </div>

--- a/ambari-web/app/templates/main/service/services/hive.hbs
+++ b/ambari-web/app/templates/main/service/services/hive.hbs
@@ -20,7 +20,7 @@
   {{view view.dashboardMasterComponentView}}
   <div class="col-md-12">
     <div class="col-md-2">
-      {{#if view.hasMultipleMasterGroups}}
+      {{#if view.showComponentsTitleForNonMasters}}
         {{t dashboard.services.hdfs.summary.components}}
       {{/if}}
     </div>

--- a/ambari-web/app/templates/main/service/services/onefs.hbs
+++ b/ambari-web/app/templates/main/service/services/onefs.hbs
@@ -39,7 +39,7 @@
     </div>
     <div class="col-md-12">
       <div class="col-md-2">
-        {{#if view.hasMultipleMasterGroups}}
+        {{#if view.showComponentsTitleForNonMasters}}
           {{t dashboard.services.hdfs.summary.components}}
         {{/if}}
       </div>

--- a/ambari-web/app/templates/main/service/services/ranger.hbs
+++ b/ambari-web/app/templates/main/service/services/ranger.hbs
@@ -20,7 +20,7 @@
   {{view view.dashboardMasterComponentView}}
   <div class="col-md-12">
     <div class="col-md-2">
-      {{#if view.hasMultipleMasterGroups}}
+      {{#if view.showComponentsTitleForNonMasters}}
         {{t dashboard.services.hdfs.summary.components}}
       {{/if}}
     </div>

--- a/ambari-web/app/templates/main/service/services/storm.hbs
+++ b/ambari-web/app/templates/main/service/services/storm.hbs
@@ -17,11 +17,11 @@
 }}
 
 <div class="row">
-  <div class="col-md-12 component-summary">
+  <div class="component-summary">
     {{view view.dashboardMasterComponentView}}
     <div class="col-md-12">
       <div class="col-md-2">
-        {{#if view.hasMultipleMasterGroups}}
+        {{#if view.showComponentsTitleForNonMasters}}
           {{t dashboard.services.hdfs.summary.components}}
         {{/if}}
       </div>

--- a/ambari-web/app/templates/main/service/services/yarn.hbs
+++ b/ambari-web/app/templates/main/service/services/yarn.hbs
@@ -22,7 +22,7 @@
     {{view view.dashboardMasterComponentView}}
     <div class="col-md-12">
       <div class="col-md-2">
-        {{#if view.parentView.hasComponents}}
+        {{#if view.showComponentsTitleForNonMasters}}
           {{t dashboard.services.hdfs.summary.components}}
         {{/if}}
       </div>

--- a/ambari-web/app/views/main/service/service.js
+++ b/ambari-web/app/views/main/service/service.js
@@ -159,6 +159,8 @@ App.MainDashboardServiceView = Em.View.extend(App.MainDashboardServiceViewWrappe
 
   hasMultipleMasterGroups: Em.computed.gt('parentView.mastersObj.length', 1),
 
+  showComponentsTitleForNonMasters: Em.computed.or('!masters.length', 'hasMultipleMasterGroups'),
+
   /**
    * Check if service component is created
    * @param componentName


### PR DESCRIPTION
## What changes were proposed in this pull request?

'Components' sub-title is displayed twice

## How was this patch tested?

Tested manually