### PR TITLE
[AMBARI-25107] Ambari is not respecting host component maintenance mode when performing "Restart All Required" at the cluster level

### DIFF
--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -2484,7 +2484,7 @@ var urls = {
           },
           "Requests/resource_filters": [
             {
-              "hosts_predicate": "HostRoles/stale_configs=true&HostRoles/cluster_name=" + data.clusterName
+              "hosts_predicate": "HostRoles/stale_configs=true&HostRoles/maintenance_state=OFF&HostRoles/cluster_name=" + data.clusterName
             }
           ]
         })


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Put HSI in maintenance mode.
- Changed auth to local mapping in core-site.
- A bunch of services got a restart indicator.
- Triggering "Restart All Required" at the cluster level schedules HSI to be restarted.  HSI restart fails so the entire operation fails.  This is cumbersome because now the user has to trigger "restart affected" for individual services.

## How was this patch tested?

Tested manually