### PR TITLE
[AMBARI-25240] : Dynamically update Rolling Upgrade Batch size

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
@@ -319,6 +319,17 @@ public class MasterHostResolver {
   }
 
   /**
+   * Find Config value for current Cluster using configType and propertyName
+   *
+   * @param configType   Config Type
+   * @param propertyName Property Name
+   * @return Value of property if present else null
+   */
+  public String getValueFromDesiredConfigurations(final String configType, final String propertyName) {
+    return m_configHelper.getValueFromDesiredConfigurations(m_cluster, configType, propertyName);
+  }
+
+  /**
    * Find the master and secondary namenode(s) based on JMX NameNodeStatus.
    */
   private HostsType.HighAvailabilityHosts findMasterAndSecondaries(NameService nameService, Set<String> componentHosts) throws ClassifyNameNodeException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
@@ -31,10 +31,9 @@ import org.apache.ambari.server.stack.upgrade.ServerActionTask;
 import org.apache.ambari.server.stack.upgrade.ServiceCheckGrouping;
 import org.apache.ambari.server.stack.upgrade.Task;
 import org.apache.ambari.server.stack.upgrade.UpgradePack.ProcessingComponent;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-
-import static org.apache.ambari.server.state.ConfigHelper.CLUSTER_ENV;
 
 /**
  * Defines how to build stages for an Upgrade or Downgrade.
@@ -282,8 +281,8 @@ public abstract class StageWrapperBuilder {
 
     if (m_grouping.parallelScheduler != null) {
       int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
-      String maxDegreeFromClusterEnv = ctx.getResolver().getValueFromDesiredConfigurations(CLUSTER_ENV,
-              "max_degree_parallelism");
+      String maxDegreeFromClusterEnv =
+              ctx.getResolver().getValueFromDesiredConfigurations(ConfigHelper.CLUSTER_ENV, "max_degree_parallelism");
       if (StringUtils.isNotEmpty(maxDegreeFromClusterEnv) && StringUtils.isNumeric(maxDegreeFromClusterEnv)) {
         taskParallelism = Integer.parseInt(maxDegreeFromClusterEnv);
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/upgrade/orchestrate/StageWrapperBuilder.java
@@ -32,6 +32,9 @@ import org.apache.ambari.server.stack.upgrade.ServiceCheckGrouping;
 import org.apache.ambari.server.stack.upgrade.Task;
 import org.apache.ambari.server.stack.upgrade.UpgradePack.ProcessingComponent;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
+import static org.apache.ambari.server.state.ConfigHelper.CLUSTER_ENV;
 
 /**
  * Defines how to build stages for an Upgrade or Downgrade.
@@ -279,6 +282,11 @@ public abstract class StageWrapperBuilder {
 
     if (m_grouping.parallelScheduler != null) {
       int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
+      String maxDegreeFromClusterEnv = ctx.getResolver().getValueFromDesiredConfigurations(CLUSTER_ENV,
+              "max_degree_parallelism");
+      if (StringUtils.isNotEmpty(maxDegreeFromClusterEnv) && StringUtils.isNumeric(maxDegreeFromClusterEnv)) {
+        taskParallelism = Integer.parseInt(maxDegreeFromClusterEnv);
+      }
       if (taskParallelism == ParallelScheduler.DEFAULT_MAX_DEGREE_OF_PARALLELISM) {
         taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
       }


### PR DESCRIPTION

## What changes were proposed in this pull request?
Dynamically update Rolling Upgrade Batch size using cluster-env property: **max_degree_parallelism**

## How was this patch tested?
The code has been tested manually. The default behavior of reading batch size value will remain same. Only if the client updates cluster-env property, the default behavior will be overriden.