### PR TITLE
AMBARI-25536. Failed to execute goal on project ambari-metrics-timelineservice (PrivateLi)

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -34,9 +34,9 @@
     <!-- Needed for generating FindBugs warnings using parent pom -->
     <!--<yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>-->
     <protobuf.version>2.5.0</protobuf.version>
-    <hadoop.version>3.1.1.3.1.4.0-315</hadoop.version>
-    <phoenix.version>5.0.0.3.1.4.0-315</phoenix.version>
-    <hbase.version>2.0.2.3.1.4.0-315</hbase.version>
+    <hadoop.version>3.1.1.3.1.4.1-1</hadoop.version>
+    <phoenix.version>5.0.0.3.1.4.1-1</phoenix.version>
+    <hbase.version>2.0.2.3.1.4.1-1</hbase.version>
   </properties>
 
   <build>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -42,7 +42,7 @@
     <!--TODO change to HDP URL-->
     <hbase.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hbase/hbase-2.0.2.3.1.4.0-315-bin.tar.gz</hbase.tar>
     <hbase.folder>hbase-2.0.2.3.1.4.0-315</hbase.folder>
-    <hadoop.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hadoop/hadoop-3.1.1.3.1.4.0-315.tar.gz</hadoop.tar>
+    <hadoop.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hadoop/hadoop-3.1.1.3.1.4.1-1.tar.gz</hadoop.tar>
     <hadoop.folder>hadoop-3.1.1.3.1.4.0-315</hadoop.folder>
     <grafana.folder>grafana-6.4.2</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.4.2.linux-amd64.tar.gz</grafana.tar>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -42,7 +42,7 @@
     <!--TODO change to HDP URL-->
     <hbase.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hbase/hbase-2.0.2.3.1.4.0-315-bin.tar.gz</hbase.tar>
     <hbase.folder>hbase-2.0.2.3.1.4.0-315</hbase.folder>
-    <hadoop.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hadoop/hadoop-3.1.1.3.1.4.1-1.tar.gz</hadoop.tar>
+    <hadoop.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hadoop/hadoop-3.1.1.3.1.4.0-315.tar.gz</hadoop.tar>
     <hadoop.folder>hadoop-3.1.1.3.1.4.0-315</hadoop.folder>
     <grafana.folder>grafana-6.4.2</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.4.2.linux-amd64.tar.gz</grafana.tar>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -40,14 +40,14 @@
     <python.ver>python &gt;= 2.6</python.ver>
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>
     <!--TODO change to HDP URL-->
-    <hbase.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hbase/hbase-2.0.2.3.1.4.0-315-bin.tar.gz</hbase.tar>
-    <hbase.folder>hbase-2.0.2.3.1.4.0-315</hbase.folder>
-    <hadoop.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/hadoop/hadoop-3.1.1.3.1.4.0-315.tar.gz</hadoop.tar>
-    <hadoop.folder>hadoop-3.1.1.3.1.4.0-315</hadoop.folder>
+    <hbase.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.1-1/tars/hbase/hbase-2.0.2.3.1.4.1-1-bin.tar.gz</hbase.tar>
+    <hbase.folder>hbase-2.0.2.3.1.4.1-1</hbase.folder>
+    <hadoop.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.1-1/tars/hadoop/hadoop-3.1.1.3.1.4.1-1.tar.gz</hadoop.tar>
+    <hadoop.folder>hadoop-3.1.1.3.1.4.1-1</hadoop.folder>
     <grafana.folder>grafana-6.4.2</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.4.2.linux-amd64.tar.gz</grafana.tar>
-    <phoenix.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.0-315/tars/phoenix/phoenix-5.0.0.3.1.4.0-315.tar.gz</phoenix.tar>
-    <phoenix.folder>phoenix-5.0.0.3.1.4.0-315</phoenix.folder>
+    <phoenix.tar>https://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.1.4.1-1/tars/phoenix/phoenix-5.0.0.3.1.4.1-1.tar.gz</phoenix.tar>
+    <phoenix.folder>phoenix-5.0.0.3.1.4.1-1</phoenix.folder>
     <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
     <powermock.version>1.6.2</powermock.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
When attempting to build Ambari, throws DependencyResolutionException, reslove failed to execute goal on project ambari-metrics-timelineservice.

## How was this patch tested?
manual tests