### PR TITLE
AMBARI-25580. After the active/standby switch, some parameters of the obtained hbase jmx are empty (allendang001)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
@@ -85,6 +85,9 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
   private static final String PORT_KEY = "tag.port";
   private static final String DOT_REPLACEMENT_CHAR = "#";
 
+  private static final String HBASE_JMX_KEY = "Hadoop:service=HBase,name=Master,sub=Server";
+  private static final String HBASE_IS_ACTIVE_MASTER_KEY = "tag.isActiveMaster";
+
   private static final Map<String, String> DEFAULT_JMX_PORTS = new HashMap<>();
 
   /**
@@ -433,6 +436,11 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
     Map<String, Object> properties = categories.get(category);
     if (property.contains(DOT_REPLACEMENT_CHAR)) {
       property = dotReplacementCharPattern.matcher(property).replaceAll(".");
+    }
+    if (category.equals(HBASE_JMX_KEY)){
+      if (!Boolean.parseBoolean((String) properties.get(HBASE_IS_ACTIVE_MASTER_KEY))){
+        return;
+      }
     }
     if (properties != null && properties.containsKey(property)) {
       Object value = properties.get(property);


### PR DESCRIPTION


## What changes were proposed in this pull request?

add hbase master active/standby identify, skip reading the jmx parameters of the standby machine

## How was this patch tested?
