### PR TITLE
AMBARI-25236. Host Ordered Upgrade: Pre Upgrade check of fs.defaultFS fails for ABFS.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesMapReduceDistributedCacheCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesMapReduceDistributedCacheCheck.java
@@ -47,7 +47,7 @@ public class ServicesMapReduceDistributedCacheCheck extends AbstractCheckDescrip
   static final String KEY_FRAMEWORK_PATH = "framework_path";
   static final String KEY_NOT_DFS = "not_dfs";
   static final String DFS_PROTOCOLS_REGEX_PROPERTY_NAME = "dfs-protocols-regex";
-  static final String DFS_PROTOCOLS_REGEX_DEFAULT = "^([^:]*dfs|wasb|ecs):.*";
+  static final String DFS_PROTOCOLS_REGEX_DEFAULT = "^([^:]*dfs|wasb|ecs|abfs):.*";
 
   /**
    * {@inheritDoc}

--- a/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesTezDistributedCacheCheck.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/checks/ServicesTezDistributedCacheCheck.java
@@ -49,7 +49,7 @@ public class ServicesTezDistributedCacheCheck extends AbstractCheckDescriptor {
   static final String KEY_LIB_NOT_TARGZ = "lib_not_targz";
   static final String KEY_USE_HADOOP_LIBS_FALSE = "tez_use_hadoop_libs_false";
   static final String DFS_PROTOCOLS_REGEX_PROPERTY_NAME = "dfs-protocols-regex";
-  static final String DFS_PROTOCOLS_REGEX_DEFAULT = "^([^:]*dfs|wasb|ecs):.*";
+  static final String DFS_PROTOCOLS_REGEX_DEFAULT = "^([^:]*dfs|wasb|ecs|abfs):.*";
 
   /**
    * {@inheritDoc}

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMapReduceDistributedCacheCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesMapReduceDistributedCacheCheckTest.java
@@ -190,7 +190,7 @@ public class ServicesMapReduceDistributedCacheCheckTest {
     Mockito.when(config.getProperties()).thenReturn(properties);
 
     Map<String, String> checkProperties = new HashMap<>();
-    checkProperties.put("dfs-protocols-regex","^([^:]*dfs|wasb|ecs):.*");
+    checkProperties.put("dfs-protocols-regex",ServicesMapReduceDistributedCacheCheck.DFS_PROTOCOLS_REGEX_DEFAULT);
     PrerequisiteCheckConfig prerequisiteCheckConfig = Mockito.mock(PrerequisiteCheckConfig.class);
     Mockito.when(prerequisiteCheckConfig.getCheckProperties(
         servicesMapReduceDistributedCacheCheck.getClass().getName())).thenReturn(checkProperties);
@@ -229,6 +229,15 @@ public class ServicesMapReduceDistributedCacheCheckTest {
     Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
 
     properties.put("fs.defaultFS", "anything");
+    properties.put("mapreduce.application.framework.path", "abfs://some/path");
+    properties.put("mapreduce.application.classpath", "anything");
+    request = new PrereqCheckRequest("cluster");
+    request.setPrerequisiteCheckConfig(prerequisiteCheckConfig);
+    check = new PrerequisiteCheck(null, null);
+    servicesMapReduceDistributedCacheCheck.perform(check, request);
+    Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
+
+    properties.put("fs.defaultFS", "anything");
     properties.put("mapreduce.application.framework.path", "ecs://some/path");
     properties.put("mapreduce.application.classpath", "anything");
     request = new PrereqCheckRequest("cluster");
@@ -256,6 +265,15 @@ public class ServicesMapReduceDistributedCacheCheckTest {
     Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
 
     properties.put("fs.defaultFS", "wasb://ha");
+    properties.put("mapreduce.application.framework.path", "/some/path");
+    properties.put("mapreduce.application.classpath", "anything");
+    request = new PrereqCheckRequest("cluster");
+    request.setPrerequisiteCheckConfig(prerequisiteCheckConfig);
+    check = new PrerequisiteCheck(null, null);
+    servicesMapReduceDistributedCacheCheck.perform(check, request);
+    Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
+
+    properties.put("fs.defaultFS", "abfs://ha");
     properties.put("mapreduce.application.framework.path", "/some/path");
     properties.put("mapreduce.application.classpath", "anything");
     request = new PrereqCheckRequest("cluster");

--- a/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesTezDistributedCacheCheckTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/checks/ServicesTezDistributedCacheCheckTest.java
@@ -207,7 +207,7 @@ public class ServicesTezDistributedCacheCheckTest {
     Mockito.when(config.getProperties()).thenReturn(properties);
 
     Map<String, String> checkProperties = new HashMap<>();
-    checkProperties.put("dfs-protocols-regex","^([^:]*dfs|wasb|ecs):.*");
+    checkProperties.put("dfs-protocols-regex", ServicesTezDistributedCacheCheck.DFS_PROTOCOLS_REGEX_DEFAULT);
     PrerequisiteCheckConfig prerequisiteCheckConfig = Mockito.mock(PrerequisiteCheckConfig.class);
     Mockito.when(prerequisiteCheckConfig.getCheckProperties(
         servicesTezDistributedCacheCheck.getClass().getName())).thenReturn(checkProperties);
@@ -247,6 +247,15 @@ public class ServicesTezDistributedCacheCheckTest {
     Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
 
     properties.put("fs.defaultFS", "anything");
+    properties.put("tez.lib.uris", "abfs://some/path/to/archive.tar.gz");
+    properties.put("tez.use.cluster.hadoop-libs", "false");
+    request = new PrereqCheckRequest("cluster");
+    request.setPrerequisiteCheckConfig(prerequisiteCheckConfig);
+    check = new PrerequisiteCheck(null, null);
+    servicesTezDistributedCacheCheck.perform(check, request);
+    Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
+
+    properties.put("fs.defaultFS", "anything");
     properties.put("tez.lib.uris", "ecs://some/path/to/archive.tar.gz");
     properties.put("tez.use.cluster.hadoop-libs", "false");
     request = new PrereqCheckRequest("cluster");
@@ -274,6 +283,15 @@ public class ServicesTezDistributedCacheCheckTest {
     Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
 
     properties.put("fs.defaultFS", "wasb://ha");
+    properties.put("tez.lib.uris", "/some/path/to/archive.tar.gz");
+    properties.put("tez.use.cluster.hadoop-libs", "false");
+    request = new PrereqCheckRequest("cluster");
+    request.setPrerequisiteCheckConfig(prerequisiteCheckConfig);
+    check = new PrerequisiteCheck(null, null);
+    servicesTezDistributedCacheCheck.perform(check, request);
+    Assert.assertEquals(PrereqCheckStatus.PASS, check.getStatus());
+
+    properties.put("fs.defaultFS", "abfs://ha");
     properties.put("tez.lib.uris", "/some/path/to/archive.tar.gz");
     properties.put("tez.use.cluster.hadoop-libs", "false");
     request = new PrereqCheckRequest("cluster");


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added abfs protocol to list of the valid protocols for the pre-upgrade checks.

## How was this patch tested?

Manual check.