### PR TITLE
[AMBARI-25619] "Prepare delete identities" takes too long

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
@@ -92,6 +92,33 @@ public class KerberosKeytabController {
   }
 
   /**
+   * Tries to find principal by host id, keytab path, principal name.
+   *
+   * @param hostId host id
+   * @param keytabPath keytab path
+   * @param principalName principal name
+   * @return found principal or null
+   */
+  public ResolvedKerberosPrincipal getPrincipalByHostKeytabAndPrincipal(Long hostId, String keytabPath, String principalName) {
+    KerberosKeytabPrincipalEntity kkpe = kerberosKeytabPrincipalDAO.findByHostKeytabAndPrincipal(hostId, keytabPath, principalName);
+    if (kkpe == null) {
+      return null;
+    }
+    KerberosPrincipalEntity kpe = kkpe.getKerberosPrincipalEntity();
+    if (kpe == null) {
+      return null;
+    }
+    return new ResolvedKerberosPrincipal(
+            kkpe.getHostId(),
+            kkpe.getHostName(),
+            kkpe.getPrincipalName(),
+            kpe.isService(),
+            kpe.getCachedKeytabPath(),
+            kkpe.getKeytabPath(),
+            kkpe.getServiceMappingAsMultimap());
+  }
+
+  /**
    * Returns all keytabs managed by ambari.
    *
    * @return all keytabs


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AMBARI-25619

## What changes were proposed in this pull request?

It removes unnecessary iterations when deleting a component in kerberized ambari cluster.
Unnecessary iterations have huge impacts on big cluster.
It barely do other operations because "Prepare delete identities" operations blocks all other operations.

## How was this patch tested?

manual tests on our cluster.