### PR TITLE
AMBARI-25253. Missed support for abfs protocol.

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/ranger-hive-security.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/services/HIVE/configuration/ranger-hive-security.xml
@@ -22,7 +22,7 @@
 
   <property>
     <name>ranger.plugin.hive.urlauth.filesystem.schemes</name>
-    <value>hdfs:,file:,wasb:,adl:,abfs:</value>
+    <value>hdfs:,file:,wasb:,adl:</value>
     <description>Add urlauth filesystem schemes</description>
     <value-attributes>
       <empty-value-valid>true</empty-value-valid>

--- a/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.6/upgrades/config-upgrade.xml
@@ -72,7 +72,7 @@
           </definition>
           <definition xsi:type="configure" id="hdp_2_6_maint_ranger_hive_plugin_urlauth_filesystem_schemes">
             <type>ranger-hive-security</type>
-            <set key="ranger.plugin.hive.urlauth.filesystem.schemes" value="hdfs:,file:,wasb:,adl:,abfs:"
+            <set key="ranger.plugin.hive.urlauth.filesystem.schemes" value="hdfs:,file:,wasb:,adl:"
               if-type="ranger-hive-security" if-key="ranger.plugin.hive.service.name" if-key-state="present"/>
           </definition>
           <definition xsi:type="configure" id="hdp_2_6_maint_jaas_config_for_hive_hook" summary="Updating hive atlas application properties">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Abfs protocol usage was reverted for default value of *ranger.plugin.hive.urlauth.filesystem.schemes* ranger hive plugin property.

## How was this patch tested?

Manual testing.