### PR TITLE
AMBARI-25246 Add module based dependency with custom version for the excluded transitiend modules (dgrinenko)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-solr-client/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-solr-client/pom.xml
@@ -92,6 +92,10 @@
       <version>3.4</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
+++ b/ambari-metrics/ambari-metrics-hadoop-sink/pom.xml
@@ -206,6 +206,9 @@ limitations under the License.
       <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
   </dependencies>
-
 </project>

--- a/ambari-metrics/ambari-metrics-storm-sink-legacy/pom.xml
+++ b/ambari-metrics/ambari-metrics-storm-sink-legacy/pom.xml
@@ -177,6 +177,10 @@ limitations under the License.
         </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-common</artifactId>
       <version>${project.version}</version>

--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -388,6 +388,16 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -135,6 +135,16 @@
         <artifactId>commons-codec</artifactId>
         <version>1.12</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.9.8</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.9.8</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding excluded transitive dependencies as dependency for the base package, to which transient one relates. In this way the target module would have all packages in place.  

## How was this patch tested?
Have packaged the application and checked the resulting file structure: 

```
-rw-r--r-- 1 root root  325619 Apr 15 09:21 jackson-core-2.9.8.jar
-rw-r--r-- 1 root root  232102 Apr 15 09:21 jackson-core-asl-1.9.9.jar
-rw-r--r-- 1 root root 1347236 Apr 15 09:21 jackson-databind-2.9.8.jar
```