### PR TITLE
AMBARI-25230 improve fast-hdfs tool exception handling (benyoka)

### DIFF
--- a/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Runner.java
+++ b/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Runner.java
@@ -31,7 +31,7 @@ import com.google.gson.Gson;
 
 public class Runner {
   public static void main(String[] args)
-      throws IOException, URISyntaxException {
+      throws IOException, URISyntaxException, Exception {
     // 1 - Check arguments
     if (args.length != 1) {
       System.err.println("Incorrect number of arguments. Please provide:\n"
@@ -65,7 +65,7 @@ public class Runner {
       // 4 - Connect to HDFS
       System.out.println("Using filesystem uri: " + FileSystem.getDefaultUri(conf).toString());
       dfs.initialize(FileSystem.getDefaultUri(conf), conf);
-      
+
       for (Resource resource : resources) {
         System.out.println("Creating: " + resource);
 
@@ -104,12 +104,14 @@ public class Runner {
     catch(Exception e) {
        System.out.println("Exception occurred, Reason: " + e.getMessage());
        e.printStackTrace();
+       throw e;
     }
     finally {
-      dfs.close();
+      if (null != dfs) {
+        dfs.close();
+      }
     }
 
     System.out.println("All resources created.");
   }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improved the exception handling for fast hdfs tool so that it does not silently ignore (except printing out to stdout which is not always captured by tooling) failures nor throws NPE hiding the original issue.

## How was this patch tested?

Tested manually, both happy- and exception paths.