### PR TITLE
AMBARI-25203 Updated jackson-databind to 2.9.8 and boucycastle libs to 1.61

### DIFF
--- a/ambari-logsearch/ambari-logsearch-it/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-it/pom.xml
@@ -34,7 +34,6 @@
     <it.skip>true</it.skip>
     <jbehave.version>4.0.5</jbehave.version>
     <jersey.version>2.23.1</jersey.version>
-    <jackson-jaxrs.version>2.9.8</jackson-jaxrs.version>
   </properties>
 
   <dependencies>
@@ -65,7 +64,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson-jaxrs.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>

--- a/ambari-logsearch/ambari-logsearch-solr-client/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-solr-client/pom.xml
@@ -34,6 +34,12 @@
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
       <version>${solr.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -68,6 +74,12 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>1.11.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -1296,6 +1296,16 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-timelineservice</artifactId>
       <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
+            <exclusion>
+                <artifactId>jackson-databind</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>

--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -1296,16 +1296,6 @@
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-timelineservice</artifactId>
       <version>${project.version}</version>
-        <exclusions>
-            <exclusion>
-                <artifactId>jackson-core</artifactId>
-                <groupId>com.fasterxml.jackson.core</groupId>
-            </exclusion>
-            <exclusion>
-                <artifactId>jackson-databind</artifactId>
-                <groupId>com.fasterxml.jackson.core</groupId>
-            </exclusion>
-        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>

--- a/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
@@ -144,6 +144,12 @@ limitations under the License.
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <scope>compile</scope>
+        <exclusions>
+            <exclusion>
+                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/ambari-metrics/ambari-metrics-storm-sink-legacy/pom.xml
+++ b/ambari-metrics/ambari-metrics-storm-sink-legacy/pom.xml
@@ -170,6 +170,12 @@ limitations under the License.
       <artifactId>storm-core</artifactId>
       <version>${storm.version}</version>
       <scope>compile</scope>
+        <exclusions>
+            <exclusion>
+                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>

--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -330,6 +330,14 @@
           <groupId>net.sourceforge.findbugs</groupId>
           <artifactId>annotations</artifactId>
         </exclusion>
+          <exclusion>
+              <artifactId>jackson-core</artifactId>
+              <groupId>com.fasterxml.jackson.core</groupId>
+          </exclusion>
+        <exclusion>
+          <artifactId>jackson-databind</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -373,6 +381,10 @@
           <groupId>org.mortbay.jetty</groupId>
           <artifactId>jsp-2.1-jetty</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -400,6 +412,12 @@
       <version>${hadoop.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
@@ -544,6 +562,18 @@
           <artifactId>commons-httpclient</artifactId>
           <groupId>commons-httpclient</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -577,6 +607,21 @@
           <groupId>commons-httpclient</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcmail-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>
@@ -647,7 +692,17 @@
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-core</artifactId>
       <type>test-jar</type>
-      <version>${phoenix.version}</version>
+        <exclusions>
+            <exclusion>
+                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
+          <exclusion>
+            <artifactId>jackson-databind</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+          </exclusion>
+        </exclusions>
+        <version>${phoenix.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -671,6 +726,14 @@
           <exclusion>
             <artifactId>zookeeper</artifactId>
             <groupId>org.apache.zookeeper</groupId>
+          </exclusion>
+            <exclusion>
+                <artifactId>jackson-core</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+            </exclusion>
+          <exclusion>
+            <artifactId>jackson-databind</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -129,6 +129,7 @@
         <artifactId>bcmail-jdk15on</artifactId>
         <version>1.61</version>
         <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -112,6 +112,24 @@
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>1.61</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>1.61</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcmail-jdk15on</artifactId>
+        <version>1.61</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -519,6 +519,11 @@
         <version>2.9.8</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>2.9.8</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>2.9.8</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Addition for #2895 ->  Removed transient dependencies
Addition to  #2896  -> port to branch-2.6

## How was this patch tested?
Server build + dep tree check: 
`# mvn dependency:tree|grep com.fasterxml.jackson.core
[INFO] |  |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.2.3:compile
[INFO] |  |  |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.2.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile`