### PR TITLE
AMBARI-23469 HostCleanup.py script is failing with AttributeError: 'NoneType' object has no attribute 'get'

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
+++ b/ambari-agent/src/main/python/ambari_agent/HostCleanup.py
@@ -141,9 +141,14 @@ class HostCleanup:
       dirList = argMap.get(DIR_SECTION)
       repoList = argMap.get(REPO_SECTION)
       proc_map = argMap.get(PROCESS_SECTION)
-      procList = proc_map.get(PROCESS_KEY)
-      procUserList = proc_map.get(PROCESS_OWNER_KEY)
-      procIdentifierList = proc_map.get(PROCESS_IDENTIFIER_KEY)
+      if proc_map:
+        procList = proc_map.get(PROCESS_KEY)
+        procUserList = proc_map.get(PROCESS_OWNER_KEY)
+        procIdentifierList = proc_map.get(PROCESS_IDENTIFIER_KEY)
+      else:
+        procList = []
+        procUserList = []
+        procIdentifierList = []
       alt_map = argMap.get(ALT_SECTION)
       additionalDirList = self.get_additional_dirs()
 


### PR DESCRIPTION
HostCleanup.py script is failing with "AttributeError: 'NoneType' object has no attribute 'get'"

When there are no process map data is present in the hostcheck file - which is a viable situation - the HostCleanup.py command fails.

## What changes were proposed in this pull request?
Check the validity of proc_map before trying to get additional data from it.

## How was this patch tested?
- Manual testing.
- Unit tests of AmbariAgent has been executed.