### PR TITLE
AMBARI-25141. Encrypting LDAP manager password in case password security is ON

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/PasswordUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/PasswordUtils.java
@@ -82,7 +82,8 @@ public class PasswordUtils {
       if (CredentialProvider.isAliasString(passwordProperty)) {
         return readPasswordFromStore(passwordProperty);
       } else {
-        return readPasswordFromFile(passwordProperty, defaultPassword);
+        final String pw = readPasswordFromFile(passwordProperty, defaultPassword);
+        return CredentialProvider.isAliasString(pw) ? readPasswordFromStore(pw) : pw;
       }
     }
     return defaultPassword;

--- a/ambari-server/src/main/python/ambari_server/setupSecurity.py
+++ b/ambari-server/src/main/python/ambari_server/setupSecurity.py
@@ -918,19 +918,15 @@ def setup_ldap(options):
     if isSecure:
       if mgr_password:
         encrypted_passwd = encrypt_password(LDAP_MGR_PASSWORD_ALIAS, mgr_password, options)
-        if mgr_password != encrypted_passwd:
-          ldap_property_value_map[LDAP_MGR_PASSWORD_PROPERTY] = encrypted_passwd
-      pass
+        ldap_property_value_map[LDAP_MGR_PASSWORD_PROPERTY] = store_password_file(encrypted_passwd, LDAP_MGR_PASSWORD_FILENAME)
+
       if ts_password:
         encrypted_passwd = encrypt_password(SSL_TRUSTSTORE_PASSWORD_ALIAS, ts_password, options)
         if ts_password != encrypted_passwd:
           ldap_property_values_in_ambari_properties[SSL_TRUSTSTORE_PASSWORD_PROPERTY] = encrypted_passwd
-      pass
-    pass
-
-    # Persisting values
-    if mgr_password:
-      ldap_property_value_map[LDAP_MGR_PASSWORD_PROPERTY] = store_password_file(mgr_password, LDAP_MGR_PASSWORD_FILENAME)
+    else: #not secure
+      if mgr_password:
+        ldap_property_value_map[LDAP_MGR_PASSWORD_PROPERTY] = store_password_file(mgr_password, LDAP_MGR_PASSWORD_FILENAME)
 
     print 'Saving LDAP properties...'
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/PasswordUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/PasswordUtilsTest.java
@@ -66,10 +66,10 @@ public class PasswordUtilsTest extends EasyMockSupport {
     final CredentialProvider credentialProvider = PowerMock.createNiceMock(CredentialProvider.class);
     setupBasicCredentialProviderExpectations(credentialProvider);
     credentialProvider.getPasswordForAlias(CS_ALIAS);
-    PowerMock.expectLastCall().andReturn("testPassword".toCharArray()).once();
+    PowerMock.expectLastCall().andReturn("testPassword".toCharArray()).anyTimes();
     PowerMock.replay(credentialProvider, CredentialProvider.class);
     replayAll();
-    assertEquals("testPassword", passwordUtils.readPassword(CS_ALIAS, "testPassword"));
+    assertEquals("testPassword", passwordUtils.readPassword(CS_ALIAS, "testPasswordDefault"));
     verifyAll();
   }
   
@@ -93,6 +93,20 @@ public class PasswordUtilsTest extends EasyMockSupport {
     final File passwordFile = writeTestPasswordFile(testPassword);
     passwordFile.setReadable(false);
     assertEquals("testPasswordDefault", passwordUtils.readPassword(passwordFile.getAbsolutePath(), "testPasswordDefault"));
+  }
+
+  @Test
+  public void shouldResolveEncryptedPaswordIfWeStoreTheAliasInPasswordFile() throws Exception {
+    final String testPassword = "testPassword";
+    final File passwordFile = writeTestPasswordFile(CS_ALIAS);
+    final CredentialProvider credentialProvider = PowerMock.createNiceMock(CredentialProvider.class);
+    setupBasicCredentialProviderExpectations(credentialProvider);
+    credentialProvider.getPasswordForAlias(CS_ALIAS);
+    PowerMock.expectLastCall().andReturn(testPassword.toCharArray()).anyTimes();
+    PowerMock.replay(credentialProvider, CredentialProvider.class);
+    replayAll();
+    assertEquals(testPassword, passwordUtils.readPassword(passwordFile.getAbsolutePath(), "testPasswordDefault"));
+    verifyAll();
   }
 
   private File writeTestPasswordFile(final String testPassword) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In 2.7.x we store LDAP password within its own file; however the content of that file is not encrypted even if password encryption is on. To approach this issue the following should be done:
- in case password encryption is enabled we will encrypt the LDAP password in the credential store and write the corresponding CS alias in the LDAP password file (just like we do with other passwords in ambari.properties)
- in case the password encryption is disabled we will write the raw password in the LDAP password file

In both cases an additional level of security can be achieved by setting the appropriate user/group access on the file system to the LDAP password file.

## How was this patch tested?

Manually tested both cases (password encryption was ON/OFF):

1. configured LDAP
2. checked if the LDAP password file content was OK
3. synched LDAP successfully