### PR TITLE
AMBARI-25418 Cannot select any configuration in logsearch configuration editor (santal)

### DIFF
--- a/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.ts
+++ b/ambari-logsearch/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.ts
@@ -41,10 +41,10 @@ export class FilterDropdownComponent extends DropdownButtonComponent implements 
   }
 
   set selection(items: ListItem[]) {
-    this.selectedItems = items;
+    this.selectedItems = Array.isArray(items) ? items : [items];
     if (this.isMultipleChoice && this.options) {
       this.options.forEach((option: ListItem): void => {
-        const selectionItem = items.find((item: ListItem): boolean => this.utils.isEqual(item.value, option.value));
+        const selectionItem = this.selectedItems.find((item: ListItem): boolean => this.utils.isEqual(item.value, option.value));
         option.isChecked = Boolean(selectionItem);
       });
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the logsearch configuration editor it is not possible add or select another configuration. It is also not possible to navigate back the service log page.

The following error appears in the dev console.

ERROR Error: Uncaught (in promise): TypeError: e.find is not a function
```
TypeError: e.find is not a function
at main.bundle.js:1
at Array.forEach (<anonymous>)
at t.set as selection (main.bundle.js:1)
at t.writeValue (main.bundle.js:1)
at t._next (main.bundle.js:1)
at t.__tryOrSetError (vendor.bundle.js:999)
at t.next (vendor.bundle.js:999)
at t._next (vendor.bundle.js:999)
at t.next (vendor.bundle.js:999)
at t._emitFinal (vendor.bundle.js:999)
at l (polyfills.bundle.js:43)
at polyfills.bundle.js:43
at e.invokeTask (polyfills.bundle.js:36)
at Object.onInvokeTask (vendor.bundle.js:443)
at e.invokeTask (polyfills.bundle.js:36)
at t.runTask (polyfills.bundle.js:36)
at r (polyfills.bundle.js:36)
at o.invokeTask as invoke (polyfills.bundle.js:36)
at j (polyfills.bundle.js:8)
at XMLHttpRequest._ (polyfills.bundle.js:8)
```
Occasionally, after refreshing the page the error didn’t appear and everything worked fine.

## How was this patch tested?

The patch was manually tested by loading the configuration editor and switching between existing configurations.
