### PR TITLE
AMBARI-25381 Save button is enabled without any config changes for Kerberos service

### DIFF
--- a/ambari-web/app/models/configs/objects/service_config_property.js
+++ b/ambari-web/app/models/configs/objects/service_config_property.js
@@ -346,9 +346,6 @@ App.ServiceConfigProperty = Em.Object.extend({
       isFinal = this.get('isFinal'),
       savedIsFinal = this.get('savedIsFinal');
 
-    if (this.get('name') === 'kdc_type') {
-      return App.router.get('mainAdminKerberosController.kdcTypesValues')[savedValue] !== value;
-    }
     // ignore precision difference for configs with type of `float` which value may ends with 0
     // e.g. between 0.4 and 0.40
     if (this.get('stackConfigProperty') && this.get('stackConfigProperty.valueAttributes.type') == 'float') {


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-25381 Save button is enabled without any config changes for Kerberos service

## How was this patch tested?

**Tested in UI**

 22528 passing (27s)
  48 pending

JQMIGRATE: jQuery.support.boxModel is deprecated

JQMIGRATE: jQuery.event.handle is undocumented and deprecated

[INFO] Executed tasks
[INFO]
[INFO] --- maven-assembly-plugin:2.2-beta-5:single (make-assembly) @ ambari-web ---
[INFO] Reading assembly descriptor: /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/ambari-project/src/main/assemblies/empty.xml
[INFO]
[INFO] --- maven-site-plugin:3.7.1:attach-descriptor (attach-descriptor) @ ambari-web ---
[INFO] No site descriptor found: nothing to attach.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:51 min
[INFO] Finished at: 2019-09-19T17:27:29+05:30
[INFO] Final Memory: 20M/226M
[INFO] ------------------------------------------------------------------------
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.