### PR TITLE
AMBARI-25453. If hive.server2.webui.use.ssl was setted to true it will always use https, does not matter if now it is false

### DIFF
--- a/ambari-web/app/mappers/service_metrics_mapper.js
+++ b/ambari-web/app/mappers/service_metrics_mapper.js
@@ -316,7 +316,7 @@ App.serviceMetricsMapper = App.QuickDataMapper.create({
     var self = this;
     App.router.get('configurationController').getCurrentConfigsBySites(['hive-site', 'hive-interactive-site']).done(function (configs) {
       var hiveWebUiPort = configs.findProperty('type', 'hive-interactive-site').properties['hive.server2.webui.port'];
-      var hiveWebUiProtoFlag = configs.findProperty('type', 'hive-interactive-site').properties['hive.server2.webui.use.ssl'];
+      var hiveWebUiProtoFlag = configs.findProperty('type', 'hive-interactive-site').properties['hive.server2.webui.use.ssl'] === 'true';
       var hiveWebUiProto = hiveWebUiProtoFlag ? 'https' : 'http';
       var hostNames = hiveInteractiveServers.mapProperty('host_name');
       var useIps = configs.findProperty('type', 'hive-interactive-site').properties['hive.server2.leadertest.use.ip'];


### PR DESCRIPTION
## What changes were proposed in this pull request?
 If hive.server2.webui.use.ssl was setted to true it will always use https, does not matter if now it is false

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.