### PR TITLE
AMBARI-25327 : Prevent NPE for bindNotificationDispatchers and getServiceConfigVersionRequest

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
@@ -687,6 +687,9 @@ public class ControllerModule extends AbstractModule {
           LOG.error("Unable to bind and register notification dispatcher {}",
                   clazz, exception);
         }
+      } else {
+        LOG.error("Binding and registering notification dispatcher is not possible for" +
+            " beanDefinition: {} in the absence of className", beanDefinition);
       }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/ControllerModule.java
@@ -666,25 +666,27 @@ public class ControllerModule extends AbstractModule {
     // the dispatch factory
     for (BeanDefinition beanDefinition : beanDefinitions) {
       String className = beanDefinition.getBeanClassName();
-      Class<?> clazz = ClassUtils.resolveClassName(className,
-          ClassUtils.getDefaultClassLoader());
-
-      try {
-        NotificationDispatcher dispatcher;
-        if (clazz.equals(AmbariSNMPDispatcher.class)) {
-          dispatcher = (NotificationDispatcher) clazz.getConstructor(Integer.class).newInstance(configuration.getAmbariSNMPUdpBindPort());
-        } else if (clazz.equals(SNMPDispatcher.class)) {
-          dispatcher = (NotificationDispatcher) clazz.getConstructor(Integer.class).newInstance(configuration.getSNMPUdpBindPort());
-        } else {
-          dispatcher = (NotificationDispatcher) clazz.newInstance();
+      if (className != null) {
+        Class<?> clazz = ClassUtils.resolveClassName(className,
+                ClassUtils.getDefaultClassLoader());
+        try {
+          NotificationDispatcher dispatcher;
+          if (clazz.equals(AmbariSNMPDispatcher.class)) {
+            dispatcher = (NotificationDispatcher) clazz.getConstructor(Integer.class)
+                    .newInstance(configuration.getAmbariSNMPUdpBindPort());
+          } else if (clazz.equals(SNMPDispatcher.class)) {
+            dispatcher = (NotificationDispatcher) clazz.getConstructor(Integer.class)
+                    .newInstance(configuration.getSNMPUdpBindPort());
+          } else {
+            dispatcher = (NotificationDispatcher) clazz.newInstance();
+          }
+          dispatchFactory.register(dispatcher.getType(), dispatcher);
+          bind((Class<NotificationDispatcher>) clazz).toInstance(dispatcher);
+          LOG.info("Binding and registering notification dispatcher {}", clazz);
+        } catch (Exception exception) {
+          LOG.error("Unable to bind and register notification dispatcher {}",
+                  clazz, exception);
         }
-        dispatchFactory.register(dispatcher.getType(), dispatcher);
-        bind((Class<NotificationDispatcher>) clazz).toInstance(dispatcher);
-
-        LOG.info("Binding and registering notification dispatcher {}", clazz);
-      } catch (Exception exception) {
-        LOG.error("Unable to bind and register notification dispatcher {}",
-            clazz, exception);
       }
     }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
@@ -471,18 +471,20 @@ public class ClusterResourceProvider extends AbstractControllerResourceProvider 
         serviceConfigVersionRequest =
             (serviceConfigVersionRequest ==null ) ? new ServiceConfigVersionRequest() : serviceConfigVersionRequest;
 
-        switch (propName) {
-          case "service_name": {
-            serviceConfigVersionRequest.setServiceName(entry.getValue().toString());
-            break;
-          }
-          case "service_config_version": {
-            serviceConfigVersionRequest.setVersion(Long.valueOf(entry.getValue().toString()));
-            break;
-          }
-          case "service_config_version_note": {
-            serviceConfigVersionRequest.setNote(entry.getValue().toString());
-            break;
+        if (propName != null) {
+          switch (propName) {
+            case "service_name": {
+              serviceConfigVersionRequest.setServiceName(entry.getValue().toString());
+              break;
+            }
+            case "service_config_version": {
+              serviceConfigVersionRequest.setVersion(Long.valueOf(entry.getValue().toString()));
+              break;
+            }
+            case "service_config_version_note": {
+              serviceConfigVersionRequest.setNote(entry.getValue().toString());
+              break;
+            }
           }
         }
       }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/ClusterResourceProvider.java
@@ -466,16 +466,24 @@ public class ClusterResourceProvider extends AbstractControllerResourceProvider 
       String absCategory = PropertyHelper.getPropertyCategory(entry.getKey());
       String propName = PropertyHelper.getPropertyName(entry.getKey());
 
-      if (absCategory.startsWith(parentCategory + "/desired_service_config_version")) {
+      if (absCategory != null &&
+              absCategory.startsWith(parentCategory + "/desired_service_config_version")) {
         serviceConfigVersionRequest =
             (serviceConfigVersionRequest ==null ) ? new ServiceConfigVersionRequest() : serviceConfigVersionRequest;
 
-        if (propName.equals("service_name"))
-          serviceConfigVersionRequest.setServiceName(entry.getValue().toString());
-        else if (propName.equals("service_config_version"))
-          serviceConfigVersionRequest.setVersion(Long.valueOf(entry.getValue().toString()));
-        else if (propName.equals("service_config_version_note")) {
-          serviceConfigVersionRequest.setNote(entry.getValue().toString());
+        switch (propName) {
+          case "service_name": {
+            serviceConfigVersionRequest.setServiceName(entry.getValue().toString());
+            break;
+          }
+          case "service_config_version": {
+            serviceConfigVersionRequest.setVersion(Long.valueOf(entry.getValue().toString()));
+            break;
+          }
+          case "service_config_version_note": {
+            serviceConfigVersionRequest.setNote(entry.getValue().toString());
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Prevent possible NPE for ControllerModule.bindNotificationDispatchers and ClusterResourceProvider.getServiceConfigVersionRequest. Also, provide switch/case for better readability of propName

## How was this patch tested?
The patch was tested with unit tests