### PR TITLE
AMBARI-25601. Ambari with AMS HA unable to change metrics collector for metrics providing on collector fail.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/CollectorHostDownRefreshCounter.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/metrics/CollectorHostDownRefreshCounter.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CollectorHostDownRefreshCounter {
 
   private int collectorDownRefreshCounterLimit = 5;
-  private AtomicInteger collectorDownRefreshCounter;
+  private AtomicInteger collectorDownRefreshCounter = new AtomicInteger(0);
 
   CollectorHostDownRefreshCounter(int counter) {
     this.collectorDownRefreshCounterLimit = counter;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now ambari server automatically changes metrics supplier on the current metrics collector down (when AMS HA is used). 

## How was this patch tested?

Manual testing on an AMS HA cluster.