### PR TITLE
AMBARI-25558. Upgrade fails because host is out of sync

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListener.java
@@ -28,6 +28,7 @@ import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.EagerSingleton;
+import org.apache.ambari.server.StackAccessException;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.events.HostsAddedEvent;
 import org.apache.ambari.server.events.HostsRemovedEvent;
@@ -137,8 +138,14 @@ public class HostVersionOutOfSyncListener {
               hostStackId.getStackName(), hostStackId.getStackVersion(), serviceName, componentName);
           continue;
         }
-        ComponentInfo component = ami.get().getComponent(hostStackId.getStackName(),
-                hostStackId.getStackVersion(), serviceName, componentName);
+
+        ComponentInfo component = ami.get().getService(hostStackId.getStackName(), hostStackId.getStackVersion(),
+                                                        serviceName).getComponentByName(componentName);
+
+        // Skip lookup if stack does not contain the component
+        if (component == null) {
+          continue;
+        }
 
         if (!component.isVersionAdvertised()) {
           RepositoryVersionState state = checkAllHostComponents(hostStackId, hostVersionEntity.getHostEntity());

--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/upgrade/HostVersionOutOfSyncListener.java
@@ -28,7 +28,6 @@ import org.apache.ambari.annotations.Experimental;
 import org.apache.ambari.annotations.ExperimentalFeature;
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.EagerSingleton;
-import org.apache.ambari.server.StackAccessException;
 import org.apache.ambari.server.api.services.AmbariMetaInfo;
 import org.apache.ambari.server.events.HostsAddedEvent;
 import org.apache.ambari.server.events.HostsRemovedEvent;


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a failure when adding upgrade adds new components because there are never found in old stack

## How was this patch tested?

Reproduced it than replaced the jar and out of sync warning was gone.