### PR TITLE
AMBARI-25278 display all .count type Kafka metrics as rates in Grafana

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDF/grafana-kafka-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDF/grafana-kafka-home.json
@@ -89,7 +89,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             },
             {
@@ -101,7 +101,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.count",
               "precision": "default",
               "refId": "B",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -172,7 +172,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -558,7 +558,7 @@
               "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -629,7 +629,7 @@
               "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -709,7 +709,7 @@
               "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "rate"
             }
           ],
@@ -780,7 +780,7 @@
               "metric": "kafka.controller.ControllerStats.UncleanLeaderElectionsPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -860,7 +860,7 @@
               "metric": "kafka.server.ReplicaManager.IsrShrinksPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -932,7 +932,7 @@
               "metric": "kafka.server.ReplicaManager.IsrExpandsPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDF/grafana-kafka-hosts.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDF/grafana-kafka-hosts.json
@@ -90,7 +90,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             },
             {
@@ -103,7 +103,7 @@
               "precision": "default",
               "refId": "B",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -175,7 +175,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -327,7 +327,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -399,7 +399,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -705,7 +705,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -777,7 +777,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDF/grafana-kafka-topics.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDF/grafana-kafka-topics.json
@@ -83,7 +83,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Messages In",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -91,7 +91,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -156,7 +156,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Bytes Out",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -164,11 +164,11 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             },
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Bytes In",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -176,7 +176,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.topic.*.count",
               "precision": "default",
               "refId": "B",
-              "transform": "none"
+              "transform": "rate"
             }
           ],
           "timeFrom": null,
@@ -249,7 +249,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Total Fetch Requests",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -257,7 +257,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -331,7 +331,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Total Produce Requests",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -339,7 +339,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.TotalProduceRequestsPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-home.json
@@ -89,7 +89,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             },
             {
@@ -101,7 +101,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.count",
               "precision": "default",
               "refId": "B",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -172,7 +172,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -558,7 +558,7 @@
               "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -629,7 +629,7 @@
               "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -709,7 +709,7 @@
               "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "rate"
             }
           ],
@@ -780,7 +780,7 @@
               "metric": "kafka.controller.ControllerStats.UncleanLeaderElectionsPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -860,7 +860,7 @@
               "metric": "kafka.server.ReplicaManager.IsrShrinksPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -932,7 +932,7 @@
               "metric": "kafka.server.ReplicaManager.IsrExpandsPerSec.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-hosts.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-hosts.json
@@ -90,7 +90,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             },
             {
@@ -103,7 +103,7 @@
               "precision": "default",
               "refId": "B",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -175,7 +175,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -327,7 +327,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -399,7 +399,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -705,7 +705,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -777,7 +777,7 @@
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-topics.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-topics.json
@@ -83,7 +83,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Messages In",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -91,7 +91,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -156,7 +156,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Bytes Out",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -164,11 +164,11 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             },
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Bytes In",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -176,7 +176,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.topic.*.count",
               "precision": "default",
               "refId": "B",
-              "transform": "none"
+              "transform": "rate"
             }
           ],
           "timeFrom": null,
@@ -249,7 +249,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Total Fetch Requests",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -257,7 +257,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],
@@ -331,7 +331,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "aggregator": "avg",
+              "aggregator": "none",
               "alias": "Total Produce Requests",
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
@@ -339,7 +339,7 @@
               "metric": "kafka.server.BrokerTopicMetrics.TotalProduceRequestsPerSec.topic.*.count",
               "precision": "default",
               "refId": "A",
-              "transform": "none",
+              "transform": "rate",
               "transformData": "none"
             }
           ],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some Kafka broker metrics mbeans contain yammer statistics. These mbeans have _count, 1MinuteRate, 5MinuteRate, MeanRate_ attributes. Grafana dashboard uses the _count_ attribute which does not make sense as it displays a monotonously growing function.

E.g. messages in/sec was displayed like this:
```
           _______
     _____/
____/
```

Whereas it should be displayed like this:
```
___/\___/\___/\___
```

Two possible solutions were considered:

- Change the metric from _count_ to _1MinuteRate_
- Change the grafana dashboard to display the metric as _rate_

The second one looked better so it was chosen.

## How was this patch tested?

Manually. Installed Kafka an Ambari Metrics, generated some traffic in Kafka and checked the results in Grafana.