### PR TITLE
AMBARI-25316 - Upgrade dependency on org.springframework:spring-web:jar:4.3.18.RELEASE in Ambari Server

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -37,8 +37,8 @@
     <swagger.maven.plugin.version>3.1.4</swagger.maven.plugin.version>
     <slf4j.version>1.7.20</slf4j.version>
     <guice.version>4.1.0</guice.version>
-    <spring.version>4.3.18.RELEASE</spring.version>
-    <spring.security.version>4.2.7.RELEASE</spring.security.version>
+    <spring.version>5.1.8.RELEASE</spring.version>
+    <spring.security.version>5.1.5.RELEASE</spring.security.version>
     <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
     <postgres.version>42.2.2</postgres.version>
     <forkCount>4</forkCount>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependency on org.springframework.security:spring-security-web 4.3.18.RELEASE in Ambari Server due to security concerns. See 

https://nvd.nist.gov/vuln/detail/CVE-2018-15756
```
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------< org.apache.ambari:ambari-server >-------------------
[INFO] Building Ambari Server 2.7.3.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
...
[INFO] +- org.springframework:spring-web:jar:4.3.18.RELEASE:compile
```
Upgrade spring to version 5.1.8.RELEASE
and spring security to version 5.1.5.RELEASE

## How was this patch tested?

mvn clean install 

manually:
1. Deploy ambari to vm.
2. Replace all jars in the directory `/usr/lib/ambari-server`
3. Start Ambari server

Check mvn dependency:tree
```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-server ---
[INFO] org.apache.ambari:ambari-server:jar:2.7.3.0.0
[INFO] +- org.apache.ambari:ambari-views:jar:2.7.3.0.0:compile
...
[INFO] +- org.springframework.security:spring-security-web:jar:5.1.5.RELEASE:compile
...
[INFO] +- org.springframework:spring-web:jar:5.1.8.RELEASE:compile
```  