### PR TITLE
[AMBARI-25573] Ambari Metrics save as JSON/CSV use custom fileName instead of default name.

### DIFF
--- a/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
+++ b/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
@@ -64,7 +64,7 @@ App.ExportMetricsMixin = Em.Mixin.create({
   },
 
   getCustomFileName: function () {
-    return this.get('targetView').title.replace(/ /g, '_').toLowerCase();
+    return this.get('targetView').title.replace(/\s+/g, '_').toLowerCase();
   },
 
   exportGraphDataSuccessCallback: function (response, request, params) {

--- a/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
+++ b/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
@@ -63,16 +63,19 @@ App.ExportMetricsMixin = Em.Mixin.create({
     });
   },
 
+  getCustomFileName: function () {
+    return this.get('targetView').title.replace(/ /g, '_').toLowerCase();
+  },
+
   exportGraphDataSuccessCallback: function (response, request, params) {
     var seriesData = this.get('targetView').getData(response);
-
     if (!seriesData.length) {
       App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));
     } else {
-      var fileType = params.isCSV ? 'csv' : 'json';
-      var fileName = (Em.isEmpty(this.get('targetView') || Em.isEmpty(this.get('targetView').title)) ?
-          'data' : this.get('targetView').title.replace(/ /g, '_').toLowerCase()) + "." + fileType;
-      var data = params.isCSV ? this.prepareCSV(seriesData) : JSON.stringify(seriesData, this.jsonReplacer(), 4);
+      var fileType = params.isCSV ? 'csv' : 'json',
+          fileName = (Em.isEmpty(this.get('targetView') || Em.isEmpty(this.get('targetView').title)) ?
+          'data' : this.getCustomFileName()) + '.' + fileType,
+          data = params.isCSV ? this.prepareCSV(seriesData) : JSON.stringify(seriesData, this.jsonReplacer(), 4);
 
       fileUtils.downloadTextFile(data, fileType, fileName);
     }

--- a/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
+++ b/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
@@ -69,8 +69,8 @@ App.ExportMetricsMixin = Em.Mixin.create({
       App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));
     } else {
       var fileType = params.isCSV ? 'csv' : 'json',
-        fileName = 'data.' + fileType,
         data = params.isCSV ? this.prepareCSV(seriesData) : JSON.stringify(seriesData, this.jsonReplacer(), 4);
+       var fileName = (Em.isEmpty(data) ? 'data.' : this.get('content.widgetName').replace(/ /g, '') + ".") + fileType;
       fileUtils.downloadTextFile(data, fileType, fileName);
     }
   },

--- a/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
+++ b/ambari-web/app/mixins/common/widgets/export_metrics_mixin.js
@@ -65,12 +65,15 @@ App.ExportMetricsMixin = Em.Mixin.create({
 
   exportGraphDataSuccessCallback: function (response, request, params) {
     var seriesData = this.get('targetView').getData(response);
+
     if (!seriesData.length) {
       App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));
     } else {
-      var fileType = params.isCSV ? 'csv' : 'json',
-        data = params.isCSV ? this.prepareCSV(seriesData) : JSON.stringify(seriesData, this.jsonReplacer(), 4);
-       var fileName = (Em.isEmpty(data) ? 'data.' : this.get('content.widgetName').replace(/ /g, '') + ".") + fileType;
+      var fileType = params.isCSV ? 'csv' : 'json';
+      var fileName = (Em.isEmpty(this.get('targetView') || Em.isEmpty(this.get('targetView').title)) ?
+          'data' : this.get('targetView').title.replace(/ /g, '_').toLowerCase()) + "." + fileType;
+      var data = params.isCSV ? this.prepareCSV(seriesData) : JSON.stringify(seriesData, this.jsonReplacer(), 4);
+
       fileUtils.downloadTextFile(data, fileType, fileName);
     }
   },

--- a/ambari-web/app/views/common/widget/graph_widget_view.js
+++ b/ambari-web/app/views/common/widget/graph_widget_view.js
@@ -369,13 +369,13 @@ App.GraphWidgetView = Em.View.extend(App.WidgetMixin, App.ExportMetricsMixin, {
     var data,
       isCSV = !!event.context,
       fileType = isCSV ? 'csv' : 'json',
-      fileName = 'data.' + fileType,
       metrics = this.get('data'),
       hasData = Em.isArray(metrics) && metrics.some(function (item) {
         return Em.isArray(item.data);
       });
     if (hasData) {
       data = isCSV ? this.prepareCSV(metrics) : JSON.stringify(metrics, this.jsonReplacer(), 4);
+      var fileName = (Em.isEmpty(metrics) ? 'data.' : this.get('content.widgetName').replace(/ /g, '') + ".") + fileType;
       fileUtils.downloadTextFile(data, fileType, fileName);
     } else {
       App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));

--- a/ambari-web/app/views/common/widget/graph_widget_view.js
+++ b/ambari-web/app/views/common/widget/graph_widget_view.js
@@ -368,7 +368,7 @@ App.GraphWidgetView = Em.View.extend(App.WidgetMixin, App.ExportMetricsMixin, {
         // get current service name if it exists.
         var currentServiceName = Em.isEmpty(this.get('controller.content.serviceName')) ? "" : this.get('controller.content.serviceName') + '_';
         // serviceName_widgetName_metricName
-        return (currentServiceName + this.get('content.widgetName').replace(/ /g, '_')).toLowerCase();
+        return (currentServiceName + this.get('content.widgetName').replace(/\s+/g, '_')).toLowerCase();
     },
 
     exportGraphData: function (event) {

--- a/ambari-web/app/views/common/widget/graph_widget_view.js
+++ b/ambari-web/app/views/common/widget/graph_widget_view.js
@@ -364,22 +364,28 @@ App.GraphWidgetView = Em.View.extend(App.WidgetMixin, App.ExportMetricsMixin, {
     }.observes('parentView.data')
   }),
 
-  exportGraphData: function (event) {
-    this.set('isExportMenuHidden', true);
-    var data,
-      isCSV = !!event.context,
-      fileType = isCSV ? 'csv' : 'json',
-      metrics = this.get('data'),
-      hasData = Em.isArray(metrics) && metrics.some(function (item) {
-        return Em.isArray(item.data);
-      });
-    if (hasData) {
-      var fileName = (Em.isEmpty(this.get('content.widgetName')) ? 'data' :this.get('content.widgetName').replace(/ /g, '_').toLowerCase()) + "." +fileType;
-      data = isCSV ? this.prepareCSV(metrics) : JSON.stringify(metrics, this.jsonReplacer(), 4);
+    getCustomFileName: function () {
+        // get current service name if it exists.
+        var currentServiceName = Em.isEmpty(this.get('controller.content.serviceName')) ? "" : this.get('controller.content.serviceName') + '_';
+        // serviceName_widgetName_metricName
+        return (currentServiceName + this.get('content.widgetName').replace(/ /g, '_')).toLowerCase();
+    },
 
-      fileUtils.downloadTextFile(data, fileType, fileName);
-    } else {
-      App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));
+    exportGraphData: function (event) {
+        this.set('isExportMenuHidden', true);
+        var data,
+            isCSV = !!event.context,
+            fileType = isCSV ? 'csv' : 'json',
+            fileName = (Em.isEmpty(this.get('content.widgetName')) ? 'data' : this.getCustomFileName()) + '.' + fileType,
+            metrics = this.get('data'),
+            hasData = Em.isArray(metrics) && metrics.some(function (item) {
+                return Em.isArray(item.data);
+            });
+        if (hasData) {
+            data = isCSV ? this.prepareCSV(metrics) : JSON.stringify(metrics, this.jsonReplacer(), 4);
+            fileUtils.downloadTextFile(data, fileType, fileName);
+        } else {
+            App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));
+        }
     }
-  }
 });

--- a/ambari-web/app/views/common/widget/graph_widget_view.js
+++ b/ambari-web/app/views/common/widget/graph_widget_view.js
@@ -374,8 +374,9 @@ App.GraphWidgetView = Em.View.extend(App.WidgetMixin, App.ExportMetricsMixin, {
         return Em.isArray(item.data);
       });
     if (hasData) {
+      var fileName = (Em.isEmpty(this.get('content.widgetName')) ? 'data' :this.get('content.widgetName').replace(/ /g, '_').toLowerCase()) + "." +fileType;
       data = isCSV ? this.prepareCSV(metrics) : JSON.stringify(metrics, this.jsonReplacer(), 4);
-      var fileName = (Em.isEmpty(metrics) ? 'data.' : this.get('content.widgetName').replace(/ /g, '') + ".") + fileType;
+
       fileUtils.downloadTextFile(data, fileType, fileName);
     } else {
       App.showAlertPopup(Em.I18n.t('graphs.noData.title'), Em.I18n.t('graphs.noData.tooltip.title'));

--- a/ambari-web/test/mixins/common/widgets/export_metrics_mixin_test.js
+++ b/ambari-web/test/mixins/common/widgets/export_metrics_mixin_test.js
@@ -149,7 +149,7 @@ describe('App.ExportMetricsMixin', function () {
         downloadTextFileCallCount: 1,
         data: '0,1',
         fileType: 'csv',
-        fileName: 'empty_metrics_object.csv',
+        fileName: 'data.csv',
         title: 'export to CSV'
       },
       {
@@ -165,7 +165,7 @@ describe('App.ExportMetricsMixin', function () {
         downloadTextFileCallCount: 1,
         data: '[{"name":"m0","data":[0,1]}]',
         fileType: 'json',
-        fileName: 'empty_metrics_object.json',
+        fileName: 'data.json',
         title: 'export to JSON'
       }
     ];

--- a/ambari-web/test/mixins/common/widgets/export_metrics_mixin_test.js
+++ b/ambari-web/test/mixins/common/widgets/export_metrics_mixin_test.js
@@ -149,7 +149,7 @@ describe('App.ExportMetricsMixin', function () {
         downloadTextFileCallCount: 1,
         data: '0,1',
         fileType: 'csv',
-        fileName: 'data.csv',
+        fileName: 'empty_metrics_object.csv',
         title: 'export to CSV'
       },
       {
@@ -165,7 +165,7 @@ describe('App.ExportMetricsMixin', function () {
         downloadTextFileCallCount: 1,
         data: '[{"name":"m0","data":[0,1]}]',
         fileType: 'json',
-        fileName: 'data.json',
+        fileName: 'empty_metrics_object.json',
         title: 'export to JSON'
       }
     ];

--- a/ambari-web/test/views/common/widget/graph_widget_view_test.js
+++ b/ambari-web/test/views/common/widget/graph_widget_view_test.js
@@ -245,7 +245,7 @@ describe('App.GraphWidgetView', function () {
               downloadArgs = fileUtils.downloadTextFile.firstCall.args;
             expect(downloadArgs[0].replace(/\s/g, '')).to.equal(item.fileData);
             expect(downloadArgs[1]).to.equal(fileType);
-            expect(downloadArgs[2]).to.equal(item.title.replace(/ /g, '_').toLowerCase() + fileType);
+            expect(downloadArgs[2]).to.equal('data.' + fileType);
           });
         }
 

--- a/ambari-web/test/views/common/widget/graph_widget_view_test.js
+++ b/ambari-web/test/views/common/widget/graph_widget_view_test.js
@@ -245,7 +245,7 @@ describe('App.GraphWidgetView', function () {
               downloadArgs = fileUtils.downloadTextFile.firstCall.args;
             expect(downloadArgs[0].replace(/\s/g, '')).to.equal(item.fileData);
             expect(downloadArgs[1]).to.equal(fileType);
-            expect(downloadArgs[2]).to.equal(item.titile.replace(/ /g, '') + "." + fileType);
+            expect(downloadArgs[2]).to.equal(item.title.replace(/ /g, '_').toLowerCase() + fileType);
           });
         }
 

--- a/ambari-web/test/views/common/widget/graph_widget_view_test.js
+++ b/ambari-web/test/views/common/widget/graph_widget_view_test.js
@@ -245,7 +245,7 @@ describe('App.GraphWidgetView', function () {
               downloadArgs = fileUtils.downloadTextFile.firstCall.args;
             expect(downloadArgs[0].replace(/\s/g, '')).to.equal(item.fileData);
             expect(downloadArgs[1]).to.equal(fileType);
-            expect(downloadArgs[2]).to.equal('data.' + fileType);
+            expect(downloadArgs[2]).to.equal(item.titile.replace(/ /g, '') + "." + fileType);
           });
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The name of the metrics data exported in Ambari-web is always data.json/csv, and the exported file usually must be renamed to distinguish which metric the data belongs to

so we try to custom the exported metric data file name, make the export function more friendly.

 there are some changes in the file name of the exported  metrics for example:
Entry | metric name | Old Exported File Name | NewExported Filname
-- | -- | -- | --
Dashboard | Memory Usage | data.csv/json | memory_usage.csv/json
Services/HDFS | NameNode GC Count | data.csv/json | hdfs_namenode_gc_count.csv/json
Services/HBase | Read Latency | data.csv/json | habse_read_latency.csv.json


## How was this patch tested?
checked all the metrics support exported, both shows ok,  part of manual test  result shows below, 

![微信截图_20201025022602](https://user-images.githubusercontent.com/52202080/97089319-7bd70b80-1669-11eb-8b4a-92a8b8411b7d.png)

