### PR TITLE
[AMBARI-25261]: hdfs_to_onefs_convert.py script should have Ambari Serv…

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/tools/hdfs_to_onefs_convert.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/tools/hdfs_to_onefs_convert.py
@@ -520,7 +520,7 @@ if __name__ == '__main__':
   print 'This script will replace the HDFS service to ONEFS'
   print 'The following prerequisites are required:'
   print '  * ONEFS management package must be installed'
-  print '  * Ambari must be upgraded to >=v2.7.0'
+  print '  * Ambari must be upgraded to >=v2.7.1'
   print '  * Stack must be upgraded to >=HDP-3.0'
   print '  * Is highly recommended to backup ambari database before you proceed.'
   conversion = Conversion(cluster, FsStorage())


### PR DESCRIPTION
## What changes were proposed in this pull request?

OneFS only works with Ambari 2.7.1+, not Ambari 2.7.0. The hdfs_to_onefs_convert.py script should be updated to say so. This fix updates the text to '... Ambari must be upgraded to >=v2.7.1'

## How was this patch tested?

I ran `hdfs_to_onefs_convert.py` with a dummy option in order to see text change. I did not test the upgrade as the change is text only to inform user about prerequisites.

![hdfs_to_onefs_ambari_server_prereq_change](https://user-images.githubusercontent.com/16868874/56398514-cfa79f80-61fd-11e9-8f1f-8aef5d11a583.png)
