### PR TITLE
AMBARI-25576. Primary key duplication error during flushing alerts from alerts cache.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertReceivedListener.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/listeners/alerts/AlertReceivedListener.java
@@ -66,7 +66,6 @@ import com.google.common.util.concurrent.Striped;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import com.google.inject.persist.Transactional;
 
 /**
  * The {@link AlertReceivedListener} class handles {@link AlertReceivedEvent}
@@ -385,7 +384,7 @@ public class AlertReceivedListener {
 
     // invokes the EntityManager create/merge on various entities in a single
     // transaction
-    saveEntities(toMerge, toCreateHistoryAndMerge);
+    m_alertsDao.saveEntities(toMerge, toCreateHistoryAndMerge);
 
     // broadcast events
     for (AlertEvent eventToFire : alertEvents) {
@@ -442,32 +441,6 @@ public class AlertReceivedListener {
     } else {
       return m_alertsDao.findCurrentByHostAndName(clusterId, alert.getHostName(),
         alert.getName());
-    }
-  }
-
-  /**
-   * Saves alert and alert history entities in single transaction
-   * @param toMerge - merge alert only
-   * @param toCreateHistoryAndMerge - create new history, merge alert
-   */
-  @Transactional
-  void saveEntities(List<AlertCurrentEntity> toMerge,
-      List<AlertCurrentEntity> toCreateHistoryAndMerge) {
-    for (AlertCurrentEntity entity : toMerge) {
-      m_alertsDao.merge(entity, m_configuration.isAlertCacheEnabled());
-    }
-
-    for (AlertCurrentEntity entity : toCreateHistoryAndMerge) {
-      m_alertsDao.create(entity.getAlertHistory());
-      m_alertsDao.merge(entity);
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(
-            "Alert State Merged: CurrentId {}, CurrentTimestamp {}, HistoryId {}, HistoryState {}",
-            entity.getAlertId(), entity.getLatestTimestamp(),
-            entity.getAlertHistory().getAlertId(),
-            entity.getAlertHistory().getAlertState());
-      }
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/AlertsDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/AlertsDAO.java
@@ -985,8 +985,18 @@ public class AlertsDAO implements Cleanable {
    *          the alert to merge (not {@code null}).
    * @return the updated alert with merged content (never {@code null}).
    */
-  @Transactional
   public AlertHistoryEntity merge(AlertHistoryEntity alert) {
+    if (m_configuration.isAlertCacheEnabled()) {
+      synchronized (this) {
+        return mergeTransactional(alert);
+      }
+    } else {
+      return mergeTransactional(alert);
+    }
+  }
+
+  @Transactional
+  protected AlertHistoryEntity mergeTransactional(AlertHistoryEntity alert) {
     return m_entityManagerProvider.get().merge(alert);
   }
 
@@ -1033,8 +1043,18 @@ public class AlertsDAO implements Cleanable {
    *          the current alert to merge (not {@code null}).
    * @return the updated current alert with merged content (never {@code null}).
    */
-  @Transactional
   public AlertCurrentEntity merge(AlertCurrentEntity alert) {
+    if (m_configuration.isAlertCacheEnabled()) {
+      synchronized (this) {
+        return mergeTransactional(alert);
+      }
+    } else {
+      return mergeTransactional(alert);
+    }
+  }
+
+  @Transactional
+  protected AlertCurrentEntity mergeTransactional(AlertCurrentEntity alert) {
     // perform the JPA merge
     alert = m_entityManagerProvider.get().merge(alert);
 
@@ -1174,8 +1194,18 @@ public class AlertsDAO implements Cleanable {
    * Writes all cached {@link AlertCurrentEntity} instances to the database and
    * clears the cache.
    */
+  public synchronized void flushCachedEntitiesToJPA() {
+    if (m_configuration.isAlertCacheEnabled()) {
+      synchronized (this) {
+        flushCachedEntitiesToJPATransactional();
+      }
+    } else {
+      flushCachedEntitiesToJPATransactional();
+    }
+  }
+
   @Transactional
-  public void flushCachedEntitiesToJPA() {
+  protected void flushCachedEntitiesToJPATransactional() {
     if (!m_configuration.isAlertCacheEnabled()) {
       LOG.warn("Unable to flush cached alerts to JPA because caching is not enabled");
       return;
@@ -1212,6 +1242,10 @@ public class AlertsDAO implements Cleanable {
       AlertCacheKey key = AlertCacheKey.build(alert);
       AlertCurrentEntity cachedEntity = m_currentAlertCache.getIfPresent(key);
       if (null != cachedEntity) {
+        if (cachedEntity.getAlertHistory() == null) {
+          LOG.warn("There is current entity with null history in the cache, currentId: {}, persisted historyId: {}",
+              cachedEntity.getAlertId(), alert.getHistoryId());
+        }
         alert = cachedEntity;
       }
 
@@ -1582,6 +1616,43 @@ public class AlertsDAO implements Cleanable {
         timestamp, entityType, affectedRows);
 
     return affectedRows;
+  }
+
+  /**
+   * Saves alert and alert history entities in single transaction
+   * @param toMerge - merge alert only
+   * @param toCreateHistoryAndMerge - create new history, merge alert
+   */
+  public void saveEntities(List<AlertCurrentEntity> toMerge,
+                                 List<AlertCurrentEntity> toCreateHistoryAndMerge) {
+    if (m_configuration.isAlertCacheEnabled()) {
+      synchronized (this) {
+        saveEntitiesTransactional(toMerge, toCreateHistoryAndMerge);
+      }
+    } else {
+      saveEntitiesTransactional(toMerge, toCreateHistoryAndMerge);
+    }
+  }
+
+  @Transactional
+  protected void saveEntitiesTransactional(List<AlertCurrentEntity> toMerge,
+                    List<AlertCurrentEntity> toCreateHistoryAndMerge) {
+    for (AlertCurrentEntity entity : toMerge) {
+      merge(entity, m_configuration.isAlertCacheEnabled());
+    }
+
+    for (AlertCurrentEntity entity : toCreateHistoryAndMerge) {
+      create(entity.getAlertHistory());
+      merge(entity);
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Alert State Merged: CurrentId {}, CurrentTimestamp {}, HistoryId {}, HistoryState {}",
+            entity.getAlertId(), entity.getLatestTimestamp(),
+            entity.getAlertHistory().getAlertId(),
+            entity.getAlertHistory().getAlertState());
+      }
+    }
   }
 
 }

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/AlertsDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/AlertsDAO.java
@@ -1194,22 +1194,18 @@ public class AlertsDAO implements Cleanable {
    * Writes all cached {@link AlertCurrentEntity} instances to the database and
    * clears the cache.
    */
-  public synchronized void flushCachedEntitiesToJPA() {
+  public void flushCachedEntitiesToJPA() {
     if (m_configuration.isAlertCacheEnabled()) {
       synchronized (this) {
         flushCachedEntitiesToJPATransactional();
       }
     } else {
-      flushCachedEntitiesToJPATransactional();
+      LOG.warn("Unable to flush cached alerts to JPA because caching is not enabled");
     }
   }
 
   @Transactional
   protected void flushCachedEntitiesToJPATransactional() {
-    if (!m_configuration.isAlertCacheEnabled()) {
-      LOG.warn("Unable to flush cached alerts to JPA because caching is not enabled");
-      return;
-    }
 
     // capture for logging purposes
     long cachedEntityCount = m_currentAlertCache.size();

--- a/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AggregateAlertListenerTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/state/alerts/AggregateAlertListenerTest.java
@@ -112,6 +112,8 @@ public class AggregateAlertListenerTest {
     EasyMock.expect(
         m_alertsDao.findAggregateCounts(EasyMock.anyLong(), EasyMock.eq("mock-aggregate-alert"))).andReturn(
         summaryDTO).atLeastOnce();
+    m_alertsDao.saveEntities(EasyMock.anyObject(), EasyMock.anyObject());
+    EasyMock.expectLastCall().anyTimes();
 
     EasyMock.replay(m_alertsDao, m_aggregateMapping, currentEntityMock);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now all merge operations are made synchronously for AlertCurrent entity. this allow to avoid primary key duplication error.

## How was this patch tested?

Manual testing.