### PR TITLE
AMBARI-25294. Druid requires HDFS_CLIENT to be co-hosted, doesn't recognize ONEFS_CLIENT (amagyar)

### DIFF
--- a/ambari-server/src/main/resources/stacks/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/stack_advisor.py
@@ -1849,6 +1849,9 @@ class DefaultStackAdvisor(StackAdvisor):
     component = next((component for component in componentsList
                               if component["component_name"] == componentName), None)
 
+    if component is None and componentName == 'HDFS_CLIENT':
+      component = next((component for component in componentsList if component["component_type"] == 'HCFS_CLIENT'), None)
+
     return component
 
   def getComponentAttribute(self, component, attribute):


### PR DESCRIPTION
## What changes were proposed in this pull request?

While deploying Druid with OneFS using the Ambari OneFS mpack, an error is emitted while assigning slaves and clients. If Druid Historical or Druid MiddleManager is assigned, the error reads "Druid [component] requires HDFS_CLIENT to be co-hosted". If either is NOT assigned, the error reads "You have selected 0 Druid [component] components. Please consider that at least 1 Druid [component] components should be installed in cluster."

## How was this patch tested?

manually