### PR TITLE
AMBARI-25540. Failed to compile ambari-admin.

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -102,7 +102,7 @@
               <workingDirectory>${basedir}/src/main/resources/ui/admin-web</workingDirectory>
               <executable>${basedir}/src/main/resources/ui/admin-web/node/${executable.node}</executable>
               <arguments>
-                <argument>${basedir}/src/main/resources/ui/admin-web/node_modules/bower/bin/bower</argument>
+                <argument>bower</argument>
                 <argument>install</argument>
                 <argument>--allow-root</argument>
               </arguments>


### PR DESCRIPTION
AMBARI-25540 Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (Bower install) on project ambari-admin

## What changes were proposed in this pull request?
When attempting to build Ambari V2.7.5, throws Command execution failed, reslove failed to Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (Bower install) on project ambari-admin.

## How was this patch tested?
mvn -B clean install rpm:rpm -DnewVersion=2.7.5.0.0 -DbuildNumber=5895e4ed6b30a2da8a90fee2403b6cab91d19972 -DskipTests -Dpython.ver="python >= 2.6" -Drat.ignoreErrors=true -rf :ambari-admin

[compile error.txt](https://github.com/apache/ambari/files/5027345/compile.error.txt)