### PR TITLE
AMBARI-25096 Cluster Installation fails when installing the cluster via Redhat satellite repositories (no internet connectivity Cluster)

### DIFF
--- a/ambari-web/app/controllers/installer.js
+++ b/ambari-web/app/controllers/installer.js
@@ -848,8 +848,10 @@ App.InstallerController = App.WizardController.extend(App.Persist, {
       if (!verifyBaseUrl) {
         dfd.resolve();
       }
+      //for redhat satellite/spacewalk the os urls will be empty
+      var useRedhatSatellite = wizardStep1Controller.get('selectedStack.useRedhatSatellite');
       selectedStack.get('operatingSystems').forEach(function (os) {
-        if (os.get('isSelected') && !os.get('isEmpty')) {
+        if (os.get('isSelected') && (useRedhatSatellite || !os.get('isEmpty'))) {
           os.get('repositories').forEach(function (repo) {
             if (repo.get('showRepo')) {
               repo.setProperties({


### PR DESCRIPTION

## What changes were proposed in this pull request?

AMBARI-25096 Cluster Installation fails when installing the cluster via Redhat satellite repositories (no internet connectivity Cluster)

## How was this patch tested?
Tested in UI
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.