### PR TITLE
[AMBARI-25592] Fix the problem that JVM related metrics in hbase and ams cannot be displayed

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
@@ -1,3 +1,29 @@
+jvm.JvmMetrics.GcCount
+jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcNumWarnThresholdExceeded
+jvm.JvmMetrics.GcTimeMillis
+jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
+jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTotalExtraSleepTime
+jvm.JvmMetrics.LogError
+jvm.JvmMetrics.LogFatal
+jvm.JvmMetrics.MemHeapCommittedM
+jvm.JvmMetrics.MemHeapMaxM
+jvm.JvmMetrics.MemHeapUsedM
+jvm.JvmMetrics.MemNonHeapCommittedM
+jvm.JvmMetrics.MemNonHeapMaxM
+jvm.JvmMetrics.MemNonHeapUsedM
+jvm.JvmMetrics.ThreadsBlocked
+jvm.JvmMetrics.ThreadsNew
+jvm.JvmMetrics.ThreadsRunnable
+jvm.JvmMetrics.ThreadsTerminated
+jvm.JvmMetrics.ThreadsTimedWaiting
+jvm.JvmMetrics.ThreadsWaiting
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.Master.JvmMetrics.ThreadsBlocked
 jvm.Master.JvmMetrics.ThreadsNew
 jvm.Master.JvmMetrics.ThreadsRunnable

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
@@ -4,6 +4,10 @@ jvm.Master.JvmMetrics.ThreadsRunnable
 jvm.Master.JvmMetrics.ThreadsTerminated
 jvm.Master.JvmMetrics.ThreadsTimedWaiting
 jvm.Master.JvmMetrics.ThreadsWaiting
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
 jvm.RegionServer.JvmMetrics.GcCount
 jvm.RegionServer.JvmMetrics.GcCountConcurrentMarkSweep
 jvm.RegionServer.JvmMetrics.GcCountParNew

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/windows/amshbase_metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/windows/amshbase_metrics_whitelist
@@ -1,3 +1,29 @@
+jvm.JvmMetrics.GcCount
+jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcNumWarnThresholdExceeded
+jvm.JvmMetrics.GcTimeMillis
+jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
+jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTotalExtraSleepTime
+jvm.JvmMetrics.LogError
+jvm.JvmMetrics.LogFatal
+jvm.JvmMetrics.MemHeapCommittedM
+jvm.JvmMetrics.MemHeapMaxM
+jvm.JvmMetrics.MemHeapUsedM
+jvm.JvmMetrics.MemNonHeapCommittedM
+jvm.JvmMetrics.MemNonHeapMaxM
+jvm.JvmMetrics.MemNonHeapUsedM
+jvm.JvmMetrics.ThreadsBlocked
+jvm.JvmMetrics.ThreadsNew
+jvm.JvmMetrics.ThreadsRunnable
+jvm.JvmMetrics.ThreadsTerminated
+jvm.JvmMetrics.ThreadsTimedWaiting
+jvm.JvmMetrics.ThreadsWaiting
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.Master.JvmMetrics.ThreadsBlocked
 jvm.Master.JvmMetrics.ThreadsNew
 jvm.Master.JvmMetrics.ThreadsRunnable
@@ -22,6 +48,10 @@ jvm.RegionServer.JvmMetrics.ThreadsRunnable
 jvm.RegionServer.JvmMetrics.ThreadsTerminated
 jvm.RegionServer.JvmMetrics.ThreadsTimedWaiting
 jvm.RegionServer.JvmMetrics.ThreadsWaiting
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
 master.AssignmentManager.ritCount
 master.AssignmentManager.ritCountOverThreshold
 master.AssignmentManager.ritOldestAge

--- a/ambari-metrics/ambari-metrics-timelineservice/conf/windows/metrics_whitelist
+++ b/ambari-metrics/ambari-metrics-timelineservice/conf/windows/metrics_whitelist
@@ -223,6 +223,10 @@ jvm.JvmMetrics.ThreadsRunnable
 jvm.JvmMetrics.ThreadsTerminated
 jvm.JvmMetrics.ThreadsTimedWaiting
 jvm.JvmMetrics.ThreadsWaiting
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
 jvm.LlapDaemonJVMMetrics.LlapDaemonDirectBufferMemoryUsed
 jvm.LlapDaemonJVMMetrics.LlapDaemonDirectBufferTotalCapacity
 jvm.LlapDaemonJVMMetrics.LlapDaemonMappedBufferMemoryUsed
@@ -251,6 +255,10 @@ jvm.RegionServer.JvmMetrics.ThreadsRunnable
 jvm.RegionServer.JvmMetrics.ThreadsTerminated
 jvm.RegionServer.JvmMetrics.ThreadsTimedWaiting
 jvm.RegionServer.JvmMetrics.ThreadsWaiting
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
 jvm.daemon_thread_count
 jvm.file_descriptor_usage
 jvm.gc.ConcurrentMarkSweep.count

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/webapp/TimelineWebServices.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/webapp/TimelineWebServices.java
@@ -520,7 +520,8 @@ public class TimelineWebServices {
     List<String> list = new ArrayList<String>(split.length);
     for (String s : split) {
       if (!s.trim().isEmpty()){
-        list.add(s);
+        String metricName = s.startsWith("jvm.RegionServer.JvmMetrics.") ? s.replace("jvm.RegionServer", "jvm") : s;
+        list.add(metricName);
       }
     }
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_REGIONSERVER.dat
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_REGIONSERVER.dat
@@ -25,10 +25,6 @@ ipc.IPC.QueueCallTime_num_ops
 ipc.IPC.queueSize 
 ipc.IPC.receivedBytes 
 ipc.IPC.sentBytes 
-jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
-jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
-jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
-jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
 jvm.RegionServer.JvmMetrics.GcCount
 jvm.RegionServer.JvmMetrics.GcCountConcurrentMarkSweep
 jvm.RegionServer.JvmMetrics.GcCountParNew

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_REGIONSERVER.dat
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_REGIONSERVER.dat
@@ -25,6 +25,10 @@ ipc.IPC.QueueCallTime_num_ops
 ipc.IPC.queueSize 
 ipc.IPC.receivedBytes 
 ipc.IPC.sentBytes 
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
 jvm.RegionServer.JvmMetrics.GcCount
 jvm.RegionServer.JvmMetrics.GcCountConcurrentMarkSweep
 jvm.RegionServer.JvmMetrics.GcCountParNew

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-regionservers.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-regionservers.json
@@ -8564,6 +8564,7 @@
           "targets": [
             {
               "aggregator": "avg",
+              "alias": "ParNew",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8575,6 +8576,7 @@
             },
             {
               "aggregator": "avg",
+              "alias": "G1 Young Generation",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8645,6 +8647,7 @@
           "targets": [
             {
               "aggregator": "max",
+              "alias": "ConcurrentMarkSweep",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8656,6 +8659,7 @@
             },
             {
               "aggregator": "max",
+              "alias": "G1 Old Generation",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8805,6 +8809,7 @@
           "targets": [
             {
               "aggregator": "avg",
+              "alias": "ParNew",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8816,6 +8821,7 @@
             },
             {
               "aggregator": "avg",
+              "alias": "G1 Young Generation",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8886,6 +8892,7 @@
           "targets": [
             {
               "aggregator": "avg",
+              "alias": "ConcurrentMarkSweep",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8897,6 +8904,7 @@
             },
             {
               "aggregator": "avg",
+              "alias": "G1 Old Generation",
               "app": "hbase",
               "downsampleAggregator": "avg",
               "errors": {},

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-regionservers.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/HDP/grafana-hbase-regionservers.json
@@ -8572,11 +8572,22 @@
               "refId": "A",
               "transform": "rate",
               "templatedHost": ""
+            },
+            {
+              "aggregator": "avg",
+              "app": "hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation",
+              "precision": "default",
+              "refId": "B",
+              "transform": "rate",
+              "templatedHost": ""
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Count ParNew /s",
+          "title": "GC Count(ParNew/G1 Young Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"
@@ -8642,11 +8653,22 @@
               "refId": "A",
               "transform": "rate",
               "templatedHost": ""
+            },
+            {
+              "aggregator": "max",
+              "app": "hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation",
+              "precision": "minutes",
+              "refId": "B",
+              "transform": "rate",
+              "templatedHost": ""
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Count CMS /s",
+          "title": "GC Count(CMS/G1 Old Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"
@@ -8791,11 +8813,22 @@
               "refId": "A",
               "transform": "rate",
               "templatedHost": ""
+            },
+            {
+              "aggregator": "avg",
+              "app": "hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation",
+              "precision": "default",
+              "refId": "B",
+              "transform": "rate",
+              "templatedHost": ""
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Times ParNew /s",
+          "title": "GC Times(ParNew/G1 Young Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"
@@ -8861,11 +8894,22 @@
               "refId": "A",
               "transform": "rate",
               "templatedHost": ""
+            },
+            {
+              "aggregator": "avg",
+              "app": "hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation",
+              "precision": "default",
+              "refId": "B",
+              "transform": "rate",
+              "templatedHost": ""
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Times CMS /s",
+          "title": "GC Times(CMS/G1 Old Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-regionservers.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-regionservers.json
@@ -8572,11 +8572,22 @@
               "refId": "A",
               "templatedHost": "",
               "transform": "rate"
+            },
+            {
+              "aggregator": "avg",
+              "app": "ams-hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation",
+              "precision": "default",
+              "refId": "B",
+              "templatedHost": "",
+              "transform": "rate"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Count ParNew /s",
+          "title": "GC Count(ParNew/G1 Young Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"
@@ -8642,11 +8653,22 @@
               "refId": "A",
               "templatedHost": "",
               "transform": "rate"
+            },
+            {
+              "aggregator": "max",
+              "app": "ams-hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation",
+              "precision": "minutes",
+              "refId": "B",
+              "templatedHost": "",
+              "transform": "rate"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Count CMS /s",
+          "title": "GC Count(CMS/G1 Old Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"
@@ -8791,11 +8813,22 @@
               "refId": "A",
               "templatedHost": "",
               "transform": "rate"
+            },
+            {
+              "aggregator": "avg",
+              "app": "ams-hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation",
+              "precision": "default",
+              "refId": "B",
+              "templatedHost": "",
+              "transform": "rate"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Times ParNew /s",
+          "title": "GC Times(ParNew/G1 Young Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"
@@ -8861,11 +8894,22 @@
               "refId": "A",
               "templatedHost": "",
               "transform": "rate"
+            },
+            {
+              "aggregator": "avg",
+              "app": "ams-hbase",
+              "downsampleAggregator": "avg",
+              "errors": {},
+              "metric": "jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation",
+              "precision": "default",
+              "refId": "B",
+              "templatedHost": "",
+              "transform": "rate"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "GC Times CMS /s",
+          "title": "GC Times(CMS/G1 Old Generation) /s",
           "tooltip": {
             "shared": false,
             "value_type": "cumulative"

--- a/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-regionservers.json
+++ b/ambari-server/src/main/resources/common-services/AMBARI_METRICS/0.1.0/package/files/grafana-dashboards/default/grafana-ams-hbase-regionservers.json
@@ -8564,6 +8564,7 @@
           "targets": [
             {
               "aggregator": "avg",
+              "alias": "ParNew",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8575,6 +8576,7 @@
             },
             {
               "aggregator": "avg",
+              "alias": "G1 Young Generation",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8645,6 +8647,7 @@
           "targets": [
             {
               "aggregator": "max",
+              "alias": "ConcurrentMarkSweep",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8656,6 +8659,7 @@
             },
             {
               "aggregator": "max",
+              "alias": "G1 Old Generation",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8805,6 +8809,7 @@
           "targets": [
             {
               "aggregator": "avg",
+              "alias": "ParNew",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8816,6 +8821,7 @@
             },
             {
               "aggregator": "avg",
+              "alias": "G1 Young Generation",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8886,6 +8892,7 @@
           "targets": [
             {
               "aggregator": "avg",
+              "alias": "MarkSweep",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},
@@ -8897,6 +8904,7 @@
             },
             {
               "aggregator": "avg",
+              "alias": "G1 Old Generation",
               "app": "ams-hbase",
               "downsampleAggregator": "avg",
               "errors": {},


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Fix jvm metrics of the ams-hbase and hbase compoments cannot be displayed
2. Rename some widget name  in ams-hbase/hbase and introduced new G1GC related metrics, as shown below:

| location                              | old title          | curren title                            |
| ------------------------------------- | ------------------ | --------------------------------------- |
| hbase-regionservers/JVM-GC COUNTS     | GC Count ParNew /s | GC Count(ParNew/G1 Young Generation) /s |
| hbase-regionservers/JVM-GC TIMES      | GC Times ParNew /s | GC Times(ParNew/G1 Young Generation) /s |
| ams-hbase-regionservers/JVM-GC COUNTS | GC Count ParNew /s | GC Count(ParNew/G1 Young Generation) /s |
| hbase-regionservers/JVM-GC COUNTS     | GC Times ParNew /s | GC Times(ParNew/G1 Young Generation) /s |

This modification mainly considers that HBase may now use G1GC or CMS. The previous widget names only covered CMS metrics. We renamed the widget titles , and also introduced the metricscorresponding to G1GC into the widget to ensure that both  G1GC and CMS can be displayed normally.

## How was this patch tested?

manual tests work well as below:


**hbase-regionservers_MEMORY**
![hbase-regionservers_MEMORY-fixed](https://user-images.githubusercontent.com/52202080/100224292-9c8bcd00-2f57-11eb-9b9f-64a0a778f25a.png)
**hbase-regionservers_JVM-GC TIMES USED G1GC**
![hbase-regionservers_JVM-GC TIMES-fixed](https://user-images.githubusercontent.com/52202080/100224298-9e559080-2f57-11eb-940d-f4bf3f9115df.png)


**ams-hbase-regionservers_JVM-GC TIMES USED CMS**
![ams-hbase-regionservers_JVM GC TIMES-fixed](https://user-images.githubusercontent.com/52202080/100224814-48cdb380-2f58-11eb-8c81-1143705e1804.png)


**hbase-regionservers_JVM GC COUNTS USED G1GC**
![hbase-regionservers_JVM GC COUNTS-fixed](https://user-images.githubusercontent.com/52202080/100224302-9f86bd80-2f57-11eb-8a7e-045c2cf1bae4.png)

**ams-hbase-regionservers_JVM GC COUNTS  USED CMS**
![Uploading ams-hbase-regionservers_JVM GC COUNTS-fixed.png…]()


**hbase-home_REGIONSERVER MEMORY**
![hbase-home_REGIONSERVER MEMORY-fixed](https://user-images.githubusercontent.com/52202080/100224312-a1e91780-2f57-11eb-9101-b30744f94a0f.png)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.