### PR TITLE
[AMBARI-25492] Ambari Sends Empty metrics_collector_hosts parameters after AMS service is deleted

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/StageUtils.java
@@ -410,8 +410,11 @@ public class StageUtils {
       TreeSet<Integer> sortedSet = new TreeSet<>(entry.getValue());
 
       Set<String> replacedRangesSet = replaceRanges(sortedSet);
-
-      clusterHostInfo.put(entry.getKey(), replacedRangesSet);
+      //risk of passing empty hosts for component array to agent
+      if(!replacedRangesSet.isEmpty())
+      {
+        clusterHostInfo.put(entry.getKey(), replacedRangesSet);
+      }
     }
 
     clusterHostInfo.put(HOSTS_LIST, hostsSet);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the issue below:

```
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/common-services/NIFI/1.0.0/package/scripts/nifi.py", line 304, in <module>
    Master().execute()
  File "/usr/lib/ambari-agent/lib/resource_management/libraries/script/script.py", line 352, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/common-services/NIFI/1.0.0/package/scripts/nifi.py", line 139, in start
    import params
  File "/var/lib/ambari-agent/cache/common-services/NIFI/1.0.0/package/scripts/params.py", line 302, in <module>
    metrics_collector_host = str(config['clusterHostInfo']['metrics_collector_hosts'][0])
IndexError: list index out of range
```

## How was this patch tested?

manually tested
