### PR TITLE
AMBARI-25206: HDFS NameSpace Widget Threshold Values Are Not Updated after Change

### DIFF
--- a/ambari-web/app/views/main/dashboard/widget.js
+++ b/ambari-web/app/views/main/dashboard/widget.js
@@ -170,8 +170,10 @@ App.DashboardWidgetView = Em.View.extend({
       const parsedWidgetId = parseInt(widgetId);
       if (this.get('isAllItemsSubGroup')) {
         userPreferences.groups[this.get('groupId')]['*'].threshold[this.get('subGroupId')][parsedWidgetId] = preparedThresholds;
+        this.set('widget.threshold', userPreferences.groups[this.get('groupId')]['*'].threshold[this.get('subGroupId')][parsedWidgetId]);
       } else {
         userPreferences.groups[this.get('groupId')][this.get('subGroupId')].threshold[parsedWidgetId] = preparedThresholds;
+        this.set('widget.threshold', userPreferences.groups[this.get('groupId')][this.get('subGroupId')].threshold[parsedWidgetId]);
       }
     } else {
       userPreferences.threshold[widgetIdToNumber] = preparedThresholds;


### PR DESCRIPTION
Jira:  AMBARI-25206
## What changes were proposed in this pull request?
Fix the issue that hdfs namespace widget threshold values are not updated after change

## How was this patch tested?
Tested in a real cluster


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.