### PR TITLE
AMBARI-25471. After node reboot autostart of components takes too much time

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ComponentStatusExecutor.py
+++ b/ambari-agent/src/main/python/ambari_agent/ComponentStatusExecutor.py
@@ -112,7 +112,7 @@ class ComponentStatusExecutor(threading.Thread):
               if result:
                 cluster_reports[cluster_id].append(result)
 
-
+        self.recovery_manager.statuses_computed_at_least_once = True
         cluster_reports = self.discard_stale_reports(cluster_reports)
         self.send_updates_to_server(cluster_reports)
       except ConnectionIsAlreadyClosed: # server and agent disconnected during sending data. Not an issue

--- a/ambari-agent/src/test/python/ambari_agent/TestAlerts.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestAlerts.py
@@ -1403,7 +1403,7 @@ class TestAlerts(TestCase):
     """
     with patch("__builtin__.open") as open_mock:
       open_mock.side_effect = self.open_side_effect
-      cluster_configuration = ClusterConfigurationCache("/tmp/test_cache")
+      cluster_configuration = ClusterConfigurationCache("/tmp/test_cache", None)
       return cluster_configuration
 
 

--- a/ambari-agent/src/test/python/ambari_agent/TestRecoveryManager.py
+++ b/ambari-agent/src/test/python/ambari_agent/TestRecoveryManager.py
@@ -347,6 +347,7 @@ class _TestRecoveryManager(TestCase):
       [1000, 1001, 1104, 1105, 1106, 1807, 1808, 1809, 1810, 1811, 1812]
 
     rm = RecoveryManager(MagicMock())
+    rm.statuses_computed_at_least_once = True
     rm.update_config(5, 5, 0, 11, True, False, False)
 
     command1 = copy.deepcopy(self.command)


### PR DESCRIPTION
The reason for this is because ambari-agent does not know start order. And so if INFRA_SOLR with timeout of 10 hours starts before ZOOKEEPER, which it requires, it’s a big problem. As well as it blocks agent queue for any other commands.

The solution is to run the commands in parallel.