### PR TITLE
AMBARI-25273. Ambari-server 2.7.3 uninstall removes ambari-python-wrap even when agent is still installed (amagyar)

### DIFF
--- a/ambari-server/conf/unix/install-helper.sh
+++ b/ambari-server/conf/unix/install-helper.sh
@@ -29,7 +29,7 @@ OLD_PYLIB_PATH="${ROOT}/usr/lib/python2.6/site-packages"
 OLD_PY_MODULES="ambari_commons;resource_management;ambari_jinja2;ambari_simplejson;ambari_server"
 
 AMBARI_SERVER_ROOT_DIR="${ROOT}/usr/lib/${AMBARI_UNIT}"
-AMBARI_AGENT_ROOT_DIR=="${ROOT}/usr/lib/ambari-agent"
+AMBARI_AGENT_ROOT_DIR="${ROOT}/usr/lib/ambari-agent"
 AMBARI_SERVER="${AMBARI_SERVER_ROOT_DIR}/lib/ambari_server"
 
 CA_CONFIG="${ROOT}/var/lib/${AMBARI_UNIT}/keys/ca.config"


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a erroneous equal sign in the following expression:

```bash
AMBARI_AGENT_ROOT_DIR=="${ROOT}/usr/lib/ambari-agent"
```

in /var/lib/ambari-server/install-helper.sh. The double equal sign causes the AMBARI_AGENT_ROOT_DIR to be evaluated to "=/usr/lib/ambari-agent" (note the leading =).

## How was this patch tested?

```bash
[root@c7401 vagrant]# yum remove ambari-server
[root@c7401 vagrant]# ls -al /usr/bin/ambari-python-wrap
lrwxrwxrwx. 1 root root 15 May  6 08:31 /usr/bin/ambari-python-wrap -> /usr/bin/python
```
