### PR TITLE
[AMBARI-25422] the interface to get serviceInfo is too slow

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -2138,9 +2138,7 @@ public class ConfigHelper {
    */
   public Map<String, Map<String, String>> calculateExistingConfigurations(AmbariManagementController ambariManagementController, Cluster cluster) throws AmbariException {
     final Map<String, Map<String, String>> configurations = new HashMap<>();
-    for (Host host : cluster.getHosts()) {
-      configurations.putAll(calculateExistingConfigurations(ambariManagementController, cluster, host.getHostName()));
-    }
+    configurations.putAll(calculateExistingConfigurations(ambariManagementController, cluster, null));
     return configurations;
   }
 
@@ -2159,7 +2157,7 @@ public class ConfigHelper {
     // global:version1:{a1:A1,b1:B1,d1:D1} + global:{a1:A2,c1:C1,DELETED_d1:x} ==>
     // global:{a1:A2,b1:B1,c1:C1}
     final Map<String, Map<String, String>> configurations = new HashMap<>();
-    final Map<String, Map<String, String>> configurationTags = ambariManagementController.findConfigurationTagsWithOverrides(cluster, hostname);
+    final Map<String, Map<String, String>> configurationTags = hostname == null ? getEffectiveDesiredTags(cluster, null, cluster.getDesiredConfigs()) : ambariManagementController.findConfigurationTagsWithOverrides(cluster, hostname);
     final Map<String, Map<String, String>> configProperties = getEffectiveConfigProperties(cluster, configurationTags);
 
     // Apply the configurations saved with the Execution Cmd on top of


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

There are unnecessary iteration on [List Services API](https://github.com/apache/ambari/blob/trunk/ambari-server/docs/api/v1/services.md).
There is no need to iterate all hosts to get effective config properties.

As Ambari cluster grows with mant hosts, Ambari UI first load is getting slower.
(As mentioned in https://issues.apache.org/jira/browse/AMBARI-25422 caused by api call : ```http://{ip}:{port}/api/v1/clusters/{cluster}/services?fields=ServiceInfo/state,ServiceInfo/maintenance_state,ServiceInfo/desired_repository_version_id,components/ServiceComponentInfo/component_name&minimal_response=true&_=1572316944944```)



## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
I tested it with test ambari cluster in our company.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.