### PR TITLE
AMBARI-25615 Add force_metrics_fetch flag to get the live metrics data from the HDFS (ihorlukianov)

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/api/resources/BaseResourceDefinition.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/api/resources/BaseResourceDefinition.java
@@ -41,10 +41,15 @@ import org.apache.ambari.server.controller.utilities.ClusterControllerHelper;
 import org.apache.commons.codec.EncoderException;
 import org.apache.commons.codec.net.URLCodec;
 
+import com.google.common.collect.Sets;
+
 /**
  * Base resource definition.  Contains behavior common to all resource types.
  */
 public abstract class BaseResourceDefinition implements ResourceDefinition {
+
+  private static final Set<String> DEFAULT_DIRECTIVES =
+    Sets.newHashSet(org.apache.ambari.server.controller.spi.Request.DIRECTIVE_FORCE_METRICS_FETCH);
 
   /**
    * Resource type.  One of {@link Resource.Type}
@@ -241,7 +246,7 @@ public abstract class BaseResourceDefinition implements ResourceDefinition {
    * @param directives the map of directives from which to copy
    */
   private void initializeDirectives(DirectiveType type, Map<DirectiveType, ? extends Collection<String>> directives) {
-    HashSet<String> requestDirectives = new HashSet<>();
+    HashSet<String> requestDirectives = new HashSet<>(DEFAULT_DIRECTIVES);
 
     if ((directives != null) && directives.get(type) != null) {
       requestDirectives.addAll(directives.get(type));

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/RequestImpl.java
@@ -76,6 +76,11 @@ public class RequestImpl implements Request {
    */
   private final boolean dryRun;
 
+  /**
+   * Is it a force metrics fetch request?
+   */
+  private final boolean forceMetricsFetch;
+
   // ----- Constructors ------------------------------------------------------
 
   /**
@@ -120,6 +125,9 @@ public class RequestImpl implements Request {
     m_pageRequest = pageRequest;
 
     this.dryRun = this.requestInfoProperties.containsKey(DIRECTIVE_DRY_RUN) && Boolean.parseBoolean(this.requestInfoProperties.get(DIRECTIVE_DRY_RUN));
+
+    this.forceMetricsFetch = this.requestInfoProperties.containsKey(DIRECTIVE_FORCE_METRICS_FETCH) &&
+      Boolean.parseBoolean(this.requestInfoProperties.get(DIRECTIVE_FORCE_METRICS_FETCH));
   }
 
   // ----- Request -----------------------------------------------------------
@@ -157,6 +165,11 @@ public class RequestImpl implements Request {
   @Override
   public boolean isDryRunRequest() {
     return dryRun;
+  }
+
+  @Override
+  public boolean isForceMetricsFetchRequest() {
+    return forceMetricsFetch;
   }
 
   @Override

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/jmx/JMXPropertyProvider.java
@@ -264,8 +264,10 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
         // build the URL
         String jmxUrl = getSpec(protocol, hostName, port, "/jmx");
 
+        boolean forceImmediateMetricsFetch = request.isForceMetricsFetchRequest();
+
         // always submit a request to cache the latest data
-        metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, jmxUrl);
+        metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, jmxUrl, forceImmediateMetricsFetch);
 
         // check to see if there is a cached value and use it if there is
         JMXMetricHolder jmxMetricHolder = metricsRetrievalService.getCachedJMXMetric(jmxUrl);
@@ -275,7 +277,7 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
           String publicJmxUrl = getSpec(protocol, publicHostName, port, "/jmx");
 
           // always submit a request to cache the latest data
-          metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, publicJmxUrl);
+          metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, publicJmxUrl, forceImmediateMetricsFetch);
 
           // check to see if there is a cached value and use it if there is
           jmxMetricHolder = metricsRetrievalService.getCachedJMXMetric(publicJmxUrl);
@@ -300,7 +302,7 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
               }
               if (queryURL != null) {
                 String adHocUrl = getSpec(protocol, hostName, port, queryURL);
-                metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, adHocUrl);
+                metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, adHocUrl, forceImmediateMetricsFetch);
                 JMXMetricHolder adHocJMXMetricHolder = metricsRetrievalService.getCachedJMXMetric(adHocUrl);
 
                 if( adHocJMXMetricHolder == null && !hostName.equalsIgnoreCase(publicHostName)) {
@@ -308,7 +310,7 @@ public class JMXPropertyProvider extends ThreadPoolEnabledPropertyProvider {
                   String publicAdHocUrl = getSpec(protocol, publicHostName, port, queryURL);
 
                   // always submit a request to cache the latest data
-                  metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, publicAdHocUrl);
+                  metricsRetrievalService.submitRequest(MetricSourceType.JMX, streamProvider, publicAdHocUrl, forceImmediateMetricsFetch);
 
                   // check to see if there is a cached value and use it if there is
                   adHocJMXMetricHolder = metricsRetrievalService.getCachedJMXMetric(publicAdHocUrl);

--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/spi/Request.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/spi/Request.java
@@ -33,6 +33,8 @@ public interface Request {
 
   String DIRECTIVE_DRY_RUN = "dry_run";
 
+  String DIRECTIVE_FORCE_METRICS_FETCH = "force_metrics_fetch";
+
   /**
    * Get the set of property ids being requested.  Used for requests to get
    * resources.  An empty set signifies that all supported properties should
@@ -91,4 +93,10 @@ public interface Request {
    * @return true - if request is dry run request, false otherwise.
    */
   boolean isDryRunRequest();
+
+  /**
+   * Is this a force metrics fetch request.
+   * @return true - if request metrics should be immediately fetched from the source, bypassing the cache, false otherwise.
+   */
+  boolean isForceMetricsFetchRequest();
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/BaseResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/BaseResourceDefinitionTest.java
@@ -148,7 +148,7 @@ public class BaseResourceDefinitionTest {
   public void testReadDirectives() {
     ResourceDefinition resource = getResourceDefinition();
 
-    assertEquals(Collections.emptySet(), resource.getReadDirectives());
+    assertEquals(new HashSet<String>() {{add("force_metrics_fetch");}}, resource.getReadDirectives());
 
     Map<BaseResourceDefinition.DirectiveType, List<String>> directives = new HashMap<>();
     directives.put(BaseResourceDefinition.DirectiveType.DELETE, Arrays.asList("do_something_delete", "do_something_else_delete"));
@@ -158,10 +158,10 @@ public class BaseResourceDefinitionTest {
 
     resource = getResourceDefinition(directives);
 
-    assertEquals(new HashSet<String>() {{add("do_something_delete"); add("do_something_else_delete");}}, resource.getDeleteDirectives());
-    assertEquals(new HashSet<String>() {{add("do_something_get"); add("do_something_else_get");}}, resource.getReadDirectives());
-    assertEquals(new HashSet<String>() {{add("do_something_post"); add("do_something_else_post");}}, resource.getCreateDirectives());
-    assertEquals(new HashSet<String>() {{add("do_something_put"); add("do_something_else_put");}}, resource.getUpdateDirectives());
+    assertEquals(new HashSet<String>() {{add("force_metrics_fetch"); add("do_something_delete"); add("do_something_else_delete");}}, resource.getDeleteDirectives());
+    assertEquals(new HashSet<String>() {{add("force_metrics_fetch"); add("do_something_get"); add("do_something_else_get");}}, resource.getReadDirectives());
+    assertEquals(new HashSet<String>() {{add("force_metrics_fetch"); add("do_something_post"); add("do_something_else_post");}}, resource.getCreateDirectives());
+    assertEquals(new HashSet<String>() {{add("force_metrics_fetch"); add("do_something_put"); add("do_something_else_put");}}, resource.getUpdateDirectives());
   }
 
   private BaseResourceDefinition getResourceDefinition() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/BlueprintResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/BlueprintResourceDefinitionTest.java
@@ -57,7 +57,7 @@ public class BlueprintResourceDefinitionTest {
   public void testGetCreateDirectives() {
     BlueprintResourceDefinition definition = new BlueprintResourceDefinition();
     Collection<String> directives = definition.getCreateDirectives();
-    Assert.assertEquals(1, directives.size());
+    Assert.assertEquals(2, directives.size());
     Assert.assertTrue(directives.contains("validate_topology"));
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/CredentialResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/CredentialResourceDefinitionTest.java
@@ -57,6 +57,6 @@ public class CredentialResourceDefinitionTest {
   public void testGetCreateDirectives() {
     CredentialResourceDefinition definition = new CredentialResourceDefinition();
     Collection<String> directives = definition.getCreateDirectives();
-    Assert.assertEquals(0, directives.size());
+    Assert.assertEquals(1, directives.size());
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/SimpleResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/SimpleResourceDefinitionTest.java
@@ -53,19 +53,11 @@ public class SimpleResourceDefinitionTest {
   public void testDirectives() {
     ResourceDefinition resourceDefinition;
 
-    resourceDefinition = new SimpleResourceDefinition(Resource.Type.Stage, "stage", "stages",
-        Resource.Type.Task);
-
-    validateDirectives(Collections.emptySet(), resourceDefinition.getCreateDirectives());
-    validateDirectives(Collections.emptySet(), resourceDefinition.getReadDirectives());
-    validateDirectives(Collections.emptySet(), resourceDefinition.getUpdateDirectives());
-    validateDirectives(Collections.emptySet(), resourceDefinition.getDeleteDirectives());
-
     HashMap<BaseResourceDefinition.DirectiveType, Collection<String>> directives = new HashMap<>();
-    directives.put(BaseResourceDefinition.DirectiveType.CREATE, Arrays.asList("POST1", "POST2"));
-    directives.put(BaseResourceDefinition.DirectiveType.READ, Arrays.asList("GET1", "GET2"));
-    directives.put(BaseResourceDefinition.DirectiveType.UPDATE, Arrays.asList("PUT1", "PUT2"));
-    directives.put(BaseResourceDefinition.DirectiveType.DELETE, Arrays.asList("DEL1", "DEL2"));
+    directives.put(BaseResourceDefinition.DirectiveType.CREATE, Arrays.asList("force_metrics_fetch", "POST1", "POST2"));
+    directives.put(BaseResourceDefinition.DirectiveType.READ, Arrays.asList("force_metrics_fetch", "GET1", "GET2"));
+    directives.put(BaseResourceDefinition.DirectiveType.UPDATE, Arrays.asList("force_metrics_fetch", "PUT1", "PUT2"));
+    directives.put(BaseResourceDefinition.DirectiveType.DELETE, Arrays.asList("force_metrics_fetch", "DEL1", "DEL2"));
 
     resourceDefinition = new SimpleResourceDefinition(Resource.Type.Stage, "stage", "stages",
         Collections.singleton(Resource.Type.Task), directives);

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/UpgradeResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/UpgradeResourceDefinitionTest.java
@@ -54,7 +54,7 @@ public class UpgradeResourceDefinitionTest {
     ResourceDefinition resourceDefinition = new UpgradeResourceDefinition();
 
     assertEquals(Sets.newHashSet(UpgradeResourceDefinition.SKIP_SERVICE_CHECKS_DIRECTIVE,
-                                 Request.DIRECTIVE_FORCE_METRICS_FETCH),
+                                  Request.DIRECTIVE_FORCE_METRICS_FETCH),
         resourceDefinition.getCreateDirectives());
   }
 }

--- a/ambari-server/src/test/java/org/apache/ambari/server/api/resources/UpgradeResourceDefinitionTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/api/resources/UpgradeResourceDefinitionTest.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.api.resources;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.ambari.server.controller.spi.Request;
 import org.apache.ambari.server.controller.spi.Resource;
 import org.junit.Test;
 
@@ -52,7 +53,8 @@ public class UpgradeResourceDefinitionTest {
   public void testGetCreateDirectives() {
     ResourceDefinition resourceDefinition = new UpgradeResourceDefinition();
 
-    assertEquals(Sets.newHashSet(UpgradeResourceDefinition.SKIP_SERVICE_CHECKS_DIRECTIVE),
+    assertEquals(Sets.newHashSet(UpgradeResourceDefinition.SKIP_SERVICE_CHECKS_DIRECTIVE,
+                                 Request.DIRECTIVE_FORCE_METRICS_FETCH),
         resourceDefinition.getCreateDirectives());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added the option force_metrics_fetch to immediately fetched from the source,  bypassing the cache

## How was this patch tested?
Manually + UT
