### PR TITLE
[AMBARI-25221] fix directory creation from mkdir to mkdirs to avoid crash

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -231,7 +231,7 @@ public class MpackManager {
     LOG.debug("Download mpack.json and store in :" + targetPath);
 
     if (!stagingDir.exists()) {
-      stagingDir.mkdir();
+      stagingDir.mkdirs();
     }
 
     Files.copy(url.openStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
@@ -370,7 +370,7 @@ public class MpackManager {
   private void createServicesDirectory(Path extractedMpackDirectory, Mpack mpack) throws IOException {
     File servicesDir = new File(extractedMpackDirectory.toAbsolutePath() + File.separator + MODULES_DIRECTORY);
     if (!servicesDir.exists()) {
-      servicesDir.mkdir();
+      servicesDir.mkdirs();
     }
     List<Module> modules = mpack.getModules();
 
@@ -447,7 +447,7 @@ public class MpackManager {
     URL url = new URL(mpackTarURI);
 
     if (!stagingDir.exists()) {
-      stagingDir.mkdir();
+      stagingDir.mkdirs();
     }
 
     Files.copy(url.openStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);

--- a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java
@@ -405,7 +405,7 @@ public class MpackManager {
           File mpackDirectory = new File(mpackStaging + File.separator + mpack.getName());
 
           if (!mpackDirectory.exists()) {
-            mpackDirectory.mkdir();
+            mpackDirectory.mkdirs();
           }
           return true;
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Location : a/ambari-server/src/main/java/org/apache/ambari/server/mpack/MpackManager.java:408
Change: change File.mkdir() to File.mkdirs().