### PR TITLE
AMBARI-25370 Producer and Customer Request /s graphs are failing on K…

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/metrics_whitelist
@@ -273,6 +273,8 @@ kafka.controller.KafkaController.OfflinePartitionsCount
 kafka.log.LogFlushStats.LogFlushRateAndTimeMs.1MinuteRate
 kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.count
 kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count
+kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.version.*.count
+kafka.network.RequestMetrics.RequestsPerSec.request.Produce.version.*.count
 kafka.network.RequestMetrics.TotalTimeMs.request.FetchConsumer.99percentile
 kafka.network.RequestMetrics.TotalTimeMs.request.FetchConsumer.max
 kafka.network.RequestMetrics.TotalTimeMs.request.FetchConsumer.mean

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/windows/metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/windows/metrics_whitelist
@@ -273,6 +273,8 @@ kafka.controller.KafkaController.OfflinePartitionsCount
 kafka.log.LogFlushStats.LogFlushRateAndTimeMs.1MinuteRate
 kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.count
 kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count
+kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.version.*.count
+kafka.network.RequestMetrics.RequestsPerSec.request.Produce.version.*.count
 kafka.network.RequestMetrics.TotalTimeMs.request.FetchConsumer.99percentile
 kafka.network.RequestMetrics.TotalTimeMs.request.FetchConsumer.max
 kafka.network.RequestMetrics.TotalTimeMs.request.FetchConsumer.mean

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-home.json
@@ -555,11 +555,12 @@
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count",
+              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.%.count",
               "precision": "default",
               "refId": "A",
               "transform": "rate",
-              "transformData": "none"
+              "transformData": "none",
+              "seriesAggregator": "sum"
             }
           ],
           "timeFrom": null,
@@ -626,11 +627,12 @@
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.count",
+              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.%.count",
               "precision": "default",
               "refId": "A",
               "transform": "rate",
-              "transformData": "none"
+              "transformData": "none",
+              "seriesAggregator": "sum"
             }
           ],
           "timeFrom": null,
@@ -1073,7 +1075,7 @@
     "list": []
   },
   "schemaVersion": 8,
-  "version": 16,
+  "version": 17,
   "links": [
     {
       "asDropdown": true,

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-hosts.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-kafka-hosts.json
@@ -323,12 +323,13 @@
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count",
+              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.%.count",
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
               "transform": "rate",
-              "transformData": "none"
+              "transformData": "none",
+              "seriesAggregator": "sum"
             }
           ],
           "timeFrom": null,
@@ -395,12 +396,13 @@
               "app": "kafka_broker",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.count",
+              "metric": "kafka.network.RequestMetrics.RequestsPerSec.request.FetchConsumer.%.count",
               "precision": "default",
               "refId": "A",
               "templatedHost": "",
               "transform": "rate",
-              "transformData": "none"
+              "transformData": "none",
+              "seriesAggregator": "sum"
             }
           ],
           "timeFrom": null,
@@ -1991,7 +1993,7 @@
     "list": []
   },
   "schemaVersion": 8,
-  "version": 16,
+  "version": 17,
   "links": [
     {
       "asDropdown": true,


### PR DESCRIPTION
Change-Id: I08656a6f43923b08b3bbc1f1e0346bd93211bbe8

## What changes were proposed in this pull request?
From kafka 2.0.0 there has been addition of version tag in kafka.network.RequestMetrics.RequestsPerSec.request.* metrics.
This is breaking the the default Grafana dashboard provided by Ambari. On the Kafka - Home and Kafka - Hosts dashboards the "Producer requests /s" and "Consumer requests /s "graphs are failing to show any data.

To get the total count for a specific request type, the tool needs to be updated to aggregate across different versions.

Previous metric: kafka.network:type=RequestMetrics,name=RequestsPerSec,request=
{Produce|FetchConsumer|FetchFollower|...}
New metric: kafka.network:type=RequestMetrics,name=RequestsPerSec,request={Produce|FetchConsumer|FetchFollower|...},version=INTEGER

Documentation of the Kafka change: https://cwiki.apache.org/confluence/display/KAFKA/KIP-272%3A+Add+API+version+tag+to+broker%27s+RequestsPerSec+metric

The fix is utilising the wildcard (%) feature of AMS, and request the metrics like: "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.%.count", this includes all the versioned metrics (like: "kafka.network.RequestMetrics.RequestsPerSec.request.Produce.version.5.count") and the legacy format ("kafka.network.RequestMetrics.RequestsPerSec.request.Produce.count") as well.
Grafana is able to sum the values of the versioned metrics by using the **seriesAggregator** feature.

## How was this patch tested?
The patch was tested manually by generating Kafka produce and consume data and examining the graphs.