### PR TITLE
AMBARI-25285 Ambari always copies and overrwrites mapreduce.tar.gz to  hdfs when WebHDFS is not enabled while restarting HiveServer (asnaik)

### DIFF
--- a/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Runner.java
+++ b/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Runner.java
@@ -136,14 +136,14 @@ public class Runner {
               File f = new File(resource.getSource());
               if (null == f || !f.exists()) {
                 System.out.println(
-                    String.format("Skipping the operation of create as file doesnt exists : %s", resource.getSource()));
+                    String.format("Skipping the operation of create as file doesnt exists : %s", resource.getTarget()));
                 continue;
               }
-              double bytes = f.length();
+              long bytes = f.length();
               if (fileLength == bytes) {
                 System.out.println(String.format(
                     "Skipping the operation of create as file already exists in hdfs : %s . ActualFileSize : %s , HDFS Filesize : %s",
-                    resource.getSource(), bytes, fileLength));
+                    resource.getTarget(), bytes, fileLength));
                 continue;
               }
             }

--- a/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Runner.java
+++ b/contrib/fast-hdfs-resource/src/main/java/org/apache/ambari/fast_hdfs_resource/Runner.java
@@ -129,16 +129,15 @@ public class Runner {
 
           if (resource.getAction().equals("create")) {
             if ("file".equals(resource.getType())) {
-              // Check if the file already exists with same timestamp
-              // or not
-              FileStatus status = dfs.getFileStatus(pathHadoop);
-              long fileLength = status.getLen();
+              // Check if the file already exists or not by seeing the filesize
               File f = new File(resource.getSource());
               if (null == f || !f.exists()) {
                 System.out.println(
-                    String.format("Skipping the operation of create as file doesnt exists : %s", resource.getTarget()));
+                    String.format("Skipping the operation of create as source file doesnt exists : %s", resource.getSource()));
                 continue;
               }
+              FileStatus status = dfs.getFileStatus(pathHadoop);
+              long fileLength = status.getLen();
               long bytes = f.length();
               if (fileLength == bytes) {
                 System.out.println(String.format(


### PR DESCRIPTION
AMBARI-25285 Ambari always copies and overrwrites mapreduce.tar.gz to  hdfs when WebHDFS is not enabled while restarting HiveServer (asnaik)

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.