### PR TITLE
AMBARI-25262: Bump OneFS Management Pack version to 1.0.2.0

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/mpack.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/mpack.json
@@ -1,7 +1,7 @@
 {
   "type" : "full-release",
   "name" : "onefs-ambari-mpack",
-  "version": "1.0.1.0",
+  "version": "1.0.2.0",
   "description" : "OneFS Ambari Management Pack",
   "prerequisites": {
     "min-ambari-version" : "3.0.0.0"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The OneFS Management Pack needs a version bump from 1.0.1.0 to 1.0.2.0 with following fixes:
#3113 

## How was this patch tested?

The mpack was successfully built. Existing management pack was upgraded to this one and version verified. Management pack also has correct version on initial install of new management pack.

1. Built the mpack with new version successfully. 
2. Verified the version mpack to be v1.0.2.0 at initial installation.
2. Tested upgrading of Isilon management pack from v1.0.0.0 and v1.0.1.0 to this new version.