### PR TITLE
AMBARI-25607. Disable UI tests with system property

### DIFF
--- a/ambari-admin/pom.xml
+++ b/ambari-admin/pom.xml
@@ -61,8 +61,9 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.4</version>
+        <version>${frontend-maven-plugin.version}</version>
         <configuration>
+          <skip>${ambari.web.skip}</skip>
           <nodeVersion>v4.5.0</nodeVersion>
           <yarnVersion>v0.23.2</yarnVersion>
           <workingDirectory>src/main/resources/ui/admin-web/</workingDirectory>
@@ -104,6 +105,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <workingDirectory>${basedir}/src/main/resources/ui/admin-web</workingDirectory>
               <executable>${basedir}/src/main/resources/ui/admin-web/node/${executable.node}</executable>
               <arguments>
@@ -120,6 +122,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <workingDirectory>${basedir}/src/main/resources/ui/admin-web</workingDirectory>
               <executable>${basedir}/src/main/resources/ui/admin-web/node/${executable.node}</executable>
               <arguments>
@@ -135,6 +138,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <!-- sets Ambari version to make it accessible from code -->
               <executable>${executable.shell}</executable>
               <workingDirectory>${basedir}</workingDirectory>
@@ -149,6 +153,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <workingDirectory>${basedir}/src/main/resources/ui/admin-web</workingDirectory>
               <executable>npm</executable>
               <arguments>

--- a/ambari-logsearch/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-server/pom.xml
@@ -124,6 +124,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.7</version>
+            <configuration>
+              <skip>${ambari.web.skip}</skip>
+            </configuration>
             <executions>
               <execution>
                 <phase>package</phase>

--- a/ambari-logsearch/ambari-logsearch-web/pom.xml
+++ b/ambari-logsearch/ambari-logsearch-web/pom.xml
@@ -38,8 +38,9 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.6</version>
+        <version>${frontend-maven-plugin.version}</version>
         <configuration>
+          <skip>${ambari.web.skip}</skip>
           <nodeVersion>${node.version}</nodeVersion>
           <yarnVersion>${yarn.version}</yarnVersion>
           <workingDirectory>${project.build.directory}/webapp-build</workingDirectory>
@@ -57,6 +58,9 @@
             <goals>
               <goal>install-node-and-yarn</goal>
             </goals>
+            <configuration>
+              <skip>${ambari.web.skip}</skip>
+            </configuration>
           </execution>
           <execution>
             <id>yarn install</id>
@@ -65,6 +69,7 @@
               <goal>yarn</goal>
             </goals>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <arguments>install --ignore-engines --pure-lockfile</arguments>
             </configuration>
           </execution>
@@ -76,6 +81,7 @@
             <!-- optional: the default phase is "generate-resources" -->
             <phase>generate-resources</phase>
             <configuration>
+              <skip>${ambari.web.skip}</skip>
               <environmentVariables>
                 <NODE_ENV>production</NODE_ENV>
               </environmentVariables>
@@ -91,8 +97,8 @@
             <goal>yarn</goal>
            </goals>
            <configuration>
+            <skip>${ambari.web.skip}</skip>
             <arguments>test</arguments>
-            <skip>${skipTests}</skip>
            </configuration>
           </execution>
         </executions>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -52,6 +52,8 @@
     <reuseForks>false</reuseForks>
     <surefire.argLine>-Xmx1024m -Xms512m</surefire.argLine>
     <skipSurefireTests>false</skipSurefireTests>
+    <ambari.web.skip>${skipTests}</ambari.web.skip>
+    <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
   </properties>
 
   <licenses>
@@ -371,4 +373,18 @@
     </dependencies>
   </dependencyManagement>
 
+  <profiles>
+    <profile>
+      <id>non-x86_64</id>
+      <activation>
+        <os>
+          <arch>!amd64</arch>
+        </os>
+      </activation>
+      <properties>
+        <!-- AMBARI-25607 Do not build frontend for non-x86_64 because there is no PhantomJS for other architectures -->
+        <ambari.web.skip>true</ambari.web.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <solr.version>5.5.2</solr.version>
     <ambari.dir>${project.parent.basedir}</ambari.dir>
+    <ambari.web.skip>${skipTests}</ambari.web.skip>
+    <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
     <powermock.version>1.6.3</powermock.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
@@ -83,6 +85,18 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>non-x86_64</id>
+      <activation>
+        <os>
+          <arch>!amd64</arch>
+        </os>
+      </activation>
+      <properties>
+        <!-- AMBARI-25607 Do not build frontend for non-x86_64 because there is no PhantomJS for other architectures -->
+        <ambari.web.skip>true</ambari.web.skip>
+      </properties>
     </profile>
   </profiles>
   <dependencyManagement>

--- a/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProviderTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/controller/internal/RootServiceComponentConfigurationResourceProviderTest.java
@@ -531,7 +531,7 @@ public class RootServiceComponentConfigurationResourceProviderTest extends EasyM
     expect(configuration.isMasterKeyPersisted()).andReturn(false).once();
     expect(configuration.getMasterKeyStoreLocation()).andReturn(masterKeyStoreLocation).once();
     CredentialProvider credentialProvider = PowerMock.createMock(CredentialProvider.class);
-    PowerMock.expectNew(CredentialProvider.class, null, null, masterKeyLocation, false, masterKeyStoreLocation, null).andReturn(credentialProvider);
+    PowerMock.expectNew(CredentialProvider.class, null, null, masterKeyLocation, false, masterKeyStoreLocation).andReturn(credentialProvider);
     credentialProvider.addAliasToCredentialStore("currentPasswd", "newPasswd");
     PowerMock.expectLastCall().once();
     PowerMock.replay(credentialProvider, CredentialProvider.class);

--- a/ambari-server/src/test/java/org/apache/ambari/server/utils/PasswordUtilsTest.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/utils/PasswordUtilsTest.java
@@ -124,7 +124,7 @@ public class PasswordUtilsTest extends EasyMockSupport {
     expect(configuration.getMasterKeyLocation()).andReturn(masterKeyLocation).once();
     expect(configuration.isMasterKeyPersisted()).andReturn(false).once();
     expect(configuration.getMasterKeyStoreLocation()).andReturn(masterKeyStoreLocation).once();
-    PowerMock.expectNew(CredentialProvider.class, null, null, masterKeyLocation, false, masterKeyStoreLocation, null).andReturn(credentialProvider);
+    PowerMock.expectNew(CredentialProvider.class, null, null, masterKeyLocation, false, masterKeyStoreLocation).andReturn(credentialProvider);
   }
 
   private Injector createInjector() {

--- a/ambari-web/pom.xml
+++ b/ambari-web/pom.xml
@@ -90,8 +90,9 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
+                    <skip>${ambari.web.skip}</skip>
                     <nodeVersion>v4.5.0</nodeVersion>
                     <yarnVersion>v0.23.2</yarnVersion>
                     <workingDirectory>${basedir}</workingDirectory>
@@ -109,6 +110,9 @@
                         <goals>
                             <goal>install-node-and-yarn</goal>
                         </goals>
+                        <configuration>
+                            <skip>${ambari.web.skip}</skip>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>yarn install</id>
@@ -117,6 +121,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <arguments>install --ignore-engines --pure-lockfile</arguments>
                         </configuration>
                     </execution>
@@ -134,6 +139,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <executable>${executable.rmdir}</executable>
                             <workingDirectory>${basedir}</workingDirectory>
                             <commandlineArgs>${args.rm.clean} public ${nodemodules.dir}</commandlineArgs>
@@ -151,6 +157,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <executable>${executable.mkdir}</executable>
                             <workingDirectory>${basedir}</workingDirectory>
                             <commandlineArgs>${args.mkdir} public</commandlineArgs>
@@ -163,6 +170,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <workingDirectory>${basedir}</workingDirectory>
                             <executable>${basedir}/node/${node.executable}</executable>
                             <arguments>
@@ -178,6 +186,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <!-- sets Ambari version to make it accessible from code -->
                             <executable>${executable.shell}</executable>
                             <workingDirectory>${basedir}</workingDirectory>
@@ -217,7 +226,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipTests}</skip>
+                            <skip>${ambari.web.skip}</skip>
                             <executable>${executable.npm}</executable>
                             <workingDirectory>${basedir}</workingDirectory>
                             <commandlineArgs>${args.npm} test</commandlineArgs>
@@ -237,6 +246,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${ambari.web.skip}</skip>
                             <tasks>
                                 <apply executable="${executable.gzip}">
                                     <arg value="-f"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Introduce a system property (ambari.web.skip) that could be used to skip the build of frontend artefacts. The build on Linux ARM64 fails because there is no ARM64 binary for PhantomJS.
* Updates frontend-maven-plugin to 1.12.0
* Fix two unit tests which were failing due to wrong number of parameters passed to PowerMock

## How was this patch tested?

The build does not fail now on Linux ARM64 due to the web tests.