### PR TITLE
[AMBARI-25112] Cover errors utils with unit tests

### DIFF
--- a/ambari-web/app/assets/test/tests.js
+++ b/ambari-web/app/assets/test/tests.js
@@ -233,6 +233,8 @@ var files = [
   'test/utils/db_test',
   'test/utils/ember_computed_test',
   'test/utils/ember_reopen_test',
+  'test/utils/errors/assertions_test',
+  'test/utils/errors/definitions_test',
   'test/utils/form_field_test',
   'test/utils/file_utils_test',
   'test/utils/handlebars_helpers_test',

--- a/ambari-web/test/utils/errors/assertions_test.js
+++ b/ambari-web/test/utils/errors/assertions_test.js
@@ -19,630 +19,636 @@
 var App = require('app');
 require('utils/errors/assertions');
 
-describe('#App.assert', function () {
-  var errorCases = [
-    {
-      args: [null, false],
-      errorType: Error,
-      desc: '',
-      title: 'default error object, no description'
-    },
-    {
-      args: ['desc0', false],
-      errorType: Error,
-      desc: ' Info:  desc0',
-      title: 'default error object, custom description'
-    },
-    {
-      args: [null, false, TypeError],
-      errorType: TypeError,
-      desc: '',
-      title: 'custom error object, no description'
-    },
-    {
-      args: ['desc1', false, TypeError],
-      errorType: TypeError,
-      desc: ' Info:  desc1',
-      title: 'custom error object, custom description'
-    }
-  ];
-  errorCases.forEach(function (test) {
-    it(test.title, function () {
-      var testFunction = function () {
-        App.assert.apply(null, test.args);
-      };
-      expect(testFunction).to.throw(test.errorType, test.desc);
+describe('Error assertions', function () {
+  describe('#App.assert', function () {
+    var errorCases = [
+      {
+        args: [null, false],
+        errorType: Error,
+        desc: '',
+        title: 'default error object, no description'
+      },
+      {
+        args: ['desc0', false],
+        errorType: Error,
+        desc: ' Info:  desc0',
+        title: 'default error object, custom description'
+      },
+      {
+        args: [null, false, TypeError],
+        errorType: TypeError,
+        desc: '',
+        title: 'custom error object, no description'
+      },
+      {
+        args: ['desc1', false, TypeError],
+        errorType: TypeError,
+        desc: ' Info:  desc1',
+        title: 'custom error object, custom description'
+      }
+    ];
+    errorCases.forEach(function (test) {
+      it(test.title, function () {
+        var testFunction = function () {
+          App.assert.apply(null, test.args);
+        };
+        expect(testFunction).to.throw(test.errorType, test.desc);
+      });
+    });
+    it('no error', function () {
+      expect(App.assert.bind(null, 'desc2', true)).to.not.throw();
     });
   });
-  it('no error', function () {
-    expect(App.assert.bind(null, 'desc2', true)).to.not.throw();
-  });
-});
 
-describe('#App.assertExists', function () {
-  var errorCases = [
-      {
-        value: null,
-        desc: 'desc0',
-        title: 'null'
-      },
-      {
-        value: undefined,
-        desc: 'desc1',
-        title: 'undefined'
-      }
-    ],
-    noErrorCases = [
-      {
-        value: [],
-        title: 'empty array'
-      },
-      {
-        value: [0],
-        title: 'non-empty array'
-      },
-      {
-        value: {},
-        title: 'empty object'
-      },
-      {
-        value: {
-          a: ''
+  describe('#App.assertExists', function () {
+    var errorCases = [
+        {
+          value: null,
+          desc: 'desc0',
+          title: 'null'
         },
-        title: 'non-empty object'
-      },
-      {
-        value: Em.Object.create(),
-        title: 'empty Ember object'
-      },
-      {
-        value: Em.Object.create({
-          a: ''
-        }),
-        title: 'non-empty Ember object'
-      },
-      {
-        value: 0,
-        title: '0'
-      },
-      {
-        value: 1,
-        title: 'non-zero number'
-      },
-      {
-        value: NaN,
-        title: 'NaN'
-      },
-      {
-        value: Infinity,
-        title: 'Infinity'
-      },
-      {
-        value: false,
-        title: 'false'
-      },
-      {
-        value: true,
-        title: 'true'
-      },
-      {
-        value: '',
-        title: 'empty string'
-      },
-      {
-        value: '0',
-        title: 'non-empty string'
-      },
-      {
-        value: ' ',
-        title: 'spaces-only string'
-      },
-      {
-        value: new Number(0),
-        title: 'number object'
-      },
-      {
-        value: new String(''),
-        title: 'string object'
-      },
-      {
-        value: new Boolean(false),
-        title: 'boolean object'
-      },
-      {
-        value: new Number(1),
-        title: 'object of non-zero number'
-      },
-      {
-        value: new String('a'),
-        title: 'object of non-empty string'
-      },
-      {
-        value: new Boolean(true),
-        title: 'object of true boolean'
-      }
-    ];
-  errorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertExists.bind(null, test.value, test.desc)).to.throw(App.NotNullTypeError, test.desc);
-    });
-  });
-  noErrorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertExists.bind(null, test.value, 'desc')).to.not.throw();
-    });
-  });
-});
-
-describe('#App.assertObject', function () {
-  var errorCases = [
-      {
-        value: null,
-        desc: 'desc0',
-        title: 'null'
-      },
-      {
-        value: undefined,
-        desc: 'desc1',
-        title: 'undefined'
-      },
-      {
-        value: 1,
-        desc: 'desc2',
-        title: 'number'
-      },
-      {
-        value: NaN,
-        desc: 'desc3',
-        title: 'NaN'
-      },
-      {
-        value: Infinity,
-        desc: 'desc4',
-        title: 'Infinity'
-      },
-      {
-        value: true,
-        desc: 'desc5',
-        title: 'boolean'
-      },
-      {
-        value: 'a',
-        desc: 'desc6',
-        title: 'string'
-      },
-      {
-        value: function () {},
-        desc: 'desc7',
-        title: 'function'
-      }
-    ],
-    noErrorCases = [
-      {
-        value: [],
-        title: 'array'
-      },
-      {
-        value: {},
-        title: 'object'
-      },
-      {
-        value: new Date(),
-        title: 'date'
-      },
-      {
-        value: new RegExp(),
-        title: 'regexp'
-      },
-      {
-        value: Em.Object.create(),
-        title: 'Ember object'
-      },
-      {
-        value: Em.View.create(),
-        title: 'extended Ember object'
-      },
-      {
-        value: new Error(),
-        title: 'error object'
-      },
-      {
-        value: new Number(1),
-        title: 'number object'
-      },
-      {
-        value: new String('a'),
-        title: 'string object'
-      },
-      {
-        value: new Boolean(true),
-        title: 'boolean object'
-      }
-    ];
-  errorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertObject.bind(null, test.value, test.desc)).to.throw(App.ObjectTypeError, test.desc);
-    });
-  });
-  noErrorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertObject.bind(null, test.value, 'desc')).to.not.throw();
-    });
-  });
-});
-
-describe('#App.assertEmberObject', function () {
-  var errorCases = [
-      {
-        value: null,
-        desc: 'desc0',
-        title: 'null'
-      },
-      {
-        value: undefined,
-        desc: 'desc1',
-        title: 'undefined'
-      },
-      {
-        value: 1,
-        desc: 'desc2',
-        title: 'number'
-      },
-      {
-        value: NaN,
-        desc: 'desc3',
-        title: 'NaN'
-      },
-      {
-        value: Infinity,
-        desc: 'desc4',
-        title: 'Infinity'
-      },
-      {
-        value: true,
-        desc: 'desc5',
-        title: 'boolean'
-      },
-      {
-        value: 'a',
-        desc: 'desc6',
-        title: 'string'
-      },
-      {
-        value: function () {},
-        desc: 'desc7',
-        title: 'function'
-      },
-      {
-        value: [],
-        desc: 'desc8',
-        title: 'array'
-      },
-      {
-        value: {},
-        desc: 'desc9',
-        title: 'object'
-      },
-      {
-        value: new Date(),
-        desc: 'desc10',
-        title: 'date'
-      },
-      {
-        value: new RegExp(),
-        desc: 'desc11',
-        title: 'regexp'
-      },
-      {
-        value: new Error(),
-        desc: 'desc12',
-        title: 'error object'
-      },
-      {
-        value: Em.Object,
-        desc: 'desc13',
-        title: 'Ember object constructor'
-      },
-      {
-        value: Em.View,
-        desc: 'desc14',
-        title: 'extended Ember object constructor'
-      },
-      {
-        value: new Number(1),
-        desc: 'desc15',
-        title: 'number object'
-      },
-      {
-        value: new String('a'),
-        desc: 'desc16',
-        title: 'string object'
-      },
-      {
-        value: new Boolean(true),
-        desc: 'desc17',
-        title: 'boolean object'
-      }
-    ],
-    noErrorCases = [
-      {
-        value: Em.Object.create(),
-        title: 'Ember object'
-      },
-      {
-        value: Em.View.create(),
-        title: 'extended Ember object'
-      }
-    ];
-  errorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertEmberObject.bind(null, test.value, test.desc)).to.throw(App.EmberObjectTypeError, test.desc);
-    });
-  });
-  noErrorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertEmberObject.bind(null, test.value, 'desc')).to.not.throw();
-    });
-  });
-});
-
-describe('#App.assertArray', function () {
-  var errorCases = [
-      {
-        value: null,
-        desc: 'desc0',
-        title: 'null'
-      },
-      {
-        value: undefined,
-        desc: 'desc1',
-        title: 'undefined'
-      },
-      {
-        value: 1,
-        desc: 'desc2',
-        title: 'number'
-      },
-      {
-        value: NaN,
-        desc: 'desc3',
-        title: 'NaN'
-      },
-      {
-        value: Infinity,
-        desc: 'desc4',
-        title: 'Infinity'
-      },
-      {
-        value: true,
-        desc: 'desc5',
-        title: 'boolean'
-      },
-      {
-        value: 'a',
-        desc: 'desc6',
-        title: 'string'
-      },
-      {
-        value: function () {},
-        desc: 'desc7',
-        title: 'function'
-      },
-      {
-        value: {},
-        desc: 'desc8',
-        title: 'object'
-      },
-      {
-        value: new Date(),
-        desc: 'desc9',
-        title: 'date'
-      },
-      {
-        value: new RegExp(),
-        desc: 'desc10',
-        title: 'regexp'
-      },
-      {
-        value: new Error(),
-        desc: 'desc11',
-        title: 'error object'
-      },
-      {
-        value: Em.Object,
-        desc: 'desc12',
-        title: 'Ember object constructor'
-      },
-      {
-        value: Em.View,
-        desc: 'desc13',
-        title: 'extended Ember object constructor'
-      },
-      {
-        value: Em.Object.create(),
-        desc: 'desc14',
-        title: 'Ember object'
-      },
-      {
-        value: Em.View.create(),
-        desc: 'desc15',
-        title: 'extended Ember object'
-      },
-      {
-        value: new Number(1),
-        desc: 'desc16',
-        title: 'number object'
-      },
-      {
-        value: new Boolean(true),
-        desc: 'desc17',
-        title: 'boolean object'
-      },
-      {
-        value: {
-          setInterval: Em.K,
-          0: 'a',
-          length: 1
+        {
+          value: undefined,
+          desc: 'desc1',
+          title: 'undefined'
+        }
+      ],
+      noErrorCases = [
+        {
+          value: [],
+          title: 'empty array'
         },
-        desc: 'desc18',
-        title: 'object with setInterval property'
-      },
-      {
-        value: (function () {
-          var value = 0;
-          value.length = 0;
-          return value;
-        })(),
-        desc: 'desc19',
-        title: 'non-object with length property'
-      }
-    ],
-    noErrorCases = [
-      {
-        value: [],
-        title: 'array'
-      },
-      {
-        value: Em.A(),
-        title: 'Ember array'
-      },
-      {
-        value: {
-          0: 'a',
-          length: 1
+        {
+          value: [0],
+          title: 'non-empty array'
         },
-        title: 'array-like object'
-      },
-      {
-        value: Em.Object.create({
-          0: 'a',
-          length: 1
-        }),
-        title: 'array-like Ember object'
-      },
-      {
-        value: new String('a'),
-        title: 'string object'
-      }
-    ];
-  errorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertArray.bind(null, test.value, test.desc)).to.throw(App.ArrayTypeError, test.desc);
+        {
+          value: {},
+          title: 'empty object'
+        },
+        {
+          value: {
+            a: ''
+          },
+          title: 'non-empty object'
+        },
+        {
+          value: Em.Object.create(),
+          title: 'empty Ember object'
+        },
+        {
+          value: Em.Object.create({
+            a: ''
+          }),
+          title: 'non-empty Ember object'
+        },
+        {
+          value: 0,
+          title: '0'
+        },
+        {
+          value: 1,
+          title: 'non-zero number'
+        },
+        {
+          value: NaN,
+          title: 'NaN'
+        },
+        {
+          value: Infinity,
+          title: 'Infinity'
+        },
+        {
+          value: false,
+          title: 'false'
+        },
+        {
+          value: true,
+          title: 'true'
+        },
+        {
+          value: '',
+          title: 'empty string'
+        },
+        {
+          value: '0',
+          title: 'non-empty string'
+        },
+        {
+          value: ' ',
+          title: 'spaces-only string'
+        },
+        {
+          value: new Number(0),
+          title: 'number object'
+        },
+        {
+          value: new String(''),
+          title: 'string object'
+        },
+        {
+          value: new Boolean(false),
+          title: 'boolean object'
+        },
+        {
+          value: new Number(1),
+          title: 'object of non-zero number'
+        },
+        {
+          value: new String('a'),
+          title: 'object of non-empty string'
+        },
+        {
+          value: new Boolean(true),
+          title: 'object of true boolean'
+        }
+      ];
+    errorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertExists.bind(null, test.value, test.desc)).to.throw(App.NotNullTypeError, test.desc);
+      });
+    });
+    noErrorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertExists.bind(null, test.value, 'desc')).to.not.throw();
+      });
     });
   });
-  noErrorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertArray.bind(null, test.value, 'desc')).to.not.throw();
-    });
-  });
-});
 
-describe('#App.assertFunction', function () {
-  var errorCases = [
-      {
-        value: null,
-        desc: 'desc0',
-        title: 'null'
-      },
-      {
-        value: undefined,
-        desc: 'desc1',
-        title: 'undefined'
-      },
-      {
-        value: 1,
-        desc: 'desc2',
-        title: 'number'
-      },
-      {
-        value: NaN,
-        desc: 'desc3',
-        title: 'NaN'
-      },
-      {
-        value: Infinity,
-        desc: 'desc4',
-        title: 'Infinity'
-      },
-      {
-        value: true,
-        desc: 'desc5',
-        title: 'boolean'
-      },
-      {
-        value: 'a',
-        desc: 'desc6',
-        title: 'string'
-      },
-      {
-        value: [],
-        desc: 'desc7',
-        title: 'array'
-      },
-      {
-        value: {},
-        desc: 'desc8',
-        title: 'object'
-      },
-      {
-        value: new Date(),
-        desc: 'desc9',
-        title: 'date'
-      },
-      {
-        value: new RegExp(),
-        desc: 'desc10',
-        title: 'regexp'
-      },
-      {
-        value: Em.Object.create(),
-        desc: 'desc11',
-        title: 'Ember object'
-      },
-      {
-        value: Em.View.create(),
-        desc: 'desc12',
-        title: 'extended Ember object'
-      },
-      {
-        value: new Error(),
-        desc: 'desc13',
-        title: 'error object'
-      },
-      {
-        value: new Number(1),
-        desc: 'desc14',
-        title: 'number object'
-      },
-      {
-        value: new String('a'),
-        desc: 'desc15',
-        title: 'string object'
-      },
-      {
-        value: new Boolean(true),
-        desc: 'desc16',
-        title: 'boolean object'
-      }
-    ],
-    noErrorCases = [
-      {
-        value: function () {},
-        title: 'function'
-      },
-      {
-        value: new Function(),
-        title: 'function from constructor'
-      }
-    ];
-  errorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertFunction.bind(null, test.value, test.desc)).to.throw(App.FunctionTypeError, test.desc);
+  describe('#App.assertObject', function () {
+    var errorCases = [
+        {
+          value: null,
+          desc: 'desc0',
+          title: 'null'
+        },
+        {
+          value: undefined,
+          desc: 'desc1',
+          title: 'undefined'
+        },
+        {
+          value: 1,
+          desc: 'desc2',
+          title: 'number'
+        },
+        {
+          value: NaN,
+          desc: 'desc3',
+          title: 'NaN'
+        },
+        {
+          value: Infinity,
+          desc: 'desc4',
+          title: 'Infinity'
+        },
+        {
+          value: true,
+          desc: 'desc5',
+          title: 'boolean'
+        },
+        {
+          value: 'a',
+          desc: 'desc6',
+          title: 'string'
+        },
+        {
+          value: function () {
+          },
+          desc: 'desc7',
+          title: 'function'
+        }
+      ],
+      noErrorCases = [
+        {
+          value: [],
+          title: 'array'
+        },
+        {
+          value: {},
+          title: 'object'
+        },
+        {
+          value: new Date(),
+          title: 'date'
+        },
+        {
+          value: new RegExp(),
+          title: 'regexp'
+        },
+        {
+          value: Em.Object.create(),
+          title: 'Ember object'
+        },
+        {
+          value: Em.View.create(),
+          title: 'extended Ember object'
+        },
+        {
+          value: new Error(),
+          title: 'error object'
+        },
+        {
+          value: new Number(1),
+          title: 'number object'
+        },
+        {
+          value: new String('a'),
+          title: 'string object'
+        },
+        {
+          value: new Boolean(true),
+          title: 'boolean object'
+        }
+      ];
+    errorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertObject.bind(null, test.value, test.desc)).to.throw(App.ObjectTypeError, test.desc);
+      });
+    });
+    noErrorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertObject.bind(null, test.value, 'desc')).to.not.throw();
+      });
     });
   });
-  noErrorCases.forEach(function (test) {
-    it(test.title, function () {
-      expect(App.assertFunction.bind(null, test.value, 'desc')).to.not.throw();
+
+  describe('#App.assertEmberObject', function () {
+    var errorCases = [
+        {
+          value: null,
+          desc: 'desc0',
+          title: 'null'
+        },
+        {
+          value: undefined,
+          desc: 'desc1',
+          title: 'undefined'
+        },
+        {
+          value: 1,
+          desc: 'desc2',
+          title: 'number'
+        },
+        {
+          value: NaN,
+          desc: 'desc3',
+          title: 'NaN'
+        },
+        {
+          value: Infinity,
+          desc: 'desc4',
+          title: 'Infinity'
+        },
+        {
+          value: true,
+          desc: 'desc5',
+          title: 'boolean'
+        },
+        {
+          value: 'a',
+          desc: 'desc6',
+          title: 'string'
+        },
+        {
+          value: function () {
+          },
+          desc: 'desc7',
+          title: 'function'
+        },
+        {
+          value: [],
+          desc: 'desc8',
+          title: 'array'
+        },
+        {
+          value: {},
+          desc: 'desc9',
+          title: 'object'
+        },
+        {
+          value: new Date(),
+          desc: 'desc10',
+          title: 'date'
+        },
+        {
+          value: new RegExp(),
+          desc: 'desc11',
+          title: 'regexp'
+        },
+        {
+          value: new Error(),
+          desc: 'desc12',
+          title: 'error object'
+        },
+        {
+          value: Em.Object,
+          desc: 'desc13',
+          title: 'Ember object constructor'
+        },
+        {
+          value: Em.View,
+          desc: 'desc14',
+          title: 'extended Ember object constructor'
+        },
+        {
+          value: new Number(1),
+          desc: 'desc15',
+          title: 'number object'
+        },
+        {
+          value: new String('a'),
+          desc: 'desc16',
+          title: 'string object'
+        },
+        {
+          value: new Boolean(true),
+          desc: 'desc17',
+          title: 'boolean object'
+        }
+      ],
+      noErrorCases = [
+        {
+          value: Em.Object.create(),
+          title: 'Ember object'
+        },
+        {
+          value: Em.View.create(),
+          title: 'extended Ember object'
+        }
+      ];
+    errorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertEmberObject.bind(null, test.value, test.desc)).to.throw(App.EmberObjectTypeError, test.desc);
+      });
+    });
+    noErrorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertEmberObject.bind(null, test.value, 'desc')).to.not.throw();
+      });
+    });
+  });
+
+  describe('#App.assertArray', function () {
+    var errorCases = [
+        {
+          value: null,
+          desc: 'desc0',
+          title: 'null'
+        },
+        {
+          value: undefined,
+          desc: 'desc1',
+          title: 'undefined'
+        },
+        {
+          value: 1,
+          desc: 'desc2',
+          title: 'number'
+        },
+        {
+          value: NaN,
+          desc: 'desc3',
+          title: 'NaN'
+        },
+        {
+          value: Infinity,
+          desc: 'desc4',
+          title: 'Infinity'
+        },
+        {
+          value: true,
+          desc: 'desc5',
+          title: 'boolean'
+        },
+        {
+          value: 'a',
+          desc: 'desc6',
+          title: 'string'
+        },
+        {
+          value: function () {
+          },
+          desc: 'desc7',
+          title: 'function'
+        },
+        {
+          value: {},
+          desc: 'desc8',
+          title: 'object'
+        },
+        {
+          value: new Date(),
+          desc: 'desc9',
+          title: 'date'
+        },
+        {
+          value: new RegExp(),
+          desc: 'desc10',
+          title: 'regexp'
+        },
+        {
+          value: new Error(),
+          desc: 'desc11',
+          title: 'error object'
+        },
+        {
+          value: Em.Object,
+          desc: 'desc12',
+          title: 'Ember object constructor'
+        },
+        {
+          value: Em.View,
+          desc: 'desc13',
+          title: 'extended Ember object constructor'
+        },
+        {
+          value: Em.Object.create(),
+          desc: 'desc14',
+          title: 'Ember object'
+        },
+        {
+          value: Em.View.create(),
+          desc: 'desc15',
+          title: 'extended Ember object'
+        },
+        {
+          value: new Number(1),
+          desc: 'desc16',
+          title: 'number object'
+        },
+        {
+          value: new Boolean(true),
+          desc: 'desc17',
+          title: 'boolean object'
+        },
+        {
+          value: {
+            setInterval: Em.K,
+            0: 'a',
+            length: 1
+          },
+          desc: 'desc18',
+          title: 'object with setInterval property'
+        },
+        {
+          value: (function () {
+            var value = 0;
+            value.length = 0;
+            return value;
+          })(),
+          desc: 'desc19',
+          title: 'non-object with length property'
+        }
+      ],
+      noErrorCases = [
+        {
+          value: [],
+          title: 'array'
+        },
+        {
+          value: Em.A(),
+          title: 'Ember array'
+        },
+        {
+          value: {
+            0: 'a',
+            length: 1
+          },
+          title: 'array-like object'
+        },
+        {
+          value: Em.Object.create({
+            0: 'a',
+            length: 1
+          }),
+          title: 'array-like Ember object'
+        },
+        {
+          value: new String('a'),
+          title: 'string object'
+        }
+      ];
+    errorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertArray.bind(null, test.value, test.desc)).to.throw(App.ArrayTypeError, test.desc);
+      });
+    });
+    noErrorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertArray.bind(null, test.value, 'desc')).to.not.throw();
+      });
+    });
+  });
+
+  describe('#App.assertFunction', function () {
+    var errorCases = [
+        {
+          value: null,
+          desc: 'desc0',
+          title: 'null'
+        },
+        {
+          value: undefined,
+          desc: 'desc1',
+          title: 'undefined'
+        },
+        {
+          value: 1,
+          desc: 'desc2',
+          title: 'number'
+        },
+        {
+          value: NaN,
+          desc: 'desc3',
+          title: 'NaN'
+        },
+        {
+          value: Infinity,
+          desc: 'desc4',
+          title: 'Infinity'
+        },
+        {
+          value: true,
+          desc: 'desc5',
+          title: 'boolean'
+        },
+        {
+          value: 'a',
+          desc: 'desc6',
+          title: 'string'
+        },
+        {
+          value: [],
+          desc: 'desc7',
+          title: 'array'
+        },
+        {
+          value: {},
+          desc: 'desc8',
+          title: 'object'
+        },
+        {
+          value: new Date(),
+          desc: 'desc9',
+          title: 'date'
+        },
+        {
+          value: new RegExp(),
+          desc: 'desc10',
+          title: 'regexp'
+        },
+        {
+          value: Em.Object.create(),
+          desc: 'desc11',
+          title: 'Ember object'
+        },
+        {
+          value: Em.View.create(),
+          desc: 'desc12',
+          title: 'extended Ember object'
+        },
+        {
+          value: new Error(),
+          desc: 'desc13',
+          title: 'error object'
+        },
+        {
+          value: new Number(1),
+          desc: 'desc14',
+          title: 'number object'
+        },
+        {
+          value: new String('a'),
+          desc: 'desc15',
+          title: 'string object'
+        },
+        {
+          value: new Boolean(true),
+          desc: 'desc16',
+          title: 'boolean object'
+        }
+      ],
+      noErrorCases = [
+        {
+          value: function () {
+          },
+          title: 'function'
+        },
+        {
+          value: new Function(),
+          title: 'function from constructor'
+        }
+      ];
+    errorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertFunction.bind(null, test.value, test.desc)).to.throw(App.FunctionTypeError, test.desc);
+      });
+    });
+    noErrorCases.forEach(function (test) {
+      it(test.title, function () {
+        expect(App.assertFunction.bind(null, test.value, 'desc')).to.not.throw();
+      });
     });
   });
 });

--- a/ambari-web/test/utils/errors/assertions_test.js
+++ b/ambari-web/test/utils/errors/assertions_test.js
@@ -1,0 +1,648 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var App = require('app');
+require('utils/errors/assertions');
+
+describe('#App.assert', function () {
+  var errorCases = [
+    {
+      args: [null, false],
+      errorType: Error,
+      desc: '',
+      title: 'default error object, no description'
+    },
+    {
+      args: ['desc0', false],
+      errorType: Error,
+      desc: ' Info:  desc0',
+      title: 'default error object, custom description'
+    },
+    {
+      args: [null, false, TypeError],
+      errorType: TypeError,
+      desc: '',
+      title: 'custom error object, no description'
+    },
+    {
+      args: ['desc1', false, TypeError],
+      errorType: TypeError,
+      desc: ' Info:  desc1',
+      title: 'custom error object, custom description'
+    }
+  ];
+  errorCases.forEach(function (test) {
+    it(test.title, function () {
+      var testFunction = function () {
+        App.assert.apply(null, test.args);
+      };
+      expect(testFunction).to.throw(test.errorType, test.desc);
+    });
+  });
+  it('no error', function () {
+    expect(App.assert.bind(null, 'desc2', true)).to.not.throw();
+  });
+});
+
+describe('#App.assertExists', function () {
+  var errorCases = [
+      {
+        value: null,
+        desc: 'desc0',
+        title: 'null'
+      },
+      {
+        value: undefined,
+        desc: 'desc1',
+        title: 'undefined'
+      }
+    ],
+    noErrorCases = [
+      {
+        value: [],
+        title: 'empty array'
+      },
+      {
+        value: [0],
+        title: 'non-empty array'
+      },
+      {
+        value: {},
+        title: 'empty object'
+      },
+      {
+        value: {
+          a: ''
+        },
+        title: 'non-empty object'
+      },
+      {
+        value: Em.Object.create(),
+        title: 'empty Ember object'
+      },
+      {
+        value: Em.Object.create({
+          a: ''
+        }),
+        title: 'non-empty Ember object'
+      },
+      {
+        value: 0,
+        title: '0'
+      },
+      {
+        value: 1,
+        title: 'non-zero number'
+      },
+      {
+        value: NaN,
+        title: 'NaN'
+      },
+      {
+        value: Infinity,
+        title: 'Infinity'
+      },
+      {
+        value: false,
+        title: 'false'
+      },
+      {
+        value: true,
+        title: 'true'
+      },
+      {
+        value: '',
+        title: 'empty string'
+      },
+      {
+        value: '0',
+        title: 'non-empty string'
+      },
+      {
+        value: ' ',
+        title: 'spaces-only string'
+      },
+      {
+        value: new Number(0),
+        title: 'number object'
+      },
+      {
+        value: new String(''),
+        title: 'string object'
+      },
+      {
+        value: new Boolean(false),
+        title: 'boolean object'
+      },
+      {
+        value: new Number(1),
+        title: 'object of non-zero number'
+      },
+      {
+        value: new String('a'),
+        title: 'object of non-empty string'
+      },
+      {
+        value: new Boolean(true),
+        title: 'object of true boolean'
+      }
+    ];
+  errorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertExists.bind(null, test.value, test.desc)).to.throw(App.NotNullTypeError, test.desc);
+    });
+  });
+  noErrorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertExists.bind(null, test.value, 'desc')).to.not.throw();
+    });
+  });
+});
+
+describe('#App.assertObject', function () {
+  var errorCases = [
+      {
+        value: null,
+        desc: 'desc0',
+        title: 'null'
+      },
+      {
+        value: undefined,
+        desc: 'desc1',
+        title: 'undefined'
+      },
+      {
+        value: 1,
+        desc: 'desc2',
+        title: 'number'
+      },
+      {
+        value: NaN,
+        desc: 'desc3',
+        title: 'NaN'
+      },
+      {
+        value: Infinity,
+        desc: 'desc4',
+        title: 'Infinity'
+      },
+      {
+        value: true,
+        desc: 'desc5',
+        title: 'boolean'
+      },
+      {
+        value: 'a',
+        desc: 'desc6',
+        title: 'string'
+      },
+      {
+        value: function () {},
+        desc: 'desc7',
+        title: 'function'
+      }
+    ],
+    noErrorCases = [
+      {
+        value: [],
+        title: 'array'
+      },
+      {
+        value: {},
+        title: 'object'
+      },
+      {
+        value: new Date(),
+        title: 'date'
+      },
+      {
+        value: new RegExp(),
+        title: 'regexp'
+      },
+      {
+        value: Em.Object.create(),
+        title: 'Ember object'
+      },
+      {
+        value: Em.View.create(),
+        title: 'extended Ember object'
+      },
+      {
+        value: new Error(),
+        title: 'error object'
+      },
+      {
+        value: new Number(1),
+        title: 'number object'
+      },
+      {
+        value: new String('a'),
+        title: 'string object'
+      },
+      {
+        value: new Boolean(true),
+        title: 'boolean object'
+      }
+    ];
+  errorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertObject.bind(null, test.value, test.desc)).to.throw(App.ObjectTypeError, test.desc);
+    });
+  });
+  noErrorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertObject.bind(null, test.value, 'desc')).to.not.throw();
+    });
+  });
+});
+
+describe('#App.assertEmberObject', function () {
+  var errorCases = [
+      {
+        value: null,
+        desc: 'desc0',
+        title: 'null'
+      },
+      {
+        value: undefined,
+        desc: 'desc1',
+        title: 'undefined'
+      },
+      {
+        value: 1,
+        desc: 'desc2',
+        title: 'number'
+      },
+      {
+        value: NaN,
+        desc: 'desc3',
+        title: 'NaN'
+      },
+      {
+        value: Infinity,
+        desc: 'desc4',
+        title: 'Infinity'
+      },
+      {
+        value: true,
+        desc: 'desc5',
+        title: 'boolean'
+      },
+      {
+        value: 'a',
+        desc: 'desc6',
+        title: 'string'
+      },
+      {
+        value: function () {},
+        desc: 'desc7',
+        title: 'function'
+      },
+      {
+        value: [],
+        desc: 'desc8',
+        title: 'array'
+      },
+      {
+        value: {},
+        desc: 'desc9',
+        title: 'object'
+      },
+      {
+        value: new Date(),
+        desc: 'desc10',
+        title: 'date'
+      },
+      {
+        value: new RegExp(),
+        desc: 'desc11',
+        title: 'regexp'
+      },
+      {
+        value: new Error(),
+        desc: 'desc12',
+        title: 'error object'
+      },
+      {
+        value: Em.Object,
+        desc: 'desc13',
+        title: 'Ember object constructor'
+      },
+      {
+        value: Em.View,
+        desc: 'desc14',
+        title: 'extended Ember object constructor'
+      },
+      {
+        value: new Number(1),
+        desc: 'desc15',
+        title: 'number object'
+      },
+      {
+        value: new String('a'),
+        desc: 'desc16',
+        title: 'string object'
+      },
+      {
+        value: new Boolean(true),
+        desc: 'desc17',
+        title: 'boolean object'
+      }
+    ],
+    noErrorCases = [
+      {
+        value: Em.Object.create(),
+        title: 'Ember object'
+      },
+      {
+        value: Em.View.create(),
+        title: 'extended Ember object'
+      }
+    ];
+  errorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertEmberObject.bind(null, test.value, test.desc)).to.throw(App.EmberObjectTypeError, test.desc);
+    });
+  });
+  noErrorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertEmberObject.bind(null, test.value, 'desc')).to.not.throw();
+    });
+  });
+});
+
+describe('#App.assertArray', function () {
+  var errorCases = [
+      {
+        value: null,
+        desc: 'desc0',
+        title: 'null'
+      },
+      {
+        value: undefined,
+        desc: 'desc1',
+        title: 'undefined'
+      },
+      {
+        value: 1,
+        desc: 'desc2',
+        title: 'number'
+      },
+      {
+        value: NaN,
+        desc: 'desc3',
+        title: 'NaN'
+      },
+      {
+        value: Infinity,
+        desc: 'desc4',
+        title: 'Infinity'
+      },
+      {
+        value: true,
+        desc: 'desc5',
+        title: 'boolean'
+      },
+      {
+        value: 'a',
+        desc: 'desc6',
+        title: 'string'
+      },
+      {
+        value: function () {},
+        desc: 'desc7',
+        title: 'function'
+      },
+      {
+        value: {},
+        desc: 'desc8',
+        title: 'object'
+      },
+      {
+        value: new Date(),
+        desc: 'desc9',
+        title: 'date'
+      },
+      {
+        value: new RegExp(),
+        desc: 'desc10',
+        title: 'regexp'
+      },
+      {
+        value: new Error(),
+        desc: 'desc11',
+        title: 'error object'
+      },
+      {
+        value: Em.Object,
+        desc: 'desc12',
+        title: 'Ember object constructor'
+      },
+      {
+        value: Em.View,
+        desc: 'desc13',
+        title: 'extended Ember object constructor'
+      },
+      {
+        value: Em.Object.create(),
+        desc: 'desc14',
+        title: 'Ember object'
+      },
+      {
+        value: Em.View.create(),
+        desc: 'desc15',
+        title: 'extended Ember object'
+      },
+      {
+        value: new Number(1),
+        desc: 'desc16',
+        title: 'number object'
+      },
+      {
+        value: new Boolean(true),
+        desc: 'desc17',
+        title: 'boolean object'
+      },
+      {
+        value: {
+          setInterval: Em.K,
+          0: 'a',
+          length: 1
+        },
+        desc: 'desc18',
+        title: 'object with setInterval property'
+      },
+      {
+        value: (function () {
+          var value = 0;
+          value.length = 0;
+          return value;
+        })(),
+        desc: 'desc19',
+        title: 'non-object with length property'
+      }
+    ],
+    noErrorCases = [
+      {
+        value: [],
+        title: 'array'
+      },
+      {
+        value: Em.A(),
+        title: 'Ember array'
+      },
+      {
+        value: {
+          0: 'a',
+          length: 1
+        },
+        title: 'array-like object'
+      },
+      {
+        value: Em.Object.create({
+          0: 'a',
+          length: 1
+        }),
+        title: 'array-like Ember object'
+      },
+      {
+        value: new String('a'),
+        title: 'string object'
+      }
+    ];
+  errorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertArray.bind(null, test.value, test.desc)).to.throw(App.ArrayTypeError, test.desc);
+    });
+  });
+  noErrorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertArray.bind(null, test.value, 'desc')).to.not.throw();
+    });
+  });
+});
+
+describe('#App.assertFunction', function () {
+  var errorCases = [
+      {
+        value: null,
+        desc: 'desc0',
+        title: 'null'
+      },
+      {
+        value: undefined,
+        desc: 'desc1',
+        title: 'undefined'
+      },
+      {
+        value: 1,
+        desc: 'desc2',
+        title: 'number'
+      },
+      {
+        value: NaN,
+        desc: 'desc3',
+        title: 'NaN'
+      },
+      {
+        value: Infinity,
+        desc: 'desc4',
+        title: 'Infinity'
+      },
+      {
+        value: true,
+        desc: 'desc5',
+        title: 'boolean'
+      },
+      {
+        value: 'a',
+        desc: 'desc6',
+        title: 'string'
+      },
+      {
+        value: [],
+        desc: 'desc7',
+        title: 'array'
+      },
+      {
+        value: {},
+        desc: 'desc8',
+        title: 'object'
+      },
+      {
+        value: new Date(),
+        desc: 'desc9',
+        title: 'date'
+      },
+      {
+        value: new RegExp(),
+        desc: 'desc10',
+        title: 'regexp'
+      },
+      {
+        value: Em.Object.create(),
+        desc: 'desc11',
+        title: 'Ember object'
+      },
+      {
+        value: Em.View.create(),
+        desc: 'desc12',
+        title: 'extended Ember object'
+      },
+      {
+        value: new Error(),
+        desc: 'desc13',
+        title: 'error object'
+      },
+      {
+        value: new Number(1),
+        desc: 'desc14',
+        title: 'number object'
+      },
+      {
+        value: new String('a'),
+        desc: 'desc15',
+        title: 'string object'
+      },
+      {
+        value: new Boolean(true),
+        desc: 'desc16',
+        title: 'boolean object'
+      }
+    ],
+    noErrorCases = [
+      {
+        value: function () {},
+        title: 'function'
+      },
+      {
+        value: new Function(),
+        title: 'function from constructor'
+      }
+    ];
+  errorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertFunction.bind(null, test.value, test.desc)).to.throw(App.FunctionTypeError, test.desc);
+    });
+  });
+  noErrorCases.forEach(function (test) {
+    it(test.title, function () {
+      expect(App.assertFunction.bind(null, test.value, 'desc')).to.not.throw();
+    });
+  });
+});

--- a/ambari-web/test/utils/errors/definitions_test.js
+++ b/ambari-web/test/utils/errors/definitions_test.js
@@ -19,107 +19,109 @@
 var App = require('app');
 require('utils/errors/definitions');
 
-describe('#App.NotNullTypeError', function () {
-  var cases = [
-    {
-      input: null,
-      result: 'Not null expected. ',
-      title: 'default message'
-    },
-    {
-      input: 'Error',
-      result: 'Not null expected. Error',
-      title: 'custom message'
-    }
-  ];
-  cases.forEach(function (test) {
-    it(test.title, function () {
-      var errorObject = new App.NotNullTypeError(test.input);
-      expect(errorObject.message).to.equal(test.result);
+describe('Error definitions', function () {
+  describe('#App.NotNullTypeError', function () {
+    var cases = [
+      {
+        input: null,
+        result: 'Not null expected. ',
+        title: 'default message'
+      },
+      {
+        input: 'Error',
+        result: 'Not null expected. Error',
+        title: 'custom message'
+      }
+    ];
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        var errorObject = new App.NotNullTypeError(test.input);
+        expect(errorObject.message).to.equal(test.result);
+      });
     });
   });
-});
 
-describe('#App.ObjectTypeError', function () {
-  var cases = [
-    {
-      input: null,
-      result: 'Object expected. ',
-      title: 'default message'
-    },
-    {
-      input: 'Error',
-      result: 'Object expected. Error',
-      title: 'custom message'
-    }
-  ];
-  cases.forEach(function (test) {
-    it(test.title, function () {
-      var errorObject = new App.ObjectTypeError(test.input);
-      expect(errorObject.message).to.equal(test.result);
+  describe('#App.ObjectTypeError', function () {
+    var cases = [
+      {
+        input: null,
+        result: 'Object expected. ',
+        title: 'default message'
+      },
+      {
+        input: 'Error',
+        result: 'Object expected. Error',
+        title: 'custom message'
+      }
+    ];
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        var errorObject = new App.ObjectTypeError(test.input);
+        expect(errorObject.message).to.equal(test.result);
+      });
     });
   });
-});
 
-describe('#App.ArrayTypeError', function () {
-  var cases = [
-    {
-      input: null,
-      result: 'Array expected. ',
-      title: 'default message'
-    },
-    {
-      input: 'Error',
-      result: 'Array expected. Error',
-      title: 'custom message'
-    }
-  ];
-  cases.forEach(function (test) {
-    it(test.title, function () {
-      var errorObject = new App.ArrayTypeError(test.input);
-      expect(errorObject.message).to.equal(test.result);
+  describe('#App.ArrayTypeError', function () {
+    var cases = [
+      {
+        input: null,
+        result: 'Array expected. ',
+        title: 'default message'
+      },
+      {
+        input: 'Error',
+        result: 'Array expected. Error',
+        title: 'custom message'
+      }
+    ];
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        var errorObject = new App.ArrayTypeError(test.input);
+        expect(errorObject.message).to.equal(test.result);
+      });
     });
   });
-});
 
-describe('#App.FunctionTypeError', function () {
-  var cases = [
-    {
-      input: null,
-      result: 'Function expected. ',
-      title: 'default message'
-    },
-    {
-      input: 'Error',
-      result: 'Function expected. Error',
-      title: 'custom message'
-    }
-  ];
-  cases.forEach(function (test) {
-    it(test.title, function () {
-      var errorObject = new App.FunctionTypeError(test.input);
-      expect(errorObject.message).to.equal(test.result);
+  describe('#App.FunctionTypeError', function () {
+    var cases = [
+      {
+        input: null,
+        result: 'Function expected. ',
+        title: 'default message'
+      },
+      {
+        input: 'Error',
+        result: 'Function expected. Error',
+        title: 'custom message'
+      }
+    ];
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        var errorObject = new App.FunctionTypeError(test.input);
+        expect(errorObject.message).to.equal(test.result);
+      });
     });
   });
-});
 
-describe('#App.EmberObjectTypeError', function () {
-  var cases = [
-    {
-      input: null,
-      result: 'Ember object expected. ',
-      title: 'default message'
-    },
-    {
-      input: 'Error',
-      result: 'Ember object expected. Error',
-      title: 'custom message'
-    }
-  ];
-  cases.forEach(function (test) {
-    it(test.title, function () {
-      var errorObject = new App.EmberObjectTypeError(test.input);
-      expect(errorObject.message).to.equal(test.result);
+  describe('#App.EmberObjectTypeError', function () {
+    var cases = [
+      {
+        input: null,
+        result: 'Ember object expected. ',
+        title: 'default message'
+      },
+      {
+        input: 'Error',
+        result: 'Ember object expected. Error',
+        title: 'custom message'
+      }
+    ];
+    cases.forEach(function (test) {
+      it(test.title, function () {
+        var errorObject = new App.EmberObjectTypeError(test.input);
+        expect(errorObject.message).to.equal(test.result);
+      });
     });
   });
 });

--- a/ambari-web/test/utils/errors/definitions_test.js
+++ b/ambari-web/test/utils/errors/definitions_test.js
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var App = require('app');
+require('utils/errors/definitions');
+
+describe('#App.NotNullTypeError', function () {
+  var cases = [
+    {
+      input: null,
+      result: 'Not null expected. ',
+      title: 'default message'
+    },
+    {
+      input: 'Error',
+      result: 'Not null expected. Error',
+      title: 'custom message'
+    }
+  ];
+  cases.forEach(function (test) {
+    it(test.title, function () {
+      var errorObject = new App.NotNullTypeError(test.input);
+      expect(errorObject.message).to.equal(test.result);
+    });
+  });
+});
+
+describe('#App.ObjectTypeError', function () {
+  var cases = [
+    {
+      input: null,
+      result: 'Object expected. ',
+      title: 'default message'
+    },
+    {
+      input: 'Error',
+      result: 'Object expected. Error',
+      title: 'custom message'
+    }
+  ];
+  cases.forEach(function (test) {
+    it(test.title, function () {
+      var errorObject = new App.ObjectTypeError(test.input);
+      expect(errorObject.message).to.equal(test.result);
+    });
+  });
+});
+
+describe('#App.ArrayTypeError', function () {
+  var cases = [
+    {
+      input: null,
+      result: 'Array expected. ',
+      title: 'default message'
+    },
+    {
+      input: 'Error',
+      result: 'Array expected. Error',
+      title: 'custom message'
+    }
+  ];
+  cases.forEach(function (test) {
+    it(test.title, function () {
+      var errorObject = new App.ArrayTypeError(test.input);
+      expect(errorObject.message).to.equal(test.result);
+    });
+  });
+});
+
+describe('#App.FunctionTypeError', function () {
+  var cases = [
+    {
+      input: null,
+      result: 'Function expected. ',
+      title: 'default message'
+    },
+    {
+      input: 'Error',
+      result: 'Function expected. Error',
+      title: 'custom message'
+    }
+  ];
+  cases.forEach(function (test) {
+    it(test.title, function () {
+      var errorObject = new App.FunctionTypeError(test.input);
+      expect(errorObject.message).to.equal(test.result);
+    });
+  });
+});
+
+describe('#App.EmberObjectTypeError', function () {
+  var cases = [
+    {
+      input: null,
+      result: 'Ember object expected. ',
+      title: 'default message'
+    },
+    {
+      input: 'Error',
+      result: 'Ember object expected. Error',
+      title: 'custom message'
+    }
+  ];
+  cases.forEach(function (test) {
+    it(test.title, function () {
+      var errorObject = new App.EmberObjectTypeError(test.input);
+      expect(errorObject.message).to.equal(test.result);
+    });
+  });
+});


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cover the following files:
- `utils/errors/assertions.js`
- `utils/errors/definitions.js`

## How was this patch tested?

UI unit tests:
```
  22343 passing (27s)
  48 pending

```