### PR TITLE
AMBARI-25114. Log Search: SSL props needs to be set if only ambari-se…

### DIFF
--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/ExternalServerClient.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/ExternalServerClient.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -52,6 +52,9 @@ public class ExternalServerClient {
    */
   public Object sendGETRequest(String loginUrl, Class<?> klass, String username, String password) throws Exception {
     if (localJerseyClient == null) {
+      if (sslConfigurer.isKeyStoreSpecified()) {
+        sslConfigurer.ensureStorePasswords();
+      }
       localJerseyClient = new ThreadLocal<JerseyClient>() {
         @Override
         protected JerseyClient initialValue() {
@@ -70,7 +73,7 @@ public class ExternalServerClient {
 
     WebTarget target = client.target(url);
     LOG.debug("URL: " + url);
-    
+
     Invocation.Builder invocationBuilder =  target.request();
     try {
       Response response = invocationBuilder.get();


### PR DESCRIPTION
…rver uses SSL

## What changes were proposed in this pull request?
if logsearch uses ssl, it sets the keystore / truststore passwords inside the application
if only ambari-server uses ssl and logsearch is not, all ssl properties are passed to the application but the keystore / truststore passwords are not set. so we need to set those if the external server (ambari server) uses https

## How was this patch tested?
tests passed, FT happpened eariler with master version

please review @g-boros 
