### PR TITLE
AMBARI-25303 Cluster Information Page URL is broken

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/routes.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/routes.js
@@ -157,7 +157,9 @@ angular.module('ambariAdminConsole')
   var rootUrl = ROUTES['clusters']['clusterInformation'].url;
   angular.forEach(ROUTES, createRoute);
   $routeProvider.otherwise({
-    redirectTo: rootUrl
+    redirectTo: function () {
+      return rootUrl;
+    }
   });
 }])
 .run(['$rootScope', 'ROUTES', 'Settings', function ($rootScope, ROUTES, Settings) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cluster Information Page URL is broken 
Before install HDP, login to ambari. The first page you will be navigated to is Cluster Information Page. The URL here is not what is expected

Expected: views/ADMIN_VIEW/2.7.4.0/INSTANCE/#/clusterInformation
Actual: views/ADMIN_VIEW/2.7.4.0/INSTANCE/#!/clusterInformation#%2F

## How was this patch tested?

Tested manually