### PR TITLE
[AMBARI-25587] Metrics cannot be stored and the exception message is null when metric value is NaN

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AggregatorUtils.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AggregatorUtils.java
@@ -50,6 +50,11 @@ public class AggregatorUtils {
       for (Double value : metricValues.values()) {
         // TODO: Some nulls in data - need to investigate null values from host
         if (value != null) {
+          // As the null values does not participate in the sum of current metric, NaN is handled similarly.
+          if(value.isNaN()) {
+            continue;
+          }
+          
           if (value > max) {
             max = value;
           }

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AggregatorUtils.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AggregatorUtils.java
@@ -49,12 +49,7 @@ public class AggregatorUtils {
     if (metricValues != null && !metricValues.isEmpty()) {
       for (Double value : metricValues.values()) {
         // TODO: Some nulls in data - need to investigate null values from host
-        if (value != null) {
-          // As the null values does not participate in the sum of current metric, NaN is handled similarly.
-          if(value.isNaN()) {
-            continue;
-          }
-          
+        if (value != null && !value.isNaN()) {
           if (value > max) {
             max = value;
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Metrics cannot be stored and the exception message is null when metric value is `NaN`.
When calculating the sum of metric value, we  need to exclude` NaN`,  as `NaN + valid double = NaN`, which will cause Phoenix threw  an exception when  writting to  HBase.

## How was this patch tested?
manual tests
Just fix a little potential bug  without affecting normal metrics calculating.