### PR TITLE
AMBARI-25742: [BIGTOP]Hosts in Step 2 of ResourceManager HA Wizard Ca…

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/metainfo.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/YARN/metainfo.xml
@@ -30,7 +30,7 @@
           <name>RESOURCEMANAGER</name>
           <displayName>ResourceManager</displayName>
           <category>MASTER</category>
-          <cardinality>1</cardinality>
+          <cardinality>1-2</cardinality>
           <versionAdvertised>true</versionAdvertised>
           <reassignAllowed>true</reassignAllowed>
           <commandScript>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the issue when enabling ResourceManager HA in BigTop 3.2 cluster. 

In step 2 of ResourceManager HA wizard, if you select any other host as additional ResourceManager node in dropdown box, you will find that selected two hosts in dropdown box cannot be displayed correctly in right text area

![image](https://user-images.githubusercontent.com/13212217/192745977-8aeff6f5-1f16-450b-b72a-c11f80fd957f.png)

## How was this patch tested?
Tested in local vm cluster.
After applying this patch, this issue is fixed.

![image](https://user-images.githubusercontent.com/13212217/192745946-f56333b8-cdb9-4a05-9ed5-ba9e935bc6d6.png)


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.