### PR TITLE
AMBARI-25406 Upgrade dependency on org.quartz-scheduler:quartz:2.2.1 i…

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1593,7 +1593,7 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.2.1</version>
+      <version>2.3.2</version>
       <exclusions>
         <exclusion>
           <groupId>c3p0</groupId>
@@ -1604,7 +1604,7 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz-jobs</artifactId>
-      <version>2.2.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
…n Ambari

pom.xml update in ambari-server

## What changes were proposed in this pull request?

Upgrade dependency on org.quartz-scheduler:quartz:2.2.1 in Ambari due to security concerns. See
[CVE-2019-13990](https://nvd.nist.gov/vuln/detail/CVE-2019-13990).

## How was this patch tested?

Unit tests

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.