### PR TITLE
AMBARI-25627 ORA-01795 error when querying hostcomponentdesiredstate table on large cluster

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
@@ -18,6 +18,7 @@
 
 package org.apache.ambari.server.orm.dao;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -28,7 +29,10 @@ import javax.persistence.TypedQuery;
 import org.apache.ambari.server.orm.RequiresSession;
 import org.apache.ambari.server.orm.entities.HostComponentDesiredStateEntity;
 import org.apache.ambari.server.orm.entities.HostEntity;
+import org.apache.ambari.server.orm.helpers.SQLConstants;
+import org.apache.ambari.server.orm.helpers.SQLOperations;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -124,13 +128,21 @@ public class HostComponentDesiredStateDAO {
 
   @RequiresSession
   public List<HostComponentDesiredStateEntity> findByHostsAndCluster(Collection<Long> hostIds, Long clusterId) {
-    final TypedQuery<HostComponentDesiredStateEntity> query = entityManagerProvider.get()
-      .createNamedQuery("HostComponentDesiredStateEntity.findByHostsAndCluster", HostComponentDesiredStateEntity.class);
+    final List<HostComponentDesiredStateEntity> result = new ArrayList<>();
+    if (hostIds == null || hostIds.isEmpty()) {
+      return result;
+    }
+    final EntityManager entityManager = entityManagerProvider.get();
+    final TypedQuery<HostComponentDesiredStateEntity> query = entityManager.
+        createNamedQuery("HostComponentDesiredStateEntity.findByHostsAndCluster", HostComponentDesiredStateEntity.class);
 
-    query.setParameter("hostIds", hostIds);
-    query.setParameter("clusterId", clusterId);
-
-    return daoUtils.selectList(query);
+    SQLOperations.batch(hostIds, SQLConstants.IN_ARGUMENT_MAX_SIZE, (chunk, currentBatch, totalBatches, totalSize) -> {
+      query.setParameter("hostIds", chunk);
+      query.setParameter("clusterId", clusterId);
+      result.addAll(daoUtils.selectList(query));
+      return 0;
+    });
+    return Lists.newArrayList(result);
   }
 
   @Transactional

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/HostComponentDesiredStateDAO.java
@@ -20,6 +20,7 @@ package org.apache.ambari.server.orm.dao;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -31,6 +32,7 @@ import org.apache.ambari.server.orm.entities.HostComponentDesiredStateEntity;
 import org.apache.ambari.server.orm.entities.HostEntity;
 import org.apache.ambari.server.orm.helpers.SQLConstants;
 import org.apache.ambari.server.orm.helpers.SQLOperations;
+import org.apache.commons.collections.CollectionUtils;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -128,14 +130,14 @@ public class HostComponentDesiredStateDAO {
 
   @RequiresSession
   public List<HostComponentDesiredStateEntity> findByHostsAndCluster(Collection<Long> hostIds, Long clusterId) {
-    final List<HostComponentDesiredStateEntity> result = new ArrayList<>();
-    if (hostIds == null || hostIds.isEmpty()) {
-      return result;
+    if (CollectionUtils.isEmpty(hostIds)) {
+      return Collections.<HostComponentDesiredStateEntity>emptyList();
     }
     final EntityManager entityManager = entityManagerProvider.get();
     final TypedQuery<HostComponentDesiredStateEntity> query = entityManager.
         createNamedQuery("HostComponentDesiredStateEntity.findByHostsAndCluster", HostComponentDesiredStateEntity.class);
 
+    final List<HostComponentDesiredStateEntity> result = new ArrayList<>();
     SQLOperations.batch(hostIds, SQLConstants.IN_ARGUMENT_MAX_SIZE, (chunk, currentBatch, totalBatches, totalSize) -> {
       query.setParameter("hostIds", chunk);
       query.setParameter("clusterId", clusterId);


### PR DESCRIPTION
## What changes were proposed in this pull request?
On clusters when there are more than 1000 nodes and Oracle is used as a rdbms backend the following query is failing due to Oracle's limitation that maximum 1000 parameters are allowed in the 'IN' clause.
`SELECT id, admin_state, blueprint_provisioning_state, cluster_id, component_name, desired_state, host_id, maintenance_state, restart_required, service_name FROM hostcomponentdesiredstate WHERE ((host_id IN ?)...`

This fix attempts to solve the problem by executing the query in batches < 1000.

## How was this patch tested?

Manually.