### PR TITLE
AMBARI-25523. Ambari UI keeps loading at step3 while adding the new namespace for HDFS for the second time (dpidhaiets)

### DIFF
--- a/ambari-web/app/controllers/main/admin/federation/step3_controller.js
+++ b/ambari-web/app/controllers/main/admin/federation/step3_controller.js
@@ -105,7 +105,9 @@ App.NameNodeFederationWizardStep3Controller = Em.Controller.extend(App.Blueprint
     var hdfsSiteConfigs = configsFromServer.findProperty('type', 'hdfs-site').properties;
     var nameServices = App.HDFSService.find().objectAt(0).get('masterComponentGroups').mapProperty('name');
     ret.nameServicesList = nameServices.join(',');
-    ret.nameservice1 = nameServices[0];
+    ret.nameservice1 = nameServices.find(function (ns){
+      return hdfsSiteConfigs['dfs.namenode.rpc-address.' + ns + '.nn1'];
+    });
     ret.newNameservice = this.get('content.nameServiceId');
     ret.namenode1 = hdfsSiteConfigs['dfs.namenode.rpc-address.' + ret.nameservice1 + '.nn1'].split(':')[0];
     ret.namenode2 = hdfsSiteConfigs['dfs.namenode.rpc-address.' + ret.nameservice1 + '.nn2'].split(':')[0];


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI UI KEEPS LOADING AT STEP3 WHILE ADDING THE NEW NAMESPACE FOR HDFS For the Second Time

## How was this patch tested?

manually
