### PR TITLE
AMBARI-25405 Remove dependency on com.fasterxml.jackson.core:jackson-…

### DIFF
--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -343,7 +343,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.3</version>
+        <version>2.10.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-logfeeder-container-registry/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.3</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -330,7 +330,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.3</version>
+        <version>2.10.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -56,8 +56,8 @@
     <distMgmtStagingId>apache.staging.https</distMgmtStagingId>
     <distMgmtStagingName>Apache Release Distribution Repository</distMgmtStagingName>
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
-    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
   </properties>
   <distributionManagement>
     <repository>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -40,8 +40,8 @@
     <guice.version>4.1.0</guice.version>
     <spring.version>5.1.8.RELEASE</spring.version>
     <spring.security.version>5.1.5.RELEASE</spring.security.version>
-    <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
     <postgres.version>42.2.2</postgres.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>


### PR DESCRIPTION
…databind:2.9.6-2.9.9.1 in Ambari

pom.xml upgrades

## What changes were proposed in this pull request?

Upgrade dependency on com.fasterxml.jackson.core:jackson-databind:2.9.6-2.9.9.1 in Ambari due to security concerns. See [CVE-2019-14379](https://nvd.nist.gov/vuln/detail/CVE-2019-14379).

## How was this patch tested?

Unit tests should cover the affected functionalities.
