### PR TITLE
[AMBARI-25491] newline characters are ignored on custom property

### DIFF
--- a/ambari-web/app/utils/config.js
+++ b/ambari-web/app/utils/config.js
@@ -240,7 +240,7 @@ App.config = Em.Object.create({
       });
 
     for (var index in properties) {
-      var serviceConfigObj = this.getDefaultConfig(index, filename);
+      var serviceConfigObj = this.getDefaultConfig(index, filename, {value: properties[index]});
 
       if (serviceConfigObj.isRequiredByAgent !== false) {
         serviceConfigObj.value = serviceConfigObj.savedValue = this.formatPropertyValue(serviceConfigObj, properties[index]);
@@ -285,7 +285,7 @@ App.config = Em.Object.create({
   getDefaultConfig: function(name, fileName, coreObject) {
     name = JSON.parse('"' + name + '"');
     var cfg = App.configsCollection.getConfigByName(name, fileName) ||
-      App.config.createDefaultConfig(name, fileName, false);
+      App.config.createDefaultConfig(name, fileName, false, coreObject);
     if (Em.typeOf(coreObject) === 'object') {
       Em.setProperties(cfg, coreObject);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It allows using multiline value on custom property which doesn't exist on stack.

## How was this patch tested?

manual tests

![Screenshot_20200305_095625](https://user-images.githubusercontent.com/12639125/75937302-dac3f680-5ec7-11ea-83f2-6b7e496f6d51.png)
![Screenshot_20200305_095639](https://user-images.githubusercontent.com/12639125/75937306-dbf52380-5ec7-11ea-8eeb-35d8eaa2bc94.png)
![Screenshot_20200305_095756](https://user-images.githubusercontent.com/12639125/75937321-e4e5f500-5ec7-11ea-9178-5369bc0d6574.png)



![image](https://user-images.githubusercontent.com/12639125/75937568-9dac3400-5ec8-11ea-9ff3-b544ef1b55e8.png)

@aBabiichuk 
Could you review this, please?