### PR TITLE
AMBARI-25483 Web alert triggers a wrong critical alert in kerberized cluster

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/curl_krb_request.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/curl_krb_request.py
@@ -124,7 +124,7 @@ def curl_krb_request(tmp_dir, keytab, principal, url, cache_file_prefix,
     # kinit if it's time; this helps to avoid problems approaching ticket boundary when
     # executing a klist and then a curl
     last_kinit_time = _KINIT_CACHE_TIMES.get(ccache_file_name, 0)
-    current_time = long(time.time())
+    current_time = long(time.time() * 1000)
     if current_time - kinit_timer_ms > last_kinit_time:
       is_kinit_required = True
 


### PR DESCRIPTION
Python use function time.time() get current time the unit is second, but we need a millisecond here.

## What changes were proposed in this pull request?

When a kerberized "WEB" type alert checks its status with kinit for the very first time. It will create a cache file with command "kinit -c /path/to/tmp/cache -kt /path/to/keytab/file some-principal", next time the alert executes, it will check the cache file status first, which checks the difference between current timestamp and last kinit timestamp. But when compare these two timestamps, we should use "millisecond" unit, not "second". From the variable name of kinit_timer_ms we also could firgure is out. Otherwise, the "if" statement at line 128 will never return True after 14400000 seconds(166.66 days) later.

## How was this patch tested?

manual tests
