### PR TITLE
AMBARI-25473 Upgrade Infra Solr Clients fails if it is installed on only one host (santal)

### DIFF
--- a/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
+++ b/ambari-infra/ambari-infra-solr-client/src/main/python/migrationHelper.py
@@ -509,6 +509,11 @@ def upgrade_solr_clients(options, accessor, parser, config):
   host = socket.gethostname()
   if host in solr_client_hosts:
     solr_client_hosts.remove(host)
+
+  if not len(solr_client_hosts):
+    print 'The Solr Clients upgrade request has been aborted because no other host can be upgraded.'
+    sys.exit(0)
+
   context = "Upgrade Solr Clients"
   sys.stdout.write("Sending upgrade request: [{0}] ".format(context))
   sys.stdout.flush()


### PR DESCRIPTION

## What changes were proposed in this pull request?

The solr client update request must be terminated if no other host can be upgraded.

## How was this patch tested?

The patch was tested manually.
