### PR TITLE
[AMBARI-25189] Enable livy.server.access-control.enabled by default.(…

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/livy2-conf.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/SPARK2/configuration/livy2-conf.xml
@@ -110,5 +110,13 @@
         </description>
         <on-ambari-upgrade add="false"/>
     </property>
+    <property>
+        <name>livy.server.access-control.enabled</name>
+        <value>true</value>
+        <description>
+            Property to configure Livy user access.
+        </description>
+        <on-ambari-upgrade add="false"/>
+    </property>
 </configuration>
 


### PR DESCRIPTION
…vbrodetskyi)

Add property livy.server.access-control.enabled to livy2-conf and set default value = true.


## How was this patch tested?

Deployed cluster and validated that property is available.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.