### PR TITLE
AMBARI-25199. Ambari does not update "dfs.namenode.lifeline.rpc-address" during Namenode move operation (amagyar)

### DIFF
--- a/ambari-web/app/utils/configs/move_namenode_config_initializer.js
+++ b/ambari-web/app/utils/configs/move_namenode_config_initializer.js
@@ -30,7 +30,8 @@ App.MoveNameNodeConfigInitializer = App.MoveComponentConfigInitializerClass.crea
   initializers: {
     'dfs.namenode.http-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(50070),
     'dfs.namenode.https-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(50470),
-    'dfs.namenode.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8020)
+    'dfs.namenode.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8020),
+    'dfs.namenode.lifeline.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8050)
   },
 
   uniqueInitializers: {


### PR DESCRIPTION
## What changes were proposed in this pull request?

While performing Namenode (NN) move from one host to another dfs.namenode.lifeline.rpc-address property is not updated, causing the namenode fail to start after the move.

## How was this patch tested?

1. Have a HDFS HA cluster. 
2. Make sure "dfs.namenode.lifeline.rpc-address" is set for both the NNs.
3. Perform the NN move operation from any NN to new host.
4. Successfully start NameNodes
