### PR TITLE
[AMBARI-25240] : Dynamically update Rolling Upgrade Batch size

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/MasterHostResolver.java
@@ -268,6 +268,17 @@ public class MasterHostResolver {
   }
 
   /**
+   * Find Config value for current Cluster using configType and propertyName
+   *
+   * @param configType   Config Type
+   * @param propertyName Property Name
+   * @return Value of property if present else null
+   */
+  public String getValueFromDesiredConfigurations(final String configType, final String propertyName) {
+    return m_configHelper.getValueFromDesiredConfigurations(m_cluster, configType, propertyName);
+  }
+
+  /**
    * Get mapping of the HDFS Namenodes from the state ("active" or "standby") to the hostname.
    * @return Returns a map from the state ("active" or "standby" to the hostname with that state if exactly
    * one active and one standby host were found, otherwise, return null.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/Grouping.java
@@ -32,6 +32,7 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.stack.HostsType;
+import org.apache.ambari.server.state.ConfigHelper;
 import org.apache.ambari.server.state.UpgradeContext;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.ambari.server.state.stack.UpgradePack.OrderService;
@@ -224,10 +225,14 @@ public class Grouping {
 
       // Expand some of the TaskWrappers into multiple based on the batch size.
       for (TaskWrapper tw : tasks) {
-        List<Set<String>> hostSets = null;
-
+        List<Set<String>> hostSets;
         if (m_grouping.parallelScheduler != null) {
           int taskParallelism = m_grouping.parallelScheduler.maxDegreeOfParallelism;
+          String maxDegreeFromClusterEnv = ctx.getResolver()
+                  .getValueFromDesiredConfigurations(ConfigHelper.CLUSTER_ENV, "max_degree_parallelism");
+          if (StringUtils.isNotEmpty(maxDegreeFromClusterEnv) && StringUtils.isNumeric(maxDegreeFromClusterEnv)) {
+            taskParallelism = Integer.parseInt(maxDegreeFromClusterEnv);
+          }
           if (taskParallelism == Integer.MAX_VALUE) {
             taskParallelism = ctx.getDefaultMaxDegreeOfParallelism();
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Dynamically update Rolling Upgrade Batch size using cluster-env property: **max_degree_parallelism**

## How was this patch tested?
The code has been tested manually. The default behavior of reading batch size value will remain same. Only if the client updates cluster-env property, the default behavior will be overriden.

Backporting [PR](https://github.com/apache/ambari/pull/2927) to branch-2.6