### PR TITLE
AMBARI-25638 FindBugs: Class defines equals() and uses Object.hashCode()

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/alert/MetricSource.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/alert/MetricSource.java
@@ -20,13 +20,14 @@ package org.apache.ambari.server.state.alert;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.IntStream.range;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.ambari.server.controller.jmx.JMXMetricHolder;
 import org.apache.ambari.server.state.UriInfo;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.ListUtils;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
@@ -137,18 +138,22 @@ public class MetricSource extends Source {
 
     @Override
     public boolean equals(Object object) {
-      if (!JmxInfo.class.isInstance(object)) {
-        return false;
+      if (object instanceof JmxInfo) {
+        JmxInfo other = (JmxInfo) object;
+        if (propertyList == null) {
+          return other.propertyList == null;
+        } else {
+          // !!! even if out of order, this is enough to fail
+          return other.propertyList != null &&
+              CollectionUtils.isEqualCollection(ListUtils.unmodifiableList(propertyList), ListUtils.unmodifiableList(other.propertyList));
+        }
       }
+      return false;
+    }
 
-      JmxInfo other = (JmxInfo)object;
-
-      List<String> list1 = new ArrayList<>(propertyList);
-      List<String> list2 = new ArrayList<>(other.propertyList);
-
-      // !!! even if out of order, this is enough to fail
-      return list1.equals(list2);
-
+    @Override
+    public int hashCode() {
+      return Objects.hash(propertyList);
     }
 
     public String getUrlSuffix() {

--- a/ambari-server/src/test/java/org/apache/ambari/server/metric/system/impl/MetricsSourceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metric/system/impl/MetricsSourceTest.java
@@ -27,7 +27,6 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;

--- a/ambari-server/src/test/java/org/apache/ambari/server/metric/system/impl/MetricsSourceTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/metric/system/impl/MetricsSourceTest.java
@@ -20,11 +20,16 @@ package org.apache.ambari.server.metric.system.impl;
 
 import static java.util.Collections.singletonList;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -184,5 +189,39 @@ public class MetricsSourceTest {
     MetricSource.JmxInfo deserialized = mapper.readValue(mapper.writeValueAsString(jmxInfo), MetricSource.JmxInfo.class);
     assertEquals("custom", deserialized.getValue().toString());
     assertEquals(singletonList("prop1"), deserialized.getPropertyList());
+  }
+
+  @Test
+  public void testJmxInfoEquality() {
+    MetricSource.JmxInfo jmxInfo = new MetricSource.JmxInfo();
+    MetricSource.JmxInfo otherJmxInfo = null;
+
+    assertFalse(jmxInfo.equals(otherJmxInfo));
+
+    otherJmxInfo = new MetricSource.JmxInfo();
+
+    assertTrue(jmxInfo.equals(otherJmxInfo));
+    assertTrue(otherJmxInfo.equals(jmxInfo));
+    assertEquals(jmxInfo.hashCode(), otherJmxInfo.hashCode());
+
+    jmxInfo.setPropertyList(Arrays.asList("a", "b", "c", "d"));
+    assertFalse(jmxInfo.equals(otherJmxInfo));
+    assertFalse(otherJmxInfo.equals(jmxInfo));
+    assertFalse(jmxInfo.hashCode() == otherJmxInfo.hashCode());
+
+    otherJmxInfo.setPropertyList(Arrays.asList("a", "b", "c", "d"));
+    assertTrue(jmxInfo.equals(otherJmxInfo));
+    assertTrue(otherJmxInfo.equals(jmxInfo));
+    assertEquals(jmxInfo.hashCode(), otherJmxInfo.hashCode());
+
+    jmxInfo.setPropertyList(Collections.emptyList());
+    assertFalse(jmxInfo.equals(otherJmxInfo));
+    assertFalse(otherJmxInfo.equals(jmxInfo));
+    assertFalse(jmxInfo.hashCode() == otherJmxInfo.hashCode());
+
+    otherJmxInfo.setPropertyList(Arrays.asList("b", "c", "d", "a"));
+    assertFalse(jmxInfo.equals(otherJmxInfo));
+    assertFalse(otherJmxInfo.equals(jmxInfo));
+    assertFalse(jmxInfo.hashCode() == otherJmxInfo.hashCode());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix a FindBugs finding where org.apache.ambari.server.state.alert.MetricSource$JmxInfo defines equals() but does not have own hashCode() implementation.

## How was this patch tested?

Unit test has been added.