### PR TITLE
AMBARI-25275 - Changes in Yarn Capacity Scheduler is requesting for restart of Resource Manager

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queues.js
+++ b/contrib/views/capacity-scheduler/src/main/resources/ui/app/controllers/queues.js
@@ -267,6 +267,11 @@ App.QueuesController = Ember.ArrayController.extend({
    * @type {Boolean}
    */
   hasDeletedQueues: Em.computed.alias('store.hasDeletedQueues'),
+  /**
+   * !hasDeletedQueues
+   * @type {Boolean}
+   */
+  doesNotHaveDeletedQueues: Em.computed.not('store.hasDeletedQueues'),
 
 
 
@@ -331,7 +336,13 @@ App.QueuesController = Ember.ArrayController.extend({
    * check there is some changes for save
    * @type {bool}
    */
-  needSave: cmp.any('needRestart', 'needRefresh'),
+  needRestartOrRefresh: cmp.any('needRestart', 'needRefresh'),
+  /**
+   * check there is some changes for save and no deleted queues
+   * queue deletion requires Yarn Resource Manager restart
+   * @type {bool}
+   */
+  needSave: cmp.and('needRestartOrRefresh', 'doesNotHaveDeletedQueues'),
 
   /**
    * check if can save configs


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the modification of queues in the configs of Capacity Scheduler either via configs tab in Ambari or using YARN Queue Manager view Ambari asks for restart of Resource manager.
This is only required if a queue was deleted. 

fix.: On the YARN Queue Manager view the "Save Only" menu item is enabled only if any change was not saved on the view and there are no unsaved deleted queues.

## How was this patch tested?

1. Deploy Ambari and a cluster: HDFS, ZOOKEEPER, YARN
2. Go to  YARN Queue Manager view by clicking Manage Ambari -> Views -> Capacity Scheduler
3. Add a queue and save it.
4. Delete the queue.
5. Click actions -> the drop down menu appears and the "Save Only" menu item should be disabled 