### PR TITLE
AMBARI-25713 : Upgrade commons-io to 2.8.0 to resolve CVEs

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -123,7 +123,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade commons-io to 2.8.0 to resolve CVEs


## How was this patch tested?

Verified it was built ok. Started the server and installed a few services.