### PR TITLE
[AMBARI-25325] : RetryUpgradeActionService not updating host_role_command in Transaction (backport to branch-2.7)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/services/RetryUpgradeActionService.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/services/RetryUpgradeActionService.java
@@ -190,7 +190,7 @@ public class RetryUpgradeActionService extends AbstractScheduledService {
    * @param requestId Request Id to search tasks for.
    */
   @Transactional
-  void retryHoldingCommandsInRequest(Long requestId) {
+  public void retryHoldingCommandsInRequest(Long requestId) {
     if (requestId == null) {
       return;
     }
@@ -294,13 +294,17 @@ public class RetryUpgradeActionService extends AbstractScheduledService {
    * @param hrc Host Role Command entity
    */
   private void retryHostRoleCommand(HostRoleCommandEntity hrc) {
-    hrc.setStatus(HostRoleStatus.PENDING);
-    hrc.setStartTime(-1L);
-    // Don't change the original start time.
-    hrc.setEndTime(-1L);
-    hrc.setLastAttemptTime(-1L);
-
-    // This will invalidate the cache, as expected.
-    m_hostRoleCommandDAO.merge(hrc);
+    try {
+      hrc.setStatus(HostRoleStatus.PENDING);
+      hrc.setStartTime(-1L);
+      // Don't change the original start time.
+      hrc.setEndTime(-1L);
+      hrc.setLastAttemptTime(-1L);
+      // This will invalidate the cache, as expected.
+      m_hostRoleCommandDAO.merge(hrc);
+    } catch (Exception e) {
+      LOG.error("Error while updating hostRoleCommand. Entity: {}", hrc, e);
+      throw e;
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
non-public method in the same instance with guice @[Transactional](https://github.com/google/guice/blob/master/extensions/persist/src/com/google/inject/persist/Transactional.java) doesn't initiate Transaction at the beginning of the method and tear down after execution of the method. The same is the case with RetryUpgradeActionService updating host_role_command entries during Rolling Upgrade for commands with HOLDING_* failed status. Created a new Singleton class to offload the responsibility of creating Transaction using AOP proxy so that Transaction is applied to retryHoldingCommandsInRequest()

## How was this patch tested?
The patch was tested manually during Rolling Upgrade as well as with unit testing available in RetryUpgradeActionServiceTest. Verified Transactional behavior with/without some Exception to Rollback/Commit the ongoing Transaction for both - before/after applying the patch

This is a backport PR to branch-2.7 from PR: https://github.com/apache/ambari/pull/3032