### PR TITLE
AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379

### DIFF
--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -343,17 +343,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-xml</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.woodstox</groupId>

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -326,17 +326,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-xml</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.woodstox</groupId>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -56,7 +56,8 @@
     <distMgmtStagingId>apache.staging.https</distMgmtStagingId>
     <distMgmtStagingName>Apache Release Distribution Repository</distMgmtStagingName>
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
-    <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
   </properties>
   <distributionManagement>
     <repository>
@@ -97,7 +98,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml.jackson.version}</version>
+        <version>${fasterxml.jackson.databind.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -39,7 +39,8 @@
     <guice.version>4.1.0</guice.version>
     <spring.version>5.1.8.RELEASE</spring.version>
     <spring.security.version>5.1.5.RELEASE</spring.security.version>
-    <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
     <postgres.version>42.2.2</postgres.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>
@@ -648,7 +649,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml.jackson.version}</version>
+        <version>${fasterxml.jackson.databind.version}</version>
       </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379

## What changes were proposed in this pull request?
Upgrade fasterxml jackson dependency due to CVE-2019-14379

## How was this patch tested?
The patch was tested manually