### PR TITLE
[AMBARI-25240] : Dynamically update Rolling Upgrade Batch size

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
@@ -313,6 +313,17 @@ public class MasterHostResolver {
   }
 
   /**
+   * Find Config value for current Cluster using configType and propertyName
+   *
+   * @param configType   Config Type
+   * @param propertyName Property Name
+   * @return Value of property if present else null
+   */
+  public String getValueFromDesiredConfigurations(final String configType, final String propertyName) {
+    return m_configHelper.getValueFromDesiredConfigurations(m_cluster, configType, propertyName);
+  }
+
+  /**
    * Find the master and secondary namenode(s) based on JMX NameNodeStatus.
    */
   private HostsType.HighAvailabilityHosts findMasterAndSecondaries(NameService nameService, Set<String> componentHosts) throws ClassifyNameNodeException {

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -41,6 +41,8 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Objects;
 
+import static org.apache.ambari.server.state.ConfigHelper.CLUSTER_ENV;
+
 /**
  *
  */
@@ -228,6 +230,11 @@ public class Grouping {
 
         if (m_grouping.parallelScheduler != null) {
           int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
+          String maxDegreeFromClusterEnv = ctx.getResolver().getValueFromDesiredConfigurations(CLUSTER_ENV,
+                  "max_degree_parallelism");
+          if (StringUtils.isNotEmpty(maxDegreeFromClusterEnv) && StringUtils.isNumeric(maxDegreeFromClusterEnv)) {
+            taskParallelism = Integer.parseInt(maxDegreeFromClusterEnv);
+          }
           if (taskParallelism == Integer.MAX_VALUE) {
             taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
           }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -32,6 +32,7 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.stack.HostsType;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.UpgradeContext;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.UpgradePack.OrderService;
@@ -40,8 +41,6 @@ import org.apache.ambari.server.utils.SetUtils;
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Objects;
-
-import static org.apache.ambari.server.state.ConfigHelper.CLUSTER_ENV;
 
 /**
  *
@@ -226,12 +225,11 @@ public class Grouping {
 
       // Expand some of the TaskWrappers into multiple based on the batch size.
       for (TaskWrapper tw : tasks) {
-        List<Set<String>> hostSets = null;
-
+        List<Set<String>> hostSets;
         if (m_grouping.parallelScheduler != null) {
           int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
-          String maxDegreeFromClusterEnv = ctx.getResolver().getValueFromDesiredConfigurations(CLUSTER_ENV,
-                  "max_degree_parallelism");
+          String maxDegreeFromClusterEnv = ctx.getResolver()
+                  .getValueFromDesiredConfigurations(ConfigHelper.CLUSTER_ENV, "max_degree_parallelism");
           if (StringUtils.isNotEmpty(maxDegreeFromClusterEnv) && StringUtils.isNumeric(maxDegreeFromClusterEnv)) {
             taskParallelism = Integer.parseInt(maxDegreeFromClusterEnv);
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Dynamically update Rolling Upgrade Batch size using cluster-env property: **max_degree_parallelism**

## How was this patch tested?
The code has been tested manually. The default behavior of reading batch size value will remain same. Only if the client updates cluster-env property, the default behavior will be overriden.

Backporting [PR](https://github.com/apache/ambari/pull/2926) to branch-2.7 