### PR TITLE
[AMBARI-25262]: Bump OneFS Management Pack version to 1.0.1.0

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/mpack.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/mpack.json
@@ -1,7 +1,7 @@
 {
   "type" : "full-release",
   "name" : "onefs-ambari-mpack",
-  "version": "0.1",
+  "version": "1.0.1.0",
   "description" : "OneFS Ambari Management Pack",
   "prerequisites": {
     "min-ambari-version" : "3.0.0.0"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The OneFS Management Pack has a number of fixes that have/need to go into it. 
https://github.com/apache/ambari/pull/2944
https://github.com/apache/ambari/pull/2943
https://github.com/apache/ambari/pull/2940

This **should not** be merged until #2943 and #2944 are merged. 

## How was this patch tested?
The mpack was successfully built. Existing management pack was upgraded to this one and version verified. Management pack also has correct version on initial install of new management pack.
