### PR TITLE
AMBARI-25381 Save button is enabled without any config changes for Kerberos service

### DIFF
--- a/ambari-web/app/models/configs/objects/service_config_property.js
+++ b/ambari-web/app/models/configs/objects/service_config_property.js
@@ -346,9 +346,6 @@ App.ServiceConfigProperty = Em.Object.extend({
       isFinal = this.get('isFinal'),
       savedIsFinal = this.get('savedIsFinal');
 
-    if (this.get('name') === 'kdc_type') {
-      return App.router.get('mainAdminKerberosController.kdcTypesValues')[savedValue] !== value;
-    }
     // ignore precision difference for configs with type of `float` which value may ends with 0
     // e.g. between 0.4 and 0.40
     if (this.get('stackConfigProperty') && this.get('stackConfigProperty.valueAttributes.type') == 'float') {


### PR DESCRIPTION
AMBARI-25381 Save button is enabled without any config changes for Kerberos service
## What changes were proposed in this pull request?

AMBARI-25381 Save button is enabled without any config changes for Kerberos service


## How was this patch tested?

tested in UI
UT is success, Local build is success


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.