### PR TITLE
AMBARI-25167 HDFS Summary Dashboard does not show "TOTAL FILES + DIRECTORIES" properly In Ambari 2.7 (asnaik)

### DIFF
--- a/ambari-web/app/mappers/service_metrics_mapper.js
+++ b/ambari-web/app/mappers/service_metrics_mapper.js
@@ -81,7 +81,7 @@ App.serviceMetricsMapper = App.QuickDataMapper.create({
     dfs_corrupt_blocks_values: 'metrics.dfs.FSNamesystem.CorruptBlocks',
     dfs_missing_blocks_values: 'metrics.dfs.FSNamesystem.MissingBlocks',
     dfs_under_replicated_blocks_values: 'metrics.dfs.FSNamesystem.UnderReplicatedBlocks',
-    dfs_total_files_values: 'metrics.dfs.namenode.TotalFiles',
+    dfs_total_files_values: 'metrics.dfs.FSNamesystem.FilesTotal',
     work_status_values: 'HostRoles.state',
     upgrade_status_values: 'metrics.dfs.namenode.UpgradeFinalized',
     safe_mode_status_values: 'metrics.dfs.namenode.Safemode',

--- a/ambari-web/app/views/main/service/info/summary/hdfs/widgets.js
+++ b/ambari-web/app/views/main/service/info/summary/hdfs/widgets.js
@@ -77,7 +77,7 @@ App.HDFSSummaryWidgetsView = Em.View.extend(App.NameNodeWidgetMixin, App.HDFSSum
 
   dfsTotalFilesValue: Em.computed.getByKey('model.dfsTotalFilesValues', 'hostName'),
 
-  dfsTotalFiles: Em.computed.formatUnavailable('model.dfsTotalFilesValue'),
+  dfsTotalFiles: Em.computed.formatUnavailable('dfsTotalFilesValue'),
 
   healthStatus: Em.computed.getByKey('model.healthStatusValues', 'hostName'),
 


### PR DESCRIPTION

## What changes were proposed in this pull request?
AMBARI-25167 HDFS Summary Dashboard does not show "TOTAL FILES + DIRECTORIES" properly In Ambari 2.7 (asnaik)

(Please fill in changes proposed in this fix)

## How was this patch tested?
* Tested in UI
* UT is pass
  21754 passing (27s)
  48 pending

* Build is success
  main:
[INFO] Executed tasks
[INFO]
[INFO] --- maven-assembly-plugin:2.2-beta-5:single (make-assembly) @ ambari-web ---
[INFO] Reading assembly descriptor: /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/ambari-project/src/main/assemblies/empty.xml
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ ambari-web ---
[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/ambari-web/pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/ambari-web/2.7.3.0.0/ambari-web-2.7.3.0.0.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:19 min
[INFO] Finished at: 2019-02-28T11:41:06+05:30
[INFO] Final Memory: 14M/220M
[INFO] ------------------------------------------------------------------------
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.