### PR TITLE
Revert "AMBARImbari-25568] Fix The 'NodeManager RAM Utilized' metric …

### DIFF
--- a/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/YARN_widgets.json
+++ b/ambari-server/src/main/resources/common-services/YARN/2.1.0.2.0/YARN_widgets.json
@@ -577,7 +577,7 @@
             }
           ],
           "properties": {
-            "display_unit": "GB",
+            "display_unit": "",
             "max_limit": "100"
           }
         },

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/YARN/YARN_widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/YARN/YARN_widgets.json
@@ -636,7 +636,7 @@
             }
           ],
           "properties": {
-            "display_unit": "GB",
+            "display_unit": "",
             "max_limit": "100"
           }
         },


### PR DESCRIPTION
Revert commit because accidentally merged the patch while editing the commit message so it ended up with invalid message.