### PR TITLE
AMBARI-25391 Ambari logging Grafana Password in ActionQueue.py (santal)

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -25,6 +25,7 @@ import os
 import ambari_simplejson as json
 import time
 import signal
+import re
 
 from AgentException import AgentException
 from ambari_agent.BackgroundCommandExecutionHandle import BackgroundCommandExecutionHandle
@@ -36,6 +37,13 @@ logger = logging.getLogger()
 installScriptHash = -1
 
 MAX_SYMBOLS_PER_LOG_MESSAGE = 7900
+
+_PASSWORD_REPLACEMENT = '********'
+__passwordPattern = re.compile(r"('\S*password':\s*u?')(\S+)(')")
+
+def hide_passwords(text):
+  """ Replaces the matching passwords with **** in the given text """
+  return None if text is None else __passwordPattern.sub(r'\1{}\3'.format(_PASSWORD_REPLACEMENT), text)
 
 
 class ActionQueue(threading.Thread):
@@ -393,12 +401,12 @@ class ActionQueue(threading.Thread):
     If logs are redirected to syslog (syslog_enabled=1), this is very useful for logging big messages.
     As syslog usually truncates long messages.
     """
-    chunks = split_on_chunks(text, MAX_SYMBOLS_PER_LOG_MESSAGE)
+    chunks = split_on_chunks(hide_passwords(text), MAX_SYMBOLS_PER_LOG_MESSAGE)
     if len(chunks) > 1:
       for i in range(len(chunks)):
         logger.info("Cmd log for taskId={0} and chunk {1}/{2} of log for command: \n".format(taskId, i+1, len(chunks)) + chunks[i])
     else:
-      logger.info("Cmd log for taskId={0}: ".format(taskId) + text)
+      logger.info("Cmd log for taskId={0}: ".format(taskId) + chunks[0])
 
   def get_retry_delay(self, last_delay):
     """

--- a/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
+++ b/ambari-agent/src/main/python/ambari_agent/ActionQueue.py
@@ -38,12 +38,12 @@ installScriptHash = -1
 
 MAX_SYMBOLS_PER_LOG_MESSAGE = 7900
 
-_PASSWORD_REPLACEMENT = '********'
-__passwordPattern = re.compile(r"('\S*password':\s*u?')(\S+)(')")
+PASSWORD_REPLACEMENT = '[PROTECTED]'
+PASSWORD_PATTERN = re.compile(r"('\S*password':\s*u?')(\S+)(')")
 
 def hide_passwords(text):
   """ Replaces the matching passwords with **** in the given text """
-  return None if text is None else __passwordPattern.sub(r'\1{}\3'.format(_PASSWORD_REPLACEMENT), text)
+  return None if text is None else PASSWORD_PATTERN.sub(r'\1{}\3'.format(PASSWORD_REPLACEMENT), text)
 
 
 class ActionQueue(threading.Thread):

--- a/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
@@ -21,7 +21,7 @@ from Queue import Queue
 
 from unittest import TestCase
 from ambari_agent.LiveStatus import LiveStatus
-from ambari_agent.ActionQueue import ActionQueue
+from ambari_agent.ActionQueue import ActionQueue, hide_passwords
 from ambari_agent.AmbariConfig import AmbariConfig
 import os, errno, time, pprint, tempfile, threading
 import sys
@@ -1166,6 +1166,22 @@ class TestActionQueue(TestCase):
       "cancelTaskIdTargets":"13,14"
     },
   }
+
+  def test_hide_passwords_no_matching_password(self):
+    self.assertEqual(hide_passwords(None), None)
+    self.assertEqual(hide_passwords('No password in this text'), 'No password in this text')
+    self.assertEqual(hide_passwords("No 'password' 'in' this text'"), "No 'password' 'in' this text'")
+    self.assertEqual(hide_passwords("No 'password': in this text"), "No 'password': in this text")
+    self.assertEqual(hide_passwords("No u'password': u'' in this text"), "No u'password': u'' in this text")
+
+  def test_hide_passwords(self):
+    self.assertEqual(hide_passwords("u'password': u'changeIT!'"), "u'password': u'********'")
+    self.assertEqual(hide_passwords("'password': 'password'"), "'password': '********'")
+    self.assertEqual(hide_passwords("'some.password': 'password', 'other.password': 'password',"), "'some.password': '********', 'other.password': '********',")
+    self.assertEqual(hide_passwords("u'metrics_grafana_password': u'mypassword123!'"), "u'metrics_grafana_password': u'********'")
+
+    self.assertEqual(hide_passwords("u'metrics_grafana_username': u'admin', u'metrics_grafana_password': u'mypassword123!', some text, u'clientssl.keystore.password': u'myKeyFilePassword', another text, "),
+                     "u'metrics_grafana_username': u'admin', u'metrics_grafana_password': u'********', some text, u'clientssl.keystore.password': u'********', another text, ")
 
 def patch_output_file(pythonExecutor):
   def windows_py(command, tmpout, tmperr):

--- a/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestActionQueue.py
@@ -1175,13 +1175,13 @@ class TestActionQueue(TestCase):
     self.assertEqual(hide_passwords("No u'password': u'' in this text"), "No u'password': u'' in this text")
 
   def test_hide_passwords(self):
-    self.assertEqual(hide_passwords("u'password': u'changeIT!'"), "u'password': u'********'")
-    self.assertEqual(hide_passwords("'password': 'password'"), "'password': '********'")
-    self.assertEqual(hide_passwords("'some.password': 'password', 'other.password': 'password',"), "'some.password': '********', 'other.password': '********',")
-    self.assertEqual(hide_passwords("u'metrics_grafana_password': u'mypassword123!'"), "u'metrics_grafana_password': u'********'")
+    self.assertEqual(hide_passwords("u'password': u'changeIT!'"), "u'password': u'[PROTECTED]'")
+    self.assertEqual(hide_passwords("'password': 'password'"), "'password': '[PROTECTED]'")
+    self.assertEqual(hide_passwords("'some.password': 'password', 'other.password': 'password',"), "'some.password': '[PROTECTED]', 'other.password': '[PROTECTED]',")
+    self.assertEqual(hide_passwords("u'metrics_grafana_password': u'mypassword123!'"), "u'metrics_grafana_password': u'[PROTECTED]'")
 
     self.assertEqual(hide_passwords("u'metrics_grafana_username': u'admin', u'metrics_grafana_password': u'mypassword123!', some text, u'clientssl.keystore.password': u'myKeyFilePassword', another text, "),
-                     "u'metrics_grafana_username': u'admin', u'metrics_grafana_password': u'********', some text, u'clientssl.keystore.password': u'********', another text, ")
+                     "u'metrics_grafana_username': u'admin', u'metrics_grafana_password': u'[PROTECTED]', some text, u'clientssl.keystore.password': u'[PROTECTED]', another text, ")
 
 def patch_output_file(pythonExecutor):
   def windows_py(command, tmpout, tmperr):


### PR DESCRIPTION
## What changes were proposed in this pull request?




This is a critical Security Issue. Grafana uses the admin password for Ambari by default during its setup. This password is getting logged from the ActionQueue.py....  As this is the admin password for the cluster this is a huge security risk to have this logged in plaintext in Syslog.

```
ActionQueue.py [ 6398 ] - root - INFO - Cmd log for taskId=456 and chunk 3/42 of log for command: #012s_user\', \'hdfs\')}}/hadoop-{{default(\'configurations/hadoop-
.
.
.
  u'metrics_grafana_log_dir': u'/var/log/ambari-metrics-grafana',
  u'metrics_grafana_username': u'admin',
*  u'metrics_grafana_password': u'mypassword123!',*
  u'metrics_grafana_pid_dir': u'/var/run/ambari-metrics-grafana',
  u'metrics_grafana_data_dir': u'/var/lib/ambari-metrics-grafana'
}, u'ranger-hive-policymgr-ssl': {
  u'xasecure.policymgr.clientssl.keystore': u'/usr/hdp/current/hive-server2/conf/ranger-plugin-keystore.jks',
  u'xasecure.policymgr.clientssl.truststore': u'/usr/hdp/current/hive-server2/conf/ranger-plugin-truststore.jks',
  u'xasecure.policymgr.clientssl.truststore.credential.file': u'jceks://file{{credential_file}}',
  u'xasecure.policymgr.clientssl.keystore.password': u'myKeyFilePassword',
  u'xasecure.policymgr.clientssl.truststore.password': u'changeit',
  u'xasecure.policymgr.clientssl.keystore.credential.file': u'jceks://file{{credential_file}}'
}, u'hivemetastore-site': {
  u'hive.service.metrics.hadoop2.component': u'hivemetastore',
  u'hive.metastore.metrics.enabled': u'true',
  u'hive.service.metrics.reporter': u'HADOOP2'
}, u'llap-cli-log4j2': { u'content': u'\n# Licensed to the Apache Software Foundation (ASF) under

```
The fix looks for matching passwords in the log message and replaces them with *****.

## How was this patch tested?

The patch was tested by unit tests.
