### PR TITLE
[AMBARI-25187] Kerberos operations are shown in service action dropdown when not needed

### DIFF
--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -372,7 +372,7 @@ App.HostComponentActionMap = {
         action: 'regenerateKeytabFileOperations',
         label: Em.I18n.t('admin.kerberos.button.regenerateKeytabs'),
         cssClass: 'glyphicon glyphicon-repeat',
-        isHidden: !App.get('isKerberosEnabled')
+        isHidden: !App.get('isKerberosEnabled') || App.get('isManualKerberos')
       },
       REFRESHQUEUES: {
         action: 'refreshYarnQueues',

--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -372,7 +372,7 @@ App.HostComponentActionMap = {
         action: 'regenerateKeytabFileOperations',
         label: Em.I18n.t('admin.kerberos.button.regenerateKeytabs'),
         cssClass: 'glyphicon glyphicon-repeat',
-        isHidden: !App.get('isKerberosEnabled') || App.get('isManualKerberos')
+        isHidden: !App.get('isKerberosEnabled') || Em.computed.bool('App.router.mainAdminKerberosController.isManualKerberos')
       },
       REFRESHQUEUES: {
         action: 'refreshYarnQueues',

--- a/ambari-web/app/templates/main/admin/kerberos.hbs
+++ b/ambari-web/app/templates/main/admin/kerberos.hbs
@@ -21,10 +21,10 @@
       <span class="text-success">{{t admin.security.enabled}}</span>
       {{#isAuthorized "CLUSTER.TOGGLE_KERBEROS"}}
         {{#if App.supports.enableToggleKerberos}}
-          <button class="btn btn-padding btn-warning admin-disable-security-btn" {{bindAttr disabled="isKerberosButtonsDisabled"}} {{action notifySecurityOffPopup target="controller"}}>{{t admin.kerberos.button.disable}} </button>
-          {{#unless isManualKerberos}}
+          <button class="btn btn-padding btn-warning admin-disable-security-btn" {{bindAttr disabled="controller.isKerberosButtonsDisabled"}} {{action notifySecurityOffPopup target="controller"}}>{{t admin.kerberos.button.disable}} </button>
+          {{#unless controller.isManualKerberos}}
             <button class="btn btn-success"
-                    id="regenerate-keytabs" {{bindAttr disabled="isKerberosButtonsDisabled"}} {{action regenerateKeytabs target="controller"}}>
+                    id="regenerate-keytabs" {{bindAttr disabled="controller.isKerberosButtonsDisabled"}} {{action regenerateKeytabs target="controller"}}>
               <i class="glyphicon glyphicon-repeat"></i>&nbsp; {{t admin.kerberos.button.regenerateKeytabs}}</button>
             {{#if App.isCredentialStorePersistent}}
               <button class="btn btn-primary" {{action showManageKDCCredentialsPopup target="controller"}}>{{t admin.kerberos.credentials.store.menu.label}}</button>


### PR DESCRIPTION


Change-Id: I9084f56a1397a080494a5ba34cddd77d2cf59f3a

## What changes were proposed in this pull request?

- Kerberos page template (kerberos.hbs) is fixed to properly reach the "isManualKerberos" and "isKerberosButtonsDisabled" variables in the controller. This way the "REGENERATE KEYTABS" button is removed from the UI.
- Also, the "ACTIONS" service dropdown menu is fixed and the "Regenerate Kerberos" menu item is removed if Kerberos is not managed by Ambari.

## How was this patch tested?
The patch was tested manually. 
- When Kerberos was enabled on the cluster "Manual Kerberos Setup" was chosen.
- As a result the "REGENERATE KEYTABS" button is not shown on the Kerberos
![Screenshot Kerberos page](https://user-images.githubusercontent.com/35402259/55493408-2c6d5c80-5639-11e9-85e4-9a17846645c9.png)
 page.
- In the dropdown service menu the "REGENERATE KEYTABS" menu item is removed.
![Screenshot 2019-04-04 at 16 36 23](https://user-images.githubusercontent.com/35402259/55564407-18d4fb00-56f8-11e9-87e5-596d2f4beb28.png)


- No unit test was added.