### PR TITLE
AMBARI-25178. [Knox TP] Config Group selection is empty while Adding Service in Ambari (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/predicate/QueryLexer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/predicate/QueryLexer.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.api.predicate;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -127,6 +129,11 @@ public class QueryLexer {
    * @throws InvalidQueryException if the query is invalid
    */
   public Token[] tokens(String exp, Collection<String> ignoreProperties) throws InvalidQueryException {
+    try {
+      exp = URLDecoder.decode(exp,  "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new InvalidQueryException("Could not decode: " + exp, e);
+    }
     ScanContext ctx = new ScanContext();
     ctx.addPropertiesToIgnore(SET_IGNORE);
     ctx.addPropertiesToIgnore(ignoreProperties);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Ambari is behind Knox Config Group Selection doesn't work. The group_id>0 predicate is url encoded by knox and Ambari fails to parse the encoded query param.

```text
GET https://ctr-e139-1542663976389-81666-01-000003.hwx.site:8443/gateway/default/ambari/api/v1/clusters/cl1/configurations/service_config_versions?is_current=true&group_id%3E0&fields=*&_=1551793258100

{"status":400,"message":"Unable to compile query predicate: Invalid Query Token: token='&', previous token type=PROPERTY_OPERAND"}
```

## How was this patch tested?

manually
