### PR TITLE
AMBARI-25162 Fix Oozie Service Check

### DIFF
--- a/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/common-services/OOZIE/4.0.0.2.0/package/scripts/service_check.py
@@ -20,6 +20,7 @@ limitations under the License.
 import os
 import glob
 
+from resource_management.core.exceptions import Fail
 from resource_management.core.resources.system import Execute
 from resource_management.core.resources import File
 from resource_management.core.source import StaticFile


### PR DESCRIPTION
Added missing import statement

## What changes were proposed in this pull request?

Fixed AMBARI-25162 by adding the messing import statement

## How was this patch tested?

Manually. The same changes were used in a live cluster to fix the issue and run successful service check.
