### PR TITLE
AMBARI-25736: Fix BIGTOP stack_advisor Invalid

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/stack_advisor.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/stack_advisor.py
@@ -29,19 +29,19 @@ from resource_management.libraries.functions.mounted_dirs_helper import get_moun
 from stack_advisor import DefaultStackAdvisor
 
 
-class BIGTOP32StackAdvisor(DefaultStackAdvisor):
+class BIGTOP320StackAdvisor(DefaultStackAdvisor):
 
   def __init__(self):
-    super(BIGTOP32StackAdvisor, self).__init__()
-    self.initialize_logger("BIGTOP32StackAdvisor")
+    super(BIGTOP320StackAdvisor, self).__init__()
+    self.initialize_logger("BIGTOP320StackAdvisor")
 
   def getComponentLayoutValidations(self, services, hosts):
     """Returns array of Validation objects about issues with hostnames components assigned to"""
-    items = super(BIGTOP32StackAdvisor, self).getComponentLayoutValidations(services, hosts)
+    items = super(BIGTOP320StackAdvisor, self).getComponentLayoutValidations(services, hosts)
 
     # Validating NAMENODE and SECONDARY_NAMENODE are on different hosts if possible
     # Use a set for fast lookup
-    hostsSet =  set(super(BIGTOP32StackAdvisor, self).getActiveHosts([host["Hosts"] for host in hosts["items"]]))  #[host["Hosts"]["host_name"] for host in hosts["items"]]
+    hostsSet =  set(super(BIGTOP320StackAdvisor, self).getActiveHosts([host["Hosts"] for host in hosts["items"]]))  #[host["Hosts"]["host_name"] for host in hosts["items"]]
     hostsCount = len(hostsSet)
 
     componentsListList = [service["components"] for service in services["services"]]


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fix stack_advisor.py in BIGTOP stack

## How was this patch tested?
![BIGTOP_stack_advisor_20220925174912](https://user-images.githubusercontent.com/16263438/192137682-9e2fa382-81eb-47df-98e7-4adf14ca5efd.png)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.