### PR TITLE
AMBARI-14526 Special deployment for SLES12 containing systemD specifi…

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -726,14 +726,14 @@
               <group>Development</group>
               <mappings>
                 <mapping>
-                  <directory>/var/lib/${project.artifactId}/tmp</directory>
+                  <directory>/etc/${project.artifactId}/conf/custom</directory>
                   <username>root</username>
                   <groupname>root</groupname>
                   <filemode>644</filemode>
                   <directoryIncluded>false</directoryIncluded>
                   <sources>
                     <source>
-                      <location>${project.build.directory}${dirsep}${project.artifactId}-${project.version}${dirsep}etc${dirsep}ambari-agent${dirsep}conf${dirsep}custom${dirsep}sles12.sh</location>
+                      <location>${project.build.directory}${dirsep}${project.artifactId}-${project.version}${dirsep}var${dirsep}lib${dirsep}ambari-agent${dirsep}tmp${dirsep}sles12.sh</location>
                     </source>
                   </sources>
                 </mapping>


### PR DESCRIPTION
…c configuration

This is a fix for copying data to the directory where custom scripts a located.

## What changes were proposed in this pull request?

Copying files to /etc/ambari-agent/conf/custom instead of /var/lib/ambari-agent/tmp.

## How was this patch tested?
This patch has been tested manually with building rpms for SLES12 and Centos7. I checked the following:
- sles12.sh is deployed on SLES12 
- sles12.sh is not deployed on Centos7
- on both systems systemD starts ambari-agent automatically after restart