### PR TITLE
AMBARI-25274. Discard and Save buttons are always active in HIVE service configs

### DIFF
--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -329,7 +329,7 @@ App.config = Em.Object.create({
       value: '',
       savedValue: null,
       isFinal: false,
-      savedIsFinal: null,
+      savedIsFinal: false,
       /** UI and Stack properties **/
       recommendedValue: null,
       recommendedIsFinal: null,
@@ -1195,7 +1195,7 @@ App.config = Em.Object.create({
 
     var newOverride = App.ServiceConfigProperty.create(serviceConfigProperty);
 
-    newOverride.setProperties({ 'savedValue': null, 'savedIsFinal': null });
+    newOverride.setProperties({ 'savedValue': null, 'savedIsFinal': false });
 
     if (!Em.isNone(override)) {
       for (var key in override) {

--- a/ambari-web/test/utils/config_test.js
+++ b/ambari-web/test/utils/config_test.js
@@ -442,7 +442,7 @@ describe('App.config', function () {
       savedValue: "sv1",
       isFinal: true,
       recommendedIsFinal: false,
-      savedIsFinal: true
+      savedIsFinal: false
     };
 
     var configProperty = App.ServiceConfigProperty.create(template);
@@ -452,7 +452,7 @@ describe('App.config', function () {
     Object.keys(template).forEach(function (key) {
       it(key, function () {
         var override = App.config.createOverride(configProperty, {}, group);
-        if (['savedValue', 'savedIsFinal'].contains(key)) {
+        if (['savedValue'].contains(key)) {
           expect(override.get(key)).to.equal(null);
         } else {
           expect(override.get(key)).to.equal(template[key]);
@@ -734,7 +734,7 @@ describe('App.config', function () {
       value: '',
       savedValue: null,
       isFinal: false,
-      savedIsFinal: null,
+      savedIsFinal: false,
       /** UI and Stack properties **/
       recommendedValue: null,
       recommendedIsFinal: null,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Discard and Save buttons are always active in HIVE service configs

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.