### PR TITLE
AMBARI-25234 - Ambari audit log shows "null" user when executing an API call as admin

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/AmbariAuthenticationEventHandlerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/AmbariAuthenticationEventHandlerImpl.java
@@ -153,19 +153,5 @@ public class AmbariAuthenticationEventHandlerImpl implements AmbariAuthenticatio
 
   @Override
   public void beforeAttemptAuthentication(AmbariAuthenticationFilter filter, ServletRequest servletRequest, ServletResponse servletResponse) {
-    HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-
-    // Using the Ambari audit logger, log this event (if enabled)
-    if (auditLogger.isEnabled() && filter.shouldApply(httpServletRequest) && (AuthorizationHelper.getAuthenticatedName() == null)) {
-      AuditEvent loginFailedAuditEvent = LoginAuditEvent.builder()
-          .withRemoteIp(RequestUtils.getRemoteAddress(httpServletRequest))
-          .withTimestamp(System.currentTimeMillis())
-          .withReasonOfFailure("Authentication required")
-          .withUserName(null)
-          .withProxyUserName(null)
-          .build();
-      auditLogger.log(loginFailedAuditEvent);
-    }
-
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When calling an ambari a REST API for the first time, so the client has not authenticated before two entries are written to the ambari-audit.log file.
Example:
```
2019-04-08T10:19:04.991Z, User(null), RemoteIp(x.x.x.x), Operation(User login), Roles(), Status(Failed), Reason(Authentication required), Consecutive failures(UNKNOWN USER)

2019-04-08T10:19:04.999Z, User(admin), RemoteIp(x.x.x.x), Operation(User login), Roles(Ambari: Ambari Administrator), Status(Success)
```
The first one is produced before authentication but the contained information is misleading and the user is hardcoded to null.

## How was this patch tested?
mvn clean install

Manually:
1. deploy ambari and a minimal cluster.
2. replace ambari-server.jar with the one contains the fix
3. execute a REST api call
```
curl -k -i -u admin:<passwd> -H "X-Requested-By: ambari" -X GET http://<ambari-host>:8080/api/v1/clusters
```
4. check `/var/log/ambari-server/ambari-audit.log` contains only one entry per request with a successful status

5. execute another request using a bad password
6. the audit log contains an entry with a failed status with reason `Invalid username/password`