### PR TITLE
OneFS mpack fix for performance (new version 1.0.3)

### DIFF
--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/addon-services/ONEFS/1.0.0/service_advisor.py
@@ -116,8 +116,14 @@ else:
         putHdfsSiteProperty("dfs.namenode.http-address", Uri.http_namenode(services).fix_host(onefs_host))
         putHdfsSiteProperty("dfs.namenode.https-address", Uri.https_namenode(services).fix_host(onefs_host))
         # self.updateYarnConfig(configs, services) TODO doesn't work possibly due to a UI bug (Couldn't retrieve 'capacity-scheduler' from services)
+        self.updateHbaseConfig(configs, services)
       except KeyError as e:
         self.logger.info('Cannot get OneFS properties from config. KeyError: %s' % e)
+
+    def updateHbaseConfig(self, configs, services):
+      if not 'HBASE' in self.installedServices(services): return
+      putHbaseSiteProperty = self.putProperty(configs, "hbase-site", services)
+      putHbaseSiteProperty("hbase.wal.provider", "filesystem")
 
     def updateYarnConfig(self, configs, services):
       if not 'YARN' in self.installedServices(services): return

--- a/contrib/management-packs/isilon-onefs-mpack/src/main/resources/mpack.json
+++ b/contrib/management-packs/isilon-onefs-mpack/src/main/resources/mpack.json
@@ -1,7 +1,7 @@
 {
   "type" : "full-release",
   "name" : "onefs-ambari-mpack",
-  "version": "1.0.2.0",
+  "version": "1.0.3.0",
   "description" : "OneFS Ambari Management Pack",
   "prerequisites": {
     "min-ambari-version" : "3.0.0.0"


### PR DESCRIPTION
## What changes were proposed in this pull request?

(see. https://issues.apache.org/jira/browse/AMBARI-25505)
The problem is that a feature of HBase 2 AsyncFSWAL causes worse performance with OneFS. We need to disable this in the OneFS Ambari management pack by setting the property name: "hbase.wal.provider" with value: "filesystem" for HBASE. The way to change the property has been already introduced at:
https://jira.apache.org/jira/browse/HBASE-15536
 We are going to issue a new version of isilon-onefs-mpack (1.0.3) where we will have some code lines which add this property to HBASE settings. Change of property is applied automatically after installation of HBASE service and installing a new version of mpack.

Business Justification: The problem we are working on is that a new feature of HBase 2 (AsyncFSWAL) causes worse performance with OneFS.
Some Isilon customers which use HBASE with Ambari with OneFS suffer from this problem. The fix should help these customers.

## How was this patch tested?

Performed unit testing and manual testing for 4 main use cases. 
As they are textually long, please look at:  https://jira.apache.org/jira/browse/HBASE-15536
for detailed explanations.
