### PR TITLE
[AMBARI-25220] : NameNode to provide rack topology

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/metainfo.xml
@@ -63,6 +63,13 @@
                 <scriptType>PYTHON</scriptType>
               </commandScript>
             </customCommand>
+            <customCommand>
+              <name>PRINT_TOPOLOGY</name>
+              <commandScript>
+                <script>scripts/namenode.py</script>
+                <scriptType>PYTHON</scriptType>
+              </commandScript>
+            </customCommand>
           </customCommands>
         </component>
 

--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -118,6 +118,16 @@ class NameNode(Script):
     hdfs_binary = self.get_hdfs_binary()
     namenode(action="decommission", hdfs_binary=hdfs_binary)
 
+  def print_topology(self, env):
+    import params
+    env.set_params(params)
+    Execute("hdfs dfsadmin -printTopology",
+            user=params.hdfs_user,
+            path=[params.hadoop_bin_dir],
+            logoutput=True
+            )
+
+
 @OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
 class NameNodeDefault(NameNode):
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
NameNode should provide an option to print rack based topology of datanodes.

## How was this patch tested?
The patch was tested manually. This is backport change to branch-2.6 from: https://github.com/apache/ambari/pull/2970

<img width="243" alt="Screen Shot 2019-05-12 at 9 55 35 PM" src="https://user-images.githubusercontent.com/34790606/57585733-b3033c80-7509-11e9-8fc9-1b399035c5e9.png">
<img width="986" alt="Screen Shot 2019-05-12 at 10 26 03 PM" src="https://user-images.githubusercontent.com/34790606/57585737-b3033c80-7509-11e9-81a3-5f548a9d132a.png">
