### PR TITLE
AMBARI-25090 - Logsearch should index keywords without the ending periods(.)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
@@ -91,7 +91,7 @@
   <field name="ip" type="key_lower_case"/>
   <field name="level" type="key_lower_case"/>
   <field name="logType" type="key_lower_case" multiValued="false"/>
-  <field name="log_message" type="text_ws" multiValued="false" omitNorms="false"/>
+  <field name="log_message" type="text_std_token_lower_case" multiValued="false" omitNorms="false"/>
   <field name="logfile_line_number" type="tint" omitNorms="false"/>
   <field name="logger_name" type="key_lower_case"/>
   <field name="message_md5" type="string" multiValued="false"/>

--- a/ambari-logsearch/ambari-logsearch-server/src/main/configsets/hadoop_logs/conf/managed-schema
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/configsets/hadoop_logs/conf/managed-schema
@@ -96,7 +96,7 @@
   <field name="ip" type="string" multiValued="false"/>
   <field name="level" type="lowercase" multiValued="false"/>
   <field name="line_number" type="tint" omitNorms="false"/>
-  <field name="log_message" type="text_ws" multiValued="false" omitNorms="false"/>
+  <field name="log_message" type="text_general" multiValued="false" omitNorms="false"/>
   <field name="logfile_line_number" type="tint" omitNorms="false"/>
   <field name="logger_name" type="string" multiValued="false"/>
   <field name="logtime" type="tdate" multiValued="false"  docValues="true"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

same as:
https://github.com/apache/ambari-logsearch/pull/70

cc @g-boros 