### PR TITLE
[AMBARI-25574] Start/Stop All Button color are not displayed correctly

### DIFF
--- a/ambari-web/app/styles/application.less
+++ b/ambari-web/app/styles/application.less
@@ -574,11 +574,11 @@ h1 {
 }
 
 .glyphicon-exclamation-sign {
-  color:#B94A48;
+  color:#B94A48 !important;
 }
 
 .glyphicon-play.enabled {
-  color: @green;
+  color: @green !important;
 }
 
 .glyphicon-stop.enabled{


### PR DESCRIPTION
## What changes were proposed in this pull request?

```css
# default css style
.navigation-bar-container ul.nav.side-nav-menu .more-actions .dropdown-menu > li > a i, .navigation-bar-container ul.nav.side-nav-footer .more-actions .dropdown-menu > li > a i {
    color: #333;
}

# start all button style
.glyphicon-play.enabled {
  color: #69be28;
}

# stop all button style
.glyphicon-stop.enabled {
    color: red;
}
```
The priority of default css style is higher than the priority of start/stop button, causing the color style of button to be overwritten

## How was this patch tested?
This is just a little improvement, manual tests result shows as belows:

![start-all-fixed](https://user-images.githubusercontent.com/52202080/97109552-d24a5580-170e-11eb-8523-381ce1aed902.png)

![stop-all-fixed](https://user-images.githubusercontent.com/52202080/97109604-1fc6c280-170f-11eb-9705-68d91d5813a8.png)

