### PR TITLE
AMBARI-25567. Fix escaping issues in check database command

### DIFF
--- a/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive_service.py
+++ b/ambari-server/src/main/resources/common-services/HIVE/0.12.0.2.0/package/scripts/hive_service.py
@@ -33,6 +33,7 @@ from resource_management.libraries.functions import get_user_call_output
 from resource_management.libraries.functions.show_logs import show_logs
 from resource_management.libraries.functions import StackFeature
 from resource_management.libraries.functions.stack_features import check_stack_feature
+from resource_management.core.utils import PasswordString
 
 from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
 from ambari_commons import OSConst
@@ -149,8 +150,10 @@ def validate_connection(target_path_to_jdbc, hive_lib_path):
                       " in hive lib dir. So, db connection check can fail. Please run 'ambari-server setup --jdbc-db={db_name} --jdbc-driver={path_to_jdbc} on server host.'"
       Logger.error(error_message)
 
-  db_connection_check_command = format(
-    "{java64_home}/bin/java -cp {check_db_connection_jar}:{path_to_jdbc} org.apache.ambari.server.DBConnectionVerification '{hive_jdbc_connection_url}' {hive_metastore_user_name} {hive_metastore_user_passwd!p} {hive_jdbc_driver}")
+  db_connection_check_command = (format('{java64_home}/bin/java'), '-cp',
+                                 format('{check_db_connection_jar}:{path_to_jdbc}'), 'org.apache.ambari.server.DBConnectionVerification',
+                                 params.hive_jdbc_connection_url, params.hive_metastore_user_name,
+                                 PasswordString(params.hive_metastore_user_passwd), params.hive_jdbc_driver)
 
   try:
     Execute(db_connection_check_command,

--- a/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
+++ b/ambari-server/src/main/resources/custom_actions/scripts/check_host.py
@@ -39,6 +39,7 @@ from resource_management.core.exceptions import Fail
 from ambari_commons.constants import AMBARI_SUDO_BINARY
 from resource_management.core import shell
 from resource_management.core.logger import Logger
+from resource_management.core.utils import PasswordString
 
 
 # WARNING. If you are adding a new host check that is used by cleanup, add it to BEFORE_CLEANUP_HOST_CHECKS
@@ -445,9 +446,9 @@ class CheckHost(Script):
       user_name = "SYS AS SYSDBA"
 
     # try to connect to db
-    db_connection_check_command = format("{java_exec} -cp {check_db_connection_path}{class_path_delimiter}" \
-           "{jdbc_jar_path} -Djava.library.path={java_library_path} org.apache.ambari.server.DBConnectionVerification \"{db_connection_url}\" " \
-           "\"{user_name}\" {user_passwd!p} {jdbc_driver_class}")
+    db_connection_check_command = (java_exec, '-cp', format("{check_db_connection_path}{class_path_delimiter}{jdbc_jar_path}"),
+                                   format("-Djava.library.path={java_library_path}"), "org.apache.ambari.server.DBConnectionVerification",
+                                   db_connection_url, user_name, PasswordString(user_passwd), jdbc_driver_class)
 
     if db_name == DB_SQLA:
       db_connection_check_command = "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{0}{1} {2}".format(agent_cache_dir,

--- a/ambari-server/src/test/python/custom_actions/TestCheckHost.py
+++ b/ambari-server/src/test/python/custom_actions/TestCheckHost.py
@@ -161,9 +161,6 @@ class TestCheckHost(TestCase):
 
     self.assertEquals(structured_out_mock.call_args[0][0], {'db_connection_check': {'message': 'test message',
                                                                                     'exit_code': 1}})
-    self.assertEquals(format_mock.call_args[0][0],'{java_exec} -cp {check_db_connection_path}{class_path_delimiter}'
-            '{jdbc_jar_path} -Djava.library.path={java_library_path} org.apache.ambari.server.DBConnectionVerification'
-            ' "{db_connection_url}" "{user_name}" {user_passwd!p} {jdbc_driver_class}')
 
     # test, db connection success
     download_file_mock.reset_mock()

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_metastore.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_metastore.py
@@ -23,6 +23,7 @@ from mock.mock import MagicMock, call, patch
 from stacks.utils.RMFTestCase import *
 
 from resource_management.libraries.functions import stack_features
+from resource_management.core.utils import PasswordString
 
 # used for faking out stack features when the config files used by unit tests use older stacks
 def mock_stack_feature(stack_feature, stack_version):
@@ -68,11 +69,18 @@ class TestHiveMetastore(RMFTestCase):
         user = 'hive',
         path = ['/bin:/usr/hdp/current/hive-server2/bin:/usr/hdp/current/hadoop-client/bin'],
     )
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-        path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-        tries = 5,
-        try_sleep = 10,
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   def test_stop_default(self):
@@ -128,11 +136,18 @@ class TestHiveMetastore(RMFTestCase):
         user = 'hive',
         path = ['/bin:/usr/hdp/current/hive-server2/bin:/usr/hdp/2.1.0.0-1234/hadoop/bin'],
     )
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-        path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-        tries = 5,
-        try_sleep = 10,
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   def test_stop_secured(self):
@@ -567,9 +582,17 @@ class TestHiveMetastore(RMFTestCase):
         user = 'hive',
         path = ['/bin:/usr/hdp/current/hive-server2/bin:/usr/hdp/2.3.0.0-1234/hadoop/bin'])
 
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive aaa com.mysql.jdbc.Driver',
-        path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-        tries = 5,
-        try_sleep = 10)
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("aaa"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
 
     self.assertNoMoreResources()

--- a/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_server.py
+++ b/ambari-server/src/test/python/stacks/2.0.6/HIVE/test_hive_server.py
@@ -34,6 +34,7 @@ from resource_management.libraries.functions.constants import StackFeature
 from resource_management.libraries.functions import stack_features
 from resource_management.libraries.functions import stack_select
 from resource_management.libraries.functions import conf_select
+from resource_management.core.utils import PasswordString
 
 # used for faking out stack features when the config files used by unit tests use older stacks
 def mock_stack_feature(stack_feature, stack_version):
@@ -99,12 +100,18 @@ class TestHiveServer(RMFTestCase):
         user = 'hive',
         path = ['/bin:/usr/hdp/current/hive-server2/bin:mock_hadoop_dir'],
     )
-    self.assertResourceCalled('Execute',
-                              '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-                              tries=5,
-                              try_sleep=10
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   @patch("resource_management.libraries.functions.copy_tarball.copy_to_hdfs")
@@ -129,12 +136,18 @@ class TestHiveServer(RMFTestCase):
                               user = 'hive',
                               path = ['/bin:/usr/hdp/current/hive-server2/bin:mock_hadoop_dir'],
                               )
-    self.assertResourceCalled('Execute',
-                              '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-                              tries=5,
-                              try_sleep=10
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   def test_start_default_no_copy(self):
@@ -160,9 +173,18 @@ class TestHiveServer(RMFTestCase):
         path = ['/bin:/usr/hdp/current/hive-server2/bin:mock_hadoop_dir'],
     )
 
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'], tries=5, try_sleep=10
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   @patch("resource_management.libraries.functions.copy_tarball.copy_to_hdfs")
@@ -190,9 +212,18 @@ class TestHiveServer(RMFTestCase):
         path = ['/bin:/usr/hdp/current/hive-server2/bin:mock_hadoop_dir'],
     )
 
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'], tries=5, try_sleep=10
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   @patch("resource_management.libraries.functions.copy_tarball.copy_to_hdfs")
@@ -220,9 +251,18 @@ class TestHiveServer(RMFTestCase):
         path = ['/bin:/usr/hdp/current/hive-server2/bin:mock_hadoop_dir'],
     )
 
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'], tries=5, try_sleep=10
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
   def test_stop_default(self):
@@ -291,12 +331,18 @@ class TestHiveServer(RMFTestCase):
         user = 'hive',
         path = ['/bin:/usr/hdp/current/hive-server2/bin:mock_hadoop_dir'],
     )
-    self.assertResourceCalled('Execute',
-                              '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive \'!`"\'"\'"\' 1\' com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-                              tries=5,
-                              try_sleep=10,
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("!`\"' 1"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
     self.assertNoMoreResources()
 
     self.assertTrue(check_fs_root_mock.called)

--- a/ambari-server/src/test/python/stacks/2.1/HIVE/test_hive_metastore.py
+++ b/ambari-server/src/test/python/stacks/2.1/HIVE/test_hive_metastore.py
@@ -24,6 +24,7 @@ import os
 from mock.mock import MagicMock, call, patch
 from stacks.utils.RMFTestCase import *
 from resource_management.libraries.functions.constants import Direction, StackFeature
+from resource_management.core.utils import PasswordString
 
 # used for faking out stack features when the config files used by unit tests use older stacks
 def mock_stack_feature(stack_feature, stack_version):
@@ -77,11 +78,18 @@ class TestHiveMetastore(RMFTestCase):
         path = ['/bin:/usr/hdp/current/hive-server2/bin:/usr/hdp/2.2.1.0-2067/hadoop/bin'],
     )
 
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive aaa com.mysql.jdbc.Driver',
-        path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
-        tries = 5,
-        try_sleep = 10,
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("aaa"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
 
     self.assertNoMoreResources()
 
@@ -106,7 +114,14 @@ class TestHiveMetastore(RMFTestCase):
         user = 'hive',
         path = ['/bin:/usr/hdp/current/hive-server2/bin:/usr/hdp/2.2.1.0-2067/hadoop/bin'],
     )
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive aaa com.mysql.jdbc.Driver',
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("aaa"),
+                                          u'com.mysql.jdbc.Driver'),
                               path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
                               tries = 5,
                               try_sleep = 10,
@@ -169,9 +184,18 @@ class TestHiveMetastore(RMFTestCase):
         path = ['/bin:/usr/hdp/current/hive-server2/bin:/usr/hdp/current/hadoop-client/bin'],
     )
 
-    self.assertResourceCalled('Execute', '/usr/jdk64/jdk1.7.0_45/bin/java -cp /usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar org.apache.ambari.server.DBConnectionVerification \'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true\' hive asd com.mysql.jdbc.Driver',
-                              path=['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'], tries=5, try_sleep=10
-    )
+    self.assertResourceCalled('Execute', (u'/usr/jdk64/jdk1.7.0_45/bin/java',
+                                          '-cp',
+                                          '/usr/lib/ambari-agent/DBConnectionVerification.jar:/usr/hdp/current/hive-server2/lib/mysql-connector-java.jar',
+                                          'org.apache.ambari.server.DBConnectionVerification',
+                                          u'jdbc:mysql://c6402.ambari.apache.org/hive?createDatabaseIfNotExist=true',
+                                          u'hive',
+                                          PasswordString("asd"),
+                                          u'com.mysql.jdbc.Driver'),
+                              path = ['/usr/sbin:/sbin:/usr/local/bin:/bin:/usr/bin'],
+                              tries = 5,
+                              try_sleep = 10,
+                              )
 
     self.assertNoMoreResources()
 

--- a/ambari-server/src/test/python/stacks/2.5/HIVE/test_hive_server_int.py
+++ b/ambari-server/src/test/python/stacks/2.5/HIVE/test_hive_server_int.py
@@ -30,6 +30,7 @@ from resource_management.libraries.script.config_dictionary import UnknownConfig
 from hive_server_interactive import HiveServerInteractiveDefault
 from resource_management.libraries.script.script import Script
 from resource_management.core import shell
+from resource_management.core.utils import PasswordString
 
 @patch("resource_management.libraries.Script.get_tmp_dir", new=MagicMock(return_value=('/var/lib/ambari-agent/tmp')))
 @patch.object(functions, "get_stack_version", new=MagicMock(return_value="2.0.0.0-1234"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed issue which caused escaping errors in username.

## How was this patch tested?

Clicked "Test Database Connection" button and tested the patch worked with different usernames.