### PR TITLE
Fixed advertised.listeners block in kafka

### DIFF
--- a/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka.py
+++ b/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/kafka.py
@@ -62,10 +62,11 @@ def kafka(upgrade_type=None):
          Logger.info(format("Kafka advertised listeners: {listeners}"))
        else:
          kafka_server_config['listeners'] = listeners
-         if 'advertised.listeners' in kafka_server_config:
-           advertised_listeners = kafka_server_config['advertised.listeners'].replace("localhost", params.hostname)
-           kafka_server_config['advertised.listeners'] = advertised_listeners
-           Logger.info(format("Kafka advertised listeners: {advertised_listeners}"))
+
+       if 'advertised.listeners' in kafka_server_config:
+         advertised_listeners = kafka_server_config['advertised.listeners'].replace("localhost", params.hostname)
+         kafka_server_config['advertised.listeners'] = advertised_listeners
+         Logger.info(format("Kafka advertised listeners: {advertised_listeners}"))
     else:
       kafka_server_config['host.name'] = params.hostname
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

advertised.listeners were not set properly and they remain as localhost:<portNumber>. Code responsible for the same was under else block of params.kerberos_security_enabled. Advertised.listeners were just being set in case if kerberos security is disabled. Advertised.listeners block should be called irrespective of kerberos enabled or disabled and depending on if someone has set this property in config or not. 

## How was this patch tested?

Made changes to file and restarted kafka-broker. Advertised.listeners have hostname instead of localhost

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.