### PR TITLE
AMBARI-25436. Unable to uncheck 'hidden' checkbox in ambari stackVersions page

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/stackVersions/StackVersionsListCtrl.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/stackVersions/StackVersionsListCtrl.js
@@ -164,6 +164,6 @@ angular.module('ambariAdminConsole')
     };
 
     $scope.isHideCheckBoxEnabled = function ( repo ) {
-      return !repo.isProccessing && ( (!repo.cluster && repo.status !== 'OUT_OF_SYNC') || repo.isPatch && ( repo.status === 'INSTALLED' || repo.status === 'INSTALL_FAILED') );
+      return !repo.isProccessing && ( (!repo.cluster && repo.status !== 'OUT_OF_SYNC') || repo.isPatch && ( repo.status === 'INSTALLED' || repo.status === 'INSTALL_FAILED' ) || repo.hidden);
     }
   }]);


### PR DESCRIPTION
On managing versions page ff version is hidden - we need always allow to make it visible.

## How was this patch tested?
manually


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.