### PR TITLE
[AMBARI-25170] Dashboard 'Yarn Container' widget always shows n/a in …

### DIFF
--- a/ambari-web/app/views/main/dashboard/widgets/yarn_containers.js
+++ b/ambari-web/app/views/main/dashboard/widgets/yarn_containers.js
@@ -19,7 +19,7 @@
 var App = require('app');
 
 function counterOrNA(key) {
-  var _key = 'model.{0}.length'.format(key);
+  var _key = 'model.{0}'.format(key);
   return Em.computed(_key, function () {
     if (Em.isNone(this.get('model.'+ key)) || this.get('model.metricsNotAvailable')) {
       return Em.I18n.t('services.service.summary.notAvailable');
@@ -32,9 +32,9 @@ App.YarnContainersView = App.TextDashboardWidgetView.extend({
 
   hiddenInfo: function () {
     return [
-      this.get('containersAllocated') + ' ' + Em.I18n.t('dashboard.services.yarn.containers.allocated'),
-      this.get('containersPending') + ' ' + Em.I18n.t('dashboard.services.yarn.containers.pending'),
-      this.get('containersReserved')+ ' ' + Em.I18n.t('dashboard.services.yarn.containers.reserved')
+      this.get('model.containersAllocated') + ' ' + Em.I18n.t('dashboard.services.yarn.containers.allocated'),
+      this.get('model.containersPending') + ' ' + Em.I18n.t('dashboard.services.yarn.containers.pending'),
+      this.get('model.containersReserved')+ ' ' + Em.I18n.t('dashboard.services.yarn.containers.reserved')
     ];
   }.property('containersAllocated', 'containersPending', 'containersReserved'),
 


### PR DESCRIPTION
[AMBARI-25170] Dashboard 'Yarn Container' widget always shows n/a in Ambari 2.7.3

## What changes were proposed in this pull request?
To read the data from the model . (like model. containersAllocated). else it becomes 0. 

## How was this patch tested?
Manually Tested the fix.

Build was successful:
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Main ........................................ SUCCESS [  5.974 s]
[INFO] Apache Ambari Project POM .......................... SUCCESS [  0.018 s]
[INFO] Ambari Web ......................................... SUCCESS [02:11 min]
[INFO] Ambari Views ....................................... SUCCESS [  3.693 s]
[INFO] Ambari Admin View .................................. SUCCESS [01:29 min]
[INFO] ambari-utility ..................................... SUCCESS [01:14 min]
[INFO] ambari-metrics ..................................... SUCCESS [  0.165 s]

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.