### PR TITLE
[AMBARI-25317] : Updating incorrect css class name for different popups

### DIFF
--- a/ambari-web/app/controllers/main/alerts/alert_definitions_actions_controller.js
+++ b/ambari-web/app/controllers/main/alerts/alert_definitions_actions_controller.js
@@ -220,7 +220,7 @@ App.MainAlertDefinitionActionsController = Em.ArrayController.extend({
     var configProperties = App.router.get('clusterController.clusterEnv.properties');
 
     return App.ModalPopup.show({
-      classNames: ['fourty-percent-width-modal'],
+      classNames: ['forty-percent-width-modal'],
       header: Em.I18n.t('alerts.actions.manageSettings'),
       primary: Em.I18n.t('common.save'),
       secondary: Em.I18n.t('common.cancel'),

--- a/ambari-web/app/controllers/main/alerts/definition_details_controller.js
+++ b/ambari-web/app/controllers/main/alerts/definition_details_controller.js
@@ -280,7 +280,7 @@ App.MainAlertDefinitionDetailsController = Em.Controller.extend({
     var alertsRepeatTolerance = App.router.get('clusterController.clusterEnv.properties.alerts_repeat_tolerance') || "1";
 
     return App.ModalPopup.show({
-      classNames: ['fourty-percent-width-modal'],
+      classNames: ['forty-percent-width-modal'],
       header: Em.I18n.t('alerts.actions.editRepeatTolerance.header'),
       primary: Em.I18n.t('common.save'),
       secondary: Em.I18n.t('common.cancel'),

--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -824,7 +824,7 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
   rebalanceHdfsNodes: function () {
     var controller = this;
     App.ModalPopup.show({
-      classNames: ['fourty-percent-width-modal'],
+      classNames: ['forty-percent-width-modal'],
       header: Em.I18n.t('services.service.actions.run.rebalanceHdfsNodes.context'),
       primary: Em.I18n.t('common.start'),
       secondary: Em.I18n.t('common.cancel'),


### PR DESCRIPTION
## What changes were proposed in this pull request?
For some popups, incorrect css class name "fourty-percent-width-modal" is being referred which is not defined in alerts.less. Correcting it to reflect the css changes.

## How was this patch tested?
The patch was tested manually.

Screenshot of 3 popups under consideration for this patch:

![Screenshot from 2019-06-20 18-32-16](https://user-images.githubusercontent.com/34790606/59851347-0dee4600-938a-11e9-82e7-e3f882d4f3e5.png)
![Screenshot from 2019-06-20 18-31-06](https://user-images.githubusercontent.com/34790606/59851348-0dee4600-938a-11e9-89db-9ea7e87d7c98.png)
![Screenshot from 2019-06-20 18-24-14](https://user-images.githubusercontent.com/34790606/59851350-0e86dc80-938a-11e9-8293-baf3557f5b04.png)


Popup 1 - Rabalance HDFS:
Go to HDFS tab and click on Actions -> Rebalance HDFS

Popup 2 - Manage Alert Settings
Go to Alerts tab and click on Actions -> Manage Alert Settings

Popup 3 - Edit Alert Check Count
Go to Alerts tab and click on any alert. Click on Edit button present with Check Count