### PR TITLE
[AMBARI-25317] : Updating incorrect css class name for different popups(cherry-pick to branch-2.7)

### DIFF
--- a/ambari-web/app/controllers/main/alerts/alert_definitions_actions_controller.js
+++ b/ambari-web/app/controllers/main/alerts/alert_definitions_actions_controller.js
@@ -220,7 +220,7 @@ App.MainAlertDefinitionActionsController = Em.ArrayController.extend({
     var configProperties = App.router.get('clusterController.clusterEnv.properties');
 
     return App.ModalPopup.show({
-      classNames: ['fourty-percent-width-modal'],
+      classNames: ['forty-percent-width-modal'],
       header: Em.I18n.t('alerts.actions.manageSettings'),
       primary: Em.I18n.t('common.save'),
       secondary: Em.I18n.t('common.cancel'),

--- a/ambari-web/app/controllers/main/alerts/definition_details_controller.js
+++ b/ambari-web/app/controllers/main/alerts/definition_details_controller.js
@@ -280,7 +280,7 @@ App.MainAlertDefinitionDetailsController = Em.Controller.extend({
     var alertsRepeatTolerance = App.router.get('clusterController.clusterEnv.properties.alerts_repeat_tolerance') || "1";
 
     return App.ModalPopup.show({
-      classNames: ['fourty-percent-width-modal'],
+      classNames: ['forty-percent-width-modal'],
       header: Em.I18n.t('alerts.actions.editRepeatTolerance.header'),
       primary: Em.I18n.t('common.save'),
       secondary: Em.I18n.t('common.cancel'),

--- a/ambari-web/app/controllers/main/service/item.js
+++ b/ambari-web/app/controllers/main/service/item.js
@@ -829,7 +829,7 @@ App.MainServiceItemController = Em.Controller.extend(App.SupportClientConfigsDow
   rebalanceHdfsNodes: function () {
     var controller = this;
     App.ModalPopup.show({
-      classNames: ['fourty-percent-width-modal'],
+      classNames: ['forty-percent-width-modal'],
       header: Em.I18n.t('services.service.actions.run.rebalanceHdfsNodes.context'),
       primary: Em.I18n.t('common.start'),
       secondary: Em.I18n.t('common.cancel'),


### PR DESCRIPTION
## What changes were proposed in this pull request?
For some popups, incorrect css class name "fourty-percent-width-modal" is being referred which is not defined in alerts.less. Correcting it to reflect the css changes.

## How was this patch tested?
The patch was tested manually. This is backport PR to branch-2.7 from PR: https://github.com/apache/ambari/pull/3023