### PR TITLE
AMBARI-25243. Tez/MR service check fails with ClassNotFoundException LzoCodec during host ordered upgrade (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariActionExecutionHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariActionExecutionHelper.java
@@ -22,6 +22,7 @@ import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AGENT_STA
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.AGENT_STACK_RETRY_ON_UNAVAILABILITY;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.COMMAND_TIMEOUT;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.COMPONENT_CATEGORY;
+import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.GPL_LICENSE_ACCEPTED;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SCRIPT;
 import static org.apache.ambari.server.agent.ExecutionCommand.KeyNames.SCRIPT_TYPE;
 
@@ -457,6 +458,7 @@ public class AmbariActionExecutionHelper {
         resourceFilter.getComponentName() : componentName);
 
       Map<String, String> hostLevelParams = execCmd.getHostLevelParams();
+      hostLevelParams.put(GPL_LICENSE_ACCEPTED, configs.getGplLicenseAccepted().toString());
       hostLevelParams.put(AGENT_STACK_RETRY_ON_UNAVAILABILITY, configs.isAgentStackRetryOnInstallEnabled());
       hostLevelParams.put(AGENT_STACK_RETRY_COUNT, configs.getAgentStackRetryOnInstallCount());
       for (Map.Entry<String, String> dbConnectorName : configs.getDatabaseConnectorNames().entrySet()) {

--- a/ambari-server/src/main/resources/custom_actions/scripts/install_packages.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/install_packages.py
@@ -41,6 +41,7 @@ from resource_management.libraries.functions.stack_features import check_stack_f
 from resource_management.libraries.resources.repository import Repository
 from resource_management.libraries.script.script import Script
 from resource_management.core import sudo
+from resource_management.libraries.functions import lzo_utils
 
 
 class InstallPackages(Script):
@@ -147,6 +148,12 @@ class InstallPackages(Script):
     except Exception as err:
       num_errors += 1
       Logger.logger.exception("Could not install packages. Error: {0}".format(str(err)))
+
+    try:
+      lzo_utils.install_lzo_if_needed()
+    except Exception as err:
+      num_errors += 1
+      Logger.logger.exception("Could not install LZO packages. Error: {0}".format(str(err)))
 
     # Provide correct exit code
     if num_errors > 0:


### PR DESCRIPTION
## What changes were proposed in this pull request?

After host upgrade Tez/MR service checks fail because of a classpath issue.

The classpath used by on the client side is:

```
/usr/hdp/<NEW.HDP.VERSION>/hadoop/lib/hadoop-lzo-0.6.0.<NEW.HDP.VERSION>.jar
```

LzoPackage is installed lazily therefore it's not available at the server side. This patch ensures that LZO is installed before the upgrade.

## How was this patch tested?

- Performed host ordered upgrade with TEZ service check enabled
