### PR TITLE
AMBARI-25534. DB purge fails removing topology requests.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RequestDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RequestDAO.java
@@ -487,7 +487,7 @@ public class RequestDAO implements Cleanable {
     });
 
     if (!partialHostRequestIds.isEmpty()) {
-      topologyRequestIds.addAll(topologyHostTaskDAO.findHostRequestIdsByHostTaskIds(partialHostRequestIds));
+      topologyRequestIds.addAll(topologyLogicalRequestDAO.findRequestIdsByIds(partialHostRequestIds));
     }
     return topologyRequestIds;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now Ambari DB purge operation removes topology_request records by logical_request_id from topology_host_request.

## How was this patch tested?

Manual check.

Results of `mvn clean test  -pl ambari-server,ambari-web,ambari-metrics/ambari-metrics-common,ambari-views,ambari-utility`:
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Web 2.7.5.0.0 ............................... SUCCESS [01:46 min]
[INFO] Ambari Views 2.7.5.0.0 ............................. SUCCESS [  2.422 s]
[INFO] ambari-utility 1.0.0.0-SNAPSHOT .................... SUCCESS [  3.263 s]
[INFO] Ambari Metrics Common 2.7.5.0.0 .................... SUCCESS [  7.695 s]
[INFO] Ambari Server 2.7.5.0.0 ............................ SUCCESS [28:53 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  30:53 min
[INFO] Finished at: 2020-07-27T12:20:37+03:00
[INFO] ------------------------------------------------------------------------
