### PR TITLE
AMBARI-25635 Clear Cluster and METRIC_AGGREGATORS MBeans upon shutdown

### DIFF
--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
@@ -223,15 +223,8 @@ public class MetricCollectorHAController {
       PropertyKey.Builder keyBuilder = new PropertyKey.Builder(CLUSTER_NAME);
       manager.removeListener(keyBuilder.liveInstances(), liveInstanceTracker);
       liveInstanceTracker.shutdown();
-
       aggregationTaskRunner.stop();
       manager.disconnect();
-
-      try {
-        admin.dropInstance(CLUSTER_NAME, instanceConfig);
-      } catch (HelixException e) {
-        LOG.error(String.format("Could not drop instance: %s due to: %s", instanceConfig.getInstanceName(), e.getMessage()));
-      }
       admin.close();
 
       isInitialized = false;

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
@@ -81,8 +81,7 @@ public class MetricCollectorHAController {
   @VisibleForTesting
   HelixAdmin admin;
   // Helix Manager
-  @VisibleForTesting
-  HelixManager manager;
+  private HelixManager manager;
 
   private volatile boolean isInitialized = false;
 

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
@@ -49,8 +49,6 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.OnlineOfflineSMD;
-import org.apache.helix.model.StateModelDefinition;
-import org.apache.helix.tools.StateModelConfigGenerator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
@@ -164,8 +162,7 @@ public class MetricCollectorHAController {
     // Add a state model
     if (admin.getStateModelDef(CLUSTER_NAME, DEFAULT_STATE_MODEL) == null) {
       LOG.info("Adding ONLINE-OFFLINE state model to the cluster");
-      admin.addStateModelDef(CLUSTER_NAME, DEFAULT_STATE_MODEL, new StateModelDefinition(
-        StateModelConfigGenerator.generateConfigForOnlineOffline()));
+      admin.addStateModelDef(CLUSTER_NAME, DEFAULT_STATE_MODEL, OnlineOfflineSMD.build());
     }
 
     // Add resources with 1 cluster-wide replica

--- a/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -52,41 +52,44 @@ import org.apache.helix.model.OnlineOfflineSMD;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.StateModelConfigGenerator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 
-;
 
 public class MetricCollectorHAController {
   private static final Log LOG = LogFactory.getLog(MetricCollectorHAController.class);
 
+  @VisibleForTesting
   static final String CLUSTER_NAME = "ambari-metrics-cluster";
+  @VisibleForTesting
   static final String METRIC_AGGREGATORS = "METRIC_AGGREGATORS";
+  @VisibleForTesting
   static final String DEFAULT_STATE_MODEL = OnlineOfflineSMD.name;
-  static final String INSTANCE_NAME_DELIMITER = "_";
+  private static final String INSTANCE_NAME_DELIMITER = "_";
 
+  @VisibleForTesting
   final String zkConnectUrl;
-  final String instanceHostname;
-  final InstanceConfig instanceConfig;
-  final AggregationTaskRunner aggregationTaskRunner;
-  final TimelineMetricConfiguration configuration;
+  private final String instanceHostname;
+  private final InstanceConfig instanceConfig;
+  private final AggregationTaskRunner aggregationTaskRunner;
 
   // Cache list of known live instances
-  final List<String> liveInstanceNames = new ArrayList<>();
+  private final List<String> liveInstanceNames = new ArrayList<>(2);
 
   // Helix Admin
+  @VisibleForTesting
   HelixAdmin admin;
   // Helix Manager
+  @VisibleForTesting
   HelixManager manager;
 
   private volatile boolean isInitialized = false;
 
   public MetricCollectorHAController(TimelineMetricConfiguration configuration) {
-    this.configuration = configuration;
     String instancePort;
     try {
       instanceHostname = configuration.getInstanceHostnameFromEnv();
       instancePort = configuration.getInstancePort();
-
     } catch (Exception e) {
       LOG.error("Error reading configs from classpath, will resort to defaults.", e);
       throw new MetricsSystemInitializationException(e.getMessage());
@@ -97,42 +100,32 @@ public class MetricCollectorHAController {
       String zkQuorum = configuration.getClusterZKQuorum();
 
       if (StringUtils.isEmpty(zkClientPort) || StringUtils.isEmpty(zkQuorum)) {
-        throw new Exception("Unable to parse zookeeper quorum. clientPort = "
-          + zkClientPort +", quorum = " + zkQuorum);
+        throw new Exception(String.format("Unable to parse zookeeper quorum. clientPort = %s, quorum = %s", zkClientPort, zkQuorum));
       }
 
       zkConnectUrl = configuration.getZkConnectionUrl(zkClientPort, zkQuorum);
-
     } catch (Exception e) {
       LOG.error("Unable to load hbase-site from classpath.", e);
-      throw new MetricsSystemInitializationException(e.getMessage());
+      throw new MetricsSystemInitializationException(e.getMessage(), e);
     }
 
     instanceConfig = new InstanceConfig(instanceHostname + INSTANCE_NAME_DELIMITER + instancePort);
     instanceConfig.setHostName(instanceHostname);
     instanceConfig.setPort(instancePort);
     instanceConfig.setInstanceEnabled(true);
-    aggregationTaskRunner = new AggregationTaskRunner(
-      instanceConfig.getInstanceName(), zkConnectUrl, getClusterName());
-  }
 
-  /**
-   * Name of Helix znode
-   */
-  public String getClusterName() {
-    return CLUSTER_NAME;
+    aggregationTaskRunner = new AggregationTaskRunner(instanceConfig.getInstanceName(), zkConnectUrl, CLUSTER_NAME);
   }
 
   /**
    * Initialize the instance with zookeeper via Helix
    */
   public void initializeHAController() throws Exception {
-    String clusterName = getClusterName();
     admin = new ZKHelixAdmin(zkConnectUrl);
     // create cluster
-    LOG.info("Creating zookeeper cluster node: " + clusterName);
-    boolean clusterAdded = admin.addCluster(clusterName, false);
-    LOG.info("Was cluster added successfully? " + clusterAdded);
+    LOG.info(String.format("Creating zookeeper cluster node: %s", CLUSTER_NAME));
+    boolean clusterAdded = admin.addCluster(CLUSTER_NAME, false);
+    LOG.info(String.format("Was cluster added successfully? %s", clusterAdded));
 
     // Adding host to the cluster
     boolean success = false;
@@ -141,16 +134,16 @@ public class MetricCollectorHAController {
 
     for (int i = 0; i < tries && !success; i++) {
       try {
-        List<String> nodes = admin.getInstancesInCluster(clusterName);
+        List<String> nodes = admin.getInstancesInCluster(CLUSTER_NAME);
         if (CollectionUtils.isEmpty(nodes) || !nodes.contains(instanceConfig.getInstanceName())) {
-          LOG.info("Adding participant instance " + instanceConfig);
-          admin.addInstance(clusterName, instanceConfig);
+          LOG.info(String.format("Adding participant instance %s", instanceConfig));
+          admin.addInstance(CLUSTER_NAME, instanceConfig);
         }
         success = true;
       } catch (HelixException | ZkNoNodeException ex) {
         LOG.warn("Helix Cluster not yet setup fully.");
         if (i < tries - 1) {
-          LOG.info("Waiting for " + sleepTimeInSeconds + " seconds and retrying.");
+          LOG.info(String.format("Waiting for %d seconds and retrying.", sleepTimeInSeconds));
           TimeUnit.SECONDS.sleep(sleepTimeInSeconds);
         } else {
           LOG.error(ex);
@@ -159,19 +152,19 @@ public class MetricCollectorHAController {
     }
 
     if (!success) {
-      LOG.info("Trying to create " + clusterName + " again since waiting for the creation did not help.");
-      admin.addCluster(clusterName, true);
-      List<String> nodes = admin.getInstancesInCluster(clusterName);
+      LOG.info(String.format("Trying to create %s again since waiting for the creation did not help.", CLUSTER_NAME));
+      admin.addCluster(CLUSTER_NAME, true);
+      List<String> nodes = admin.getInstancesInCluster(CLUSTER_NAME);
       if (CollectionUtils.isEmpty(nodes) || !nodes.contains(instanceConfig.getInstanceName())) {
-        LOG.info("Adding participant instance " + instanceConfig);
-        admin.addInstance(clusterName, instanceConfig);
+        LOG.info(String.format("Adding participant instance %s", instanceConfig));
+        admin.addInstance(CLUSTER_NAME, instanceConfig);
       }
     }
 
     // Add a state model
-    if (admin.getStateModelDef(clusterName, DEFAULT_STATE_MODEL) == null) {
+    if (admin.getStateModelDef(CLUSTER_NAME, DEFAULT_STATE_MODEL) == null) {
       LOG.info("Adding ONLINE-OFFLINE state model to the cluster");
-      admin.addStateModelDef(clusterName, DEFAULT_STATE_MODEL, new StateModelDefinition(
+      admin.addStateModelDef(CLUSTER_NAME, DEFAULT_STATE_MODEL, new StateModelDefinition(
         StateModelConfigGenerator.generateConfigForOnlineOffline()));
     }
 
@@ -179,14 +172,14 @@ public class MetricCollectorHAController {
     // Since our aggregators are unbalanced in terms of work distribution we
     // only need to distribute writes to METRIC_AGGREGATE and
     // METRIC_RECORD_MINUTE
-    List<String> resources = admin.getResourcesInCluster(clusterName);
+    List<String> resources = admin.getResourcesInCluster(CLUSTER_NAME);
     if (!resources.contains(METRIC_AGGREGATORS)) {
-      LOG.info("Adding resource " + METRIC_AGGREGATORS + " with 2 partitions and 1 replicas");
-      admin.addResource(clusterName, METRIC_AGGREGATORS, 2, DEFAULT_STATE_MODEL, FULL_AUTO.toString());
+      LOG.info(String.format("Adding resource %s with 2 partitions and 1 replicas", METRIC_AGGREGATORS));
+      admin.addResource(CLUSTER_NAME, METRIC_AGGREGATORS, 2, DEFAULT_STATE_MODEL, FULL_AUTO.toString());
     }
     // this will set up the ideal state, it calculates the preference list for
     // each partition similar to consistent hashing
-    admin.rebalance(clusterName, METRIC_AGGREGATORS, 1);
+    admin.rebalance(CLUSTER_NAME, METRIC_AGGREGATORS, 1);
 
     // Start participant
     startAggregators();
@@ -194,13 +187,10 @@ public class MetricCollectorHAController {
     // Start controller
     startController();
 
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      public void run() {
-        aggregationTaskRunner.stop();
-        manager.disconnect();
-      }
-    });
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      aggregationTaskRunner.stop();
+      manager.disconnect();
+    }));
 
     isInitialized = true;
   }
@@ -215,20 +205,14 @@ public class MetricCollectorHAController {
   private void startAggregators() {
     try {
       aggregationTaskRunner.initialize();
-
     } catch (Exception e) {
       LOG.error("Unable to start aggregators.", e);
-      throw new MetricsSystemInitializationException(e.getMessage());
+      throw new MetricsSystemInitializationException(e.getMessage(), e);
     }
   }
 
   private void startController() throws Exception {
-    manager = HelixManagerFactory.getZKHelixManager(
-      getClusterName(),
-      instanceHostname,
-      InstanceType.CONTROLLER,
-      zkConnectUrl
-    );
+    manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, instanceHostname, InstanceType.CONTROLLER, zkConnectUrl);
 
     manager.connect();
     HelixController controller = new HelixController();
@@ -240,7 +224,7 @@ public class MetricCollectorHAController {
   }
 
   public List<String> getLiveInstanceHostNames() {
-    List<String> liveInstanceHostNames = new ArrayList<>();
+    List<String> liveInstanceHostNames = new ArrayList<>(2);
 
     for (String instance : liveInstanceNames) {
       liveInstanceHostNames.add(instance.split(INSTANCE_NAME_DELIMITER)[0]);
@@ -249,9 +233,9 @@ public class MetricCollectorHAController {
     return liveInstanceHostNames;
   }
 
-  public class HelixController extends GenericHelixController {
-    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-    Joiner joiner = Joiner.on(", ").skipNulls();
+  public final class HelixController extends GenericHelixController {
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private final Joiner joiner = Joiner.on(", ").skipNulls();
 
     @Override
     public void onLiveInstanceChange(List<LiveInstance> liveInstances, NotificationContext changeContext) {
@@ -262,39 +246,29 @@ public class MetricCollectorHAController {
         liveInstanceNames.add(instance.getInstanceName());
       }
 
-      LOG.info("Detected change in liveliness of Collector instances. " +
-        "LiveIsntances = " + joiner.join(liveInstanceNames));
+      LOG.info(String.format("Detected change in liveliness of Collector instances. LiveInstances = %s", joiner.join(liveInstanceNames)));
       // Print HA state - after some delay
-      executorService.schedule(new Runnable() {
-        @Override
-        public void run() {
-          printClusterState();
-        }
-      }, 30, TimeUnit.SECONDS);
-
-
+      executorService.schedule(() -> printClusterState(), 30, TimeUnit.SECONDS);
     }
   }
 
   public void printClusterState() {
     StringBuilder sb = new StringBuilder("\n######################### Cluster HA state ########################");
 
-    ExternalView resourceExternalView = admin.getResourceExternalView(getClusterName(), METRIC_AGGREGATORS);
+    ExternalView resourceExternalView = admin.getResourceExternalView(CLUSTER_NAME, METRIC_AGGREGATORS);
     if (resourceExternalView != null) {
-      getPrintableResourceState(resourceExternalView, METRIC_AGGREGATORS, sb);
+      getPrintableResourceState(resourceExternalView, sb);
     }
     sb.append("\n##################################################");
     LOG.info(sb.toString());
   }
 
-  private void getPrintableResourceState(ExternalView resourceExternalView,
-                                         String resourceName,
-                                         StringBuilder sb) {
+  private void getPrintableResourceState(ExternalView resourceExternalView, StringBuilder sb) {
     TreeSet<String> sortedSet = new TreeSet<>(resourceExternalView.getPartitionSet());
     sb.append("\nCLUSTER: ");
-    sb.append(getClusterName());
+    sb.append(CLUSTER_NAME);
     sb.append("\nRESOURCE: ");
-    sb.append(resourceName);
+    sb.append(MetricCollectorHAController.METRIC_AGGREGATORS);
     for (String partitionName : sortedSet) {
       sb.append("\nPARTITION: ");
       sb.append(partitionName).append("\t");

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAControllerTest.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAControllerTest.java
+++ b/ambari-metrics/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/availability/MetricCollectorHAControllerTest.java
@@ -100,7 +100,6 @@ public class MetricCollectorHAControllerTest extends AbstractMiniHBaseClusterTes
     // Re-assigned partitions
     Assert.assertEquals(2, partitionInstanceMap.size());
 
-    haController.getAggregationTaskRunner().stop();
-    haController.manager.disconnect();
+    haController.shutdownHAController();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When starting up or shutting down Ambari Metics in HA mode the following exceptions appear in the log:

`javax.management.InstanceAlreadyExistsException: ClusterStatus: cluster=... ,instanceName=...`
and
`javax.management.InstanceNotFoundException: ClusterStatus: cluster=..,instanceName=...,resourceName=...`

These are happening when trying to register/unregister an MBean.
The double registration happens because the `HelixController` class was a subclass of `GenericHelixController` class, thus effectively it was a _Controller_ instance, despite the fact that it only needs to be a listener to track live Collector instances. By registering this `HelixController` class we basically used **two Controllers**, that caused the double registration and wasting of resources.

The fix refactored `HelixController` to a `LiveInstanceTracker` class that is only a listener this way eliminating the situation where we had two Controllers.

Furthermore the fix refactors the shutdown mechanism `MetricCollectorHAController` to provide a more graceful shutdown. 
Code cleanup was also performed.
## How was this patch tested?

The change was tested manually by setting up a Ambari Metrics HA cluster and testing start up and shutdown of instances.
- Stopping one of the instances to check HA capabilities and the cleanness of the shutdown.
- Starting the stopped instance to see if the HA state restored and there are no complains about the MBean registration.
- Did the same tests of stopping/starring both instances together.