### PR TITLE
AMBARI-25735: Fix build failure on Ambari Agent due to maven-shade-plugin version

### DIFF
--- a/ambari-agent/pom.xml
+++ b/ambari-agent/pom.xml
@@ -439,7 +439,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>shade-zkmigrator</id>

--- a/contrib/fast-hdfs-resource/pom.xml
+++ b/contrib/fast-hdfs-resource/pom.xml
@@ -90,7 +90,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
AMBARI-25735: Fix build failure on Ambari Agent due to maven-shade-plugin version

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.