### PR TITLE
AMBARI-25545 Downloaded zip-file name shows empty in the fileview (akiyamaneko) (#3220)

### DIFF
--- a/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
+++ b/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
@@ -62,6 +62,7 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import java.net.URLEncoder;
 
 /**
  * Service for download and aggregate files
@@ -228,7 +229,7 @@ public class DownloadService extends HdfsService {
         }
       };
       return Response.ok(result)
-          .header("Content-Disposition", "inline; filename=\"" + name +"\"").build();
+          .header("Content-Disposition", "inline; filename=\"" + URLEncoder.encode(name, "UTF-8") +"\"").build();
     } catch (WebApplicationException ex) {
       LOG.error("Error occurred : ",ex);
       throw ex;

--- a/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
+++ b/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
@@ -114,12 +114,12 @@ public class DownloadService extends HdfsService {
       ResponseBuilder result = Response.ok(fs);
       if (download) {
         result.header("Content-Disposition",
-          "attachment; filename=\"" + status.getPath().getName() + "\"").type(MediaType.APPLICATION_OCTET_STREAM);
+          "attachment; filename=\"" + URLEncoder(status.getPath().getName(), "UTF-8") + "\"").type(MediaType.APPLICATION_OCTET_STREAM);
       } else {
         FileNameMap fileNameMap = URLConnection.getFileNameMap();
         String mimeType = fileNameMap.getContentTypeFor(status.getPath().getName());
         result.header("Content-Disposition",
-          "filename=\"" + status.getPath().getName() + "\"").type(mimeType);
+          "filename=\"" + URLEncoder(status.getPath().getName(), "UTF-8") + "\"").type(mimeType);
       }
       return result.build();
     } catch (WebApplicationException ex) {

--- a/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
+++ b/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
@@ -114,12 +114,12 @@ public class DownloadService extends HdfsService {
       ResponseBuilder result = Response.ok(fs);
       if (download) {
         result.header("Content-Disposition",
-          "attachment; filename=\"" + URLEncoder(status.getPath().getName(), "UTF-8") + "\"").type(MediaType.APPLICATION_OCTET_STREAM);
+          "attachment; filename=\"" + URLEncoder.encode(status.getPath().getName(), "UTF-8") + "\"").type(MediaType.APPLICATION_OCTET_STREAM);
       } else {
         FileNameMap fileNameMap = URLConnection.getFileNameMap();
         String mimeType = fileNameMap.getContentTypeFor(status.getPath().getName());
         result.header("Content-Disposition",
-          "filename=\"" + URLEncoder(status.getPath().getName(), "UTF-8") + "\"").type(mimeType);
+          "filename=\"" + URLEncoder.encode(status.getPath().getName(), "UTF-8") + "\"").type(mimeType);
       }
       return result.build();
     } catch (WebApplicationException ex) {


### PR DESCRIPTION
fix downloaded zip-file name shows empty in the fileview

https://issues.apache.org/jira/browse/AMBARI-25545

# How was this patch tested?
manual tests


**the problem is below**:

![question-screenshot](https://user-images.githubusercontent.com/52202080/91270959-099e9380-e7ac-11ea-927c-1fa28d937ecb.png)

**after modify the result like below:**
![question-fixed-screenshot](https://user-images.githubusercontent.com/52202080/91270930-fe4b6800-e7ab-11ea-9870-76a751975b27.png)
