### PR TITLE
[AMBARI-25212] configs.py output and Ambari API output of config prop…

### DIFF
--- a/ambari-server/src/main/resources/scripts/configs.py
+++ b/ambari-server/src/main/resources/scripts/configs.py
@@ -20,6 +20,7 @@ limitations under the License.
 
 import optparse
 from optparse import OptionGroup
+from collections import OrderedDict
 import sys
 import urllib2, ssl
 import time
@@ -134,7 +135,7 @@ def get_current_config(cluster, config_type, accessor):
   config_tag = get_config_tag(cluster, config_type, accessor)
   logger.info("### on (Site:{0}, Tag:{1})".format(config_type, config_tag))
   response = accessor(CONFIGURATION_URL.format(cluster, config_type, config_tag))
-  config_by_tag = json.loads(response)
+  config_by_tag = json.loads(response, object_pairs_hook=OrderedDict)
   current_config = config_by_tag[ITEMS][0]
   return current_config[PROPERTIES], current_config.get(ATTRIBUTES, {})
 


### PR DESCRIPTION
…erties are not in same sorted order.

## What changes were proposed in this pull request?
configs.py script loads the json using **"json.loads(response)"** approach which is causing the sorted order of properties to be jumbled.  Where as Ambari API returns the config properties in sorted order.  
Using Python OrderedDict feature to use the same order which ambari API is returning for those properties. 

## How was this patch tested?
Manually tested.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.