### PR TITLE
AMBARI-25740: Fails to enable NameNode HA 

### DIFF
--- a/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
+++ b/ambari-web/app/controllers/main/admin/highAvailability/nameNode/step7_controller.js
@@ -32,11 +32,11 @@ App.HighAvailabilityWizardStep7Controller = App.HighAvailabilityProgressPageCont
       tasksToRemove.push('startAmbariInfra');
     }
 
-    if (App.ClientComponent.getModelByComponentName('RANGER_ADMIN').get('installedCount') === 0) {
+    if (App.ClientComponent.getModelByComponentName('RANGER_ADMIN') == null || App.ClientComponent.getModelByComponentName('RANGER_ADMIN').get('installedCount') === 0) {
       tasksToRemove.push('startRanger');
     }
 
-    if (App.ClientComponent.getModelByComponentName('MYSQL_SERVER').get('installedCount') === 0) {
+    if (App.ClientComponent.getModelByComponentName('MYSQL_SERVER') == null || App.ClientComponent.getModelByComponentName('MYSQL_SERVER').get('installedCount') === 0) {
       tasksToRemove.push('startMysqlServer');
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

NameNode HA wizard runs into an error in BIGTOP 3.2.0 cluster
The reason is that BIGTOP lacks relevant components.
![17c450b9e37b57760e89ada2afcc834](https://user-images.githubusercontent.com/13212217/192266186-6402ebc2-7170-419f-b3ee-cb4782aef596.jpg)


## How was this patch tested?
Tested in local vm cluster.
NameNode HA now can be enabled step by step smoothly.

![0fa7a96eaf5a8fb9d4030bc7f16c858](https://user-images.githubusercontent.com/13212217/192267226-e47d3f1c-cf4a-41be-973d-281ec1b44fff.jpg)

![83d19b332e3a539949b01ea2343b52d](https://user-images.githubusercontent.com/13212217/192267954-e8196953-dd43-4851-b468-137909b43afe.jpg)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.