### PR TITLE
AMBARI-25264. Service checks mentioned in HOU upgrade plan are run on the same node that was upgraded.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -1158,7 +1158,7 @@ public class UpgradeResourceProvider extends AbstractControllerResourceProvider 
     List<RequestResourceFilter> filters = new ArrayList<>();
 
     for (TaskWrapper tw : wrapper.getTasks()) {
-      filters.add(new RequestResourceFilter(tw.getService(), "", Collections.<String> emptyList()));
+      filters.add(new RequestResourceFilter(tw.getService(), "", new ArrayList<>(tw.getHosts())));
     }
 
     Cluster cluster = context.getCluster();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponent.java
@@ -73,6 +73,8 @@ public interface ServiceComponent {
 
   Map<String, ServiceComponentHost> getServiceComponentHosts();
 
+  Map<String, Host> getHostsForServiceComponents();
+
   ServiceComponentHost getServiceComponentHost(String hostname)
       throws AmbariException;
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentImpl.java
@@ -263,6 +263,15 @@ public class ServiceComponentImpl implements ServiceComponent {
   }
 
   @Override
+  public Map<String, Host> getHostsForServiceComponents() {
+    Map<String, Host> hosts = new HashMap<>();
+    for (Map.Entry<String, ServiceComponentHost> hostComponent : hostComponents.entrySet()) {
+      hosts.put(hostComponent.getKey(), hostComponent.getValue().getHost());
+    }
+    return hosts;
+  }
+
+  @Override
   public void addServiceComponentHosts(
       Map<String, ServiceComponentHost> hostComponents) throws AmbariException {
     // TODO validation

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UpgradeContext.java
@@ -1278,7 +1278,7 @@ public class UpgradeContext {
       List<String> hostsFromRequest = new ArrayList<>(hostOrderItems.size());
       for (HostOrderItem hostOrderItem : hostOrderItems) {
         if (hostOrderItem.getType() == HostOrderActionType.HOST_UPGRADE) {
-          hostsFromRequest.addAll(hostOrderItem.getActionItems());
+          hostsFromRequest.addAll(hostOrderItem.getHosts());
         }
       }
 
@@ -1350,11 +1350,11 @@ public class UpgradeContext {
         }
 
         if (CollectionUtils.isNotEmpty(hosts)) {
-          hostOrderItems.add(new HostOrderItem(HostOrderActionType.HOST_UPGRADE, hosts));
+          hostOrderItems.add(new HostOrderItem(HostOrderActionType.HOST_UPGRADE, hosts, Collections.<String>emptyList()));
         }
 
         if (CollectionUtils.isNotEmpty(serviceChecks)) {
-          hostOrderItems.add(new HostOrderItem(HostOrderActionType.SERVICE_CHECK, serviceChecks));
+          hostOrderItems.add(new HostOrderItem(HostOrderActionType.SERVICE_CHECK, hosts, serviceChecks));
         }
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -139,6 +139,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Functions;
+import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -2838,5 +2839,18 @@ public class ClusterImpl implements Cluster {
     }
 
     return componentVersionMap;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ClusterImpl cluster = (ClusterImpl) o;
+    return clusterId == cluster.clusterId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(clusterId);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/HostOrderItem.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/upgrade/HostOrderItem.java
@@ -58,7 +58,15 @@ public class HostOrderItem {
    * {@link HostOrderActionType#SERVICE_CHECK}, then this should be a list of
    * services.
    */
-  private final List<String> m_actionItems;
+  private final List<String> m_hosts;
+
+  /**
+   * The items to take action on. If {@link HostOrderActionType#HOST_UPGRADE},
+   * then this should be a list of hosts. If
+   * {@link HostOrderActionType#SERVICE_CHECK}, then this should be a list of
+   * services.
+   */
+  private final List<String> m_checks;
 
   /**
    * Constructor.
@@ -66,9 +74,10 @@ public class HostOrderItem {
    * @param type
    * @param actionItems
    */
-  public HostOrderItem(HostOrderActionType type, List<String> actionItems) {
+  public HostOrderItem(HostOrderActionType type, List<String> hosts, List<String> checks) {
     m_type = type;
-    m_actionItems = actionItems;
+    m_hosts = hosts;
+    m_checks = checks;
   }
 
   /**
@@ -86,8 +95,12 @@ public class HostOrderItem {
    *
    * @return the list of action items.
    */
-  public List<String> getActionItems() {
-    return m_actionItems;
+  public List<String> getHosts() {
+    return m_hosts;
+  }
+
+  public List<String> getChecks() {
+    return m_checks;
   }
 
   /**
@@ -95,7 +108,10 @@ public class HostOrderItem {
    */
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("type", m_type).add("items",
-        StringUtils.join(m_actionItems, ", ")).omitNullValues().toString();
+    return Objects.toStringHelper(this)
+        .add("m_type", m_type)
+        .add("m_hosts", m_hosts)
+        .add("m_checks", m_checks)
+        .toString();
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/UpgradeHelperTest.java
@@ -2107,10 +2107,10 @@ public class UpgradeHelperTest extends EasyMockSupport {
 
     // !!! make a custom grouping
     HostOrderItem hostItem = new HostOrderItem(HostOrderActionType.HOST_UPGRADE,
-        Lists.newArrayList("h1", "h2"));
+        Lists.newArrayList("h1", "h2"), Collections.<String>emptyList());
 
     HostOrderItem checkItem = new HostOrderItem(HostOrderActionType.SERVICE_CHECK,
-        Lists.newArrayList("ZOOKEEPER", "HBASE"));
+        Lists.newArrayList("h1", "h2"), Lists.newArrayList("ZOOKEEPER", "HBASE"));
 
     Grouping g = new HostOrderGrouping();
     ((HostOrderGrouping) g).setHostOrderItems(Lists.newArrayList(hostItem, checkItem));
@@ -2140,7 +2140,7 @@ public class UpgradeHelperTest extends EasyMockSupport {
     assertEquals(1, groups.size());
 
     UpgradeGroupHolder holder = groups.get(0);
-    assertEquals(9, holder.items.size());
+    assertEquals(11, holder.items.size());
 
     for (int i = 0; i < 7; i++) {
       StageWrapper w = holder.items.get(i);
@@ -2163,8 +2163,11 @@ public class UpgradeHelperTest extends EasyMockSupport {
       }
     }
 
+    // two hosts with two checks for each
     assertEquals(StageWrapper.Type.SERVICE_CHECK, holder.items.get(7).getType());
     assertEquals(StageWrapper.Type.SERVICE_CHECK, holder.items.get(8).getType());
+    assertEquals(StageWrapper.Type.SERVICE_CHECK, holder.items.get(9).getType());
+    assertEquals(StageWrapper.Type.SERVICE_CHECK, holder.items.get(10).getType());
 
     // !!! test downgrade when all host components have failed
     zookeeperServer1.setVersion(repoVersion211.getVersion());
@@ -2181,7 +2184,7 @@ public class UpgradeHelperTest extends EasyMockSupport {
     groups = m_upgradeHelper.createSequence(upgradePack, context);
 
     assertEquals(1, groups.size());
-    assertEquals(2, groups.get(0).items.size());
+    assertEquals(4, groups.get(0).items.size());
 
     // !!! test downgrade when one of the hosts had failed
     zookeeperServer1.setVersion(repoVersion211.getVersion());
@@ -2198,7 +2201,7 @@ public class UpgradeHelperTest extends EasyMockSupport {
     groups = m_upgradeHelper.createSequence(upgradePack, context);
 
     assertEquals(1, groups.size());
-    assertEquals(5, groups.get(0).items.size());
+    assertEquals(7, groups.get(0).items.size());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server runs service checks for each host from upgrade step instead random cluster host. Upgrade request will have been failed in case there are no appropriate hosts.
[{ "hosts": ["host1"], "service_checks": ["KAFKA", "ZOOKEEPER"] },
{ "hosts": ["host2"], "service_checks": ["ZOOKEEPER"] },
{ "hosts": ["host3", "host4"], "service_checks": ["CUSTOMSERVICE"] }]
For instance, "CUSTOMSERVICE" check will have been run for both "host3" and "host4" hosts. 

## How was this patch tested?

Manual check.