### PR TITLE
[AMBARI-25315][AMBARI-25211] Fix the logic on constucting JDBC URL for Spark2 thrift server alert

### DIFF
--- a/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_thrift_port.py
+++ b/ambari-server/src/main/resources/common-services/SPARK2/2.0.0/package/scripts/alerts/alert_spark2_thrift_port.py
@@ -153,7 +153,7 @@ def execute(configurations={}, parameters={}, host_name=None):
         if transport_mode == "http":
             beeline_url.append("httpPath=cliservice")
             if spark_ssl_enabled:
-                beeline_url.append("ssl=true;sslTrustStore={spark_truststore_path};trustStorePassword={spark_truststore_pass!p}")
+                beeline_url.extend(["ssl=true", "sslTrustStore={spark_truststore_path}", "trustStorePassword={spark_truststore_pass!p}"])
 
         # append url according to used transport
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The patch proposes to fix the logic on constructing JDBC URL for alert on Spark2 thrift server. Previously it doesn't wrap the URL with single quotation mark in some condition (if ssl is enabled it wraps, otherwise not), as well as joins each element with white space which should be `;`.

This also changes the approach on constructing URL from specifying full URL for each condition to adding up, which should be cleaner and less chance to be error-prone.

This patch also fixes AMBARI-25211 as well for side effect, as the fix is straightforward - when transport mode is `http`, we should add `httpPath=cliservice` as well.

## How was this patch tested?

Manually tested with below steps:

- Setup Ambari 2.6.1.5 with Kerberos enabled, no SSL
- Upgraded Ambari 2.6.1.5 to 2.7.4 (doesn't change HDP stack - 2.x - during upgrade)
- Ran alert for Spark2 thrift server to see expected error (Please refer AMBARI-25135 for error message.)
- Replaced alert script with patched one
- Ran alert for Spark2 thrift server to see successful message
