### PR TITLE
AMBARI-25228 add a second HiveServer2Interactive Button Missing in Ambari UI is there is config group for Hive Service (asnaik)

### DIFF
--- a/ambari-web/app/mixins/main/service/configs/hive_interactive_check.js
+++ b/ambari-web/app/mixins/main/service/configs/hive_interactive_check.js
@@ -33,6 +33,13 @@ App.HiveInteractiveCheck = Em.Mixin.create({
   },
 
   onLoadHiveConfigs: function (data) {
-    this.set('enableHiveInteractive', data.items[0].configurations.findProperty('type', 'hive-interactive-env').properties['enable_hive_interactive'] === 'true');
+    var enableHiveInteractive = false;
+    data.items.forEach(function(item) {
+        var hiveInteractive = item.configurations.findProperty('type', 'hive-interactive-env');
+        if(hiveInteractive) {
+          enableHiveInteractive = hiveInteractive.properties['enable_hive_interactive'] === 'true';
+        }
+      });
+    this.set('enableHiveInteractive',enableHiveInteractive);
   }
 });


### PR DESCRIPTION
AMBARI-25228 add a second HiveServer2Interactive Button Missing in Ambari UI is there is config group for Hive Service (asnaik)
## What changes were proposed in this pull request?
The Add HiveServer2Interactive Button was missing in ambari UI due to script error which happens if there exists config group defined for hive service.
(Please fill in changes proposed in this fix)

## How was this patch tested?


  21755 passing (25s)
  48 pending

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:26 min
[INFO] Finished at: 2019-04-03T13:41:34+05:30
[INFO] Final Memory: 15M/146M
[INFO] ------------------------------------------------------------------------
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.