### PR TITLE
AMBARI-25733 Make JDK8 the minimum requirement

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -214,8 +214,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/ambari-funtest/pom.xml
+++ b/ambari-funtest/pom.xml
@@ -21,9 +21,6 @@
   <packaging>jar</packaging>
   <name>Ambari Functional Tests</name>
   <description>Ambari Functional Tests</description>
-  <properties>
-    <jdk.version>1.8</jdk.version>
-  </properties>
   <build>
     <plugins>
       <plugin>

--- a/ambari-server-spi/pom.xml
+++ b/ambari-server-spi/pom.xml
@@ -30,7 +30,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <xlint>none</xlint>
-    <jdk.version>1.8</jdk.version>
   </properties>
 
   <build>

--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -53,7 +53,6 @@
     <empty.dir>src/main/package</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
     <el.log>ALL</el.log> <!-- log level for EclipseLink eclipselink-staticweave-maven-plugin -->
     <xlint>none</xlint> <!-- passed to Java compiler -Xlint: flag -->
-    <jdk.version>1.8</jdk.version>
   </properties>
   <build>
     <plugins>

--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -105,7 +105,7 @@
         <version>3.2</version>
         <configuration>
           <source>${jdk.version}</source>
-          <target>1.7</target>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/ambari-serviceadvisor/pom.xml
+++ b/ambari-serviceadvisor/pom.xml
@@ -104,7 +104,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
+          <source>${jdk.version}</source>
           <target>1.7</target>
         </configuration>
       </plugin>

--- a/ambari-utility/pom.xml
+++ b/ambari-utility/pom.xml
@@ -139,8 +139,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>

--- a/contrib/views/pig/pom.xml
+++ b/contrib/views/pig/pom.xml
@@ -295,8 +295,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/contrib/views/wfmanager/pom.xml
+++ b/contrib/views/wfmanager/pom.xml
@@ -224,8 +224,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/contrib/views/wfmanager/src/main/resources/ui/pom.xml
+++ b/contrib/views/wfmanager/src/main/resources/ui/pom.xml
@@ -104,8 +104,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <revision>3.0.0.0-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <clover.license>${user.home}/clover.license</clover.license>
+    <jdk.version>1.8</jdk.version>
     <buildnumber-maven-plugin-version>1.2</buildnumber-maven-plugin-version>
     <deb.publisher>Hortonworks</deb.publisher>
     <deb.section>universe/admin</deb.section>
@@ -225,8 +226,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Force JDK8 syntax and produce JDK8 classes.

## How was this patch tested?

existing unit tests.