### PR TITLE
Prevent basic authentication over HTTP

### DIFF
--- a/ambari-funtest/src/test/java/org/apache/ambari/funtest/server/AmbariHttpWebRequest.java
+++ b/ambari-funtest/src/test/java/org/apache/ambari/funtest/server/AmbariHttpWebRequest.java
@@ -56,7 +56,6 @@ import org.apache.commons.lang.StringUtils;
  */
 public class AmbariHttpWebRequest extends WebRequest {
     private static final Log LOG = LogFactory.getLog(AmbariHttpWebRequest.class);
-    private static String SERVER_URL_FORMAT = "http://%s:%d";
     private static String SERVER_SSL_URL_FORMAT = "https://%s:%d";
 
     private String content;
@@ -245,7 +244,7 @@ public class AmbariHttpWebRequest extends WebRequest {
      * @return - Ambari server URL.
      */
     protected String getServerApiUrl() {
-        return String.format(SERVER_URL_FORMAT, getServerName(), getServerApiPort());
+        return String.format(SERVER_SSL_URL_FORMAT, getServerName(), getServerApiPort());
     }
 
     /**
@@ -254,7 +253,7 @@ public class AmbariHttpWebRequest extends WebRequest {
      * @return - Agent server URL.
      */
     protected String getServerAgentUrl() {
-        return String.format(SERVER_URL_FORMAT, getServerName(), getServerAgentPort());
+        return String.format(SERVER_SSL_URL_FORMAT, getServerName(), getServerAgentPort());
     }
 
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sensitive information like username and password shall not be sent over the cleartext HTTP channel. Basic authentication only obfuscates username/password in Base64 encoding, which can be easily recognized and reversed. 

The class <code>ambari-funtest/src/test/java/org/apache/ambari/funtest/server/AmbariHttpWebRequest.java</code> sends username and password in basic authentication over an HTTP connection. Sending username and password using the HTTP protocol violates CWE-522 "Insufficiently Protected Credentials". 

Although the vulnerable class is in the <code>ambari-funtest</code> package, as Ambari is a popular repository of Apache that is watched and used by many users and organizations, whose code could be extended and customized, the issue shall be resolved in my opinion. 

## How was this patch tested?
The change is minimal and only involves one class.

Please investigate and consider merging the PR as well as opening a security advisory if you agree this is a valid issue.

Thanks,
@luchua-bc