### PR TITLE
AMBARI-25345 Cannot verify that the url does not contain leading spaces

### DIFF
--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -652,7 +652,7 @@ App.config = Em.Object.create({
       default:
         return function (value, name) {
           if (['javax.jdo.option.ConnectionURL', 'oozie.service.JPAService.jdbc.url'].contains(name)
-            && !validator.isConfigValueLink(value) && validator.isConfigValueLink(value)) {
+            && !validator.isConfigValueLink(value) && validator.isNotTrimmed(value)) {
             return Em.I18n.t('errorMessage.config.spaces.trim');
           }
           return validator.isNotTrimmedRight(value) ? Em.I18n.t('errorMessage.config.spaces.trailing') : '';


### PR DESCRIPTION
## What changes were proposed in this pull request?

It fixed that we cannot check properties ( 'javax.jdo.option.ConnectionURL', 'oozie.service.JPAService.jdbc.url') does not contain leading whitespace.

## How was this patch tested?
In HIVE service configurations (Database)
before：
![image](https://user-images.githubusercontent.com/32010892/62119817-fabc8780-b2f2-11e9-8a51-18480362ead7.png)
now:
![image](https://user-images.githubusercontent.com/32010892/62119976-413cc280-b2b0-11e9-872f-0ab1b69670a9.png)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.