### PR TITLE
AMBARI-25175. Start, Stop, Service Check and other request actions using PUT/POST from Ambari UI do not respond when tried via Knox TP

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/RequestFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/RequestFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.api.services;
 
+import org.apache.ambari.server.api.predicate.QueryLexer;
 import org.apache.ambari.server.api.resources.ResourceDefinition;
 import org.apache.ambari.server.api.resources.ResourceInstance;
 
@@ -84,7 +85,6 @@ public class RequestFactory {
    */
   private Request createPostRequest(HttpHeaders headers, RequestBody body, UriInfo uriInfo, ResourceInstance resource) {
     boolean batchCreate = !applyDirectives(Request.Type.POST, body, uriInfo, resource);;
-
     return (batchCreate) ?
         new QueryPostRequest(headers, body, uriInfo, resource) :
         new PostRequest(headers, body, uriInfo, resource);
@@ -153,6 +153,7 @@ public class RequestFactory {
    */
   private boolean applyDirectives(Request.Type requestType, RequestBody body, UriInfo uriInfo, ResourceInstance resource) {
     Map<String, String> queryParameters = getQueryParameters(uriInfo, body);
+    queryParameters.remove(QueryLexer.QUERY_DOAS); // KNOX appends a doAs parameter to every request. Ignore this as it's neither a query predicate nor a directive.
     Map<String, String> requestInfoProperties;
     boolean allDirectivesApplicable = true;
     if (!queryParameters.isEmpty()) {

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -3141,6 +3141,10 @@ var formatRequest = function (data) {
   if (this.format) {
     jQuery.extend(opt, this.format(data, opt));
   }
+  if (!('headers' in opt && 'Content-Type' in opt.headers)) {
+    // With the default www-url-form-encoded Content-Type KNOX would corrupt the json content.
+    opt.headers['Content-Type'] = 'text/plain';
+  }
   var statusCode = jQuery.extend({}, require('data/statusCodes'));
   statusCode['404'] = function () {
     console.log("Error code 404: URI not found. -> " + opt.url);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Start/Stop commands are failing with an error like:

```json
{
  "status" : 400,
  "message" : "Invalid Request: Malformed Request Body.  An exception occurred parsing the request body: Unexpected character ('%' (code 37)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')\n at [Source: java.io.StringReader@5e9b8d28; line: 1, column: 3]"
}
```

when Ambari is behind a Knox proxy. Ambari sends json documents with www-form-urlencoded content type and Knox tries to reencode them.

## How was this patch tested?

Manually through Ambari UI