### PR TITLE
[AMBARI-25227] Unable to move Hive metastore from one node to another 

### DIFF
--- a/ambari-web/app/controllers/main/service/reassign/step1_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step1_controller.js
@@ -27,12 +27,12 @@ App.ReassignMasterWizardStep1Controller = Em.Controller.extend({
    */
   dbPropertyMap: {
     'HIVE_SERVER': {
-      type: 'hive-site',
-      name: 'javax.jdo.option.ConnectionDriverName'
+      type: 'hive-env',
+      name: 'hive_database_type'
     },
     'HIVE_METASTORE': {
-      type: 'hive-site',
-      name: 'javax.jdo.option.ConnectionDriverName'
+      type: 'hive-env',
+      name: 'hive_database_type'
     },
     'OOZIE_SERVER': {
       type: 'oozie-site',

--- a/ambari-web/app/controllers/main/service/reassign/step4_controller.js
+++ b/ambari-web/app/controllers/main/service/reassign/step4_controller.js
@@ -72,21 +72,6 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
 
   dependentHostComponents: [],
 
-  dbPropertyMap: {
-    'HIVE_SERVER': {
-      type: 'hive-site',
-      name: 'javax.jdo.option.ConnectionDriverName'
-    },
-    'HIVE_METASTORE': {
-      type: 'hive-site',
-      name: 'javax.jdo.option.ConnectionDriverName'
-    },
-    'OOZIE_SERVER': {
-      type: 'oozie-site',
-      name: 'oozie.service.JPAService.jdbc.url'
-    }
-  },
-
   /**
    * load step info
    */
@@ -659,30 +644,12 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
     return propertiesMap[this.get('content.reassign.service_id')];
   }.property(),
 
-  dbType: function() {
-    var databaseTypes = /MySQL|PostgreS|Oracle|Derby|MSSQL|Anywhere/gi,
-      dbPropertyMapItem = Em.getWithDefault(this.get('dbPropertyMap'), this.get('content.reassign.component_name'), null),
-      databasePropMatch,
-      databaseProp,
-      result;
-
-    if (dbPropertyMapItem) {
-      databaseProp = Em.getWithDefault(this.get('content.configs'), dbPropertyMapItem.type, {})[dbPropertyMapItem.name];
-      databasePropMatch = databaseProp && databaseProp.match(databaseTypes);
-      if (databasePropMatch) {
-        result = databasePropMatch[0];
-      }
-    }
-
-    return result;
-  }.property(),
-
   prepareDBCheckAction: function() {
     var params = this.get('preparedDBProperties');
 
     var ambariProperties = App.router.get('clusterController.ambariProperties');
 
-    params['db_name'] = this.get('dbType');
+    params['db_name'] = this.get('content.databaseType');
     params['jdk_location'] = ambariProperties['jdk_location'];
     params['jdk_name'] = ambariProperties['jdk.name'];
     params['java_home'] = ambariProperties['java.home'];
@@ -774,7 +741,7 @@ App.ReassignMasterWizardStep4Controller = App.HighAvailabilityProgressPageContro
 
   testDBRetryTooltip: function() {
     var db_host = this.get('content.serviceProperties.database_hostname');
-    var db_type = this.get('dbType');
+    var db_type = this.get('content.databaseType');
     var db_props = this.get('preparedDBProperties');
 
     return Em.I18n.t('services.reassign.step4.tasks.testDBConnection.tooltip').format(


### PR DESCRIPTION
## What changes were proposed in this pull request?

While moving Hive Metastore from one node to another, it is failing at test DB connection step in configure Component page.Seeing following error in ambari-agent logs:

```
19-03-22 11:15:38,527 - DB connection check started.
2019-03-22 11:15:38,527 - There was an unknown error while checking database connectivity: Configuration parameter 'db_name' was not found in configurations dictionary!
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/check_host.py", line 145, in actionexecute
    db_connection_check_structured_output = self.execute_db_connection_check(config, tmp_dir)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/check_host.py", line 281, in execute_db_connection_check
    if db_name == DB_MYSQL:
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/config_dictionary.py", line 73, in __getattr__
    raise Fail("Configuration parameter '" + self.name + "' was not found in configurations dictionary!")
Fail: Configuration parameter 'db_name' was not found in configurations dictionary!
2019-03-22 11:15:38,528 - Host checks completed.
2019-03-22 11:15:38,529 - Check db_connection_check was unsuccessful. Exit code: 1. Message: Configuration parameter 'db_name' was not found in configurations dictionary!

Command failed after 1 tries
```

## How was this patch tested?

Tested manually