### PR TITLE
Use https for hdp repo

### DIFF
--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -74,7 +74,7 @@
     <repository>
       <id>apache-hadoop</id>
       <name>hdp</name>
-      <url>http://nexus-private.hortonworks.com/nexus/content/groups/public</url>
+      <url>https://nexus-private.hortonworks.com/nexus/content/groups/public</url>
     </repository>
     <repository>
       <id>apache-snapshots</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `https` for Hortonworks Maven repo, as `http` no longer works.

```
[WARNING] Could not transfer metadata net.minidev:json-smart/maven-metadata.xml from/to apache-hadoop (http://nexus-private.hortonworks.com/nexus/content/groups/public): Connect to nexus-private.hortonworks.com:80 [nexus-private.hortonworks.com/54.173.242.72] failed: Connection timed out (Connection timed out)
```

## How was this patch tested?

```
$ mvn -am -pl :ambari-metrics-hadoop-sink clean package
...
[INFO] Ambari Metrics Hadoop Sink 2.7.3.0.0 ............... SUCCESS [ 16.114 s]
...
[INFO] BUILD SUCCESS
```