### PR TITLE
[AMBARI-25600] modify the default name of the cloned widget to match js verification.

### DIFF
--- a/ambari-web/app/mixins/common/widgets/widget_mixin.js
+++ b/ambari-web/app/mixins/common/widgets/widget_mixin.js
@@ -48,7 +48,7 @@ App.WidgetMixin = Ember.Mixin.create({
    * @type {string}
    * @const
    */
-  CLONE_SUFFIX: '(Copy)',
+  CLONE_SUFFIX: '-Copy',
 
   /**
    * @type {number|null}


### PR DESCRIPTION
## What changes were proposed in this pull request?

After cloning an existing widget, try to  edit the cloned widget name and find that even if nothing is modified, the save button cannot be clicked, prompting that the widget name is invalid.

as shows belows:
```javascript
isValidWidgetName: function(value) {
 var widgetNameRegex = /^[\s0-9a-z_\-%]+$/i;
 return widgetNameRegex.test(value);
 }
 ```

The automatically generated widget name ends with (Copy), but the regular expression of widgetname does not support parentheses, which often confuses users, so we  modified the default name of the cloned widget to match js verification.

## How was this patch tested?
manual test works well.
