### PR TITLE
AMBARI-25313 - Upgrade dependency on com.mchange:c3p0:jar:0.9.5.2 in Ambari Server

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1760,7 +1760,7 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>[0.9.5.2]</version>
+      <version>[0.9.5.4]</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade dependency on com.mchange:c3p0:jar:0.9.5. in Ambari Server due to security concerns. See 

https://nvd.nist.gov/vuln/detail/CVE-2018-20433

```
± % mvn dependency:tree -Dincludes=com.mchange:c3p0
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------< org.apache.ambari:ambari-server >-------------------
[INFO] Building Ambari Server 2.7.3.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.7.3.0.0
[INFO] \- com.mchange:c3p0:jar:0.9.5.2:compile
```
Recommendation is to remove the dependency or upgrade to the latest version: 0.9.5.4.

## How was this patch tested?

mvn clean install