### PR TITLE
AMBARI-9016 - Ambari API uses HTTP Header Content-Type:text/plain when the content is JSON.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/ContentTypeOverrideFilter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/ContentTypeOverrideFilter.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -62,7 +63,7 @@ public class ContentTypeOverrideFilter implements Filter {
 
     private static final Logger logger = LoggerFactory.getLogger(ContentTypeOverrideFilter.class);
 
-    private final Set<String> excludedUrls = new HashSet<>();
+    private final Set<Pattern> excludedUrls = new HashSet<>();
 
     class ContentTypeOverrideRequestWrapper extends HttpServletRequestWrapper {
 
@@ -133,7 +134,7 @@ public class ContentTypeOverrideFilter implements Filter {
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
             String contentType = httpServletRequest.getContentType();
 
-            if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON) && !excludedUrls.contains(httpServletRequest.getPathInfo())) {
+            if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON) && !isUrlExcluded(httpServletRequest.getPathInfo())) {
                 ContentTypeOverrideRequestWrapper requestWrapper = new ContentTypeOverrideRequestWrapper(httpServletRequest);
                 ContentTypeOverrideResponseWrapper responseWrapper = new ContentTypeOverrideResponseWrapper((HttpServletResponse) response);
 
@@ -161,7 +162,7 @@ public class ContentTypeOverrideFilter implements Filter {
                             Consumes consumesAnnotation = method.getAnnotation(Consumes.class);
                             for (String consume : consumesAnnotation.value()) {
                                 if (MediaType.APPLICATION_JSON.equals(consume)) {
-                                    excludedUrls.add(path.value());
+                                    excludedUrls.add(Pattern.compile(path.value()));
                                     continue restart;
                                 }
                             }
@@ -173,8 +174,14 @@ public class ContentTypeOverrideFilter implements Filter {
             logger.error("Failed to discover URLs that are excluded from Content-Type override. Falling back to pre-defined list of exluded URLs.", e);
 
             /* Do not fail here, but fallback to manual definition of excluded endpoints. */
-            excludedUrls.add("/bootstrap");
+            excludedUrls.add(Pattern.compile("/bootstrap"));
+        } finally {
+            excludedUrls.add(Pattern.compile("/views/SMARTSENSE/.*"));
         }
+    }
+
+    private boolean isUrlExcluded(String pathInfo) {
+        return excludedUrls.stream().anyMatch(p -> p.matcher(pathInfo).matches());
     }
 
     @Override


### PR DESCRIPTION
The AMBARI-9016 is causing regression in SmartSense by inappropriately changing the Content-Type
to "text/plain" for every request with "application/json" Content-Type. This is a proper
workaround for the Ambari API but not for SmartSense.
This is causing SmartSense API calls fail with "Unsupported Media Type" error.

## What changes were proposed in this pull request?
The ContentTypeOverrideFilter omits every "/views/SMARTSENSE/.*" requests, thus not changing
it's Content-Type.

## How was this patch tested?
- Manually: The failing SmartSense API calls were checked manually.
- The ambari-server untit tests has been executed.