### PR TITLE
[AMBARI-25124] ambari-audit.log entries span multiple lines (apappu)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/event/LoginAuditEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/event/LoginAuditEvent.java
@@ -62,15 +62,14 @@ public class LoginAuditEvent extends AbstractUserAuditEvent {
     protected void buildAuditMessage(StringBuilder builder) {
       super.buildAuditMessage(builder);
 
-      builder.append(", Operation(User login), Roles(").append(System.lineSeparator());
+      builder.append(", Operation(User login), Roles(");
 
       if (roles != null && !roles.isEmpty()) {
         List<String> lines = new LinkedList<>();
         for (Map.Entry<String, List<String>> entry : roles.entrySet()) {
           lines.add("    " + entry.getKey() + ": " + StringUtils.join(entry.getValue(), ", "));
         }
-        builder.append(StringUtils.join(lines, System.lineSeparator()));
-        builder.append(System.lineSeparator());
+        builder.append(StringUtils.join(lines, " , "));
       }
       builder.append("), Status(")
         .append(reasonOfFailure == null ? "Success" : "Failed");

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/AddRepositoryVersionRequestAuditEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/AddRepositoryVersionRequestAuditEvent.java
@@ -88,18 +88,15 @@ public class AddRepositoryVersionRequestAuditEvent extends RequestAuditEvent {
         .append(repoVersion)
         .append("), Repositories(");
 
-      if (!repos.isEmpty()) {
-        builder.append(System.lineSeparator());
-      }
 
       for (Map.Entry<String, List<Map<String, String>>> repo : repos.entrySet()) {
         builder.append("Operating system: ").append(repo.getKey());
-        builder.append(System.lineSeparator());
+        builder.append(" ( ");
         for (Map<String, String> properties : repo.getValue()) {
           builder.append("    Repository ID(").append(properties.get("repo_id"));
           builder.append("), Repository name(").append(properties.get("repo_name"));
           builder.append("), Base url(").append(properties.get("base_url")).append(")");
-          builder.append(System.lineSeparator());
+          builder.append(" ) ");
         }
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/ChangeRepositoryVersionRequestAuditEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/ChangeRepositoryVersionRequestAuditEvent.java
@@ -89,18 +89,15 @@ public class ChangeRepositoryVersionRequestAuditEvent extends RequestAuditEvent 
         .append(repoVersion)
         .append("), Repositories(");
 
-      if (!repos.isEmpty()) {
-        builder.append(System.lineSeparator());
-      }
 
       for (Map.Entry<String, List<Map<String, String>>> repo : repos.entrySet()) {
         builder.append("Operating system: ").append(repo.getKey());
-        builder.append(System.lineSeparator());
+        builder.append(" ( ");
         for (Map<String, String> properties : repo.getValue()) {
           builder.append("    Repository ID(").append(properties.get("repo_id"));
           builder.append("), Repository name(").append(properties.get("repo_name"));
           builder.append("), Base url(").append(properties.get("base_url")).append(")");
-          builder.append(System.lineSeparator());
+          builder.append(" ) ");
         }
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/ClusterPrivilegeChangeRequestAuditEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/ClusterPrivilegeChangeRequestAuditEvent.java
@@ -80,9 +80,6 @@ public class ClusterPrivilegeChangeRequestAuditEvent extends RequestAuditEvent {
       roleSet.addAll(roles.keySet());
 
       builder.append(", Roles(");
-      if (!users.isEmpty() || !groups.isEmpty()|| !roles.isEmpty()) {
-        builder.append(System.lineSeparator());
-      }
 
       List<String> lines = new LinkedList<>();
 
@@ -99,7 +96,7 @@ public class ClusterPrivilegeChangeRequestAuditEvent extends RequestAuditEvent {
         }
       }
 
-      builder.append(StringUtils.join(lines, System.lineSeparator()));
+      builder.append(StringUtils.join(lines, " , "));
 
       builder.append(")");
     }

--- a/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/ViewPrivilegeChangeRequestAuditEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/audit/event/request/ViewPrivilegeChangeRequestAuditEvent.java
@@ -101,9 +101,6 @@ public class ViewPrivilegeChangeRequestAuditEvent extends RequestAuditEvent {
       roleSet.addAll(roles.keySet());
 
       builder.append(", Permissions(");
-      if (!users.isEmpty() || !groups.isEmpty() || !roles.isEmpty()) {
-        builder.append(System.lineSeparator());
-      }
 
       List<String> lines = new LinkedList<>();
 
@@ -120,7 +117,7 @@ public class ViewPrivilegeChangeRequestAuditEvent extends RequestAuditEvent {
         }
       }
 
-      builder.append(StringUtils.join(lines, System.lineSeparator()));
+      builder.append(StringUtils.join(lines, " , "));
 
       builder.append(")");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed moving the entries to new line - instead separated out with "," and brackets "()"
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
Deployed the changes in live ambari server and tested flows like,

1. logged with admin and non-admin users
2. add a new service
3. add a new repo version.
4. delete service.
Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.