### PR TITLE
AMBARI-25214. Moving resource manager does not update yarn.resourcemanager.address property

### DIFF
--- a/ambari-web/app/utils/configs/move_rm_config_initializer.js
+++ b/ambari-web/app/utils/configs/move_rm_config_initializer.js
@@ -58,6 +58,7 @@ App.MoveRmConfigInitializer = App.MoveComponentConfigInitializerClass.create({
     'yarn.resourcemanager.webapp.address.{{suffix}}': getRmHaDependedConfig(true),
     'yarn.resourcemanager.webapp.https.address.{{suffix}}': getRmHaDependedConfig(true),
     'yarn.resourcemanager.resource-tracker.address.{{suffix}}': getRmHaDependedConfig(true),
+    'yarn.resourcemanager.address.{{suffix}}': getRmHaDependedConfig(true),
     'yarn.resourcemanager.ha': getRmHaHawqConfig(true),
     'yarn.resourcemanager.scheduler.ha': getRmHaHawqConfig(true)
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?
Moving resource manager does not update yarn.resourcemanager.address property

## How was this patch tested?
 manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.