### PR TITLE
[AMBARI-25154] can't delete Kerberos when user exits step 4 in enabling Kerberos wizard

### DIFF
--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -1392,7 +1392,7 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
       popupHeader = Em.I18n.t('services.service.delete.popup.header'),
       dependentServicesToDeleteFmt = this.servicesDisplayNames(interDependentServices);
 
-    if (serviceName === 'KERBEROS') {
+    if (serviceName === 'KERBEROS' && App.get('isKerberosEnabled')) {
       this.kerberosDeleteWarning(popupHeader);
       return;
     }


### PR DESCRIPTION
can't delete kerberos when user exits step 4 in enabling kerberos

Jira: #AMBARI-25154


## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

@afernandez @u39kun @Jetly-Jaimin @ncole 