### PR TITLE
AMBARI-25235. Add a sysprep configurations to run conf-selects only a single time.

### DIFF
--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/params.py
@@ -28,6 +28,7 @@ from resource_management.libraries.functions import conf_select
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions import format_jvm_option
 from resource_management.libraries.functions.version import format_stack_version, get_major_version
+from resource_management.libraries.functions.format import format
 from string import lower
 
 config = Script.get_config()
@@ -120,3 +121,5 @@ link_configs_lock_file = get_config_lock_file()
 stack_select_lock_file = os.path.join(tmp_dir, "stack_select_lock_file")
 
 upgrade_suspended = default("/roleParams/upgrade_suspended", False)
+sysprep_skip_conf_select = default("/configurations/cluster-env/sysprep_skip_conf_select", False)
+conf_select_marker_file = format("{tmp_dir}/conf_select_done_marker")

--- a/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
+++ b/ambari-server/src/main/resources/stack-hooks/after-INSTALL/scripts/shared_initialization.py
@@ -135,7 +135,14 @@ def link_configs(struct_out_file):
     Logger.info("Could not load 'version' from {0}".format(struct_out_file))
     return
 
-  # On parallel command execution this should be executed by a single process at a time.
-  with FcntlBasedProcessLock(params.link_configs_lock_file, enabled = params.is_parallel_execution_enabled, skip_fcntl_failures = True):
-    for package_name, directories in conf_select.get_package_dirs().iteritems():
-      conf_select.convert_conf_directories_to_symlinks(package_name, json_version, directories)
+  if not params.sysprep_skip_conf_select or not os.path.exists(params.conf_select_marker_file):
+    # On parallel command execution this should be executed by a single process at a time.
+    with FcntlBasedProcessLock(params.link_configs_lock_file, enabled = params.is_parallel_execution_enabled, skip_fcntl_failures = True):
+      for package_name, directories in conf_select.get_package_dirs().iteritems():
+        conf_select.convert_conf_directories_to_symlinks(package_name, json_version, directories)
+
+    # create a file to mark that conf-selects were already done
+    with open(params.conf_select_marker_file, "wb") as fp:
+      pass
+  else:
+    Logger.info(format("Skipping conf-select stage, since cluster-env/sysprep_skip_conf_select is set and mark file {conf_select_marker_file} exists"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Conf-selects will have been run once when cluster-env "sysprep_skip_conf_select" property is set to true.

## How was this patch tested?

Manual check.