### PR TITLE
AMBARI-25478. Badly formatted request may cause Ambari to crash.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPaddingMethod.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPaddingMethod.java
@@ -67,7 +67,12 @@ public class MetricsPaddingMethod {
 
     // in the case we have invalid end time, replace it with last available timestamp
     if (intervalEndTime < 0) {
-      intervalEndTime = values.lastKey();
+      intervalEndTime = dataEndTime;
+    }
+
+    // if the start time is after the end time it is an invalid request
+    if (intervalStartTime > intervalEndTime) {
+      return;
     }
 
     long dataInterval = getTimelineMetricInterval(values, intervalStartTime, intervalEndTime);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPaddingMethod.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/MetricsPaddingMethod.java
@@ -65,6 +65,11 @@ public class MetricsPaddingMethod {
     long dataStartTime = longToMillis(values.firstKey());
     long dataEndTime = longToMillis(values.lastKey());
 
+    // in the case we have invalid end time, replace it with last available timestamp
+    if (intervalEndTime < 0) {
+      intervalEndTime = values.lastKey();
+    }
+
     long dataInterval = getTimelineMetricInterval(values, intervalStartTime, intervalEndTime);
 
     if (dataInterval == -1 || dataInterval < MINIMUM_STEP_INTERVAL) {

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/timeline/MetricsPaddingMethodTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/timeline/MetricsPaddingMethodTest.java
@@ -251,7 +251,7 @@ public class MetricsPaddingMethodTest {
   @Test
   public void testEndTimeMissedPaddingRequested() throws Exception {
     MetricsPaddingMethod paddingMethod =
-      new MetricsPaddingMethod(MetricsPaddingMethod.PADDING_STRATEGY.NONE);
+      new MetricsPaddingMethod(MetricsPaddingMethod.PADDING_STRATEGY.ZEROS);
 
     long now = System.currentTimeMillis();
 
@@ -267,6 +267,32 @@ public class MetricsPaddingMethodTest {
     timelineMetric.setMetricValues(inputValues);
 
     TemporalInfo temporalInfo = getTemporalInfo(now - 1000, -1000L, 10l);
+    paddingMethod.applyPaddingStrategy(timelineMetric, temporalInfo);
+    TreeMap<Long, Double> values = (TreeMap<Long, Double>) timelineMetric.getMetricValues();
+
+    // (1000 - 300) / 10 + 3
+    Assert.assertEquals(73, values.size());
+  }
+
+  @Test
+  public void testInvalidStartTimePaddingRequested() throws Exception {
+    MetricsPaddingMethod paddingMethod =
+      new MetricsPaddingMethod(MetricsPaddingMethod.PADDING_STRATEGY.ZEROS);
+
+    long now = System.currentTimeMillis();
+
+    TimelineMetric timelineMetric = new TimelineMetric();
+    timelineMetric.setMetricName("m1");
+    timelineMetric.setHostName("h1");
+    timelineMetric.setAppId("a1");
+    timelineMetric.setStartTime(now);
+    TreeMap<Long, Double> inputValues = new TreeMap<>();
+    inputValues.put(now - 100, 1.0d);
+    inputValues.put(now - 200, 2.0d);
+    inputValues.put(now - 300, 3.0d);
+    timelineMetric.setMetricValues(inputValues);
+
+    TemporalInfo temporalInfo = getTemporalInfo(now + 1000, -1000L, 10l);
     paddingMethod.applyPaddingStrategy(timelineMetric, temporalInfo);
     TreeMap<Long, Double> values = (TreeMap<Long, Double>) timelineMetric.getMetricValues();
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/timeline/MetricsPaddingMethodTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/metrics/timeline/MetricsPaddingMethodTest.java
@@ -248,6 +248,31 @@ public class MetricsPaddingMethodTest {
     Assert.assertEquals(3, values.size());
   }
 
+  @Test
+  public void testEndTimeMissedPaddingRequested() throws Exception {
+    MetricsPaddingMethod paddingMethod =
+      new MetricsPaddingMethod(MetricsPaddingMethod.PADDING_STRATEGY.NONE);
+
+    long now = System.currentTimeMillis();
+
+    TimelineMetric timelineMetric = new TimelineMetric();
+    timelineMetric.setMetricName("m1");
+    timelineMetric.setHostName("h1");
+    timelineMetric.setAppId("a1");
+    timelineMetric.setStartTime(now);
+    TreeMap<Long, Double> inputValues = new TreeMap<>();
+    inputValues.put(now - 100, 1.0d);
+    inputValues.put(now - 200, 2.0d);
+    inputValues.put(now - 300, 3.0d);
+    timelineMetric.setMetricValues(inputValues);
+
+    TemporalInfo temporalInfo = getTemporalInfo(now - 1000, -1000L, 10l);
+    paddingMethod.applyPaddingStrategy(timelineMetric, temporalInfo);
+    TreeMap<Long, Double> values = (TreeMap<Long, Double>) timelineMetric.getMetricValues();
+
+    Assert.assertEquals(3, values.size());
+  }
+
   private TemporalInfo getTemporalInfo(final Long startTime, final Long endTime, final Long step) {
     return new TemporalInfo() {
       @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server uses last timestamp from current metric in the case end time of range is not set.

## How was this patch tested?

Manual test.