### PR TITLE
AMBARI-25117. getAsPost requests don't work when ambari is used behind knox proxy (amagyar)

### DIFF
--- a/ambari-web/app/utils/http_client.js
+++ b/ambari-web/app/utils/http_client.js
@@ -68,7 +68,7 @@ App.HttpClient = Em.Object.create({
     xhr.open(method, url + (url.indexOf('?') >= 0 ? '&_=' : '?_=') + curTime, true);
     if (isGetAsPost) {
       xhr.setRequestHeader("X-Http-Method-Override", "GET");
-      xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+      xhr.setRequestHeader("Content-type", "text/plain");
     }
     xhr.send(params);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a http request goes through knox it'll try to re-encode it because of the incorrectly used application/x-www-form-urlencoded content type. This causes problems when ambari tries to parse the json document.

Changing to application/json would cause lots of problems in the backend because many places we take the request body and map it to a Java String parameter and parse it later by hand. If the content-type was json then jersey's json provider would try to parse it into a String automatically.

## How was this patch tested?

- enabled knox trusted proxy 
- checked ambari UI through knox