### PR TITLE
AMBARI-25139 Yarn Capacity Scheduler Authorization issues due to AuthToLocal Rules

### DIFF
--- a/contrib/views/capacity-scheduler/src/main/java/org/apache/ambari/view/capacityscheduler/ConfigurationService.java
+++ b/contrib/views/capacity-scheduler/src/main/java/org/apache/ambari/view/capacityscheduler/ConfigurationService.java
@@ -316,7 +316,7 @@ public class ConfigurationService {
    */
   private boolean isOperator() {
 
-    String url = String.format(AMBARI_OR_CLUSTER_ADMIN_PRIVILEGE_URL, context.getUsername(), context.getCluster().getName());
+    String url = String.format(AMBARI_OR_CLUSTER_ADMIN_PRIVILEGE_URL, context.getLoggedinUser(), context.getCluster().getName());
 
     try {
       String response = ambariApi.readFromAmbari(url, "GET", null, null);


### PR DESCRIPTION

## What changes were proposed in this pull request?
AMBARI-25139 Yarn Capacity Scheduler Authorization issues due to AuthToLocal Rules


(Please fill in changes proposed in this fix)

## How was this patch tested?

tested in UI

[INFO] Installing /Users/asnaik/Documents/Work/code/forked_Ambari/ambari/contrib/views/capacity-scheduler/pom.xml to /Users/asnaik/.m2/repository/org/apache/ambari/contrib/views/capacity-scheduler/1.0.0.0-SNAPSHOT/capacity-scheduler-1.0.0.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:06 min
[INFO] Finished at: 2019-10-01T12:08:11+05:30
[INFO] Final Memory: 40M/221M
[INFO] ------------------------------------------------------------------------

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.