### PR TITLE
[AMBARI-25150] Implement additional error reporting for ambari-web unit tests

### DIFF
--- a/ambari-web/app/assets/test/tests.js
+++ b/ambari-web/app/assets/test/tests.js
@@ -585,7 +585,13 @@ describe('Ambari Web Unit tests', function() {
 
   files.forEach(function (file) {
     describe(file, function() {
-      require(file);
+      try {
+        require(file);
+      } catch (error) {
+        it('Execution of test suite was terminated', function () {
+          throw error;
+        });
+      }
     });
   });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If ambari-web unit tests fail because of JS error thrown in test files outside the callbacks passed to `it`/`before`/`beforeEach`/`after`/`afterEach` methods, the execution is just stopped without reporting the cause. This might be confusing because failure isn't reported if none of the previous tests failed.

## How was this patch tested?

Tested manually.
UI unit tests:
```
  22491 passing (24s)
  48 pending
```