### PR TITLE
[AMBARI-25189] Enable livy.server.access-control.enabled by default.(…

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/config-upgrade.xml
@@ -189,6 +189,14 @@
           </definition>
         </changes>
       </component>
+      <component name="LIVY2_SERVER">
+        <changes>
+          <definition xsi:type="configure" id="hdp_2_6_6_0_set_server_access_control">
+            <type>livy2-conf</type>
+            <set key="livy.server.access-control.enabled" value="false" if-type="livy2-conf" if-key="livy.server.access-control.enabled" if-key-state="absent"/>
+          </definition>
+        </changes>
+      </component>
     </service>
 
     <service name="TEZ">

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/nonrolling-upgrade-2.6.xml
@@ -115,6 +115,7 @@
       <service name="SPARK2">
         <component>SPARK2_JOBHISTORYSERVER</component>
         <component>SPARK2_THRIFTSERVER</component>
+        <component>LIVY2_SERVER</component>
       </service>
 
       <service name="ZEPPELIN">
@@ -698,6 +699,10 @@
       <execute-stage service="SPARK2" component="SPARK2_CLIENT" title="Apply config changes for Spark2 Client log4j">
         <task xsi:type="configure" id="hdp_2_5_0_0_spark2_client_log4j"/>
       </execute-stage>
+
+      <execute-stage service="SPARK2" component="LIVY2_SERVER" title="Set config changes for livy2 server">
+        <task xsi:type="configure" id="hdp_2_6_6_0_set_server_access_control"/>
+      </execute-stage>
     </group>
 
     <!--
@@ -969,6 +974,7 @@
       <service name="SPARK2">
         <component>SPARK2_JOBHISTORYSERVER</component>
         <component>SPARK2_THRIFTSERVER</component>
+        <component>LIVY2_SERVER</component>
       </service>
     </group>
 
@@ -1479,6 +1485,11 @@
         </upgrade>
       </component>
       <component name="SPARK2_THRIFTSERVER">
+        <upgrade>
+          <task xsi:type="restart-task"/>
+        </upgrade>
+      </component>
+      <component name="LIVY2_SERVER">
         <upgrade>
           <task xsi:type="restart-task"/>
         </upgrade>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
@@ -277,6 +277,7 @@
       <service name="SPARK2">
         <component>SPARK2_JOBHISTORYSERVER</component>
         <component>SPARK2_THRIFTSERVER</component>
+        <component>LIVY2_SERVER</component>
       </service>
     </group>
 
@@ -961,6 +962,15 @@
           <task xsi:type="configure" id="hdp_2_5_0_0_spark2_client_log4j"/>
         </pre-upgrade>
         <pre-downgrade/>
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="LIVY2_SERVER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="hdp_2_6_6_0_set_server_access_control"/>
+        </pre-upgrade>
+        <pre-downgrade />
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
@@ -279,6 +279,14 @@
           </definition>
         </changes>
       </component>
+      <component name="LIVY2_SERVER">
+        <changes>
+          <definition xsi:type="configure" id="hdp_2_6_6_0_set_server_access_control">
+            <type>livy2-conf</type>
+            <set key="livy.server.access-control.enabled" value="false" if-type="livy2-conf" if-key="livy.server.access-control.enabled" if-key-state="absent"/>
+          </definition>
+        </changes>
+      </component>
     </service>
 
     <service name="TEZ">

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/nonrolling-upgrade-2.6.xml
@@ -424,6 +424,10 @@
         <task xsi:type="configure" id="hdp_2_6_0_0_spark2_thriftserver"/>
       </execute-stage>
 
+      <execute-stage service="SPARK2" component="LIVY2_SERVER" title="Set config changes for livy2 server">
+        <task xsi:type="configure" id="hdp_2_6_6_0_set_server_access_control"/>
+      </execute-stage>
+
       <!-- RANGER -->
       <execute-stage service="RANGER" component="RANGER_USERSYNC" title="Enabling Nested Group Sync for Ranger">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.RangerUsersyncConfigCalculation">

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/upgrade-2.6.xml
@@ -897,6 +897,10 @@
         </upgrade>
       </component>
       <component name="LIVY2_SERVER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="hdp_2_6_6_0_set_server_access_control"/>
+        </pre-upgrade>
+        <pre-downgrade />
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>


### PR DESCRIPTION
…vbrodetskyi)

## What changes were proposed in this pull request?

Added changed to stack upgrade configs to work with new property in correct way.

## How was this patch tested?

Tested stack upgrades from HDP-2.5 to HDP-2.6. Probably will also test 2.6.* to 2.6.*.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.