### PR TITLE
AMBARI-25459. Ambari doesn't show versions page after invalid repo was added.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/URLCredentialsHider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/URLCredentialsHider.java
@@ -45,9 +45,9 @@ public class URLCredentialsHider {
     String userInfo = url.getUserInfo();
     if (StringUtils.isNotEmpty(userInfo)) {
       if (userInfo.contains(":")) {
-        return urlString.replaceFirst(userInfo, HIDDEN_CREDENTIALS);
+        return StringUtils.replaceOnce(urlString, userInfo, HIDDEN_CREDENTIALS);
       } else {
-        return urlString.replaceFirst(userInfo, HIDDEN_USER);
+        return StringUtils.replaceOnce(urlString, userInfo, HIDDEN_USER);
       }
     }
     return urlString;

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/URLCredentialsHiderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/URLCredentialsHiderTest.java
@@ -37,5 +37,9 @@ public class URLCredentialsHiderTest {
 
     String invalidURL = "htt://user01:pass@host:8443/api/v1";
     Assert.assertEquals(URLCredentialsHider.INVALID_URL, URLCredentialsHider.hideCredentials(invalidURL));
+
+    String testURL3 = "http://***:***@host:8443/api/v1";
+    Assert.assertEquals(String.format("http://%s@host:8443/api/v1", URLCredentialsHider.HIDDEN_CREDENTIALS),
+                        URLCredentialsHider.hideCredentials(testURL3));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now repository credentials are escaped (to be more compatible for processing as regex) before replacing with hidden symbols (`*****:*****`).

## How was this patch tested?

Manual testing.