### PR TITLE
AMBARI-25304. Request configurations when needed during server-side actions rather than rely on configuration data from the execution command (amagyar)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/AbstractServerAction.java
@@ -173,29 +173,6 @@ public abstract class AbstractServerAction implements ServerAction {
     return (commandParameters == null) ? null : commandParameters.get(propertyName);
   }
 
-  /**
-   * Returns the configurations value from the ExecutionCommand
-   * <p/>
-   * The returned map should be assumed to be read-only.
-   *
-   * @return the (assumed read-only) configurations value from the ExecutionCommand
-   */
-  protected Map<String, Map<String, String>> getConfigurations() {
-    return (executionCommand == null) ? Collections.emptyMap() : executionCommand.getConfigurations();
-  }
-
-  /**
-   * Returns the requested configuration Map from the ExecutionCommand
-   * <p/>
-   * The returned map should be assumed to be read-only.
-   *
-   * @param configurationName a String indicating the name of the configuration data to retrieve
-   * @return the (assumed read-only) configuration Map from the ExecutionCommand, or null if not available
-   */
-  protected Map<String, String> getConfiguration(String configurationName) {
-    return getConfigurations().get(configurationName);
-  }
-
   protected void auditLog(AuditEvent ae) {
     auditLogger.log(ae);
   }

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/DestroyPrincipalsServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/DestroyPrincipalsServerAction.java
@@ -110,7 +110,7 @@ public class DestroyPrincipalsServerAction extends KerberosServerAction {
     String defaultRealm = getDefaultRealm(commandParameters);
 
     KerberosOperationHandler operationHandler = kerberosOperationHandlerFactory.getKerberosOperationHandler(kdcType);
-    Map<String, String> kerberosConfiguration = getConfiguration("kerberos-env");
+    Map<String, String> kerberosConfiguration = getConfigurationProperties("kerberos-env");
 
     try {
       operationHandler.open(administratorCredential, defaultRealm, kerberosConfiguration);

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
@@ -47,8 +47,8 @@ import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerbero
 import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerberosPrincipal;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
-import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.state.Config;
+import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.After;

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerActionTest.java
@@ -48,6 +48,7 @@ import org.apache.ambari.server.serveraction.kerberos.stageutils.ResolvedKerbero
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
+import org.apache.ambari.server.state.Config;
 import org.apache.ambari.server.state.stack.OsFamily;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
@@ -63,6 +64,8 @@ import junit.framework.Assert;
 
 public class KerberosServerActionTest extends EasyMockSupport {
 
+  private  static final Map<String, String> KERBEROS_ENV_PROPERTIES = Collections.singletonMap("admin_server_host", "kdc.example.com");
+
   Map<String, String> commandParams = new HashMap<>();
   File temporaryDirectory;
   private Injector injector;
@@ -72,7 +75,11 @@ public class KerberosServerActionTest extends EasyMockSupport {
 
   @Before
   public void setUp() throws Exception {
+    Config kerberosEnvConfig = createMock(Config.class);
+    expect(kerberosEnvConfig.getProperties()).andReturn(KERBEROS_ENV_PROPERTIES).anyTimes();
+
     cluster = createMock(Cluster.class);
+    expect(cluster.getDesiredConfigByType("kerberos-env")).andReturn(kerberosEnvConfig).anyTimes();
 
     Clusters clusters = createMock(Clusters.class);
     expect(clusters.getCluster(anyString())).andReturn(cluster).anyTimes();
@@ -279,6 +286,29 @@ public class KerberosServerActionTest extends EasyMockSupport {
     CommandReport report = action.processIdentities(sharedMap);
     Assert.assertNotNull(report);
     Assert.assertEquals(HostRoleStatus.FAILED.toString(), report.getStatus());
+
+    verifyAll();
+  }
+
+  @Test
+  public void testGetConfigurationProperties() throws AmbariException {
+    Config emptyConfig = createMock(Config.class);
+    expect(emptyConfig.getProperties()).andReturn(Collections.emptyMap()).once();
+
+    Config missingPropertiesConfig = createMock(Config.class);
+    expect(missingPropertiesConfig.getProperties()).andReturn(null).once();
+
+    expect(cluster.getDesiredConfigByType("invalid-type")).andReturn(null).once();
+    expect(cluster.getDesiredConfigByType("missing-properties-type")).andReturn(missingPropertiesConfig).once();
+    expect(cluster.getDesiredConfigByType("empty-type")).andReturn(emptyConfig).once();
+
+    replayAll();
+
+    Assert.assertNull(action.getConfigurationProperties(null));
+    Assert.assertNull(action.getConfigurationProperties("invalid-type"));
+    Assert.assertNull(action.getConfigurationProperties("missing-properties-type"));
+    Assert.assertEquals(Collections.emptyMap(), action.getConfigurationProperties("empty-type"));
+    Assert.assertEquals(KERBEROS_ENV_PROPERTIES, action.getConfigurationProperties("kerberos-env"));
 
     verifyAll();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport of an existing patch.

Request configurations when needed during server-side actions rather than rely on configuration data from the execution command.

Due to a recent change, which appeared to remove configuration data from the execution command JSON document, data needed for Kerberos-related service-side actions is missing. This data may be requested when needed from the cluster data at the time of execution rather than when setting up the stages.

