### PR TITLE
AMBARI-25205. hdfs_to_onefs_convert.py script missing HDP3.1 + upgrade logic (amagyar)

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/tools/hdfs_to_onefs_convert.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/tools/hdfs_to_onefs_convert.py
@@ -370,14 +370,13 @@ class Conversion:
   def __init__(self, cluster, storage):
     self.cluster = cluster
     self.storage = storage
-    self.supported_stacks = ['HDP-3.0']
 
   def check_prerequisites(self):
     print 'Checking %s' % self.cluster
     ver = self.cluster.version()
     print 'Found stack %s' % ver
-    if ver not in self.supported_stacks:
-      print 'Only %s stacks are supported.' % self.supported_stacks
+    if not ver.startswith('HDP-3.'):
+      print 'Only HDP.3.x stacks are supported.'
       return False
     if not self.cluster.installed_stack().has_service('ONEFS'):
       print 'ONEFS management pack is not installed.'
@@ -522,7 +521,7 @@ if __name__ == '__main__':
   print 'The following prerequisites are required:'
   print '  * ONEFS management package must be installed'
   print '  * Ambari must be upgraded to >=v2.7.0'
-  print '  * Stack must be upgraded to HDP-3.0'
+  print '  * Stack must be upgraded to >=HDP-3.0'
   print '  * Is highly recommended to backup ambari database before you proceed.'
   conversion = Conversion(cluster, FsStorage())
   if not conversion.check_prerequisites():

--- a/contrib/management-packs/isilon-onefs-mpack/src/main/tools/hdfs_to_onefs_convert.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/tools/hdfs_to_onefs_convert.py
@@ -376,7 +376,7 @@ class Conversion:
     ver = self.cluster.version()
     print 'Found stack %s' % ver
     if not ver.startswith('HDP-3.'):
-      print 'Only HDP.3.x stacks are supported.'
+      print 'Only HDP-3.x stacks are supported.'
       return False
     if not self.cluster.installed_stack().has_service('ONEFS'):
       print 'ONEFS management pack is not installed.'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding support for HDP-3.x version to hdfs->onefs conversion script. The previous check was too strict and only allowed HDP-3.0.

## How was this patch tested?

Manually with HDP 3.1.

```bash
$ python hdfs_to_onefs_convert.py --cluster cc --host localhost --port 8080 --user admin --password admin --protocol http

This script will replace the HDFS service to ONEFS
The following prerequisites are required:
  * ONEFS management package must be installed
  * Ambari must be upgraded to >=v2.7.0
  * Stack must be upgraded to >=HDP-3.0
  * Is highly recommended to backup ambari database before you proceed.
Checking Cluster: cc (http://localhost:8080/api/v1/clusters/cc)
Found stack HDP-3.1
Please, confirm you have made backup of the Ambari db [y/n] (n)?
```
