### PR TITLE
AMBARI-25582. Change the way AMS Grafana datasource discovers the Kafka topics

### DIFF
--- a/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
+++ b/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
@@ -777,7 +777,7 @@ define([
                 // patterns to check possible kafka topics
                 var kafkaTopicPatterns = ['^kafka\\.server.*\\.topic\\.(.*)\\.[\\d\\w]*$',
                   '^kafka\\.log\\.Log\\..*.topic\\.(.*)$',
-                  '^kafka\\.cluster.*\\.topic\\.(.*)$']
+                  '^kafka\\.cluster.*\\.topic\\.(.*)$'];
 
                 var kafkaMetrics = getMetrics(allMetrics, "kafka_broker");
                 var topics = []
@@ -789,8 +789,7 @@ define([
 
                 _.forEach(kafkaTopicPatterns, function(topicPattern) {
                   _.forEach(topicMetrics, function(checkTopic) {
-                      var re=RegExp(topicPattern);
-                      var match = checkTopic.match(re);
+                      var match = checkTopic.match(RegExp(topicPattern));
                       var topicName = match ? match[1] : null;
                       if (topicName != null && topicName != "ambari_kafka_service_check" && topics.indexOf(topicName) < 0) {
                         topics.push(topicName);

--- a/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
+++ b/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
@@ -789,9 +789,9 @@ define([
 
                 _.forEach(kafkaTopicPatterns, function(topicPattern) {
                   _.forEach(topicMetrics, function(checkTopic) {
-                      var match = checkTopic.match(RegExp(topicPattern));
-                      var topicName = match ? match[1] : null;
-                      if (topicName != null && topicName != "ambari_kafka_service_check" && topics.indexOf(topicName) < 0) {
+                      var topicMatch = checkTopic.match(RegExp(topicPattern));
+                      var topicName = topicMatch ? topicMatch[1] : null;
+                      if (topicName && topicName != "ambari_kafka_service_check" && topics.indexOf(topicName) < 0) {
                         topics.push(topicName);
                       }
                   })

--- a/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
+++ b/ambari-metrics/ambari-metrics-grafana/ambari-metrics/datasource.js
@@ -774,15 +774,29 @@ define([
           if(interpolated === "kafka-topics") {
             return this.initMetricAppidMapping()
               .then(function () {
-                var kafkaTopics = getMetrics(allMetrics, "kafka_broker");
-                var extractTopics = kafkaTopics.filter(/./.test.bind(new RegExp("\\b.log.Log.\\b", 'g')));
-                var topics =_.map(extractTopics, function (topic) {
-                  var topicPrefix = "topic.";
-                  return topic.substring(topic.lastIndexOf(topicPrefix)+topicPrefix.length, topic.length);
+                // patterns to check possible kafka topics
+                var kafkaTopicPatterns = ['^kafka\\.server.*\\.topic\\.(.*)\\.[\\d\\w]*$',
+                  '^kafka\\.log\\.Log\\..*.topic\\.(.*)$',
+                  '^kafka\\.cluster.*\\.topic\\.(.*)$']
+
+                var kafkaMetrics = getMetrics(allMetrics, "kafka_broker");
+                var topics = []
+
+                // filter metrics that can contain topic name
+                var topicMetrics = kafkaMetrics.filter(function(metric) {
+                  return metric.indexOf(".topic.") > 0;
                 });
-                topics = _.sortBy(_.uniq(topics));
-                var i = topics.indexOf("ambari_kafka_service_check");
-                if(i != -1) { topics.splice(i, 1);}
+
+                _.forEach(kafkaTopicPatterns, function(topicPattern) {
+                  _.forEach(topicMetrics, function(checkTopic) {
+                      var re=RegExp(topicPattern);
+                      var match = checkTopic.match(re);
+                      var topicName = match ? match[1] : null;
+                      if (topicName != null && topicName != "ambari_kafka_service_check" && topics.indexOf(topicName) < 0) {
+                        topics.push(topicName);
+                      }
+                  })
+                })
                 return _.map(topics, function (topics) {
                   return {
                     text: topics


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now ambari grafana datasource calculates present kafka topics with using all of kafka metrics. So kafka topics will be get correctly even with enabled whitelisting which filters out some metrics.

## How was this patch tested?

Manual testing.