### PR TITLE
[AMBARI-25250] Blueprint processor should support multiple ZooKeeper nodes for Livy

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessor.java
@@ -2825,6 +2825,7 @@ public class BlueprintConfigurationProcessor {
     Map<String, PropertyUpdater> oozieEnvHeapSizeMap = new HashMap<>();
     Map<String, PropertyUpdater> multiWebhcatSiteMap = new HashMap<>();
     Map<String, PropertyUpdater> multiHbaseSiteMap = new HashMap<>();
+    Map<String, PropertyUpdater> livy2Conf = new HashMap<>();
     Map<String, PropertyUpdater> multiStormSiteMap = new HashMap<>();
     Map<String, PropertyUpdater> multiCoreSiteMap = new HashMap<>();
     Map<String, PropertyUpdater> multiHdfsSiteMap = new HashMap<>();
@@ -2898,6 +2899,7 @@ public class BlueprintConfigurationProcessor {
     multiHostTopologyUpdaters.put("accumulo-site", multiAccumuloSiteMap);
     multiHostTopologyUpdaters.put("kms-site", multiRangerKmsSiteMap);
     multiHostTopologyUpdaters.put("application-properties", atlasPropsMap);
+    multiHostTopologyUpdaters.put("livy2-conf", livy2Conf);
 
     dbHostTopologyUpdaters.put("hive-site", dbHiveSiteMap);
 
@@ -3224,6 +3226,8 @@ public class BlueprintConfigurationProcessor {
     druidCommon.put("metastore_hostname", HostGroupUpdater.INSTANCE);
     druidCommon.put("druid.metadata.storage.connector.connectURI", HostGroupUpdater.INSTANCE);
     druidCommon.put("druid.zk.service.host", new MultipleHostTopologyUpdater("ZOOKEEPER_SERVER"));
+
+    livy2Conf.put("livy.server.recovery.state-store.url", new MultipleHostTopologyUpdater("ZOOKEEPER_SERVER"));
   }
 
   private static void addUnitPropertyUpdaters() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/BlueprintConfigurationProcessorTest.java
@@ -2792,6 +2792,10 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     Map<String, String> typeProps = new HashMap<>();
     typeProps.put("hbase.zookeeper.quorum", "localhost");
     properties.put("hbase-site", typeProps);
+    Map<String, String> livyConf = new HashMap<>();
+    livyConf.put("livy.server.recovery.state-store.url", "/livy2-recovery");
+    properties.put("livy2-conf", livyConf);
+    Map<String, String> originalLivyConf = ImmutableMap.copyOf(livyConf);
 
     Configuration clusterConfig = new Configuration(properties, emptyMap());
 
@@ -2827,7 +2831,8 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
     ClusterTopology topology = createClusterTopology(bp, clusterConfig, hostGroups);
     BlueprintConfigurationProcessor updater = new BlueprintConfigurationProcessor(topology);
     updater.doUpdateForClusterCreate();
-    String updatedVal = topology.getConfiguration().getFullProperties().get("hbase-site").get("hbase.zookeeper.quorum");
+    Map<String, Map<String, String>> fullProperties = topology.getConfiguration().getFullProperties();
+    String updatedVal = fullProperties.get("hbase-site").get("hbase.zookeeper.quorum");
     String[] hosts = updatedVal.split(",");
 
     Collection<String> expectedHosts = new HashSet<>();
@@ -2841,6 +2846,8 @@ public class BlueprintConfigurationProcessorTest extends EasyMockSupport {
       assertTrue(expectedHosts.contains(host));
       expectedHosts.remove(host);
     }
+
+    assertEquals(originalLivyConf, fullProperties.get("livy2-conf"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #2935, for `trunk`.

https://issues.apache.org/jira/browse/AMBARI-25250