### PR TITLE
AMBARI-25176 Misconfiguration of jersey log in log4j.properties

### DIFF
--- a/ambari-server/conf/unix/log4j.properties
+++ b/ambari-server/conf/unix/log4j.properties
@@ -90,6 +90,7 @@ log4j.appender.eclipselink.layout=org.apache.log4j.PatternLayout
 log4j.appender.eclipselink.layout.ConversionPattern=%m%n
 
 # Jersey
+log4j.logger.com.sun.jersey=WARN,file
 log4j.logger.org.glassfish.jersey=WARN,file
 
 # Jetty


### PR DESCRIPTION
## What changes were proposed in this pull request?

The jersey we used in ambari-server is the older version from Sun, not from the Glassfish. Therefore, we add a new line for `com.sun.jersey`.

Same with #2846 , we apply same patch to branch-2.7 for 2.7.4 release.

## How was this patch tested?

No tests needed.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.