### PR TITLE
AMBARI-25613: Fix ConcurrentModificationException in HostRequest.getPhysicalTaskMapping

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/topology/HostRequest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.ambari.server.actionmanager.HostRoleCommand;
 import org.apache.ambari.server.actionmanager.HostRoleStatus;
@@ -81,7 +82,7 @@ public class HostRequest implements Comparable<HostRequest> {
   Map<Long, HostRoleCommand> logicalTasks = new HashMap<>();
 
   // logical task id -> physical tasks
-  private Map<Long, Long> physicalTasks = new HashMap<>();
+  private Map<Long, Long> physicalTasks = new ConcurrentHashMap<>();
 
   private List<TopologyHostTask> topologyTasks = new ArrayList<>();
 
@@ -455,7 +456,7 @@ public class HostRequest implements Comparable<HostRequest> {
   }
 
   public Map<Long, Long> getPhysicalTaskMapping() {
-    return new HashMap<>(physicalTasks);
+    return new ConcurrentHashMap<>(physicalTasks);
   }
 
   //todo: since this is used to determine equality, using hashCode() isn't safe as it can return the same


### PR DESCRIPTION
Issue:
Concurrent Modification exception in HostRequest.getPhysicalTaskMapping 

Rootcause:
The installation and registration though done in parallel, each thread tries to get the entire cluster’s view of the current physical tasks. So it is bound to happen that when a registration is happening the other thread can do a getPhysicalTaskMapping().  (leading to CME)

Fix:
Replaced the HashMap with ConcurrentHashMap