### PR TITLE
AMBARI-25360 Disable Kerberos failed at hive with CNF exception (dgrinenko)

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -118,6 +118,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper-jute</artifactId>
+      <version>3.5.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <version>2.9.0</version>
@@ -273,7 +278,7 @@
           </execution>
         </executions>
         <configuration>
-          <copyright>2012, Apache Software Foundation</copyright>
+          <license>2012, Apache Software Foundation</license>
           <group>Development</group>
           <description>Maven Recipe: RPM Package.</description>
           <requires>
@@ -429,6 +434,7 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.zookeeper:zookeeper</include>
+                  <include>org.apache.zookeeper:zookeeper-jute</include>
                   <include>commons-cli:commons-cli</include>
                   <include>org.slf4j:*</include>
                   <include>log4j:*</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bundle `zookeeper-jute` to `ZKMigration` tool, as it is required by `zookeeper 3.5.5`

## How was this patch tested?
By executing tool on test cluster and verifying content of produced jar