### PR TITLE
[AMBARI-25270] Admin View build fails due to unavailable npm package ecstatic

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/package.json
+++ b/ambari-admin/src/main/resources/ui/admin-web/package.json
@@ -18,7 +18,7 @@
     "gulp-size": "0.3.0",
     "gulp-uglify": "0.2.1",
     "gulp-useref": "0.4.2",
-    "http-server": "0.6.1",
+    "http-server": ">=0.6.1",
     "karma": "0.12.16",
     "karma-chrome-launcher": "0.1.4",
     "karma-jasmine": "0.1.5",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build error:

```
[ERROR] npm ERR! notarget No compatible version found: ecstatic@'>=0.4.0 <0.5.0'
[ERROR] npm ERR! notarget Valid install targets:
[ERROR] npm ERR! notarget ["4.1.2"]
...
[ERROR] npm ERR! notarget It was specified as a dependency of 'http-server'
```

https://issues.apache.org/jira/browse/AMBARI-25270

## How was this patch tested?

Built `ambari-admin` locally, replaced on a cluster, restarted ambari-server, verified that Admin View works OK.