### PR TITLE
[AMBARI-25137] SecondaryNamenodeDeletedCheck did not consider the situation of multi-clusters

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/SecondaryNamenodeDeletedCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/SecondaryNamenodeDeletedCheck.java
@@ -95,7 +95,7 @@ public class SecondaryNamenodeDeletedCheck extends AbstractCheckDescriptor {
 
     // Try another method to find references to SECONDARY_NAMENODE
     if (hosts.isEmpty()) {
-      List<HostComponentStateEntity> allHostComponents = hostComponentStateDao.findAll();
+      List<HostComponentStateEntity> allHostComponents = hostComponentStateDao.findByCluster(cluster.getClusterId());
       for(HostComponentStateEntity hc : allHostComponents) {
         if (hc.getServiceName().equalsIgnoreCase(HDFS_SERVICE_NAME) && hc.getComponentName().equalsIgnoreCase(SECONDARY_NAMENODE)) {
           hosts.add(hc.getHostName());

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentStateDAO.java
@@ -72,6 +72,20 @@ public class HostComponentStateDAO {
   }
 
   /**
+   * Retrieve all of the Host Component States for the given cluster id.
+   *
+   * @param cluster_id HOst name
+   * @return Return all of the Host Component States that match the criteria.
+   */
+  @RequiresSession
+  public List<HostComponentStateEntity> findByCluster(long cluster_id) {
+    final TypedQuery<HostComponentStateEntity> query = entityManagerProvider.get().createNamedQuery("HostComponentStateEntity.findByCluster", HostComponentStateEntity.class);
+    query.setParameter("clusterId", cluster_id);
+
+    return daoUtils.selectList(query);
+    }
+
+  /**
    * Retrieve all of the Host Component States for the given service.
    *
    * @param serviceName Service Name

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostComponentStateEntity.java
@@ -55,6 +55,9 @@ import com.google.common.base.Objects;
         name = "HostComponentStateEntity.findByHost",
         query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.hostEntity.hostName=:hostName"),
     @NamedQuery(
+        name = "HostComponentStateEntity.findByCluster",
+        query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.clusterId=:clusterId"),
+    @NamedQuery(
         name = "HostComponentStateEntity.findByService",
         query = "SELECT hcs from HostComponentStateEntity hcs WHERE hcs.serviceName=:serviceName"),
     @NamedQuery(


### PR DESCRIPTION
…ple clusters,fix it

## What changes were proposed in this pull request?

add findByCluster method in HostComponentStateDAO for using in SecondaryNamenodeDeletedCheck to get the cluster HostComponentStateEntity list

## How was this patch tested?

manual tests 
