### PR TITLE
AMBARI-25159. http.strict-transport-security change does not take affect in 2.7.x.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariServer.java
@@ -134,6 +134,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SessionIdManager;
@@ -633,6 +634,7 @@ public class AmbariServer {
 
 
       HttpConfiguration https_config = new HttpConfiguration();
+      https_config.addCustomizer(new SecureRequestCustomizer());
       https_config.setRequestHeaderSize(configs.getHttpRequestHeaderSize());
       https_config.setResponseHeaderSize(configs.getHttpResponseHeaderSize());
       https_config.setSendServerVersion(false);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for previous patch. Secure request customizer has been returned for 2-way SSL connection with agent.

## How was this patch tested?

Manual testing.