### PR TITLE
AMBARI-25625 druid.emitter.ambari-metrics.hostname set improperly

### DIFF
--- a/ambari-server/src/main/resources/common-services/DRUID/0.10.1/package/scripts/params.py
+++ b/ambari-server/src/main/resources/common-services/DRUID/0.10.1/package/scripts/params.py
@@ -166,18 +166,19 @@ metric_truststore_path = default("/configurations/ams-ssl-client/ssl.client.trus
 metric_truststore_type = default("/configurations/ams-ssl-client/ssl.client.truststore.type", "")
 metric_truststore_password = default("/configurations/ams-ssl-client/ssl.client.truststore.password", "")
 
-ams_collector_hosts = default("/clusterHostInfo/metrics_collector_hosts", [])
+set_instanceId = "false"
 if 'cluster-env' in config['configurations'] and \
-    'metrics_collector_external_hosts' in config['configurations']['cluster-env']:
+        'metrics_collector_external_hosts' in config['configurations']['cluster-env']:
   ams_collector_hosts = config['configurations']['cluster-env']['metrics_collector_external_hosts']
   set_instanceId = "true"
 else:
   ams_collector_hosts = ",".join(default("/clusterHostInfo/metrics_collector_hosts", []))
-has_metric_collector = not len(ams_collector_hosts) == 0
+
+has_metric_collector = len(ams_collector_hosts) > 0
 
 if has_metric_collector:
   metric_emitter_type = "ambari-metrics"
-  metric_collector_host = ams_collector_hosts[0]
+  metric_collector_host = ams_collector_hosts.split(",")[0]
   if 'cluster-env' in config['configurations'] and \
       'metrics_collector_external_port' in config['configurations']['cluster-env']:
     metric_collector_port = config['configurations']['cluster-env']['metrics_collector_external_port']


### PR DESCRIPTION
When installing Druid the `druid.emitter.ambari-metrics.hostname` property is set to the first character of the hostname of the AMS collector host even though the property in Ambari is set to `metric_collector_host`. 

/etc/druid/conf/_common/common.runtime.properties file contains:
```
druid.emitter=ambari-metrics
druid.emitter.ambari-metrics.eventConverter={"type":"whiteList"}
druid.emitter.ambari-metrics.hostname=c
druid.emitter.ambari-metrics.port=6188
druid.emitter.ambari-metrics.protocol=https
druid.emitter.ambari-metrics.trustStorePassword=clientTrustStorePassword
druid.emitter.ambari-metrics.trustStorePath=/etc/security/clientKeys/all.jks
druid.emitter.ambari-metrics.trustStoreType=jks
```
## What changes were proposed in this pull request?
The extraction of the first hostname from the list if metric collector hosts has been fixed.

## How was this patch tested?
Tested manually by installing/restarting Druid when one, two or zero Metrics Collector is present in the cluster and watched the content of '/etc/druid/conf/_common/common.runtime.properties' file.