### PR TITLE
AMBARI-25280 - Improper error handling when managing Ambari users

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/ResultStatus.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/ResultStatus.java
@@ -131,7 +131,7 @@ public class ResultStatus {
    */
   public ResultStatus(STATUS status, Exception e) {
     m_status = status;
-    m_msg = e.toString();
+    m_msg = e.getMessage();
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/handlers/ReadHandlerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/handlers/ReadHandlerTest.java
@@ -174,7 +174,7 @@ public class ReadHandlerTest {
     ReadHandler handler = new ReadHandler();
     Result result = handler.handleRequest(request);
     assertEquals(ResultStatus.STATUS.SERVER_ERROR, result.getStatus().getStatus());
-    assertEquals(systemException.toString(), result.getStatus().getMessage());
+    assertEquals(systemException.getMessage(), result.getStatus().getMessage());
     verify(request, resource, query, predicate);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/serializers/JsonSerializerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/serializers/JsonSerializerTest.java
@@ -235,8 +235,7 @@ public class JsonSerializerTest {
         "      \"error\" : {\n" +
         "        \"key\" : \"key2\",\n" +
         "        \"code\" : 403,\n" +
-        "        \"message\" : \"org.apache.ambari.server.security.authorization.AuthorizationException:"+
-                              " The authenticated user is not authorized to perform the requested operation\"\n" +
+        "        \"message\" : \"The authenticated user is not authorized to perform the requested operation\"\n" +
         "      }\n" +
         "    }\n" +
         "  ]\n" +


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using REST API to manage users Ambari does not handle the error properly and reveals internal class names in the error message as shown in the below HTTP Request and Response. Ex.:  an admin user tries to add a user that doesn't exist to a group.

HTTP Request:
```
PUT /api/v1/groups/csrf%20test/members HTTP/1.1
Host: xyz601:8080
Content-Length: 69
Accept: application/json, text/plain, */*
Origin: http://xyz601:8080
X-Requested-By: ambari
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
like Gecko) Chrome/70.0.3538.102 Safari/537.36
Content-Type: plain/text
Referer: http://xyz601:8080/views/ADMIN_VIEW/2.6.2.2/INSTANCE/
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9
Cookie: AMBARISESSIONID=nd54akraeumr1cmnz0gazantv
Connection: close
[{"MemberInfo/user_name":"test","MemberInfo/group_name":"csrf test"}]
```
HTTP Response:
```
HTTP/1.1 500 Internal Server Error
X-Frame-Options: DENY
Severity: Low
Status: New
Ease of Exploit: Easy
Classification: Improper Output Handling
Hadoop refresh (Break Glass) - UMF Visa Restricted 32
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Cache-Control: no-store
Pragma: no-cache
User: hitepate
Content-Type: text/plain
Connection: close
{
"status" : 500,
"message" : "org.apache.ambari.server.controller.spi.SystemException: An internal
system exception occurred: User test doesn't exist"
}
```

Cause: When the `ResultStatus` object which contains the error message constructed (and later serialized into the response body) the error message is initialized by calling `toString()` of the wrapped `Exception` object. This adds the fully qualified class name.

Fix: Use `Exception.getMessage()` instead.     

## How was this patch tested?

1. Build ambari-server.jar which contains the fix.
2. Deploy ambari-server and replace ambari-server.jar
3. Call the API mentioned in the example.
4. The response should contains the exception message only without the class name.