### PR TITLE
AMBARI-25486. Configs page not loading after Ambari upgrade

### DIFF
--- a/ambari-web/app/mappers/configs/config_groups_mapper.js
+++ b/ambari-web/app/mappers/configs/config_groups_mapper.js
@@ -120,7 +120,13 @@ App.configGroupsMapper = App.QuickDataMapper.create({
    * @private
    */
   _getAllHosts: function() {
-    return App.get('allHostNames.length') ? App.get('allHostNames') : Object.keys(App.get('router.installerController.content.hosts'));
+    var hosts;
+    try {
+      hosts = App.get('allHostNames.length') ? App.get('allHostNames') : Object.keys(App.get('router.installerController.content.hosts'));
+    } catch (e){
+      hosts = [];
+    }
+    return hosts;
   },
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Configs page not loading after Ambari upgrade - trouble was that ambari does not expect that hosts list can be empty

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.