### PR TITLE
[Ambari-25578]HBase 'Num Scan Next Requests' metric in grafana always shows 'No datapoints'	

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
@@ -105,6 +105,7 @@ regionserver.Server.Replay_median
 regionserver.Server.Replay_min
 regionserver.Server.Replay_num_ops
 regionserver.Server.ScanNext_num_ops
+regionserver.Server.ScanSize_num_ops
 regionserver.Server.ScanTime_75th_percentile
 regionserver.Server.ScanTime_95th_percentile
 regionserver.Server.ScanTime_99th_percentile

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/metrics_whitelist
@@ -433,7 +433,9 @@ regionserver.Server.Replay_median
 regionserver.Server.Replay_min
 regionserver.Server.Replay_num_ops
 regionserver.Server.ScanNext_95th_percentile
+regionserver.Server.ScanSize_95th_percentile
 regionserver.Server.ScanNext_num_ops
+regionserver.Server.ScanSize_num_ops
 regionserver.Server.ScanTime_75th_percentile
 regionserver.Server.ScanTime_95th_percentile
 regionserver.Server.ScanTime_99th_percentile

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/windows/amshbase_metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/windows/amshbase_metrics_whitelist
@@ -105,6 +105,7 @@ regionserver.Server.Replay_median
 regionserver.Server.Replay_min
 regionserver.Server.Replay_num_ops
 regionserver.Server.ScanNext_num_ops
+regionserver.Server.ScanSize_num_ops
 regionserver.Server.ScanTime_75th_percentile
 regionserver.Server.ScanTime_95th_percentile
 regionserver.Server.ScanTime_99th_percentile

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/windows/metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/windows/metrics_whitelist
@@ -432,7 +432,9 @@ regionserver.Server.Replay_median
 regionserver.Server.Replay_min
 regionserver.Server.Replay_num_ops
 regionserver.Server.ScanNext_95th_percentile
+regionserver.Server.ScanSize_95th_percentile
 regionserver.Server.ScanNext_num_ops
+regionserver.Server.ScanSize_num_ops
 regionserver.Server.ScanTime_75th_percentile
 regionserver.Server.ScanTime_95th_percentile
 regionserver.Server.ScanTime_99th_percentile

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-home.json
@@ -650,7 +650,7 @@
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "regionserver.Server.ScanNext_num_ops",
+              "metric": "regionserver.Server.ScanSize_num_ops",
               "precision": "default",
               "refId": "B",
               "transform": "rate"

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-regionservers.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-regionservers.json
@@ -609,7 +609,7 @@
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "regionserver.Server.ScanNext_num_ops",
+              "metric": "regionserver.Server.ScanSize_num_ops",
               "precision": "default",
               "refId": "B",
               "transform": "rate",

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-home.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-home.json
@@ -649,7 +649,7 @@
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "regionserver.Server.ScanNext_num_ops",
+              "metric": "regionserver.Server.ScanSize_num_ops",
               "precision": "default",
               "refId": "B",
               "transform": "rate"

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-regionservers.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-regionservers.json
@@ -609,7 +609,7 @@
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
-              "metric": "regionserver.Server.ScanNext_num_ops",
+              "metric": "regionserver.Server.ScanSize_num_ops",
               "precision": "default",
               "refId": "B",
               "templatedHost": "",

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HBASE/metrics.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HBASE/metrics.json
@@ -301,8 +301,8 @@
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/hbase/regionserver/Server/ScanNext_num_ops": {
-              "metric": "regionserver.Server.ScanNext_num_ops",
+            "metrics/hbase/regionserver/Server/ScanSize_num_ops": {
+              "metric": "regionserver.Server.ScanSize_num_ops",
               "pointInTime": false,
               "temporal": true
             },
@@ -332,8 +332,8 @@
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/hbase/regionserver/Server/ScanNext_95th_percentile": {
-              "metric": "regionserver.Server.ScanNext_95th_percentile",
+            "metrics/hbase/regionserver/Server/ScanSize_95th_percentile": {
+              "metric": "regionserver.Server.ScanSize_95th_percentile",
               "unit": "ms",
               "pointInTime": true,
               "temporal": true
@@ -1098,33 +1098,33 @@
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_75th_percentile": {
-              "metric": "regionserver.Server.ScanNext_75th_percentile",
+            "metrics/regionserver/Server/ScanSize_75th_percentile": {
+              "metric": "regionserver.Server.ScanSize_75th_percentile",
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_99th_percentile": {
-              "metric": "regionserver.Server.ScanNext_99th_percentile",
+            "metrics/regionserver/Server/ScanSize_99th_percentile": {
+              "metric": "regionserver.Server.ScanSize_99th_percentile",
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_max": {
-              "metric": "regionserver.Server.ScanNext_max",
+            "metrics/regionserver/Server/ScanSize_max": {
+              "metric": "regionserver.Server.ScanSize_max",
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_mean": {
-              "metric": "regionserver.Server.ScanNext_mean",
+            "metrics/regionserver/Server/ScanSize_mean": {
+              "metric": "regionserver.Server.ScanSize_mean",
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_median": {
-              "metric": "regionserver.Server.ScanNext_median",
+            "metrics/regionserver/Server/ScanSize_median": {
+              "metric": "regionserver.Server.ScanSize_median",
               "pointInTime": true,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_min": {
-              "metric": "regionserver.Server.ScanNext_min",
+            "metrics/regionserver/Server/ScanSize_min": {
+              "metric": "regionserver.Server.ScanSize_min",
               "pointInTime": true,
               "temporal": true
             },
@@ -1390,8 +1390,8 @@
               "pointInTime": true,
               "temporal": false
             },
-            "metrics/hbase/regionserver/ScanNext_num_ops": {
-              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanNext_num_ops",
+            "metrics/hbase/regionserver/ScanSize_num_ops": {
+              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanSize_num_ops",
               "pointInTime": true,
               "temporal": false
             },
@@ -1405,8 +1405,8 @@
               "pointInTime": true,
               "temporal": false
             },
-            "metrics/hbase/regionserver/ScanNext_95th_percentile": {
-              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanNext_95th_percentile",
+            "metrics/hbase/regionserver/ScanSize_95th_percentile": {
+              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanSize_95th_percentile",
               "pointInTime": true,
               "temporal": false
             },
@@ -2754,44 +2754,44 @@
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_75th_percentile": {
-              "metric": "regionserver.Server.ScanNext_75th_percentile",
+            "metrics/regionserver/Server/ScanSize_75th_percentile": {
+              "metric": "regionserver.Server.ScanSize_75th_percentile",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_95th_percentile": {
-              "metric": "regionserver.Server.ScanNext_95th_percentile",
+            "metrics/regionserver/Server/ScanSize_95th_percentile": {
+              "metric": "regionserver.Server.ScanSize_95th_percentile",
               "unit": "ms",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_99th_percentile": {
-              "metric": "regionserver.Server.ScanNext_99th_percentile",
+            "metrics/regionserver/Server/ScanSize_99th_percentile": {
+              "metric": "regionserver.Server.ScanSize_99th_percentile",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_max": {
-              "metric": "regionserver.Server.ScanNext_max",
+            "metrics/regionserver/Server/ScanSize_max": {
+              "metric": "regionserver.Server.ScanSize_max",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_mean": {
-              "metric": "regionserver.Server.ScanNext_mean",
+            "metrics/regionserver/Server/ScanSize_mean": {
+              "metric": "regionserver.Server.ScanSize_mean",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_median": {
-              "metric": "regionserver.Server.ScanNext_median",
+            "metrics/regionserver/Server/ScanSize_median": {
+              "metric": "regionserver.Server.ScanSize_median",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_min": {
-              "metric": "regionserver.Server.ScanNext_min",
+            "metrics/regionserver/Server/ScanSize_min": {
+              "metric": "regionserver.Server.ScanSize_min",
               "pointInTime": false,
               "temporal": true
             },
-            "metrics/regionserver/Server/ScanNext_num_ops": {
-              "metric": "regionserver.Server.ScanNext_num_ops",
+            "metrics/regionserver/Server/ScanSize_num_ops": {
+              "metric": "regionserver.Server.ScanSize_num_ops",
               "pointInTime": false,
               "temporal": true
             },
@@ -3072,8 +3072,8 @@
               "pointInTime": true,
               "temporal": false
             },
-            "metrics/hbase/regionserver/ScanNext_num_ops": {
-              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanNext_num_ops",
+            "metrics/hbase/regionserver/ScanSize_num_ops": {
+              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanSize_num_ops",
               "pointInTime": true,
               "temporal": false
             },
@@ -3087,8 +3087,8 @@
               "pointInTime": true,
               "temporal": false
             },
-            "metrics/hbase/regionserver/ScanNext_95th_percentile": {
-              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanNext_95th_percentile",
+            "metrics/hbase/regionserver/ScanSize_95th_percentile": {
+              "metric": "Hadoop:service=HBase,name=RegionServer,sub=Server.ScanSize_95th_percentile",
               "pointInTime": true,
               "temporal": false
             },

--- a/ambari-server/src/main/resources/stacks/HDP/2.3/services/HBASE/widgets.json
+++ b/ambari-server/src/main/resources/stacks/HDP/2.3/services/HBASE/widgets.json
@@ -18,8 +18,8 @@
               "component_name": "HBASE_REGIONSERVER"
             },
             {
-              "name": "regionserver.Server.ScanNext_num_ops._rate",
-              "metric_path": "metrics/hbase/regionserver/Server/ScanNext_num_ops._rate",
+              "name": "regionserver.Server.ScanSize_num_ops._rate",
+              "metric_path": "metrics/hbase/regionserver/Server/ScanSize_num_ops._rate",
               "service_name": "HBASE",
               "component_name": "HBASE_REGIONSERVER"
             },
@@ -51,7 +51,7 @@
           "values": [
             {
               "name": "Read Requests",
-              "value": "${regionserver.Server.Get_num_ops._rate + regionserver.Server.ScanNext_num_ops._rate}"
+              "value": "${regionserver.Server.Get_num_ops._rate + regionserver.Server.ScanSize_num_ops._rate}"
             },
             {
               "name": "Write Requests",
@@ -76,8 +76,8 @@
               "component_name": "HBASE_REGIONSERVER"
             },
             {
-              "name": "regionserver.Server.ScanNext_95th_percentile._max",
-              "metric_path": "metrics/hbase/regionserver/Server/ScanNext_95th_percentile._max",
+              "name": "regionserver.Server.ScanSize_95th_percentile._max",
+              "metric_path": "metrics/hbase/regionserver/Server/ScanSize_95th_percentile._max",
               "service_name": "HBASE",
               "component_name": "HBASE_REGIONSERVER"
             }
@@ -89,7 +89,7 @@
             },
             {
               "name": "Cluster wide maximum of 95% ScanNext Latency",
-              "value": "${regionserver.Server.ScanNext_95th_percentile._max}"
+              "value": "${regionserver.Server.ScanSize_95th_percentile._max}"
             }
           ],
           "properties": {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The ScanNext metric in HBase is no longer valid in [HBASE-15376](https://issues.apache.org/jira/browse/HBASE-15376) , now we must use ScanSize refer to [HBASE-15376.patch](https://issues.apache.org/jira/secure/attachment/12791093/HBASE-15376_v1.patch).
## How was this patch tested?
manual tests works well , the result shows below:

![screenshot](https://user-images.githubusercontent.com/52202080/97611589-57a47180-1a51-11eb-8949-a4df4208ab55.png)

