### PR TITLE
AMBARI-25440. Server sets blueprint_provisioning_state for component to finished before start command execution.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/svccomphost/ServiceComponentHostImpl.java
@@ -1020,7 +1020,7 @@ public class ServiceComponentHostImpl implements ServiceComponentHost {
           STOMPUpdatePublisher.publish(new HostComponentsUpdateEvent(Collections.singletonList(
               HostComponentUpdate.createHostComponentStatusUpdate(stateEntity, oldState))));
         }
-        if (event.getType().equals(ServiceComponentHostEventType.HOST_SVCCOMP_START)) {
+        if (event.getType().equals(ServiceComponentHostEventType.HOST_SVCCOMP_STARTED)) {
           HostComponentDesiredStateEntity desiredStateEntity = getDesiredStateEntity();
           if (desiredStateEntity.getBlueprintProvisioningState() == BlueprintProvisioningState.IN_PROGRESS) {
             desiredStateEntity.setBlueprintProvisioningState(BlueprintProvisioningState.FINISHED);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server sets FINISHED state for component's blueprint_provisioning_state parameter only after start execution command completion.

## How was this patch tested?

Manual testing.