### PR TITLE
AMBARI-25454 API exception on trying to assign permission to user group with custom Ambari Views (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariPrivilegeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/AmbariPrivilegeResourceProvider.java
@@ -23,7 +23,7 @@ import static org.apache.ambari.server.controller.internal.ViewPrivilegeResource
 import static org.apache.ambari.server.controller.internal.ViewPrivilegeResourceProvider.VIEW_NAME;
 
 import java.util.EnumSet;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,7 +121,7 @@ public class AmbariPrivilegeResourceProvider extends PrivilegeResourceProvider<O
 
   @Override
   public Map<Long, Object> getResourceEntities(Map<String, Object> properties) {
-    Map<Long, Object> resourceEntities = new HashMap<>();
+    Map<Long, Object> resourceEntities = new LinkedHashMap<>();
 
     resourceEntities.put(ResourceEntity.AMBARI_RESOURCE_ID, null);
     // add cluster entities


### PR DESCRIPTION
## What changes were proposed in this pull request?

The resource list order should be maintained as in some scenarios it may put improper  objects at the first  place and cause wrong result for the requested operation.

## How was this patch tested?

Life cluster with custom Views and check query:
```
curl -u admin:admin -H "X-Requested-By:ambari" -i -X POST http://127.0.0.1:8080/api/v1/privileges -d '{
 "PrivilegeInfo": {
 "permission_name": "AMBARI.ADMINISTRATOR",
 "principal_name": "some-admin-group",
 "principal_type": "GROUP",
 "type": "AMBARI"
 }
}'
```
