### PR TITLE
AMBARI-25225 Zeppelin Restart via Ambari Changes Permissions on log folder which causes Permission issue for impersonated users (Asnaik)

### DIFF
--- a/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
+++ b/ambari-server/src/main/resources/common-services/ZEPPELIN/0.7.0/package/scripts/master.py
@@ -101,7 +101,7 @@ class Master(Script):
               group=params.zeppelin_group,
               cd_access="a",
               create_parents=True,
-              mode=0755
+              mode=0775
               )
 
   def create_zeppelin_hdfs_conf_dir(self, env):


### PR DESCRIPTION
AMBARI-25225 Zeppelin Restart via Ambari Changes Permissions on log folder which causes Permission issue for impersonated users (Asnaik).


## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.