### PR TITLE
AMBARI-25489. On adding new VDF the Base URLs are not auto populated

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/stackVersions/StackVersionsCreateCtrl.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/stackVersions/StackVersionsCreateCtrl.js
@@ -220,10 +220,6 @@ angular.module('ambariAdminConsole')
             $scope.osList.push(stackOs);
           }
         });
-        if ($scope.selectedOption.index == $scope.localOption.index) {
-          $scope.clearRepoVersions();
-          $scope.validateRepoUrl();
-        }
       })
       .catch(function (data) {
         Alert.error($t('versions.alerts.osListError'), data.message);


### PR DESCRIPTION
## What changes were proposed in this pull request?
On adding new VDF the Base URLs are not auto populated (in case of local option)

## How was this patch tested?
Manually

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.