### PR TITLE
[AMBARI-25310] : Replace deprecated methods of FileUtils

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorRunner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/StackAdvisorRunner.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.api.services.stackadvisor;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -162,7 +163,7 @@ public class StackAdvisorRunner {
   private String printMessage(String type, String file) {
     String message = null;
     try {
-      message = FileUtils.readFileToString(new File(file)).trim();
+      message = FileUtils.readFileToString(new File(file), Charset.defaultCharset()).trim();
       LOG.info("    Advisor script {}: {}", type, message);
     } catch (IOException io) {
       LOG.error("Error in reading script log files", io);

--- a/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommand.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommand.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -319,11 +320,15 @@ public abstract class StackAdvisorCommand<T extends StackAdvisorResponse> extend
     try {
       createRequestDirectory();
 
-      FileUtils.writeStringToFile(new File(requestDirectory, "hosts.json"), adjusted.hostsJSON);
-      FileUtils.writeStringToFile(new File(requestDirectory, "services.json"), adjusted.servicesJSON);
+      FileUtils.writeStringToFile(new File(requestDirectory, "hosts.json"), adjusted.hostsJSON,
+              Charset.defaultCharset());
+      FileUtils
+              .writeStringToFile(new File(requestDirectory, "services.json"), adjusted.servicesJSON,
+                      Charset.defaultCharset());
 
       saRunner.runScript(serviceAdvisorType, getCommandType(), requestDirectory);
-      String result = FileUtils.readFileToString(new File(requestDirectory, getResultFileName()));
+      String result = FileUtils.readFileToString(new File(requestDirectory, getResultFileName()),
+              Charset.defaultCharset());
 
       T response = this.mapper.readValue(result, this.type);
       return updateResponse(request, setRequestId(response));

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSHostStatusCollector.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSHostStatusCollector.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -75,7 +76,7 @@ class BSHostStatusCollector {
       } else {
         status.setStatus("FAILED");
         try {
-          String statusCode = FileUtils.readFileToString(done).trim();
+          String statusCode = FileUtils.readFileToString(done, Charset.defaultCharset()).trim();
           if (statusCode.equals("0")) {
             status.setStatus("DONE");
           }

--- a/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSRunner.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/bootstrap/BSRunner.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -131,11 +132,11 @@ class BSRunner extends Thread {
   }
 
   private void writeSshKeyFile(String data) throws IOException {
-    FileUtils.writeStringToFile(sshKeyFile, data);
+    FileUtils.writeStringToFile(sshKeyFile, data, Charset.defaultCharset());
   }
 
   private void writePasswordFile(String data) throws IOException {
-    FileUtils.writeStringToFile(passwordFile, data);
+    FileUtils.writeStringToFile(passwordFile, data, Charset.defaultCharset());
   }
 
   /**
@@ -290,8 +291,10 @@ class BSRunner extends Thread {
         String outMesg = "";
         String errMesg = "";       
         try {
-          outMesg = FileUtils.readFileToString(new File(bootStrapOutputFilePath));
-          errMesg = FileUtils.readFileToString(new File(bootStrapErrorFilePath));
+          outMesg = FileUtils
+                  .readFileToString(new File(bootStrapOutputFilePath), Charset.defaultCharset());
+          errMesg = FileUtils
+                  .readFileToString(new File(bootStrapErrorFilePath), Charset.defaultCharset());
         } catch(IOException io) {
           LOG.info("Error in reading files ", io);
         }

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -2847,7 +2848,7 @@ public class Configuration {
       try {
         password = RandomStringUtils.randomAlphanumeric(Integer
             .parseInt(configsMap.get(SRVR_CRT_PASS_LEN.getKey())));
-        FileUtils.writeStringToFile(passFile, password);
+        FileUtils.writeStringToFile(passFile, password, Charset.defaultCharset());
         ShellCommandUtil.setUnixFilePermissions(
           ShellCommandUtil.MASK_OWNER_ONLY_RW, passFile.getAbsolutePath());
       } catch (IOException e) {
@@ -2858,7 +2859,7 @@ public class Configuration {
     } else {
       LOG.info("Reading password from existing file");
       try {
-        password = FileUtils.readFileToString(passFile);
+        password = FileUtils.readFileToString(passFile, Charset.defaultCharset());
         password = password.replaceAll("\\p{Cntrl}", "");
       } catch (IOException e) {
         e.printStackTrace();
@@ -2874,7 +2875,7 @@ public class Configuration {
       if (httpsPassFile.exists()) {
         LOG.info("Reading password from existing file");
         try {
-          password = FileUtils.readFileToString(httpsPassFile);
+          password = FileUtils.readFileToString(httpsPassFile, Charset.defaultCharset());
           password = password.replaceAll("\\p{Cntrl}", "");
         } catch (IOException e) {
           e.printStackTrace();
@@ -3556,7 +3557,9 @@ public class Configuration {
    */
   public String getServerVersion() {
     try {
-      return FileUtils.readFileToString(new File(getServerVersionFilePath())).trim();
+      return FileUtils
+              .readFileToString(new File(getServerVersionFilePath()), Charset.defaultCharset())
+              .trim();
     } catch (IOException e) {
       LOG.error("Unable to read server version file", e);
     }
@@ -5708,7 +5711,7 @@ public class Configuration {
       markdown = markdown.replace(MARKDOWN_BASELINE_VALUES_KEY, baselineBuffer.toString());
 
       File file = new File(outputFile);
-      FileUtils.writeStringToFile(file, markdown);
+      FileUtils.writeStringToFile(file, markdown, Charset.defaultCharset());
       System.out.println("Successfully created " + outputFile);
       LOG.info("Successfully created {}", outputFile);
     } finally {

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/CertificateManager.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/CertificateManager.java
@@ -287,7 +287,7 @@ public class CertificateManager {
     File agentCrtReqFile = new File(srvrKstrDir + File.separator +
         agentCrtReqName);
     try {
-      FileUtils.writeStringToFile(agentCrtReqFile, agentCrtReqContent);
+      FileUtils.writeStringToFile(agentCrtReqFile, agentCrtReqContent, Charset.defaultCharset());
     } catch (IOException e1) {
       // TODO Auto-generated catch block
       e1.printStackTrace();
@@ -307,7 +307,7 @@ public class CertificateManager {
 
     String agentCrtContent = "";
     try {
-      agentCrtContent = FileUtils.readFileToString(agentCrtFile);
+      agentCrtContent = FileUtils.readFileToString(agentCrtFile, Charset.defaultCharset());
     } catch (IOException e) {
       e.printStackTrace();
       LOG.error("Error reading signed agent certificate");

--- a/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/CertificateUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/encryption/CertificateUtils.java
@@ -18,35 +18,16 @@
 package org.apache.ambari.server.security.encryption;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Utility class containing methods to works with certificates
  */
 public class CertificateUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(CertificateUtils.class);
-
-  /**
-   * Get RSA public key from X.509 certificate file
-   * @param filePath path to certificate file
-   * @return RSA public key
-   * @throws IOException
-   * @throws CertificateException
-   */
-  public static RSAPublicKey getPublicKeyFromFile(String filePath) throws IOException, CertificateException {
-    String pemString = FileUtils.readFileToString(new File(filePath));
-    return getPublicKeyFromString(pemString);
-  }
 
   /**
    * Get RSA public key from X.509 certificate string (full crt file content, including header and footer)

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.serveraction.kerberos;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
@@ -249,12 +250,12 @@ public class ConfigureAmbariIdentitiesServerAction extends KerberosServerAction 
     if (jaasConfPath != null) {
       File jaasConfigFile = new File(jaasConfPath);
       try {
-        String jaasConfig = FileUtils.readFileToString(jaasConfigFile);
+        String jaasConfig = FileUtils.readFileToString(jaasConfigFile, Charset.defaultCharset());
         File oldJaasConfigFile = new File(jaasConfPath + ".bak");
-        FileUtils.writeStringToFile(oldJaasConfigFile, jaasConfig);
+        FileUtils.writeStringToFile(oldJaasConfigFile, jaasConfig, Charset.defaultCharset());
         jaasConfig = jaasConfig.replaceFirst(KEYTAB_PATTERN, "keyTab=\"" + keytabFilePath + "\"");
         jaasConfig = jaasConfig.replaceFirst(PRINCIPAL_PATTERN, "principal=\"" + principal + "\"");
-        FileUtils.writeStringToFile(jaasConfigFile, jaasConfig);
+        FileUtils.writeStringToFile(jaasConfigFile, jaasConfig, Charset.defaultCharset());
         String message = String.format("JAAS config file %s modified successfully for principal %s.",
             jaasConfigFile.getName(), principal);
         if (actionLog != null) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ConfigurationDirectory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ConfigurationDirectory.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.stack;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -147,7 +148,8 @@ public class ConfigurationDirectory extends StackDefinitionDirectory {
         File propertyFile = new File(propertyFilePath);
         if (propertyFile.exists() && propertyFile.isFile()) {
           try {
-            String propertyValue = FileUtils.readFileToString(propertyFile);
+            String propertyValue =
+                    FileUtils.readFileToString(propertyFile, Charset.defaultCharset());
             boolean valid = true;
             switch (propertyFileType.toLowerCase()) {
               case "xml" :

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
@@ -71,9 +71,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import com.google.common.collect.Lists;
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/services/stackadvisor/commands/StackAdvisorCommandTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -198,15 +199,14 @@ public class StackAdvisorCommandTest {
     doReturn(data).when(command)
         .adjust(any(StackAdvisorData.class), any(StackAdvisorRequest.class));
 
-    doAnswer(new Answer() {
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        String resultFilePath = String.format("%s/%s", requestId, command.getResultFileName());
-        File resultFile = new File(recommendationsDir, resultFilePath);
-        resultFile.getParentFile().mkdirs();
-        FileUtils.writeStringToFile(resultFile, testResourceString);
-        return null;
-      }
-    }).when(saRunner).runScript(any(ServiceInfo.ServiceAdvisorType.class), any(StackAdvisorCommandType.class), any(File.class));
+    doAnswer(invocation -> {
+      String resultFilePath = String.format("%s/%s", requestId, command.getResultFileName());
+      File resultFile = new File(recommendationsDir, resultFilePath);
+      resultFile.getParentFile().mkdirs();
+      FileUtils.writeStringToFile(resultFile, testResourceString, Charset.defaultCharset());
+      return null;
+    }).when(saRunner).runScript(any(ServiceInfo.ServiceAdvisorType.class),
+            any(StackAdvisorCommandType.class), any(File.class));
 
     TestResource result = command.invoke(request, ServiceInfo.ServiceAdvisorType.PYTHON);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/bootstrap/BootStrapTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/bootstrap/BootStrapTest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.bootstrap;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -125,7 +126,7 @@ public class BootStrapTest extends TestCase {
       File echo = new File(bootdir, "echo.py");
       //Ensure the file wasn't there
       echo.delete();
-      FileUtils.writeStringToFile(echo, pythonEcho);
+      FileUtils.writeStringToFile(echo, pythonEcho, Charset.defaultCharset());
 
       return echo.getPath();
     } else {
@@ -185,8 +186,8 @@ public class BootStrapTest extends TestCase {
     if (!requestDir.exists()) {
       LOG.warn("RequestDir does not exists");
     }
-    FileUtils.writeStringToFile(new File(requestDir, "host1.done"), "0");
-    FileUtils.writeStringToFile(new File(requestDir, "host2.done"), "1");
+    FileUtils.writeStringToFile(new File(requestDir, "host1.done"), "0", Charset.defaultCharset());
+    FileUtils.writeStringToFile(new File(requestDir, "host2.done"), "1", Charset.defaultCharset());
       /* do a query */
     BootStrapStatus status = impl.getStatus(response.getRequestId());
     LOG.info("Status " + status.getStatus());
@@ -210,10 +211,12 @@ public class BootStrapTest extends TestCase {
   public void testPolling() throws Exception {
     File tmpFolder = temp.newFolder("bootstrap");
     /* create log and done files */
-    FileUtils.writeStringToFile(new File(tmpFolder, "host1.done"), "0");
-    FileUtils.writeStringToFile(new File(tmpFolder, "host1.log"), "err_log_1");
-    FileUtils.writeStringToFile(new File(tmpFolder, "host2.done"), "1");
-    FileUtils.writeStringToFile(new File(tmpFolder, "host2.log"), "err_log_2");
+    FileUtils.writeStringToFile(new File(tmpFolder, "host1.done"), "0", Charset.defaultCharset());
+    FileUtils.writeStringToFile(new File(tmpFolder, "host1.log"), "err_log_1",
+            Charset.defaultCharset());
+    FileUtils.writeStringToFile(new File(tmpFolder, "host2.done"), "1", Charset.defaultCharset());
+    FileUtils.writeStringToFile(new File(tmpFolder, "host2.log"), "err_log_2",
+            Charset.defaultCharset());
 
     List<String> listHosts = new ArrayList<>();
     listHosts.add("host1");

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
@@ -30,6 +30,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
@@ -174,7 +175,7 @@ public class ConfigurationTest {
 
     String password = "pass12345";
 
-    FileUtils.writeStringToFile(passFile, password);
+    FileUtils.writeStringToFile(passFile, password, Charset.defaultCharset());
 
     Properties ambariProperties = new Properties();
     ambariProperties.setProperty(Configuration.API_USE_SSL.getKey(), "true");

--- a/ambari-server/src/test/java/org/apache/ambari/server/resources/TestResources.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/resources/TestResources.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.createNiceMock;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.nio.charset.Charset;
 import java.util.Properties;
 
 import org.apache.ambari.server.configuration.Configuration;
@@ -51,18 +52,20 @@ public class TestResources extends TestCase {
 
   protected Properties buildTestProperties() {
 
-	Properties properties = new Properties();
+    Properties properties = new Properties();
     try {
-		tempFolder.create();
+      tempFolder.create();
 
-		properties.setProperty(Configuration.SRVR_KSTR_DIR.getKey(), tempFolder.getRoot().getAbsolutePath());
-		properties.setProperty(Configuration.RESOURCES_DIR.getKey(), tempFolder.getRoot().getAbsolutePath());
+      properties.setProperty(Configuration.SRVR_KSTR_DIR.getKey(),
+              tempFolder.getRoot().getAbsolutePath());
+      properties.setProperty(Configuration.RESOURCES_DIR.getKey(),
+              tempFolder.getRoot().getAbsolutePath());
 
-	    resourceFile = tempFolder.newFile(RESOURCE_FILE_NAME);
-	    FileUtils.writeStringToFile(resourceFile, RESOURCE_FILE_CONTENT);
-	} catch (IOException e) {
-		e.printStackTrace();
-	}
+      resourceFile = tempFolder.newFile(RESOURCE_FILE_NAME);
+      FileUtils.writeStringToFile(resourceFile, RESOURCE_FILE_CONTENT, Charset.defaultCharset());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
     return properties;
   }
 
@@ -107,7 +110,7 @@ public class TestResources extends TestCase {
   public void testGetResource() throws Exception {
     File resFile = resMan.getResource(resourceFile.getName());
     assertTrue(resFile.exists());
-    String resContent = FileUtils.readFileToString(resFile);
+    String resContent = FileUtils.readFileToString(resFile, Charset.defaultCharset());
     assertEquals(resContent, RESOURCE_FILE_CONTENT);
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/security/CertGenerationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/security/CertGenerationTest.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
@@ -201,7 +202,7 @@ public class CertGenerationTest {
 
     Assert.assertTrue(passFile.exists());
 
-    String pass = FileUtils.readFileToString(passFile);
+    String pass = FileUtils.readFileToString(passFile, Charset.defaultCharset());
 
     Assert.assertEquals(pass.length(), passLen);
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerActionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerActionTest.java
@@ -25,6 +25,7 @@ import static org.easymock.EasyMock.expectLastCall;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 
 import javax.persistence.EntityManager;
 
@@ -166,7 +167,7 @@ public class ConfigureAmbariIdentitiesServerActionTest extends EasyMockSupport {
             "    useTicketCache=false;\n" +
             "};\n";
 
-    FileUtils.writeStringToFile(jaasConfFile, originalJAASFileContent);
+    FileUtils.writeStringToFile(jaasConfFile, originalJAASFileContent, Charset.defaultCharset());
 
     Injector injector = createInjector();
 
@@ -196,11 +197,12 @@ public class ConfigureAmbariIdentitiesServerActionTest extends EasyMockSupport {
             "    storeKey=true\n" +
             "    useTicketCache=false;\n" +
             "};\n",
-        FileUtils.readFileToString(jaasConfFile)
+            FileUtils.readFileToString(jaasConfFile, Charset.defaultCharset())
     );
 
     // Ensure the backup file matches the original content
-    Assert.assertEquals(originalJAASFileContent, FileUtils.readFileToString(jaasConfFileBak));
+    Assert.assertEquals(originalJAASFileContent,
+            FileUtils.readFileToString(jaasConfFileBak, Charset.defaultCharset()));
   }
 
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/repository/VersionDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/repository/VersionDefinitionTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,7 +64,7 @@ public class VersionDefinitionTest extends EasyMockSupport {
 
   @Test
   public void testLoadingString() throws Exception {
-    String xmlString = FileUtils.readFileToString(file);
+    String xmlString = FileUtils.readFileToString(file, Charset.defaultCharset());
     VersionDefinitionXml xml = VersionDefinitionXml.load(xmlString);
 
     validateXml(xml);

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog260Test.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1020,7 +1021,7 @@ public class UpgradeCatalog260Test {
 
     File dataDirectory = temporaryFolder.newFolder();
     File file = new File(dataDirectory, "hdfs_widget.json");
-    FileUtils.writeStringToFile(file, widgetStr);
+    FileUtils.writeStringToFile(file, widgetStr, Charset.defaultCharset());
 
     final Injector mockInjector = Guice.createInjector(new AbstractModule() {
       @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace usages of deprecated methods from FileUtils: readFileToString and writeStringToFile

## How was this patch tested?
The patch was tested manually and with unit tests