### PR TITLE
AMBARI-25413 Ambari is changing the truststore permission from 444/644 to 640. (santal)

### DIFF
--- a/ambari-server/src/main/python/ambari_server/serverConfiguration.py
+++ b/ambari-server/src/main/python/ambari_server/serverConfiguration.py
@@ -412,7 +412,7 @@ class ServerConfigDefaults(object):
 
     self.MASTER_KEY_FILE_PERMISSIONS = "640"
     self.CREDENTIALS_STORE_FILE_PERMISSIONS = "640"
-    self.TRUST_STORE_LOCATION_PERMISSIONS = "640"
+    self.TRUST_STORE_LOCATION_PERMISSIONS = "644"
 
     self.DEFAULT_DB_NAME = "ambari"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running ambari-server setup-security and choosing '[1] Enable HTTPS for Ambari server.' we give the following information:
Do you want to disable HTTPS [y/n] ? n
SSL port [8080] ? 8080
Enter path to Certificate: <Certificate File>
Enter path to Private Key: <Key File>
Please enter password for Private Key: <empty>
Generating random password for HTTPS keystore...done.
Importing and saving Certificate...done.

Thereafter Unix permission of the systemwide Java truststore
/var/lib/ca-certificates/java-cacerts are changed from mode 444 to 640.
In consequence Applications do not start anymore because the truststore is not world readable. It's creating impact on applications which is run by other users.

## How was this patch tested?

The patch was tested manually.
