### PR TITLE
[AMBARI-25174] Add OneFS Mpack missing Spark2 configuration setting

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
@@ -27,7 +27,8 @@
             "hadoop.security.authentication": "kerberos",
             "hadoop.security.authorization": "true",
             "hadoop.proxyuser.HTTP.groups": "${hadoop-env/proxyuser_group}",
-            "hadoop.security.token.service.use_ip" : "false"
+            "hadoop.security.token.service.use_ip" : "false",
+            "dfs.namenode.kerberos.principal": "${hadoop-env/hdfs_user}${principal_suffix}/${onefs/onefs_host}@${realm}"
           }
         },
         {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The OneFS management pack does not include the HDFS configuration setting `"dfs.namenode.kerberos.principal"`. Adding setting this configuration in `kerberos.json` is the only setting change needed for Spark2 to work with Kerberos. 

## How was this patch tested?

Built mpack and manually tested three ways. 
* New install of fixed mpack with new HDP 3.0 deployment - the Spark2 service check passes after Kerberizing
* Re-create existing issue and upgrade previous mpack to mpack with fix - the Spark2 service check passes after regenerating keytabs
* Re-create existing issue (with workaround added in custom hdfs-site.xml) and upgrade previous mpack to mpack with fix - the Spark2 service check passes after regenerating keytabs
