### PR TITLE
AMBARI-25569 Reassess Ambari Metrics data migration

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/AbstractPhoenixMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/AbstractPhoenixMetricsCopier.java
@@ -116,11 +116,13 @@ public abstract class AbstractPhoenixMetricsCopier implements Runnable {
       LOG.info("Skipping metrics progress save as the file is null");
       return;
     }
-    for (String metricName : metricNames) {
-      try {
-        this.processedMetricsFile.append(inputTable).append(":").append(metricName).append(System.lineSeparator());
-      } catch (IOException e) {
-        LOG.error(e);
+    synchronized (this.processedMetricsFile) {
+      for (String metricName : metricNames) {
+        try {
+          this.processedMetricsFile.append(inputTable).append(":").append(metricName).append(System.lineSeparator());
+        } catch (IOException e) {
+          LOG.error(e);
+        }
       }
     }
   }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
@@ -21,10 +21,12 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.ambari.metrics.core.timeline.PhoenixHBaseAccessor;
 import org.apache.ambari.metrics.core.timeline.TimelineMetricConfiguration;
+import org.apache.ambari.metrics.core.timeline.discovery.TimelineMetricMetadataKey;
 import org.apache.ambari.metrics.core.timeline.discovery.TimelineMetricMetadataManager;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -34,6 +36,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -44,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.METRICS_AGGREGATE_DAILY_TABLE_NAME;
@@ -62,7 +66,7 @@ import static org.apache.ambari.metrics.core.timeline.query.PhoenixTransactSQL.M
 public class MetricsDataMigrationLauncher {
   private static final Log LOG = LogFactory.getLog(MetricsDataMigrationLauncher.class);
   private static final Long DEFAULT_TIMEOUT_MINUTES = 60*24L;
-  private static String patternPrefix = "._p_";
+  private static final String PATTERN_PREFIX = "._p_";
   private static final int DEFAULT_BATCH_SIZE = 5;
   public static final Map<String, String> CLUSTER_AGGREGATE_TABLES_MAPPING = new HashMap<>();
   public static final Map<String, String> HOST_AGGREGATE_TABLES_MAPPING = new HashMap<>();
@@ -83,127 +87,142 @@ public class MetricsDataMigrationLauncher {
 
   private final Set<Set<String>> metricNamesBatches;
   private final String processedMetricsFilePath;
-  private Set<String> metricNames;
 
-  private Long startTime;
-  private Integer batchSize;
-  private Integer numberOfThreads;
+  private final Long startTime;
+  private final Integer numberOfThreads;
   private TimelineMetricConfiguration timelineMetricConfiguration;
   private PhoenixHBaseAccessor hBaseAccessor;
   private TimelineMetricMetadataManager timelineMetricMetadataManager;
   private Map<String, Set<String>> processedMetrics;
 
   public MetricsDataMigrationLauncher(String whitelistedFilePath, String processedMetricsFilePath, Long startTime, Integer numberOfThreads, Integer batchSize) throws Exception {
-    this.startTime = startTime == null? DEFAULT_START_TIME : startTime;
-    this.numberOfThreads = numberOfThreads == null? DEFAULT_NUMBER_OF_THREADS : numberOfThreads;
-    this.batchSize = batchSize == null? DEFAULT_BATCH_SIZE : batchSize;
-    this.processedMetricsFilePath = processedMetricsFilePath == null? DEFAULT_PROCESSED_METRICS_FILE_LOCATION : processedMetricsFilePath;
+    this.startTime = (startTime == null) ? DEFAULT_START_TIME : startTime;
+    this.numberOfThreads = (numberOfThreads == null) ? DEFAULT_NUMBER_OF_THREADS : numberOfThreads;
+    this.processedMetricsFilePath = (processedMetricsFilePath == null) ? DEFAULT_PROCESSED_METRICS_FILE_LOCATION : processedMetricsFilePath;
 
     initializeHbaseAccessor();
-
-    LOG.info("Looking for whitelisted metric names...");
-
-    if (whitelistedFilePath != null) {
-      this.metricNames = readMetricWhitelistFromFile(whitelistedFilePath);
-    } else {
-      String whitelistFile = timelineMetricConfiguration.getMetricsConf().get(TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_FILE, TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_FILE_LOCATION_DEFAULT);
-      metricNames = readMetricWhitelistFromFile(whitelistFile);
-    }
-
     readProcessedMetricsMap();
 
-    LOG.info("Setting up batches...");
-    this.metricNamesBatches = new HashSet<>();
+    final Set<String> metricNames = getMetricNames(whitelistedFilePath);
 
-    Iterables.partition(metricNames, this.batchSize)
+    LOG.info("Setting up batches...");
+    if (batchSize == null) batchSize = DEFAULT_BATCH_SIZE;
+    this.metricNamesBatches = new HashSet<>(batchSize);
+
+    Iterables.partition(metricNames, batchSize)
       .forEach(batch -> metricNamesBatches.add(new HashSet<>(batch)));
-    LOG.info(String.format("Split metric names into %s batches with size of %s", metricNamesBatches.size(), this.batchSize));
+    LOG.info(String.format("Split metric names into %s batches with size of %s", metricNamesBatches.size(), batchSize));
   }
 
+  private Set<String> getMetricNames(String whitelistedFilePath) throws MalformedURLException, URISyntaxException, SQLException {
+    if(whitelistedFilePath != null) {
+      LOG.info(String.format("Whitelist file %s has been provided.", whitelistedFilePath));
+      LOG.info("Looking for whitelisted metric names based on the file content...");
+      return readMetricWhitelistFromFile(whitelistedFilePath);
+    }
+
+    final Configuration conf = this.timelineMetricConfiguration.getMetricsConf();
+    if (Boolean.parseBoolean(conf.get(TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_ENABLED))) {
+      whitelistedFilePath = conf.get(TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_FILE,
+              TimelineMetricConfiguration.TIMELINE_METRICS_WHITELIST_FILE_LOCATION_DEFAULT);
+      LOG.info(String.format("No whitelist file has been provided but Ambari Metrics Whitelisting is enabled. " +
+              "Using %s as whitelist file.", whitelistedFilePath));
+      LOG.info("Looking for whitelisted metric names based on the file content...");
+      return readMetricWhitelistFromFile(whitelistedFilePath);
+    }
+
+    LOG.info("No whitelist file has been provided and Ambari Metrics Whitelisting is disabled.");
+    LOG.info("Looking for all the metric names in the Metrics Database...");
+    return this.hBaseAccessor.getTimelineMetricMetadataV1().keySet().stream()
+        .map(TimelineMetricMetadataKey::getMetricName).collect(Collectors.toSet());
+  }
 
   private void readProcessedMetricsMap() {
-    Map<String, Set<String>> result = new HashMap<>();
-    if (!Files.exists(Paths.get(processedMetricsFilePath))) {
-      LOG.info(String.format("The processed metrics file %s is missing, assuming there were no metrics processed.", processedMetricsFilePath));
-      this.processedMetrics = new HashMap<>();
-    }
-    LOG.info(String.format("Reading the list of already copied metrics from %s", processedMetricsFilePath));
-    try {
-      try (Stream<String> stream = Files.lines(Paths.get(processedMetricsFilePath))) {
-        stream.forEach( line -> {
-          String [] lineSplit = line.split(":");
-          if (!result.containsKey(lineSplit[0])) {
-            result.put(lineSplit[0], new HashSet<>(Collections.singletonList(lineSplit[1])));
-          } else {
-            result.get(lineSplit[0]).add(lineSplit[1]);
-          }
-        });
+    final Map<String, Set<String>> result = new HashMap<>();
+    final Path path = Paths.get(this.processedMetricsFilePath);
+
+    if (Files.notExists(path)) {
+      LOG.info(String.format("The processed metrics file %s is missing, assuming there were no metrics processed.", this.processedMetricsFilePath));
+    } else {
+      LOG.info(String.format("Reading the list of already copied metrics from %s", this.processedMetricsFilePath));
+      try {
+        try (Stream<String> stream = Files.lines(path)) {
+          stream.forEach(line -> {
+            String[] lineSplit = line.split(":");
+            if (!result.containsKey(lineSplit[0])) {
+              result.put(lineSplit[0], new HashSet<>(Collections.singletonList(lineSplit[1])));
+            } else {
+              result.get(lineSplit[0]).add(lineSplit[1]);
+            }
+          });
+        }
+      } catch (IOException e) {
+        LOG.error(e);
       }
-    } catch (IOException e) {
-      LOG.error(e);
     }
     this.processedMetrics = result;
   }
 
   public void runMigration(Long timeoutInMinutes) throws IOException {
+    try (FileWriter processedMetricsFileWriter = new FileWriter(this.processedMetricsFilePath, true)) {
+      LOG.info("Setting up copiers...");
+      Set<AbstractPhoenixMetricsCopier> copiers = new HashSet<>();
+      for (Set<String> batch : metricNamesBatches) {
+        for (Map.Entry<String, String> entry : CLUSTER_AGGREGATE_TABLES_MAPPING.entrySet()) {
+          Set<String> filteredMetrics = filterProcessedMetrics(batch, this.processedMetrics, entry.getKey());
+          if (!filteredMetrics.isEmpty()) {
+            copiers.add(new PhoenixClusterMetricsCopier(entry.getKey(), entry.getValue(), this.hBaseAccessor,
+                filteredMetrics, this.startTime, processedMetricsFileWriter));
+          }
+        }
 
-    FileWriter processedMetricsFileWriter = new FileWriter(processedMetricsFilePath, true);
-    LOG.info("Setting up copiers...");
-    Set<AbstractPhoenixMetricsCopier> copiers = new HashSet<>();
-    for (Set<String> batch : metricNamesBatches) {
-      for (Map.Entry<String, String> entry : CLUSTER_AGGREGATE_TABLES_MAPPING.entrySet()) {
-        Set<String> filteredMetrics = filterProcessedMetrics(batch, this.processedMetrics, entry.getKey());
-        if (!filteredMetrics.isEmpty()) {
-          copiers.add(new PhoenixClusterMetricsCopier(entry.getKey(), entry.getValue(), hBaseAccessor,
-            filteredMetrics, startTime, processedMetricsFileWriter));
+        for (Map.Entry<String, String> entry : HOST_AGGREGATE_TABLES_MAPPING.entrySet()) {
+          Set<String> filteredMetrics = filterProcessedMetrics(batch, this.processedMetrics, entry.getKey());
+          if (!filteredMetrics.isEmpty()) {
+            copiers.add(new PhoenixHostMetricsCopier(entry.getKey(), entry.getValue(), this.hBaseAccessor,
+                filteredMetrics, this.startTime, processedMetricsFileWriter));
+          }
         }
       }
 
-      for (Map.Entry<String, String> entry : HOST_AGGREGATE_TABLES_MAPPING.entrySet()) {
-        Set<String> filteredMetrics = filterProcessedMetrics(batch, processedMetrics, entry.getKey());
-        if (!filteredMetrics.isEmpty()) {
-          copiers.add(new PhoenixHostMetricsCopier(entry.getKey(), entry.getValue(), hBaseAccessor,
-            filteredMetrics, startTime, processedMetricsFileWriter));
+      if (copiers.isEmpty()) {
+        LOG.info("No copy threads to run, looks like all metrics have been copied.");
+        return;
+      }
+
+      LOG.info("Running the copy threads...");
+      long startTimer = System.currentTimeMillis();
+      ExecutorService executorService = null;
+      try {
+        executorService = Executors.newFixedThreadPool(this.numberOfThreads);
+        for (AbstractPhoenixMetricsCopier copier : copiers) {
+          executorService.submit(copier);
+        }
+      } finally {
+        if (executorService != null) {
+          executorService.shutdown();
+          try {
+            executorService.awaitTermination(timeoutInMinutes, TimeUnit.MINUTES);
+          } catch (InterruptedException e) {
+            LOG.error(e);
+          }
         }
       }
+
+      long estimatedTime = System.currentTimeMillis() - startTimer;
+      LOG.info(String.format("Copying took %s seconds", estimatedTime / 1000.0));
     }
-
-    if (copiers.isEmpty()) {
-      LOG.info("No copy threads to run, looks like all metrics have been copied.");
-      processedMetricsFileWriter.close();
-      return;
-    }
-
-    LOG.info("Running the copy threads...");
-    long startTimer = System.currentTimeMillis();
-    ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads == null ? DEFAULT_NUMBER_OF_THREADS : numberOfThreads);
-    for (AbstractPhoenixMetricsCopier copier : copiers) {
-      executorService.submit(copier);
-    }
-
-    executorService.shutdown();
-
-    try {
-      executorService.awaitTermination(timeoutInMinutes, TimeUnit.MINUTES);
-    } catch (InterruptedException e) {
-      LOG.error(e);
-    }
-
-    long estimatedTime = System.currentTimeMillis() - startTimer;
-    LOG.info(String.format("Copying took %s seconds", estimatedTime/1000.0));
-
-    processedMetricsFileWriter.close();
   }
 
   private void initializeHbaseAccessor() throws MalformedURLException, URISyntaxException {
     this.hBaseAccessor = new PhoenixHBaseAccessor(null);
     this.timelineMetricConfiguration = TimelineMetricConfiguration.getInstance();
-    timelineMetricConfiguration.initialize();
+    this.timelineMetricConfiguration.initialize();
 
-    timelineMetricMetadataManager = new TimelineMetricMetadataManager(hBaseAccessor);
-    timelineMetricMetadataManager.initializeMetadata(false);
+    this.timelineMetricMetadataManager = new TimelineMetricMetadataManager(this.hBaseAccessor);
+    this.timelineMetricMetadataManager.initializeMetadata(false);
 
-    hBaseAccessor.setMetadataInstance(timelineMetricMetadataManager);
+    this.hBaseAccessor.setMetadataInstance(this.timelineMetricMetadataManager);
   }
 
   private static Set<String> filterProcessedMetrics(Set<String> metricNames, Map<String, Set<String>> processedMetrics, String tableName) {
@@ -219,21 +238,18 @@ public class MetricsDataMigrationLauncher {
    */
   private static Set<String> readMetricWhitelistFromFile(String whitelistFile) {
     LOG.info(String.format("Reading metric names from %s", whitelistFile));
-    Set<String> whitelistedMetrics = new HashSet<>();
+    final Set<String> whitelistedMetrics = new HashSet<>();
 
-    BufferedReader br = null;
     String strLine;
 
-    try(FileInputStream fstream = new FileInputStream(whitelistFile)) {
-      br = new BufferedReader(new InputStreamReader(fstream));
-
+    try(BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(whitelistFile)))) {
       while ((strLine = br.readLine()) != null)   {
         strLine = strLine.trim();
         if (StringUtils.isEmpty(strLine)) {
           continue;
         }
-        if (strLine.startsWith(patternPrefix)) {
-          strLine = strLine.replace(patternPrefix, "");
+        if (strLine.startsWith(PATTERN_PREFIX)) {
+          strLine = strLine.replace(PATTERN_PREFIX, "");
         }
         if (strLine.contains("*")) {
           strLine = strLine.replaceAll("\\*", "%");
@@ -248,11 +264,10 @@ public class MetricsDataMigrationLauncher {
 
   private void saveMetadata() throws SQLException {
     LOG.info("Saving metadata to store...");
-    timelineMetricMetadataManager.updateMetadataCacheUsingV1Tables();
-    timelineMetricMetadataManager.forceMetricsMetadataSync();
+    this.timelineMetricMetadataManager.updateMetadataCacheUsingV1Tables();
+    this.timelineMetricMetadataManager.forceMetricsMetadataSync();
     LOG.info("Metadata was saved.");
   }
-
 
   /**
    *
@@ -260,8 +275,10 @@ public class MetricsDataMigrationLauncher {
    * REQUIRED args[0] - processedMetricsFilePath - full path to the file where processed metric are/will be stored
    *
    * OPTIONAL args[1] - whitelistedFilePath      - full path to the file with whitelisted metrics filenames
-   *                                               if not provided the default whitelist file location will be used if configured
-   *                                               if not configured - will result in error
+   *                                               if not provided and AMS whitelisting is enabled the default whitelist
+   *                                               file location will be used if configured
+   *                                               if not provided and AMS whitelisting is disabled then no whitelisting
+   *                                               will be used and all the metrics will be migrated
    *          args[2] - startTime                - default value is set to the last 30 days
    *          args[3] - numberOfThreads          - default value is 3
    *          args[4] - batchSize                - default value is 5
@@ -303,24 +320,23 @@ public class MetricsDataMigrationLauncher {
       System.exit(1);
     }
 
+    int exitCode = 0;
     try {
-      //Setup shutdown hook for metadata save.
-      MetricsDataMigrationLauncher finalDataMigrationLauncher = dataMigrationLauncher;
-      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-        try {
-          finalDataMigrationLauncher.saveMetadata();
-        } catch (SQLException e) {
-          LOG.error("Exception during metadata saving, exiting...", e);
-        }
-      }));
-
       dataMigrationLauncher.runMigration(timeoutInMinutes);
-    } catch (IOException e) {
+    } catch (Throwable e) {
+      exitCode = 1;
       LOG.error("Exception during data migration, exiting...", e);
-      System.exit(1);
+    } finally {
+      try {
+        dataMigrationLauncher.saveMetadata();
+      } catch (SQLException e) {
+        exitCode = 1;
+        LOG.error("Exception while saving the Metadata, exiting...", e);
+      }
     }
 
-    System.exit(0);
+    if(exitCode == 0) LOG.info("Data migration finished successfully.");
 
+    System.exit(exitCode);
   }
 }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixClusterMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixClusterMetricsCopier.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 public class PhoenixClusterMetricsCopier extends AbstractPhoenixMetricsCopier {
   private static final Log LOG = LogFactory.getLog(PhoenixClusterMetricsCopier.class);
-  private Map<TimelineClusterMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
+  private final Map<TimelineClusterMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
 
   PhoenixClusterMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, FileWriter processedMetricsFileWriter) {
     super(inputTableName, outputTableName, hBaseAccessor, metricNames, startTime, processedMetricsFileWriter);
@@ -53,7 +53,7 @@ public class PhoenixClusterMetricsCopier extends AbstractPhoenixMetricsCopier {
   @Override
   protected void saveMetrics() throws SQLException {
     LOG.debug(String.format("Saving %s results read from %s into %s", aggregateMap.size(), inputTable, outputTable));
-    hBaseAccessor.saveClusterAggregateRecordsSecond(aggregateMap, outputTable);
+    this.hBaseAccessor.saveClusterAggregateRecordsSecond(aggregateMap, outputTable);
   }
 
   @Override
@@ -62,13 +62,8 @@ public class PhoenixClusterMetricsCopier extends AbstractPhoenixMetricsCopier {
             rs.getString("METRIC_NAME"), rs.getString("APP_ID"),
             rs.getString("INSTANCE_ID"), rs.getLong("SERVER_TIME"));
 
-    MetricHostAggregate metricHostAggregate = new MetricHostAggregate();
-    metricHostAggregate.setSum(rs.getDouble("METRIC_SUM"));
-    metricHostAggregate.setNumberOfSamples(rs.getLong("METRIC_COUNT"));
-    metricHostAggregate.setMax(rs.getDouble("METRIC_MAX"));
-    metricHostAggregate.setMin(rs.getDouble("METRIC_MIN"));
+    MetricHostAggregate metricHostAggregate = extractMetricHostAggregate(rs);
 
-    aggregateMap.put(timelineMetric, metricHostAggregate);
-
+    this.aggregateMap.put(timelineMetric, metricHostAggregate);
   }
 }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixHostMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixHostMetricsCopier.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 public class PhoenixHostMetricsCopier extends AbstractPhoenixMetricsCopier {
   private static final Log LOG = LogFactory.getLog(PhoenixHostMetricsCopier.class);
-  private Map<TimelineMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
+  private final Map<TimelineMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
 
   PhoenixHostMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, FileWriter processedMetricsFileWriter) {
     super(inputTableName, outputTableName, hBaseAccessor, metricNames, startTime, processedMetricsFileWriter);
@@ -54,7 +54,7 @@ public class PhoenixHostMetricsCopier extends AbstractPhoenixMetricsCopier {
   @Override
   protected void saveMetrics() throws SQLException {
     LOG.debug(String.format("Saving %s results read from %s into %s", aggregateMap.size(), inputTable, outputTable));
-    hBaseAccessor.saveHostAggregateRecords(aggregateMap, outputTable);
+    this.hBaseAccessor.saveHostAggregateRecords(aggregateMap, outputTable);
   }
 
   @Override
@@ -66,12 +66,8 @@ public class PhoenixHostMetricsCopier extends AbstractPhoenixMetricsCopier {
     timelineMetric.setInstanceId(rs.getString("INSTANCE_ID"));
     timelineMetric.setStartTime(rs.getLong("SERVER_TIME"));
 
-    MetricHostAggregate metricHostAggregate = new MetricHostAggregate();
-    metricHostAggregate.setSum(rs.getDouble("METRIC_SUM"));
-    metricHostAggregate.setNumberOfSamples(rs.getLong("METRIC_COUNT"));
-    metricHostAggregate.setMax(rs.getDouble("METRIC_MAX"));
-    metricHostAggregate.setMin(rs.getDouble("METRIC_MIN"));
+    MetricHostAggregate metricHostAggregate = extractMetricHostAggregate(rs);
 
-    aggregateMap.put(timelineMetric, metricHostAggregate);
+    this.aggregateMap.put(timelineMetric, metricHostAggregate);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The data migration code only looks for the metrics that are present in the whitelist file. This is true even in the case when the AMS Whitelisting is not enabled. The user will only have those metrics migrated that are present in the whitelist file, which is usually not all that are required.

**The proposed change no 1:**

- If whitelist file parameter is provided then
    - migrate only the metrics that are in the whitelist file
- if whitelist file parameter is not provided then
    - if whitelisting is enabled then
        - discover the whitelist file configured in AMS and
        migrate only the metrics that are in the whitelist file
    - if whitelisting is disabled then
        - migrate all the metrics present in the database

**The proposed change no 2:**
Furthermore, the migration process frequently dies silently while saving the metadata. To fix this, the change suggests removing the initiating of saving metadata from the shutdown hook and call it "normally" in a _finally_ block.

**The proposed change no 3:**
Code cleanup.

## How was this patch tested?
The patch was tested by manual data migrations.