### PR TITLE
[AMBARI-25194] Increase the Agent cert validity to 3 years

### DIFF
--- a/ambari-server/conf/unix/ca.config
+++ b/ambari-server/conf/unix/ca.config
@@ -8,7 +8,7 @@ new_certs_dir          = $dir/newcerts
 
 database               = $dir/index.txt
 serial                 = $dir/serial
-default_days           = 365    
+default_days           = 1095    
 
 default_crl_days       = 7  
 default_md             = sha256


### PR DESCRIPTION
## What changes were proposed in this pull request?
[AMBARI-25194] Increase the Agent cert validity to 3 years

(Please fill in changes proposed in this fix)

## How was this patch tested?
Manually tested by updating the ca.config file.
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.