### PR TITLE
[AMBARI-25284] Remove suffix from dfs.namenode.kerberos.principal

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
@@ -28,7 +28,7 @@
             "hadoop.security.authorization": "true",
             "hadoop.proxyuser.HTTP.groups": "${hadoop-env/proxyuser_group}",
             "hadoop.security.token.service.use_ip" : "false",
-            "dfs.namenode.kerberos.principal": "${hadoop-env/hdfs_user}${principal_suffix}/${onefs/onefs_host}@${realm}"
+            "dfs.namenode.kerberos.principal": "${hadoop-env/hdfs_user}/${onefs/onefs_host}@${realm}"
           }
         },
         {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The principal will always be `hdfs/<onefs_host>@REALM` not `hdfs-<principal-suffix>/<onefs_host>@REALM`.

## How was this patch tested?

Manually install and upgrade

@zeroflag 