### PR TITLE
AMBARI-25235. Add a sysprep configurations to run conf-selects only a single time.

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.0.6/hooks/after-INSTALL/scripts/params.py
+++ b/ambari-server/src/main/resources/stacks/HDP/2.0.6/hooks/after-INSTALL/scripts/params.py
@@ -92,3 +92,5 @@ link_configs_lock_file = get_config_lock_file()
 stack_select_lock_file = os.path.join(tmp_dir, "stack_select_lock_file")
 
 upgrade_suspended = default("/roleParams/upgrade_suspended", False)
+sysprep_skip_conf_select = default("/configurations/cluster-env/sysprep_skip_conf_select", False)
+conf_select_marker_file = os.path.join(tmp_dir, "conf_select_done_marker")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Conf-selects will have been run once when cluster-env "sysprep_skip_conf_select" property is set to true.

## How was this patch tested?

Manual check.