### PR TITLE
[AMBARI-25585] Fix problems in the remote cluster management

### DIFF
--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/remoteClusters/RemoteClustersCreateCtrl.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/controllers/remoteClusters/RemoteClustersCreateCtrl.js
@@ -50,7 +50,7 @@ angular.module('ambariAdminConsole')
           $location.path('/remoteClusters/'+ $scope.cluster.cluster_name +'/edit')
         })
         .catch(function(resp) {
-          console.log(data);
+          console.log(resp);
           Alert.error(resp.data.message);
        });
 

--- a/ambari-admin/src/main/resources/ui/admin-web/app/scripts/i18n.config.js
+++ b/ambari-admin/src/main/resources/ui/admin-web/app/scripts/i18n.config.js
@@ -485,7 +485,7 @@ angular.module('ambariAdminConsole')
     'exportBlueprint.dataLoaded': 'Data loaded...',
 
     'remoteClusters.ambariClusterName': 'Ambari Cluster Name',
-    'remoteClusters.clusterURLPlaceholder': 'http://ambari.server:8080/api/v1/clusters/c1',
+    'remoteClusters.clusterURLPlaceholder': 'http://ambari.server:8080/api/v1/clusters/clusterName',
 
     'remoteClusters.alerts.fetchError': 'Error in fetching remote clusters.'
   });

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RemoteClusterResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RemoteClusterResourceProvider.java
@@ -81,6 +81,7 @@ public class RemoteClusterResourceProvider extends AbstractAuthorizedResourcePro
    */
   private static Map<Resource.Type, String> keyPropertyIds = ImmutableMap.<Resource.Type, String>builder()
       .put(Resource.Type.RemoteCluster, CLUSTER_NAME_PROPERTY_ID)
+      .put(Resource.Type.Service, SERVICES_PROPERTY_ID)
       .build();
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RemoteAmbariClusterDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RemoteAmbariClusterDAO.java
@@ -100,7 +100,13 @@ public class RemoteAmbariClusterDAO {
   @Transactional
   public void update(RemoteAmbariClusterEntity entity) {
     entityManagerProvider.get().merge(entity);
-
+    if(maxHistoryServiceId != null) {
+      TypedQuery<RemoteAmbariClusterServiceEntity> query = entityManagerProvider.get().createNamedQuery(
+                "deleteRemoteClusterOldService", RemoteAmbariClusterServiceEntity.class);
+      query.setParameter("id", maxHistoryServiceId);
+      query.setParameter("clusterId", entity.getId());
+      daoUtils.executeUpdate(query);
+    }
   }
 
   /**

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RemoteAmbariClusterDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RemoteAmbariClusterDAO.java
@@ -25,6 +25,7 @@ import javax.persistence.TypedQuery;
 
 import org.apache.ambari.server.orm.RequiresSession;
 import org.apache.ambari.server.orm.entities.RemoteAmbariClusterEntity;
+import org.apache.ambari.server.orm.entities.RemoteAmbariClusterServiceEntity;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RemoteAmbariClusterDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/RemoteAmbariClusterDAO.java
@@ -98,7 +98,7 @@ public class RemoteAmbariClusterDAO {
    * @param entity
      */
   @Transactional
-  public void update(RemoteAmbariClusterEntity entity) {
+  public void update(RemoteAmbariClusterEntity entity, Long maxHistoryServiceId) {
     entityManagerProvider.get().merge(entity);
     if(maxHistoryServiceId != null) {
       TypedQuery<RemoteAmbariClusterServiceEntity> query = entityManagerProvider.get().createNamedQuery(

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
@@ -18,11 +18,11 @@
 
 package org.apache.ambari.server.orm.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
@@ -18,15 +18,7 @@
 
 package org.apache.ambari.server.orm.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.TableGenerator;
+import javax.persistence.*;
 
 /**
  * Remote Ambari Service to Remote Cluster Mapping

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.orm.entities;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
@@ -18,7 +18,15 @@
 
 package org.apache.ambari.server.orm.entities;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.TableGenerator;
 
 /**
  * Remote Ambari Service to Remote Cluster Mapping

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/RemoteAmbariClusterServiceEntity.java
@@ -37,6 +37,10 @@ import javax.persistence.TableGenerator;
   , pkColumnValue = "remote_cluster_service_id_seq"
   , initialValue = 1
 )
+@NamedQueries({
+        @NamedQuery(name = "deleteRemoteClusterOldService", query = "DELETE FROM RemoteAmbariClusterServiceEntity remoteambariclusterservice " +
+                "WHERE remoteambariclusterservice.clusterId= :clusterId AND remoteambariclusterservice.id <= :id"),
+})
 @Entity
 public class RemoteAmbariClusterServiceEntity {
 
@@ -52,6 +56,9 @@ public class RemoteAmbariClusterServiceEntity {
   @JoinColumn(name = "cluster_id", referencedColumnName = "cluster_id", nullable = false)
   private RemoteAmbariClusterEntity cluster;
 
+  @Column(name = "cluster_id", nullable = false, insertable = false, updatable = false, length = 10)
+  private Long clusterId;
+  
   /**
    * Get Id
    *
@@ -88,6 +95,14 @@ public class RemoteAmbariClusterServiceEntity {
     this.cluster = cluster;
   }
 
+  public Long getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(Long clusterId) {
+    this.clusterId = clusterId;
+  }
+  
   /**
    * Get service name
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

The functions related to remote cluster have the following problems:
1. When adding a remote cluster, the Ambari URL input prompt is misleading:'c1' has no meaning
2. If we failed to add a new cluster, JS exception caused the page to fail to pop up an error message
3. After successfully adding a new cluster, the service column in the table shows empty, but the ambari.remoteambariclusterservice table actual has servcie data.
4. If you update the existing remote cluster (even if you just delete 1 character and then add it again and then click the save button), we checked the database table and found that the services corresponding to the cluster in the ambari.remoteambariclusterservice table had added completely duplicate data,

I try to fix these 4 problems that  have found.

## How was this patch tested?

 manual tests

1. changed the Ambari URL input prompt.
![fix-1](https://user-images.githubusercontent.com/52202080/99098265-bbaf6400-2613-11eb-90bc-6ad380d47a41.png)

2. If we failed to add a new cluster, ensure the page can display the failed reason.
![fix-2](https://user-images.githubusercontent.com/52202080/99098266-bbaf6400-2613-11eb-8cfb-8212a0b537b2.png)

3-4.  After successfully adding a new remote cluster or updating an existing remote cluster, the page shows ok,
![fix 3-4](https://user-images.githubusercontent.com/52202080/99098267-bc47fa80-2613-11eb-85aa-f473b1997346.png)



