### PR TITLE
[AMBARI-25333] Regenerate keytab generates empty keytab file if no fi…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreatePrincipalsServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreatePrincipalsServerAction.java
@@ -150,8 +150,9 @@ public class CreatePrincipalsServerAction extends KerberosServerAction {
         // This principal has not been processed before, process it.
         processPrincipal = true;
       } else if (!StringUtils.isEmpty(kerberosPrincipalEntity.getCachedKeytabPath())) {
-        // This principal has been processed and a keytab file has been cached for it... do not process it.
-        processPrincipal = false;
+        // This principal has been processed, process again only if there is no physical keytab file.
+	File file = new File(kerberosPrincipalEntity.getCachedKeytabPath());
+	processPrincipal = !file.exists();	
       } else {
         // This principal has been processed but a keytab file for it has not been distributed... process it.
         processPrincipal = true;

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/KerberosServerAction.java
@@ -293,19 +293,13 @@ public abstract class KerberosServerAction extends AbstractServerAction {
    *                                 to a given request
    * @return A Map of principals-to-password
    */
+  @SuppressWarnings("unchecked")
   protected static Map<String, String> getPrincipalPasswordMap(Map<String, Object> requestSharedDataContext) {
     if (requestSharedDataContext == null) {
       return null;
-    } else {
-      Object map = requestSharedDataContext.get(PRINCIPAL_PASSWORD_MAP);
-
-      if (map == null) {
-        map = new HashMap<String, String>();
-        requestSharedDataContext.put(PRINCIPAL_PASSWORD_MAP, map);
-      }
-
-      return (Map<String, String>) map;
-    }
+    } 
+    Object map = requestSharedDataContext.computeIfAbsent(PRINCIPAL_PASSWORD_MAP, k -> new HashMap<String, String>());
+    return (Map<String, String>) map;
   }
 
   /**
@@ -319,19 +313,13 @@ public abstract class KerberosServerAction extends AbstractServerAction {
    *                                 to a given request
    * @return A Map of principals-to-key_numbers
    */
+  @SuppressWarnings("unchecked")
   protected static Map<String, Integer> getPrincipalKeyNumberMap(Map<String, Object> requestSharedDataContext) {
     if (requestSharedDataContext == null) {
       return null;
-    } else {
-      Object map = requestSharedDataContext.get(PRINCIPAL_KEY_NUMBER_MAP);
-
-      if (map == null) {
-        map = new HashMap<String, String>();
-        requestSharedDataContext.put(PRINCIPAL_KEY_NUMBER_MAP, map);
-      }
-
-      return (Map<String, Integer>) map;
     }
+    Object map = requestSharedDataContext.computeIfAbsent(PRINCIPAL_KEY_NUMBER_MAP, k -> new HashMap<String, String>());
+    return (Map<String, Integer>) map;
   }
 
   /**


### PR DESCRIPTION
…le present in cache (apappu)

## What changes were proposed in this pull request?

Added a validation to check if keytab file exist - if not process the principle 
(Please fill in changes proposed in this fix)

## How was this patch tested?
Have deployed the changes in Ambari2.7.3 and tried like 1. removed the keytab files and performed "regenerate only missing keytabs" operation in UI

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.