### PR TITLE
AMBARI-25374. Use host names instead ip addresses while checking hive interactive service status

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/configuration/hive-interactive-site.xml
+++ b/ambari-server/src/main/resources/stacks/HDP/2.5/services/HIVE/configuration/hive-interactive-site.xml
@@ -257,6 +257,12 @@ limitations under the License.
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>hive.server2.leadertest.use.ip</name>
+    <value>true</value>
+    <description>Use ip address to check hive interactive service status</description>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>hive.server2.zookeeper.namespace</name>
     <value>hiveserver2-hive2</value>
     <description>The parent node in ZooKeeper used by HiveServer2 when supporting dynamic service discovery.</description>

--- a/ambari-web/app/utils/ajax/ajax.js
+++ b/ambari-web/app/utils/ajax/ajax.js
@@ -3220,7 +3220,7 @@ var urls = {
     mock: '',
     format: function (data) {
       return {
-        url: 'http://' + data.hsiHost + ':' + data.port + '/leader'
+        url: data.proto + '://' + data.hsiHost + ':' + data.port + '/leader'
       }
     }
   }

--- a/ambari-web/test/mappers/service_metrics_mapper_test.js
+++ b/ambari-web/test/mappers/service_metrics_mapper_test.js
@@ -273,7 +273,7 @@ describe('App.serviceMetricsMapper', function () {
       sinon.stub(configurationController, 'getCurrentConfigsBySites', function () {
         return {done: function (callback) {
           return callback([
-            {type: 'hive-interactive-site', properties: {'hive.server2.webui.port': '1'}}
+            {type: 'hive-interactive-site', properties: {'hive.server2.webui.port': '1', 'hive.server2.leadertest.use.ip': true}},
           ]);
         }};
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?
if hive.server2.webui.use.ssl is true we should use https
add new property hive.server2.leadertest.use.ip and set it to true by default
if hive.server2.leadertest.use.ip is false we sould use host names is url

## How was this patch tested?
unit

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.