### PR TITLE
Fix import order. Fixes Checkstyle error at build time

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java
@@ -20,6 +20,8 @@ package org.apache.ambari.server.orm.entities;
 
 import static org.apache.commons.lang.StringUtils.defaultString;
 
+import java.util.Objects;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -32,8 +34,6 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 
 import org.apache.ambari.server.state.HostState;
-
-import java.util.Objects;
 
 @javax.persistence.Table(name = "hoststate")
 @Entity


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changes the order of imports in a .java file.
Currently the build breaks with:

```
INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ ambari-server ---
[INFO] Starting audit...
[ERROR] /home/ubuntu/git/apache/ambari/ambari-server/src/main/java/org/apache/ambari/server/orm/entities/HostStateEntity.java:36: Wrong order for 'java.util.Objects' import. [ImportOrder]
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Ambari Admin View 3.0.0.0-SNAPSHOT ................. SUCCESS [  8.914 s]
[INFO] ambari-utility 3.0.0.0-SNAPSHOT .................... SUCCESS [01:28 min]
[INFO] Ambari Server SPI 3.0.0.0-SNAPSHOT ................. SUCCESS [  5.731 s]
[INFO] Ambari Service Advisor 1.0.0.0-SNAPSHOT ............ SUCCESS [  3.070 s]
[INFO] Ambari Server 3.0.0.0-SNAPSHOT ..................... FAILURE [13:54 min]
[INFO] Ambari Functional Tests 3.0.0.0-SNAPSHOT ........... SKIPPED
[INFO] Ambari Agent 3.0.0.0-SNAPSHOT ...................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15:40 min
[INFO] Finished at: 2021-05-13T08:59:12+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (checkstyle) on project ambari-server: Failed during checkstyle execution: There is 1 error reported by Checkstyle 8.9 with /home/ubuntu/git/apache/ambari/ambari-server/checkstyle.xml ruleset. -> [Help 1]
[ERROR] 
```

## How was this patch tested?

The build passed after this change.