### PR TITLE
AMBARI-25599 Consider to eliminate HDP public binary references (santal)

### DIFF
--- a/ambari-infra/ambari-infra-assembly/pom.xml
+++ b/ambari-infra/ambari-infra-assembly/pom.xml
@@ -29,8 +29,7 @@
 
   <properties>
     <mapping.base.path>/usr/lib</mapping.base.path>
-    <!-- original url: <solr.tar>http://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.tgz</solr.tar> -->
-    <solr.tar>https://public-repo-1.hortonworks.com/ARTIFACTS/dist/lucene/solr/${solr.version}/solr-${solr.version}.tgz</solr.tar>
+    <solr.tar>http://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.tgz</solr.tar>
     <solr.mapping.path>${mapping.base.path}/ambari-infra-solr</solr.mapping.path>
     <solr.package.name>ambari-infra-solr</solr.package.name>
     <solr.client.package.name>ambari-infra-solr-client</solr.client.package.name>

--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -34,9 +34,9 @@
     <!-- Needed for generating FindBugs warnings using parent pom -->
     <!--<yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>-->
     <protobuf.version>2.5.0</protobuf.version>
-    <hadoop.version>3.1.1.3.1.4.1-1</hadoop.version>
-    <phoenix.version>5.0.0.3.1.4.1-1</phoenix.version>
-    <hbase.version>2.0.2.3.1.4.1-1</hbase.version>
+    <hadoop.version>3.1.1</hadoop.version>
+    <phoenix.version>5.0.0-HBase-2.0</phoenix.version>
+    <hbase.version>2.0.2</hbase.version>
   </properties>
 
   <build>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -40,14 +40,14 @@
     <python.ver>python &gt;= 2.6</python.ver>
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>
     <!--TODO change to HDP URL-->
-    <hbase.tar>https://private-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.4.1-1/tars/hbase/hbase-2.0.2.3.1.4.1-1-bin.tar.gz</hbase.tar>
-    <hbase.folder>hbase-2.0.2.3.1.4.1-1</hbase.folder>
-    <hadoop.tar>https://private-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.4.1-1/tars/hadoop/hadoop-3.1.1.3.1.4.1-1.tar.gz</hadoop.tar>
-    <hadoop.folder>hadoop-3.1.1.3.1.4.1-1</hadoop.folder>
+    <hbase.tar>https://archive.apache.org/dist/hbase/2.0.2/hbase-2.0.2-bin.tar.gz</hbase.tar>
+    <hbase.folder>hbase-2.0.2</hbase.folder>
+    <hadoop.tar>https://archive.apache.org/dist/hadoop/common/hadoop-3.1.1/hadoop-3.1.1.tar.gz</hadoop.tar>
+    <hadoop.folder>hadoop-3.1.1</hadoop.folder>
     <grafana.folder>grafana-6.7.4</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.7.4.linux-amd64.tar.gz</grafana.tar>
-    <phoenix.tar>https://private-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.4.1-1/tars/phoenix/phoenix-5.0.0.3.1.4.1-1.tar.gz</phoenix.tar>
-    <phoenix.folder>phoenix-5.0.0.3.1.4.1-1</phoenix.folder>
+    <phoenix.tar>https://downloads.apache.org/phoenix/apache-phoenix-5.0.0-HBase-2.0/bin/apache-phoenix-5.0.0-HBase-2.0-bin.tar.gz</phoenix.tar>
+    <phoenix.folder>apache-phoenix-5.0.0-HBase-2.0-bin</phoenix.folder>
     <resmonitor.install.dir>/usr/lib/python2.6/site-packages/resource_monitoring</resmonitor.install.dir>
     <powermock.version>1.6.2</powermock.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>


### PR DESCRIPTION
Change-Id: I7a560a7c2d6ff6c3681fc384d51c23bbb36330c8

## What changes were proposed in this pull request?

Public HDP binaries will no longer available: https://my.cloudera.com/knowledge/Cloudera-Customer-Advisory-Paywall-Update-External?id=306085
Please analyse and eliminate(replace) the necessary references from the codebase where rpms and tarballs of HDP are accessible.
Additionally non managed HDP tarballs should be replaced with open source ones. For example: https://github.com/apache/ambari/blob/branch-2.7/ambari-metrics/pom.xml#L43

## How was this patch tested?

the patch was tested manually