### PR TITLE
AMBARI-25517. Should not use '!=' to compare 'Long hostId' in HostStateEntity, which could lead to unforeseen problems

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
@@ -20,6 +20,8 @@ package org.apache.ambari.server.orm.entities;
 
 import static org.apache.commons.lang.StringUtils.defaultString;
 
+import java.util.Objects;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -32,8 +34,6 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 
 import org.apache.ambari.server.state.HostState;
-
-import java.util.Objects;
 
 @javax.persistence.Table(name = "hoststate")
 @Entity

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
@@ -33,6 +33,8 @@ import javax.persistence.OneToOne;
 
 import org.apache.ambari.server.state.HostState;
 
+import java.util.Objects;
+
 @javax.persistence.Table(name = "hoststate")
 @Entity
 @NamedQueries({
@@ -137,23 +139,16 @@ public class HostStateEntity {
 
     HostStateEntity that = (HostStateEntity) o;
 
-    if (hostId != null ? hostId != that.hostId : that.hostId != null) return false;
-    if (availableMem != null ? !availableMem.equals(that.availableMem) : that.availableMem != null) return false;
-    if (timeInState != null ? !timeInState.equals(that.timeInState) : that.timeInState!= null) return false;
-    if (agentVersion != null ? !agentVersion.equals(that.agentVersion) : that.agentVersion != null) return false;
-    if (currentState != null ? !currentState.equals(that.currentState) : that.currentState != null) return false;
-
-    return true;
+    return Objects.equals(hostId, that.hostId) &&
+            Objects.equals(availableMem, that.availableMem) &&
+            Objects.equals(timeInState, that.timeInState) &&
+            Objects.equals(agentVersion, that.agentVersion) &&
+            currentState == that.currentState;
   }
 
   @Override
   public int hashCode() {
-    int result = hostId != null ? hostId.intValue() : 0;
-    result = 31 * result + (availableMem != null ? availableMem.intValue() : 0);
-    result = 31 * result + (timeInState != null ? timeInState.intValue() : 0);
-    result = 31 * result + (agentVersion != null ? agentVersion.hashCode() : 0);
-    result = 31 * result + (currentState != null ? currentState.hashCode() : 0);
-    return result;
+    return Objects.hash(hostId, availableMem, timeInState, agentVersion, currentState);
   }
 
   public HostEntity getHostEntity() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Should not use '!=' to compare 'Long hostId' in HostStateEntity, which could lead to unforeseen problems

## How was this patch tested?
Compile and test in our development environment.

@hapylestat : The pull request to branch-2.7 is ready.