### PR TITLE
AMBARI-25126.fix ambari-metric exception printed in namenode

### DIFF
--- a/ambari-metrics/ambari-metrics-common/src/main/java/org/apache/hadoop/metrics2/sink/timeline/availability/MetricSinkWriteShardHostnameHashingStrategy.java
+++ b/ambari-metrics/ambari-metrics-common/src/main/java/org/apache/hadoop/metrics2/sink/timeline/availability/MetricSinkWriteShardHostnameHashingStrategy.java
@@ -36,6 +36,10 @@ public class MetricSinkWriteShardHostnameHashingStrategy implements MetricSinkWr
 
   @Override
   public String findCollectorShard(List<String> collectorHosts) {
+    if(collectorHosts.size() ==0) {
+      LOG.warn("No metrics collectors alive, please check collector status!");
+      return "";
+    }
     long index = hostnameHash % collectorHosts.size();
     index = index < 0 ? index + collectorHosts.size() : index;
     String collectorHost = collectorHosts.get((int) index);


### PR DESCRIPTION
if there is no collector alive，return empty. other than divided by 0. 
