### PR TITLE
[AMBARI-25362] Hive View throws TimeoutException deadline passed for few queries randomly

### DIFF
--- a/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/client/NonPersistentCursor.java
+++ b/contrib/views/hive-next/src/main/java/org/apache/ambari/view/hive2/client/NonPersistentCursor.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class NonPersistentCursor implements Cursor<Row, ColumnDescription> {
   private final Logger LOG = LoggerFactory.getLogger(getClass());
-  private static long DEFAULT_WAIT_TIMEOUT = 60 * 1000L;
+  private static scala.concurrent.duration.FiniteDuration WAIT_TIME = Duration.create(12, TimeUnit.HOURS);
 
   private final ActorSystem system;
   private final ActorRef actorRef;
@@ -124,8 +124,7 @@ public class NonPersistentCursor implements Cursor<Row, ColumnDescription> {
     inbox.send(actorRef, new Next());
     Object receive;
     try {
-      receive = inbox.receive(Duration.create(actorConfiguration.getResultFetchTimeout(DEFAULT_WAIT_TIMEOUT),
-        TimeUnit.MILLISECONDS));
+      receive = inbox.receive(WAIT_TIME);
     } catch (Throwable ex) {
       String errorMessage = "Result fetch timed out";
       LOG.error(errorMessage, ex);

--- a/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/client/NonPersistentCursor.java
+++ b/contrib/views/hive20/src/main/java/org/apache/ambari/view/hive20/client/NonPersistentCursor.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class NonPersistentCursor implements Cursor<Row, ColumnDescription> {
   private final Logger LOG = LoggerFactory.getLogger(getClass());
-  private static long DEFAULT_WAIT_TIMEOUT = 60 * 1000L;
+  private static scala.concurrent.duration.FiniteDuration WAIT_TIME = Duration.create(12, TimeUnit.HOURS);
 
   private final ActorSystem system;
   private final ActorRef actorRef;
@@ -124,8 +124,7 @@ public class NonPersistentCursor implements Cursor<Row, ColumnDescription> {
     inbox.send(actorRef, new Next());
     Object receive;
     try {
-      receive = inbox.receive(Duration.create(actorConfiguration.getResultFetchTimeout(DEFAULT_WAIT_TIMEOUT),
-        TimeUnit.MILLISECONDS));
+      receive = inbox.receive(WAIT_TIME);
     } catch (Throwable ex) {
       String errorMessage = "Result fetch timed out";
       LOG.error(errorMessage, ex);


### PR DESCRIPTION
[AMBARI-25362] Hive View throws TimeoutException deadline passed for few queries randomly few queries randomly.
## What changes were proposed in this pull request?
[AMBARI-25362] Hive View throws TimeoutException deadline passed for few queries randomly few queries randomly.

## How was this patch tested?
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 101, Failures: 0, Errors: 0, Skipped: 0
.
.
.
.

[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/contrib/views/hive20/pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/contrib/views/hive20/2.0.0.0-SNAPSHOT/hive20-2.0.0.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:06 min
[INFO] Finished at: 2019-08-27T13:09:10+05:30
[INFO] Final Memory: 70M/636M
[INFO] ------------------------------------------------------------------------


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.