### PR TITLE
[AMBARI-25671] Moved cache deletion at the end  in delete flow

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/cluster/ClustersImpl.java
@@ -776,9 +776,6 @@ public class ClustersImpl implements Clusters {
       }
 
       unmapHostClusterEntities(hostname, cluster.getClusterId());
-
-      getHostClustersMap().get(hostname).remove(cluster);
-      getClusterHostsMap().get(cluster.getClusterName()).remove(host);
     }
 
     deleteConfigGroupHostMapping(hostEntity.getHostId());
@@ -827,7 +824,8 @@ public class ClustersImpl implements Clusters {
       throw new HostNotFoundException(hostname);
     }
 
-    deleteHostEntityRelationships(hostname);
+    Host host = deleteHostEntityRelationships(hostname);
+    deleteHostFromMap(host);
   }
 
   @Override
@@ -848,7 +846,7 @@ public class ClustersImpl implements Clusters {
    * @throws AmbariException
    */
   @Transactional
-  void deleteHostEntityRelationships(String hostname) throws AmbariException {
+  Host deleteHostEntityRelationships(String hostname) throws AmbariException {
     if (!getHostsByName().containsKey(hostname)) {
       throw new HostNotFoundException("Could not find host " + hostname);
     }
@@ -856,7 +854,7 @@ public class ClustersImpl implements Clusters {
     HostEntity entity = hostDAO.findByName(hostname);
 
     if (entity == null) {
-      return;
+      return null;
     }
 
     // Remove from all clusters in the cluster_host_mapping table.
@@ -901,10 +899,25 @@ public class ClustersImpl implements Clusters {
     getHostsById().remove(entity.getHostId());
 
     hostDAO.remove(entity);
-
+    return host;
     // Note, if the host is still heartbeating, then new records will be
     // re-inserted
     // into the hosts and hoststate tables
+  }
+
+  public void deleteHostFromMap(Host host) throws AmbariException {
+    // Remove from dictionaries
+    Long hostId = host.getHostId();
+    String hostname = host.getHostName();
+    Set<Cluster> clusters = getHostClustersMap().get(hostname);
+    for (Cluster cluster : clusters) {
+      LOG.info("Deleting cache for cluster: {} and hostName: {}", cluster.getClusterName(), hostname);
+      getHostClustersMap().get(hostname).remove(cluster);
+      getClusterHostsMap().get(cluster.getClusterName()).remove(host);
+    }
+    getHostsByName().remove(hostname);
+    getHostsById().remove(hostId);
+    LOG.info("Deleted Host From Map for hostName: {}, hostId: {}", hostname, hostId);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
According to current delete flow, we are deleting the cache data first and then deleting data from db. But if due to anycase like Rollback exceptions , we delete the data from cache but data in DB is rollbacked. Due to this when again we try to delete the host data, it throws hostNotFound since it takes this check from cache given below.
 
Set<Cluster> clusters = getHostClustersMap().get(hostname);
    if (clusters == null) {
      throw new HostNotFoundException(hostname);
    }
 
if (!getHostsByName().containsKey(hostname)) { throw new HostNotFoundException("Could not find host " + hostname); }
    
So even though data is not actually deleted from DB , we still wont delete from DB because of this. The current  way is to restart ambari server which fills up the cache again and then it works fine, but until that, we wont be able to delete anything for this hostName.


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.