### PR TITLE
[AMBARI-25219] : Yum to complete transactions internally and Ambari t…

### DIFF
--- a/ambari-server/src/main/resources/custom_actions/scripts/install_packages.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/install_packages.py
@@ -121,7 +121,6 @@ class InstallPackages(Script):
       # check package manager non-completed transactions
       if self.repo_mgr.check_uncompleted_transactions():
         self.repo_mgr.print_uncompleted_transaction_hint()
-        num_errors += 1
     except Exception as e:  # we need to ignore any exception
       Logger.warning("Failed to check for uncompleted package manager transactions: " + str(e))
 


### PR DESCRIPTION
…o not fail installation

## What changes were proposed in this pull request?
Ambari should not fail installation for incomplete transaction of yum. Since yum itself takes care of completing incomplete transactions and also installing ongoing packages, we should not prevent yum's own way of dealing with this behavior.

## How was this patch tested?
This patch was tested manually

Please review @aonishuk  @jayush 