### PR TITLE
AMBARI-25461. Move JournalNode wizard generates wrong dfs.namenode.shared.edits.dir

### DIFF
--- a/ambari-web/app/controllers/main/admin/highAvailability/journalNode/step2_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability/journalNode/step2_controller.js
@@ -80,7 +80,8 @@ App.ManageJournalNodeWizardStep2Controller = Em.Controller.extend({
 
   onLoadConfigs: function (data) {
     this.set('serverConfigData',data);
-    this.set('content.nameServiceId', data.items[0].properties['dfs.nameservices']);
+    this.set('content.nameServiceId',
+              data.items[0].properties['dfs.internal.nameservices'] || data.items[0].properties['dfs.nameservices'].split(',')[0]);
     this.tweakServiceConfigs(this.get('moveJNConfig.configs'));
     this.renderServiceConfigs(this.get('moveJNConfig'));
     this.set('isLoaded', true);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Correct dfs.namenode.shared.edits.dir

## How was this patch tested?
manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.