### PR TITLE
AMBARI-25479. Set Keytab: Kerberos Client operation takes lot of time and timing out (dgrinenko)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/KerberosHelper.java
@@ -633,6 +633,27 @@ public interface KerberosHelper {
    * @param kerberosDescriptor a map of general Kerberos descriptor properties
    * @param includePreconfigureData <code>true</code> to include the preconfigure data; otherwise false
    * @param calculateClusterHostInfo
+   * @param componentHosts map of cached cluster host info
+   * @return a Map of calculated configuration types
+   * @throws AmbariException
+   */
+  Map<String, Map<String, String>> calculateConfigurations(Cluster cluster, String hostname,
+                                                           KerberosDescriptor kerberosDescriptor,
+                                                           boolean includePreconfigureData,
+                                                           boolean calculateClusterHostInfo,
+                                                           Map<String, String> componentHosts)
+      throws AmbariException;
+
+  /**
+   * Calculates the map of configurations relative to the cluster and host.
+   * <p/>
+   * Most of this was borrowed from {@link org.apache.ambari.server.actionmanager.ExecutionCommandWrapper#getExecutionCommand()}
+   *
+   * @param cluster                      the relevant Cluster
+   * @param hostname                     the relevant hostname
+   * @param kerberosDescriptor a map of general Kerberos descriptor properties
+   * @param includePreconfigureData <code>true</code> to include the preconfigure data; otherwise false
+   * @param calculateClusterHostInfo
    * @return a Map of calculated configuration types
    * @throws AmbariException
    */

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProvider.java
@@ -458,12 +458,8 @@ public class HostStackVersionResourceProvider extends AbstractControllerResource
 
     // Generate cluster host info
     String clusterHostInfoJson;
-    try {
-      clusterHostInfoJson = StageUtils.getGson().toJson(
-        StageUtils.getClusterHostInfo(cluster));
-    } catch (AmbariException e) {
-      throw new SystemException("Could not build cluster topology", e);
-    }
+    clusterHostInfoJson = StageUtils.getGson().toJson(
+      StageUtils.getClusterHostInfo(cluster));
 
     Stage stage = stageFactory.createNew(req.getId(),
             "/tmp/ambari",

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackArtifactResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/StackArtifactResourceProvider.java
@@ -534,16 +534,12 @@ public class StackArtifactResourceProvider extends AbstractControllerResourcePro
           "Parent stack/service resource doesn't exist: stackName='%s', stackVersion='%s', serviceName='%s'",
           stackName, stackVersion, serviceName));
     }
-    File kerberosFile = serviceInfo.getKerberosDescriptorFile();
 
-    if (kerberosFile != null) {
-      KerberosServiceDescriptor serviceDescriptor =
-          kerberosServiceDescriptorFactory.createInstance(kerberosFile, serviceName);
-
-      if (serviceDescriptor != null) {
-        return serviceDescriptor.toMap();
-      }
+    KerberosServiceDescriptor serviceDescriptor = kerberosServiceDescriptorFactory.getInstance(serviceInfo, serviceName);
+    if (serviceDescriptor != null) {
+      return serviceDescriptor.toMap();
     }
+
     return null;
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
@@ -83,14 +83,17 @@ public class AgentCommandsPublisher {
   @Inject
   private AgentConfigsHolder agentConfigsHolder;
 
+
   public void sendAgentCommand(Multimap<Long, AgentCommand> agentCommands) throws AmbariException {
     if (agentCommands != null && !agentCommands.isEmpty()) {
       Map<Long, TreeMap<String, ExecutionCommandsCluster>> executionCommandsClusters = new TreeMap<>();
+
       for (Map.Entry<Long, AgentCommand> acHostEntry : agentCommands.entries()) {
         Long hostId = acHostEntry.getKey();
         AgentCommand ac = acHostEntry.getValue();
         populateExecutionCommandsClusters(executionCommandsClusters, hostId, ac);
       }
+
       for (Map.Entry<Long, TreeMap<String, ExecutionCommandsCluster>> hostEntry : executionCommandsClusters.entrySet()) {
         Long hostId = hostEntry.getKey();
         ExecutionCommandEvent executionCommandEvent = new ExecutionCommandEvent(hostId,
@@ -110,13 +113,14 @@ public class AgentCommandsPublisher {
 
   private void populateExecutionCommandsClusters(Map<Long, TreeMap<String, ExecutionCommandsCluster>> executionCommandsClusters,
                                             Long hostId, AgentCommand ac) throws AmbariException {
-    try {
-      if (LOG.isDebugEnabled()) {
+    if (LOG.isDebugEnabled()) {
+      try {
         LOG.debug("Sending command string = " + StageUtils.jaxbToString(ac));
+      } catch (Exception e) {
+        throw new AmbariException("Could not get jaxb string for command", e);
       }
-    } catch (Exception e) {
-      throw new AmbariException("Could not get jaxb string for command", e);
     }
+
     switch (ac.getCommandType()) {
       case BACKGROUND_EXECUTION_COMMAND:
       case EXECUTION_COMMAND: {

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
@@ -302,9 +302,10 @@ public class KerberosKeytabController {
     if (!hosts.contains(ambariServerHostname)) {
       hosts.add(ambariServerHostname);
     }
+    Map<String, String> componentHosts = new HashMap<>();
     for( String hostName : hosts ) {
       Map<String, Map<String, String>> configurations = kerberosHelper.calculateConfigurations(
-        cluster, hostName, kerberosDescriptor, false, false);
+        cluster, hostName, kerberosDescriptor, false, false, componentHosts);
       hostConfigurations.put(hostName, configurations);
     }
     for (String service : services) {

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ExtensionModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ExtensionModule.java
@@ -430,7 +430,7 @@ public class ExtensionModule extends BaseModule<ExtensionModule, ExtensionInfo> 
    *
    * @param serviceDirectory the child service directory
    */
-  private void populateService(ServiceDirectory serviceDirectory)  {
+  private void populateService(ServiceDirectory serviceDirectory) throws AmbariException {
     Collection<ServiceModule> serviceModules = new ArrayList<>();
     // unfortunately, we allow multiple services to be specified in the same metainfo.xml,
     // so we can't move the unmarshal logic into ServiceModule

--- a/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceModule.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/stack/ServiceModule.java
@@ -122,7 +122,8 @@ public class ServiceModule extends BaseModule<ServiceModule, ServiceInfo> implem
    * @param serviceInfo       associated service info
    * @param serviceDirectory  used for all IO interaction with service directory in stack definition
    */
-  public ServiceModule(StackContext stackContext, ServiceInfo serviceInfo, ServiceDirectory serviceDirectory) {
+  public ServiceModule(StackContext stackContext, ServiceInfo serviceInfo, ServiceDirectory serviceDirectory)
+    throws AmbariException{
     this(stackContext, serviceInfo, serviceDirectory, false);
   }
 
@@ -135,7 +136,8 @@ public class ServiceModule extends BaseModule<ServiceModule, ServiceInfo> implem
    * @param isCommonService   flag to mark a service as a common service
    */
   public ServiceModule(
-      StackContext stackContext, ServiceInfo serviceInfo, ServiceDirectory serviceDirectory, boolean isCommonService) {
+      StackContext stackContext, ServiceInfo serviceInfo, ServiceDirectory serviceDirectory, boolean isCommonService)
+  throws AmbariException{
     this.serviceInfo = serviceInfo;
     this.stackContext = stackContext;
     this.serviceDirectory = serviceDirectory;

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/Clusters.java
@@ -189,6 +189,13 @@ public interface Clusters {
   Map<String, Host> getHostsForCluster(String clusterName);
 
   /**
+   * Gets all the hosts associated with the cluster
+   * @param clusterName The name of the cluster
+   * @return <code>List</code> containing <code>Host</code>
+   */
+  List<Host> getHostsListForCluster(String clusterName);
+
+  /**
    * Gets all the host Ids associated with the cluster
    * @param clusterName The name of the cluster
    * @return <code>Map</code> containing host id and <code>Host</code>

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/StackInfo.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.apache.ambari.server.controller.StackVersionResponse;
 import org.apache.ambari.server.stack.Validable;
+import org.apache.ambari.server.state.kerberos.KerberosDescriptor;
 import org.apache.ambari.server.state.repository.VersionDefinitionXml;
 import org.apache.ambari.server.state.stack.ConfigUpgradePack;
 import org.apache.ambari.server.state.stack.RepositoryXml;
@@ -62,6 +63,7 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
   private List<PropertyInfo> properties;
   private Map<String, Map<String, Map<String, String>>> configTypes;
   private Map<String, UpgradePack> upgradePacks;
+  private KerberosDescriptor kerberosDescriptor;
   private ConfigUpgradePack configUpgradePack;
   private StackRoleCommandOrder roleCommandOrder;
   private boolean valid = true;
@@ -405,6 +407,22 @@ public class StackInfo implements Comparable<StackInfo>, Validable {
    */
   public void setKerberosDescriptorPreConfigurationFileLocation(String kerberosDescriptorPreConfigurationFileLocation) {
     this.kerberosDescriptorPreConfigurationFileLocation = kerberosDescriptorPreConfigurationFileLocation;
+  }
+
+  /**
+   * Sets kerberos descriptor
+   *
+   * @param kerberosDescriptor an Kerberos descriptor object
+   */
+  public void setKerberosDescriptor(KerberosDescriptor kerberosDescriptor) {
+    this.kerberosDescriptor = kerberosDescriptor;
+  }
+
+  /**
+   * Gets kerberos descriptor
+   */
+  public KerberosDescriptor getKerberosDescriptor() {
+    return kerberosDescriptor;
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -2290,7 +2290,7 @@ public class ClusterImpl implements Cluster {
 
   @Override
   public Collection<Host> getHosts() {
-    return clusters.getHostsForCluster(clusterName).values();
+    return clusters.getHostsListForCluster(clusterName);
   }
 
   private ClusterHealthReport getClusterHealthReport(

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -716,6 +716,11 @@ public class ClustersImpl implements Clusters {
   }
 
   @Override
+  public List<Host> getHostsListForCluster(String clusterName) {
+    return new ArrayList<>(getClusterHostsMap().get(clusterName));
+  }
+
+  @Override
   public Map<Long, Host> getHostIdsForCluster(String clusterName)
       throws AmbariException {
     Map<Long, Host> hosts = new HashMap<>();

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/AbstractKerberosDescriptorContainer.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/AbstractKerberosDescriptorContainer.java
@@ -23,6 +23,8 @@ import static java.util.stream.Collectors.toList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -167,6 +169,25 @@ public abstract class AbstractKerberosDescriptorContainer extends AbstractKerber
           }
         }
       }
+    }
+  }
+
+  /**
+   * Initialize new object from and existing by creating duplicate properties with shallow copy of objects inside
+   *
+   * @param object object to copy
+   */
+  protected AbstractKerberosDescriptorContainer(AbstractKerberosDescriptorContainer object) {
+    if (object.identities != null) {
+      this.identities = new ArrayList<>(object.identities);
+    }
+
+    if (object.authToLocalProperties != null) {
+      this.authToLocalProperties = new HashSet<>(object.authToLocalProperties);
+    }
+
+    if (object.configurations != null) {
+      this.configurations = new HashMap<>(object.configurations);
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosDescriptor.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosDescriptor.java
@@ -108,7 +108,24 @@ public class KerberosDescriptor extends AbstractKerberosDescriptorContainer {
    * Creates an empty KerberosDescriptor
    */
   public KerberosDescriptor() {
-    this(null);
+    this((Map<?,?>)null);
+  }
+
+  /**
+   * Initialize new object from and existing by creating duplicate properties with shallow copy of objects inside
+   *
+   * @param object object to copy
+   */
+  public KerberosDescriptor(KerberosDescriptor object) {
+    super(object);
+
+    if (object.properties != null) {
+      this.properties = new HashMap<>(object.properties);
+    }
+
+    if (object.services != null) {
+      this.services = new HashMap<>(object.services);
+    }
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosServiceDescriptorFactory.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/kerberos/KerberosServiceDescriptorFactory.java
@@ -23,8 +23,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.state.ServiceInfo;
 
 import com.google.inject.Singleton;
 
@@ -156,6 +160,23 @@ public class KerberosServiceDescriptorFactory extends AbstractKerberosDescriptor
     } catch (AmbariException e) {
       throw new AmbariException(String.format("An error occurred processing the JSON-formatted file: %s", file.getAbsolutePath()), e);
     }
+  }
+
+  /**
+   * Return pre-created kerberos descriptor instance
+   */
+  @Nullable
+  public KerberosServiceDescriptor getInstance(ServiceInfo serviceInfo, String serviceName) {
+    KerberosServiceDescriptor[] descriptors = serviceInfo.getKerberosServiceDescriptors();
+
+    if (descriptors == null) {
+      return null;
+    }
+
+    return Stream.of(descriptors)
+      .filter(x -> x.getName().equals(serviceName))
+      .findFirst()
+      .orElse(null);
   }
 
   /**

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/KerberosHelperTest.java
@@ -86,6 +86,7 @@ import org.apache.ambari.server.orm.dao.HostRoleCommandDAO;
 import org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO;
 import org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO.KeytabPrincipalFindOrCreateResult;
 import org.apache.ambari.server.orm.dao.KerberosPrincipalDAO;
+import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.KerberosKeytabPrincipalEntity;
 import org.apache.ambari.server.scheduler.ExecutionScheduler;
 import org.apache.ambari.server.scheduler.ExecutionSchedulerImpl;
@@ -1033,7 +1034,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
-    expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(Collections.singletonMap("host1", schKerberosClient)).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(Collections.singleton("host1")).anyTimes();
 
     final Service serviceKerberos = createNiceMock(Service.class);
     expect(serviceKerberos.getDesiredStackId()).andReturn(stackId).anyTimes();
@@ -1198,6 +1199,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(Collections.singleton("host1")).anyTimes();
     expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(Collections.singletonMap("host1", schKerberosClient)).anyTimes();
 
     final Service serviceKerberos = createNiceMock(Service.class);
@@ -1384,20 +1386,19 @@ public class KerberosHelperTest extends EasyMockSupport {
 
       hostInvalid = createMockHost("host1");
     } else {
-      schKerberosClientInvalid = null;
       hostInvalid = null;
     }
 
-    Map<String, ServiceComponentHost> map = new HashMap<>();
+    Set<String> hostsSet = new HashSet<>();
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
-    map.put("host1", schKerberosClient);
+    hostsSet.add("host1");
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
 
     if (testInvalidHost) {
-      map.put("host2", schKerberosClientInvalid);
+      hostsSet.add("host2");
     }
 
-    expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(map).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(hostsSet).anyTimes();
 
     final Service serviceKerberos = createStrictMock(Service.class);
     expect(serviceKerberos.getDesiredStackId()).andReturn(new StackId("HDP-2.2")).anyTimes();
@@ -3002,15 +3003,8 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
-    expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(
-        new HashMap<String, ServiceComponentHost>() {
-          {
-            put("hostA", schKerberosClientA);
-            put("hostB", schKerberosClientB);
-            put("hostC", schKerberosClientC);
-          }
-        }
-    ).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(new HashSet<>(
+      Arrays.asList("hostA", "hostB", "hostC"))).anyTimes();
 
     final Service serviceKerberos = createStrictMock(Service.class);
     expect(serviceKerberos.getDesiredStackId()).andReturn(new StackId("HDP-2.2")).anyTimes();
@@ -3258,7 +3252,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
-    expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(Collections.singletonMap("host1", schKerberosClient)).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(Collections.singleton("host1")).anyTimes();
 
     final Service serviceKerberos = createStrictMock(Service.class);
     expect(serviceKerberos.getDesiredStackId()).andReturn(new StackId("HDP-2.2")).anyTimes();
@@ -3481,7 +3475,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
       final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
       expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
-      expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(Collections.singletonMap("host1", schKerberosClient)).anyTimes();
+      expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(Collections.singleton("host1")).anyTimes();
 
       final Service serviceKerberos = createNiceMock(Service.class);
       expect(serviceKerberos.getDesiredStackId()).andReturn(new StackId("HDP-2.2")).anyTimes();
@@ -3635,6 +3629,9 @@ public class KerberosHelperTest extends EasyMockSupport {
     Host host1 = createMock(Host.class);
     expect(host1.getHostId()).andReturn(1l).anyTimes();
 
+    HostEntity hostEntity1 = createNiceMock(HostEntity.class);
+    expect(host1.getHostEntity()).andReturn(hostEntity1).anyTimes();
+
     final ServiceComponentHost schKerberosClient = createMock(ServiceComponentHost.class);
     expect(schKerberosClient.getServiceName()).andReturn(Service.Type.KERBEROS.name()).anyTimes();
     expect(schKerberosClient.getServiceComponentName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
@@ -3660,7 +3657,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
-    expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(Collections.singletonMap("host1", schKerberosClient)).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(Collections.singleton("host1")).anyTimes();
 
     final Service serviceKerberos = createNiceMock(Service.class);
     expect(serviceKerberos.getDesiredStackId()).andReturn(new StackId("HDP-2.2")).anyTimes();
@@ -3831,7 +3828,7 @@ public class KerberosHelperTest extends EasyMockSupport {
 
     final ServiceComponent serviceComponentKerberosClient = createNiceMock(ServiceComponent.class);
     expect(serviceComponentKerberosClient.getName()).andReturn(Role.KERBEROS_CLIENT.name()).anyTimes();
-    expect(serviceComponentKerberosClient.getServiceComponentHosts()).andReturn(Collections.singletonMap("host1", schKerberosClient1)).anyTimes();
+    expect(serviceComponentKerberosClient.getServiceComponentsHosts()).andReturn(Collections.singleton("host1")).anyTimes();
 
     final Service serviceKerberos = createNiceMock(Service.class);
     expect(serviceKerberos.getDesiredStackId()).andReturn(new StackId("HDP-2.2")).anyTimes();
@@ -4203,6 +4200,7 @@ public class KerberosHelperTest extends EasyMockSupport {
     expect(component.isMasterComponent()).andReturn(isMasterComponent).anyTimes();
     expect(component.isClientComponent()).andReturn(!isMasterComponent).anyTimes();
     expect(component.getServiceComponentHosts()).andReturn(hosts).anyTimes();
+    expect(component.getServiceComponentsHosts()).andReturn(hosts.keySet()).anyTimes();
     return component;
   }
 
@@ -4221,6 +4219,9 @@ public class KerberosHelperTest extends EasyMockSupport {
     expect(host.getCurrentPingPort()).andReturn(1).anyTimes();
     expect(host.getRackInfo()).andReturn("rack1").anyTimes();
     expect(host.getIPv4()).andReturn("1.2.3.4").anyTimes();
+
+    HostEntity hostEntity = createNiceMock(HostEntity.class);
+    expect(host.getHostEntity()).andReturn(hostEntity).anyTimes();
     return host;
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/HostStackVersionResourceProviderTest.java
@@ -62,6 +62,7 @@ import org.apache.ambari.server.orm.GuiceJpaInitializer;
 import org.apache.ambari.server.orm.InMemoryDefaultTestModule;
 import org.apache.ambari.server.orm.dao.HostVersionDAO;
 import org.apache.ambari.server.orm.dao.RepositoryVersionDAO;
+import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.entities.HostVersionEntity;
 import org.apache.ambari.server.orm.entities.RepoDefinitionEntity;
 import org.apache.ambari.server.orm.entities.RepoOsEntity;
@@ -209,7 +210,9 @@ public class HostStackVersionResourceProviderTest {
     final Host host1 = createNiceMock("host1", Host.class);
     expect(host1.getHostName()).andReturn("host1").anyTimes();
     expect(host1.getOsFamily()).andReturn("redhat6").anyTimes();
-    replay(host1);
+    HostEntity hostEntity = createNiceMock(HostEntity.class);
+    expect(host1.getHostEntity()).andReturn(hostEntity).anyTimes();
+    replay(host1, hostEntity);
     Map<String, Host> hostsForCluster = Collections.singletonMap(host1.getHostName(), host1);
 
     ServiceComponentHost sch = createMock(ServiceComponentHost.class);
@@ -404,7 +407,9 @@ public class HostStackVersionResourceProviderTest {
     final Host host1 = createNiceMock("host1", Host.class);
     expect(host1.getHostName()).andReturn("host1").anyTimes();
     expect(host1.getOsFamily()).andReturn("redhat6").anyTimes();
-    replay(host1);
+    HostEntity hostEntity = createNiceMock(HostEntity.class);
+    expect(host1.getHostEntity()).andReturn(hostEntity).anyTimes();
+    replay(host1, hostEntity);
     Map<String, Host> hostsForCluster = Collections.singletonMap(host1.getHostName(), host1);
 
     ServiceComponentHost sch = createMock(ServiceComponentHost.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/orm/InMemoryDefaultTestModule.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/orm/InMemoryDefaultTestModule.java
@@ -18,10 +18,15 @@
 package org.apache.ambari.server.orm;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
 
 import org.apache.ambari.server.audit.AuditLogger;
 import org.apache.ambari.server.configuration.Configuration;
@@ -40,7 +45,223 @@ import com.google.inject.util.Modules;
 
 public class InMemoryDefaultTestModule extends AbstractModule {
 
-  Properties properties = new Properties();
+  /**
+   * Properties instance with ability to mock test-specific properties
+   */
+  public static class MockedProperties extends Properties {
+
+    private static final String STACKS_DIR = "src/test/resources/stacks";
+    private static final String VERSION_FILE = "src/test/resources/version";
+    private static final String RESOURCE_ROOT = "src/test/resources/";
+
+    private static final String REAL_RESOURCE_ROOT = "src/main/resources";
+    private static final String REAL_STACKS_DIR = "src/main/resources/stacks";
+    private static final String REAL_COMMON_SERVICES_DIR = "src/main/resources/common-services";
+
+    private static final String TEMP_DIR_PATTERN = "Temp";
+
+    private File stacks, version, resourcesRoot, commonServices;
+    boolean useRealPath = false;
+    boolean setExtraProperties = false;
+
+    public MockedProperties() {
+      super();
+      initBaseProperties(null, null, null, null);
+    }
+
+    public MockedProperties(boolean useRealPath, boolean setExtraProperties) {
+      super();
+      this.useRealPath = useRealPath;
+      this.setExtraProperties = setExtraProperties;
+      initBaseProperties(null, null, null, null);
+    }
+
+    public MockedProperties(boolean useRealPath, boolean setExtraProperties, @Nullable String stacksDir,
+                            @Nullable String versionFile, @Nullable String resourceRootDir,
+                            @Nullable String commonServicesDir) {
+      super();
+      this.useRealPath = useRealPath;
+      this.setExtraProperties = setExtraProperties;
+      initBaseProperties(stacksDir, versionFile, resourceRootDir, commonServicesDir);
+    }
+
+    protected void initBaseProperties(@Nullable String stacksDir, @Nullable String versionFile,
+                                      @Nullable String resourceRootDir, @Nullable String commonServicesDir) {
+
+      if (System.getProperty("os.name").contains("Windows")) {
+        // here is a resource root in target/test-classes/*
+        stacks = new File(Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("stacks")).getPath());
+
+        File realResourceRoot, realTestResourceRoot;
+        try {
+          File realRootDir = new File(stacks.getParent(), "../..").getCanonicalFile();
+          realResourceRoot = new File(realRootDir, REAL_RESOURCE_ROOT);
+          realTestResourceRoot = new File(realRootDir, RESOURCE_ROOT);
+
+        } catch (IOException e) {
+          throw new RuntimeException(String.format("Unable to resolve stack root dir: %s", REAL_RESOURCE_ROOT));
+        }
+
+        version = new File(realTestResourceRoot, "version");  // should be always be resolved from the test dir
+        resourcesRoot = (useRealPath)
+          ? realResourceRoot
+          : realTestResourceRoot;
+
+        stacks = new File(resourcesRoot, "stacks");
+        commonServices = new File(resourcesRoot, new File(REAL_COMMON_SERVICES_DIR).getName());
+
+        if (stacksDir != null) { // override stacks dir only in relation to actual resources dir
+          stacks = (stacksDir.contains(TEMP_DIR_PATTERN))
+            ? new File(stacksDir)
+            :new File(resourcesRoot, new File(stacksDir).getName());
+        }
+
+        if (resourceRootDir != null) {
+         resourcesRoot = (resourceRootDir.contains(TEMP_DIR_PATTERN))
+           ? new File(resourceRootDir)
+           : new File(resourcesRoot, new File(resourceRootDir).getName());
+        }
+
+        if (commonServicesDir != null) {
+          commonServices = (commonServicesDir.contains(TEMP_DIR_PATTERN))
+            ? new File(commonServicesDir)
+            : new File(resourcesRoot, new File(commonServicesDir).getName());
+        }
+      } else {
+        stacks = new File(Optional.ofNullable(stacksDir).orElse(
+          (useRealPath)
+          ? REAL_STACKS_DIR
+          : STACKS_DIR
+        ));
+        resourcesRoot = new File(Optional.ofNullable(resourceRootDir).orElse(
+          (useRealPath)
+          ? REAL_RESOURCE_ROOT
+          : RESOURCE_ROOT
+        ));
+        version = new File(Optional.ofNullable(versionFile).orElse(VERSION_FILE));
+        commonServices = new File(Optional.ofNullable(commonServicesDir).orElse(REAL_COMMON_SERVICES_DIR));
+      }
+      setProperty(Configuration.METADATA_DIR_PATH.getKey(), stacks.getPath());
+      setProperty(Configuration.SERVER_VERSION_FILE.getKey(), version.getPath());
+      setProperty(Configuration.RESOURCES_DIR.getKey(), resourcesRoot.getPath());
+      setProperty(Configuration.SHARED_RESOURCES_DIR.getKey(), resourcesRoot.getPath());
+      if (setExtraProperties) {
+        setProperty(Configuration.COMMON_SERVICES_DIR_PATH.getKey(), commonServices.getPath());
+      }
+    }
+
+    public File getCommonServicesDir() {
+      return commonServices;
+    }
+
+    public File getStacksDir() {
+      return stacks;
+    }
+
+    public File getVersionFile() {
+      return version;
+    }
+
+    public File getResourcesRoot() {
+      return resourcesRoot;
+    }
+
+    public static File getCommonServiceDir() {
+      return (System.getProperty("os.name").contains("Windows"))
+        ? new File(getDefaultResourcesDir(), new File(REAL_COMMON_SERVICES_DIR).getName())
+        : new File(REAL_COMMON_SERVICES_DIR);
+    }
+
+    public static File getDefaultStackDir() {
+      if (System.getProperty("os.name").contains("Windows")) {
+        File stackRoot = new File(
+          Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("stacks")).getPath()
+        );
+
+        File realTestResourceRoot;
+        try {
+          File realRootDir = new File(stackRoot.getParent(), "../..").getCanonicalFile();
+          realTestResourceRoot = new File(realRootDir, RESOURCE_ROOT);
+        } catch (IOException e) {
+          throw new RuntimeException(String.format("Unable to resolve stack root dir: %s", RESOURCE_ROOT));
+        }
+
+        return new File(realTestResourceRoot, new File(STACKS_DIR).getName());
+      }
+
+      return new File(STACKS_DIR);
+    }
+
+    public  static File getDefaultVersionFile() {
+      return (System.getProperty("os.name").contains("Windows"))
+        ? new File(getDefaultResourcesDir(), "version")
+        : new File(VERSION_FILE);
+    }
+
+    public  static File getDefaultResourcesDir() {
+      return (System.getProperty("os.name").contains("Windows"))
+        ? new File(getDefaultStackDir().getParent())
+        : new File(RESOURCE_ROOT);
+    }
+  }
+
+  /**
+   * MockProperties build helper
+   */
+  public static class MockedPropertiesBuilder {
+    private String stacksDir = null;
+    private String versionFile = null;
+    private String resourceRootDir = null;
+    private String commonServiceDir = null;
+    private boolean useRealPath = false;
+    private boolean setExtraProperties = false;
+
+    public MockedPropertiesBuilder() {
+      super();
+    }
+
+    public MockedPropertiesBuilder(boolean useRealPath) {
+      super();
+      this.useRealPath = useRealPath;
+    }
+
+    public MockedPropertiesBuilder useRealPath() {
+      this.useRealPath = true;
+      return this;
+    }
+
+    public MockedPropertiesBuilder setExtraProperties() {
+      this.setExtraProperties = true;
+      return this;
+    }
+
+    public MockedPropertiesBuilder commonServiceDir(String commonServiceDir) {
+      this.commonServiceDir = commonServiceDir;
+      return this;
+    }
+
+    public MockedPropertiesBuilder stacksDir(String stacksDir) {
+      this.stacksDir = stacksDir;
+      return this;
+    }
+
+    public MockedPropertiesBuilder versionFile(String verionFile) {
+      this.versionFile = verionFile;
+      return this;
+    }
+
+    public MockedPropertiesBuilder resourceRootDir(String resourceRootDir) {
+      this.resourceRootDir = resourceRootDir;
+      return this;
+    }
+
+    public MockedProperties build() {
+      return new MockedProperties(useRealPath, setExtraProperties, stacksDir, versionFile, resourceRootDir,
+        commonServiceDir);
+    }
+  }
+
+  MockedProperties properties = new MockedProperties();
 
   /**
    * Saves all {@link ControllerModule} logic, but changes bean discovery mechanism.
@@ -78,39 +299,12 @@ public class InMemoryDefaultTestModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    String stacks = "src/test/resources/stacks";
-    String version = "src/test/resources/version";
-    String sharedResourcesDir = "src/test/resources/";
-    String resourcesDir = "src/test/resources/";
-    String mpacksv2 = "src/main/resources/mpacks-v2";
-    if (System.getProperty("os.name").contains("Windows")) {
-      stacks = ClassLoader.getSystemClassLoader().getResource("stacks").getPath();
-      version = new File(new File(ClassLoader.getSystemClassLoader().getResource("").getPath()), "version").getPath();
-      sharedResourcesDir = ClassLoader.getSystemClassLoader().getResource("").getPath();
-    }
-
     if (!properties.containsKey(Configuration.SERVER_PERSISTENCE_TYPE.getKey())) {
       properties.setProperty(Configuration.SERVER_PERSISTENCE_TYPE.getKey(), "in-memory");
     }
 
-    if (!properties.containsKey(Configuration.METADATA_DIR_PATH.getKey())) {
-      properties.setProperty(Configuration.METADATA_DIR_PATH.getKey(), stacks);
-    }
-
-    if (!properties.containsKey(Configuration.SERVER_VERSION_FILE.getKey())) {
-      properties.setProperty(Configuration.SERVER_VERSION_FILE.getKey(), version);
-    }
-
     if (!properties.containsKey(Configuration.OS_VERSION.getKey())) {
       properties.setProperty(Configuration.OS_VERSION.getKey(), "centos5");
-    }
-
-    if (!properties.containsKey(Configuration.SHARED_RESOURCES_DIR.getKey())) {
-      properties.setProperty(Configuration.SHARED_RESOURCES_DIR.getKey(), sharedResourcesDir);
-    }
-
-    if (!properties.containsKey(Configuration.RESOURCES_DIR.getKey())) {
-      properties.setProperty(Configuration.RESOURCES_DIR.getKey(), resourcesDir);
     }
 
     try {

--- a/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/stack/ServiceModuleTest.java
@@ -1152,7 +1152,7 @@ public class ServiceModuleTest {
   }
 
   @Test
-  public void testInvalidServiceInfo() {
+  public void testInvalidServiceInfo() throws AmbariException{
     // Given
     ServiceInfo serviceInfo = new ServiceInfo();
     serviceInfo.setName("TEST_SERVICE");
@@ -1298,7 +1298,7 @@ public class ServiceModuleTest {
   }
 
 
-  private ServiceModule createServiceModule(ServiceInfo serviceInfo) {
+  private ServiceModule createServiceModule(ServiceInfo serviceInfo) throws AmbariException{
     String configType = "type1";
 
     if (serviceInfo.getName() == null) {
@@ -1319,7 +1319,7 @@ public class ServiceModuleTest {
 
   private ServiceModule createServiceModule(ServiceInfo serviceInfo,
                                             Collection<ConfigurationModule> configurations,
-                                            StackContext context) {
+                                            StackContext context) throws AmbariException{
 
     if (serviceInfo.getName() == null) {
       serviceInfo.setName("service1");
@@ -1331,7 +1331,8 @@ public class ServiceModuleTest {
     return createServiceModule(context, serviceInfo, serviceDirectory);
   }
 
-  private ServiceModule createServiceModule(ServiceInfo serviceInfo, Collection<ConfigurationModule> configurations) {
+  private ServiceModule createServiceModule(ServiceInfo serviceInfo, Collection<ConfigurationModule> configurations)
+   throws AmbariException{
     String serviceName = serviceInfo.getName();
 
     if (serviceInfo.getName() == null) {
@@ -1342,7 +1343,7 @@ public class ServiceModuleTest {
   }
 
   private ServiceModule createServiceModule(StackContext context, ServiceInfo serviceInfo,
-                                            ServiceDirectory serviceDirectory) {
+                                            ServiceDirectory serviceDirectory) throws AmbariException {
 
     return new ServiceModule(context, serviceInfo, serviceDirectory);
   }

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/StageUtilsTest.java
@@ -54,6 +54,7 @@ import org.apache.ambari.server.agent.ExecutionCommand;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.orm.dao.HostDAO;
+import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.state.Cluster;
 import org.apache.ambari.server.state.Clusters;
 import org.apache.ambari.server.state.Host;
@@ -191,6 +192,9 @@ public class StageUtilsTest extends EasyMockSupport {
       expect(host.getHostName()).andReturn(hostname).anyTimes();
       expect(host.getHostAttributes()).andReturn(hostAttributes).anyTimes();
       expect(host.getCurrentPingPort()).andReturn(pingPorts.get(i)).anyTimes();
+
+      HostEntity hostEntity = createNiceMock(HostEntity.class);
+      expect(host.getHostEntity()).andReturn(hostEntity).anyTimes();
 
       hosts.add(host);
       hostNames.add(hostname);
@@ -360,7 +364,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return nnServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(nnComponent.getServiceComponentHosts()).andReturn(nnServiceComponentHosts).anyTimes();
+    expect(nnComponent.getServiceComponentsHosts()).andReturn(nnServiceComponentHosts.keySet()).anyTimes();
     expect(nnComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent snnComponent = createMock(ServiceComponent.class);
@@ -373,7 +377,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return snnServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(snnComponent.getServiceComponentHosts()).andReturn(snnServiceComponentHosts).anyTimes();
+    expect(snnComponent.getServiceComponentsHosts()).andReturn(snnServiceComponentHosts.keySet()).anyTimes();
     expect(snnComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent dnComponent = createMock(ServiceComponent.class);
@@ -386,7 +390,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return dnServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(dnComponent.getServiceComponentHosts()).andReturn(dnServiceComponentHosts).anyTimes();
+    expect(dnComponent.getServiceComponentsHosts()).andReturn(dnServiceComponentHosts.keySet()).anyTimes();
     expect(dnComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent hbmComponent = createMock(ServiceComponent.class);
@@ -399,7 +403,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return hbmServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(hbmComponent.getServiceComponentHosts()).andReturn(hbmServiceComponentHosts).anyTimes();
+    expect(hbmComponent.getServiceComponentsHosts()).andReturn(hbmServiceComponentHosts.keySet()).anyTimes();
     expect(hbmComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent hbrsComponent = createMock(ServiceComponent.class);
@@ -418,7 +422,7 @@ public class StageUtilsTest extends EasyMockSupport {
         return s.equals("h1");
       }
     });
-    expect(hbrsComponent.getServiceComponentHosts()).andReturn(hbrsServiceComponentHosts).anyTimes();
+    expect(hbrsComponent.getServiceComponentsHosts()).andReturn(hbrsServiceComponentHosts.keySet()).anyTimes();
     expect(hbrsComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent mrjtComponent = createMock(ServiceComponent.class);
@@ -431,7 +435,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return mrjtServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(mrjtComponent.getServiceComponentHosts()).andReturn(mrjtServiceComponentHosts).anyTimes();
+    expect(mrjtComponent.getServiceComponentsHosts()).andReturn(mrjtServiceComponentHosts.keySet()).anyTimes();
     expect(mrjtComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent mrttCompomnent = createMock(ServiceComponent.class);
@@ -444,7 +448,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return mrttServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(mrttCompomnent.getServiceComponentHosts()).andReturn(mrttServiceComponentHosts).anyTimes();
+    expect(mrttCompomnent.getServiceComponentsHosts()).andReturn(mrttServiceComponentHosts.keySet()).anyTimes();
     expect(mrttCompomnent.isClientComponent()).andReturn(false).anyTimes();
 
     final ServiceComponent nnsComponent = createMock(ServiceComponent.class);
@@ -457,7 +461,7 @@ public class StageUtilsTest extends EasyMockSupport {
             return nnsServiceComponentHosts.get(args[0]);
           }
         }).anyTimes();
-    expect(nnsComponent.getServiceComponentHosts()).andReturn(nnsServiceComponentHosts).anyTimes();
+    expect(nnsComponent.getServiceComponentsHosts()).andReturn(nnsServiceComponentHosts.keySet()).anyTimes();
     expect(nnsComponent.isClientComponent()).andReturn(false).anyTimes();
 
     final Service hdfsService = createMock(Service.class);

--- a/ambari-server/src/test/resources/stacks/HDP/2.2.1/services/RANGER/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.2.1/services/RANGER/metainfo.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>RANGER</name>
+      <displayName>Ranger</displayName>
+      <comment>Comprehensive security for Hadoop</comment>
+      <version>0.4.0</version>
+      <components>
+          
+        <component>
+          <name>RANGER_ADMIN</name>
+          <displayName>Ranger Admin</displayName>
+          <category>MASTER</category>
+          <cardinality>1+</cardinality>
+          <versionAdvertised>true</versionAdvertised>
+          <commandScript>
+            <script>scripts/ranger_admin.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+          <logs>
+            <log>
+              <logId>ranger_admin</logId>
+              <primary>true</primary>
+            </log>
+            <log>
+              <logId>ranger_dbpatch</logId>
+            </log>
+          </logs>
+        </component>
+
+        <component>
+          <name>RANGER_USERSYNC</name>
+          <displayName>Ranger Usersync</displayName>
+          <category>MASTER</category>
+          <cardinality>1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
+          <auto-deploy>
+            <enabled>true</enabled>
+            <co-locate>RANGER/RANGER_ADMIN</co-locate>
+          </auto-deploy>
+          <commandScript>
+            <script>scripts/ranger_usersync.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+          <logs>
+            <log>
+              <logId>ranger_usersync</logId>
+              <primary>true</primary>
+            </log>
+          </logs>
+        </component>
+
+      </components>
+      <configuration-dependencies>
+        <config-type>admin-properties</config-type>
+        <config-type>ranger-site</config-type>
+        <config-type>usersync-properties</config-type>
+      </configuration-dependencies>
+      <commandScript>
+        <script>scripts/service_check.py</script>
+        <scriptType>PYTHON</scriptType>
+        <timeout>300</timeout>
+      </commandScript>
+      <themes>
+        <theme>
+          <fileName>theme_version_1.json</fileName>
+          <default>true</default>
+        </theme>
+      </themes>
+      <osSpecifics>
+        <osSpecific>
+          <osFamily>redhat7,amazonlinux2,redhat6,suse11,suse12</osFamily>
+          <packages>
+            <package>
+              <name>ranger_${stack_version}-admin</name>
+            </package>
+            <package>
+              <name>ranger_${stack_version}-usersync</name>
+            </package>
+          </packages>
+        </osSpecific>
+        <osSpecific>
+          <osFamily>debian7,ubuntu12,ubuntu14,ubuntu16</osFamily>
+          <packages>
+            <package>
+              <name>ranger-${stack_version}-admin</name>
+            </package>
+            <package>
+              <name>ranger-${stack_version}-usersync</name>
+            </package>
+          </packages>
+        </osSpecific>
+      </osSpecifics>
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+
+    </service>
+  </services>
+</metainfo>

--- a/ambari-server/src/test/resources/stacks/HDP/2.5.0/services/RANGER/metainfo.xml
+++ b/ambari-server/src/test/resources/stacks/HDP/2.5.0/services/RANGER/metainfo.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>RANGER</name>
+      <extends>common-services/RANGER/0.5.0</extends>
+      <version>0.6.0</version>
+
+      <components>
+        <component>
+          <name>RANGER_ADMIN</name>
+          <cardinality>1+</cardinality>
+          <dependencies>
+            <dependency>
+              <name>AMBARI_INFRA_SOLR/INFRA_SOLR_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+          </dependencies>
+        </component>
+
+        <component>
+          <name>RANGER_TAGSYNC</name>
+          <displayName>Ranger Tagsync</displayName>
+          <category>SLAVE</category>
+          <cardinality>0-1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
+          <commandScript>
+            <script>scripts/ranger_tagsync.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+          <configuration-dependencies>
+            <config-type>ranger-tagsync-site</config-type>
+            <config-type>tagsync-application-properties</config-type>
+          </configuration-dependencies>
+        </component>
+      </components>
+
+      <themes>
+        <theme>
+          <fileName>theme_version_3.json</fileName>
+          <default>true</default>
+        </theme>
+      </themes>
+
+      <osSpecifics>
+        <osSpecific>
+          <osFamily>redhat7,amazonlinux2,redhat6,suse11,suse12</osFamily>
+          <packages>
+            <package>
+              <name>ranger_${stack_version}-admin</name>
+            </package>
+            <package>
+              <name>ranger_${stack_version}-usersync</name>
+            </package>
+            <package>
+              <name>ranger_${stack_version}-tagsync</name>
+              <condition>should_install_ranger_tagsync</condition>
+            </package>
+            <package>
+              <name>ambari-infra-solr-client</name>
+              <condition>should_install_infra_solr_client</condition>
+            </package>
+          </packages>
+        </osSpecific>
+        <osSpecific>
+          <osFamily>debian7,ubuntu12,ubuntu14,ubuntu16</osFamily>
+          <packages>
+            <package>
+              <name>ranger-${stack_version}-admin</name>
+            </package>
+            <package>
+              <name>ranger-${stack_version}-usersync</name>
+            </package>
+            <package>
+              <name>ranger-${stack_version}-tagsync</name>
+              <condition>should_install_ranger_tagsync</condition>
+            </package>
+            <package>
+              <name>ambari-infra-solr-client</name>
+              <condition>should_install_infra_solr_client</condition>
+            </package>
+          </packages>
+        </osSpecific>
+      </osSpecifics>
+
+      <configuration-dependencies>
+        <config-type>admin-log4j</config-type>
+        <config-type>usersync-log4j</config-type>
+      </configuration-dependencies>
+
+    </service>
+  </services>
+</metainfo>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kerberos keytab injection to the agent command were optimized to be executed much more faster. Previously, we have created descriptors on the fly by reading them from the stack and merging in-to one.  However, we have repeated this procedure each time we needed the descriptor. 

In current particular place, we can't effectively cache already loaded descriptors without implementing their expire time as well as expire time on state change on the disk. Due to this fact, the idea were changed - now we will load them as part of the meta information, where are they locating now, and do not generate much IO operations when we creating a bunch of descriptors. 

## How was this patch tested?

Manually on a perf cluster and performance analyze on profiler snapshot,