### PR TITLE
AMBARI-25561 Python Test for zeppelin failing (santal)

### DIFF
--- a/ambari-server/src/test/python/stacks/2.6/ZEPPELIN/test_zeppelin_070.py
+++ b/ambari-server/src/test/python/stacks/2.6/ZEPPELIN/test_zeppelin_070.py
@@ -205,7 +205,6 @@ class TestZeppelin070(RMFTestCase):
                               )
 
   @patch('os.path.exists', return_value=True)
-  @unittest.skip("Disabled for stabilization, check AMBARI-25561")
   def test_start_secured(self, os_path_exists_mock):
     self.executeScript(self.COMMON_SERVICES_PACKAGE_DIR + "/scripts/master.py",
                        classname="Master",


### PR DESCRIPTION
## What changes were proposed in this pull request?

re-enabled the `test_zeppelin_070.TestZeppelin070.test_start_secured` test

## How was this patch tested?

manual tests