### PR TITLE
AMBARI-25181. Host registration through Ambari UI failed with an error "Unsupported Media Type" (amagyar)

### DIFF
--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -3141,7 +3141,7 @@ var formatRequest = function (data) {
   if (this.format) {
     jQuery.extend(opt, this.format(data, opt));
   }
-  if (!('headers' in opt && 'Content-Type' in opt.headers)) {
+  if (!('headers' in opt && 'Content-Type' in opt.headers) && opt.contentType === undefined) {
     // With the default www-url-form-encoded Content-Type KNOX would corrupt the json content.
     opt.headers['Content-Type'] = 'text/plain';
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Host registration didn't work because of content-type mismatch.

## How was this patch tested?

- created a cluster using Ambari UI