### PR TITLE
AMBARI-25716 : Bump up Httpclient to 4.5.13 to resolve CVEs

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -133,7 +133,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.5</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jettison</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump up Httpclient to 4.5.13

## How was this patch tested?

Verified it was built ok. Started the server and installed a few services.