### PR TITLE
AMBARI-25402 Please provide jvm metrics for kafka components in Ambari (santal)

### DIFF
--- a/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSet.java
+++ b/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSet.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.util.RatioGauge;
@@ -152,32 +153,11 @@ public class JvmMetricSet {
         .collect(Collectors.toList());
   }
 
-  private String getThreadMetricNameByState(Thread.State state) {
-    String name = "thread-states.";
-    switch (state) {
-      case BLOCKED:
-        name += "blocked";
-        break;
-      case RUNNABLE:
-        name += "runnable";
-        break;
-      case TIMED_WAITING:
-        name += "timed_waiting";
-        break;
-      case TERMINATED:
-        name += "terminated";
-        break;
-      case NEW:
-        name += "new";
-        break;
-      case WAITING:
-        name += "waiting";
-        break;
-    }
-    return name;
+  private String getThreadMetricNameByState(@Nonnull Thread.State state) {
+    return String.format("thread-states.%s", state.name().toLowerCase());
   }
 
-  private long getThreadCountByState(Thread.State state) {
+  private long getThreadCountByState(@Nonnull Thread.State state) {
     return Arrays.stream(threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 0))
       .filter(threadInfo -> threadInfo.getThreadState().equals(state))
       .count();

--- a/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSet.java
+++ b/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSet.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.metrics2.sink.kafka;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.util.RatioGauge;
+
+public class JvmMetricSet {
+
+  private static final String GARBAGE_COLLECTOR = "gc";
+  private static final String MEMORY = "memory";
+  private static final String THREADS = "threads";
+  private static final String RUNTIME = "runtime";
+
+
+  private static final JvmMetricSet INSTANCE = new JvmMetricSet();
+
+
+  public static JvmMetricSet getInstance() {
+    return INSTANCE;
+  }
+
+  private final MemoryMXBean mxBean;
+  private final ThreadMXBean threads;
+  private final RuntimeMXBean runtimeBean;
+
+  private class JvmMetric {
+    private final MetricName metricName;
+    private final Gauge<?> metric;
+
+    JvmMetric(MetricName metricName, Gauge<?> metric) {
+      this.metricName = metricName;
+      this.metric = metric;
+    }
+
+    MetricName getMetricName() {
+      return metricName;
+    }
+
+    Gauge<?> getMetric() {
+      return metric;
+    }
+  }
+
+
+  private JvmMetricSet() {
+    this(ManagementFactory.getMemoryMXBean(), ManagementFactory.getThreadMXBean(),
+      ManagementFactory.getRuntimeMXBean());
+
+  }
+
+  private JvmMetricSet(MemoryMXBean mxBean, ThreadMXBean threads, RuntimeMXBean runtimeBean) {
+    this.mxBean = mxBean;
+    this.threads = threads;
+    this.runtimeBean = runtimeBean;
+  }
+
+  public Map<MetricName, Gauge<?>> getJvmMetrics() {
+    return Stream.concat(
+      getMemoryUsageMetrics().stream(),
+      Stream.concat(
+        getThreadMetrics().stream(),
+        Stream.of(getRuntimeMetrics())
+      ))
+      .collect(Collectors.toMap(JvmMetric::getMetricName, JvmMetric::getMetric));
+  }
+
+  private List<JvmMetric> getMemoryUsageMetrics() {
+
+    return Stream.of(
+      new AbstractMap.SimpleEntry<>("heap_usage", mxBean.getHeapMemoryUsage()),
+      new AbstractMap.SimpleEntry<>("non_heap_usage", mxBean.getNonHeapMemoryUsage()))
+      .map(entry ->
+        new JvmMetric(
+          MetricNameBuilder.builder().type(MEMORY).name(entry.getKey()).build(),
+          new RatioGauge() {
+
+            @Override
+            protected double getNumerator() {
+              return entry.getValue().getUsed();
+            }
+
+            @Override
+            protected double getDenominator() {
+              return entry.getValue().getMax();
+            }
+          }
+        ))
+      .collect(Collectors.toList());
+
+  }
+
+  private List<JvmMetric> getThreadMetrics() {
+
+    return
+      Stream.concat(
+        Stream.of(
+          new JvmMetric(
+            MetricNameBuilder.builder().type(THREADS).name("thread_count").build(),
+            new Gauge<Integer>() {
+              @Override
+              public Integer value() {
+                return threads.getThreadCount();
+              }
+            }
+          ),
+          new JvmMetric(
+            MetricNameBuilder.builder().type(THREADS).name("daemon_thread_count").build(),
+            new Gauge<Integer>() {
+              @Override
+              public Integer value() {
+                return threads.getDaemonThreadCount();
+              }
+            }
+          )),
+        Stream
+          .of(Thread.State.RUNNABLE, Thread.State.BLOCKED, Thread.State.TIMED_WAITING, Thread.State.TERMINATED)
+          .map(state -> new JvmMetric(
+            MetricNameBuilder.builder().type(THREADS).name(getThreadMetricNameByState(state)).build(),
+            new Gauge<Long>() {
+              @Override
+              public Long value() {
+                return getThreadCountByState(state);
+              }
+            }
+          )))
+        .collect(Collectors.toList());
+  }
+
+  private String getThreadMetricNameByState(Thread.State state) {
+    String name = "thread-states.";
+    switch (state) {
+      case BLOCKED:
+        name += "blocked";
+        break;
+      case RUNNABLE:
+        name += "runnable";
+        break;
+      case TIMED_WAITING:
+        name += "timed_waiting";
+        break;
+      case TERMINATED:
+        name += "terminated";
+        break;
+      case NEW:
+        name += "new";
+        break;
+      case WAITING:
+        name += "waiting";
+        break;
+    }
+    return name;
+  }
+
+  private long getThreadCountByState(Thread.State state) {
+    return Arrays.stream(threads.getThreadInfo(threads.getAllThreadIds(), 0))
+      .filter(threadInfo -> threadInfo.getThreadState().equals(state))
+      .count();
+  }
+
+  private JvmMetric getRuntimeMetrics() {
+    return new JvmMetric(
+      MetricNameBuilder.builder().type(RUNTIME).name("uptime").build(),
+      new Gauge<Long>() {
+        @Override
+        public Long value() {
+          return runtimeBean.getUptime();
+        }
+      }
+    );
+  }
+
+}
+
+

--- a/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/KafkaTimelineMetricsReporter.java
+++ b/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/KafkaTimelineMetricsReporter.java
@@ -18,6 +18,24 @@
 
 package org.apache.hadoop.metrics2.sink.kafka;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.metrics2.sink.timeline.AbstractTimelineMetricsSink;
+import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
+import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
+import org.apache.hadoop.metrics2.sink.timeline.cache.TimelineMetricsCache;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Gauge;
@@ -33,24 +51,6 @@ import com.yammer.metrics.stats.Snapshot;
 import kafka.metrics.KafkaMetricsConfig;
 import kafka.metrics.KafkaMetricsReporter;
 import kafka.utils.VerifiableProperties;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.ClassUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.metrics2.sink.timeline.AbstractTimelineMetricsSink;
-import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
-import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
-import org.apache.hadoop.metrics2.sink.timeline.cache.TimelineMetricsCache;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import static org.apache.hadoop.metrics2.sink.timeline.TimelineMetricMetadata.MetricType;
 import static org.apache.hadoop.metrics2.sink.timeline.cache.TimelineMetricsCache.MAX_EVICTION_TIME_MILLIS;
 import static org.apache.hadoop.metrics2.sink.timeline.cache.TimelineMetricsCache.MAX_RECS_PER_NAME_DEFAULT;
@@ -302,6 +302,10 @@ public class KafkaTimelineMetricsReporter extends AbstractTimelineMetricsSink
 
     protected TimelineScheduledReporter(MetricsRegistry registry, String name, TimeUnit rateUnit, TimeUnit durationUnit) {
       super(registry, name, rateUnit, durationUnit);
+
+      JvmMetricSet.getInstance()
+        .getJvmMetrics()
+        .forEach(registry::newGauge);
     }
 
     @Override

--- a/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/MetricNameBuilder.java
+++ b/ambari-metrics/ambari-metrics-kafka-sink/src/main/java/org/apache/hadoop/metrics2/sink/kafka/MetricNameBuilder.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.metrics2.sink.kafka;
+
+import java.util.regex.Pattern;
+
+import com.yammer.metrics.core.MetricName;
+
+import static java.util.Optional.ofNullable;
+
+public class MetricNameBuilder {
+  private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+
+  private String group = "jvm";
+  private String type;
+  private String name;
+
+  private final String replacement;
+
+  static MetricNameBuilder builder() {
+    return new MetricNameBuilder();
+  }
+
+  MetricNameBuilder() {
+    this(null);
+  }
+
+  MetricNameBuilder(String replacement) {
+    this.replacement = ofNullable(replacement).orElse("_");
+  }
+
+  public MetricNameBuilder group(String group) {
+    this.group = group;
+    return this;
+  }
+
+  public MetricNameBuilder type(String type) {
+    this.type = replaceWhiteSpaces(type);
+    return this;
+  }
+
+  public MetricNameBuilder name(String name) {
+    this.name = ofNullable(this.name).orElse("") + replaceWhiteSpaces(name);
+    return this;
+  }
+
+  private String replaceWhiteSpaces(String value) {
+    return ofNullable(value)
+      .map(val -> WHITESPACE.matcher(val).replaceAll(replacement))
+      .orElse("");
+  }
+
+  public MetricName build() {
+    return new MetricName(this.group, type, name, null, createMBeanName());
+  }
+
+  private String createMBeanName() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append(group);
+    builder.append(":type=");
+    builder.append(type);
+    if (name.length() > 0) {
+      builder.append(",name=");
+      builder.append(name);
+    }
+    return builder.toString();
+  }
+
+}

--- a/ambari-metrics/ambari-metrics-kafka-sink/src/test/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSetTest.java
+++ b/ambari-metrics/ambari-metrics-kafka-sink/src/test/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSetTest.java
@@ -1,0 +1,30 @@
+package org.apache.hadoop.metrics2.sink.kafka;
+
+import java.util.Map;
+import org.junit.Test;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.hasItems;
+
+public class JvmMetricSetTest {
+
+  @Test
+  public void testGetJvmMetrics() {
+
+    Map<MetricName, Gauge<?>> result = JvmMetricSet.getInstance().getJvmMetrics();
+
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertThat(
+      result.keySet()
+        .stream()
+        .map(MetricName::getName)
+        .collect(toList()),
+      hasItems("heap_usage", "thread-states.blocked", "thread-states.timed_waiting", "uptime"));
+  }
+
+}

--- a/ambari-metrics/ambari-metrics-kafka-sink/src/test/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSetTest.java
+++ b/ambari-metrics/ambari-metrics-kafka-sink/src/test/java/org/apache/hadoop/metrics2/sink/kafka/JvmMetricSetTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.metrics2.sink.kafka;
 
 import java.util.Map;

--- a/ambari-server/src/main/resources/common-services/KAFKA/1.0.1/metainfo.xml
+++ b/ambari-server/src/main/resources/common-services/KAFKA/1.0.1/metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>KAFKA</name>
+      <extends>common-services/KAFKA/0.10.0</extends>
+      <version>1.0.1</version>
+      <restartRequiredAfterRackChange>true</restartRequiredAfterRackChange>
+    </service>
+  </services>
+</metainfo>

--- a/ambari-server/src/main/resources/common-services/KAFKA/1.0.1/metrics.json
+++ b/ambari-server/src/main/resources/common-services/KAFKA/1.0.1/metrics.json
@@ -1,0 +1,239 @@
+{
+  "KAFKA_BROKER": {
+    "Component": [
+      {
+        "type": "ganglia",
+        "metrics": {
+          "default": {
+            "metrics/jvm/uptime": {
+              "metric": "jvm.runtime.uptime",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/heap_usage": {
+              "metric": "jvm.memory.heap_usage",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/non_heap_usage": {
+              "metric": "jvm.memory.non_heap_usage",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/thread-states/runnable": {
+              "metric": "jvm.threads.thread-states.runnable",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/thread-states/blocked": {
+              "metric": "jvm.threads.thread-states.blocked",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/thread-states/timed_waiting": {
+              "metric": "jvm.threads.thread-states.timed_waiting",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/thread-states/terminated": {
+              "metric": "jvm.threads.thread-states.terminated",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/thread_count": {
+              "metric": "jvm.threads.thread_count",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/jvm/daemon_thread_count": {
+              "metric": "jvm.threads.daemon_thread_count",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsMessagesInPerSec/1MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.1MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsMessagesInPerSec/5MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.5MinuteRate",
+              "pointInTime": false,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsMessagesInPerSec/15MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.15MinuteRate",
+              "pointInTime": false,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsMessagesInPerSec/meanRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.meanRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsMessagesInPerSec/count": {
+              "metric": "kafka.server.BrokerTopicMetrics.MessagesInPerSec.count",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesInPerSec/1MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.1MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesInPerSec/5MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.5MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesInPerSec/15MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.15MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesInPerSec/meanRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.meanRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesInPerSec/count": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesInPerSec.count",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesOutPerSec/1MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.1MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesOutPerSec/5MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.5MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesOutPerSec/15MinuteRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.15MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesOutPerSec/meanRate": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.meanRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/BrokerTopicMetrics/AllTopicsBytesOutPerSec/count": {
+              "metric": "kafka.server.BrokerTopicMetrics.BytesOutPerSec.count",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/KafkaController/ActiveControllerCount": {
+              "metric": "kafka.controller.KafkaController.ActiveControllerCount",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/LeaderElectionRateAndTimeMs/meanRate": {
+              "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.meanRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/LeaderElectionRateAndTimeMs/1MinuteRate": {
+              "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.1MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/LeaderElectionRateAndTimeMs/5MinuteRate": {
+              "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.5MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/LeaderElectionRateAndTimeMs/15MinuteRate": {
+              "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.15MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/LeaderElectionRateAndTimeMs/count": {
+              "metric": "kafka.controller.ControllerStats.LeaderElectionRateAndTimeMs.count",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/UncleanLeaderElectionsPerSec/1MinuteRate": {
+              "metric": "kafka.controller.ControllerStats.UncleanLeaderElectionsPerSec.1MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/UncleanLeaderElectionsPerSec/5MinuteRate": {
+              "metric": "kafka.controller.ControllerStats.UncleanLeaderElectionsPerSec.5MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/UncleanLeaderElectionsPerSec/15MinuteRate": {
+              "metric": "kafka.controller.ControllerStats.UncleanLeaderElectionsPerSec.15MinuteRate",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/controller/ControllerStats/OfflinePartitionsCount": {
+              "metric": "kafka.controller.ControllerStats.OfflinePartitionsCount",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/ReplicaManager/PartitionCount": {
+              "metric": "kafka.server.ReplicaManager.PartitionCount",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/ReplicaManager/LeaderCount": {
+              "metric": "kafka.server.ReplicaManager.LeaderCount",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/ReplicaManager/UnderReplicatedPartitions": {
+              "metric": "kafka.server.ReplicaManager.UnderReplicatedPartitions",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/ReplicaManager/ISRShrinksPerSec": {
+              "metric": "kafka.server.ReplicaManager.ISRShrinksPerSec",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/ReplicaManager/ISRExpandsPerSec": {
+              "metric": "kafka.server.ReplicaManager.ISRExpandsPerSec",
+              "pointInTime": true,
+              "temporal": true
+            },
+
+            "metrics/kafka/server/ReplicaFetcherManager/Replica-MaxLag": {
+              "metric": "kafka.server.ReplicaFetcherManager.MaxLag.clientId.Replica",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/ProducerRequestPurgatory/PurgatorySize": {
+              "metric": "kafka.server.ProducerRequestPurgatory.PurgatorySize",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/server/FetchRequestPurgatory/PurgatorySize": {
+              "metric": "kafka.server.FetchRequestPurgatory.PurgatorySize",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/cluster/Partition/$1-UnderReplicated": {
+              "metric": "kafka.cluster.Partition.(\\w+)-UnderReplicated",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/consumer/ConsumerFetcherManager/$1-MaxLag": {
+              "metric": "kafka.consumer.ConsumerFetcherManager.(\\w+)-MaxLag",
+              "pointInTime": true,
+              "temporal": true
+            },
+            "metrics/kafka/consumer/ConsumerFetcherManager/$1-MinFetch": {
+              "metric": "kafka.consumer.ConsumerFetcherManager.(\\w+)-MinFetch",
+              "pointInTime": true,
+              "temporal": true
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently kakfa jvm metrics are not collected. 

Implemented to provide the missing jvm metrics via kafka-sink.

## How was this patch tested?

The patch was tested manually by creating jvm metric widges for the kafka service.

![kafka-jvm-metrics](https://user-images.githubusercontent.com/3410619/67697538-ff9fde80-f9a8-11e9-851a-b2af0507d5ad.png)
