### PR TITLE
AMBARI-25719. Fail to enable kerberos due to NullPointerException and HostNotFoundException

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/events/publishers/AgentCommandsPublisher.java
@@ -120,7 +120,10 @@ public class AgentCommandsPublisher {
             populateExecutionCommandsClusters(executionCommandsClusters, hostId, ac, desiredConfigs);
           });
         }).get();
-      } catch (InterruptedException|ExecutionException ignored) {}
+      } catch (InterruptedException|ExecutionException e) {
+        LOG.error("Exception on sendAgentCommand", e);
+        throw new RuntimeException(e);
+      }
 
       try {
         threadPools.getAgentPublisherCommandsPool().submit(() -> {
@@ -132,7 +135,10 @@ public class AgentCommandsPublisher {
             ));
           });
         }).get();
-      } catch (InterruptedException|ExecutionException ignored) {}
+      } catch (InterruptedException|ExecutionException e) {
+        LOG.error("Exception on sendAgentCommand", e);
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosKeytabPrincipalDAO.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/orm/dao/KerberosKeytabPrincipalDAO.java
@@ -88,11 +88,15 @@ public class KerberosKeytabPrincipalDAO {
 
     Long hostId = hostEntity == null ? null : hostEntity.getHostId();
     // The DB requests should be avoided due to heavy impact on the performance
-    KerberosKeytabPrincipalEntity kkp = (keytabList == null)
+    KerberosKeytabPrincipalEntity kkp = (keytabList == null || keytabList.isEmpty())
       ? findByNaturalKey(hostId, kerberosKeytabEntity.getKeytabPath(), kerberosPrincipalEntity.getPrincipalName())
       : keytabList.stream()
       .filter(keytab ->
-        keytab.getHostId().equals(hostId)
+        keytab != null
+          && keytab.getHostId() != null
+          && keytab.getKeytabPath() != null
+          && keytab.getPrincipalName() != null
+          && keytab.getHostId().equals(hostId)
           && keytab.getKeytabPath().equals(kerberosKeytabEntity.getKeytabPath())
           && keytab.getPrincipalName().equals(kerberosPrincipalEntity.getPrincipalName())
       )

--- a/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/serveraction/kerberos/stageutils/KerberosKeytabController.java
@@ -311,15 +311,19 @@ public class KerberosKeytabController {
     Set<String> hosts = new HashSet<>(hostMap.keySet());
     Map<String, String> componentHosts = new HashMap<>();
 
-    hosts.add(StageUtils.getHostName());
-
-    for(String hostName: hosts) {
+    for (String hostName: hosts) {
       hostConfigurations.put(
         hostName,
         kerberosHelper.calculateConfigurations(cluster, hostName, kerberosDescriptor, userDescriptor,
           false,false, componentHosts, desiredConfigs)
       );
     }
+
+    // ambari-agent may not be installed on ambari-server. Add ambari-server after calculating configurations.
+    // If not, HostNotFoundException will raise
+    String ambariServerHostname = StageUtils.getHostName();
+    hosts.add(ambariServerHostname);
+
     for (String service: services) {
       kerberosHelper.getActiveIdentities(clusterName,null, service, null,true,
         hostConfigurations,kerberosDescriptor, desiredConfigs).values().forEach(serviceIdentities::addAll);

--- a/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/ConfigHelper.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 
 import org.apache.ambari.server.AmbariException;
 import org.apache.ambari.server.AmbariRuntimeException;
+import org.apache.ambari.server.HostNotFoundException;
 import org.apache.ambari.server.agent.stomp.AgentConfigsHolder;
 import org.apache.ambari.server.agent.stomp.MetadataHolder;
 import org.apache.ambari.server.agent.stomp.dto.ClusterConfigs;
@@ -188,8 +189,14 @@ public class ConfigHelper {
    */
   public Map<String, Map<String, String>> getEffectiveDesiredTags(Cluster cluster, String hostName,
       @Nullable Map<String, DesiredConfig> desiredConfigs) throws AmbariException {
-
-    Host host = (hostName == null) ? null : clusters.getHost(hostName);
+    Host host = null;
+    if (hostName != null) {
+      try {
+        host = clusters.getHost(hostName);
+      } catch (HostNotFoundException e) {
+        LOG.error("Cannot get desired config for unknown host {}", hostName, e);
+      }
+    }
     Map<String, HostConfig> desiredHostConfigs = (host == null) ? null
         : host.getDesiredHostConfigs(cluster, desiredConfigs);
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/utils/ThreadPools.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/utils/ThreadPools.java
@@ -98,7 +98,10 @@ public class ThreadPools {
       agentPublisherCommandsPool = new ForkJoinPool(
         configuration.getAgentCommandPublisherThreadPoolSize(),
         createNamedFactory(AGENT_COMMAND_PUBLISHER_POOL_NAME),
-        null,
+        (t, e) -> {
+          LOG.error("Unexpected exception in thread: " + t, e);
+          throw new RuntimeException(e);
+        },
         false
       );
     }
@@ -111,7 +114,10 @@ public class ThreadPools {
       defaultForkJoinPool = new ForkJoinPool(
         configuration.getDefaultForkJoinPoolSize(),
         createNamedFactory(DEFAULT_FORK_JOIN_POOL_NAME),
-        null,
+        (t, e) -> {
+          LOG.error("Unexpected exception in thread: " + t, e);
+          throw new RuntimeException(e);
+        },
         false
       );
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- fix bugs which raise NullPointerException and HostNotFoundException
- make a log on threads, propagate Exception and don't ignore it silently

On `KerberosKeytabPrincipalDAO#findOrCreate`, `keytabList` may not be null but empty list. It causes NullPointerException.

```
2022-08-20 05:42:47,840  WARN [Server Action Executor Worker 611] ServerActionExecutor:471 - Task #611 failed to complete execution due to thrown exception: java.lang.NullPointerException:null
java.lang.NullPointerException
	at org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO.lambda$findOrCreate$0(KerberosKeytabPrincipalDAO.java:95)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361)
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531)
	at org.apache.ambari.server.orm.dao.KerberosKeytabPrincipalDAO.findOrCreate(KerberosKeytabPrincipalDAO.java:99)
	at org.apache.ambari.server.controller.KerberosHelperImpl.lambda$null$3(KerberosHelperImpl.java:2050)
	at com.google.common.collect.AbstractMapBasedMultimap.lambda$null$2(AbstractMapBasedMultimap.java:1266)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at com.google.common.collect.AbstractMapBasedMultimap.lambda$forEach$3(AbstractMapBasedMultimap.java:1266)
	at java.util.HashMap.forEach(HashMap.java:1290)
	at com.google.common.collect.AbstractMapBasedMultimap.forEach(AbstractMapBasedMultimap.java:1265)
	at com.google.common.collect.ArrayListMultimap.forEach(ArrayListMultimap.java:61)
	at org.apache.ambari.server.controller.KerberosHelperImpl.lambda$createResolvedKeytab$4(KerberosHelperImpl.java:2048)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at org.apache.ambari.server.controller.KerberosHelperImpl.createResolvedKeytab(KerberosHelperImpl.java:2038)
	at org.apache.ambari.server.orm.AmbariJpaLocalTxnInterceptor.invoke(AmbariJpaLocalTxnInterceptor.java:128)
	at org.apache.ambari.server.serveraction.kerberos.AbstractPrepareKerberosServerAction.lambda$processServiceComponents$1(AbstractPrepareKerberosServerAction.java:221)
	at java.util.HashMap$Values.forEach(HashMap.java:982)
	at org.apache.ambari.server.serveraction.kerberos.AbstractPrepareKerberosServerAction.processServiceComponents(AbstractPrepareKerberosServerAction.java:221)
	at org.apache.ambari.server.serveraction.kerberos.AbstractPrepareKerberosServerAction.processServiceComponentHosts(AbstractPrepareKerberosServerAction.java:99)
	at org.apache.ambari.server.serveraction.kerberos.PrepareEnableKerberosServerAction.execute(PrepareEnableKerberosServerAction.java:111)
	at org.apache.ambari.server.serveraction.ServerActionExecutor$Worker.execute(ServerActionExecutor.java:550)
	at org.apache.ambari.server.serveraction.ServerActionExecutor$Worker.run(ServerActionExecutor.java:466)
	at java.lang.Thread.run(Thread.java:750)
```

---

![image](https://user-images.githubusercontent.com/12639125/186287431-c8bdf6d7-f6fe-4ccd-af83-0a1db783f9e6.png)
![image](https://user-images.githubusercontent.com/12639125/186287446-26201d49-081e-4aeb-853a-ccf5946e2b6b.png)


After fixing the NPE, `Test Kerberos Client` or `Distribute Keytabs` stage cannot proceed because of `HostNotFoundException`. It is hard to find because there is no log. Exceptions on threads are being ignored. I found the exception with jvm remote debug.

![image](https://user-images.githubusercontent.com/12639125/186287467-56acd99b-5346-4e10-98bd-204d5ed92bd2.png)

This bug may be related to optimization patch (AMBARI-25332, AMBARI-25630). This bug can be regenerate if you don't install ambari-agent on the same machine with ambari-server.


## How was this patch tested?

- manually tested with cluster made by docker compose
  - https://github.com/eubnara/dockerize-ambari

