### PR TITLE
AMBARI-24950 - Logsearch: use os timezone in Logfeeder

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/loglevelfilter/LogLevelFilterHandler.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/loglevelfilter/LogLevelFilterHandler.java
@@ -18,7 +18,17 @@
  */
 package org.apache.ambari.logfeeder.loglevelfilter;
 
-import com.google.gson.Gson;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 import org.apache.ambari.logfeeder.common.LogFeederConstants;
 import org.apache.ambari.logfeeder.conf.LogFeederProps;
 import org.apache.ambari.logfeeder.plugin.input.InputMarker;
@@ -37,32 +47,16 @@ import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
+import com.google.gson.Gson;
 
 public class LogLevelFilterHandler implements LogLevelFilterMonitor {
   private static final Logger LOG = LoggerFactory.getLogger(LogLevelFilterHandler.class);
 
-  private static final String TIMEZONE = "GMT";
   private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
   private static final boolean DEFAULT_VALUE = true;
 
-  private static ThreadLocal<DateFormat> formatter = new ThreadLocal<DateFormat>() {
-    protected DateFormat initialValue() {
-      SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
-      dateFormat.setTimeZone(TimeZone.getTimeZone(TIMEZONE));
-      return dateFormat;
-    }
-  };
+  private static ThreadLocal<DateFormat> formatter = ThreadLocal.withInitial(() -> new SimpleDateFormat(DATE_FORMAT));
 
   @Inject
   private LogFeederProps logFeederProps;
@@ -80,7 +74,6 @@ public class LogLevelFilterHandler implements LogLevelFilterMonitor {
 
   @PostConstruct
   public void init() throws Exception {
-    TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE));
     if (logFeederProps.isZkFilterStorage() && logFeederProps.isUseLocalConfigs()) {
       LogLevelFilterManagerZK filterManager = (LogLevelFilterManagerZK) config.getLogLevelFilterManager();
       CuratorFramework client = filterManager.getClient();


### PR DESCRIPTION
# What changes were proposed in this pull request?

cherry picked a part of https://github.com/apache/ambari-logsearch/pull/41

Logfeeder sets the default timezone to GMT at start up. Most service logs' logtime are in os timezone. If os timezone is set to other than UTC Logfeeder does not convert the logtime values to UTC when sending the log entry to Solr and Logsearch portal shows invalid log time values.
Fix: 
Remove explicitly set the default time zone to GMT. This case the default time zone going to be the os time zone
Or it can be overridden by JVM option.


## How was this patch tested?

Manually:
1. Deploy Ambari and a cluster: Zookeeper, Infra-Solr, Logsearch
2. Set the time zone en each node to America/Chicago: 
```timedatectl set-timezone America/Chicago```
3. Restart Amabari server/agents and all services
4. Check Ambari server log and notice that the log time values are at the new time zone in the end of the logfile while the values in the beginning are in UTC
```
grep 'State of service component' /var/log/ambari-server/ambari-server.log
2018-11-23 15:04:53,058  INFO [agent-report-processor-0] HeartbeatProcessor:647 - State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report
2018-11-23 15:05:19,535  INFO [agent-report-processor-0] HeartbeatProcessor:647 - State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report
2018-11-23 09:18:35,669  INFO [agent-report-processor-0] HeartbeatProcessor:647 - State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7401.ambari.apache.org according to STATUS_COMMAND report
2018-11-23 09:18:42,652  INFO [agent-report-processor-1] HeartbeatProcessor:647 - State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7402.ambari.apache.org according to STATUS_COMMAND report
```
5. Check that all ambari server log entries logtime is converted to UTC in Solr
```
{
        "log_message":"State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report",
        "id":"606519d6-a315-4553-8f49-dda2eba7437f",
        "logtime":"2018-11-23T15:04:53.058Z"},
      {
        "log_message":"State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report",
        "id":"97760f62-ec8b-447f-92e4-b49f616ed897",
        "logtime":"2018-11-23T15:05:19.535Z"},
      {
        "log_message":"State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7401.ambari.apache.org according to STATUS_COMMAND report",
        "id":"19aefe4f-ab22-43b5-a952-4bd355a0f6b3",
        "logtime":"2018-11-23T15:18:35.669Z"},
      {
        "log_message":"State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7402.ambari.apache.org according to STATUS_COMMAND report",
        "id":"3601f700-7272-4c38-bd7d-5d89552bdcc2",
        "logtime":"2018-11-23T15:18:42.652Z"},
```
6. Check that the logtime values are converted to the specified timezone on Logsearch portal