### PR TITLE
[AMBARI-25166]:Modifying the value of node memory in the YARN service will affect the maximum value of container memory, but the modification cannot be saved.

### DIFF
--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -1240,8 +1240,8 @@ class DefaultStackAdvisor(StackAdvisor):
     nodeManagerHost = self.getHostWithComponent("YARN", "NODEMANAGER", services, hosts)
     if (nodeManagerHost is not None):
       if "yarn-site" in services["configurations"] and "yarn.nodemanager.resource.percentage-physical-cpu-limit" in services["configurations"]["yarn-site"]["properties"]:
-        putYarnPropertyAttribute('yarn.scheduler.minimum-allocation-mb', 'maximum', configurations["yarn-site"]["properties"]["yarn.nodemanager.resource.memory-mb"])
-        putYarnPropertyAttribute('yarn.scheduler.maximum-allocation-mb', 'maximum', configurations["yarn-site"]["properties"]["yarn.nodemanager.resource.memory-mb"])
+        putYarnPropertyAttribute('yarn.scheduler.minimum-allocation-mb', 'maximum', services["configurations"]["yarn-site"]["properties"]["yarn.nodemanager.resource.memory-mb"])
+        putYarnPropertyAttribute('yarn.scheduler.maximum-allocation-mb', 'maximum', services["configurations"]["yarn-site"]["properties"]["yarn.nodemanager.resource.memory-mb"])
 
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
AMBARI-25166 repairs the following problem: Modifying the value of node memory in the YARN service will affect the maximum value of container memory, but the modification cannot be saved.

## How was this patch tested?
We cannot save the maximum value of container memory associated with node memory value when modifying the YARN node memory.
see https://issues.apache.org/jira/browse/AMBARI-25166
For example:

The following is the initial configuration: 
![image](https://user-images.githubusercontent.com/32010892/53341099-9a8d7800-3945-11e9-85e4-6c28e12836fd.png)
Step 1: if we modify the node memory (Memory allocated for all YARN containers on a node) in YARN CONFIGS page, the maximum value of "Minimum/Maximum Container Size (Memory)" and the current value of "Maximum Container Size (Memory)" will be affected.
![image](https://user-images.githubusercontent.com/32010892/53385512-8e430280-39b9-11e9-967f-21a616735df5.png)
Step 2: however, the configuration modifications do not take effect when we click the "save" button.
![image](https://user-images.githubusercontent.com/32010892/53341143-b55fec80-3945-11e9-944f-9b3ff28ca805.png)
Step 3: Now we can save the maximum value of container memory when modifying the value of node memory with the committed modifications.
![image](https://user-images.githubusercontent.com/32010892/53341964-dcb7b900-3947-11e9-80e2-3a715cccb8e3.png)