### PR TITLE
AMBARI-25403 Ambari Management Pack: Ambari throws 500 error while downloading OneFS client configuration (santal)

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/package/scripts/params_linux.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/package/scripts/params_linux.py
@@ -24,6 +24,7 @@ from resource_management.libraries.functions.default import default
 from resource_management.libraries.functions.get_not_managed_resources import get_not_managed_resources
 from resource_management.libraries.resources.hdfs_resource import HdfsResource
 from resource_management.libraries.functions import stack_select
+from resource_management.libraries.functions.expect import expect
 
 config = Script.get_config()
 
@@ -42,6 +43,7 @@ hadoop_bin_dir = stack_select.get_hadoop_dir("bin")
 hadoop_conf_dir = conf_select.get_hadoop_conf_dir()
 hdfs_site = config['configurations']['hdfs-site']
 default_fs = config['configurations']['core-site']['fs.defaultFS']
+java_version = expect("/ambariLevelParams/java_version", int)
 
 ambari_libs_dir = "/var/lib/ambari-agent/lib"
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

When attemping to download OneFS client configuration, Ambari throws 500 error with below exception:

```
org.apache.ambari.server.controller.spi.SystemException: 
Execution of "ambari-python-wrap /var/lib/ambari-server/resources/stacks/HDP/3.0/services/ONEFS/package/scripts/onefs_client.py generate_configs 
/var/lib/ambari-server/data/tmp/ONEFS_CLIENT7933335097995561813-configuration.json /var/lib/ambari-server/resources/stacks/HDP/3.0/services/ONEFS/package 
/var/lib/ambari-server/data/tmp/structured-out.json INFO /var/lib/ambari-server/data/tmp" returned 1. java.lang.Throwable: ambari_jinja2.exceptions.UndefinedError: 'java_version' is undefined
```
Reproduction steps:

1. Log into Amabri UI
2. Click on "Services" --> "Download All Client Configs"
OR
3. Click on "Service" --> "OneFS" --> "Actions" --> "Download Client Configs"

## How was this patch tested?

The patch was tested manually.
