### PR TITLE
AMBARI-24908 OneFS mpack should have dfs.webhdfs.enabled = true (#2624)

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/configuration/hdfs-site.xml
@@ -19,6 +19,13 @@
 <!-- Put site-specific property overrides in this file. -->
 <configuration supports_final="true">
   <property>
+    <name>dfs.webhdfs.enabled</name>
+    <value>true</value>
+    <display-name>WebHDFS enabled</display-name>
+    <description>Whether to enable WebHDFS feature</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>dfs.namenode.http-address</name>
     <value>localhost:8082</value>
     <description>The name of the default file system.  Either the


### PR DESCRIPTION
clone of #2624 

## How was this patch tested?

Manually re-tested by building and deploying mpack. 

@zeroflag please review