### PR TITLE
AMBARI-25590. Ambari Get Hosts API returning empty json

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClusterImpl.java
@@ -2915,4 +2915,17 @@ public class ClusterImpl implements Cluster {
 
     return componentVersionMap;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ClusterImpl cluster = (ClusterImpl) o;
+    return clusterId == cluster.clusterId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clusterId);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When API calls in Ambari fail due to DB exceptions. Ambari re-populates caches from the DB. This causes situation that threads have different instances of ClusterImpl, so we need an equals and hashCode implemented. So that look-up in Sets/Maps/comparison worked.

## How was this patch tested?
We were able to find a stable way to reproduce the issue by feeding an API request that produces DB exception. Once we applied the patch this was no longer reproducible.