### PR TITLE
AMBARI-25207 The Ubuntu repository id for the cached apt package list  is generated wrong in case if were used URL with https protocol (dgrinenko)

### DIFF
--- a/ambari-common/src/main/python/resource_management/core/providers/package/apt.py
+++ b/ambari-common/src/main/python/resource_management/core/providers/package/apt.py
@@ -275,6 +275,21 @@ class AptProvider(PackageProvider):
 
     return packages
 
+  def transform_baseurl_to_repoid(self, base_url):
+    """
+    Transforms the URL looking like proto://localhost/some/long/path to localhost_some_long_path
+
+    :type base_url str
+    :rtype str
+    """
+    url_proto_mask = "://"
+    url_proto_pos = base_url.find(url_proto_mask)
+    if url_proto_pos > 0:
+      base_url = base_url[url_proto_pos+len(url_proto_mask):]
+
+    return base_url.replace("/", "_").replace(" ", "_")
+
+
   def get_available_packages_in_repos(self, repos):
     """
     Gets all (both installed and available) packages that are available at given repositories.
@@ -287,7 +302,7 @@ class AptProvider(PackageProvider):
     repo_ids = []
 
     for repo in repos.items:
-      repo_ids.append(repo.base_url.replace("http://", "").replace("/", "_"))
+      repo_ids.append(self.transform_baseurl_to_repoid(repo.base_url))
 
     if repos.feat.scoped:
       Logger.info("Looking for matching packages in the following repositories: {0}".format(", ".join(repo_ids)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add ubuntu repo_id generation independent from url protocol used. Port of #2887

## How was this patch tested?

Life cluster.