### PR TITLE
AMBARI-25183 Need a stack feature constant for add zoneName field in collection used for Ranger plugin audit

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/constants.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/constants.py
@@ -126,3 +126,4 @@ class StackFeature:
   AMS_LEGACY_HADOOP_SINK = "ams_legacy_hadoop_sink"
   RANGER_ALL_ADMIN_CHANGE_DEFAULT_PASSWORD = 'ranger_all_admin_change_default_password'
   KAFKA_ENV_INCLUDE_RANGER_SCRIPT='kafka_env_include_ranger_script'
+  RANGER_SUPPORT_SECURITY_ZONE_FEATURE = 'ranger_support_security_zone_feature'


### PR DESCRIPTION
## What changes were proposed in this pull request?
As a part to add zoneName field in Ranger Solr collection during upgrade, need a stack feature constant to support this feature.

## How was this patch tested?
Tested fresh & upgrade scenario.


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.