### PR TITLE
AMBARI-25537. Fix AMS ambari-database and hbase dashboards.

### DIFF
--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ambari-server-database.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ambari-server-database.json
@@ -903,6 +903,7 @@
         "options": [
         ],
         "label": "Hosts",
+        "refresh": true,
         "query": "hosts.$cluster",
         "type": "query"
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now Grafana displays "Ambari Server - Database" dashboard with all required metrics.

## How was this patch tested?
Manual check.

Results of `mvn clean test -pl ambari-server,ambari-web,ambari-metrics/ambari-metrics-common,ambari-views,ambari-utility`:

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Web 2.7.5.0.0 ............................... SUCCESS [01:34 min]
[INFO] Ambari Views 2.7.5.0.0 ............................. SUCCESS [  2.402 s]
[INFO] ambari-utility 1.0.0.0-SNAPSHOT .................... SUCCESS [  3.047 s]
[INFO] Ambari Metrics Common 2.7.5.0.0 .................... SUCCESS [  7.260 s]
[INFO] Ambari Server 2.7.5.0.0 ............................ SUCCESS [31:23 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33:11 min
[INFO] Finished at: 2020-07-28T12:44:35+03:00
[INFO] ------------------------------------------------------------------------