### PR TITLE
AMBARI-25303 Cluster Information Page URL is broken - additional patch

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/directives/linkToDir.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/directives/linkToDir.js
@@ -28,7 +28,7 @@ angular.module('ambariAdminConsole')
       id: '@'
     },
 
-    template: '<a ng-href="#!{{href}}" ng-transclude></a>',
+    template: '<a ng-href="#{{href}}" ng-transclude></a>',
     controller: ['$scope', 'ROUTES', function($scope, ROUTES) {
       var route = ROUTES;
       angular.forEach($scope.route.split('.'), function(routeObj) {

--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/routes.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/routes.js
@@ -147,6 +147,7 @@ angular.module('ambariAdminConsole')
   }
 })
 .config(['$routeProvider', '$locationProvider', 'ROUTES', function ($routeProvider, $locationProvider, ROUTES) {
+  $locationProvider.hashPrefix('');
   var createRoute = function (routeObj) {
     if (routeObj.url) {
       $routeProvider.when(routeObj.url, routeObj);
@@ -157,9 +158,7 @@ angular.module('ambariAdminConsole')
   var rootUrl = ROUTES['clusters']['clusterInformation'].url;
   angular.forEach(ROUTES, createRoute);
   $routeProvider.otherwise({
-    redirectTo: function () {
-      return rootUrl;
-    }
+    redirectTo: rootUrl
   });
 }])
 .run(['$rootScope', 'ROUTES', 'Settings', function ($rootScope, ROUTES, Settings) {

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/ambariViews/edit.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/ambariViews/edit.html
@@ -17,7 +17,7 @@
 -->
 <div class="clearfix">
   <ol class="breadcrumb pull-left">
-    <li><a href="#!/views">{{'common.views' | translate}}</a></li>
+    <li><a href="#/views">{{'common.views' | translate}}</a></li>
     <li class="active">{{instance.ViewInstanceInfo.label}}
       <a class="gotoinstance" ng-show="instance.ViewInstanceInfo.visible"
          href="{{fromSiteRoot('/#/main/views/' + viewUrl)}}" target="_blank">
@@ -94,10 +94,10 @@
           </div>
             <div ng-if="!settings.shortUrl">
               <p ng-hide="!editDetailsSettingsDisabled" class="form-control-static">
-                <a href="#!/urls/link/{{instance.ViewInstanceInfo.view_name}}/{{instance.ViewInstanceInfo.version}}/{{instance.ViewInstanceInfo.instance_name}}">{{'urls.createNewUrl' | translate}}</a>
+                <a href="#/urls/link/{{instance.ViewInstanceInfo.view_name}}/{{instance.ViewInstanceInfo.version}}/{{instance.ViewInstanceInfo.instance_name}}">{{'urls.createNewUrl' | translate}}</a>
               </p>
               <p class="form-control-static" ng-hide="editDetailsSettingsDisabled">
-                <a href="#!/urls/link/{{instance.ViewInstanceInfo.view_name}}/{{instance.ViewInstanceInfo.version}}/{{instance.ViewInstanceInfo.instance_name}}">{{'urls.createNewUrl' | translate}}</a>
+                <a href="#/urls/link/{{instance.ViewInstanceInfo.view_name}}/{{instance.ViewInstanceInfo.version}}/{{instance.ViewInstanceInfo.instance_name}}">{{'urls.createNewUrl' | translate}}</a>
               </p>
             </div>
           </div>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/ambariViews/viewsList.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/ambariViews/viewsList.html
@@ -88,7 +88,7 @@
                 </span>
 
                 <span ng-switch-when="DEPLOYED">
-                    <a  href="#!/views/{{instance.view_name}}/versions/{{instance.version}}/instances/{{instance.instance_name}}/edit">
+                    <a href="#/views/{{instance.view_name}}/versions/{{instance.version}}/instances/{{instance.instance_name}}/edit">
                         <i class="fa fa-pencil"></i>
                     </a>
                     <a href ng-click="cloneInstance(instance);">

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/remoteClusters/editRemoteClusterPage.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/remoteClusters/editRemoteClusterPage.html
@@ -17,7 +17,7 @@
 -->
 <div class="clearfix">
   <ol class="breadcrumb pull-left">
-    <li><a href="#!/remoteClusters">{{'common.remoteClusters' | translate}}</a></li>
+    <li><a href="#/remoteClusters">{{'common.remoteClusters' | translate}}</a></li>
     <li class="active">{{cluster.cluster_name}}</li>
   </ol>
   <div class="pull-right top-margin-4">

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/remoteClusters/list.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/remoteClusters/list.html
@@ -19,7 +19,7 @@
 <div class="users-pane">
   <div class="clearfix">
     <div class="pull-right">
-      <a href="#!/remoteClusters/create" class="btn btn-default">
+      <a href="#/remoteClusters/create" class="btn btn-default">
         {{'views.registerRemoteCluster' | translate}}
       </a>
     </div>
@@ -50,7 +50,7 @@
     </thead>
     <tbody>
     <tr ng-repeat="remoteCluster in remoteClusters  | filter : { isShowed: true }">
-      <td class="col-sm-3"><a href="#!/remoteClusters/{{remoteCluster.ClusterInfo.name}}/edit">{{ remoteCluster.clusterName }}</a></td>
+      <td class="col-sm-3"><a href="#/remoteClusters/{{remoteCluster.ClusterInfo.name}}/edit">{{ remoteCluster.clusterName }}</a></td>
       <td class="col-sm-9">
         <span ng-repeat="service in remoteCluster.ClusterInfo.services" ng-if="remoteCluster.ClusterInfo.services.length > 0">{{ service }}{{$last ? '' : ','}} </span>
         <span ng-if="remoteCluster.ClusterInfo.services.length == 0">--</span>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/remoteClusters/remoteClusterPage.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/remoteClusters/remoteClusterPage.html
@@ -16,7 +16,7 @@
 * limitations under the License.
 -->
 <ol class="breadcrumb">
-  <li><a href="#!/remoteClusters">{{'common.remoteClusters' | translate}}</a></li>
+  <li><a href="#/remoteClusters">{{'common.remoteClusters' | translate}}</a></li>
   <li class="active">{{'common.register' | translate}}</li>
 </ol>
 <hr>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/sideNav.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/sideNav.html
@@ -47,15 +47,15 @@
         </a>
         <ul class="sub-menu nav nav-pills nav-stacked">
           <li class="submenu-li" ng-class="{active: isActive('clusters.clusterInformation')}">
-            <a href="#!/clusterInformation" class="clusterInformation">
+            <a href="#/clusterInformation" class="clusterInformation">
               {{'common.clusterInformation' | translate}}
             </a>
           </li>
           <li class="submenu-li"  ng-class="{active: isActive('stackVersions.list')}" ng-show="cluster && totalRepos > 0">
-            <a href="#!/stackVersions">{{'common.versions' | translate}}</a>
+            <a href="#/stackVersions">{{'common.versions' | translate}}</a>
           </li>
           <li class="submenu-li" ng-class="{active: isActive('remoteClusters.list')}">
-            <a href="#!/remoteClusters">{{'common.remoteClusters' | translate}}</a>
+            <a href="#/remoteClusters">{{'common.remoteClusters' | translate}}</a>
           </li>
         </ul>
       </li>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/stackVersions/list.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/stackVersions/list.html
@@ -19,7 +19,7 @@
 <div id="stack-versions">
   <div class="clearfix">
     <div class="pull-right">
-      <a href="#!/stackVersions/create" class="btn btn-default">
+      <a href="#/stackVersions/create" class="btn btn-default">
         {{'versions.register.title' | translate}}
       </a>
     </div>
@@ -63,7 +63,7 @@
         <span>{{repo.stack_name}}-{{repo.stack_version}}</span>
       </td>
       <td class="col-medium">
-        <a href="#!/stackVersions/{{repo.stack_name}}/{{repo.repository_version}}/edit">
+        <a href="#/stackVersions/{{repo.stack_name}}/{{repo.repository_version}}/edit">
           {{repo.display_name}}
         </a>
       </td>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/stackVersions/stackVersionPage.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/stackVersions/stackVersionPage.html
@@ -18,7 +18,7 @@
 
 <div class="clearfix">
   <ol class="breadcrumb pull-left">
-    <li><a href="#!/stackVersions">{{'common.versions' | translate}}</a></li>
+    <li><a href="#/stackVersions">{{'common.versions' | translate}}</a></li>
     <li class="active" ng-if="editController">
       {{displayName}}&nbsp;
       <span class="sub-text">({{repoVersionFullName}})</span>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/groupEdit.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/groupEdit.html
@@ -19,7 +19,7 @@
 <div id="group-edit">
   <div class="clearfix">
     <ol class="breadcrumb pull-left">
-      <li><a href="#!/userManagement?tab=groups">{{'common.groups' | translate}}</a></li>
+      <li><a href="#/userManagement?tab=groups">{{'common.groups' | translate}}</a></li>
       <li class="active">{{group.group_name}}</li>
     </ol>
   </div>
@@ -66,7 +66,7 @@
           <tr ng-repeat="(name, privilege) in privileges.clusters">
             <td>
               <span class="glyphicon glyphicon-cloud"></span>
-              <a href="#!/clusters/{{name}}/manageAccess">{{name}}</a>
+              <a href="#/clusters/{{name}}/manageAccess">{{name}}</a>
             </td>
             <td>
               <span tooltip="{{item}}" ng-repeat="item in privilege">{{item | translate}}{{$last ? '' : ', '}}</span>
@@ -86,7 +86,7 @@
           <tr ng-repeat="(name, privilege) in privileges.views">
             <td>
               <span class="glyphicon glyphicon-th"></span>
-              <a href="#!/views/{{privilege.view_name}}/versions/{{privilege.version}}/instances/{{name}}/edit">{{name}}</a>
+              <a href="#/views/{{privilege.view_name}}/versions/{{privilege.version}}/instances/{{name}}/edit">{{name}}</a>
             </td>
             <td>
               <span tooltip="{{item}}" ng-repeat="item in privilege.privileges">{{item | translate}}{{$last ? '' : ', '}}</span>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/main.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/main.html
@@ -19,10 +19,10 @@
 <div id="user-management">
   <ul class="nav nav-tabs">
     <li ng-class="{active: activeTab === 'USERS'}">
-      <a href="#!/userManagement?tab=users" >{{'common.users' | translate}}</a>
+      <a href="#/userManagement?tab=users" >{{'common.users' | translate}}</a>
     </li>
     <li ng-class="{active: activeTab === 'GROUPS'}">
-      <a href="#!/userManagement?tab=groups" >{{'common.groups' | translate}}</a>
+      <a href="#/userManagement?tab=groups" >{{'common.groups' | translate}}</a>
     </li>
   </ul>
   <div>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/userEdit.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/userEdit.html
@@ -19,7 +19,7 @@
 <div ng-show="user" id="user-edit">
   <div class="clearfix">
     <ol class="breadcrumb pull-left">
-      <li><a href="#!/userManagement?tab=users">{{'common.users' | translate}}</a></li>
+      <li><a href="#/userManagement?tab=users">{{'common.users' | translate}}</a></li>
       <li class="active">{{user.user_name}}</li>
     </ol>
   </div>
@@ -96,7 +96,7 @@
             <tr ng-repeat="(name, privilege) in privilegesView.clusters">
               <td>
                 <span class="glyphicon glyphicon-cloud"></span> 
-                <a href="#!/clusters/{{name}}/manageAccess">{{name}}</a>
+                <a href="#/clusters/{{name}}/manageAccess">{{name}}</a>
               </td>
               <td>
                 <span tooltip="{{privilege.permission_label}}">{{privilege.permission_label}}</span>
@@ -116,7 +116,7 @@
             <tr ng-repeat="(name, privilege) in privilegesView.views">
               <td>
                 <span class="glyphicon glyphicon-th"></span>
-                <a href="#!/views/{{privilege.view_name}}/versions/{{privilege.version}}/instances/{{name}}/edit">{{name}}</a>
+                <a href="#/views/{{privilege.view_name}}/versions/{{privilege.version}}/instances/{{name}}/edit">{{name}}</a>
               </td>
               <td>
                 <span tooltip="{{item}}" ng-repeat="item in privilege.privileges track by $index">{{item | translate}}{{$last ? '' : ', '}}</span>

--- a/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/usersList.html
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/views/userManagement/usersList.html
@@ -74,7 +74,7 @@
         <td><span>{{user.Users.userTypeName}}</span></td>
         <td><span>{{user.Users.groups.length ? user.Users.groups.join(' ') : '-'}}</span></td>
         <td class="entity-actions">
-          <a href="#!/users/{{user.Users.encodedName}}/edit">
+          <a href="#/users/{{user.Users.encodedName}}/edit">
             <i class="fa fa-pencil"></i>
           </a>
           <a href ng-click="deleteUser(user.Users)" ng-disabled="!user.Users.isDeletable">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cluster Information Page URL is broken 
Before install HDP, login to ambari. The first page you will be navigated to is Cluster Information Page. The URL here is not what is expected

Expected: views/ADMIN_VIEW/2.7.4.0/INSTANCE/#/clusterInformation
Actual: views/ADMIN_VIEW/2.7.4.0/INSTANCE/#!/clusterInformation#%2F

## How was this patch tested?

Tested manually