### PR TITLE
AMBARI-25158 Dashboard is unable to load . Common console error : "SEVERE TypeError: widgetGroups is undefined"

### DIFF
--- a/ambari-web/app/views/main/dashboard/widgets.js
+++ b/ambari-web/app/views/main/dashboard/widgets.js
@@ -171,6 +171,7 @@ App.MainDashboardWidgetsView = Em.View.extend(App.Persist, App.LocalStorage, App
     }
     this.loadWidgetsSettings().complete(() => {
       this.get('widgetGroupsDeferred').done(() => {
+        if (this.get('isDestroyed')) return;
         this.checkServicesChange();
         this.renderWidgets();
         this.set('isDataLoaded', true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found a corner scenario where the dashboard never loads.
If we click on Dashboard link on landing page before dashboard completely loads upon login, dashboard never loads.

## How was this patch tested?

 21754 passing (37s)
  48 pending
