### PR TITLE
[AMBARI-25631] Correct the import order in HostStateEntity.java

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
@@ -18,6 +18,8 @@
 
 package org.apache.ambari.server.orm.entities;
 
+import java.util.Objects;
+
 import static org.apache.commons.lang.StringUtils.defaultString;
 
 import javax.persistence.Basic;
@@ -32,8 +34,6 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 
 import org.apache.ambari.server.state.HostState;
-
-import java.util.Objects;
 
 @javax.persistence.Table(name = "hoststate")
 @Entity


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change correct the import order to fix the error when run checkstyle

## How was this patch tested?

without this change, when run `mvn install` in Ambari, it will raise following error:
```
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---                                                                                                                                    
[INFO] Starting audit...                                                                                                                                                                                          
[ERROR] /home/ambari/ambari/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java:36: Wrong order for 'java.util.Objects' import. [ImportOrder] 
```