### PR TITLE
AMBARI-25293 - Logsearch: logfeeder throws NPE when updating checkpoint

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/ResumeLineNumberHelper.java
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/ResumeLineNumberHelper.java
@@ -18,16 +18,15 @@
  */
 package org.apache.ambari.logfeeder.input.file;
 
+import java.io.EOFException;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.util.Map;
+
 import org.apache.ambari.logfeeder.input.InputFile;
 import org.apache.ambari.logfeeder.util.LogFeederUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.EOFException;
-import java.io.File;
-import java.io.RandomAccessFile;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ResumeLineNumberHelper {
 
@@ -43,10 +42,7 @@ public class ResumeLineNumberHelper {
     try {
       LOG.info("Checking existing checkpoint file. " + inputFile.getShortDescription());
 
-      String checkPointFileName = inputFile.getBase64FileKey() + inputFile.getCheckPointExtension();
-      File checkPointFolder = inputFile.getInputManager().getCheckPointFolderFile();
-      checkPointFile = new File(checkPointFolder, checkPointFileName);
-      inputFile.getCheckPointFiles().put(inputFile.getBase64FileKey(), checkPointFile);
+      checkPointFile = FileCheckInHelper.attachCheckpointFileToInput(inputFile);
       Map<String, Object> jsonCheckPoint = null;
       if (!checkPointFile.exists()) {
         LOG.info("Checkpoint file for log file " + inputFile.getFilePath() + " doesn't exist, starting to read it from the beginning");
@@ -74,12 +70,10 @@ public class ResumeLineNumberHelper {
       }
       if (jsonCheckPoint == null) {
         // This seems to be first time, so creating the initial checkPoint object
-        jsonCheckPoint = new HashMap<String, Object>();
-        jsonCheckPoint.put("file_path", inputFile.getFilePath());
-        jsonCheckPoint.put("file_key", inputFile.getBase64FileKey());
+        FileCheckInHelper.createNewCheckpointObject(inputFile);
       }
 
-      inputFile.getJsonCheckPoints().put(inputFile.getBase64FileKey(), jsonCheckPoint);
+      FileCheckInHelper.attachCheckpointToInput(inputFile, jsonCheckPoint);
 
     } catch (Throwable t) {
       LOG.error("Error while configuring checkpoint file. Will reset file. checkPointFile=" + checkPointFile, t);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Every time when logfeeder sends a log entry to solr it updates the corresponding checkpoint file. After a log file rolled over every subsequent checkpoint file update fails with NPE
```
2019-06-04 00:00:13,611 [OutputSolr,audit_logs,worker=0] ERROR org.apache.ambari.logfeeder.util.LogFeederUtil (LogFeederUtil.java:134) - Caught exception checkIn. , input=input:source=file, path=/var/log/hadoop/hdfs/hdfs-audit.log
java.lang.NullPointerException
        at org.apache.ambari.logfeeder.input.file.FileCheckInHelper.checkIn(FileCheckInHelper.java:45)
        at org.apache.ambari.logfeeder.input.InputFile.checkIn(InputFile.java:147)
        at org.apache.ambari.logfeeder.input.InputFile.checkIn(InputFile.java:49)
        at org.apache.ambari.logfeeder.output.OutputSolr$SolrWorkerThread.addToSolr(OutputSolr.java:472)
        at org.apache.ambari.logfeeder.output.OutputSolr$SolrWorkerThread.sendToSolr(OutputSolr.java:380)
        at org.apache.ambari.logfeeder.output.OutputSolr$SolrWorkerThread.run(OutputSolr.java:340)
```

There is no entry in the map returned by `inputFile.getCheckPointFiles()` with the new file key
https://github.com/apache/ambari/blob/fd3024cc2d7e8493446ccf42e81ed52497379cce/ambari-logsearch/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/input/file/FileCheckInHelper.java#L43

fix:
1. Check whether a checkpoint object exists for the given file key and create one if not
2. Check whether a checkpoint file exists for the given file key and create one if not 

## How was this patch tested?
mvn clean install

Manually:
1. Install Ambari and deploy a cluster: Zookeeper, HDFS, Ambari Infra, Logsearch
2. Set hdfs-audit DailyRollingFileAppender DatePattern to `.yyyy-MM-dd-HH-mm` using ambari UI and restart components as required
3. Produce some HDFS audit log using the NameNode UI -> Browse Filesystem UI
4. Monitor logfeeder logs and search for NullPointerExceptions when hdfs audit logs are produced and hdfs-audit log file is rolled
5. Monitor Logsearch UI: check all hdfs audit logs are shown
