### PR TITLE
AMBARI-25639. StackOverflowError appears on MethodArgument*Exception during stomp message handling.

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/RootStompConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/RootStompConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.servlet.ServletContext;
 
+import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.agent.AgentSessionManager;
 import org.apache.ambari.server.agent.stomp.AmbariSubscriptionRegistry;
 import org.apache.ambari.server.api.AmbariSendToMethodReturnValueHandler;
@@ -116,12 +117,9 @@ public class RootStompConfig {
     @MessageExceptionHandler(Exception.class)
     @SendToUser("/")
     public ErrorMessage handle(Exception e) {
-
-      //LOG.error("Exception caught while processing message: " + e.getMessage(), e);
-      return new ErrorMessage(e);
+      LOG.error("Exception caught while processing a message: " + e.getMessage(), e);
+      return new ErrorMessage(new AmbariException(e.getMessage()));
     }
-
-
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now server sends AmbariException with a message only, this prevents mapping of any other exception structure. For issues analyzing we have a full exception stacktrace in server logs and a message in agent logs.

## How was this patch tested?

Manual testing