### PR TITLE
[AMBARI-25586] File/Directory Permission can't be auto refreshed after modified

### DIFF
--- a/contrib/views/files/src/main/resources/ui/app/components/permission-modal.js
+++ b/contrib/views/files/src/main/resources/ui/app/components/permission-modal.js
@@ -101,6 +101,7 @@ export default Ember.Component.extend(OperationModal, {
         this.get('selected').set('permission', response.permission);
         this.set('isUpdating', false);
         this.send('close');
+        this.sendAction('refreshAction');
       }, (error) => {
         this.set('isUpdating', false);
         this.send('close');

--- a/contrib/views/files/src/main/resources/ui/app/templates/components/context-row-menu.hbs
+++ b/contrib/views/files/src/main/resources/ui/app/templates/components/context-row-menu.hbs
@@ -34,6 +34,6 @@
       {{open-preview-modal closeModalAction="modalClosed" name="ctx-open"}}
       {{rename-modal closeModalAction="modalClosed" refreshAction="refreshCurrentRoute" name="ctx-rename"}}
       {{delete-modal closeModalAction="modalClosed" refreshAction="refreshCurrentRoute" name="ctx-delete" currentPathIsTrash=currentPathIsTrash}}
-      {{permission-modal closeModalAction="modalClosed" name="ctx-permission"}}
+      {{permission-modal closeModalAction="modalClosed" refreshAction="refreshCurrentRoute" name="ctx-permission"}}
     </div>
 {{/if}}


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the Files View page in Ambari, select a directory or file to modify its permission. After the operation was finished, the permission didn't  automatically refresh, which often makes users confused and mistakenly believed that the operation was not successful.

## How was this patch tested?

manual tests

![permissions_modified_auto_refreshed](https://user-images.githubusercontent.com/52202080/99216077-b6b70400-280f-11eb-9707-072f6f084e1a.gif)
