### PR TITLE
AMBARI-25182. Add 'hadoop.kms.authentication.zk-dt-secret-manager.enable' property during multiple Ranger KMS

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1451,6 +1451,11 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
           haValue: 'false'
         },
         {
+          name: 'hadoop.kms.authentication.zk-dt-secret-manager.enable',
+          notHaValue: 'false',
+          haValue: 'true'
+        },
+        {
           name: 'hadoop.kms.cache.timeout.ms',
           notHaValue: '600000',
           haValue: '0'

--- a/ambari-web/test/controllers/main/host/details_test.js
+++ b/ambari-web/test/controllers/main/host/details_test.js
@@ -3445,6 +3445,7 @@ describe('App.MainHostDetailsController', function () {
             properties: {
               'kms-site': {
                 'hadoop.kms.cache.enable': 'true',
+                'hadoop.kms.authentication.zk-dt-secret-manager.enable': 'false',
                 'hadoop.kms.cache.timeout.ms': '600000',
                 'hadoop.kms.current.key.cache.timeout.ms': '30000',
                 'hadoop.kms.authentication.signer.secret.provider': 'random',
@@ -3478,6 +3479,7 @@ describe('App.MainHostDetailsController', function () {
             properties: {
               'kms-site': {
                 'hadoop.kms.cache.enable': 'false',
+                'hadoop.kms.authentication.zk-dt-secret-manager.enable': 'true',
                 'hadoop.kms.cache.timeout.ms': '0',
                 'hadoop.kms.current.key.cache.timeout.ms': '0',
                 'hadoop.kms.authentication.signer.secret.provider': 'zookeeper',


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add 'hadoop.kms.authentication.zk-dt-secret-manager.enable' property during multiple Ranger KMS

## How was this patch tested?
Unit, manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.