### PR TITLE
[AMBARI-25020] Allow unattended mpack install with purge

### DIFF
--- a/ambari-server/src/main/python/ambari_server/setupMpacks.py
+++ b/ambari-server/src/main/python/ambari_server/setupMpacks.py
@@ -347,11 +347,12 @@ def validate_purge(options, purge_list, mpack_dir, mpack_metadata, replay_mode=F
 
   if not replay_mode:
     purge_resources = set((v) for k, v in RESOURCE_FRIENDLY_NAMES.iteritems() if k in purge_list)
+    answer = 'yes' if options.silent else 'no'
     warn_msg = "CAUTION: You have specified the --purge option with --purge-list={0}. " \
                "This will replace all existing {1} currently installed.\n" \
-               "Are you absolutely sure you want to perform the purge [yes/no]? (no)".format(
-        purge_list, ", ".join(purge_resources))
-    okToPurge = get_YN_input(warn_msg, False)
+               "Are you absolutely sure you want to perform the purge [yes/no]? ({2})".format(
+        purge_list, ", ".join(purge_resources), answer)
+    okToPurge = get_YN_input(warn_msg, options.silent, answer)
     if not okToPurge:
       err = "Management pack installation cancelled by user"
       raise FatalException(1, err)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make it possible to install mpacks from scripts without workarounds that depend on the prompt/input text.

The question that pops up if `purge` is specified prevents installing mpacks without user input.  The default answer is "no", which gets automatically selected in `silent` mode, causing the installation to be cancelled.

```
$ ambari-server install-mpack --purge --silent --verbose --mpack=...
...
CAUTION: You have specified the --purge option with --purge-list=['stack-definitions', 'mpacks']. This will replace all existing stack definitions, management packs currently installed.
Are you absolutely sure you want to perform the purge [yes/no]? (no)
ERROR: Exiting with exit code 1.
REASON: Management pack installation cancelled by user
```

The default answer should be "no" for regular mode, but "yes" for silent mode, to make unattended install possible.

https://issues.apache.org/jira/browse/AMBARI-25020

## How was this patch tested?

Tested `install-mpack` command both without and with `--silent` option.

Confirmed that without the option, the command still defaults to aborting:

```
$ ambari-server install-mpack --purge --verbose --mpack=hdf.tar.gz
Installing management pack
...
CAUTION: You have specified the --purge option with --purge-list=['stack-definitions', 'mpacks']. This will replace all existing stack definitions, management packs currently installed.
Are you absolutely sure you want to perform the purge [yes/no]? (no)
ERROR: Exiting with exit code 1.
REASON: Management pack installation cancelled by user
```

But with `--silent` it defaults to continuing, and completes successfully:

```
$ ambari-server install-mpack --purge --silent --verbose --mpack=hdf.tar.gz
Installing management pack
...
CAUTION: You have specified the --purge option with --purge-list=['stack-definitions', 'mpacks']. This will replace all existing stack definitions, management packs currently installed.
Are you absolutely sure you want to perform the purge [yes/no]? (yes)
INFO: Loading properties from /etc/ambari-server/conf/ambari.properties
INFO: Purging existing stack definitions and management packs
INFO: Purging stack location: /var/lib/ambari-server/resources/stacks
...
INFO: Management pack hdf-ambari-mpack-3.3.0.0-165 successfully installed! Please restart ambari-server.
...
Ambari Server 'install-mpack' completed successfully.
```