### PR TITLE
[AMBARI-25093] "Spark2 Thrift Server alert does not work with HTTPS/SSL (apappu)

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_thrift_port.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_thrift_port.py
@@ -36,12 +36,18 @@ OK_MESSAGE = "TCP OK - {0:.3f}s response on port {1}"
 CRITICAL_MESSAGE = "Connection failed on host {0}:{1} ({2})"
 
 HIVE_SERVER_THRIFT_PORT_KEY = '{{spark2-hive-site-override/hive.server2.thrift.port}}'
+HIVE_SERVER_THRIFT_HTTP_PORT_KEY = '{{spark2-hive-site-override/hive.server2.thrift.http.port}}'
+
 HIVE_SERVER_TRANSPORT_MODE_KEY = '{{spark2-hive-site-override/hive.server2.transport.mode}}'
 SECURITY_ENABLED_KEY = '{{cluster-env/security_enabled}}'
 
 HIVE_SERVER2_AUTHENTICATION_KEY = '{{hive-site/hive.server2.authentication}}'
 HIVE_SERVER2_KERBEROS_KEYTAB = '{{hive-site/hive.server2.authentication.kerberos.keytab}}'
 HIVE_SERVER2_PRINCIPAL_KEY = '{{hive-site/hive.server2.authentication.kerberos.principal}}'
+
+SPARK_SSL_ENABLED = '{{spark2-defaults/spark.ssl.enabled}}'
+SPARK_TRUST_STORE_PATH = '{{spark2-defaults/spark.ssl.trustStore}}'
+SPARK_TRUST_STORE_PASS = '{{spark2-defaults/spark.ssl.trustStorePassword}}'
 
 # The configured Kerberos executable search paths, if any
 KERBEROS_EXECUTABLE_SEARCH_PATHS_KEY = '{{kerberos-env/executable_search_paths}}'
@@ -63,7 +69,7 @@ def get_tokens():
     to build the dictionary passed into execute
     """
     return (HIVE_SERVER_THRIFT_PORT_KEY, HIVE_SERVER_TRANSPORT_MODE_KEY, SECURITY_ENABLED_KEY, KERBEROS_EXECUTABLE_SEARCH_PATHS_KEY,
-            HIVEUSER_DEFAULT, HIVE_SERVER2_KERBEROS_KEYTAB, HIVE_SERVER2_PRINCIPAL_KEY)
+            HIVEUSER_DEFAULT, HIVE_SERVER2_KERBEROS_KEYTAB, HIVE_SERVER2_PRINCIPAL_KEY, SPARK_SSL_ENABLED, SPARK_TRUST_STORE_PATH, SPARK_TRUST_STORE_PASS, HIVE_SERVER_THRIFT_HTTP_PORT_KEY)
 
 @OsFamilyFuncImpl(os_family=OsFamilyImpl.DEFAULT)
 def execute(configurations={}, parameters={}, host_name=None):
@@ -88,7 +94,9 @@ def execute(configurations={}, parameters={}, host_name=None):
     port = THRIFT_PORT_DEFAULT
     if transport_mode.lower() == 'binary' and HIVE_SERVER_THRIFT_PORT_KEY in configurations:
         port = int(configurations[HIVE_SERVER_THRIFT_PORT_KEY])
-
+    elif transport_mode.lower() == 'http' and HIVE_SERVER_THRIFT_HTTP_PORT_KEY in configurations:
+    	port = int(configurations[HIVE_SERVER_THRIFT_HTTP_PORT_KEY])
+    
     security_enabled = False
     if SECURITY_ENABLED_KEY in configurations:
         security_enabled = str(configurations[SECURITY_ENABLED_KEY]).upper() == 'TRUE'
@@ -104,6 +112,15 @@ def execute(configurations={}, parameters={}, host_name=None):
     if HIVE_SERVER2_PRINCIPAL_KEY in configurations:
         hive_principal = configurations[HIVE_SERVER2_PRINCIPAL_KEY]
         hive_principal = hive_principal.replace('_HOST',host_name.lower())
+
+    # Get the Trust store and pass
+    spark_truststore_path = None
+    spark_truststore_pass = None
+    spark_ssl_enabled = False
+    if SPARK_SSL_ENABLED in configurations:
+         spark_truststore_path = configurations[SPARK_TRUST_STORE_PATH]
+         spark_truststore_pass = configurations[SPARK_TRUST_STORE_PASS]
+         spark_ssl_enabled = str(configurations[SPARK_SSL_ENABLED]).upper() == 'TRUE'
 
     # Get the configured Kerberos executable search paths, if any
     if KERBEROS_EXECUTABLE_SEARCH_PATHS_KEY in configurations:
@@ -131,9 +148,16 @@ def execute(configurations={}, parameters={}, host_name=None):
             host_name = socket.getfqdn()
 
         if security_enabled:
-            beeline_url = ["'jdbc:hive2://{host_name}:{port}/default;principal={hive_principal}'","transportMode={transport_mode}"]
+            if spark_ssl_enabled:
+                beeline_url = ['"jdbc:hive2://{host_name}:{port}/default;principal={hive_principal};transportMode={transport_mode;ssl=true;sslTrustStore={spark_truststore_path};trustStorePassword={spark_truststore_pass!p};httpPath=cliservice"']
+            else:
+                beeline_url = ["jdbc:hive2://{host_name}:{port}/default;principal={hive_principal}","transportMode={transport_mode}"]
         else:
-            beeline_url = ["'jdbc:hive2://{host_name}:{port}/default'","transportMode={transport_mode}"]
+            if spark_ssl_enabled:
+                beeline_url = ['"jdbc:hive2://{host_name}:{port}/default;transportMode={transport_mode};ssl=true;sslTrustStore={spark_truststore_path};trustStorePassword={spark_truststore_pass!p};httpPath=cliservice"']
+            else:
+                beeline_url = ["jdbc:hive2://{host_name}:{port}/default","transportMode={transport_mode}"]
+                
         # append url according to used transport
 
         beeline_cmd = os.path.join(spark_home, "bin", "beeline")

--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_thrift_port.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_thrift_port.py
@@ -149,7 +149,7 @@ def execute(configurations={}, parameters={}, host_name=None):
 
         if security_enabled:
             if spark_ssl_enabled:
-                beeline_url = ['"jdbc:hive2://{host_name}:{port}/default;principal={hive_principal};transportMode={transport_mode;ssl=true;sslTrustStore={spark_truststore_path};trustStorePassword={spark_truststore_pass!p};httpPath=cliservice"']
+                beeline_url = ['"jdbc:hive2://{host_name}:{port}/default;principal={hive_principal};transportMode={transport_mode};ssl=true;sslTrustStore={spark_truststore_path};trustStorePassword={spark_truststore_pass!p};httpPath=cliservice"']
             else:
                 beeline_url = ["jdbc:hive2://{host_name}:{port}/default;principal={hive_principal}","transportMode={transport_mode}"]
         else:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified alert code to use Truststore and TrusTstore password in beeline command if there is SSL enabled.
(Please fill in changes proposed in this fix)

## How was this patch tested?
Have deployed the changes in ambari server with SSL and without SSL and both times it has worked fine. 
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.