### PR TITLE
AMBARI-24606. Deleting a service should do a better job of cleaning up the Ambari DB.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/DatabaseConsistencyCheckHelper.java
@@ -59,7 +59,6 @@ import org.apache.ambari.server.orm.entities.ClusterConfigEntity;
 import org.apache.ambari.server.orm.entities.HostComponentDesiredStateEntity;
 import org.apache.ambari.server.orm.entities.HostComponentStateEntity;
 import org.apache.ambari.server.orm.entities.MetainfoEntity;
-import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.state.ClientConfigFileDefinition;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
@@ -589,7 +588,7 @@ public class DatabaseConsistencyCheckHelper {
     List<ClusterConfigEntity> notMappedClusterConfigs = getNotMappedClusterConfigsToService();
 
     for (ClusterConfigEntity clusterConfigEntity : notMappedClusterConfigs){
-      if (!clusterConfigEntity.isUnmapped()){
+      if (clusterConfigEntity.isUnmapped()){
         continue; // skip clusterConfigs that did not leave after service deletion
       }
       List<String> types = new ArrayList<>();
@@ -1339,8 +1338,6 @@ public class DatabaseConsistencyCheckHelper {
           try {
             Cluster cluster = clusters.getCluster(configGroup.getClusterName());
             cluster.deleteConfigGroup(id);
-          } catch (AuthorizationException e) {
-            // This call does not thrown Authorization Exception
           } catch (AmbariException e) {
             // Ignore if cluster not found
           }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ConfigGroupResourceProvider.java
@@ -519,8 +519,6 @@ public class ConfigGroupResourceProvider extends
         cluster.getClusterName(), getManagementController().getAuthName(), configGroup.getName(), request.getId());
 
     cluster.deleteConfigGroup(request.getId());
-
-    m_configHelper.get().updateAgentConfigs(Collections.singleton(request.getClusterName()));
   }
 
   private void validateRequest(ConfigGroupRequest request) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Cluster.java
@@ -35,7 +35,6 @@ import org.apache.ambari.server.orm.entities.ClusterEntity;
 import org.apache.ambari.server.orm.entities.PrivilegeEntity;
 import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
 import org.apache.ambari.server.orm.entities.UpgradeEntity;
-import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.state.configgroup.ConfigGroup;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.scheduler.RequestExecution;
@@ -504,7 +503,7 @@ public interface Cluster {
    * @param id
    * @throws AmbariException
    */
-  void deleteConfigGroup(Long id) throws AmbariException, AuthorizationException;
+  void deleteConfigGroup(Long id) throws AmbariException;
 
   /**
    * Find all config groups associated with the give hostname
@@ -520,6 +519,13 @@ public interface Cluster {
    * @return config group
    */
   ConfigGroup getConfigGroupsById(Long configId);
+
+  /**
+   * Find all config groups associated with the give service name
+   * @param serviceName
+   * @return Map of config group id to config group
+   */
+  Map<Long, ConfigGroup> getConfigGroupsByServiceName(String serviceName);
 
   /**
    * Add a @RequestExecution to the cluster

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -1531,7 +1531,8 @@ public class ConfigHelper {
           currentConfigEvents.put(host.getHostId(), m_agentConfigsHolder.get().getCurrentData(hostId));
         }
         if (!previousConfigEvents.containsKey(host.getHostId())) {
-          previousConfigEvents.put(host.getHostId(), m_agentConfigsHolder.get().getData(hostId));
+          previousConfigEvents.put(host.getHostId(),
+              m_agentConfigsHolder.get().initializeDataIfNeeded(hostId, true));
         }
       }
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -113,7 +113,6 @@ import org.apache.ambari.server.orm.entities.ServiceConfigEntity;
 import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.orm.entities.TopologyRequestEntity;
 import org.apache.ambari.server.orm.entities.UpgradeEntity;
-import org.apache.ambari.server.security.authorization.AuthorizationException;
 import org.apache.ambari.server.stack.upgrade.orchestrate.UpgradeContext;
 import org.apache.ambari.server.stack.upgrade.orchestrate.UpgradeContextFactory;
 import org.apache.ambari.server.state.BlueprintProvisioningState;
@@ -541,6 +540,20 @@ public class ClusterImpl implements Cluster {
   }
 
   @Override
+  public Map<Long, ConfigGroup> getConfigGroupsByServiceName(String serviceName) {
+    Map<Long, ConfigGroup> configGroups = new HashMap<>();
+
+    for (Entry<Long, ConfigGroup> groupEntry : clusterConfigGroups.entrySet()) {
+      Long id = groupEntry.getKey();
+      ConfigGroup group = groupEntry.getValue();
+      if (StringUtils.equals(serviceName, group.getServiceName())) {
+        configGroups.put(id, group);
+      }
+    }
+    return configGroups;
+  }
+
+  @Override
   public void addRequestExecution(RequestExecution requestExecution) throws AmbariException {
     LOG.info("Adding a new request schedule" + ", clusterName = " + getClusterName() + ", id = "
         + requestExecution.getId() + ", description = " + requestExecution.getDescription());
@@ -572,7 +585,7 @@ public class ClusterImpl implements Cluster {
   }
 
   @Override
-  public void deleteConfigGroup(Long id) throws AmbariException, AuthorizationException {
+  public void deleteConfigGroup(Long id) throws AmbariException {
     ConfigGroup configGroup = clusterConfigGroups.get(id);
     if (configGroup == null) {
       throw new ConfigGroupNotFoundException(getClusterName(), id.toString());
@@ -583,6 +596,8 @@ public class ClusterImpl implements Cluster {
 
     configGroup.delete();
     clusterConfigGroups.remove(id);
+
+    configHelper.updateAgentConfigs(Collections.singleton(configGroup.getClusterName()));
   }
 
   public ServiceComponentHost getServiceComponentHost(String serviceName,

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/ServiceTest.java
@@ -18,10 +18,17 @@
 
 package org.apache.ambari.server.state;
 
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,8 +41,11 @@ import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
 import org.apache.ambari.server.orm.OrmTestHelper;
 import org.apache.ambari.server.orm.dao.ClusterServiceDAO;
+import org.apache.ambari.server.orm.entities.ClusterConfigEntity;
 import org.apache.ambari.server.orm.entities.ClusterServiceEntity;
 import org.apache.ambari.server.orm.entities.RepositoryVersionEntity;
+import org.apache.ambari.server.state.configgroup.ConfigGroup;
+import org.apache.commons.collections.MapUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +65,7 @@ public class ServiceTest {
   private ServiceComponentFactory serviceComponentFactory;
   private ServiceComponentHostFactory serviceComponentHostFactory;
   private OrmTestHelper ormTestHelper;
+  private ConfigFactory configFactory;
 
   private final String STACK_VERSION = "0.1";
   private final String REPO_VERSION = "0.1-1234";
@@ -69,6 +80,7 @@ public class ServiceTest {
     serviceFactory = injector.getInstance(ServiceFactory.class);
     serviceComponentFactory = injector.getInstance(ServiceComponentFactory.class);
     serviceComponentHostFactory = injector.getInstance(ServiceComponentHostFactory.class);
+    configFactory = injector.getInstance(ConfigFactory.class);
 
     ormTestHelper = injector.getInstance(OrmTestHelper.class);
     repositoryVersion = ormTestHelper.getOrCreateRepositoryVersion(STACK_ID, REPO_VERSION);
@@ -345,6 +357,71 @@ public class ServiceTest {
     map.put("hdfs-site", Collections.singletonMap("hadoop.security.authentication", "kerberos"));
     Assert.assertTrue(service.isKerberosEnabled(map));
 
+  }
+
+  @Test
+  public void testClusterConfigsUnmappingOnDeleteAllServiceConfigs() throws AmbariException {
+    String serviceName = "HDFS";
+    Service s = serviceFactory.createNew(cluster, serviceName, repositoryVersion);
+    cluster.addService(s);
+
+    Service service = cluster.getService(serviceName);
+
+    // add some cluster and service configs
+    Config config1 = configFactory.createNew(cluster, "hdfs-site", "version1",
+        new HashMap<String, String>() {{ put("a", "b"); }}, new HashMap<>());
+    cluster.addDesiredConfig("admin", Collections.singleton(config1));
+
+    Config config2 = configFactory.createNew(cluster, "hdfs-site", "version2",
+        new HashMap<String, String>() {{ put("a", "b"); }}, new HashMap<>());
+    cluster.addDesiredConfig("admin", Collections.singleton(config2));
+
+
+    // check all cluster configs are mapped
+    Collection<ClusterConfigEntity> clusterConfigEntities = cluster.getClusterEntity().getClusterConfigEntities();
+    for (ClusterConfigEntity clusterConfigEntity : clusterConfigEntities) {
+      assertFalse(clusterConfigEntity.isUnmapped());
+    }
+
+    ((ServiceImpl)service).deleteAllServiceConfigs();
+
+    // check all cluster configs are unmapped
+    clusterConfigEntities = cluster.getClusterEntity().getClusterConfigEntities();
+    for (ClusterConfigEntity clusterConfigEntity : clusterConfigEntities) {
+      assertTrue(clusterConfigEntity.isUnmapped());
+    }
+  }
+
+  @Test
+  public void testDeleteAllServiceConfigGroups() throws AmbariException {
+    String serviceName = "HDFS";
+    Service s = serviceFactory.createNew(cluster, serviceName, repositoryVersion);
+    cluster.addService(s);
+
+    Service service = cluster.getService(serviceName);
+
+    ConfigGroup configGroup1 = createNiceMock(ConfigGroup.class);
+    ConfigGroup configGroup2 = createNiceMock(ConfigGroup.class);
+
+    expect(configGroup1.getId()).andReturn(1L).anyTimes();
+    expect(configGroup2.getId()).andReturn(2L).anyTimes();
+
+    expect(configGroup1.getServiceName()).andReturn(serviceName).anyTimes();
+    expect(configGroup2.getServiceName()).andReturn(serviceName).anyTimes();
+
+    expect(configGroup1.getClusterName()).andReturn(cluster.getClusterName()).anyTimes();
+    expect(configGroup2.getClusterName()).andReturn(cluster.getClusterName()).anyTimes();
+
+    replay(configGroup1, configGroup2);
+
+    cluster.addConfigGroup(configGroup1);
+    cluster.addConfigGroup(configGroup2);
+
+    ((ServiceImpl)service).deleteAllServiceConfigGroups();
+
+    assertTrue(MapUtils.isEmpty(cluster.getConfigGroupsByServiceName(serviceName)));
+
+    verify(configGroup1, configGroup2);
   }
 
   private void addHostToCluster(String hostname,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now appropriate config groups are removed when service is removed. Also configs unmapping flag set during service removing was fixed.

## How was this patch tested?

Manual testing.