### PR TITLE
[AMBARI-25333] Regenerate keytab generates empty keytab file if no fi…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreatePrincipalsServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreatePrincipalsServerAction.java
@@ -151,8 +151,8 @@ public class CreatePrincipalsServerAction extends KerberosServerAction {
         processPrincipal = true;
       } else if (!StringUtils.isEmpty(kerberosPrincipalEntity.getCachedKeytabPath())) {
         // This principal has been processed, process again only if there is no physical keytab file.
-	File file = new File(kerberosPrincipalEntity.getCachedKeytabPath());
-	processPrincipal = !file.exists();	
+        File file = new File(kerberosPrincipalEntity.getCachedKeytabPath());
+        processPrincipal = !file.exists();
       } else {
         // This principal has been processed but a keytab file for it has not been distributed... process it.
         processPrincipal = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

I see that AMBARI-25333 is committed to the branch-2.7 under ca4a712 hash. However, some lines have a bad formatting.
Could we fix the code formatting and close the jira? 

## How was this patch tested?

No functionality is affected by this patch at all so no additional/adjusted tests needed in this case. Tabs have been replaced by spaces only.
