### PR TITLE
[AMBARI-25322] : Standardized Logger properties - Easy integration of logs with Splunk/ELK

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/main.py
+++ b/ambari-agent/src/main/python/ambari_agent/main.py
@@ -118,7 +118,7 @@ alerts_logger_global = logging.getLogger('ambari_agent.alerts')
 apscheduler_logger = logging.getLogger('apscheduler')
 apscheduler_logger_global = logging.getLogger('ambari_agent.apscheduler')
 
-formatstr = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d - %(message)s"
+formatstr = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d - %(message)s"
 agentPid = os.getpid()
 
 # Global variables to be set later.

--- a/ambari-server/conf/unix/log4j.properties
+++ b/ambari-server/conf/unix/log4j.properties
@@ -35,7 +35,7 @@ log4j.appender.file.File=${ambari.log.dir}/${ambari.log.file}
 log4j.appender.file.MaxFileSize=80MB
 log4j.appender.file.MaxBackupIndex=60
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
+log4j.appender.file.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}:%L - %m%n
 
 # Log config changes
 log4j.logger.configchange=INFO,configchange
@@ -43,7 +43,7 @@ log4j.additivity.configchange=false
 log4j.appender.configchange=org.apache.log4j.FileAppender
 log4j.appender.configchange.File=${ambari.log.dir}/${ambari.config-changes.file}
 log4j.appender.configchange.layout=org.apache.log4j.PatternLayout
-log4j.appender.configchange.layout.ConversionPattern=%d{ISO8601} %5p - %m%n
+log4j.appender.configchange.layout.ConversionPattern=%d{ISO8601} %-5p - %m%n
 
 # Log alert state changes
 log4j.logger.alerts=INFO,alerts
@@ -59,14 +59,14 @@ log4j.additivity.org.apache.ambari.server.checks.DatabaseConsistencyChecker=fals
 log4j.appender.dbcheck=org.apache.log4j.FileAppender
 log4j.appender.dbcheck.File=${ambari.log.dir}/${ambari.dbcheck.file}
 log4j.appender.dbcheck.layout=org.apache.log4j.PatternLayout
-log4j.appender.dbcheck.layout.ConversionPattern=%d{ISO8601} %5p - %m%n
+log4j.appender.dbcheck.layout.ConversionPattern=%d{ISO8601} %-5p - %m%n
 
 log4j.logger.org.apache.ambari.server.checks.DatabaseConsistencyCheckHelper=INFO, dbcheckhelper
 log4j.additivity.org.apache.ambari.server.checks.DatabaseConsistencyCheckHelper=false
 log4j.appender.dbcheckhelper=org.apache.log4j.FileAppender
 log4j.appender.dbcheckhelper.File=${ambari.log.dir}/${ambari.dbcheck.file}
 log4j.appender.dbcheckhelper.layout=org.apache.log4j.PatternLayout
-log4j.appender.dbcheckhelper.layout.ConversionPattern=%d{ISO8601} %5p - %m%n
+log4j.appender.dbcheckhelper.layout.ConversionPattern=%d{ISO8601} %-5p - %m%n
 
 # EclipsLink -> slf4j bridge
 log4j.logger.eclipselink=TRACE,eclipselink
@@ -76,7 +76,7 @@ log4j.appender.eclipselink.File=${ambari.log.dir}/${ambari.eclipselink.file}
 log4j.appender.eclipselink.MaxFileSize=50MB
 log4j.appender.eclipselink.MaxBackupIndex=10
 log4j.appender.eclipselink.layout=org.apache.log4j.PatternLayout
-log4j.appender.eclipselink.layout.ConversionPattern=%m%n
+log4j.appender.eclipselink.layout.ConversionPattern=%d{ISO8601} %m%n
 
 # Jersey
 log4j.logger.com.sun.jersey=WARN,file
@@ -96,7 +96,7 @@ log4j.appender.audit.rollingPolicy.maxIndex=13
 log4j.appender.audit.triggeringPolicy=org.apache.log4j.rolling.SizeBasedTriggeringPolicy
 log4j.appender.audit.triggeringPolicy.maxFileSize=50000000
 log4j.appender.audit.layout=org.apache.log4j.PatternLayout
-log4j.appender.audit.layout.ConversionPattern=%m%n
+log4j.appender.audit.layout.ConversionPattern=%d{ISO8601} %m%n
 
 log4j.logger.org.apache.hadoop.yarn.client=WARN
 log4j.logger.org.apache.ambari.server.security.authorization=WARN

--- a/ambari-server/src/main/python/ambari-server.py
+++ b/ambari-server/src/main/python/ambari-server.py
@@ -63,7 +63,7 @@ from ambari_server_main import server_process_main
 
 logger = logging.getLogger()
 
-formatstr = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d - %(message)s"
+formatstr = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d - %(message)s"
 
 SERVER_STOP_TIMEOUT = 30
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change in Log properties to make ambari-server and agent logs more flexible and make it flow to splunk/ELK as logs are sorted based on ASC/DESC order of timestamp and loaded.

## How was this patch tested?
The patch was tested locally and the logs can be easily accessed from Splunk/ELK