### PR TITLE
AMBARI-25546 To prevent negative float and NaN value in heatmap metrics page.

### DIFF
--- a/ambari-web/app/controllers/main/charts/heatmap_metrics/heatmap_metric.js
+++ b/ambari-web/app/controllers/main/charts/heatmap_metrics/heatmap_metric.js
@@ -93,7 +93,7 @@ App.MainChartHeatmapMetric = Em.Object.extend({
    * 
    */
   slotDefinitions: function () {
-    var max = this.get('maximumValue') ? parseFloat(this.get('maximumValue')) : 0;
+    var max = this.getMaximumValue();
     var slotCount = this.get('numberOfSlots');
     var units = this.get('units');
     var delta = (max - this.get('minimumValue')) / slotCount;
@@ -174,6 +174,15 @@ App.MainChartHeatmapMetric = Em.Object.extend({
     return hatchStyle;
   },
 
+  /**
+   * compatible with special input value, such as negative float number or string
+   * @return {float}
+   */
+  getMaximumValue: function getMaximumValue() {
+    var max = this.get('maximumValue') ? parseFloat(this.get('maximumValue')) : 0;
+    return isNaN(max) ? 0 : Math.max(0, max);
+  },
+  
   /**
    * In slot definitions this value is used to construct the label by appending
    * it to slot min-max values. For example giving '%' here would result in slot


### PR DESCRIPTION
The jira is : https://issues.apache.org/jira/browse/AMBARI-25546


To prevent negative float and NaN value in heatmap metrics page.
 we test it like below:

# How was this patch tested?
manual tests

before modify:
![heatmap-negative-screentshot.png](https://i.loli.net/2020/08/26/UHPaOhwSEMT7JXN.png)
![heatmap--metrics-NaN-screentshot.png](https://i.loli.net/2020/08/26/lah7cJdbBrxyPNU.png)

after modify
![heatmap-metrics-negative-fixed-screenshot.png](https://i.loli.net/2020/08/26/srfLJhAdNpqzZjk.png)
![heatmap--metrics-NaN-fixed-screentshot.png](https://i.loli.net/2020/08/26/EKVscQitMk2mHgu.png)