### PR TITLE
[AMBARI-25231] : Replace deprecated hadoop commands

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/providers/__init__.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/__init__.py
@@ -38,6 +38,7 @@ PROVIDERS = dict(
   ),
   default=dict(
     ExecuteHadoop="resource_management.libraries.providers.execute_hadoop.ExecuteHadoopProvider",
+    ExecuteHDFS="resource_management.libraries.providers.execute_hdfs.ExecuteHDFSProvider",
     TemplateConfig="resource_management.libraries.providers.template_config.TemplateConfigProvider",
     XmlConfig="resource_management.libraries.providers.xml_config.XmlConfigProvider",
     PropertiesFile="resource_management.libraries.providers.properties_file.PropertiesFileProvider",

--- a/ambari-common/src/main/python/resource_management/libraries/providers/execute_hdfs.py
+++ b/ambari-common/src/main/python/resource_management/libraries/providers/execute_hdfs.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Ambari Agent
+
+"""
+
+from resource_management.core.providers import Provider
+from resource_management.core.resources import Execute
+from resource_management.core.shell import quote_bash_args
+from resource_management.libraries.functions.format import format
+
+
+class ExecuteHDFSProvider(Provider):
+    def action_run(self):
+        conf_dir = self.resource.conf_dir
+        command = self.resource.command
+        if isinstance(command, (list, tuple)):
+            command = ' '.join(quote_bash_args(x) for x in command)
+        Execute(format("hdfs --config {conf_dir} {command}"),
+                user=self.resource.user,
+                tries=self.resource.tries,
+                try_sleep=self.resource.try_sleep,
+                logoutput=self.resource.logoutput,
+                path=self.resource.bin_dir,
+                environment=self.resource.environment,
+                )

--- a/ambari-common/src/main/python/resource_management/libraries/resources/execute_hdfs.py
+++ b/ambari-common/src/main/python/resource_management/libraries/resources/execute_hdfs.py
@@ -20,13 +20,18 @@ Ambari Agent
 
 """
 
-from resource_management.libraries.resources.execute_hadoop import *
-from resource_management.libraries.resources.execute_hdfs import *
-from resource_management.libraries.resources.template_config import *
-from resource_management.libraries.resources.xml_config import *
-from resource_management.libraries.resources.properties_file import *
-from resource_management.libraries.resources.repository import *
-from resource_management.libraries.resources.monitor_webserver import *
-from resource_management.libraries.resources.hdfs_resource import *
-from resource_management.libraries.resources.msi import *
-from resource_management.libraries.resources.modify_properties_file import *
+_all__ = ["ExecuteHDFS"]
+from resource_management.core.base import Resource, ForcedListArgument, ResourceArgument
+
+
+class ExecuteHDFS(Resource):
+    action = ForcedListArgument(default="run")
+    command = ResourceArgument(default=lambda obj: obj.name)
+    tries = ResourceArgument(default=1)
+    try_sleep = ResourceArgument(default=0)
+    user = ResourceArgument()
+    logoutput = ResourceArgument()
+    bin_dir = ResourceArgument(default=[])
+    environment = ResourceArgument(default={})
+    conf_dir = ResourceArgument()
+    actions = Resource.actions + ["run"]

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/hdfs_namenode.py
@@ -30,6 +30,7 @@ from resource_management.libraries.functions.decorator import retry
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.check_process_status import check_process_status
 from resource_management.libraries.resources.execute_hadoop import ExecuteHadoop
+from resource_management.libraries.resources.execute_hdfs import ExecuteHDFS
 from resource_management.libraries.functions import Direction
 from ambari_commons import OSCheck, OSConst
 from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl
@@ -462,10 +463,11 @@ def decommission():
       nn_refresh_cmd = format('dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
     else:
       nn_refresh_cmd = format('dfsadmin -fs {namenode_address} -refreshNodes')
-    ExecuteHadoop(nn_refresh_cmd,
-                  user=hdfs_user,
-                  conf_dir=conf_dir,
-                  bin_dir=params.hadoop_bin_dir)
+    ExecuteHDFS(nn_refresh_cmd,
+                user=hdfs_user,
+                conf_dir=conf_dir,
+                bin_dir=params.hadoop_bin_dir)
+
 
 @OsFamilyFuncImpl(os_family=OSConst.WINSRV_FAMILY)
 def decommission():
@@ -489,9 +491,9 @@ def decommission():
   if params.dfs_ha_enabled:
     # due to a bug in hdfs, refreshNodes will not run on both namenodes so we
     # need to execute each command scoped to a particular namenode
-    nn_refresh_cmd = format('cmd /c hadoop dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
+    nn_refresh_cmd = format('cmd /c hdfs dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
   else:
-    nn_refresh_cmd = format('cmd /c hadoop dfsadmin -fs {namenode_address} -refreshNodes')
+    nn_refresh_cmd = format('cmd /c hdfs dfsadmin -fs {namenode_address} -refreshNodes')
   Execute(nn_refresh_cmd, user=hdfs_user)
 
 

--- a/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/0.8/services/HDFS/package/scripts/hdfs_namenode.py
@@ -163,8 +163,8 @@ def decommission():
       nn_refresh_cmd = format('dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
     else:
       nn_refresh_cmd = format('dfsadmin -refreshNodes')
-    ExecuteHadoop(nn_refresh_cmd,
-                  user=hdfs_user,
-                  conf_dir=conf_dir,
-                  kinit_override=True,
-                  bin_dir=params.hadoop_bin_dir)
+    ExecuteHDFS(nn_refresh_cmd,
+                user=hdfs_user,
+                conf_dir=conf_dir,
+                kinit_override=True,
+                bin_dir=params.hadoop_bin_dir)

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.0/services/HDFS/package/scripts/hdfs_namenode.py
@@ -34,6 +34,7 @@ from resource_management.core.resources.service import Service
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.check_process_status import check_process_status
 from resource_management.libraries.resources.execute_hadoop import ExecuteHadoop
+from resource_management.libraries.resources.execute_hdfs import ExecuteHDFS
 from ambari_commons import OSCheck, OSConst
 from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl
 from utils import get_dfsadmin_base_command
@@ -393,11 +394,12 @@ def decommission():
       nn_refresh_cmd = format('dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
     else:
       nn_refresh_cmd = format('dfsadmin -refreshNodes')
-    ExecuteHadoop(nn_refresh_cmd,
-                  user=hdfs_user,
-                  conf_dir=conf_dir,
-                  kinit_override=True,
-                  bin_dir=params.hadoop_bin_dir)
+    ExecuteHDFS(nn_refresh_cmd,
+                user=hdfs_user,
+                conf_dir=conf_dir,
+                kinit_override=True,
+                bin_dir=params.hadoop_bin_dir)
+
 
 def bootstrap_standby_namenode(params):
   try:

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2.5/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2.5/services/HDFS/package/scripts/hdfs_namenode.py
@@ -28,6 +28,7 @@ from resource_management.libraries.functions.decorator import retry
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.check_process_status import check_process_status
 from resource_management.libraries.resources.execute_hadoop import ExecuteHadoop
+from resource_management.libraries.resources.execute_hdfs import ExecuteHDFS
 from resource_management.libraries.functions import Direction
 from ambari_commons import OSCheck, OSConst
 from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl
@@ -431,10 +432,11 @@ def decommission():
       nn_refresh_cmd = format('dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
     else:
       nn_refresh_cmd = format('dfsadmin -fs {namenode_address} -refreshNodes')
-    ExecuteHadoop(nn_refresh_cmd,
-                  user=hdfs_user,
-                  conf_dir=conf_dir,
-                  bin_dir=params.hadoop_bin_dir)
+    ExecuteHDFS(nn_refresh_cmd,
+                user=hdfs_user,
+                conf_dir=conf_dir,
+                bin_dir=params.hadoop_bin_dir)
+
 
 @OsFamilyFuncImpl(os_family=OSConst.WINSRV_FAMILY)
 def decommission():
@@ -450,9 +452,9 @@ def decommission():
   if params.dfs_ha_enabled:
     # due to a bug in hdfs, refreshNodes will not run on both namenodes so we
     # need to execute each command scoped to a particular namenode
-    nn_refresh_cmd = format('cmd /c hadoop dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
+    nn_refresh_cmd = format('cmd /c hdfs dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
   else:
-    nn_refresh_cmd = format('cmd /c hadoop dfsadmin -fs {namenode_address} -refreshNodes')
+    nn_refresh_cmd = format('cmd /c hdfs dfsadmin -fs {namenode_address} -refreshNodes')
   Execute(nn_refresh_cmd, user=hdfs_user)
 
 

--- a/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/HDFS/package/scripts/hdfs_namenode.py
+++ b/ambari-server/src/main/resources/stacks/BigInsights/4.2/services/HDFS/package/scripts/hdfs_namenode.py
@@ -34,6 +34,7 @@ from resource_management.core.resources.service import Service
 from resource_management.libraries.functions.format import format
 from resource_management.libraries.functions.check_process_status import check_process_status
 from resource_management.libraries.resources.execute_hadoop import ExecuteHadoop
+from resource_management.libraries.resources.execute_hdfs import ExecuteHDFS
 from ambari_commons import OSCheck, OSConst
 from ambari_commons.os_family_impl import OsFamilyImpl, OsFamilyFuncImpl
 from utils import get_dfsadmin_base_command
@@ -387,11 +388,12 @@ def decommission():
       nn_refresh_cmd = format('dfsadmin -fs hdfs://{namenode_rpc} -refreshNodes')
     else:
       nn_refresh_cmd = format('dfsadmin -fs {namenode_address} -refreshNodes')
-    ExecuteHadoop(nn_refresh_cmd,
-                  user=hdfs_user,
-                  conf_dir=conf_dir,
-                  kinit_override=True,
-                  bin_dir=params.hadoop_bin_dir)
+    ExecuteHDFS(nn_refresh_cmd,
+                user=hdfs_user,
+                conf_dir=conf_dir,
+                kinit_override=True,
+                bin_dir=params.hadoop_bin_dir)
+
 
 def bootstrap_standby_namenode(params, use_path=False):
 

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1037,7 +1037,7 @@ class TestNamenode(RMFTestCase):
                               group = 'hadoop',
                               )
     self.assertResourceCalled('Execute', '', user = 'hdfs')
-    self.assertResourceCalled('ExecuteHadoop', 'dfsadmin -fs hdfs://c6401.ambari.apache.org:8020 -refreshNodes',
+    self.assertResourceCalled('ExecuteHDFS', 'dfsadmin -fs hdfs://c6401.ambari.apache.org:8020 -refreshNodes',
                               user = 'hdfs',
                               conf_dir = '/etc/hadoop/conf',
                               bin_dir = '/usr/bin')
@@ -1073,7 +1073,7 @@ class TestNamenode(RMFTestCase):
                               group = 'hadoop',
                               )
     self.assertResourceCalled('Execute', '', user = 'hdfs')
-    self.assertResourceCalled('ExecuteHadoop', 'dfsadmin -fs hdfs://c6401.ambari.apache.org:8020 -refreshNodes',
+    self.assertResourceCalled('ExecuteHDFS', 'dfsadmin -fs hdfs://c6401.ambari.apache.org:8020 -refreshNodes',
                               user = 'hdfs',
                               conf_dir = '/etc/hadoop/conf',
                               bin_dir = '/usr/bin')
@@ -1096,7 +1096,7 @@ class TestNamenode(RMFTestCase):
     self.assertResourceCalled('Execute', '/usr/bin/kinit -kt /etc/security/keytabs/nn.service.keytab nn/c6401.ambari.apache.org@EXAMPLE.COM;',
         user = 'hdfs',
     )
-    self.assertResourceCalled('ExecuteHadoop', 'dfsadmin -fs hdfs://c6401.ambari.apache.org:8020 -refreshNodes',
+    self.assertResourceCalled('ExecuteHDFS', 'dfsadmin -fs hdfs://c6401.ambari.apache.org:8020 -refreshNodes',
         bin_dir = '/usr/bin',
         conf_dir = '/etc/hadoop/conf',
         user = 'hdfs',


### PR DESCRIPTION
## What changes were proposed in this pull request?
hadoop refreshNodes command is deprecated and it is recommended to start using hdfs command for refreshNodes.

## How was this patch tested?
The patch was tested manually. While decommissiong/recommissioning of datanode, refreshNodes command is run on all NameNodes. This was tested with UI. All changes are covered with Unit Tests as well.

<img width="984" alt="Screen Shot 2019-05-05 at 11 31 35 PM" src="https://user-images.githubusercontent.com/34790606/57198359-5cd54d00-6f8f-11e9-8da6-bc470f1e3bfc.png">
