### PR TITLE
AMBARI-25425. Recommendations API error during cluster creation wizard

### DIFF
--- a/ambari-web/app/mixins/common/configs/enhanced_configs.js
+++ b/ambari-web/app/mixins/common/configs/enhanced_configs.js
@@ -221,8 +221,10 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
     var updateDependencies = Em.isArray(changedConfigs) && changedConfigs.length > 0;
     var stepConfigs = this.get('stepConfigs');
     var requiredTags = [];
-    const isAutoComplete = !updateDependencies;
-    this.set('isRecommendationsAutoComplete', isAutoComplete);
+    var isAutoComplete = !updateDependencies && this.get('isRecommendationsAutoComplete') !== undefined;
+    if (this.get('isRecommendationsAutoComplete') !== undefined) {
+      this.set('isRecommendationsAutoComplete', isAutoComplete);
+    }
 
     if (updateDependencies || Em.isNone(this.get('recommendationsConfigs'))) {
       var recommendations = isAutoComplete ? {} : this.get('hostGroups');
@@ -267,7 +269,7 @@ App.EnhancedConfigsMixin = Em.Mixin.create(App.ConfigWithOverrideRecommendationP
    * @param stepConfigs
    */
   addRecommendationRequestParams: function(recommendations, dataToSend, stepConfigs) {
-    const isAutoComplete = Boolean(this.get('isRecommendationsAutoComplete'));
+    var isAutoComplete = Boolean(this.get('isRecommendationsAutoComplete'));
     if (!isAutoComplete) {
         recommendations.blueprint.configurations = blueprintUtils.buildConfigsJSON(stepConfigs);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ambari Cluster wizard step #7 shows an error. The recommendations API returns with [400] BadRequest as no clusterId is provided in the http request body.
UI is sending wrong request.
Same issue exists on kerberos wizard 

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.