### PR TITLE
AMBARI-25321 - Remove dependency on org.eclipse.jetty.*:9.3.19.v20170502 in Ambari Logsearch Logfeeder

### DIFF
--- a/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml
@@ -186,6 +186,30 @@
           <groupId>jdk.tools</groupId>
           <artifactId>jdk.tools</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-security</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-webapp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-xml</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependency on org.eclipse.jetty.* 9.3.19.v20170502 in Ambari Logsearch Logfeeder due to security concerns. See

https://nvd.nist.gov/vuln/detail/CVE-2018-12536

https://nvd.nist.gov/vuln/detail/CVE-2017-7658

https://nvd.nist.gov/vuln/detail/CVE-2017-7657

https://nvd.nist.gov/vuln/detail/CVE-2017-7656
```
± % mvn dependency:tree -Dincludes=org.eclipse.jetty
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.ambari:ambari-logsearch-logfeeder:jar:2.7.3.0.0
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-compiler-plugin @ org.apache.ambari:ambari-logsearch-logfeeder:[unknown-version], /Users/gboros/Documents/dev/ambari/ambari-logsearch/ambari-logsearch-logfeeder/pom.xml, line 311, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] ------------< org.apache.ambari:ambari-logsearch-logfeeder >------------
[INFO] Building Ambari Logsearch Log Feeder 2.7.3.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ ambari-logsearch-logfeeder ---
[INFO] org.apache.ambari:ambari-logsearch-logfeeder:jar:2.7.3.0.0
[INFO] \- org.apache.hadoop:hadoop-common:jar:3.0.0:compile
[INFO]    +- org.eclipse.jetty:jetty-server:jar:9.3.19.v20170502:compile
[INFO]    |  +- org.eclipse.jetty:jetty-http:jar:9.3.19.v20170502:compile
[INFO]    |  \- org.eclipse.jetty:jetty-io:jar:9.3.19.v20170502:compile
[INFO]    +- org.eclipse.jetty:jetty-util:jar:9.3.19.v20170502:compile
[INFO]    +- org.eclipse.jetty:jetty-servlet:jar:9.3.19.v20170502:compile
[INFO]    |  \- org.eclipse.jetty:jetty-security:jar:9.3.19.v20170502:compile
[INFO]    \- org.eclipse.jetty:jetty-webapp:jar:9.3.19.v20170502:compile
[INFO]       \- org.eclipse.jetty:jetty-xml:jar:9.3.19.v20170502:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.939 s
[INFO] Finished at: 2019-06-17T14:36:58+02:00
[INFO] ------------------------------------------------------------------------
```
Exclude org.eclipse.jetty.* dependencies


## How was this patch tested?
mvn clean install

manually:

1. Create rpm
2. deploy cluster with Ambari, Logsearch, Infra, Zookeeper
3. replace Logfeeder rpm to the new one
4. Check if logfeeder post log entries: check new logentries appear on Logsearch UI
5. Check for errors in logfeeder log `/var/log/ambari-logsearch-logfeeder/logfeeder.log`

search for org.eclipse.jetty.* dependencies in dependency tree 