### PR TITLE
AMBARI-25668 Integrate the Apache released HBase as back store of Ambari Metrics

### DIFF
--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -266,7 +266,42 @@
                             <exclude>lib/*tests.jar</exclude>
                             <exclude>lib/findbugs*.jar</exclude>
                             <exclude>lib/jdk.tools*.jar</exclude>
+                            <exclude>lib/hadoop*.jar</exclude>
+                            <exclude>lib/guava-11.0.2.jar</exclude>
+                            <exclude>lib/commons-beanutils-core-1.8.0.jar</exclude>
                           </excludes>
+                        </source>
+                      </sources>
+                    </mapping>
+                    <mapping>
+                      <!--embedded applications-->
+                      <directory>/usr/lib/ams-hbase/lib/</directory>
+                      <directoryIncluded>false</directoryIncluded>
+                      <sources>
+                        <source>
+                          <location>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/hdfs</location>
+                          <includes>
+                            <include>hadoop-hdfs-${hadoop.version}.jar</include>
+                            <include>hadoop-hdfs-client-${hadoop.version}.jar</include>
+                          </includes>
+                        </source>
+                        <source>
+                          <location>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/tools/lib</location>
+                          <includes>
+                            <include>hadoop-aws*.jar</include>
+                            <include>hadoop-distcp-*.jar</include>
+                          </includes>
+                        </source>
+                        <source>
+                          <location>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/mapreduce</location>
+                          <includes>
+                              <include>hadoop-mapreduce-client-app-${hadoop.version}.jar</include>
+                              <include>hadoop-mapreduce-client-common-${hadoop.version}.jar</include>
+                              <include>hadoop-mapreduce-client-core-${hadoop.version}.jar</include>
+                              <include>hadoop-mapreduce-client-hs-${hadoop.version}.jar</include>
+                              <include>hadoop-mapreduce-client-jobclient-${hadoop.version}.jar</include>
+                              <include>hadoop-mapreduce-client-shuffle-${hadoop.version}.jar</include>
+                          </includes>
                         </source>
                       </sources>
                     </mapping>
@@ -287,6 +322,28 @@
                           <includes>
                             <include>phoenix*.jar</include>
                             <include>antlr*.jar</include>
+                            <include>re2j*.jar</include>
+                            <include>failureaccess*.jar</include>
+                            <include>guava-28*.jar</include>
+                            <include>stax2-api*.jar</include>
+                            <include>woodstox-core*.jar</include>
+                            <include>hadoop-annotations-${hadoop.version}.jar</include>
+                            <include>hadoop-auth-${hadoop.version}.jar</include>
+                            <include>hadoop-common-${hadoop.version}.jar</include>
+                            <include>hadoop-client-${hadoop.version}.jar</include>
+                            <include>hadoop-minicluster-${hadoop.version}.jar</include>
+                            <include>commons-configuration2-*.jar</include>
+                            <include>hadoop-yarn-api-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-client-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-common-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-registry-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-server-applicationhistoryservice-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-server-common-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-server-nodemanager-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-server-resourcemanager-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-server-timelineservice-${hadoop.version}.jar</include>
+                            <include>hadoop-yarn-server-web-proxy-${hadoop.version}.jar</include>
+                            <include>commons-beanutils-1.9.4.jar </include>
                           </includes>
                         </source>
                       </sources>
@@ -837,10 +894,40 @@
                 <data>
                   <src>${collector.dir}/target/embedded/${hbase.folder}</src>
                   <type>directory</type>
-                  <excludes>bin/**,bin/*,lib/*tests.jar</excludes>
+                  <excludes>bin/**,bin/*,lib/*tests.jar,lib/hadoop*jar,lib/guava-11.0.2.jar,lib/commons-beanutils-core-1.8.0.jar</excludes>
                   <mapper>
                     <type>perm</type>
                     <prefix>/usr/lib/ams-hbase</prefix>
+                    <filemode>644</filemode>
+                  </mapper>
+                </data>
+                <data>
+                  <src>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/hdfs</src>
+                  <type>directory</type>
+                  <includes>hadoop-hdfs-${hadoop.version}.jar,hadoop-hdfs-client-${hadoop.version}.jar</includes>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/usr/lib/ams-hbase/lib</prefix>
+                    <filemode>644</filemode>
+                  </mapper>
+                </data>
+                <data>
+                  <src>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/tools/lib</src>
+                  <type>directory</type>
+                  <includes>hadoop-aws*.jar,hadoop-distcp-*.jar</includes>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/usr/lib/ams-hbase/lib</prefix>
+                    <filemode>644</filemode>
+                  </mapper>
+                </data>
+                <data>
+                  <src>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/mapreduce</src>
+                  <type>directory</type>
+                  <includes>hadoop-mapreduce-client-app-${hadoop.version}.jar,hadoop-mapreduce-client-common-${hadoop.version}.jar,hadoop-mapreduce-client-core-${hadoop.version}.jar,hadoop-mapreduce-client-hs-${hadoop.version}.jar,hadoop-mapreduce-client-jobclient-${hadoop.version}.jar,hadoop-mapreduce-client-shuffle-${hadoop.version}.jar</includes>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/usr/lib/ams-hbase/lib</prefix>
                     <filemode>644</filemode>
                   </mapper>
                 </data>
@@ -865,7 +952,7 @@
                 <data>
                   <src>${collector.dir}/target/lib</src>
                   <type>directory</type>
-                  <includes>phoenix*.jar,antlr*.jar</includes>
+                  <includes>phoenix*.jar,antlr*.jar,re2j*.jar,failureaccess*.jar,guava-28*.jar,stax2-api*.jar,woodstox-core*.jar,hadoop-annotations*.jar,hadoop-auth*.jar,hadoop-common*.jar,hadoop-client*.jar,hadoop-minicluster*.jar,commons-configuration2*.jar,hadoop-yarn-api-*.jar,hadoop-yarn-client-*.jar,hadoop-yarn-common-*.jar,hadoop-yarn-registry-*.jar,hadoop-yarn-server-applicationhistoryservice-*.jar,hadoop-yarn-server-common-*.jar,hadoop-yarn-server-nodemanager-*.jar,hadoop-yarn-server-resourcemanager-*.jar,hadoop-yarn-server-timelineservice-*.jar,hadoop-yarn-server-web-proxy-*.jar,commons-beanutils-1.9*.jar</includes>
                   <mapper>
                     <type>perm</type>
                     <filemode>644</filemode>

--- a/ambari-metrics/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics/ambari-metrics-assembly/pom.xml
@@ -266,6 +266,7 @@
                             <exclude>lib/*tests.jar</exclude>
                             <exclude>lib/findbugs*.jar</exclude>
                             <exclude>lib/jdk.tools*.jar</exclude>
+                            <!-- hadoop, guava and commons-beanutils are excluded because they will be replaced with different versions -->
                             <exclude>lib/hadoop*.jar</exclude>
                             <exclude>lib/guava-11.0.2.jar</exclude>
                             <exclude>lib/commons-beanutils-core-1.8.0.jar</exclude>
@@ -283,6 +284,12 @@
                           <includes>
                             <include>hadoop-hdfs-${hadoop.version}.jar</include>
                             <include>hadoop-hdfs-client-${hadoop.version}.jar</include>
+                          </includes>
+                        </source>
+                        <source>
+                          <location>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/common/lib</location>
+                          <includes>
+                            <include>commons-beanutils-*.jar</include>
                           </includes>
                         </source>
                         <source>
@@ -330,8 +337,6 @@
                             <include>hadoop-annotations-${hadoop.version}.jar</include>
                             <include>hadoop-auth-${hadoop.version}.jar</include>
                             <include>hadoop-common-${hadoop.version}.jar</include>
-                            <include>hadoop-client-${hadoop.version}.jar</include>
-                            <include>hadoop-minicluster-${hadoop.version}.jar</include>
                             <include>commons-configuration2-*.jar</include>
                             <include>hadoop-yarn-api-${hadoop.version}.jar</include>
                             <include>hadoop-yarn-client-${hadoop.version}.jar</include>
@@ -343,7 +348,6 @@
                             <include>hadoop-yarn-server-resourcemanager-${hadoop.version}.jar</include>
                             <include>hadoop-yarn-server-timelineservice-${hadoop.version}.jar</include>
                             <include>hadoop-yarn-server-web-proxy-${hadoop.version}.jar</include>
-                            <include>commons-beanutils-1.9.4.jar </include>
                           </includes>
                         </source>
                       </sources>
@@ -894,6 +898,7 @@
                 <data>
                   <src>${collector.dir}/target/embedded/${hbase.folder}</src>
                   <type>directory</type>
+                   <!-- hadoop, guava and commons-beanutils are excluded because they will be replaced with different versions -->
                   <excludes>bin/**,bin/*,lib/*tests.jar,lib/hadoop*jar,lib/guava-11.0.2.jar,lib/commons-beanutils-core-1.8.0.jar</excludes>
                   <mapper>
                     <type>perm</type>
@@ -905,6 +910,16 @@
                   <src>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/hdfs</src>
                   <type>directory</type>
                   <includes>hadoop-hdfs-${hadoop.version}.jar,hadoop-hdfs-client-${hadoop.version}.jar</includes>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/usr/lib/ams-hbase/lib</prefix>
+                    <filemode>644</filemode>
+                  </mapper>
+                </data>
+  		          <data>
+                  <src>${project.build.directory}/embedded/${hadoop.folder}/share/hadoop/common/lib</src>
+                  <type>directory</type>
+                  <includes>commons-beanutils-*.jar</includes>
                   <mapper>
                     <type>perm</type>
                     <prefix>/usr/lib/ams-hbase/lib</prefix>
@@ -952,7 +967,7 @@
                 <data>
                   <src>${collector.dir}/target/lib</src>
                   <type>directory</type>
-                  <includes>phoenix*.jar,antlr*.jar,re2j*.jar,failureaccess*.jar,guava-28*.jar,stax2-api*.jar,woodstox-core*.jar,hadoop-annotations*.jar,hadoop-auth*.jar,hadoop-common*.jar,hadoop-client*.jar,hadoop-minicluster*.jar,commons-configuration2*.jar,hadoop-yarn-api-*.jar,hadoop-yarn-client-*.jar,hadoop-yarn-common-*.jar,hadoop-yarn-registry-*.jar,hadoop-yarn-server-applicationhistoryservice-*.jar,hadoop-yarn-server-common-*.jar,hadoop-yarn-server-nodemanager-*.jar,hadoop-yarn-server-resourcemanager-*.jar,hadoop-yarn-server-timelineservice-*.jar,hadoop-yarn-server-web-proxy-*.jar,commons-beanutils-1.9*.jar</includes>
+                  <includes>phoenix*.jar,antlr*.jar,re2j*.jar,failureaccess*.jar,guava-28*.jar,stax2-api*.jar,woodstox-core*.jar,hadoop-annotations*.jar,hadoop-auth*.jar,hadoop-common*.jar,commons-configuration2*.jar,hadoop-yarn-api-*.jar,hadoop-yarn-client-*.jar,hadoop-yarn-common-*.jar,hadoop-yarn-registry-*.jar,hadoop-yarn-server-applicationhistoryservice-*.jar,hadoop-yarn-server-common-*.jar,hadoop-yarn-server-nodemanager-*.jar,hadoop-yarn-server-resourcemanager-*.jar,hadoop-yarn-server-timelineservice-*.jar,hadoop-yarn-server-web-proxy-*.jar</includes>
                   <mapper>
                     <type>perm</type>
                     <filemode>644</filemode>

--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -738,24 +738,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-minicluster</artifactId>
-      <version>${hadoop.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <version>${hadoop.version}</version>
-    </dependency>
-
-    <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
-    </dependency>
-
     <!-- for unit tests only -->
     <dependency>
       <groupId>org.apache.phoenix</groupId>

--- a/ambari-metrics/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics/ambari-metrics-timelineservice/pom.xml
@@ -34,7 +34,6 @@
     <!-- Needed for generating FindBugs warnings using parent pom -->
     <!--<yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>-->
     <protobuf.version>2.5.0</protobuf.version>
-    <hadoop.version>3.1.1</hadoop.version>
     <phoenix.version>5.0.0-HBase-2.0</phoenix.version>
     <hbase.version>2.0.2</hbase.version>
   </properties>
@@ -738,6 +737,25 @@
       <version>3.2</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.4</version>
+    </dependency>
+
     <!-- for unit tests only -->
     <dependency>
       <groupId>org.apache.phoenix</groupId>

--- a/ambari-metrics/pom.xml
+++ b/ambari-metrics/pom.xml
@@ -44,6 +44,7 @@
     <hbase.folder>hbase-2.0.2</hbase.folder>
     <hadoop.tar>https://archive.apache.org/dist/hadoop/common/hadoop-3.1.1/hadoop-3.1.1.tar.gz</hadoop.tar>
     <hadoop.folder>hadoop-3.1.1</hadoop.folder>
+    <hadoop.version>3.1.1</hadoop.version>
     <grafana.folder>grafana-6.7.4</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-6.7.4.linux-amd64.tar.gz</grafana.tar>
     <phoenix.tar>https://downloads.apache.org/phoenix/apache-phoenix-5.0.0-HBase-2.0/bin/apache-phoenix-5.0.0-HBase-2.0-bin.tar.gz</phoenix.tar>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since the non managed HDP tarballs are not accessible anymore publicly AMBARI-25599 was an attempt to replace those dependencies of Ambari Metrics with the open source versions. After AMBARI-25599 the Apache version of HBase (  https://archive.apache.org/dist/hbase/2.0.2/hbase-2.0.2-bin.tar.gz  ) does not starting up and failing with:

```
[root@c7401 ambari-metrics-collector]# less hbase-ams-master-c7401.ambari.apache.org.log
2021-02-10 08:19:01,953 ERROR [main] master.HMasterCommandLine: Master exiting
 java.lang.NoClassDefFoundError: org/apache/commons/configuration/Configuration
 at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.<init>(DefaultMetricsSystem.java:38)
 at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.<clinit>(DefaultMetricsSystem.java:36)
 at org.apache.hadoop.hbase.master.HMasterCommandLine.startMaster(HMasterCommandLine.java:159)
 at org.apache.hadoop.hbase.master.HMasterCommandLine.run(HMasterCommandLine.java:140)
 at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
 at org.apache.hadoop.hbase.util.ServerCommandLine.doMain(ServerCommandLine.java:149)
 at org.apache.hadoop.hbase.master.HMaster.main(HMaster.java:2964)
 Caused by: java.lang.ClassNotFoundException: org.apache.commons.configuration.Configuration
```
This error was caused by the lack of a few jar files.

This modification includes copying the missing jar files to the proper location. After this modification the Ambari metrics can start if the Metrics Service operation mode is embedded.

## How was this patch tested?
Manual tests