### PR TITLE
[AMBARI-25209] : Bulk Operation Refresh Configs for selected hosts

### DIFF
--- a/ambari-web/app/controllers/main/host/bulk_operations_controller.js
+++ b/ambari-web/app/controllers/main/host/bulk_operations_controller.js
@@ -64,6 +64,9 @@ App.BulkOperationsController = Em.Controller.extend({
         else if (operationData.action === 'DELETE'){
           this.bulkOperationForHostsDeleteDryRun(operationData, hosts);
         }
+        else if (operationData.action === 'CONFIGURE') {
+          this.bulkOperationForHostsRefreshConfig(operationData, hosts);
+        }
         else {
           if (operationData.action === 'PASSIVE_STATE') {
             this.bulkOperationForHostsPassiveState(operationData, hosts);
@@ -351,6 +354,41 @@ App.BulkOperationsController = Em.Controller.extend({
     } else if (deletableHosts.length) {
       this.bulkOperationForHostsDelete(deletableHosts);
     }
+  },
+
+  /**
+   * Bulk refresh configs for selected hosts
+   * @param {Object} operationData - data about bulk operation (action, hostComponents etc)
+   * @param {Ember.Enumerable} hosts - list of affected/selected hosts
+   */
+  bulkOperationForHostsRefreshConfig: function (operationData, hosts) {
+    return batchUtils.getComponentsFromServer({
+      passiveState: 'OFF',
+      hosts: hosts.mapProperty('hostName'),
+      displayParams: ['host_components/HostRoles/component_name']
+    }, this._getComponentsFromServerForRefreshConfigsCallback);
+  },
+
+  /**
+   *
+   * @param {object} data
+   * @private
+   * @method _getComponentsFromServerForRefreshConfigsCallback
+   */
+  _getComponentsFromServerForRefreshConfigsCallback: function (data) {
+    var hostComponents = [];
+    var clients = App.components.get('clients');
+    data.items.forEach(function (host) {
+      host.host_components.forEach(function (hostComponent) {
+        if (clients.contains((hostComponent.HostRoles.component_name))) {
+          hostComponents.push(O.create({
+            componentName: hostComponent.HostRoles.component_name,
+            hostName: host.Hosts.host_name
+          }));
+        }
+      })
+    });
+    batchUtils.restartHostComponents(hostComponents, Em.I18n.t('rollingrestart.context.configs.allOnSelectedHosts'), "HOST");
   },
 
   /**

--- a/ambari-web/app/messages.js
+++ b/ambari-web/app/messages.js
@@ -2574,6 +2574,7 @@ Em.I18n.translations = {
   'hosts.table.menu.l2.allComponents':'All Components',
   'hosts.table.menu.l2.restartAllComponents':'Restart All Components',
   'hosts.table.menu.l2.reinstallFailedComponents':'Reinstall Failed Components',
+  'hosts.table.menu.l2.refreshConfigsClientComponents':'Refresh All Configs',
 
   'hosts.bulkOperation.confirmation.header':'Confirm Bulk Operation',
   'hosts.bulkOperation.confirmation.hosts':'Are you sure you want to <strong>{0}</strong> on the following {1} hosts?',
@@ -3092,6 +3093,7 @@ Em.I18n.translations = {
   'rollingrestart.dialog.msg.staleConfigsOnly': 'Only restart {0}s with stale configs',
   'rollingrestart.rest.context': 'Rolling Restart of {0}s - batch {1} of {2}',
   'rollingrestart.context.allOnSelectedHosts':'Restart all components on the selected hosts',
+  'rollingrestart.context.configs.allOnSelectedHosts':'Refresh all configs on the selected hosts',
   'rollingrestart.context.allForSelectedService':'Restart all components for {0}',
   'rollingrestart.context.allWithStaleConfigsForSelectedService':'Restart all components with Stale Configs for {0}',
   'rollingrestart.context.allClientsOnSelectedHost':'Restart all clients on {0}',

--- a/ambari-web/app/views/main/host/hosts_table_menu_view.js
+++ b/ambari-web/app/views/main/host/hosts_table_menu_view.js
@@ -275,6 +275,13 @@ App.HostTableMenuView = Em.View.extend({
               action: 'REINSTALL',
               message: Em.I18n.t('hosts.table.menu.l2.reinstallFailedComponents')
             })
+          }),
+          O.create({
+            label: Em.I18n.t('hosts.table.menu.l2.refreshConfigsClientComponents'),
+            operationData: O.create({
+              action: 'CONFIGURE',
+              message: Em.I18n.t('hosts.table.menu.l2.refreshConfigsClientComponents')
+            })
           })
         ]);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The changes are related to introducing new bulk operation to perform Refresh Configs for All/Selected hosts. The changes are related to ambari-web.

## How was this patch tested?

The patch was tested manually on UI. The screenshots are attached in JIRA: https://issues.apache.org/jira/browse/AMBARI-25209

<img width="561" alt="Screen Shot 2019-03-26 at 2 26 58 PM" src="https://user-images.githubusercontent.com/34790606/57198730-e555ec80-6f93-11e9-9a3d-72de0e4846c5.png">
<img width="550" alt="Screen Shot 2019-03-26 at 2 27 30 PM" src="https://user-images.githubusercontent.com/34790606/57198732-e555ec80-6f93-11e9-96da-1df27c839deb.png">
<img width="1002" alt="Screen Shot 2019-03-26 at 2 27 46 PM" src="https://user-images.githubusercontent.com/34790606/57198733-e5ee8300-6f93-11e9-90cd-b815eb0d10a1.png">
