### PR TITLE
[AMBARI-25184] configs.py: cannot set an empty property value (apappu)

### DIFF
--- a/ambari-server/src/main/resources/scripts/configs.py
+++ b/ambari-server/src/main/resources/scripts/configs.py
@@ -349,7 +349,7 @@ def main():
   accessor = api_accessor(host, user, password, protocol, port, options.unsafe)
   if action == SET_ACTION:
 
-    if not options.file and (not options.key or not options.value):
+    if not options.file and (not options.key or options.value is None):
       parser.error("You should use option (-f) to set file where entire configurations are saved OR (-k) key and (-v) value for one property")
     if options.file:
       action_args = [options.file]


### PR DESCRIPTION
## What changes were proposed in this pull request?

UI allows to enter empty value for some of the configs but configs.py does not allow.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested in live Ambari server.
1. Tried to run configs.py with empty value for specific key - it worked
2. Tried to run configs.py with some xxx value for specific key - it worked
3. Tried to run configs.py with inputs from json file  - it worked
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.