### PR TITLE
[AMBARI-25209] : Bulk Operation Refresh Configs for selected hosts (Backport to branch-2.7)

### DIFF
--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -2701,6 +2701,7 @@ Em.I18n.translations = {
   'hosts.table.menu.l2.allComponents':'All Components',
   'hosts.table.menu.l2.restartAllComponents':'Restart All Components',
   'hosts.table.menu.l2.reinstallFailedComponents':'Reinstall Failed Components',
+  'hosts.table.menu.l2.refreshConfigsClientComponents':'Refresh All Configs',
 
   'hosts.bulkOperation.confirmation.header':'Confirm Bulk Operation',
   'hosts.bulkOperation.confirmation.hosts':'Are you sure you want to <strong>{0}</strong> on the following {1} hosts?',
@@ -3267,6 +3268,7 @@ Em.I18n.translations = {
   'rollingrestart.dialog.msg.staleConfigsOnly': 'Only restart {0} with stale configs',
   'rollingrestart.rest.context': 'Rolling Restart of {0}s - batch {1} of {2}',
   'rollingrestart.context.allOnSelectedHosts':'Restart all components on the selected hosts',
+  'rollingrestart.context.configs.allOnSelectedHosts':'Refresh all configs on the selected hosts',
   'rollingrestart.context.allForSelectedService':'Restart all components for {0}',
   'rollingrestart.context.allWithStaleConfigsForSelectedService':'Restart all components with Stale Configs for {0}',
   'rollingrestart.context.ClientOnSelectedHost':'Restart {0} on {1}',

--- a/ambari-web/app/views/main/host/hosts_table_menu_view.js
+++ b/ambari-web/app/views/main/host/hosts_table_menu_view.js
@@ -288,6 +288,13 @@ App.HostTableMenuView = Em.View.extend({
               action: 'REINSTALL',
               message: Em.I18n.t('hosts.table.menu.l2.reinstallFailedComponents')
             })
+          }),
+          O.create({
+            label: Em.I18n.t('hosts.table.menu.l2.refreshConfigsClientComponents'),
+            operationData: O.create({
+              action: 'CONFIGURE',
+              message: Em.I18n.t('hosts.table.menu.l2.refreshConfigsClientComponents')
+            })
           })
         ]);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The changes are related to introducing new bulk operation to perform Refresh Configs for All/Selected hosts. The changes are related to ambari-web.

## How was this patch tested?

The patch was tested manually on UI. The screenshots are attached in JIRA: https://issues.apache.org/jira/browse/AMBARI-25209

<img width="561" alt="Screen Shot 2019-03-26 at 2 26 58 PM" src="https://user-images.githubusercontent.com/34790606/57198744-0f0f1380-6f94-11e9-9a7e-006eabd917b0.png">


Please review @hiveww @atkach @ishanbha