### PR TITLE
AMBARI-25465 Postgresql service naming convention changed on SUSE 12 SP2

### DIFF
--- a/ambari-common/src/main/python/ambari_commons/os_linux.py
+++ b/ambari-common/src/main/python/ambari_commons/os_linux.py
@@ -84,3 +84,7 @@ def os_set_open_files_limit(maxOpenFiles):
 
 def os_getpass(prompt):
   return getpass.unix_getpass(prompt)
+
+def os_is_service_exist(serviceName):
+  status = os.system("service %s status >/dev/null 2>&1" % serviceName)
+  return status != 256

--- a/ambari-common/src/main/python/ambari_commons/os_linux.py
+++ b/ambari-common/src/main/python/ambari_commons/os_linux.py
@@ -86,8 +86,7 @@ def os_getpass(prompt):
   return getpass.unix_getpass(prompt)
 
 def os_is_service_exist(serviceName):
-  systemManager = os.popen('ps --no-headers -o comm 1').read().strip()
-  if systemManager == 'systemd':
+  if os.path.exists('/run/systemd/system/'):
     return os.popen('systemctl list-units --full -all | grep "%s.service"' % serviceName).read().strip() != ''
 
   status = os.system("service %s status >/dev/null 2>&1" % serviceName)

--- a/ambari-common/src/main/python/ambari_commons/os_linux.py
+++ b/ambari-common/src/main/python/ambari_commons/os_linux.py
@@ -86,5 +86,9 @@ def os_getpass(prompt):
   return getpass.unix_getpass(prompt)
 
 def os_is_service_exist(serviceName):
+  systemManager = os.popen('ps --no-headers -o comm 1').read().strip()
+  if systemManager == 'systemd':
+    return os.popen('systemctl list-units --full -all | grep "%s.service"' % serviceName).read().strip() != ''
+
   status = os.system("service %s status >/dev/null 2>&1" % serviceName)
   return status != 256

--- a/ambari-common/src/main/python/ambari_commons/os_utils.py
+++ b/ambari-common/src/main/python/ambari_commons/os_utils.py
@@ -33,11 +33,11 @@ else:
 
 if OSCheck.is_windows_family():
   from ambari_commons.os_windows import os_change_owner, os_getpass, os_is_root, os_run_os_command, \
-    os_set_open_files_limit, os_set_file_permissions
+    os_set_open_files_limit, os_set_file_permissions, os_is_service_exist
 else:
   # MacOS not supported
   from ambari_commons.os_linux import os_change_owner, os_getpass, os_is_root, os_run_os_command, \
-    os_set_open_files_limit, os_set_file_permissions
+    os_set_open_files_limit, os_set_file_permissions, os_is_service_exist
   pass
 
 from ambari_commons.exceptions import FatalException
@@ -130,6 +130,9 @@ def set_open_files_limit(maxOpenFiles):
 
 def get_password(prompt):
   return os_getpass(prompt)
+
+def is_service_exist(serviceName):
+  return os_is_service_exist(serviceName)
 
 def find_in_path(file):
   full_path = _search_file(file, os.environ["PATH"], os.pathsep)

--- a/ambari-common/src/main/python/ambari_commons/os_windows.py
+++ b/ambari-common/src/main/python/ambari_commons/os_windows.py
@@ -471,6 +471,16 @@ def wait_for_pid_wmi(processName, parentPid, pattern, timeout):
   return 0
 
 
+def os_is_service_exist(serviceName):
+  try:
+    win32serviceutil.QueryServiceStatus(serviceName)
+  except:
+    # "Windows service NOT installed"
+    return False
+  else:
+    # "Windows service installed"
+    return True
+
 #need this for redirecting output form python process to file
 class SyncStreamWriter(object):
   def __init__(self, stream, hMutexWrite):

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -31,7 +31,7 @@ import pwd
 from ambari_commons import OSCheck, OSConst
 from ambari_commons.logging_utils import get_silent, get_verbose, print_error_msg, print_info_msg, print_warning_msg
 from ambari_commons.exceptions import NonFatalException, FatalException
-from ambari_commons.os_utils import copy_files, find_in_path, is_root, remove_file, run_os_command
+from ambari_commons.os_utils import copy_files, find_in_path, is_root, remove_file, run_os_command, is_service_exist
 from ambari_server.dbConfiguration import DBMSConfig, USERNAME_PATTERN, SETUP_DB_CONNECT_ATTEMPTS, \
     SETUP_DB_CONNECT_TIMEOUT, STORAGE_TYPE_LOCAL, DEFAULT_USERNAME, DEFAULT_PASSWORD
 from ambari_server.serverConfiguration import encrypt_password, store_password_file, \
@@ -385,11 +385,23 @@ class PGConfig(LinuxDBMSConfig):
     PG_HBA_RELOAD_CMD = AMBARI_SUDO_BINARY + " %s reload %s" % (SERVICE_CMD, PG_SERVICE_NAME)
   else:
     SERVICE_CMD = "/usr/bin/env service"
-    PG_ST_CMD = "%s %s status" % (SERVICE_CMD, PG_SERVICE_NAME)
     if os.path.isfile("/usr/bin/postgresql-setup"):
         PG_INITDB_CMD = "/usr/bin/postgresql-setup initdb"
     else:
+      if OSCheck.is_suse_family() and not is_service_exist(PG_SERVICE_NAME):
+        versioned_script_paths = glob.glob("/usr/pgsql-*/bin/postgresql*-setup")
+        if versioned_script_paths:
+          for versioned_script_path in versioned_script_paths:
+            pgsql_version = re.search(r'pgsql-([0-9]+\.?[0-9]+)', versioned_script_path).group(1)
+            pgsql_service_file_name = "postgresql-%s" % pgsql_version
+            if is_service_exist(pgsql_service_file_name):
+              PG_SERVICE_NAME = pgsql_service_file_name
+              PG_INITDB_CMD = "%s initdb" % versioned_script_path
+              break
+      else:
         PG_INITDB_CMD = "%s %s initdb" % (SERVICE_CMD, PG_SERVICE_NAME)
+
+    PG_ST_CMD = "%s %s status" % (SERVICE_CMD, PG_SERVICE_NAME)
 
     PG_START_CMD = AMBARI_SUDO_BINARY + " %s %s start" % (SERVICE_CMD, PG_SERVICE_NAME)
     PG_RESTART_CMD = AMBARI_SUDO_BINARY + " %s %s restart" % (SERVICE_CMD, PG_SERVICE_NAME)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari server setup is failing to succeed when being initiated on Suse 12 SP2 operating system.
The new installation of pgsql 9.6 creates "/usr/lib/systemd/system/postgresql-9.6.service" instead of "/usr/lib/systemd/system/postgresql.service".
This was handled for Redhat previously but due to this [wiki](https://wiki.postgresql.org/wiki/Zypper_Installation) site the same fix is needed on SLES 12 as well.

## How was this patch tested?

The fix was tested manually.