### PR TITLE
AMBARI-25379 Upgrade AMS Grafana version to 6.4.2 - Fix AMS Datasource deploy on debian/ubuntu

### DIFF
--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -777,6 +777,7 @@
                     <path>/var/lib/ambari-metrics-monitor/lib</path>
                     <path>/var/lib/ambari-metrics-grafana</path>
                     <path>/var/lib/ambari-metrics-grafana/plugins</path>
+                    <path>/var/lib/ambari-metrics-grafana/plugins/ambari-metrics</path>
                     <path>/usr/lib/ambari-metrics-hadoop-sink</path>
                     <path>/usr/lib/ambari-metrics-kafka-sink</path>
                     <path>/usr/lib/ambari-metrics-kafka-sink/lib</path>
@@ -990,6 +991,15 @@
                     <type>perm</type>
                     <filemode>644</filemode>
                     <prefix>/etc/ambari-metrics-grafana/conf</prefix>
+                  </mapper>
+                </data>
+                <data>
+                  <src>${grafana.dir}/ambari-metrics</src>
+                  <type>directory</type>
+                  <mapper>
+                    <type>perm</type>
+                    <filemode>755</filemode>
+                    <prefix>/var/lib/ambari-metrics-grafana/plugins/ambari-metrics</prefix>
                   </mapper>
                 </data>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
On Debian and Ubuntu platforms the Grafana dashboards are not working because the AMS Datasource cannot be found.
The root cause of the problem is that by the Grafana update the AMS Datasource deploy location moved from "/usr/lib/ambari-metrics-grafana/public/app/plugins/datasource" to "/var/lib/ambari-metrics-grafana/plugins/ambari-metrics/" and this new location and its content is not included in the ambari-metrics-assembly-*.deb package.

The fix updates the jdeb section of ambari-metrics-assembly/pom.xml  to create the required directory and add the required content.

## How was this patch tested?
- A build was initiated on Ubuntu16 and a cluster was deployed.
- AMS service was added.
- Grafana dashboards has been checked: the AMS Datasource was identified and used by Grafana.

The "/var/lib/ambari-metrics-grafana/plugins/ambari-metrics/" directory was present on the Grafana node and the AMS Datasource's code was deployed there.