### PR TITLE
[AMBARI-25250] Blueprint processor should support multiple ZooKeeper nodes for Livy

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -2826,6 +2826,7 @@ public class BlueprintConfigurationProcessor {
     Map<String, PropertyUpdater> oozieEnvHeapSizeMap = new HashMap<>();
     Map<String, PropertyUpdater> multiWebhcatSiteMap = new HashMap<>();
     Map<String, PropertyUpdater> multiHbaseSiteMap = new HashMap<>();
+    Map<String, PropertyUpdater> livy2Conf = new HashMap<>();
     Map<String, PropertyUpdater> multiStormSiteMap = new HashMap<>();
     Map<String, PropertyUpdater> multiCoreSiteMap = new HashMap<>();
     Map<String, PropertyUpdater> multiHdfsSiteMap = new HashMap<>();
@@ -2899,6 +2900,7 @@ public class BlueprintConfigurationProcessor {
     multiHostTopologyUpdaters.put("accumulo-site", multiAccumuloSiteMap);
     multiHostTopologyUpdaters.put("kms-site", multiRangerKmsSiteMap);
     multiHostTopologyUpdaters.put("application-properties", atlasPropsMap);
+    multiHostTopologyUpdaters.put("livy2-conf", livy2Conf);
 
     dbHostTopologyUpdaters.put("hive-site", dbHiveSiteMap);
 
@@ -3225,6 +3227,8 @@ public class BlueprintConfigurationProcessor {
     druidCommon.put("metastore_hostname", HostGroupUpdater.INSTANCE);
     druidCommon.put("druid.metadata.storage.connector.connectURI", HostGroupUpdater.INSTANCE);
     druidCommon.put("druid.zk.service.host", new MultipleHostTopologyUpdater("ZOOKEEPER_SERVER"));
+
+    livy2Conf.put("livy.server.recovery.state-store.url", new MultipleHostTopologyUpdater("ZOOKEEPER_SERVER"));
   }
 
   private static void addUnitPropertyUpdaters() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -2764,6 +2764,10 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Map<String, String> typeProps = new HashMap<>();
     typeProps.put("hbase.zookeeper.quorum", "localhost");
     properties.put("hbase-site", typeProps);
+    Map<String, String> livyConf = new HashMap<>();
+    livyConf.put("livy.server.recovery.state-store.url", "/livy2-recovery");
+    properties.put("livy2-conf", livyConf);
+    Map<String, String> originalLivyConf = ImmutableMap.copyOf(livyConf);
 
     Configuration clusterConfig = new Configuration(properties, emptyMap());
 
@@ -2799,7 +2803,8 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     ClusterTopology topology = createClusterTopology(bp, clusterConfig, hostGroups);
     BlueprintConfigurationProcessor updater = new BlueprintConfigurationProcessor(topology);
     updater.doUpdateForClusterCreate();
-    String updatedVal = topology.getConfiguration().getFullProperties().get("hbase-site").get("hbase.zookeeper.quorum");
+    Map<String, Map<String, String>> fullProperties = topology.getConfiguration().getFullProperties();
+    String updatedVal = fullProperties.get("hbase-site").get("hbase.zookeeper.quorum");
     String[] hosts = updatedVal.split(",");
 
     Collection<String> expectedHosts = new HashSet<>();
@@ -2813,6 +2818,8 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
       assertTrue(expectedHosts.contains(host));
       expectedHosts.remove(host);
     }
+
+    assertEquals(originalLivyConf, fullProperties.get("livy2-conf"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add multi-node host group replacement for `livy.server.recovery.state-store.url` so that the full ZK quorum is substituted instead of a random ZK node.

https://issues.apache.org/jira/browse/AMBARI-25250

## How was this patch tested?

Adjusted unit test.

Deployed cluster via blueprint with multiple ZK nodes and the property set to `%HOSTGROUP::zk%:2181`.  Verified that `livy.server.recovery.state-store.url` in the cluster config contains all ZK nodes.

Deployed cluster via blueprint without setting the related properties (defaults to filesystem-based recovery).  Verified that `livy.server.recovery.state-store.url` is not changed by the blueprint logic.