### PR TITLE
[AMBARI-25543] fix hdfs Disk I/O Utilization result.

### DIFF
--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
@@ -530,7 +530,7 @@
           }
         },
         {
-          "widget_name": "DataNode Process Disk I/O Utilization",
+          "widget_name": "DataNode Process Disk I/O Rate",
           "default_section_name": "HDFS_HEATMAPS",
           "description": "",
           "widget_type": "HEATMAP",
@@ -563,7 +563,7 @@
           ],
           "values": [
             {
-              "name": "DataNode Process Disk I/O Utilization",
+              "name": "DataNode Process Disk I/O Rate",
               "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*0.9766/1024}"
             }
           ],

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
@@ -564,12 +564,12 @@
           "values": [
             {
               "name": "DataNode Process Disk I/O Utilization",
-              "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*50}"
+              "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*0.9766}"
             }
           ],
           "properties": {
-            "display_unit": "%",
-            "max_limit": "100"
+            "display_unit": "KB/s",
+            "max_limit": "50000"
           }
         },
         {
@@ -606,12 +606,12 @@
           "values": [
             {
               "name": "DataNode Process Network I/O Utilization",
-              "value": "${((dfs.datanode.RemoteBytesRead/dfs.datanode.ReadsFromRemoteClient)+(dfs.datanode.RemoteBytesWritten/dfs.datanode.WritesFromRemoteClient))*50}"
+              "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*0.9766}"
             }
           ],
           "properties": {
-            "display_unit": "%",
-            "max_limit": "100"
+            "display_unit": "KB/s",
+            "max_limit": "50000"
           }
         },
         {

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
@@ -564,12 +564,12 @@
           "values": [
             {
               "name": "DataNode Process Disk I/O Utilization",
-              "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*0.9766}"
+              "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*0.9766/1024}"
             }
           ],
           "properties": {
-            "display_unit": "KB/s",
-            "max_limit": "50000"
+            "display_unit": "MB/s",
+            "max_limit": "1024"
           }
         },
         {

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HDFS/widgets.json
@@ -606,12 +606,12 @@
           "values": [
             {
               "name": "DataNode Process Network I/O Utilization",
-              "value": "${((dfs.datanode.BytesRead/dfs.datanode.TotalReadTime)+(dfs.datanode.BytesWritten/dfs.datanode.TotalWriteTime))*0.9766}"
+              "value": "${((dfs.datanode.RemoteBytesRead/dfs.datanode.ReadsFromRemoteClient)+(dfs.datanode.RemoteBytesWritten/dfs.datanode.WritesFromRemoteClient))*50}"
             }
           ],
           "properties": {
-            "display_unit": "KB/s",
-            "max_limit": "50000"
+            "display_unit": "%",
+            "max_limit": "100"
           }
         },
         {


### PR DESCRIPTION
## What changes were proposed in this pull request?
I meet the same problem with [AMBARI-25543](https://issues.apache.org/jira/browse/AMBARI-25543) and try to fix it.
It seems the old formula had no  means, so I tried to rewrite the formula and replace the unit of the result with `KB/s` instead of ` %` (`1byte/1ms =1000KB/1024s approximately equal to the 0.9766KB/s`).






## How was this patch tested?
I have test the patch with munual tests, the results as below:
![fixed](https://user-images.githubusercontent.com/52202080/99191856-88eba400-27aa-11eb-9dc0-7ab74ff8cf36.png)


