### PR TITLE
[AMBARI-25579] Historical configuration parameters display garbled characters

### DIFF
--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -1045,8 +1045,8 @@ class MySQLConfig(LinuxDBMSConfig):
     self.database_port = DBMSConfig._init_member_with_prop_default(options, "database_port",
                                                                    properties, JDBC_PORT_PROPERTY, "3306")
 
-    self.database_url_pattern = "jdbc:mysql://{0}:{1}/{2}"
-    self.database_url_pattern_alt = "jdbc:mysql://{0}:{1}/{2}"
+    self.database_url_pattern = "jdbc:mysql://{0}:{1}/{2}?useUnicode=true&characterEncoding=utf-8"
+    self.database_url_pattern_alt = "jdbc:mysql://{0}:{1}/{2}?useUnicode=true&characterEncoding=utf-8"
 
     self.JDBC_DRIVER_INSTALL_MSG = 'Before starting Ambari Server, ' \
                                      'you must copy the {0} JDBC driver JAR file to {1} and set property "server.jdbc.driver.path=[path/to/custom_jdbc_driver]" in ambari.properties.'.format(

--- a/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
+++ b/ambari-server/src/main/python/ambari_server/dbConfiguration_linux.py
@@ -1045,8 +1045,8 @@ class MySQLConfig(LinuxDBMSConfig):
     self.database_port = DBMSConfig._init_member_with_prop_default(options, "database_port",
                                                                    properties, JDBC_PORT_PROPERTY, "3306")
 
-    self.database_url_pattern = "jdbc:mysql://{0}:{1}/{2}?useUnicode=true&characterEncoding=utf-8"
-    self.database_url_pattern_alt = "jdbc:mysql://{0}:{1}/{2}?useUnicode=true&characterEncoding=utf-8"
+    self.database_url_pattern = "jdbc:mysql://{0}:{1}/{2}?useUnicode=true&characterEncoding=UTF-8"
+    self.database_url_pattern_alt = "jdbc:mysql://{0}:{1}/{2}?useUnicode=true&characterEncoding=UTF-8"
 
     self.JDBC_DRIVER_INSTALL_MSG = 'Before starting Ambari Server, ' \
                                      'you must copy the {0} JDBC driver JAR file to {1} and set property "server.jdbc.driver.path=[path/to/custom_jdbc_driver]" in ambari.properties.'.format(

--- a/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
+++ b/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql
@@ -119,7 +119,7 @@ CREATE TABLE serviceconfig (
   stack_id BIGINT NOT NULL,
   user_name VARCHAR(255) NOT NULL DEFAULT '_db',
   group_id BIGINT,
-  note LONGTEXT,
+  note LONGTEXT CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   CONSTRAINT PK_serviceconfig PRIMARY KEY (service_config_id),
   CONSTRAINT FK_serviceconfig_stack_id FOREIGN KEY (stack_id) REFERENCES stack(stack_id),
   CONSTRAINT UQ_scv_service_version UNIQUE (cluster_id, service_name, version));


### PR DESCRIPTION
## What changes were proposed in this pull request?
+ Ambari has some tables that explicitly specify the encoding type of the field as UTF-8([Ambari-DDL-MySQL-CREATE.sql#L973](https://github.com/apache/ambari/tree/branch-2.7/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql#L973) and [Ambari-DDL-MySQL-CREATE.sql#L993](https://github.com/apache/ambari/tree/branch-2.7/ambari-server/src/main/resources/Ambari-DDL-MySQL-CREATE.sql#L993)),  However, the mysql URL in `/etc/ambari-server/conf/ambari.properties` does not specify a charset, which would cause the charset of MySQL and Ambari-server to be inconsistent.
+ The `note` field in the `serviceconfig` table of mysql preferably also supports non-ASCII characters.
## How was this patch tested?
munual test result shows like this:
![ambari serviceconfig in mysql shows illegal-fixed](https://user-images.githubusercontent.com/52202080/97853865-aa24ad00-1d33-11eb-8551-70dd9de39c5f.png)
![ambari serviceconfig in web page shows illegal-fixed](https://user-images.githubusercontent.com/52202080/97853878-ad1f9d80-1d33-11eb-85cc-ca553b4db8e5.png)
