### PR TITLE
AMBARI-25296 alert_ldap_password for Hive service check does not allow single-quotes (ihorlukianov)

### DIFF
--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_service_check.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_service_check.py
@@ -46,7 +46,7 @@ class TestServiceCheck(RMFTestCase):
                         stack_version = self.STACK_VERSION,
                         target = RMFTestCase.TARGET_COMMON_SERVICES
     )
-    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;auth=noSasl'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
+    self.assertResourceCalled('Execute', "beeline -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;auth=noSasl' -n hive -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
                               path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
                               user = 'ambari-qa',
                               timeout = 30,
@@ -165,7 +165,7 @@ class TestServiceCheck(RMFTestCase):
     self.assertResourceCalled('Execute', '/usr/bin/kinit -kt /etc/security/keytabs/smokeuser.headless.keytab ambari-qa@EXAMPLE.COM; ',
                               user = 'ambari-qa',
                               )
-    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;principal=hive/_HOST@EXAMPLE.COM'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
+    self.assertResourceCalled('Execute', "beeline -u 'jdbc:hive2://c6402.ambari.apache.org:10000/;transportMode=binary;principal=hive/_HOST@EXAMPLE.COM' -n hive -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
                               path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
                               user = 'ambari-qa',
                               timeout = 30,
@@ -283,7 +283,7 @@ class TestServiceCheck(RMFTestCase):
       stack_version = self.STACK_VERSION,
       target = RMFTestCase.TARGET_COMMON_SERVICES)
 
-    self.assertResourceCalled('Execute', "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
+    self.assertResourceCalled('Execute', "beeline -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary' -n hive -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
       path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
       timeout = 30,
       user = 'ambari-qa',
@@ -322,7 +322,7 @@ class TestServiceCheck(RMFTestCase):
       target = RMFTestCase.TARGET_COMMON_SERVICES)
 
     self.assertResourceCalled('Execute',
-      "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
+      "beeline -u 'jdbc:hive2://c6402.ambari.apache.org:10010/;transportMode=binary' -n hive -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
       path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
       timeout = 30,
       user = 'ambari-qa',
@@ -330,7 +330,7 @@ class TestServiceCheck(RMFTestCase):
     )
 
     self.assertResourceCalled('Execute',
-      "beeline -n hive -u 'jdbc:hive2://c6402.ambari.apache.org:10500/;transportMode=binary'  -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
+      "beeline -u 'jdbc:hive2://c6402.ambari.apache.org:10500/;transportMode=binary' -n hive -e ';' 2>&1 | awk '{print}' | grep -i -e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'",
       path = ['/bin/', '/usr/bin/', '/usr/lib/hive/bin/', '/usr/sbin/'],
       timeout = 30,
       user = 'ambari-qa',


### PR DESCRIPTION
## What changes were proposed in this pull request?

changed the way command is called to escape all special characters

## How was this patch tested?

manually
