### PR TITLE
AMBARI-25332. Kerberos keytab regeneration working slow (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -2616,6 +2616,13 @@ public class Configuration {
   public static final ConfigurationProperty<Integer> KERBEROS_SERVER_ACTION_FINALIZE_SECONDS = new ConfigurationProperty<>(
     "server.kerberos.finalize.timeout", 600);
 
+  /**
+   * The number of threads to use when executing server-side Kerberos commands, such as generate keytabs.
+   */
+  @Markdown(description = "The number of threads to use when executing server-side Kerberos commands, such as generate keytabs.")
+  public static final ConfigurationProperty<Integer> KERBEROS_SERVER_ACTION_THREADPOOL_SIZE = new ConfigurationProperty<>(
+    "server.kerberos.action.threadpool.size", 1);
+
   private static final Logger LOG = LoggerFactory.getLogger(
     Configuration.class);
 
@@ -3041,7 +3048,7 @@ public class Configuration {
     writeConfigFile(existingProperties, false);
 
     // reloading properties
-    this.properties = readConfigFile();
+    properties = readConfigFile();
   }
 
   /**
@@ -5566,6 +5573,16 @@ public class Configuration {
    */
   public int getDefaultMaxParallelismForUpgrades() {
     return Integer.parseInt(getProperty(DEFAULT_MAX_DEGREE_OF_PARALLELISM_FOR_UPGRADES));
+  }
+
+  /**
+   * Gets the number of threads to use when executing server-side Kerberos
+   * commands, such as generate keytabs.
+   *
+   * @return the threadpool size, defaulting to 1
+   */
+  public int getKerberosServerActionThreadpoolSize() {
+    return Integer.parseInt(getProperty(KERBEROS_SERVER_ACTION_THREADPOOL_SIZE));
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
@@ -704,32 +704,52 @@ public interface KerberosHelper {
   Map<String, Map<String, String>> getIdentityConfigurations(List<KerberosIdentityDescriptor> identityDescriptors);
 
   /**
-   * Returns the active identities for the named cluster.  Results are filtered by host, service,
-   * and/or component; and grouped by host.
+   * Returns the active identities for the named cluster. Results are filtered
+   * by host, service, and/or component; and grouped by host.
    * <p/>
-   * The cluster name is mandatory; however the active identities may be filtered by one or more of
-   * host, service, or component. A <code>null</code> value for any of these filters indicates no
-   * filter for that parameter.
+   * The cluster name is mandatory; however the active identities may be
+   * filtered by one or more of host, service, or component. A <code>null</code>
+   * value for any of these filters indicates no filter for that parameter.
    * <p/>
-   * The return values are grouped by host and optionally <code>_HOST</code> in principals will be
-   * replaced with the relevant hostname if specified to do so.
+   * The return values are grouped by host and optionally <code>_HOST</code> in
+   * principals will be replaced with the relevant hostname if specified to do
+   * so.
    *
-   * @param clusterName      the name of the relevant cluster (mandatory)
-   * @param hostName         the name of a host for which to find results, null indicates all hosts
-   * @param serviceName      the name of a service for which to find results, null indicates all
-   *                         services
-   * @param componentName    the name of a component for which to find results, null indicates all
-   *                         components
-   * @param replaceHostNames if true, _HOST in principals will be replace with the relevant host
-   *                         name
+   * @param clusterName
+   *          the name of the relevant cluster (mandatory)
+   * @param hostName
+   *          the name of a host for which to find results, null indicates all
+   *          hosts
+   * @param serviceName
+   *          the name of a service for which to find results, null indicates
+   *          all services
+   * @param componentName
+   *          the name of a component for which to find results, null indicates
+   *          all components
+   * @param replaceHostNames
+   *          if true, _HOST in principals will be replace with the relevant
+   *          host name
+   * @param hostConfigurations
+   *          a mapping of hostname to configurations for that host. Fetching
+   *          this ahead of time for every host in the cluster will ensure that
+   *          this method doesn't need to do it inside of a loop. If
+   *          {@code null} or empty, then this method will do the lookup itself,
+   *          at considerable cost.
+   * @param kerberosDescriptor
+   *          the kerberos descriptor to use when looking up identities. If
+   *          {@code null}, then this method will deserialize the descriptor
+   *          inside of a loop at considerable cost.
    * @return a map of host names to kerberos identities
-   * @throws AmbariException if an error occurs processing the cluster's active identities
+   * @throws AmbariException
+   *           if an error occurs processing the cluster's active identities
    */
   Map<String, Collection<KerberosIdentityDescriptor>> getActiveIdentities(String clusterName,
                                                                           String hostName,
                                                                           String serviceName,
                                                                           String componentName,
-                                                                          boolean replaceHostNames)
+                                                                          boolean replaceHostNames,
+                                                                          Map<String, Map<String, Map<String, String>>> hostConfigurations,
+                                                                          KerberosDescriptor kerberosDescriptor)
       throws AmbariException;
 
   /**
@@ -814,7 +834,7 @@ public interface KerberosHelper {
    * @return a map of configuration types to sets of property names
    */
   Map<String, Set<String>> translateConfigurationSpecifications(Collection<String> configurationSpecifications);
-  
+
   /**
    * Gathers the Kerberos-related data from configurations and stores it in a new KerberosDetails
    * instance.
@@ -827,7 +847,7 @@ public interface KerberosHelper {
    * @throws AmbariException
    */
   KerberosDetails getKerberosDetails(Cluster cluster, Boolean manageIdentities)
-    throws KerberosInvalidConfigurationException, AmbariException;  
+    throws KerberosInvalidConfigurationException, AmbariException;
 
   /**
    * Types of Kerberos descriptors related to where the data is stored.

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostKerberosIdentityResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostKerberosIdentityResourceProvider.java
@@ -40,6 +40,9 @@ import org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO;
 import org.apache.ambari.server.orm.dao.KerberosPrincipalDAO;
 import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.KerberosKeytabPrincipalEntity;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosKeytabDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosPrincipalDescriptor;
@@ -158,9 +161,15 @@ public class HostKerberosIdentityResourceProvider extends ReadOnlyResourceProvid
         String clusterName = (String) propertyMap.get(KERBEROS_IDENTITY_CLUSTER_NAME_PROPERTY_ID);
         String hostName = (String) propertyMap.get(KERBEROS_IDENTITY_HOST_NAME_PROPERTY_ID);
 
+        Clusters clusters = getManagementController().getClusters();        
+        Cluster cluster = clusters.getCluster(clusterName);
+            
+        KerberosDescriptor kerberosDescriptor = kerberosHelper.getKerberosDescriptor(cluster, false);
+        
         // Retrieve the active identities for the cluster filtered and grouped by hostname
         Map<String, Collection<KerberosIdentityDescriptor>> hostDescriptors =
-            kerberosHelper.getActiveIdentities(clusterName, hostName, null, null, true);
+            kerberosHelper.getActiveIdentities(clusterName, hostName, null, null, true, null, 
+                kerberosDescriptor);
 
         if (hostDescriptors != null) {
           for (Map.Entry<String, Collection<KerberosIdentityDescriptor>> entry : hostDescriptors.entrySet()) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosKeytabDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosKeytabDAO.java
@@ -21,6 +21,7 @@ package org.apache.ambari.server.orm.dao;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
@@ -32,6 +33,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Stopwatch;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -88,9 +90,15 @@ public class KerberosKeytabDAO {
 
   @RequiresSession
   public List<KerberosKeytabEntity> findByPrincipalAndHost(String principalName, Long hostId) {
+    Stopwatch stopwatch = Stopwatch.createStarted();
     if(hostId == null) {
-      return findByPrincipalAndNullHost(principalName);
+      List<KerberosKeytabEntity> result = findByPrincipalAndNullHost(principalName);
+      LOG.debug("Loading keytabs by principal name took {}ms",
+          stopwatch.elapsed(TimeUnit.MILLISECONDS));
+
+      return result;
     }
+
     TypedQuery<KerberosKeytabEntity> query = entityManagerProvider.get().
       createNamedQuery("KerberosKeytabEntity.findByPrincipalAndHost", KerberosKeytabEntity.class);
     query.setParameter("hostId", hostId);
@@ -99,6 +107,10 @@ public class KerberosKeytabDAO {
     if(result == null) {
       return Collections.emptyList();
     }
+
+    LOG.debug("Loading keytabs by principal name and host took {}ms",
+        stopwatch.elapsed(TimeUnit.MILLISECONDS));
+
     return result;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosKeytabPrincipalDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosKeytabPrincipalDAO.java
@@ -74,20 +74,28 @@ public class KerberosKeytabPrincipalDAO {
    * @param kerberosPrincipalEntity      {@link KerberosPrincipalEntity} which related to this principal
    * @return evaluated entity
    */
-  public KerberosKeytabPrincipalEntity findOrCreate(KerberosKeytabEntity kerberosKeytabEntity, HostEntity hostEntity, KerberosPrincipalEntity kerberosPrincipalEntity) {
+  public KeytabPrincipalFindOrCreateResult findOrCreate(KerberosKeytabEntity kerberosKeytabEntity, HostEntity hostEntity, KerberosPrincipalEntity kerberosPrincipalEntity) {
+    KeytabPrincipalFindOrCreateResult result = new KeytabPrincipalFindOrCreateResult();
+    result.created = false;
+
     Long hostId = hostEntity == null ? null : hostEntity.getHostId();
     KerberosKeytabPrincipalEntity kkp = findByNaturalKey(hostId, kerberosKeytabEntity.getKeytabPath(), kerberosPrincipalEntity.getPrincipalName());
     if (kkp == null) {
+      result.created = true;
+
       kkp = new KerberosKeytabPrincipalEntity(
           kerberosKeytabEntity,
           hostEntity,
           kerberosPrincipalEntity
       );
       create(kkp);
+
       kerberosKeytabEntity.addKerberosKeytabPrincipal(kkp);
       kerberosPrincipalEntity.addKerberosKeytabPrincipal(kkp);
     }
-    return kkp;
+
+    result.kkp = kkp;
+    return result;
   }
 
   @Transactional
@@ -344,5 +352,15 @@ public class KerberosKeytabPrincipalDAO {
           componentNames,
           principalNames);
     }
+  }
+
+  /**
+   * Used to return a keytab principal and whether or not it was created. This
+   * is required so that callers know whether associated keytabs and principals
+   * need bi-direcitonal merges.
+   */
+  public static class KeytabPrincipalFindOrCreateResult {
+    public KerberosKeytabPrincipalEntity kkp;
+    public boolean created;
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosPrincipalDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosPrincipalDAO.java
@@ -69,8 +69,10 @@ public class KerberosPrincipalDAO {
    * @param service       a boolean value declaring whether the principal represents a service (true) or not )false).
    */
   @Transactional
-  public void create(String principalName, boolean service) {
-    create(new KerberosPrincipalEntity(principalName, service, null));
+  public KerberosPrincipalEntity create(String principalName, boolean service) {
+    KerberosPrincipalEntity kpe = new KerberosPrincipalEntity(principalName, service, null);
+    create(kpe);
+    return kpe;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/KerberosKeytabEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/KerberosKeytabEntity.java
@@ -29,6 +29,7 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
+import javax.persistence.QueryHint;
 import javax.persistence.Table;
 
 @Entity
@@ -37,8 +38,10 @@ import javax.persistence.Table;
   @NamedQuery(name = "KerberosKeytabEntity.findAll", query = "SELECT kk FROM KerberosKeytabEntity kk"),
   @NamedQuery(
     name = "KerberosKeytabEntity.findByPrincipalAndHost",
-    query = "SELECT kk FROM KerberosKeytabEntity kk JOIN kk.kerberosKeytabPrincipalEntities kkp WHERE kkp.hostId=:hostId AND kkp.principalName=:principalName"
-  ),
+        query = "SELECT kk FROM KerberosKeytabEntity kk, KerberosKeytabPrincipalEntity kkp WHERE kkp.hostId=:hostId AND kkp.principalName=:principalName AND kkp.keytabPath = kk.keytabPath",
+        hints = {
+            @QueryHint(name = "eclipselink.query-results-cache", value = "true"),
+            @QueryHint(name = "eclipselink.query-results-cache.size", value = "500") }),
   @NamedQuery(
     name = "KerberosKeytabEntity.findByPrincipalAndNullHost",
     query = "SELECT kk FROM KerberosKeytabEntity kk JOIN kk.kerberosKeytabPrincipalEntities kkp WHERE kkp.hostId IS NULL AND kkp.principalName=:principalName"

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/ConfigureAmbariIdentitiesServerAction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.agent.CommandReport;
@@ -46,6 +47,7 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.Striped;
 import com.google.inject.Inject;
 
 /**
@@ -78,6 +80,11 @@ public class ConfigureAmbariIdentitiesServerAction extends KerberosServerAction 
   @Inject
   private HostDAO hostDAO;
 
+  /**
+   * Used to prevent multiple threads from working with the same keytab.
+   */
+  private Striped<Lock> m_locksByKeytab = Striped.lazyWeakLock(25);  
+  
   /**
    * Called to execute this action.  Upon invocation, calls
    * {@link KerberosServerAction#processIdentities(Map)} )}
@@ -136,18 +143,24 @@ public class ConfigureAmbariIdentitiesServerAction extends KerberosServerAction 
           File hostDirectory = new File(dataDirectory, hostName);
           File srcKeytabFile = new File(hostDirectory, DigestUtils.sha256Hex(destKeytabFilePath));
 
-          if (srcKeytabFile.exists()) {
-            String ownerAccess = keytab.getOwnerAccess();
-            String groupAccess = keytab.getGroupAccess();
-
-            installAmbariServerIdentity(resolvedPrincipal, srcKeytabFile.getAbsolutePath(), destKeytabFilePath,
-              keytab.getOwnerName(), ownerAccess,
-              keytab.getGroupName(), groupAccess, actionLog);
-
-            if (serviceMappingEntry.getValue().contains("AMBARI_SERVER_SELF")) {
-              // Create/update the JAASFile...
-              configureJAAS(resolvedPrincipal.getPrincipal(), destKeytabFilePath, actionLog);
+          Lock lock = m_locksByKeytab.get(destKeytabFilePath);
+          lock.lock();
+          try {
+            if (srcKeytabFile.exists()) {
+              String ownerAccess = keytab.getOwnerAccess();
+              String groupAccess = keytab.getGroupAccess();
+  
+              installAmbariServerIdentity(resolvedPrincipal, srcKeytabFile.getAbsolutePath(), destKeytabFilePath,
+                keytab.getOwnerName(), ownerAccess,
+                keytab.getGroupName(), groupAccess, actionLog);
+  
+              if (serviceMappingEntry.getValue().contains("AMBARI_SERVER_SELF")) {
+                // Create/update the JAASFile...
+                configureJAAS(resolvedPrincipal.getPrincipal(), destKeytabFilePath, actionLog);
+              }
             }
+          } finally {
+            lock.unlock();
           }
         }
       }
@@ -215,7 +228,7 @@ public class ConfigureAmbariIdentitiesServerAction extends KerberosServerAction 
       for(Map.Entry<String, String> mapping : principal.getServiceMapping().entries()) {
         String serviceName = mapping.getKey();
         String componentName = mapping.getValue();
-        KerberosKeytabPrincipalEntity entity = kerberosKeytabPrincipalDAO.findOrCreate(kke, hostEntity, kpe);
+        KerberosKeytabPrincipalEntity entity = kerberosKeytabPrincipalDAO.findOrCreate(kke, hostEntity, kpe).kkp;
         entity.setDistributed(true);
         entity.putServiceMapping(serviceName, componentName);
         kerberosKeytabPrincipalDAO.merge(entity);

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreatePrincipalsServerAction.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/CreatePrincipalsServerAction.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
@@ -39,6 +40,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.Striped;
 import com.google.inject.Inject;
 
 /**
@@ -67,6 +69,11 @@ public class CreatePrincipalsServerAction extends KerberosServerAction {
   @Inject
   private KerberosKeytabPrincipalDAO kerberosKeytabPrincipalDAO;
 
+  /**
+   * Used to prevent multiple threads from working with the same principal.
+   */
+  private Striped<Lock> locksByPrincipal = Striped.lazyWeakLock(25);
+  
   /**
    * A set of visited principal names used to prevent unnecessary processing on already processed
    * principal names
@@ -161,32 +168,40 @@ public class CreatePrincipalsServerAction extends KerberosServerAction {
       if (processPrincipal) {
         Map<String, String> principalPasswordMap = getPrincipalPasswordMap(requestSharedDataContext);
 
-        String password = principalPasswordMap.get(resolvedPrincipal.getPrincipal());
+        String principal = resolvedPrincipal.getPrincipal();
+        Lock lock = locksByPrincipal.get(principal);
+        lock.lock();
+        
+        String password = principalPasswordMap.get(principal);
 
-        if (password == null) {
-          CreatePrincipalResult result = createPrincipal(resolvedPrincipal.getPrincipal(), servicePrincipal, kerberosConfiguration, operationHandler, regenerateKeytabs, actionLog);
-          if (result == null) {
-            commandReport = createCommandReport(1, HostRoleStatus.FAILED, "{}", actionLog.getStdOut(), actionLog.getStdErr());
-          } else {
-            Map<String, Integer> principalKeyNumberMap = getPrincipalKeyNumberMap(requestSharedDataContext);
-
-            principalPasswordMap.put(resolvedPrincipal.getPrincipal(), result.getPassword());
-            principalKeyNumberMap.put(resolvedPrincipal.getPrincipal(), result.getKeyNumber());
-            // invalidate given principal for all keytabs to make them redistributed again
-            for (KerberosKeytabPrincipalEntity kkpe: kerberosKeytabPrincipalDAO.findByPrincipal(resolvedPrincipal.getPrincipal())) {
-              kkpe.setDistributed(false);
-              kerberosKeytabPrincipalDAO.merge(kkpe);
+        try {
+          if (password == null) {
+            CreatePrincipalResult result = createPrincipal(resolvedPrincipal.getPrincipal(), servicePrincipal, kerberosConfiguration, operationHandler, regenerateKeytabs, actionLog);
+            if (result == null) {
+              commandReport = createCommandReport(1, HostRoleStatus.FAILED, "{}", actionLog.getStdOut(), actionLog.getStdErr());
+            } else {
+              Map<String, Integer> principalKeyNumberMap = getPrincipalKeyNumberMap(requestSharedDataContext);
+  
+              principalPasswordMap.put(resolvedPrincipal.getPrincipal(), result.getPassword());
+              principalKeyNumberMap.put(resolvedPrincipal.getPrincipal(), result.getKeyNumber());
+              // invalidate given principal for all keytabs to make them redistributed again
+              for (KerberosKeytabPrincipalEntity kkpe: kerberosKeytabPrincipalDAO.findByPrincipal(resolvedPrincipal.getPrincipal())) {
+                kkpe.setDistributed(false);
+                kerberosKeytabPrincipalDAO.merge(kkpe);
+              }
+              // invalidate principal cache
+              KerberosPrincipalEntity principalEntity = kerberosPrincipalDAO.find(resolvedPrincipal.getPrincipal());
+              try {
+                new File(principalEntity.getCachedKeytabPath()).delete();
+              } catch (Exception e) {
+                LOG.debug("Failed to delete cache file '{}'", principalEntity.getCachedKeytabPath());
+              }
+              principalEntity.setCachedKeytabPath(null);
+              kerberosPrincipalDAO.merge(principalEntity);
             }
-            // invalidate principal cache
-            KerberosPrincipalEntity principalEntity = kerberosPrincipalDAO.find(resolvedPrincipal.getPrincipal());
-            try {
-              new File(principalEntity.getCachedKeytabPath()).delete();
-            } catch (Exception e) {
-              LOG.debug("Failed to delete cache file '{}'", principalEntity.getCachedKeytabPath());
-            }
-            principalEntity.setCachedKeytabPath(null);
-            kerberosPrincipalDAO.merge(principalEntity);
           }
+        } finally {
+          lock.unlock();
         }
       }
     }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -84,6 +84,7 @@ import org.apache.ambari.server.orm.DBAccessor;
 import org.apache.ambari.server.orm.dao.ArtifactDAO;
 import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
 import org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO;
+import org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO.KeytabPrincipalFindOrCreateResult;
 import org.apache.ambari.server.orm.dao.KerberosPrincipalDAO;
 import org.apache.ambari.server.orm.entities.KerberosKeytabPrincipalEntity;
 import org.apache.ambari.server.scheduler.ExecutionScheduler;
@@ -3429,7 +3430,12 @@ public class KerberosHelperTest extends EasyMockSupport {
   private void testCreateTestIdentity(final PrincipalKeyCredential PrincipalKeyCredential, Boolean manageIdentities) throws Exception {
     KerberosHelper kerberosHelper = injector.getInstance(KerberosHelper.class);
     KerberosKeytabPrincipalDAO kerberosKeytabPrincipalDAO = injector.getInstance(KerberosKeytabPrincipalDAO.class);
-    expect(kerberosKeytabPrincipalDAO.findOrCreate(anyObject(), anyObject(), anyObject())).andReturn(createNiceMock(KerberosKeytabPrincipalEntity.class)).anyTimes();
+    KerberosKeytabPrincipalEntity kkp = createNiceMock(KerberosKeytabPrincipalEntity.class);
+    KeytabPrincipalFindOrCreateResult result = new KeytabPrincipalFindOrCreateResult();
+    result.created = true;
+    result.kkp = kkp;
+
+    expect(kerberosKeytabPrincipalDAO.findOrCreate(anyObject(), anyObject(), anyObject())).andReturn(result).anyTimes();
     boolean managingIdentities = !Boolean.FALSE.equals(manageIdentities);
 
     final Map<String, String> kerberosEnvProperties = new HashMap<>();
@@ -3620,7 +3626,12 @@ public class KerberosHelperTest extends EasyMockSupport {
   private void testDeleteTestIdentity(final PrincipalKeyCredential PrincipalKeyCredential) throws Exception {
     KerberosHelper kerberosHelper = injector.getInstance(KerberosHelper.class);
     KerberosKeytabPrincipalDAO kerberosKeytabPrincipalDAO = injector.getInstance(KerberosKeytabPrincipalDAO.class);
-    expect(kerberosKeytabPrincipalDAO.findOrCreate(anyObject(), anyObject(), anyObject())).andReturn(createNiceMock(KerberosKeytabPrincipalEntity.class)).anyTimes();
+    KerberosKeytabPrincipalEntity kkp = createNiceMock(KerberosKeytabPrincipalEntity.class);
+    KeytabPrincipalFindOrCreateResult result = new KeytabPrincipalFindOrCreateResult();
+    result.created = true;
+    result.kkp = kkp;
+
+    expect(kerberosKeytabPrincipalDAO.findOrCreate(anyObject(), anyObject(), anyObject())).andReturn(result).anyTimes();
     Host host1 = createMock(Host.class);
     expect(host1.getHostId()).andReturn(1l).anyTimes();
 
@@ -4051,7 +4062,8 @@ public class KerberosHelperTest extends EasyMockSupport {
     injector.getInstance(AmbariMetaInfo.class).init();
 
     Map<String, Collection<KerberosIdentityDescriptor>> identities;
-    identities = kerberosHelper.getActiveIdentities(clusterName, hostName, serviceName, componentName, replaceHostNames);
+    identities = kerberosHelper.getActiveIdentities(clusterName, hostName, serviceName,
+        componentName, replaceHostNames, null, null);
 
     verifyAll();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostKerberosIdentityResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostKerberosIdentityResourceProviderTest.java
@@ -43,10 +43,14 @@ import org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO;
 import org.apache.ambari.server.orm.dao.KerberosPrincipalDAO;
 import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.KerberosKeytabPrincipalEntity;
+import org.apache.ambari.server.state.Cluster;
+import org.apache.ambari.server.state.Clusters;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosIdentityDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosKeytabDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosPrincipalDescriptor;
 import org.apache.ambari.server.state.kerberos.KerberosPrincipalType;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Test;
@@ -131,8 +135,12 @@ public class HostKerberosIdentityResourceProviderTest extends EasyMockSupport {
 
   @Test
   public void testGetResources() throws Exception {
+    Clusters clusters = createNiceMock(Clusters.class);
+    expect(clusters.getCluster(EasyMock.anyString())).andReturn(
+        createNiceMock(Cluster.class)).once();
 
     AmbariManagementController managementController = createMock(AmbariManagementController.class);
+    expect(managementController.getClusters()).andReturn(clusters).atLeastOnce();
 
     KerberosPrincipalDescriptor principalDescriptor1 = createStrictMock(KerberosPrincipalDescriptor.class);
     expect(principalDescriptor1.getValue()).andReturn("principal1@EXAMPLE.COM");
@@ -214,9 +222,15 @@ public class HostKerberosIdentityResourceProviderTest extends EasyMockSupport {
     activeIdentities.put("Host100", identities);
 
     KerberosHelper kerberosHelper = createStrictMock(KerberosHelper.class);
-    expect(kerberosHelper.getActiveIdentities("Cluster100", "Host100", null, null, true))
+    KerberosDescriptor kerberosDescriptor = createNiceMock(KerberosDescriptor.class);
+    expect(kerberosHelper.getKerberosDescriptor(
+        EasyMock.anyObject(Cluster.class),
+        EasyMock.eq(false))).andReturn(kerberosDescriptor).atLeastOnce();
+
+    expect(kerberosHelper.getActiveIdentities("Cluster100", "Host100", null, null, true, null,
+        kerberosDescriptor))
         .andReturn(activeIdentities)
-        .times(1);
+        .once();
 
     // replay
     replayAll();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Various Kerberos optimizations: 

- Adding possibility to create and process keytabs in multi-threaded way
- Reduced amount reads of kerberos descriptors from drive
- Optimized queries to DB

## How was this patch tested?

On test cluster