### PR TITLE
AMBARI-25441. HDP-GPL field is not available in version registration page but present in edit page

### DIFF
--- a/ambari-web/app/templates/main/admin/stack_upgrade/edit_repositories.hbs
+++ b/ambari-web/app/templates/main/admin/stack_upgrade/edit_repositories.hbs
@@ -38,12 +38,14 @@
           <table class="table table-condensed no-borders inner-table">
             <tbody>
               {{#each repository in os.repositories}}
-                <tr {{bindAttr class="repository.repoName"}}>
-                  <td class="col-md-2">{{repository.repoName}}</td>
-                  <td class="col-md-8">
-                    <div {{bindAttr class="repository.hasError:error :form-group"}}>{{view App.BaseUrlTextField repositoryBinding="repository" disabledBinding="view.content.useRedhatSatellite"}}</div>
-                  </td>
-                </tr>
+                {{#if repository.showRepo}}
+                  <tr {{bindAttr class="repository.repoName"}}>
+                    <td class="col-md-2">{{repository.repoName}}</td>
+                    <td class="col-md-8">
+                      <div {{bindAttr class="repository.hasError:error :form-group"}}>{{view App.BaseUrlTextField repositoryBinding="repository" disabledBinding="view.content.useRedhatSatellite"}}</div>
+                    </td>
+                  </tr>
+                {{/if}}
               {{/each}}
             </tbody>
           </table>

--- a/ambari-web/app/views/main/admin/stack_upgrade/upgrade_version_box_view.js
+++ b/ambari-web/app/views/main/admin/stack_upgrade/upgrade_version_box_view.js
@@ -480,7 +480,8 @@ App.UpgradeVersionBoxView = Em.View.extend({
               repoName: repository.get('repoName'),
               repoId: repository.get('repoId'),
               baseUrl: repository.get('baseUrl'),
-              hasError: false
+              hasError: false,
+              showRepo: repository.get('showRepo')
             });
           })
         });


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDP-GPL field is not available in version registration page but present in edit page

## How was this patch tested?
manually

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.