### PR TITLE
[AMBARI-25232] : Refresh NameNode client with Commission/Decommission…

### DIFF
--- a/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
+++ b/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/package/scripts/namenode.py
@@ -117,6 +117,8 @@ class NameNode(Script):
     env.set_params(params)
     hdfs_binary = self.get_hdfs_binary()
     namenode(action="decommission", hdfs_binary=hdfs_binary)
+    self.configure(env)
+
 
 @OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
 class NameNodeDefault(NameNode):

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1104,6 +1104,7 @@ class TestNamenode(RMFTestCase):
         conf_dir = '/etc/hadoop/conf',
         user = 'hdfs',
     )
+    self.assert_configure_secured(False)
     self.assertNoMoreResources()
 
   def assert_configure_default(self):

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1041,6 +1041,7 @@ class TestNamenode(RMFTestCase):
                               user = 'hdfs',
                               conf_dir = '/etc/hadoop/conf',
                               bin_dir = '/usr/bin')
+    self.assert_configure_default()
     self.assertNoMoreResources()
 
   def test_decommission_update_files_only(self):
@@ -1056,6 +1057,7 @@ class TestNamenode(RMFTestCase):
                               content = Template('exclude_hosts_list.j2'),
                               group = 'hadoop',
                               )
+    self.assert_configure_default()
     self.assertNoMoreResources()
 
 
@@ -1077,6 +1079,7 @@ class TestNamenode(RMFTestCase):
                               user = 'hdfs',
                               conf_dir = '/etc/hadoop/conf',
                               bin_dir = '/usr/bin')
+    self.assert_configure_default()
     self.assertNoMoreResources()
 
 
@@ -1101,6 +1104,7 @@ class TestNamenode(RMFTestCase):
         conf_dir = '/etc/hadoop/conf',
         user = 'hdfs',
     )
+    self.assert_configure_default()
     self.assertNoMoreResources()
 
   def assert_configure_default(self):

--- a/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HDFS/test_namenode.py
@@ -1104,7 +1104,6 @@ class TestNamenode(RMFTestCase):
         conf_dir = '/etc/hadoop/conf',
         user = 'hdfs',
     )
-    self.assert_configure_default()
     self.assertNoMoreResources()
 
   def assert_configure_default(self):


### PR DESCRIPTION
… of DataNode

## What changes were proposed in this pull request?
Including NameNode client refresh with DataNode commissioning/decommissioning

## How was this patch tested?
This patch was manually tested

This is a backport PR to branch-2.6 from [here](https://github.com/apache/ambari/pull/2976)