### PR TITLE
Fixed session timeout websocket then jump to login page

### DIFF
--- a/ambari-web/app/utils/stomp_client.js
+++ b/ambari-web/app/utils/stomp_client.js
@@ -215,6 +215,9 @@ module.exports = Em.Object.extend({
       subscription.destination = destination;
       subscription.handlers = handlers;
       this.get('subscriptions')[destination] = subscription;
+      if(subscription.message && subscription.message === 'Session closed.'){
+        window.location.href = '#/login'
+      }
       return subscription;
     }
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

fixed session timeout then stop websocket request; jump to login page

## How was this patch tested?

After stopping on the homepage for one night, the browser page freezes