### PR TITLE
AMBARI-25604. During blueprint deploy tasks sometimes fail due to KeyError

### DIFF
--- a/ambari-agent/src/main/python/ambari_agent/ClusterTopologyCache.py
+++ b/ambari-agent/src/main/python/ambari_agent/ClusterTopologyCache.py
@@ -109,7 +109,14 @@ class ClusterTopologyCache(ClusterCache):
     cluster_host_info = defaultdict(lambda: [])
     for component_dict in self[cluster_id].components:
       component_name = component_dict.componentName
-      hostnames = [self.hosts_to_id[cluster_id][host_id].hostName for host_id in component_dict.hostIds]
+      hostnames = []
+      for host_id in component_dict.hostIds:
+        if host_id in self.hosts_to_id[cluster_id]:
+          hostnames.append(self.hosts_to_id[cluster_id][host_id].hostName)
+        else:
+          # In theory this should never happen. But in practice it happened when ambari-server had corrupt DB cache.
+          logger.warning("Cannot find host_id={} in cluster_id={}".format(host_id, cluster_id))
+
       cluster_host_info[component_name.lower()+"_hosts"] += hostnames
 
     cluster_host_info['all_hosts'] = []


### PR DESCRIPTION
## What changes were proposed in this pull request?

During  blueprint deploy we don't rely on topology cache since https://issues.apache.org/jira/browse/AMBARI-23660

So topology is send with command. BUT the problem occurs when we still try to generate it on agent and fail.
We need to ignore not fail on KeyError there

```ERROR 2020-12-10 06:30:09,350 CustomServiceOrchestrator.py:459 - Caught an exception while executing custom service command: <type 'exceptions.KeyError'>: 10; 10
Traceback (most recent call last):
  File "/usr/lib/ambari-agent/lib/ambari_agent/CustomServiceOrchestrator.py", line 324, in runCommand
    command = self.generate_command(command_header)
  File "/usr/lib/ambari-agent/lib/ambari_agent/CustomServiceOrchestrator.py", line 507, in generate_command
    command_dict = self.configuration_builder.get_configuration(cluster_id, service_name, component_name, required_config_timestamp)
  File "/usr/lib/ambari-agent/lib/ambari_agent/ConfigurationBuilder.py", line 43, in get_configuration
    'clusterHostInfo': self.topology_cache.get_cluster_host_info(cluster_id),
  File "/usr/lib/ambari-agent/lib/ambari_agent/Utils.py", line 230, in newFunction
    return f(*args, **kw)
  File "/usr/lib/ambari-agent/lib/ambari_agent/ClusterTopologyCache.py", line 112, in get_cluster_host_info
    hostnames = [self.hosts_to_id[cluster_id][host_id].hostName for host_id in component_dict.hostIds]
KeyError: 10```



## How was this patch tested?

Deploy a cluster