### PR TITLE
AMBARI-25176 Fix name of jersey logger in ambari-server

### DIFF
--- a/ambari-server/conf/unix/log4j.properties
+++ b/ambari-server/conf/unix/log4j.properties
@@ -79,7 +79,7 @@ log4j.appender.eclipselink.layout=org.apache.log4j.PatternLayout
 log4j.appender.eclipselink.layout.ConversionPattern=%m%n
 
 # Jersey
-log4j.logger.org.glassfish.jersey=WARN,file
+log4j.logger.com.sun.jersey=WARN,file
 
 # Jetty
 log4j.logger.org.eclipse.jetty=WARN,file

--- a/ambari-server/conf/unix/log4j.properties
+++ b/ambari-server/conf/unix/log4j.properties
@@ -80,6 +80,7 @@ log4j.appender.eclipselink.layout.ConversionPattern=%m%n
 
 # Jersey
 log4j.logger.com.sun.jersey=WARN,file
+log4j.logger.org.glassfish.jersey=WARN,file
 
 # Jetty
 log4j.logger.org.eclipse.jetty=WARN,file


### PR DESCRIPTION
## What changes were proposed in this pull request?
AMBARI-25176 Misconfiguration of jersey log in log4j.properties

Fix name of jersey logger in log4j.properties of ambari-server.

Change the logger name of jersey from `org.glassfish.jersey` to `com.sun.jersey`.

## How was this patch tested?

No tests needed.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.