### PR TITLE
[AMBARI-25136] Scale hosts ignores rack_info

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ScaleClusterRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ScaleClusterRequest.java
@@ -180,6 +180,8 @@ public class ScaleClusterRequest extends BaseClusterRequest {
     String rackInfo = null;
     if (properties.containsKey(HostResourceProvider.HOST_RACK_INFO_PROPERTY_ID)) {
       rackInfo = (String) properties.get(HostResourceProvider.HOST_RACK_INFO_PROPERTY_ID);
+    } else if (properties.containsKey(HostResourceProvider.RACK_INFO_PROPERTY_ID)) {
+      rackInfo = (String) properties.get(HostResourceProvider.RACK_INFO_PROPERTY_ID);
     } else {
       LOGGER.debug("No rack info provided");
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ScaleClusterRequestTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ScaleClusterRequestTest.java
@@ -50,6 +50,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 /**
  * Unit tests for ScaleClusterRequest.
  */
@@ -64,6 +66,7 @@ public class ScaleClusterRequestTest {
   private static final String GROUP2_NAME = "group2";
   private static final String GROUP3_NAME = "group3";
   private static final String PREDICATE = "test/prop=foo";
+  private static final String RACK_A = "/rack/a";
 
   private static final BlueprintFactory blueprintFactory = createStrictMock(BlueprintFactory.class);
   private static final Blueprint blueprint = createNiceMock(Blueprint.class);
@@ -130,6 +133,14 @@ public class ScaleClusterRequestTest {
     assertTrue(group1Info.getHostNames().contains(HOST1_NAME));
     assertEquals(1, group1Info.getRequestedHostCount());
     assertNull(group1Info.getPredicate());
+    assertEquals(ImmutableMap.of(HOST1_NAME, RACK_A), group1Info.getHostRackInfo());
+  }
+
+  @Test
+  public void acceptsRackInfo() throws Exception {
+    Map<String, Object> props = createScaleClusterPropertiesGroup1_HostName(CLUSTER_NAME, BLUEPRINT_NAME);
+    addSingleHostByName(props);
+    addSingleHostByName(replaceWithPlainRackInfoKey(props));
   }
 
   @Test
@@ -350,6 +361,7 @@ public class ScaleClusterRequestTest {
     properties.put(HostResourceProvider.BLUEPRINT_PROPERTY_ID, blueprintName);
     properties.put(HostResourceProvider.HOST_GROUP_PROPERTY_ID, GROUP1_NAME);
     properties.put(HostResourceProvider.HOST_HOST_NAME_PROPERTY_ID, HOST1_NAME);
+    properties.put(HostResourceProvider.HOST_RACK_INFO_PROPERTY_ID, RACK_A);
 
     return properties;
   }
@@ -358,6 +370,13 @@ public class ScaleClusterRequestTest {
   private static Map<String, Object> replaceWithPlainHostNameKey(Map<String, Object> properties) {
     Object value = properties.remove(HostResourceProvider.HOST_HOST_NAME_PROPERTY_ID);
     properties.put(HostResourceProvider.HOST_NAME_PROPERTY_ID, value);
+    return properties;
+  }
+
+  // include rack info under "rack_info" key instead of "Hosts/rack_info"
+  private static Map<String, Object> replaceWithPlainRackInfoKey(Map<String, Object> properties) {
+    Object value = properties.remove(HostResourceProvider.HOST_RACK_INFO_PROPERTY_ID);
+    properties.put(HostResourceProvider.RACK_INFO_PROPERTY_ID, value);
     return properties;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[AMBARI-14772](https://issues.apache.org/jira/browse/AMBARI-14772) added the ability to specify rack info for new hosts being added to the cluster.  This is broken in `branch-2.6` due to an `else if` branch lost in the initial cherry-pick: currently only `Hosts/rack_info` is accepted.  This change restores the plain `rack_info` case, so both forms will be accepted.

The same `else if` is present on both `branch-2.5`:

https://github.com/apache/ambari/blob/27e00dde15b0d4e1c3701158521268623ff1be0d/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ScaleClusterRequest.java#L179-L189

and `branch-2.7`:

https://github.com/apache/ambari/blob/da4e607a48033ab1f359b3ace302fcf29d823e38/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ScaleClusterRequest.java#L179-L189

https://issues.apache.org/jira/browse/AMBARI-25136

## How was this patch tested?

Tested on local cluster.  Added unit test case.

```
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/hosts/c7402.ambari.apache.org?fields=Hosts/rack_info"
{
  "Hosts" : {
    "cluster_name" : "TEST",
    "host_name" : "c7402.ambari.apache.org",
    "rack_info" : "/rack/a"
  }
}
```