### PR TITLE
[AMBARI-25131] Alert notification properties are wiped after enabling/disabling the notification (dsen)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProvider.java
@@ -422,9 +422,14 @@ public class AlertTargetResourceProvider extends
       entity.setNotificationType(notificationType);
     }
 
-    String properties = s_gson.toJson(extractProperties(requestMap));
-    if (!StringUtils.isEmpty(properties)) {
-      entity.setProperties(properties);
+    Map<String, Object> propertiesMap = extractProperties(requestMap);
+
+    if (propertiesMap != null) {
+      String properties = s_gson.toJson(propertiesMap);
+      if (!StringUtils.isEmpty(properties)) {
+        LOG.debug("Updating Alert Target properties map to: " + properties);
+        entity.setProperties(properties);
+      }
     }
 
     // a null alert state implies that the key was not set and no update
@@ -533,15 +538,21 @@ public class AlertTargetResourceProvider extends
   private Map<String, Object> extractProperties(Map<String, Object> requestMap) {
     Map<String, Object> normalizedMap = new HashMap<>(
       requestMap.size());
+    boolean has_properties = false;
 
     for (Entry<String, Object> entry : requestMap.entrySet()) {
       String key = entry.getKey();
       String propCat = PropertyHelper.getPropertyCategory(key);
 
       if (propCat.equals(ALERT_TARGET_PROPERTIES)) {
+        has_properties = true;
         String propKey = PropertyHelper.getPropertyName(key);
         normalizedMap.put(propKey, entry.getValue());
       }
+    }
+
+    if (!has_properties) {
+      normalizedMap = null;
     }
 
     return normalizedMap;

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/AlertTargetResourceProviderTest.java
@@ -1007,6 +1007,53 @@ public class AlertTargetResourceProviderTest {
     verify(m_amc, m_dao);
   }
 
+  @Test
+  public void testEnable() throws Exception {
+    Capture<AlertTargetEntity> entityCapture = EasyMock.newCapture();
+    m_dao.create(capture(entityCapture));
+    expectLastCall().times(1);
+
+    AlertTargetEntity target = new AlertTargetEntity();
+    target.setEnabled(false);
+    target.setProperties("{prop1=val1}");
+    expect(m_dao.findTargetById(ALERT_TARGET_ID)).andReturn(target).times(1);
+
+    expect(m_dao.merge(capture(entityCapture))).andReturn(target).once();
+
+    replay(m_amc, m_dao);
+
+    SecurityContextHolder.getContext().setAuthentication(TestAuthenticationFactory.createAdministrator());
+
+    AlertTargetResourceProvider provider = createProvider(m_amc);
+    Map<String, Object> requestProps = getCreationProperties();
+    Request request = PropertyHelper.getCreateRequest(
+      Collections.singleton(requestProps), null);
+    provider.createResources(request);
+
+    // create new properties, and include the ID since we're not going through
+    // a service layer which would add it for us automatically
+    requestProps = new HashMap<>();
+    requestProps.put(AlertTargetResourceProvider.ALERT_TARGET_ID,
+      ALERT_TARGET_ID.toString());
+
+    requestProps.put(AlertTargetResourceProvider.ALERT_TARGET_ENABLED,
+      "true");
+
+    Predicate predicate = new PredicateBuilder().property(
+      AlertTargetResourceProvider.ALERT_TARGET_ID).equals(
+      ALERT_TARGET_ID.toString()).toPredicate();
+
+    request = PropertyHelper.getUpdateRequest(requestProps, null);
+    provider.updateResources(request, predicate);
+
+    assertTrue(entityCapture.hasCaptured());
+
+    AlertTargetEntity entity = entityCapture.getValue();
+    assertTrue("{prop1=val1}".equals(entity.getProperties()));
+    assertTrue(entity.isEnabled());
+    verify(m_amc, m_dao);
+  }
+
   /**
    * @param amc
    * @return


### PR DESCRIPTION
## What changes were proposed in this pull request?
fixed the properties assigning

## How was this patch tested?
Manually + UTs