### PR TITLE
AMBARI-25281. Hive View API response contains plain-text password (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProvider.java
@@ -48,6 +48,7 @@ import org.apache.ambari.server.view.validation.InstanceValidationResultImpl;
 import org.apache.ambari.server.view.validation.ValidationException;
 import org.apache.ambari.server.view.validation.ValidationResultImpl;
 import org.apache.ambari.view.ClusterType;
+import org.apache.ambari.view.Masker;
 import org.apache.ambari.view.validation.Validator;
 
 import com.google.inject.Inject;
@@ -259,8 +260,9 @@ public class ViewInstanceResourceProvider extends AbstractAuthorizedResourceProv
 
     // only allow an admin to access the view properties
     if (ViewRegistry.getInstance().checkAdmin()) {
+      Masker masker = ViewRegistry.getInstance().getMasker(viewEntity.getMaskerClass());
       setResourceProperty(resource, PROPERTIES_PROPERTY_ID,
-          viewInstanceEntity.getPropertyMap(), requestedIds);
+          viewInstanceEntity.getPropertyMap(masker), requestedIds);
     }
 
     Map<String, String> applicationData = new HashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ViewEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/ViewEntity.java
@@ -18,16 +18,11 @@
 
 package org.apache.ambari.server.orm.entities;
 
-import org.apache.ambari.server.configuration.Configuration;
-import org.apache.ambari.server.controller.spi.Resource;
-import org.apache.ambari.server.controller.spi.ResourceProvider;
-import org.apache.ambari.server.view.ViewSubResourceDefinition;
-import org.apache.ambari.server.view.configuration.ParameterConfig;
-import org.apache.ambari.server.view.configuration.ResourceConfig;
-import org.apache.ambari.server.view.configuration.ViewConfig;
-import org.apache.ambari.view.validation.Validator;
-import org.apache.ambari.view.View;
-import org.apache.ambari.view.ViewDefinition;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
@@ -42,11 +37,17 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import org.apache.ambari.server.configuration.Configuration;
+import org.apache.ambari.server.controller.spi.Resource;
+import org.apache.ambari.server.controller.spi.ResourceProvider;
+import org.apache.ambari.server.view.ViewSubResourceDefinition;
+import org.apache.ambari.server.view.configuration.ParameterConfig;
+import org.apache.ambari.server.view.configuration.ResourceConfig;
+import org.apache.ambari.server.view.configuration.ViewConfig;
+import org.apache.ambari.view.Masker;
+import org.apache.ambari.view.View;
+import org.apache.ambari.view.ViewDefinition;
+import org.apache.ambari.view.validation.Validator;
 
 /**
  * Entity representing a View.
@@ -893,6 +894,21 @@ public class ViewEntity implements ViewDefinition {
    */
   public static String getViewName(String name, String version) {
     return name + "{" + version + "}";
+  }
+
+  /**
+   * Get the masker class.
+   *
+   * @return the masker class
+   *
+   * @throws RuntimeException if the class can not be loaded
+   */
+  public Class<? extends Masker> getMaskerClass() {
+    try {
+      return getConfiguration().getMaskerClass(getClassLoader());
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/view/ViewRegistry.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/view/ViewRegistry.java
@@ -1451,7 +1451,7 @@ public class ViewRegistry {
   }
 
   // create masker from given class; probably replace with injector later
-  private static Masker getMasker(Class<? extends Masker> clazz) {
+  public static Masker getMasker(Class<? extends Masker> clazz) {
     try {
       return clazz.newInstance();
     } catch (Exception e) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/ViewInstanceResourceProviderTest.java
@@ -18,8 +18,28 @@
 
 package org.apache.ambari.server.controller.internal;
 
-import org.apache.ambari.server.AmbariException;
-import org.apache.ambari.server.DuplicateResourceException;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.ambari.server.controller.spi.Predicate;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.apache.ambari.server.controller.spi.ResourceAlreadyExistsException;
@@ -40,16 +60,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.*;
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.assertEquals;
 
 public class ViewInstanceResourceProviderTest {
 
@@ -84,7 +94,7 @@ public class ViewInstanceResourceProviderTest {
     propertyMap.put("par1", "val1");
     propertyMap.put("par2", "val2");
 
-    expect(viewInstanceEntity.getPropertyMap()).andReturn(propertyMap);
+    expect(viewInstanceEntity.getPropertyMap(null)).andReturn(propertyMap);
 
     expect(viewInstanceEntity.getData()).andReturn(Collections.<ViewInstanceDataEntity>emptyList()).anyTimes();
 

--- a/ambari-views/src/main/java/org/apache/ambari/view/Masker.java
+++ b/ambari-views/src/main/java/org/apache/ambari/view/Masker.java
@@ -40,4 +40,16 @@ public interface Masker {
    * @throws MaskException error happened during unmasking process
    */
   public String unmask(String value) throws MaskException;
+
+  Masker NONE = new Masker() {
+    @Override
+    public String mask(String value) {
+      return value;
+    }
+
+    @Override
+    public String unmask(String value) {
+      return value;
+    }
+  };
 }

--- a/ambari-views/src/main/java/org/apache/ambari/view/ViewInstanceDefinition.java
+++ b/ambari-views/src/main/java/org/apache/ambari/view/ViewInstanceDefinition.java
@@ -84,6 +84,13 @@ public interface ViewInstanceDefinition {
   public Map<String, String> getPropertyMap();
 
   /**
+   * Get property map, mask property values if needed
+   * @param masker
+   * @return
+   */
+  Map<String, String> getPropertyMap(Masker masker);
+
+  /**
    * Get the view instance application data.
    *
    * @return the view instance application data map


### PR DESCRIPTION
## What changes were proposed in this pull request?

Getting response from /api/v1/views/HIVE/versions/2.0.0/instances/AUTO_HIVE20_INSTANCE contains plain text password (hive.ranger.password). This only effects auto created views and default passwords.

## How was this patch tested?

* manually with curl
