### PR TITLE
[AMBARI-25197] NullPointerException if there is no proper HDP/HDF rep…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
@@ -89,13 +89,14 @@ public class UpdateActiveRepoVersionOnStartup {
           StackId stackId = repositoryVersion.getStackId();
           StackInfo stack = stackManager.getStack(stackId.getStackName(), stackId.getStackVersion());
 
-          if(stack !=null) {
+          if (stack !=null) {
             if (updateRepoVersion(stack, repositoryVersion)) {
               repositoryVersionDao.merge(repositoryVersion);
             }
           } else {
             LOG.error(String.format("Check if Stack %s  version %s is present in file system",  stackId.getStackName(), stackId.getStackVersion()));
-            throw new AmbariException(String.format("Stack %s version %s  was not found in file system",  stackId.getStackName(), stackId.getStackVersion()));
+            throw new AmbariException(String.format("Stack %s %s was not found on the file system. In the event that it was removed, " +
+              "please ensure that it exists before starting Ambari Server.",  stackId.getStackName(), stackId.getStackVersion()));
           }
         }
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
@@ -95,6 +95,7 @@ public class UpdateActiveRepoVersionOnStartup {
             }
           } else {
             LOG.error(String.format("Check if Stack %s  version %s is present in file system",  stackId.getStackName(), stackId.getStackVersion()));
+            throw new AmbariException(String.format("Stack %s version %s  was not found in file system",  stackId.getStackName(), stackId.getStackVersion()));
           }
         }
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
@@ -94,7 +94,6 @@ public class UpdateActiveRepoVersionOnStartup {
               repositoryVersionDao.merge(repositoryVersion);
             }
           } else {
-            LOG.error(String.format("Check if Stack %s  version %s is present in file system",  stackId.getStackName(), stackId.getStackVersion()));
             throw new AmbariException(String.format("Stack %s %s was not found on the file system. In the event that it was removed, " +
               "please ensure that it exists before starting Ambari Server.",  stackId.getStackName(), stackId.getStackVersion()));
           }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/UpdateActiveRepoVersionOnStartup.java
@@ -89,8 +89,12 @@ public class UpdateActiveRepoVersionOnStartup {
           StackId stackId = repositoryVersion.getStackId();
           StackInfo stack = stackManager.getStack(stackId.getStackName(), stackId.getStackVersion());
 
-          if (updateRepoVersion(stack, repositoryVersion)) {
-            repositoryVersionDao.merge(repositoryVersion);
+          if(stack !=null) {
+            if (updateRepoVersion(stack, repositoryVersion)) {
+              repositoryVersionDao.merge(repositoryVersion);
+            }
+          } else {
+            LOG.error(String.format("Check if Stack %s  version %s is present in file system",  stackId.getStackName(), stackId.getStackVersion()));
           }
         }
       }


### PR DESCRIPTION
…o version folder

## What changes were proposed in this pull request?
Doing a null check and then printing the corresponding error message so that users can check it.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Deployed the changes in Ambari server and tested without having stacks definitions with stack definitions. now it prints proper error message.


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.