### PR TITLE
[AMBARI-25269] HiveServer2 Interactive Process alert triggered in HA setup

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
@@ -74,7 +74,8 @@ def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd
 
   # -n the user to connect as (ignored when using the hive principal in the URL, can be different from the user running the beeline command)
   # -e ';' executes a SQL commmand of NOOP
-  cmd = "beeline -n %s -u '%s' %s -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:'" % \
+  cmd = ("beeline -n %s -u '%s' %s -e ';' 2>&1 | awk '{print}' | grep -i " + \
+         "-e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'") % \
         (format(hive_user), format(";".join(beeline_url)), format(credential_str))
 
   Execute(cmd,

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_service_check.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_service_check.py
@@ -46,7 +46,7 @@ class TestServiceCheck(RMFTestCase):
                         stack_version = self.STACK_VERSION,
                         target = RMFTestCase.TARGET_COMMON_SERVICES
     )
-    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;auth=noSasl'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:'",
+    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;auth=noSasl'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
                               path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
                               user = 'ambari-qa',
                               timeout = 30,
@@ -165,7 +165,7 @@ class TestServiceCheck(RMFTestCase):
     self.assertResourceCalled('Execute', '/usr/bin/kinit -kt /etc/security/keytabs/smokeuser.headless.keytab ambari-qa@EXAMPLE.COM; ',
                               user = 'ambari-qa',
                               )
-    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;principal=hive/_HOST@EXAMPLE.COM'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:'",
+    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;principal=hive/_HOST@EXAMPLE.COM'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
                               path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
                               user = 'ambari-qa',
                               timeout = 30,
@@ -283,7 +283,7 @@ class TestServiceCheck(RMFTestCase):
       stack_version = self.STACK_VERSION,
       target = RMFTestCase.TARGET_COMMON_SERVICES)
 
-    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:'",
+    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
       path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
       timeout = 30,
       user = 'ambari-qa',
@@ -322,7 +322,7 @@ class TestServiceCheck(RMFTestCase):
       target = RMFTestCase.TARGET_COMMON_SERVICES)
 
     self.assertResourceCalled('Execute',
-      "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:'",
+      "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
       path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
       timeout = 30,
       user = 'ambari-qa',
@@ -330,7 +330,7 @@ class TestServiceCheck(RMFTestCase):
     )
 
     self.assertResourceCalled('Execute',
-      "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10500/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:'",
+      "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10500/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
       path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
       timeout = 30,
       user = 'ambari-qa',


### PR DESCRIPTION
## What changes were proposed in this pull request?

Eliminate false positive _HiveServer2 Interactive Process_ alert in HA setup.  Although the inactive HSI process does not accept connections, it is still running and should not trigger the alert.

https://issues.apache.org/jira/browse/AMBARI-25269

## How was this patch tested?

Tested on real cluster with Hive Server Interactive HA.  Verified that the alert is not triggered if both instances are running, but it is still triggered after stopping one of them.

Adjusted unit test.