### PR TITLE
AMBARI-25279 Move Ambari from using jackson-databind-asl and jackson-core-asl (v1) to latest jackson v2 (dgrinenko)

### DIFF
--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -402,21 +402,20 @@
       <artifactId>jersey-guice</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.2</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.jersey-test-framework</groupId>

--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -74,14 +74,12 @@
       <version>${solr.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/logconfig/LogFeederFilter.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/logconfig/LogFeederFilter.java
@@ -25,11 +25,11 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.codehaus.jackson.annotate.JsonAutoDetect;
-import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-@JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/logconfig/LogFeederFilterWrapper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/logconfig/LogFeederFilterWrapper.java
@@ -24,11 +24,11 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.codehaus.jackson.annotate.JsonAutoDetect;
-import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-@JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/FileUtil.java
@@ -34,10 +34,11 @@ import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.DirectoryScanner;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class FileUtil {
   private static final Logger LOG = LoggerFactory.getLogger(FileUtil.class);

--- a/ambari-logsearch/ambari-logsearch-portal/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-portal/pom.xml
@@ -811,5 +811,14 @@
       <artifactId>commons-configuration</artifactId>
       <version>1.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-base</artifactId>
+      <version>2.9.8</version>
+    </dependency>
   </dependencies>
 </project>

--- a/ambari-logsearch/ambari-logsearch-solr-client/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-solr-client/pom.xml
@@ -47,10 +47,6 @@
       <version>1.3.1</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/ambari-logsearch/ambari-logsearch-solr-client/src/main/java/org/apache/ambari/logsearch/solr/commands/AbstractStateFileZkCommand.java
+++ b/ambari-logsearch/ambari-logsearch-solr-client/src/main/java/org/apache/ambari/logsearch/solr/commands/AbstractStateFileZkCommand.java
@@ -20,8 +20,9 @@ package org.apache.ambari.logsearch.solr.commands;
 
 import org.apache.ambari.logsearch.solr.AmbariSolrCloudClient;
 import org.apache.ambari.logsearch.solr.domain.AmbariSolrState;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public abstract class AbstractStateFileZkCommand extends AbstractZookeeperRetryCommand<AmbariSolrState>{
 

--- a/ambari-logsearch/ambari-logsearch-solr-client/src/main/java/org/apache/ambari/logsearch/solr/commands/UpdateStateFileZkCommand.java
+++ b/ambari-logsearch/ambari-logsearch-solr-client/src/main/java/org/apache/ambari/logsearch/solr/commands/UpdateStateFileZkCommand.java
@@ -23,13 +23,14 @@ import org.apache.ambari.logsearch.solr.domain.AmbariSolrState;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.SolrZooKeeper;
 import org.apache.zookeeper.CreateMode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class UpdateStateFileZkCommand extends AbstractStateFileZkCommand {
 

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -242,6 +242,11 @@
        <artifactId>curator-recipes</artifactId>
        <version>2.12.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-base</artifactId>
+      <version>2.9.8</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -366,29 +366,9 @@
         <version>1.19</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-core-asl</artifactId>
-        <version>1.9.9</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-jaxrs</artifactId>
-        <version>1.9.9</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-xc</artifactId>
-        <version>1.9.9</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mappper</artifactId>
-        <version>1.9.9</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>1.9.13</version>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.sun.grizzly</groupId>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1315,21 +1315,20 @@
       <artifactId>jersey-guice</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.2</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.jersey-test-framework</groupId>
@@ -1553,7 +1552,7 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
-         <exclusion>
+        <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
         </exclusion>

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/AgentEnv.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/AgentEnv.java
@@ -18,8 +18,6 @@
 package org.apache.ambari.server.agent;
 
 import com.google.gson.annotations.SerializedName;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 /**
  * Agent environment data.

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandReport.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/CommandReport.java
@@ -19,8 +19,7 @@ package org.apache.ambari.server.agent;
 
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CommandReport {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ComponentRecoveryReport.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ComponentRecoveryReport.java
@@ -17,8 +17,7 @@
  */
 package org.apache.ambari.server.agent;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ComponentRecoveryReport {
   private String name;

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/ComponentsResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/ComponentsResponse.java
@@ -20,7 +20,7 @@ package org.apache.ambari.server.agent;
 
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ComponentsResponse {
 	@JsonProperty("clusterName")

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/DiskInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/DiskInfo.java
@@ -18,8 +18,7 @@
 
 package org.apache.ambari.server.agent;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Information about a mounted disk on a given node

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeat.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HeartBeat.java
@@ -22,7 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.ambari.server.state.Alert;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  *

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HostInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HostInfo.java
@@ -21,7 +21,7 @@ package org.apache.ambari.server.agent;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  *

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/HostStatus.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/HostStatus.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ambari.server.agent;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Status of the host as described by the agent.

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/RecoveryReport.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/RecoveryReport.java
@@ -17,11 +17,11 @@
  */
 package org.apache.ambari.server.agent;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 public class RecoveryReport {

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/Register.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/Register.java
@@ -18,7 +18,7 @@
 
 package org.apache.ambari.server.agent;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  *

--- a/ambari-server/src/main/java/org/apache/ambari/server/agent/RegistrationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/agent/RegistrationResponse.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  *

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertStateSummary.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertStateSummary.java
@@ -18,7 +18,8 @@
 package org.apache.ambari.server.api.query.render;
 
 import org.apache.ambari.server.state.AlertState;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The {@link AlertStateSummary} class holds information about each possible

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertStateValues.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertStateValues.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ambari.server.api.query.render;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * The {@link AlertStateValues} class holds various information about an alert

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertSummaryGroupedRenderer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/query/render/AlertSummaryGroupedRenderer.java
@@ -33,7 +33,8 @@ import org.apache.ambari.server.controller.internal.ResourceImpl;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.state.AlertState;
 import org.apache.ambari.server.state.MaintenanceState;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The {@link AlertSummaryGroupedRenderer} is used to format the results of

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/parsers/JsonRequestBodyParser.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/parsers/JsonRequestBodyParser.java
@@ -31,10 +31,11 @@ import java.util.Set;
 import org.apache.ambari.server.api.services.NamedPropertySet;
 import org.apache.ambari.server.api.services.RequestBody;
 import org.apache.ambari.server.controller.utilities.PropertyHelper;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * JSON parser which parses a JSON string into a map of properties and values.
@@ -57,7 +58,7 @@ public class JsonRequestBodyParser implements RequestBodyParser {
       try {
         JsonNode root = mapper.readTree(ensureArrayFormat(body));
 
-        Iterator<JsonNode> iterator = root.getElements();
+        Iterator<JsonNode> iterator = root.elements();
         while (iterator.hasNext()) {
           JsonNode            node             = iterator.next();
           Map<String, Object> mapProperties    = new HashMap<String, Object>();
@@ -112,13 +113,13 @@ public class JsonRequestBodyParser implements RequestBodyParser {
   private void processNode(JsonNode node, String path, NamedPropertySet propertySet,
                            Map<String, String> requestInfoProps) {
 
-    Iterator<String> iterator = node.getFieldNames();
+    Iterator<String> iterator = node.fieldNames();
     while (iterator.hasNext()) {
       String   name  = iterator.next();
       JsonNode child = node.get(name);
       if (child.isArray()) {
         //array
-        Iterator<JsonNode>       arrayIter = child.getElements();
+        Iterator<JsonNode>       arrayIter = child.elements();
         Set<Map<String, Object>> arraySet  = new LinkedHashSet<Map<String, Object>>();
         List<String> primitives = new ArrayList<String>();
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/serializers/JsonSerializer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/serializers/JsonSerializer.java
@@ -18,22 +18,26 @@
 
 package org.apache.ambari.server.api.services.serializers;
 
-import org.apache.ambari.server.api.services.DeleteResultMetadata;
-import org.apache.ambari.server.api.services.ResultMetadata;
-import org.apache.ambari.server.api.services.ResultStatus;
-import org.apache.ambari.server.api.services.Result;
-import org.apache.ambari.server.api.util.TreeNodeImpl;
-import org.apache.ambari.server.controller.spi.Resource;
-import org.apache.ambari.server.api.util.TreeNode;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.util.DefaultPrettyPrinter;
-
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.apache.ambari.server.api.services.DeleteResultMetadata;
+import org.apache.ambari.server.api.services.Result;
+import org.apache.ambari.server.api.services.ResultMetadata;
+import org.apache.ambari.server.api.services.ResultStatus;
+import org.apache.ambari.server.api.util.TreeNode;
+import org.apache.ambari.server.api.util.TreeNodeImpl;
+import org.apache.ambari.server.controller.spi.Resource;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * JSON serializer.
@@ -97,7 +101,7 @@ public class JsonSerializer implements ResultSerializer {
     m_generator = createJsonGenerator(bytesOut);
 
     DefaultPrettyPrinter p = new DefaultPrettyPrinter();
-    p.indentArraysWith(new DefaultPrettyPrinter.Lf2SpacesIndenter());
+    p.indentArraysWith(new DefaultIndenter());
     m_generator.setPrettyPrinter(p);
 
     return bytesOut;
@@ -248,7 +252,7 @@ public class JsonSerializer implements ResultSerializer {
         Charset.forName("UTF-8").newEncoder()));
 
     DefaultPrettyPrinter p = new DefaultPrettyPrinter();
-    p.indentArraysWith(new DefaultPrettyPrinter.Lf2SpacesIndenter());
+    p.indentArraysWith(new DefaultIndenter());
     generator.setPrettyPrinter(p);
 
     return generator;

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorResponse.java
@@ -18,7 +18,7 @@
 
 package org.apache.ambari.server.api.services.stackadvisor;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Abstract stack advisor response POJO.

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommand.java
@@ -53,12 +53,14 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
-import org.codehaus.jackson.node.TextNode;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 /**
  * Parent for all commands.
@@ -116,7 +118,7 @@ public abstract class StackAdvisorCommand<T extends StackAdvisorResponse> extend
         .getActualTypeArguments()[0];
 
     this.mapper = new ObjectMapper();
-    this.mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
+    this.mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
 
     this.recommendationsDir = recommendationsDir;
     this.recommendationsArtifactsLifetime = recommendationsArtifactsLifetime;
@@ -232,17 +234,17 @@ public abstract class StackAdvisorCommand<T extends StackAdvisorResponse> extend
 
   private void populateComponentHostsMap(ObjectNode root, Map<String, Set<String>> componentHostsMap) {
     ArrayNode services = (ArrayNode) root.get(SERVICES_PROPERTY);
-    Iterator<JsonNode> servicesIter = services.getElements();
+    Iterator<JsonNode> servicesIter = services.elements();
 
     while (servicesIter.hasNext()) {
       JsonNode service = servicesIter.next();
       ArrayNode components = (ArrayNode) service.get(SERVICES_COMPONENTS_PROPERTY);
-      Iterator<JsonNode> componentsIter = components.getElements();
+      Iterator<JsonNode> componentsIter = components.elements();
 
       while (componentsIter.hasNext()) {
         JsonNode component = componentsIter.next();
         ObjectNode componentInfo = (ObjectNode) component.get(COMPONENT_INFO_PROPERTY);
-        String componentName = componentInfo.get(COMPONENT_NAME_PROPERTY).getTextValue();
+        String componentName = componentInfo.get(COMPONENT_NAME_PROPERTY).textValue();
 
         Set<String> componentHosts = componentHostsMap.get(componentName);
         ArrayNode hostnames = componentInfo.putArray(COMPONENT_HOSTNAMES_PROPERTY);
@@ -257,7 +259,7 @@ public abstract class StackAdvisorCommand<T extends StackAdvisorResponse> extend
 
   private void populateServiceAdvisors(ObjectNode root) {
     ArrayNode services = (ArrayNode) root.get(SERVICES_PROPERTY);
-    Iterator<JsonNode> servicesIter = services.getElements();
+    Iterator<JsonNode> servicesIter = services.elements();
 
     ObjectNode version = (ObjectNode) root.get("Versions");
     String stackName = version.get("stack_name").asText();
@@ -266,7 +268,7 @@ public abstract class StackAdvisorCommand<T extends StackAdvisorResponse> extend
     while (servicesIter.hasNext()) {
       JsonNode service = servicesIter.next();
       ObjectNode serviceVersion = (ObjectNode) service.get(STACK_SERVICES_PROPERTY);
-      String serviceName = serviceVersion.get("service_name").getTextValue();
+      String serviceName = serviceVersion.get("service_name").textValue();
       try {
         ServiceInfo serviceInfo = metaInfo.getService(stackName, stackVersion, serviceName);
         if (serviceInfo.getAdvisorFile() != null) {
@@ -398,10 +400,10 @@ public abstract class StackAdvisorCommand<T extends StackAdvisorResponse> extend
 
     try {
       JsonNode root = mapper.readTree(hostsJSON);
-      Iterator<JsonNode> iterator = root.get("items").getElements();
+      Iterator<JsonNode> iterator = root.get("items").elements();
       while (iterator.hasNext()) {
         JsonNode next = iterator.next();
-        String hostName = next.get("Hosts").get("host_name").getTextValue();
+        String hostName = next.get("Hosts").get("host_name").textValue();
         registeredHosts.add(hostName);
       }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/recommendations/RecommendationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/recommendations/RecommendationResponse.java
@@ -25,8 +25,9 @@ import java.util.Set;
 
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorResponse;
 import org.apache.ambari.server.state.ValueAttributesInfo;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Recommendation response POJO.

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/validations/ValidationResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/validations/ValidationResponse.java
@@ -21,7 +21,8 @@ package org.apache.ambari.server.api.services.stackadvisor.validations;
 import java.util.Set;
 
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorResponse;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Validation response POJO.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AlertDefinitionResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AlertDefinitionResponse.java
@@ -19,7 +19,8 @@ package org.apache.ambari.server.controller;
 
 import org.apache.ambari.server.orm.entities.AlertDefinitionEntity;
 import org.apache.ambari.server.state.alert.SourceType;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceConfigVersionResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ServiceConfigVersionResponse.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.controller;
 
 
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.ambari.server.StaticallyInject;
 import org.apache.ambari.server.orm.dao.HostDAO;
@@ -30,9 +29,9 @@ import org.apache.ambari.server.orm.entities.StackEntity;
 import org.apache.ambari.server.state.StackId;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.inject.Inject;
 
 @StaticallyInject

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/WidgetResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/WidgetResponse.java
@@ -18,7 +18,8 @@
 package org.apache.ambari.server.controller;
 
 import org.apache.ambari.server.orm.entities.WidgetEntity;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestResourceFilter.java
@@ -17,11 +17,11 @@
  */
 package org.apache.ambari.server.controller.internal;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class RequestResourceFilter {
   private String serviceName;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/TaskResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/TaskResourceProvider.java
@@ -43,8 +43,8 @@ import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
 import org.apache.ambari.server.orm.entities.HostRoleCommandEntity;
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.ambari.server.topology.TopologyManager;
-import org.codehaus.jackson.map.ObjectMapper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UpgradeResourceProvider.java
@@ -103,10 +103,10 @@ import org.apache.ambari.server.state.svccomphost.ServiceComponentHostServerActi
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.JsonArray;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/VersionDefinitionResourceProvider.java
@@ -71,10 +71,10 @@ import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.JsonNodeFactory;
-import org.codehaus.jackson.node.ObjectNode;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ListMultimap;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/HostComponentLoggingInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/HostComponentLoggingInfo.java
@@ -18,10 +18,9 @@
 
 package org.apache.ambari.server.controller.logging;
 
-
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class HostComponentLoggingInfo {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogFileDefinitionInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogFileDefinitionInfo.java
@@ -18,8 +18,7 @@
 
 package org.apache.ambari.server.controller.logging;
 
-
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class LogFileDefinitionInfo {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogLevelQueryResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogLevelQueryResponse.java
@@ -17,10 +17,10 @@
  */
 package org.apache.ambari.server.controller.logging;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LogLevelQueryResponse {

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogLineResult.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogLineResult.java
@@ -18,11 +18,11 @@
 
 package org.apache.ambari.server.controller.logging;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * This class represents a single entry from a LogSearch query.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogQueryResponse.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LogQueryResponse.java
@@ -18,12 +18,10 @@
 
 package org.apache.ambari.server.controller.logging;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.util.JSONPObject;
-
-import java.util.LinkedList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * This class respresents the results of a LogSearch query, as returned by

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/LoggingRequestHelperImpl.java
@@ -55,13 +55,14 @@ import org.apache.ambari.server.state.Config;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 /**
  * Convenience class to handle the connection details of a LogSearch query request.
@@ -430,7 +431,8 @@ public class LoggingRequestHelperImpl implements LoggingRequestHelper {
     AnnotationIntrospector introspector =
       new JacksonAnnotationIntrospector();
     mapper.setAnnotationIntrospector(introspector);
-    mapper.getSerializationConfig().setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+    mapper.getSerializationConfig()
+        .withPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
     return mapper;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/NameValuePair.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/logging/NameValuePair.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ambari.server.controller.logging;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class NameValuePair {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaMetric.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaMetric.java
@@ -22,7 +22,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaReportPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/ganglia/GangliaReportPropertyProvider.java
@@ -28,8 +28,6 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.SystemException;
 import org.apache.ambari.server.controller.spi.TemporalInfo;
 import org.apache.ambari.server.controller.utilities.StreamProvider;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
@@ -39,6 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import static org.apache.ambari.server.controller.metrics.MetricsServiceProvider.MetricsService.GANGLIA;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Property provider implementation for a Ganglia source. This provider is specialized

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/MetricsRequestHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/timeline/MetricsRequestHelper.java
@@ -24,11 +24,6 @@ import org.apache.http.NameValuePair;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.apache.http.client.utils.URIBuilder;
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +41,12 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+
 /**
  * Helper class to call AMS backend that is utilized by @AMSPropertyProvider
  * and @AMSReportPropertyProvider as well as @TimelineMetricCacheEntryFactory
@@ -57,11 +58,12 @@ public class MetricsRequestHelper {
   private final URLStreamProvider streamProvider;
 
   static {
-    mapper = new ObjectMapper();
+    mapper = new com.fasterxml.jackson.databind.ObjectMapper();
     AnnotationIntrospector introspector = new JaxbAnnotationIntrospector();
     mapper.setAnnotationIntrospector(introspector);
     //noinspection deprecation
-    mapper.getSerializationConfig().setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+    mapper.getSerializationConfig()
+        .withPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
     timelineObjectReader = mapper.reader(TimelineMetrics.class);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/PropertyHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/utilities/PropertyHelper.java
@@ -36,8 +36,9 @@ import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.SortRequest;
 import org.apache.ambari.server.controller.spi.TemporalInfo;
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Utility class that provides Property helper methods.

--- a/ambari-server/src/main/java/org/apache/ambari/server/hooks/users/UserHookService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/hooks/users/UserHookService.java
@@ -45,10 +45,10 @@ import org.apache.ambari.server.serveraction.users.PostUserCreationHookServerAct
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostServerActionEvent;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.Subscribe;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/users/PostUserCreationHookServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/users/PostUserCreationHookServerAction.java
@@ -34,12 +34,11 @@ import org.apache.ambari.server.actionmanager.HostRoleStatus;
 import org.apache.ambari.server.agent.CommandReport;
 import org.apache.ambari.server.hooks.users.UserHookParams;
 import org.apache.ambari.server.serveraction.AbstractServerAction;
-import org.apache.ambari.server.topology.AsyncCallableService;
 import org.apache.ambari.server.utils.ShellCommandUtil;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 
 @Singleton

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/QuickLinksConfigurationModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/QuickLinksConfigurationModule.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.stack;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.state.QuickLinksConfigurationInfo;
 import org.apache.ambari.server.state.quicklinks.QuickLinks;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class QuickLinksConfigurationModule extends BaseModule<QuickLinksConfigurationModule, QuickLinksConfigurationInfo> implements Validable {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceDirectory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceDirectory.java
@@ -27,10 +27,11 @@ import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.state.ServiceInfo;
 import org.apache.ambari.server.state.stack.ServiceMetainfoXml;
 import org.apache.ambari.server.state.stack.StackRoleCommandOrder;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Encapsulates IO operations on a stack definition service directory.

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/StackDirectory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/StackDirectory.java
@@ -35,10 +35,11 @@ import org.apache.ambari.server.state.stack.StackMetainfoXml;
 import org.apache.ambari.server.state.stack.StackRoleCommandOrder;
 import org.apache.ambari.server.state.stack.UpgradePack;
 import org.apache.commons.io.FilenameUtils;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Encapsulates IO operations on a stack definition stack directory.

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ThemeModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ThemeModule.java
@@ -20,7 +20,6 @@ package org.apache.ambari.server.stack;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.state.ThemeInfo;
 import org.apache.ambari.server.state.theme.Theme;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ThemeModule extends BaseModule<ThemeModule, ThemeInfo> implements Validable {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Alert.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Alert.java
@@ -18,7 +18,9 @@
 package org.apache.ambari.server.state;
 
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * An alert represents a problem or notice for a cluster.
  */

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ChangedConfigInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ChangedConfigInfo.java
@@ -18,7 +18,7 @@
 
 package org.apache.ambari.server.state;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ChangedConfigInfo {
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ClusterHealthReport.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ClusterHealthReport.java
@@ -18,7 +18,7 @@
 
 package org.apache.ambari.server.state;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Cluster Health Report (part of Clusters API response)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/DesiredConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/DesiredConfig.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Class that holds information about a desired config and is suitable for output
@@ -59,7 +59,7 @@ public class DesiredConfig {
    * Gets the service name (if any) for the desired config.
    * @return the service name
    */
-  @JsonSerialize(include = Inclusion.NON_NULL)
+  @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
   @JsonProperty("service_name")
   public String getServiceName() {
     return serviceName;
@@ -84,7 +84,7 @@ public class DesiredConfig {
   /**
    * Gets the user that set the desired config.
    */
-  @JsonSerialize(include = Inclusion.NON_EMPTY)
+  @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
   public String getUser() {
     return user;
   }
@@ -102,7 +102,7 @@ public class DesiredConfig {
    * Gets the host overrides for the desired config.  Cluster-based desired configs only.
    * @return the host names that override the desired config
    */
-  @JsonSerialize(include = Inclusion.NON_EMPTY)
+  @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
   @JsonProperty("host_overrides")
   public List<HostOverride> getHostOverrides() {
     return hostOverrides;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/HostConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/HostConfig.java
@@ -20,9 +20,8 @@ package org.apache.ambari.server.state;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Objects;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHostEvent.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceComponentHostEvent.java
@@ -21,9 +21,24 @@ package org.apache.ambari.server.state;
 import java.util.Map;
 
 import org.apache.ambari.server.state.fsm.event.AbstractEvent;
-import org.apache.ambari.server.state.svccomphost.*;
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostDisableEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostInstallEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpFailedEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpInProgressEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpRestartedEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostOpSucceededEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostRestoreEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostServerActionEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStartEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStartedEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStopEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostStoppedEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostUninstallEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostUpgradeEvent;
+import org.apache.ambari.server.state.svccomphost.ServiceComponentHostWipeoutEvent;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Base class for all events that affect the ServiceComponentHost FSM

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ServiceInfo.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.state;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -29,8 +31,6 @@ import org.apache.ambari.server.stack.StackDirectory;
 import org.apache.ambari.server.stack.Validable;
 import org.apache.ambari.server.state.stack.MetricDefinition;
 import org.apache.ambari.server.state.stack.StackRoleCommandOrder;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.map.annotate.JsonFilter;
 
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/UserGroupInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/UserGroupInfo.java
@@ -21,7 +21,7 @@ package org.apache.ambari.server.state;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ValueAttributesInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ValueAttributesInfo.java
@@ -18,15 +18,15 @@
 
 package org.apache.ambari.server.state;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlElements;
 import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ValueEntryInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ValueEntryInfo.java
@@ -18,13 +18,13 @@
 
 package org.apache.ambari.server.state;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @XmlAccessorType(XmlAccessType.FIELD)
-@JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+@JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 public class ValueEntryInfo {
 
   private String value;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertGroup.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertGroup.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ambari.server.state.alert;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The {@link AlertGroup} class is used to represent a grouping of alert

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertTarget.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/AlertTarget.java
@@ -20,7 +20,8 @@ package org.apache.ambari.server.state.alert;
 import java.util.Map;
 
 import org.apache.ambari.server.orm.entities.AlertTargetEntity;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Check.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Check.java
@@ -18,9 +18,9 @@
 
 package org.apache.ambari.server.state.quicklinks;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Link.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Link.java
@@ -18,14 +18,13 @@
 
 package org.apache.ambari.server.state.quicklinks;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Port.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Port.java
@@ -18,9 +18,9 @@
 
 package org.apache.ambari.server.state.quicklinks;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Protocol.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/Protocol.java
@@ -18,11 +18,11 @@
 
 package org.apache.ambari.server.state.quicklinks;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/QuickLinks.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/QuickLinks.java
@@ -18,9 +18,9 @@
 
 package org.apache.ambari.server.state.quicklinks;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/QuickLinksConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinks/QuickLinksConfiguration.java
@@ -18,14 +18,14 @@
 
 package org.apache.ambari.server.state.quicklinks;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/Component.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/Component.java
@@ -20,10 +20,9 @@ package org.apache.ambari.server.state.quicklinksprofile;
 
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/Filter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/Filter.java
@@ -19,10 +19,10 @@
 package org.apache.ambari.server.state.quicklinksprofile;
 
 import org.apache.ambari.server.state.quicklinks.Link;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/LinkAttributeFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/LinkAttributeFilter.java
@@ -21,7 +21,8 @@ package org.apache.ambari.server.state.quicklinksprofile;
 import java.util.Objects;
 
 import org.apache.ambari.server.state.quicklinks.Link;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A quicklink filter based on link attribute match (the filter's link_attribute is contained by the links set of

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/LinkNameFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/LinkNameFilter.java
@@ -21,7 +21,8 @@ package org.apache.ambari.server.state.quicklinksprofile;
 import java.util.Objects;
 
 import org.apache.ambari.server.state.quicklinks.Link;
-import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A filter that accepts quicklinks based on name match.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/QuickLinksProfile.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/QuickLinksProfile.java
@@ -20,9 +20,9 @@ package org.apache.ambari.server.state.quicklinksprofile;
 
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * A quicklinks profile is essentially a set of quick link filters defined on three levels:

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/QuickLinksProfileParser.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/QuickLinksProfileParser.java
@@ -23,16 +23,15 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.deser.std.StdDeserializer;
-import org.codehaus.jackson.map.module.SimpleModule;
-import org.codehaus.jackson.node.ObjectNode;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 
@@ -91,20 +90,20 @@ class QuickLinksFilterDeserializer extends StdDeserializer<Filter> {
   @Override
   public Filter deserialize (JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
     ObjectMapper mapper = (ObjectMapper) parser.getCodec();
-    ObjectNode root = (ObjectNode) mapper.readTree(parser);
+    ObjectNode root = mapper.readTree(parser);
     Class<? extends Filter> filterClass = null;
     List<String> invalidAttributes = new ArrayList<>();
-    for (String fieldName: ImmutableList.copyOf(root.getFieldNames())) {
+    for (String fieldName: ImmutableList.copyOf(root.fieldNames())) {
       switch(fieldName) {
         case LinkAttributeFilter.LINK_ATTRIBUTE:
           if (null != filterClass) {
-            throw new JsonParseException(PARSE_ERROR_MESSAGE_AMBIGUOUS_FILTER, parser.getCurrentLocation());
+            throw new JsonParseException(parser, PARSE_ERROR_MESSAGE_AMBIGUOUS_FILTER, parser.getCurrentLocation());
           }
           filterClass = LinkAttributeFilter.class;
           break;
         case LinkNameFilter.LINK_NAME:
           if (null != filterClass) {
-            throw new JsonParseException(PARSE_ERROR_MESSAGE_AMBIGUOUS_FILTER, parser.getCurrentLocation());
+            throw new JsonParseException(parser, PARSE_ERROR_MESSAGE_AMBIGUOUS_FILTER, parser.getCurrentLocation());
           }
           filterClass = LinkNameFilter.class;
           break;
@@ -116,12 +115,12 @@ class QuickLinksFilterDeserializer extends StdDeserializer<Filter> {
       }
     }
     if (!invalidAttributes.isEmpty()) {
-      throw new JsonParseException(PARSE_ERROR_MESSAGE_INVALID_JSON_TAG + invalidAttributes,
+      throw new JsonParseException(parser, PARSE_ERROR_MESSAGE_INVALID_JSON_TAG + invalidAttributes,
           parser.getCurrentLocation());
     }
     if (null == filterClass) {
       filterClass = AcceptAllFilter.class;
     }
-    return mapper.readValue(root, filterClass);
+    return mapper.readValue(root.traverse(), filterClass);
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/Service.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/quicklinksprofile/Service.java
@@ -20,10 +20,9 @@ package org.apache.ambari.server.state.quicklinksprofile;
 
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/AvailableService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/AvailableService.java
@@ -20,9 +20,8 @@ package org.apache.ambari.server.state.repository;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * A representation of a {@link ManifestService} that is available for upgrading.  This
@@ -34,7 +33,7 @@ public class AvailableService {
   private String name;
 
   @JsonProperty("display_name")
-  @JsonSerialize(include=Inclusion.NON_NULL)
+  @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
   private String displayName;
 
   private List<AvailableVersion> versions = new ArrayList<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/AvailableVersion.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/AvailableVersion.java
@@ -19,9 +19,8 @@ package org.apache.ambari.server.state.repository;
 
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Represents a version of a {@link ManifestService} that is available for upgrading.
@@ -34,11 +33,11 @@ public class AvailableVersion {
   private String version;
 
   @JsonProperty("release_version")
-  @JsonSerialize(include=Inclusion.NON_NULL)
+  @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
   private String releaseVersion;
 
   @JsonProperty("version_id")
-  @JsonSerialize(include=Inclusion.NON_NULL)
+  @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
   private String versionId;
 
   @JsonProperty

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/ClusterVersionSummary.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/ClusterVersionSummary.java
@@ -21,9 +21,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/ManifestServiceInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/ManifestServiceInfo.java
@@ -19,7 +19,7 @@ package org.apache.ambari.server.state.repository;
 
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Used when formulating manifest info for API consumption.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/ServiceVersionSummary.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/ServiceVersionSummary.java
@@ -17,9 +17,8 @@
  */
 package org.apache.ambari.server.state.repository;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/Batch.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/Batch.java
@@ -17,11 +17,11 @@
  */
 package org.apache.ambari.server.state.scheduler;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class Batch {
   private final List<BatchRequest> batchRequests = new ArrayList<BatchRequest>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/BatchRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/BatchRequest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ambari.server.state.scheduler;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class BatchRequest implements Comparable<BatchRequest> {
   private Long orderId;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/BatchSettings.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/BatchSettings.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ambari.server.state.scheduler;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class BatchSettings {
   private Integer batchSeparationInSeconds;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/Schedule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/scheduler/Schedule.java
@@ -17,9 +17,9 @@
  */
 package org.apache.ambari.server.state.scheduler;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class Schedule {
   private String minutes;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/services/MetricsRetrievalService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/services/MetricsRetrievalService.java
@@ -39,12 +39,12 @@ import org.apache.ambari.server.controller.jmx.JMXMetricHolder;
 import org.apache.ambari.server.controller.utilities.ScalingThreadPoolExecutor;
 import org.apache.ambari.server.controller.utilities.StreamProvider;
 import org.apache.commons.io.IOUtils;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Sets;
@@ -181,7 +181,7 @@ public class MetricsRetrievalService extends AbstractService {
    */
   public MetricsRetrievalService() {
     ObjectMapper jmxObjectMapper = new ObjectMapper();
-    jmxObjectMapper.configure(DeserializationConfig.Feature.USE_ANNOTATIONS, false);
+    jmxObjectMapper.configure(MapperFeature.USE_ANNOTATIONS, false);
     m_jmxObjectReader = jmxObjectMapper.reader(JMXMetricHolder.class);
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/MetricDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/MetricDefinition.java
@@ -18,13 +18,13 @@
 
 package org.apache.ambari.server.state.stack;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Map.Entry;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Used to represent metrics for a stack component.

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/WidgetLayout.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/WidgetLayout.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ambari.server.state.stack;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.List;
 import java.util.Map;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/stack/WidgetLayoutInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/stack/WidgetLayoutInfo.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ambari.server.state.stack;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.List;
 import java.util.Map;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/ConfigCondition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/ConfigCondition.java
@@ -19,11 +19,12 @@
 package org.apache.ambari.server.state.theme;
 
 import org.apache.ambari.server.state.ValueAttributesInfo;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/ConfigPlacement.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/ConfigPlacement.java
@@ -19,11 +19,12 @@
 package org.apache.ambari.server.state.theme;
 
 import org.apache.ambari.server.state.ValueAttributesInfo;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Layout.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Layout.java
@@ -18,16 +18,14 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Placement.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Placement.java
@@ -18,15 +18,14 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Section.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Section.java
@@ -18,15 +18,14 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Subsection.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Subsection.java
@@ -18,12 +18,11 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Tab.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Tab.java
@@ -18,12 +18,9 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/TabLayout.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/TabLayout.java
@@ -18,16 +18,14 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Theme.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Theme.java
@@ -18,10 +18,9 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/ThemeConfiguration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/ThemeConfiguration.java
@@ -18,15 +18,14 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Unit.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Unit.java
@@ -18,11 +18,9 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Widget.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/Widget.java
@@ -18,13 +18,12 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/theme/WidgetEntry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/theme/WidgetEntry.java
@@ -18,12 +18,9 @@
 
 package org.apache.ambari.server.state.theme;
 
-
-
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(include= JsonSerialize.Inclusion.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -58,11 +58,12 @@ import org.apache.ambari.server.topology.TopologyManager;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -254,8 +255,8 @@ public class StageUtils {
 
   public static <T> T fromJson(String json, Class<T> clazz) throws IOException {
     ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
-    mapper.configure(SerializationConfig.Feature.USE_ANNOTATIONS, true);
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    mapper.configure(MapperFeature.USE_ANNOTATIONS, true);
     InputStream is = new ByteArrayInputStream(json.getBytes(Charset.forName("UTF8")));
     return mapper.readValue(is, clazz);
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/AgentHostInfoTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/AgentHostInfoTest.java
@@ -23,11 +23,12 @@ import java.io.IOException;
 
 import junit.framework.Assert;
 
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * This tests makes sure the contract between the server and agent for info
@@ -36,8 +37,7 @@ import org.junit.Test;
 public class AgentHostInfoTest {
   
   @Test
-  public void testDeserializeHostInfo() throws JsonParseException, 
-    JsonMappingException, IOException {
+  public void testDeserializeHostInfo() throws IOException {
     String hostinfo = "{\"architecture\": \"x86_64\", " +
         "\"augeasversion\": \"0.10.0\"," +
     		"\"domain\": \"test.com\", " +
@@ -69,7 +69,7 @@ public class AgentHostInfoTest {
     		"\"memorytotal\": 3051356," +
     		"\"netmask\": \"255.255.255.0\"}";
     ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     HostInfo info = mapper.readValue(hostinfo, HostInfo.class);
     Assert.assertEquals(info.getMemoryTotal(), 3051356L);
     Assert.assertEquals(info.getKernel(), "Linux");

--- a/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/agent/TestHeartbeatHandler.java
@@ -98,7 +98,6 @@ import org.apache.ambari.server.state.svccomphost.ServiceComponentHostInstallEve
 import org.apache.ambari.server.utils.StageUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.codehaus.jackson.JsonGenerationException;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
@@ -108,6 +107,7 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
@@ -48,16 +48,17 @@ import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorResponse;
 import org.apache.ambari.server.api.services.stackadvisor.StackAdvisorRunner;
 import org.apache.ambari.server.api.services.stackadvisor.commands.StackAdvisorCommand.StackAdvisorData;
 import org.apache.commons.io.FileUtils;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * StackAdvisorCommand unit tests.
@@ -213,7 +214,7 @@ public class StackAdvisorCommandTest {
     ArrayNode stackVersions = (ArrayNode) stackHierarchy.get("stack_versions");
     assertNotNull(stackVersions);
     assertEquals(2, stackVersions.size());
-    Iterator<JsonNode> stackVersionsElements = stackVersions.getElements();
+    Iterator<JsonNode> stackVersionsElements = stackVersions.elements();
     assertEquals("0.9", stackVersionsElements.next().asText());
     assertEquals("0.8", stackVersionsElements.next().asText());
   }
@@ -237,7 +238,7 @@ public class StackAdvisorCommandTest {
 
     JsonNode serverProperties = objectNode.get("ambari-server-properties");
     assertNotNull(serverProperties);
-    assertEquals("b", serverProperties.iterator().next().getTextValue());
+    assertEquals("b", serverProperties.iterator().next().textValue());
   }
 
   @Test

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogLevelQueryResponseTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogLevelQueryResponseTest.java
@@ -18,18 +18,19 @@
 
 package org.apache.ambari.server.controller.logging;
 
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.StringReader;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 
 public class LogLevelQueryResponseTest {
@@ -53,7 +54,8 @@ public class LogLevelQueryResponseTest {
     AnnotationIntrospector introspector =
       new JacksonAnnotationIntrospector();
     mapper.setAnnotationIntrospector(introspector);
-    mapper.getSerializationConfig().setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+    mapper.getSerializationConfig()
+        .withPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
 
 
     ObjectReader logLevelQueryResponseReader =

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogLineResultTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogLineResultTest.java
@@ -19,17 +19,17 @@
 
 package org.apache.ambari.server.controller.logging;
 
-
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 public class LogLineResultTest {
 
@@ -74,7 +74,8 @@ public class LogLineResultTest {
     AnnotationIntrospector introspector =
       new JacksonAnnotationIntrospector();
     mapper.setAnnotationIntrospector(introspector);
-    mapper.getSerializationConfig().setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+    mapper.getSerializationConfig()
+        .withPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
 
 
     ObjectReader logLineResultReader =

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogQueryResponseTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/logging/LogQueryResponseTest.java
@@ -18,18 +18,18 @@
 
 package org.apache.ambari.server.controller.logging;
 
-
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
 import org.junit.Test;
 
 import java.io.StringReader;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 public class LogQueryResponseTest {
 
@@ -101,7 +101,8 @@ public class LogQueryResponseTest {
     AnnotationIntrospector introspector =
       new JacksonAnnotationIntrospector();
     mapper.setAnnotationIntrospector(introspector);
-    mapper.getSerializationConfig().setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+    mapper.getSerializationConfig()
+        .withPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
 
 
     ObjectReader logQueryResponseReader =

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/ThreadPoolEnabledPropertyProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/ThreadPoolEnabledPropertyProviderTest.java
@@ -19,21 +19,22 @@
 package org.apache.ambari.server.controller.metrics;
 
 import org.apache.ambari.server.controller.jmx.JMXMetricHolder;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
 public class ThreadPoolEnabledPropertyProviderTest {
 
   @Test
   public void testGetCacheKeyForException() throws Exception {
     ObjectMapper jmxObjectMapper = new ObjectMapper();
-    jmxObjectMapper.configure(DeserializationConfig.Feature.USE_ANNOTATIONS, false);
+    jmxObjectMapper.configure(MapperFeature.USE_ANNOTATIONS, false);
     ObjectReader jmxObjectReader = jmxObjectMapper.reader(JMXMetricHolder.class);
 
     List<Exception> exceptions = new ArrayList<>();

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/timeline/MetricsRequestHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/timeline/MetricsRequestHelperTest.java
@@ -23,17 +23,12 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.apache.http.client.utils.URIBuilder;
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectWriter;
-import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -41,6 +36,11 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isNull;
 import static org.easymock.EasyMock.replay;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 public class MetricsRequestHelperTest {
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/hooks/users/UserHookServiceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/hooks/users/UserHookServiceTest.java
@@ -40,7 +40,6 @@ import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostServerActionEvent;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRule;
@@ -51,6 +50,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 public class UserHookServiceTest extends EasyMockSupport {

--- a/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metadata/RoleCommandOrderTest.java
@@ -52,14 +52,14 @@ import org.apache.ambari.server.state.StackId;
 import org.apache.ambari.server.state.cluster.ClusterImpl;
 import org.apache.ambari.server.state.svccomphost.ServiceComponentHostImpl;
 import org.apache.ambari.server.utils.CollectionPresentationUtils;
-import org.codehaus.jackson.annotate.JsonAutoDetect;
-import org.codehaus.jackson.annotate.JsonMethod;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -344,7 +344,7 @@ public class RoleCommandOrderTest {
 
     rco.addDependencies(testData);
 
-    mapper.setVisibility(JsonMethod.ALL, JsonAutoDetect.Visibility.ANY);
+    mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
     String dump = mapper.writeValueAsString(rco.getDependencies());
 
     // Depends on hashing, string representation can be different

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/users/PostUserCreationHookServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/users/PostUserCreationHookServerActionTest.java
@@ -35,7 +35,6 @@ import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.hooks.users.UserHookParams;
 import org.apache.ambari.server.state.SecurityType;
 import org.apache.ambari.server.utils.ShellCommandUtil;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRule;
@@ -49,6 +48,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 
 /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/quicklinksprofile/QuickLinksProfileParserTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/quicklinksprofile/QuickLinksProfileParserTest.java
@@ -20,8 +20,9 @@ package org.apache.ambari.server.state.quicklinksprofile;
 
 import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.io.Resources;
-import org.codehaus.jackson.JsonParseException;
 import org.junit.Test;
 
 
@@ -66,14 +67,14 @@ public class QuickLinksProfileParserTest {
         yarn.getFilters().get(0));
   }
 
-  @Test(expected = JsonParseException.class)
+  @Test(expected = JsonMappingException.class)
   public void testParseInconsistentProfile_ambigousFilterDefinition() throws Exception {
     String profileName = "inconsistent_quicklinks_profile.json";
     QuickLinksProfileParser parser = new QuickLinksProfileParser();
     parser.parse(Resources.getResource(profileName));
   }
 
-  @Test(expected = JsonParseException.class)
+  @Test(expected = JsonMappingException.class)
   public void testParseInconsistentProfile_misspelledFilerDefinition() throws Exception {
     String profileName = "inconsistent_quicklinks_profile_3.json";
     QuickLinksProfileParser parser = new QuickLinksProfileParser();

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -82,13 +82,13 @@ import org.apache.ambari.server.state.stack.OsFamily;
 import org.apache.ambari.server.topology.PersistedState;
 import org.apache.ambari.server.topology.TopologyManager;
 import org.apache.ambari.server.topology.tasks.ConfigureClusterTaskFactory;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.easymock.EasyMockSupport;
 import org.easymock.IAnswer;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;

--- a/contrib/ambari-log4j/pom.xml
+++ b/contrib/ambari-log4j/pom.xml
@@ -94,9 +94,9 @@
     	<version>9.1-901-1.jdbc4</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.2</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/UploadService.java
+++ b/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/resources/uploads/UploadService.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.view.hive2.resources.uploads;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
 import org.apache.ambari.view.ViewContext;
@@ -47,8 +49,6 @@ import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/UploadService.java
+++ b/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/resources/uploads/UploadService.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.view.hive20.resources.uploads;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.sun.jersey.core.header.FormDataContentDisposition;
@@ -53,8 +55,6 @@ import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.parquet.Strings;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/contrib/views/slider/pom.xml
+++ b/contrib/views/slider/pom.xml
@@ -137,6 +137,12 @@
       <artifactId>ambari-views-utils</artifactId>
       <version>2.6.2.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+
   </dependencies>
 
   <properties>

--- a/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/SliderAppsViewControllerImpl.java
+++ b/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/SliderAppsViewControllerImpl.java
@@ -81,9 +81,9 @@ import org.apache.slider.providers.agent.application.metadata.Application;
 import org.apache.slider.providers.agent.application.metadata.Component;
 import org.apache.slider.providers.agent.application.metadata.Metainfo;
 import org.apache.slider.providers.agent.application.metadata.MetainfoParser;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;

--- a/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/rest/client/Metric.java
+++ b/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/rest/client/Metric.java
@@ -18,8 +18,6 @@
 
 package org.apache.ambari.view.slider.rest.client;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +28,9 @@ import javax.xml.xpath.XPathFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties({"keyName", "matchers", "xPathExpression", "xPathExpressionComputed"})
 public class Metric {

--- a/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/rest/client/SliderAppJmxHelper.java
+++ b/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/rest/client/SliderAppJmxHelper.java
@@ -19,9 +19,6 @@
 package org.apache.ambari.view.slider.rest.client;
 
 import org.apache.commons.io.IOUtils;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -40,6 +37,10 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 
 public class SliderAppJmxHelper {
 
@@ -71,7 +72,7 @@ public class SliderAppJmxHelper {
                                                Map<String, String> jmxProperties,
                                                Map<String, Metric> metrics) {
     ObjectMapper jmxObjectMapper = new ObjectMapper();
-    jmxObjectMapper.configure(DeserializationConfig.Feature.USE_ANNOTATIONS, false);
+    jmxObjectMapper.configure(MapperFeature.USE_ANNOTATIONS, false);
     ObjectReader jmxObjectReader = jmxObjectMapper.reader(JMXMetricHolder.class);
     JMXMetricHolder metricHolder = null;
     try {

--- a/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/rest/client/SliderAppMetricsHelper.java
+++ b/contrib/views/slider/src/main/java/org/apache/ambari/view/slider/rest/client/SliderAppMetricsHelper.java
@@ -30,13 +30,14 @@ import org.apache.ambari.view.SystemException;
 import org.apache.ambari.view.ViewContext;
 import org.apache.ambari.view.slider.TemporalInfo;
 import org.apache.http.client.utils.URIBuilder;
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectReader;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 public class SliderAppMetricsHelper {
   private static final Logger logger = LoggerFactory
@@ -53,8 +54,8 @@ public class SliderAppMetricsHelper {
     AnnotationIntrospector introspector = new JaxbAnnotationIntrospector();
     mapper.setAnnotationIntrospector(introspector);
     // no inspection deprecation
-    mapper.getSerializationConfig().setSerializationInclusion(
-        Inclusion.NON_NULL);
+    mapper.getSerializationConfig()
+        .withPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
     timelineObjectReader = mapper.reader(TimelineMetrics.class);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moving to the latest Jackson component version to avoid some vulnerabilities.

## How was this patch tested?

UT and live cluster work