### PR TITLE
[AMBARI-24865] Build error at Findbugs with Maven 3.6.

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -542,7 +542,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.5</version>
         <configuration>
           <failOnError>false</failOnError>
           <threshold>Low</threshold>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2581, for `branch-2.6`, because now Jenkins uses Maven 3.6, too:

```
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T18:41:47Z)
```

## How was this patch tested?

Build with Maven 3.6:

```
$ mvn -version
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T20:41:47+02:00)
...
$ mvn -am -pl ambari-server -DskipTests clean verify
...
[INFO] Ambari Server 2.6.2.0.0 ............................ SUCCESS [04:41 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```