### PR TITLE
AMBARI-25253. Missed support for abfs protocol.

### DIFF
--- a/ambari-server/conf/unix/ambari.properties
+++ b/ambari-server/conf/unix/ambari.properties
@@ -69,7 +69,7 @@ views.request.connect.timeout.millis=5000
 views.request.read.timeout.millis=10000
 views.ambari.request.connect.timeout.millis=30000
 views.ambari.request.read.timeout.millis=45000
-views.skip.home-directory-check.file-system.list=wasb,adls,adl
+views.skip.home-directory-check.file-system.list=wasb,adls,adl,abfs
 
 # Scheduler settings
 server.execution.scheduler.isClustered=false

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/ranger-hive-security.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/ranger-hive-security.xml
@@ -22,7 +22,7 @@
 
   <property>
     <name>ranger.plugin.hive.urlauth.filesystem.schemes</name>
-    <value>hdfs:,file:,wasb:,adl:</value>
+    <value>hdfs:,file:,wasb:,adl:,abfs:</value>
     <description>Add urlauth filesystem schemes</description>
     <value-attributes>
       <empty-value-valid>true</empty-value-valid>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
@@ -72,7 +72,7 @@
           </definition>
           <definition xsi:type="configure" id="hdp_2_6_maint_ranger_hive_plugin_urlauth_filesystem_schemes">
             <type>ranger-hive-security</type>
-            <set key="ranger.plugin.hive.urlauth.filesystem.schemes" value="hdfs:,file:,wasb:,adl:"
+            <set key="ranger.plugin.hive.urlauth.filesystem.schemes" value="hdfs:,file:,wasb:,adl:,abfs:"
               if-type="ranger-hive-security" if-key="ranger.plugin.hive.service.name" if-key-state="present"/>
           </definition>
           <definition xsi:type="configure" id="hdp_2_6_maint_jaas_config_for_hive_hook" summary="Updating hive atlas application properties">

--- a/contrib/views/utils/src/main/java/org/apache/ambari/view/utils/ambari/ValidatorUtils.java
+++ b/contrib/views/utils/src/main/java/org/apache/ambari/view/utils/ambari/ValidatorUtils.java
@@ -29,7 +29,7 @@ public class ValidatorUtils {
    * @return is url valid
    */
   public static boolean validateHdfsURL(String webhdfsUrl) {
-    String[] schemes = {"webhdfs", "hdfs", "s3", "wasb", "swebhdfs", "adl"};
+    String[] schemes = {"webhdfs", "hdfs", "s3", "wasb", "swebhdfs", "adl", "abfs"};
     return validateURL(webhdfsUrl, schemes);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Valid protocols list for view properties per-check has been extended with abfs protocol. Also ranger hive plugin uses abfs in default parameters during install and upgrade.

## How was this patch tested?

Manual check.