### PR TITLE
[Ambari-25568] Fix The 'NodeManager RAM Utilized' metric in the heatmap had no unit

### DIFF
--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/YARN_widgets.json
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/YARN_widgets.json
@@ -577,7 +577,7 @@
             }
           ],
           "properties": {
-            "display_unit": "",
+            "display_unit": "GB",
             "max_limit": "100"
           }
         },

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/YARN/YARN_widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/YARN/YARN_widgets.json
@@ -636,7 +636,7 @@
             }
           ],
           "properties": {
-            "display_unit": "",
+            "display_unit": "GB",
             "max_limit": "100"
           }
         },


### PR DESCRIPTION
## What changes were proposed in this pull request?
`NodeManager RAM Utilized`  metric represents `yarn.NodeManagerMetrics.AllocatedGB`， To avoid misunderstanding, it is better to add GB unit instead of empty.
## How was this patch tested?
manual tests
I have test in local environment,result shows as below:
![NodeManager RAM Utilized with GB unit](https://user-images.githubusercontent.com/52202080/95681616-80380900-0c13-11eb-967f-16494c0be64a.png)




