### PR TITLE
AMBARI-25034 Ambari is not updating core-site : ha.zookeeper.quorumonce a zookeeper server is added or removed (asnaik)

### DIFF
--- a/ambari-web/app/controllers/main/host/details.js
+++ b/ambari-web/app/controllers/main/host/details.js
@@ -1735,10 +1735,15 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
   constructZookeeperConfigUrlParams: function (data) {
     var urlParams = [];
     var services = App.Service.find();
+    var zooKeeperRelatedServices = this.get('zooKeeperRelatedServices').slice(0);
     if (App.get('isHaEnabled')) {
-      urlParams.push('(type=core-site&tag=' + data.Clusters.desired_configs['core-site'].tag + ')');
+      zooKeeperRelatedServices.push({
+        serviceName: 'HDFS',
+        typesToLoad: ['core-site'],
+        typesToSave: ['core-site']
+      });
     }
-    this.get('zooKeeperRelatedServices').forEach(function (service) {
+    zooKeeperRelatedServices.forEach(function (service) {
       if (services.someProperty('serviceName', service.serviceName)) {
         service.typesToLoad.forEach(function (type) {
           if (data.Clusters.desired_configs[type]) {
@@ -1767,7 +1772,15 @@ App.MainHostDetailsController = Em.Controller.extend(App.SupportClientConfigsDow
     this.updateZkConfigs(configs);
     var groups = [];
     var installedServiceNames = App.Service.find().mapProperty('serviceName');
-    this.get('zooKeeperRelatedServices').forEach(function (service) {
+    var zooKeeperRelatedServices = this.get('zooKeeperRelatedServices').slice(0);
+    if (App.get('isHaEnabled')) {
+      zooKeeperRelatedServices.push({
+        serviceName: 'HDFS',
+        typesToLoad: ['core-site'],
+        typesToSave: ['core-site']
+      });
+    }
+    zooKeeperRelatedServices.forEach(function (service) {
       if (installedServiceNames.contains(service.serviceName)) {
         var group = {
           properties: {},


### PR DESCRIPTION
AMBARI-25034 Ambari is not updating core-site : ha.zookeeper.quorumonce a zookeeper server is added or removed (asnaik)
## What changes were proposed in this pull request?

Tested the UI as per defect description

UT Test successful in the local run

22064 passing (34s)
48 pending

JQMIGRATE: jQuery.support.boxModel is deprecated

JQMIGRATE: jQuery.event.handle is undocumented and deprecated

[INFO]
[INFO] --- apache-rat-plugin:0.12:check (default) @ ambari-web ---
[INFO] RAT will not execute since it is configured to be skipped via system property 'rat.skip'.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:06 min
[INFO] Finished at: 2018-12-11T23:33:17+05:30
[INFO] Final Memory: 17M/225M
[INFO] ------------------------------------------------------------------------

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.