### PR TITLE
AMBARI-25569 Reassess Ambari Metrics data migration - 2nd part

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/AbstractPhoenixMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/AbstractPhoenixMetricsCopier.java
@@ -22,7 +22,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.metrics2.sink.timeline.MetricHostAggregate;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.sql.Connection;
@@ -33,8 +32,8 @@ import java.util.Set;
 
 public abstract class AbstractPhoenixMetricsCopier implements Runnable {
   private static final Log LOG = LogFactory.getLog(AbstractPhoenixMetricsCopier.class);
-  private static final Long DEFAULT_NATIVE_TIME_RANGE_DELAY = 120000L;
-  private final Long startTime;
+  private static final long DEFAULT_NATIVE_TIME_RANGE_DELAY = 120000L;
+  private final long startTime;
   protected final Writer processedMetricsFile;
   protected String inputTable;
   protected String outputTable;
@@ -42,7 +41,7 @@ public abstract class AbstractPhoenixMetricsCopier implements Runnable {
   protected PhoenixHBaseAccessor hBaseAccessor;
 
   public AbstractPhoenixMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor,
-                                      Set<String> metricNames, Long startTime, Writer outputStream) {
+                                      Set<String> metricNames, long startTime, Writer outputStream) {
     this.inputTable = inputTableName;
     this.outputTable = outputTableName;
     this.hBaseAccessor = hBaseAccessor;
@@ -54,7 +53,7 @@ public abstract class AbstractPhoenixMetricsCopier implements Runnable {
   @Override
   public void run(){
     LOG.info(String.format("Copying %s metrics from %s to %s", metricNames, inputTable, outputTable));
-    final long startTimer = System.currentTimeMillis();
+    final long st = System.currentTimeMillis();
     final String query = String.format("SELECT %s %s FROM %s WHERE %s AND SERVER_TIME > %s ORDER BY METRIC_NAME, SERVER_TIME",
       getQueryHint(startTime), getColumnsClause(), inputTable, getMetricNamesLikeClause(), startTime);
 
@@ -65,7 +64,7 @@ public abstract class AbstractPhoenixMetricsCopier implements Runnable {
     } catch (SQLException e) {
       LOG.error(e);
     } finally {
-      final long estimatedTime = System.currentTimeMillis() - startTimer;
+      final long estimatedTime = System.currentTimeMillis() - st;
       LOG.debug(String.format("Copying took %s seconds from table %s to table %s for metric names %s", estimatedTime/ 1000.0, inputTable, outputTable, metricNames));
 
       saveMetricsProgress();
@@ -73,7 +72,7 @@ public abstract class AbstractPhoenixMetricsCopier implements Runnable {
   }
 
   private String getMetricNamesLikeClause() {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(256);
     sb.append('(');
     int i = 0;
     for (String metricName : metricNames) {
@@ -129,7 +128,7 @@ public abstract class AbstractPhoenixMetricsCopier implements Runnable {
     }
   }
 
-  protected String getQueryHint(Long startTime) {
+  protected String getQueryHint(long startTime) {
     final StringBuilder sb = new StringBuilder();
     sb.append("/*+ ");
     sb.append("NATIVE_TIME_RANGE(");

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
@@ -113,7 +113,17 @@ public class MetricsDataMigrationLauncher {
   }
 
   private long calculateStartEpochTime(Long startDay) {
-    return LocalDateTime.now().minusDays((startDay == null) ? DEFAULT_START_DAYS : startDay).toEpochSecond(ZoneOffset.UTC);
+    final long days;
+    if (startDay == null) {
+      LOG.info("No starting day have been provided.");
+      days = DEFAULT_START_DAYS;
+    } else {
+      LOG.info(String.format("%s days have been provided as migration starting day.", startDay));
+      days = startDay;
+    }
+    LOG.info(String.format("The last %s days' data will be migrated.", days));
+
+    return LocalDateTime.now().minusDays(days).toEpochSecond(ZoneOffset.UTC);
   }
 
   private Set<String> getMetricNames(String whitelistedFilePath) throws MalformedURLException, URISyntaxException, SQLException {

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
@@ -28,7 +28,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 
-import java.io.*;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -115,13 +122,13 @@ public class MetricsDataMigrationLauncher {
   private long calculateStartEpochTime(Long startDay) {
     final long days;
     if (startDay == null) {
-      LOG.info("No starting day have been provided.");
+      LOG.info(String.format("No starting day have been provided, using default: %d", DEFAULT_START_DAYS));
       days = DEFAULT_START_DAYS;
     } else {
-      LOG.info(String.format("%s days have been provided as migration starting day.", startDay));
+      LOG.info(String.format("%d days have been provided as migration starting day.", startDay));
       days = startDay;
     }
-    LOG.info(String.format("The last %s days' data will be migrated.", days));
+    LOG.info(String.format("The last %d days' data will be migrated.", days));
 
     return LocalDateTime.now().minusDays(days).toEpochSecond(ZoneOffset.UTC);
   }
@@ -210,7 +217,7 @@ public class MetricsDataMigrationLauncher {
       }
 
       LOG.info("Running the copy threads...");
-      long startTimer = System.currentTimeMillis();
+      long timerStart = System.currentTimeMillis();
       ExecutorService executorService = null;
       try {
         executorService = Executors.newFixedThreadPool(this.numberOfThreads);
@@ -228,8 +235,8 @@ public class MetricsDataMigrationLauncher {
         }
       }
 
-      long estimatedTime = System.currentTimeMillis() - startTimer;
-      LOG.info(String.format("Copying took %s seconds", estimatedTime / 1000.0));
+      long timerDelta = System.currentTimeMillis() - timerStart;
+      LOG.info(String.format("Copying took %s seconds", timerDelta / 1000.0));
     }
   }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/MetricsDataMigrationLauncher.java
@@ -28,11 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -172,7 +168,7 @@ public class MetricsDataMigrationLauncher {
   }
 
   public void runMigration(Long timeoutInMinutes) throws IOException {
-    try (FileWriter processedMetricsFileWriter = new FileWriter(this.processedMetricsFilePath, true)) {
+    try (Writer processedMetricsFileWriter = new BufferedWriter(new FileWriter(this.processedMetricsFilePath, true))) {
       LOG.info("Setting up copiers...");
       Set<AbstractPhoenixMetricsCopier> copiers = new HashSet<>();
       for (Set<String> batch : metricNamesBatches) {

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixClusterMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixClusterMetricsCopier.java
@@ -23,7 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.metrics2.sink.timeline.MetricHostAggregate;
 
-import java.io.FileWriter;
+import java.io.Writer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -34,7 +34,7 @@ public class PhoenixClusterMetricsCopier extends AbstractPhoenixMetricsCopier {
   private static final Log LOG = LogFactory.getLog(PhoenixClusterMetricsCopier.class);
   private final Map<TimelineClusterMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
 
-  PhoenixClusterMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, FileWriter processedMetricsFileWriter) {
+  PhoenixClusterMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, Writer processedMetricsFileWriter) {
     super(inputTableName, outputTableName, hBaseAccessor, metricNames, startTime, processedMetricsFileWriter);
   }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixClusterMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixClusterMetricsCopier.java
@@ -34,7 +34,7 @@ public class PhoenixClusterMetricsCopier extends AbstractPhoenixMetricsCopier {
   private static final Log LOG = LogFactory.getLog(PhoenixClusterMetricsCopier.class);
   private final Map<TimelineClusterMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
 
-  PhoenixClusterMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, Writer processedMetricsFileWriter) {
+  PhoenixClusterMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, long startTime, Writer processedMetricsFileWriter) {
     super(inputTableName, outputTableName, hBaseAccessor, metricNames, startTime, processedMetricsFileWriter);
   }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixHostMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixHostMetricsCopier.java
@@ -35,7 +35,7 @@ public class PhoenixHostMetricsCopier extends AbstractPhoenixMetricsCopier {
   private static final Log LOG = LogFactory.getLog(PhoenixHostMetricsCopier.class);
   private final Map<TimelineMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
 
-  PhoenixHostMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, Writer processedMetricsFileWriter) {
+  PhoenixHostMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, long startTime, Writer processedMetricsFileWriter) {
     super(inputTableName, outputTableName, hBaseAccessor, metricNames, startTime, processedMetricsFileWriter);
   }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixHostMetricsCopier.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/upgrade/core/PhoenixHostMetricsCopier.java
@@ -23,7 +23,8 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.metrics2.sink.timeline.MetricHostAggregate;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 
-import java.io.FileWriter;
+
+import java.io.Writer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class PhoenixHostMetricsCopier extends AbstractPhoenixMetricsCopier {
   private static final Log LOG = LogFactory.getLog(PhoenixHostMetricsCopier.class);
   private final Map<TimelineMetric, MetricHostAggregate> aggregateMap = new HashMap<>();
 
-  PhoenixHostMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, FileWriter processedMetricsFileWriter) {
+  PhoenixHostMetricsCopier(String inputTableName, String outputTableName, PhoenixHBaseAccessor hBaseAccessor, Set<String> metricNames, Long startTime, Writer processedMetricsFileWriter) {
     super(inputTableName, outputTableName, hBaseAccessor, metricNames, startTime, processedMetricsFileWriter);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**1. Introduce an '--allmetrics' to enforce migration of all metrics regardless of other settings.**
Due to the suboptimal argument handling, if one wants to define an argument that comes after the 'whitelist file'
argument - like the 'starttime' - the 'whitelist file' argument must be defined.
But when we don't want to use the whitelist data because we need to migrate all the metrics the '--allmetrics' argument can be provided instead of 'whitelist file'.

Example: migrate all the metrics from the last year
`/usr/sbin/ambari-metrics-collector --config /etc/ambari-metrics-collector/conf/ upgrade_start --allmetrics "365"`

**2. The start time handling has been fixed and changed**
 - The code is intended to migrate data from the "last x milliseconds" as the handling of the default data shows where the startTime is subtracted from the current timestamp.
`public static final long DEFAULT_START_TIME = System.currentTimeMillis() - ONE_MONTH_MILLIS; //Last month`
But when the user externally provided the `startTime` value it was not subtracted from the current timestamp, but was used as it is, which is indeed erroneous.
- Also, I suggest using days instead of milliseconds to define the required migration time window, because it is a more realistic and convenient granularity. Like in the above example the command will migrate data from the last 365 days.
- Time handling has been changed to `LocalDateTime` use in Java 8 fashion.

3. **Possibly improve performance** by reducing synchronisation granularity and using BufferedWriter when writing the "ambari-metrics-migration-state"

## How was this patch tested?
- It was tested by manually migrating large data sets derived from real world data.
- Running the existing unit tests.