### PR TITLE
[AMBARI-25404] Remove dependency on commons-beanutils:commons-beanuti…

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
         <exclusions>
           <exclusion>
             <groupId>commons-collections</groupId>


### PR DESCRIPTION
…ls:jar:1.9.3 in Ambari

commons-beanutils version upgrade 1.9.3 -> 1.9.4

## What changes were proposed in this pull request?

Apache Commons Beanutils version upgrade from 1.9.3 to 1.9.4 based on the [CVE-2019-10086](https://nvd.nist.gov/vuln/detail/CVE-2019-10086) vulnerability report.

## How was this patch tested?

Unit tests have been passed.
