### PR TITLE
AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379(trunk)

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -39,7 +39,8 @@
     <guice.version>4.1.0</guice.version>
     <spring.version>5.1.3.RELEASE</spring.version>
     <spring.security.version>5.1.2.RELEASE</spring.security.version>
-    <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
     <postgres.version>42.2.2</postgres.version>
     <testContainers.version>1.10.2</testContainers.version>
     <forkCount>4</forkCount>
@@ -709,7 +710,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml.jackson.version}</version>
+        <version>${fasterxml.jackson.databind.version}</version>
       </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379(trunk)
## What changes were proposed in this pull request?
Upgrade fasterxml jackson dependency due to CVE-2019-14379

## How was this patch tested?
The patch was tested manually. 

Patch for branch-2.7: https://github.com/apache/ambari/pull/3066