### PR TITLE
Fix Spelling

### DIFF
--- a/ambari-server/src/test/java/org/apache/ambari/server/view/ViewDirectoryWatcherTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/view/ViewDirectoryWatcherTest.java
@@ -85,7 +85,7 @@ public class ViewDirectoryWatcherTest {
     });
     viewDirectoryWatcher.start();
     countDownLatch.await(1, SECONDS);
-    // Expect watecher to start
+    // Expect watcher to start
     Assert.assertTrue(viewDirectoryWatcher.isRunning());
     verify(configuration);
   }


### PR DESCRIPTION
There is typo in coment [https://github.com/apache/ambari/blob/trunk/ambari-server/src/test/java/org/apache/ambari/server/view/ViewDirectoryWatcherTest.java#L88](https://github.com/apache/ambari/blob/trunk/ambari-server/src/test/java/org/apache/ambari/server/view/ViewDirectoryWatcherTest.java#L88)

The comment "// Expect watecher to start" 
should be corrected as "// Expert watcher to start"

## What changes were proposed in this pull request?

Fix spelling in comment


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.