### PR TITLE
AMBARI-25309 : Updating desired stack id before saving cluster state - Rolling Upgrade

### DIFF
--- a/ambari-funtest/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test.xml
+++ b/ambari-funtest/src/test/resources/stacks/HDP/2.1.1/upgrades/upgrade_test.xml
@@ -114,6 +114,10 @@
           <command>ls</command>
         </task>
       </execute-stage>
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
       <execute-stage title="Save Cluster State" service="" component="">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction">
         </task>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.3.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.3.xml
@@ -416,7 +416,12 @@
           <function>finalize_rolling_upgrade</function>
         </task>
       </execute-stage>
-      
+
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction">
         </task>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.4.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.4.xml
@@ -462,6 +462,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction" />
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.5.xml
@@ -548,6 +548,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction" />
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/upgrades/upgrade-2.6.xml
@@ -551,6 +551,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction" />
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.4.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.4.xml
@@ -412,7 +412,12 @@
           <function>finalize_rolling_upgrade</function>
         </task>
       </execute-stage>
-      
+
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction">
         </task>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.5.xml
@@ -533,6 +533,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction" />
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.4/upgrades/upgrade-2.6.xml
@@ -540,6 +540,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction" />
       </execute-stage>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.5.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.5.xml
@@ -456,7 +456,12 @@
           <function>finalize_rolling_upgrade</function>
         </task>
       </execute-stage>
-      
+
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction">
         </task>

--- a/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/upgrades/upgrade-2.6.xml
@@ -482,6 +482,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction">
         </task>

--- a/ambari-server/src/main/resources/stacks/PERF/1.0/upgrades/upgrade-2.0.xml
+++ b/ambari-server/src/main/resources/stacks/PERF/1.0/upgrades/upgrade-2.0.xml
@@ -189,6 +189,11 @@
         </task>
       </execute-stage>
 
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
+
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction" />
       </execute-stage>

--- a/ambari-server/src/test/resources/stacks_with_upgrade_cycle/HDP/2.2.0/upgrades/upgrade_test_15388.xml
+++ b/ambari-server/src/test/resources/stacks_with_upgrade_cycle/HDP/2.2.0/upgrades/upgrade_test_15388.xml
@@ -126,6 +126,10 @@
           <function>actionexecute</function>
         </task>
       </execute-stage>
+      <execute-stage title="Update Target Repositories">
+        <task xsi:type="server_action"
+                class="org.apache.ambari.server.serveraction.upgrades.UpdateDesiredRepositoryAction"/>
+      </execute-stage>
       <execute-stage title="Save Cluster State">
         <task xsi:type="server_action" class="org.apache.ambari.server.serveraction.upgrades.FinalizeUpgradeAction">
         </task>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update desired stack id before saving cluster state during Rolling Upgrade. Unless this is done, it can have some adverse effects on future cluster operations. e.g. if desired stack id is not updated and upgrade is done successfully, if we try to onboard a new service on Ambari cluster, Ambari tries to onboard it on older stack rather than new one.

## How was this patch tested?
The patch was tested manually by performing Rolling Upgrade and checking entry in DB