### PR TITLE
[AMBARI-25220] : NameNode to provide rack topology

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/metainfo.xml
@@ -121,6 +121,13 @@
                 <scriptType>PYTHON</scriptType>
               </commandScript>
             </customCommand>
+            <customCommand>
+              <name>PRINT_TOPOLOGY</name>
+              <commandScript>
+                <script>scripts/namenode.py</script>
+                <scriptType>PYTHON</scriptType>
+              </commandScript>
+            </customCommand>
           </customCommands>
         </component>
 

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -172,7 +172,7 @@ class NameNode(Script):
   def print_topology(self, env):
     import params
     env.set_params(params)
-    Execute(format("hdfs dfsadmin -printTopology"),
+    Execute("hdfs dfsadmin -printTopology",
             user=params.hdfs_user,
             path=[params.hadoop_bin_dir],
             logoutput=True

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -169,6 +169,16 @@ class NameNode(Script):
     hdfs_binary = self.get_hdfs_binary()
     namenode(action="decommission", hdfs_binary=hdfs_binary)
 
+  def print_topology(self, env):
+    import params
+    env.set_params(params)
+    Execute(format("hdfs dfsadmin -printTopology"),
+            user=params.hdfs_user,
+            path=[params.hadoop_bin_dir],
+            logoutput=True
+            )
+
+
 @OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
 class NameNodeDefault(NameNode):
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
NameNode should provide an option to print rack based topology of datanodes.

## How was this patch tested?
The patch was tested manually.

<img width="243" alt="Screen Shot 2019-05-12 at 9 55 35 PM" src="https://user-images.githubusercontent.com/34790606/57585497-97e2fd80-7506-11e9-8caa-9e7cbe5d2824.png">
