### PR TITLE
AMBARI-25345 Cannot verify that the url does not contain leading spaces

### DIFF
--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -652,7 +652,7 @@ App.config = Em.Object.create({
       default:
         return function (value, name) {
           if (['javax.jdo.option.ConnectionURL', 'oozie.service.JPAService.jdbc.url'].contains(name)
-            && !validator.isConfigValueLink(value) && validator.isConfigValueLink(value)) {
+            && !validator.isConfigValueLink(value) && validator.isNotTrimmed(value)) {
             return Em.I18n.t('errorMessage.config.spaces.trim');
           }
           return validator.isNotTrimmedRight(value) ? Em.I18n.t('errorMessage.config.spaces.trailing') : '';


### PR DESCRIPTION
## What changes were proposed in this pull request?

It fixed that we cannot check properties ( 'javax.jdo.option.ConnectionURL', 'oozie.service.JPAService.jdbc.url') does not contain leading whitespace.

## How was this patch tested?

In HIVE service configurations (Database)
before：
![image](https://user-images.githubusercontent.com/32010892/62450865-b708c880-b79f-11e9-9f07-2ef1834a500c.png)

now:
image
![image](https://user-images.githubusercontent.com/32010892/62449902-c8e96c00-b79d-11e9-998f-e7f57d1e6004.png)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.