### PR TITLE
AMBARI-25607 AMBARI-20534 Update frontend-maven-plugin to 1.12.0

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -60,8 +60,9 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.3</version>
+        <version>${frontend-maven-plugin.version}</version>
         <configuration>
+          <skip>${ambari.web.skip}</skip>
           <nodeVersion>v4.5.0</nodeVersion>
           <npmVersion>2.15.0</npmVersion>
           <workingDirectory>src/main/resources/ui/admin-web/</workingDirectory>
@@ -142,6 +143,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <workingDirectory>${basedir}/src/main/resources/ui/admin-web</workingDirectory>
               <executable>npm</executable>
               <arguments>

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -89,8 +89,9 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
+                    <skip>${ambari.web.skip}</skip>
                     <nodeVersion>v4.5.0</nodeVersion>
                     <yarnVersion>v0.23.2</yarnVersion>
                     <workingDirectory>${basedir}</workingDirectory>
@@ -162,6 +163,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <workingDirectory>${basedir}</workingDirectory>
                             <executable>${basedir}/node/${node.executable}</executable>
                             <arguments>
@@ -177,6 +179,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <!-- sets Ambari version to make it accessible from code -->
                             <executable>${executable.shell}</executable>
                             <workingDirectory>${basedir}</workingDirectory>
@@ -236,6 +239,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <tasks>
                                 <apply executable="${executable.gzip}">
                                     <arg value="-f"/>

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -219,7 +219,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipTests}</skip>
+                            <skip>${ambari.web.skip}</skip>
                             <executable>${executable.npm}</executable>
                             <workingDirectory>${basedir}</workingDirectory>
                             <commandlineArgs>${args.npm} test</commandlineArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,8 @@
     <deb.priority>extra</deb.priority>
     <stack.distribution>HDP</stack.distribution>
     <ambari.dir>${project.basedir}</ambari.dir>
+    <ambari.web.skip>false</ambari.web.skip>
+    <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <deb.priority>extra</deb.priority>
     <stack.distribution>HDP</stack.distribution>
     <ambari.dir>${project.basedir}</ambari.dir>
-    <ambari.web.skip>false</ambari.web.skip>
+    <ambari.web.skip>${skipTests}</ambari.web.skip>
     <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
@@ -567,6 +567,18 @@
         <module>ambari-serviceadvisor</module>
         <module>ambari-utility</module>
         </modules>
+    </profile>
+    <profile>
+      <id>non-x86_64</id>
+      <activation>
+        <os>
+          <arch>!amd64</arch>
+        </os>
+      </activation>
+      <properties>
+        <!-- AMBARI-25607 Do not build frontend for non-x86_64 because there is no PhantomJS for other architectures -->
+        <ambari.web.skip>true</ambari.web.skip>
+      </properties>
     </profile>
     <profile>
       <id>ambari-serviceadvisor</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce a system property (ambari.web.skip) that could be used to skip the build of frontend artefacts. The build on Linux ARM64 fails because there is no ARM64 binary for PhantomJS

## How was this patch tested?

The build does not fail now on Linux ARM64 due to the web tests.