### PR TITLE
[AMBARI-25202] recoverHost operation fails if public hostname is diff…

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -3107,7 +3107,7 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
   
   recoverHost: function() {
     var components = this.get('content.hostComponents');
-    var hostName = this.get('content.publicHostName');
+    var hostName = this.get('content.hostName');
     var self = this;
     var batches = [
       {


### PR DESCRIPTION
…erent from actual hostname (apappu)

## What changes were proposed in this pull request?
have used "content.hostName" instead of "content.hostName" instead of "content.publicHostName" as publichostname calls would fail.
(Please fill in changes proposed in this fix)

## How was this patch tested?
Deployed the changes in working ambari setup and tried to recover the host - after changes operation is successful.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.