### PR TITLE
AMBARI-25499 Outdated bower version causes Ambari build to fail (dgrinenko)

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/package.json
+++ b/ambari-admin/src/main/resources/ui/admin-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "bower": "1.3.8",
+    "bower": "1.8.8",
     "gulp": "^3.8.8",
     "gulp-add-src": "^0.2.0",
     "gulp-autoprefixer": "0.0.7",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bower version update, to eliminate WeUI build process failure

## How was this patch tested?

On test node, while building the Ambari version and after deploying the test cluster