### PR TITLE
[AMBARI-25297] : Host names array to string conversion improvement (Backport to branch-2.7)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSRunner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSRunner.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.ambari.server.bootstrap.BootStrapStatus.BSStat;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,18 +108,7 @@ class BSRunner extends Thread {
   }
 
   private String createHostString(List<String> list) {
-    StringBuilder ret = new StringBuilder();
-    if (list == null) {
-      return "";
-    }
-
-    int i = 0;
-    for (String host: list) {
-      ret.append(host);
-      if (i++ != list.size()-1)
-        ret.append(",");
-    }
-    return ret.toString();
+    return list != null ? String.join(",", list) : StringUtils.EMPTY;
   }
 
   /** Create request id dir for each bootstrap call **/

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariManagementControllerImpl.java
@@ -692,15 +692,7 @@ public class AmbariManagementControllerImpl implements AmbariManagementControlle
     }
 
     if (!duplicates.isEmpty()) {
-      StringBuilder names = new StringBuilder();
-      boolean first = true;
-      for (String hName : duplicates) {
-        if (!first) {
-          names.append(",");
-        }
-        first = false;
-        names.append(hName);
-      }
+      final String names = String.join(",", duplicates);
       String msg;
       if (duplicates.size() == 1) {
         msg = "Attempted to create a host_component which already exists: ";

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ClusterRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ClusterRequest.java
@@ -24,9 +24,9 @@ import java.util.Set;
 
 import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.state.SecurityType;
+import org.apache.commons.lang.StringUtils;
 
 import io.swagger.annotations.ApiModelProperty;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Used for create Cluster

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ClusterRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ClusterRequest.java
@@ -26,6 +26,7 @@ import org.apache.ambari.server.controller.internal.ClusterResourceProvider;
 import org.apache.ambari.server.state.SecurityType;
 
 import io.swagger.annotations.ApiModelProperty;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Used for create Cluster
@@ -144,18 +145,9 @@ public class ClusterRequest {
         .append(", securityType=").append(securityType)
         .append(", stackVersion=").append(stackVersion)
         .append(", desired_scv=").append(serviceConfigVersionRequest)
-        .append(", hosts=[");
-    if (hostNames != null) {
-      int i = 0;
-      for (String hostName : hostNames) {
-        if (i != 0) {
-          sb.append(",");
-        }
-        ++i;
-        sb.append(hostName);
-      }
-    }
-    sb.append("] }");
+        .append(", hosts=[")
+        .append(hostNames != null ? String.join(",", hostNames) : StringUtils.EMPTY)
+        .append("] }");
     return sb.toString();
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostResourceProvider.java
@@ -510,33 +510,14 @@ public class HostResourceProvider extends AbstractControllerResourceProvider {
     }
 
     if (!duplicates.isEmpty()) {
-      StringBuilder names = new StringBuilder();
-      boolean first = true;
-      for (String hName : duplicates) {
-        if (!first) {
-          names.append(",");
-        }
-        first = false;
-        names.append(hName);
-      }
-      throw new IllegalArgumentException("Invalid request contains"
-          + " duplicate hostnames"
-          + ", hostnames=" + names);
+      throw new IllegalArgumentException("Invalid request contains duplicate hostnames"
+              + ", hostnames=" + String.join(",", duplicates));
     }
 
     if (!unknowns.isEmpty()) {
-      StringBuilder names = new StringBuilder();
-      boolean first = true;
-      for (String hName : unknowns) {
-        if (!first) {
-          names.append(",");
-        }
-        first = false;
-        names.append(hName);
-      }
-
       throw new IllegalArgumentException("Attempted to add unknown hosts to a cluster.  " +
-          "These hosts have not been registered with the server: " + names);
+              "These hosts have not been registered with the server: " +
+              String.join(",", unknowns));
     }
 
     Map<String, Set<String>> hostClustersMap = new HashMap<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Instead of appending comma separated host names to StringBuilder and then doing toString, we can use String API for better readability and performance

## How was this patch tested?
The patch was tested manually as well as with unit tests.
This is backport PR to branch-2.7 from here: https://github.com/apache/ambari/pull/3003