### PR TITLE
AMBARI-25319 - Logsearch: Upgrade dependency on org.springframework.boot:spring-boot-starter-jetty:jar:2.0.6.RELEASE

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>5.1.1.RELEASE</spring.version>
-    <spring-boot.version>2.0.6.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
   </properties>
 
   <dependencies>

--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.version>5.1.1.RELEASE</spring.version>
+    <spring.version>5.1.8.RELEASE</spring.version>
     <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
   </properties>
 

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -26,8 +26,8 @@
   <packaging>jar</packaging>
   <name>Ambari Logsearch Server</name>
   <properties>
-    <spring.version>5.1.1.RELEASE</spring.version>
-    <spring.security.version>5.1.1.RELEASE</spring.security.version>
+    <spring.version>5.1.8.RELEASE</spring.version>
+    <spring.security.version>5.1.5.RELEASE</spring.security.version>
     <spring-data-solr.version>3.0.10.RELEASE</spring-data-solr.version>
     <spring-data.version>2.0.10.RELEASE</spring-data.version>
     <spring-boot.version>2.1.5.RELEASE</spring-boot.version>

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -30,7 +30,7 @@
     <spring.security.version>5.1.1.RELEASE</spring.security.version>
     <spring-data-solr.version>3.0.10.RELEASE</spring-data-solr.version>
     <spring-data.version>2.0.10.RELEASE</spring-data.version>
-    <spring-boot.version>2.0.6.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
     <jersey.version>2.27</jersey.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <swagger.version>1.5.16</swagger.version>

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchConfigApiConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchConfigApiConfig.java
@@ -18,13 +18,11 @@
  */
 package org.apache.ambari.logsearch.conf;
 
-import org.apache.ambari.logsearch.conf.global.LogLevelFilterManagerState;
+import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PROPERTIES_FILE;
+
 import org.apache.ambari.logsearch.config.api.LogSearchPropertyDescription;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PROPERTIES_FILE;
 
 @Configuration
 public class LogSearchConfigApiConfig {
@@ -58,11 +56,6 @@ public class LogSearchConfigApiConfig {
   )
   @Value("${logsearch.config.api.filter.zk.enabled:false}")
   public boolean zkFilterStorage;
-
-  @Bean(name = "logLevelFilterManagerState")
-  public LogLevelFilterManagerState logLevelFilterManagerState() {
-    return new LogLevelFilterManagerState();
-  }
 
   public boolean isConfigApiEnabled() {
     return configApiEnabled;

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
@@ -100,6 +100,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Inject
   private LogSearchConfigApiConfig logSearchConfigApiConfig;
 
+  @Inject
+  private LogsearchAuthenticationProvider logsearchAuthenticationProvider;
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http
@@ -108,7 +111,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .requestMatchers(requestMatcher()).permitAll()
         .antMatchers("/**").authenticated()
       .and()
-      .authenticationProvider(logsearchAuthenticationProvider())
+      .authenticationProvider(logsearchAuthenticationProvider)
       .httpBasic()
         .authenticationEntryPoint(logsearchAuthenticationEntryPoint())
       .and()
@@ -141,11 +144,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Bean
   public LogsearchKRBAuthenticationFilter logsearchKRBAuthenticationFilter() {
     return new LogsearchKRBAuthenticationFilter(requestMatcher());
-  }
-
-  @Bean
-  public LogsearchAuthenticationProvider logsearchAuthenticationProvider() {
-    return new LogsearchAuthenticationProvider();
   }
 
   @Bean

--- a/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrConfig.java
+++ b/ambari-logsearch/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrConfig.java
@@ -18,10 +18,6 @@
  */
 package org.apache.ambari.logsearch.conf;
 
-import org.apache.ambari.logsearch.conf.global.SolrAuditLogsState;
-import org.apache.ambari.logsearch.conf.global.SolrCollectionState;
-import org.apache.ambari.logsearch.conf.global.SolrEventHistoryState;
-import org.apache.ambari.logsearch.conf.global.SolrServiceLogsState;
 import org.apache.ambari.logsearch.dao.SolrSchemaFieldDao;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,21 +30,6 @@ public class SolrConfig {
   @Bean
   public SolrSchemaFieldDao solrSchemaFieldDao() {
     return new SolrSchemaFieldDao();
-  }
-
-  @Bean(name = "solrServiceLogsState")
-  public SolrCollectionState solrServiceLogsState() {
-    return new SolrServiceLogsState();
-  }
-
-  @Bean(name = "solrAuditLogsState")
-  public SolrCollectionState solrAuditLogsState() {
-    return new SolrAuditLogsState();
-  }
-
-  @Bean(name = "solrEventHistoryState")
-  public SolrCollectionState solrEventHistoryState() {
-    return new SolrEventHistoryState();
   }
 
   @Bean


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependency on org.mortbay.jasper:apache-el:jar:8.5.33 in Ambari Logsearch due to security concerns. See

https://nvd.nist.gov/vuln/detail/CVE-2019-0199

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-logsearch-server ---
[INFO] org.apache.ambari:ambari-logsearch-server:jar:2.7.3.0.0
[INFO] \- org.springframework.boot:spring-boot-starter-jetty:jar:2.0.6.RELEASE:compile
[INFO]    \- org.mortbay.jasper:apache-el:jar:8.5.33:compile
[INFO]
[INFO] ------------< org.apache.ambari:ambari-logsearch-assembly >-------------
[INFO] Building Ambari Logsearch Assembly 2.7.3.0.0                     [13/14]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-logsearch-assembly ---
[INFO] org.apache.ambari:ambari-logsearch-assembly:jar:2.7.3.0.0
[INFO] \- org.apache.ambari:ambari-logsearch-server:jar:2.7.3.0.0:compile
[INFO]    \- org.springframework.boot:spring-boot-starter-jetty:jar:2.0.6.RELEASE:compile
[INFO]       \- org.mortbay.jasper:apache-el:jar:8.5.33:compile
[INFO]
[INFO] ---------------< org.apache.ambari:ambari-logsearch-it >----------------
[INFO] Building Ambari Logsearch Integration Test 2.7.3.0.0             [14/14]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-logsearch-it ---
[INFO] org.apache.ambari:ambari-logsearch-it:jar:2.7.3.0.0
[INFO] \- org.apache.ambari:ambari-logsearch-server:jar:2.7.3.0.0:compile
[INFO]    \- org.springframework.boot:spring-boot-starter-jetty:jar:2.0.6.RELEASE:compile
[INFO]       \- org.mortbay.jasper:apache-el:jar:8.5.33:compile
```

- Upgrade spring-boot to version 2.1.5.RELEASE
- Clean up multiple instance creations from the same beans which should be singleton

## How was this patch tested?

mvn clean install

manually:
1. Create rpms using the new version fo spring boot
2. deploy cluster with Ambari, Logsearch, Infra, Zookeeper
3. replace Logsearch rpms to the new ones
4. start Logsearch
5. Check for errors in logs: `/var/log/ambari-logsearch-portal/logsearch.log` and `/var/log/ambari-logsearch-logfeeder/logfeeder.log` 

mvn dependecy:tree
```
[INFO] org.apache.ambari:ambari-logsearch-logfeeder:jar:2.7.3.0.0
...
[INFO] +- org.springframework.boot:spring-boot-starter:jar:2.1.5.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot:jar:2.1.5.RELEASE:compile
```

```
[INFO] org.apache.ambari:ambari-logsearch-server:jar:2.7.3.0.0
...
[INFO] +- org.springframework.boot:spring-boot-starter:jar:2.1.5.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot:jar:2.1.5.RELEASE:compile
...
[INFO] +- org.springframework.boot:spring-boot-starter-jetty:jar:2.1.5.RELEASE:compile
```