### PR TITLE
AMBARI-25353 Seeing an error stack when running an API call against Ambari server (santal)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/Configuration.java
@@ -2629,6 +2629,13 @@ public class Configuration {
   public static final ConfigurationProperty<Integer> KERBEROS_SERVER_ACTION_THREADPOOL_SIZE = new ConfigurationProperty<>(
     "server.kerberos.action.threadpool.size", 1);
 
+  /**
+   * A flag to determine whether error stacks appear on the error page
+   */
+  @Markdown(description = "Show or hide the error stacks on the error page")
+  public static final ConfigurationProperty<String> SERVER_SHOW_ERROR_STACKS = new ConfigurationProperty<>(
+    "server.show.error.stacks", "false");
+
   private static final Logger LOG = LoggerFactory.getLogger(
     Configuration.class);
 
@@ -6114,5 +6121,14 @@ public class Configuration {
 
   public int getAlertServiceCorePoolSize() {
     return Integer.parseInt(getProperty(SERVER_SIDE_ALERTS_CORE_POOL_SIZE));
+  }
+
+  /**
+   * Determines whether error stacks appear on the error page
+   *
+   * @return true if error stacks appear on the error page (defaults to {@code false})
+   */
+  public boolean isServerShowErrorStacks() {
+    return Boolean.parseBoolean(getProperty(SERVER_SHOW_ERROR_STACKS));
   }
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariHandlerList.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariHandlerList.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.ambari.server.api.AmbariPersistFilter;
+import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.orm.entities.ViewEntity;
 import org.apache.ambari.server.orm.entities.ViewInstanceEntity;
 import org.apache.ambari.server.security.AmbariViewsSecurityHeaderFilter;
@@ -103,6 +104,9 @@ public class AmbariHandlerList extends HandlerCollection implements ViewInstance
 
   @Inject
   SessionHandlerConfigurer sessionHandlerConfigurer;
+
+  @Inject
+  Configuration configuration;
 
   /**
    * Mapping of view instance entities to handlers.
@@ -252,7 +256,7 @@ public class AmbariHandlerList extends HandlerCollection implements ViewInstance
     webAppContext.setAllowNullPathInfo(true);
 
     if (webAppContext.getErrorHandler() != null) {
-      webAppContext.getErrorHandler().setShowStacks(false);
+      webAppContext.getErrorHandler().setShowStacks(configuration.isServerShowErrorStacks());
     }
 
     return webAppContext;

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariHandlerList.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/AmbariHandlerList.java
@@ -251,6 +251,10 @@ public class AmbariHandlerList extends HandlerCollection implements ViewInstance
     webAppContext.addFilter(new FilterHolder(springSecurityFilter), "/*", AmbariServer.DISPATCHER_TYPES);
     webAppContext.setAllowNullPathInfo(true);
 
+    if (webAppContext.getErrorHandler() != null) {
+      webAppContext.getErrorHandler().setShowStacks(false);
+    }
+
     return webAppContext;
   }
 

--- a/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/configuration/ConfigurationTest.java
@@ -967,4 +967,31 @@ public class ConfigurationTest {
       // This is expected
     }
   }
+
+  @Test
+  public void testServerShowErrorStacksEnabled() throws  Exception {
+    // given
+    final Properties ambariProperties = new Properties();
+    ambariProperties.setProperty(Configuration.SERVER_SHOW_ERROR_STACKS.getKey(), "true");
+    final Configuration configuration = new Configuration(ambariProperties);
+
+    // when
+    boolean result = configuration.isServerShowErrorStacks();
+
+    // then
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void testServerShowErrorStacksDefault() throws  Exception {
+    // given
+    final Properties ambariProperties = new Properties();
+    final Configuration configuration = new Configuration(ambariProperties);
+
+    // when
+    boolean result = configuration.isServerShowErrorStacks();
+
+    // then
+    Assert.assertEquals(result, Boolean.parseBoolean(Configuration.SERVER_SHOW_ERROR_STACKS.getDefaultValue()));
+  }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariHandlerListTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/AmbariHandlerListTest.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.ambari.server.api.AmbariPersistFilter;
+import org.apache.ambari.server.configuration.Configuration;
 import org.apache.ambari.server.orm.entities.ViewEntity;
 import org.apache.ambari.server.orm.entities.ViewInstanceEntity;
 import org.apache.ambari.server.orm.entities.ViewInstanceEntityTest;
@@ -44,6 +45,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.SessionIdManager;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.session.SessionCache;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -64,7 +66,7 @@ public class AmbariHandlerListTest {
   private final SessionIdManager sessionIdManager = createNiceMock(SessionIdManager.class);
   private final SessionHandlerConfigurer sessionHandlerConfigurer = createNiceMock(SessionHandlerConfigurer.class);
   private final SessionCache sessionCache = createNiceMock(SessionCache.class);
-
+  private final Configuration configuration = createNiceMock(Configuration.class);
 
   @Test
   public void testAddViewInstance() throws Exception {
@@ -90,7 +92,16 @@ public class AmbariHandlerListTest {
     handler.addFilter(capture(securityFilterCapture), eq("/*"), eq(AmbariServer.DISPATCHER_TYPES));
     handler.setAllowNullPathInfo(true);
 
-    replay(handler, server, sessionHandler);
+    final boolean showErrorStacks = true;
+    expect(configuration.isServerShowErrorStacks()).andReturn(showErrorStacks);
+
+    ErrorHandler errorHandler = createNiceMock(ErrorHandler.class);
+    Capture<Boolean> showStackCapture = EasyMock.newCapture();
+    errorHandler.setShowStacks(EasyMock.captureBoolean(showStackCapture));
+
+    expect(handler.getErrorHandler()).andReturn(errorHandler).times(2);
+
+    replay(handler, server, sessionHandler, configuration, errorHandler);
 
     AmbariHandlerList handlerList = getAmbariHandlerList(handler);
 
@@ -103,8 +114,9 @@ public class AmbariHandlerListTest {
     Assert.assertEquals(ambariViewsSecurityHeaderFilter, securityHeaderFilterCapture.getValue().getFilter());
     Assert.assertEquals(persistFilter, persistFilterCapture.getValue().getFilter());
     Assert.assertEquals(springSecurityFilter, securityFilterCapture.getValue().getFilter());
+    Assert.assertEquals(showErrorStacks, showStackCapture.getValue());
 
-    verify(handler, server, sessionHandler);
+    verify(handler, server, sessionHandler, configuration, errorHandler);
   }
 
   @Test
@@ -185,6 +197,7 @@ public class AmbariHandlerListTest {
     handlerList.springSecurityFilter = springSecurityFilter;
     handlerList.sessionHandler = sessionHandler;
     handlerList.sessionHandlerConfigurer = sessionHandlerConfigurer;
+    handlerList.configuration = configuration;
     return handlerList;
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

If an API call responds with stack traces that are not managed it could reveal information useful to attackers. This information could then be used in further attacks. Providing debugging information as a result of operations that generate errors is considered a bad practice due to multiple reasons. For example, it may contain information on internal workings of the application such as relative paths of the point where the application is installed or how objects are referenced internally

When a runtime error occurs during request processing, server will display debugging information to the requestor. Ideally, such debug information be withheld from the requestor.

More on the security threat:

CWE-209: Information Exposure Through an Error Message

Improper Error Handling

I see the following error stack when I run an Ambari API call:

```
# curl -X GET -u admin:admin "http://<ambari-host>:8080/api/v1/security/userlist/q;%"

HTTP ERROR 500

Problem accessing /api/v1/security/userlist/q;%. Reason:

    Server Error

Caused by:
org.springframework.security.web.firewall.RequestRejectedException: The request was rejected because the URL contained a potentially malicious String ";"
	at org.springframework.security.web.firewall.StrictHttpFirewall.rejectedBlacklistedUrls(StrictHttpFirewall.java:265)
	at org.springframework.security.web.firewall.StrictHttpFirewall.getFirewalledRequest(StrictHttpFirewall.java:245)
	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:193)
	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:177)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1642)
	at org.apache.ambari.server.api.MethodOverrideFilter.doFilter(MethodOverrideFilter.java:73)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1642)
	at org.apache.ambari.server.api.AmbariPersistFilter.doFilter(AmbariPersistFilter.java:53)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1642)
	at org.apache.ambari.server.security.AbstractSecurityHeaderFilter.doFilter(AbstractSecurityHeaderFilter.java:130)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1642)
	at org.eclipse.jetty.servlets.GzipFilter.doFilter(GzipFilter.java:51)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1642)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:533)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1340)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1242)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:740)
	at org.apache.ambari.server.controller.AmbariHandlerList.processHandlers(AmbariHandlerList.java:221)
	at org.apache.ambari.server.controller.AmbariHandlerList.processHandlers(AmbariHandlerList.java:210)
	at org.apache.ambari.server.controller.AmbariHandlerList.handle(AmbariHandlerList.java:140)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:503)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:364)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:765)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:683)
	at java.lang.Thread.run(Thread.java:745)
```

## How was this patch tested?
This patch was tested manually.
