### PR TITLE
AMBARI-25210. ONEFS installation via blueprint fails (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -1950,7 +1950,7 @@ public class BlueprintConfigurationProcessor {
               return origValue;
             }
 
-            if (topology.isComponentHadoopCompatible(component)) {
+            if (isComponentNameNode() && topology.hasHadoopCompatibleService()) { // do not fail, could be a ONEFS installation
               return origValue;
             }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopology.java
@@ -181,7 +181,7 @@ public interface ClusterTopology {
   String getDefaultPassword();
 
   /**
-   * @return true if the given component belongs to a service that has serviceType=HCFS
+   * @return true if the topology contains any service with HCFS tag
    */
-  boolean isComponentHadoopCompatible(String component);
+  boolean hasHadoopCompatibleService();
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/ClusterTopologyImpl.java
@@ -315,12 +315,9 @@ public class ClusterTopologyImpl implements ClusterTopology {
   }
 
   @Override
-  public boolean isComponentHadoopCompatible(String component) {
+  public boolean hasHadoopCompatibleService() {
     return blueprint.getServiceInfos().stream()
-      .filter(service -> service.getComponentByName(component) != null)
-      .findFirst()
-      .map(service -> HADOOP_COMPATIBLE_FS.equals(service.getServiceType()))
-      .orElse(false);
+      .anyMatch(service -> HADOOP_COMPATIBLE_FS.equals(service.getServiceType()));
   }
 
   private void registerHostGroupInfo(Map<String, HostGroupInfo> requestedHostGroupInfoMap) throws InvalidTopologyException {

--- a/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterTopologyImplTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/topology/ClusterTopologyImplTest.java
@@ -21,7 +21,6 @@ package org.apache.ambari.server.topology;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.easymock.EasyMock.expect;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.createNiceMock;
 import static org.powermock.api.easymock.PowerMock.replay;
@@ -232,8 +231,7 @@ public class ClusterTopologyImplTest {
     ).anyTimes();
     replayAll();
     ClusterTopologyImpl topology = new ClusterTopologyImpl(null, new TestTopologyRequest(TopologyRequest.Type.PROVISION));
-    assertTrue(topology.isComponentHadoopCompatible("ONEFS_CLIENT"));
-    assertFalse(topology.isComponentHadoopCompatible("ZOOKEEPER_CLIENT"));
+    assertTrue(topology.hasHadoopCompatibleService());
   }
 
   private ServiceInfo aHCFSWith(ComponentInfo... components) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cluster creation fails when installing ONEFS via blueprint.

```
Logical Request: Provision Cluster 'cc' FAILED: Unable to update configuration property 'fs.defaultFS' with topology information. Component 'NAMENODE' is mapped to an invalid number of host groups '0'.
```

## How was this patch tested?

tested with the following blueprint

```json
{
  "host_groups" : [
    {
      "name" : "host_group_1",
      "components" : [
        { "name" : "ZOOKEEPER_SERVER" },
        { "name" : "ONEFS_CLIENT" },
        { "name" : "ZOOKEEPER_CLIENT" }
      ],
      "cardinality" : "1"
    }
  ],
  "Blueprints" : {
    "stack_name" : "HDP",
    "stack_version" : "3.0"
  }
}
```