### PR TITLE
AMBARI-25123. /var/lib/ambari-agent/cache not updating (Ambari 2.7)

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
+++ b/ambari-agent/src/main/python/ambari_agent/CustomServiceOrchestrator.py
@@ -347,6 +347,7 @@ class CustomServiceOrchestrator(object):
 
         # forces a hash challenge on the directories to keep them updated, even
         # if the return type is not used
+        self.file_cache.get_host_scripts_base_dir(command)
         base_dir = self.file_cache.get_service_base_dir(command)
         script_path = self.resolve_script_path(base_dir, script)
         script_tuple = (script_path, base_dir)


### PR DESCRIPTION
To reproduce:

1. deploy hosts with Ambari 2.7.3 and have them connected to an ambari-server
2. turn on DEBUG logging in ambari-agent
3. go to an ambari-agent. Notice that there is no /var/lib/ambari-agent/cache/host_scripts/.hash but there are .hash files for the stack directories.
4. on the ambari-server, add files into /var/lib/ambari-server/resources/host_scripts
5. restart ambari-agent and notice that their host_scripts directory is never updated and .hash is never generated
6. check ambari-agent.log and notice that other paths were checked (by FileCache.py) but host_scripts were not