### PR TITLE
AMBARI-25695 Pull request tests fail due to Maven 3.8.x blocks http repositories (santal)

### DIFF
--- a/ambari-infra/pom.xml
+++ b/ambari-infra/pom.xml
@@ -87,6 +87,11 @@
         <enabled>false</enabled>
       </releases>
     </repository>
+    <repository>
+      <id>maven-restlet</id>
+      <name>Public online Restlet repository</name>
+      <url>https://maven.restlet.com</url>
+    </repository>
   </repositories>
 
   <modules>

--- a/ambari-logsearch/pom.xml
+++ b/ambari-logsearch/pom.xml
@@ -103,6 +103,11 @@
         <enabled>false</enabled>
       </releases>
     </repository>
+    <repository>
+      <id>maven-restlet</id>
+      <name>Public online Restlet repository</name>
+      <url>https://maven.restlet.com</url>
+    </repository>
   </repositories>
   <build>
     <pluginManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tests for ambari-infra and ambari-logsearch cannot be perfomed because the http repositories have been blocked since Maven 3.8.1.
command: 
`$ mvn -am test -Dmaven.artifact.threads=10 -Drat.skip`
output:
```
[INFO] Reactor Summary for ambari-infra 2.7.5.0.0:
[INFO] 
[INFO] ambari-infra ....................................... SUCCESS [  1.126 s]
[INFO] Ambari Infra Solr Client ........................... SUCCESS [  6.155 s]
[INFO] Ambari Infra Solr Plugin ........................... FAILURE [  0.585 s]
[INFO] Ambari Infra Manager ............................... SKIPPED
[INFO] Ambari Infra Assembly .............................. SKIPPED
[INFO] Ambari Infra Manager Integration Tests ............. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.192 s
[INFO] Finished at: 2021-10-29T07:58:03Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project ambari-infra-solr-plugin: Could not resolve dependencies for project org.apache.ambari:ambari-infra-solr-plugin:jar:2.7.5.0.0: Failed to collect dependencies at org.apache.solr:solr-core:jar:7.7.3 -> org.restlet.jee:org.restlet:jar:2.3.0: Failed to read artifact descriptor for org.restlet.jee:org.restlet:jar:2.3.0: Could not transfer artifact org.restlet.jee:org.restlet:pom:2.3.0 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [maven-restlet (http://maven.restlet.org, default, releases+snapshots)] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :ambari-infra-solr-plugin

```
 
## How was this patch tested?

manually tested

