### PR TITLE
[AMBARI-25291]: OneFS Mpack needs namenode kerberos config pattern set

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/kerberos.json
@@ -28,7 +28,8 @@
             "hadoop.security.authorization": "true",
             "hadoop.proxyuser.HTTP.groups": "${hadoop-env/proxyuser_group}",
             "hadoop.security.token.service.use_ip" : "false",
-            "dfs.namenode.kerberos.principal": "${hadoop-env/hdfs_user}/${onefs/onefs_host}@${realm}"
+            "dfs.namenode.kerberos.principal": "${hadoop-env/hdfs_user}/${onefs/onefs_host}@${realm}",
+            "dfs.namenode.kerberos.principal.pattern": "*"
           }
         },
         {


### PR DESCRIPTION
## What changes were proposed in this pull request?

OneFS needs dfs.namenode.kerberos.principal.pattern set to the hdfs-default value of "*" for Spark2/Kerberos to work with OneFS.

## How was this patch tested?
Manually installed mpack with OneFS + HDP

@zeroflag 