### PR TITLE
[AMBARI-25499]: Unable to build ambari 2.7.5

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/package.json
+++ b/ambari-admin/src/main/resources/ui/admin-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "bower": "1.3.8",
+    "bower": "1.8.8",
     "gulp": "^3.8.8",
     "gulp-add-src": "^0.2.0",
     "gulp-autoprefixer": "0.0.7",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updating bower from 1.3.8 to 1.8.8 solves the error

## How was this patch tested?

It was test it building on Debian 9 from scratch keeping all the node and npm dependencies in-place (no change)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.