### PR TITLE
AMBARI-14526 Proper SystemD configuration(TasksMax) on SLES12 without…

### DIFF
--- a/ambari-agent/conf/unix/custom/sles12.sh
+++ b/ambari-agent/conf/unix/custom/sles12.sh
@@ -10,30 +10,12 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific
+# See the License for the specific language governing permissions and
+# limitations under the License
 
-# This service unit file is tuned for SLES 12.x. It is not suitable for RHEL like distributions due to different
-# paths for ExecStart/ExecStop.
+# This is a custom SLES12 dependent script which contains postinstall steps
+# to execute. Please note executing this might cause unexpected errors on
+# other linux distributions.
 
-[Unit]
-Description=Ambari Agent Service for SLES
-Before=runlevel3.target
-Before=runlevel5.target
-Before=shutdown.target
-After=remote-fs.target
-After=network-online.target
-Wants=network-online.target
-Conflicts=shutdown.target
-
-[Service]
-Type=forking
-PIDFile=/run/ambari-agent/ambari-agent.pid
-Restart=no
-TimeoutSec=5min
-IgnoreSIGPIPE=no
-KillMode=process
-GuessMainPID=no
-RemainAfterExit=no
-TasksMax=infinity
-ExecStart=/etc/init.d/ambari-agent start
-ExecStop=/etc/init.d/ambari-agent stop
+systemctl enable ambari-agent
+systemctl set-property ambari-agent TasksMax=infinity

--- a/ambari-agent/conf/unix/install-helper.sh
+++ b/ambari-agent/conf/unix/install-helper.sh
@@ -118,6 +118,15 @@ install_autostart(){
   fi
 }
 
+install_custom(){
+   if [ -d "/etc/ambari-agent/conf/custom" ]; then
+     for f in /etc/ambari-agent/conf/custom/*.sh; do
+       echo "${f}"
+       bash "$f" -H
+     done
+  fi
+}
+
 locate_python(){
   local python_binaries="/usr/bin/python;/usr/bin/python2;/usr/bin/python2.7"
 
@@ -153,6 +162,8 @@ do_install(){
   chmod 700 ${AMBARI_AGENT_VAR}/data
 
   install_autostart 1>>${LOG_FILE} 2>&1
+
+  install_custom 1>>${LOG_FILE} 2>&1
 
   # remove old python wrapper
   rm -f "${PYTHON_WRAPER_TARGET}"

--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -726,14 +726,14 @@
               <group>Development</group>
               <mappings>
                 <mapping>
-                  <directory>/usr/lib/systemd/system/</directory>
+                  <directory>/var/lib/${project.artifactId}/tmp</directory>
                   <username>root</username>
                   <groupname>root</groupname>
                   <filemode>644</filemode>
                   <directoryIncluded>false</directoryIncluded>
                   <sources>
                     <source>
-                      <location>${project.build.directory}${dirsep}${project.artifactId}-${project.version}${dirsep}usr${dirsep}lib${dirsep}systemd${dirsep}system${dirsep}ambari-agent.service</location>
+                      <location>${project.build.directory}${dirsep}${project.artifactId}-${project.version}${dirsep}etc${dirsep}ambari-agent${dirsep}conf${dirsep}custom${dirsep}sles12.sh</location>
                     </source>
                   </sources>
                 </mapping>

--- a/ambari-agent/src/packages/tarball/all.xml
+++ b/ambari-agent/src/packages/tarball/all.xml
@@ -146,6 +146,12 @@
       <directory>${pluggableStackDefinitionOutput}/custom_actions</directory>
       <outputDirectory>/var/lib/ambari-agent/cache/custom_actions</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directoryMode>755</directoryMode>
+      <fileMode>755</fileMode>
+      <directory>conf/unix/custom</directory>
+      <outputDirectory>/var/lib/${project.artifactId}/tmp</outputDirectory>
+    </fileSet>
   </fileSets>
   <!-- Single files. Syntax:
 	  <files>
@@ -184,11 +190,6 @@
       <fileMode>644</fileMode>
       <source>conf/unix/logging.conf.sample</source>
       <outputDirectory>/etc/ambari-agent/conf</outputDirectory>
-    </file>
-    <file>
-      <fileMode>644</fileMode>
-      <source>conf/unix/ambari-agent.service</source>
-      <outputDirectory>/usr/lib/systemd/system</outputDirectory>
     </file>
     <file>
       <fileMode>755</fileMode>


### PR DESCRIPTION
… any bad impact on other linux distributions.

## What changes were proposed in this pull request?

This patch fixes the following issues:

- autostart on Debian9 not working due to SLES12 specific SystemD unit file is installed in Ambari 2.7.4
- a SystemD specific unit file for ambari-agent is deployed on every linux distributions
- ambari-agent not autostarting on SLES12

## How was this patch tested?

Since the mentioned issues occur on different linux distributions I tested the patch manually by the steps below:

1. install ambari-server
2. setup ambari-server
3. install ambari-agent
4. check if ambari-agent & ambari-server are configured for autostart using systemd
5. restart the node
6. check if ambari-server & ambari-agent are running

The following distributions were under investigation: SLES12(rpm), Debian9(deb)