### PR TITLE
AMBARI-25746: fix the question of dev-support build docker containers

### DIFF
--- a/dev-support/docker/centos7/Dockerfile
+++ b/dev-support/docker/centos7/Dockerfile
@@ -17,7 +17,7 @@ FROM centos:7
 
 RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools chrony krb5-server krb5-libs krb5-workstation git rpm-build
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -O /usr/share/java/mysql-connector-java.jar
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven.tar.gz \
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven.tar.gz --no-check-certificate \
   && mkdir -p /usr/share/maven && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

--- a/dev-support/docker/centos7/Dockerfile
+++ b/dev-support/docker/centos7/Dockerfile
@@ -15,8 +15,12 @@
 
 FROM centos:7
 
-RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools chrony krb5-server krb5-libs krb5-workstation
+RUN yum -y install sudo wget openssh-clients openssh-server vim mariadb mariadb-server java-1.8.0-openjdk* net-tools chrony krb5-server krb5-libs krb5-workstation git rpm-build
 RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -O /usr/share/java/mysql-connector-java.jar
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -O /tmp/apache-maven.tar.gz \
+  && mkdir -p /usr/share/maven && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
 RUN /bin/sed -i 's,#   StrictHostKeyChecking ask,StrictHostKeyChecking no,g' /etc/ssh/ssh_config
 

--- a/dev-support/docker/centos7/README.md
+++ b/dev-support/docker/centos7/README.md
@@ -12,11 +12,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-1、Build image ambari/develop:trunk-centos-7(build-image.sh)
-2、Build containers for cluster env(build-containers.sh)
-3、Clear containers after tests done(clear-containers.sh)
-4、Ambari UI、Ambari Server Debug Port、MariaDB Server are also exposed to local ports: 8080、5005、3306
-5、Docker host names are: ambari-server、ambari-agent-01、ambari-agent-02
-6、Extra configurations are in `build-containers.sh` last few lines, eg. Kerberos Configuration、Hive DB Configuration
-7、Re-build Ambari without re-creating clusters when code updates(build-ambari.sh)
-8、Distribute stack scripts without re-creating clusters(distribute-scripts.sh)
+1. Build image ambari/develop:trunk-centos-7(build-image.sh)
+2. Build containers for cluster env(build-containers.sh)
+3. Clear containers after tests done(clear-containers.sh)
+4. Ambari UI、Ambari Server Debug Port、MariaDB Server are also exposed to local ports: 8080、5005、3306 
+5. Docker host names are: ambari-server、ambari-agent-01、ambari-agent-02 
+6. Extra configurations are in `build-containers.sh` last few lines, eg. Kerberos Configuration、Hive DB Configuration 
+7. Re-build Ambari without re-creating clusters when code updates(build-ambari.sh)
+8. Distribute stack scripts without re-creating clusters(distribute-scripts.sh)

--- a/dev-support/docker/centos7/README.md
+++ b/dev-support/docker/centos7/README.md
@@ -12,11 +12,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-1. Build image ambari/develop:trunk-centos-7(build-image.sh)
-2. Build containers for cluster env(build-containers.sh)
-3. Clear containers after tests done(clear-containers.sh)
-4. Ambari UI、Ambari Server Debug Port、MariaDB Server are also exposed to local ports: 8080、5005、3306 
-5. Docker host names are: ambari-server、ambari-agent-01、ambari-agent-02 
-6. Extra configurations are in `build-containers.sh` last few lines, eg. Kerberos Configuration、Hive DB Configuration 
-7. Re-build Ambari without re-creating clusters when code updates(build-ambari.sh)
-8. Distribute stack scripts without re-creating clusters(distribute-scripts.sh)
+1、Build image ambari/develop:trunk-centos-7(build-image.sh)
+2、Build containers for cluster env(build-containers.sh)
+3、Clear containers after tests done(clear-containers.sh)
+4、Ambari UI、Ambari Server Debug Port、MariaDB Server are also exposed to local ports: 8080、5005、3306
+5、Docker host names are: ambari-server、ambari-agent-01、ambari-agent-02
+6、Extra configurations are in `build-containers.sh` last few lines, eg. Kerberos Configuration、Hive DB Configuration
+7、Re-build Ambari without re-creating clusters when code updates(build-ambari.sh)
+8、Distribute stack scripts without re-creating clusters(distribute-scripts.sh)

--- a/dev-support/docker/centos7/build-ambari.sh
+++ b/dev-support/docker/centos7/build-ambari.sh
@@ -15,15 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo -e "\033[32mCompiling ambari\033[0m"
+echo -e "\033[32mStarting container ambari-rpm-build\033[0m"
 if [[ -z $(docker ps -a --format "table {{.Names}}" | grep "ambari-rpm-build") ]];then
-  docker run -it --name ambari-rpm-build --privileged=true -e "container=docker" \
+  docker run -it -d --name ambari-rpm-build --privileged=true -e "container=docker" \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD/../../../:/opt/ambari/ \
     -w /opt/ambari \
-    ambari/develop:trunk-centos-7 bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+    ambari/develop:trunk-centos-7
 else
-  docker start -i ambari-rpm-build
+  docker start ambari-rpm-build
 fi
+
+echo -e "\033[32mCompiling ambari\033[0m"
+docker exec ambari-rpm-build bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+docker stop ambari-rpm-build
 
 echo -e "\033[32mRestarting ambari-server\033[0m"
 docker exec ambari-server bash -c "ambari-server stop"

--- a/dev-support/docker/centos7/build-ambari.sh
+++ b/dev-support/docker/centos7/build-ambari.sh
@@ -16,11 +16,8 @@
 # limitations under the License.
 
 echo -e "\033[32mStarting container ambari-rpm-build\033[0m"
-if [[ -z $(docker ps -a --format "table {{.Names}}" | grep "ambari-rpm-build") ]];then
-  docker run -it -d --name ambari-rpm-build --privileged=true -e "container=docker" \
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD/../../../:/opt/ambari/ \
-    -w /opt/ambari \
-    ambari/develop:trunk-centos-7
+if [ `docker inspect --format '{{.State.Running}}' ambari-rpm-build` == true ];then
+  docker exec ambari-rpm-build bash -c "pkill -KILL -f maven"
 else
   docker start ambari-rpm-build
 fi

--- a/dev-support/docker/centos7/build-containers.sh
+++ b/dev-support/docker/centos7/build-containers.sh
@@ -15,16 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo -e "\033[32mInstall mvn\033[0m"
-if [ ! "$(command -v mvn)" ]; then
-  echo "mvn not found and will be installed" >&2
-  yum install -y maven
-fi
-
 echo -e "\033[32mCompiling ambari\033[0m"
-cd ../../../
-mvn clean install rpm:rpm -DskipTests -Drat.skip=true
-cd -
+docker run -it --rm --name ambari-rpm-build --privileged=true -e "container=docker" \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /root/.m2:/root/.m2 -v $PWD/../../../:/opt/ambari/ \
+  ambari/develop:trunk-centos-7 bash -c "cd /opt/ambari && mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
 
 echo -e "\033[32mCreating network ambari\033[0m"
 docker network create --driver bridge ambari

--- a/dev-support/docker/centos7/build-containers.sh
+++ b/dev-support/docker/centos7/build-containers.sh
@@ -15,15 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo -e "\033[32mCompiling ambari\033[0m"
+echo -e "\033[32mStarting container ambari-rpm-build\033[0m"
 if [[ -z $(docker ps -a --format "table {{.Names}}" | grep "ambari-rpm-build") ]];then
-  docker run -it --name ambari-rpm-build --privileged=true -e "container=docker" \
+  docker run -it -d --name ambari-rpm-build --privileged=true -e "container=docker" \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD/../../../:/opt/ambari/ \
     -w /opt/ambari \
-    ambari/develop:trunk-centos-7 bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+    ambari/develop:trunk-centos-7
 else
-  docker start -i ambari-rpm-build
+  docker start ambari-rpm-build
 fi
+
+echo -e "\033[32mCompiling ambari\033[0m"
+docker exec ambari-rpm-build bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+docker stop ambari-rpm-build
 
 echo -e "\033[32mCreating network ambari\033[0m"
 docker network create --driver bridge ambari

--- a/dev-support/docker/centos7/build-containers.sh
+++ b/dev-support/docker/centos7/build-containers.sh
@@ -16,9 +16,13 @@
 # limitations under the License.
 
 echo -e "\033[32mCompiling ambari\033[0m"
-docker run -it --rm --name ambari-rpm-build --privileged=true -e "container=docker" \
-  -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /root/.m2:/root/.m2 -v $PWD/../../../:/opt/ambari/ \
-  ambari/develop:trunk-centos-7 bash -c "cd /opt/ambari && mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+if [[ -z $(docker ps -a --format "table {{.Names}}" | grep "ambari-rpm-build") ]];then
+  docker run -it --name ambari-rpm-build --privileged=true -e "container=docker" \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD/../../../:/opt/ambari/ \
+    ambari/develop:trunk-centos-7 bash -c "cd /opt/ambari && mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+else
+  docker start -i ambari-rpm-build
+fi
 
 echo -e "\033[32mCreating network ambari\033[0m"
 docker network create --driver bridge ambari

--- a/dev-support/docker/centos7/build-containers.sh
+++ b/dev-support/docker/centos7/build-containers.sh
@@ -19,7 +19,8 @@ echo -e "\033[32mCompiling ambari\033[0m"
 if [[ -z $(docker ps -a --format "table {{.Names}}" | grep "ambari-rpm-build") ]];then
   docker run -it --name ambari-rpm-build --privileged=true -e "container=docker" \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD/../../../:/opt/ambari/ \
-    ambari/develop:trunk-centos-7 bash -c "cd /opt/ambari && mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
+    -w /opt/ambari \
+    ambari/develop:trunk-centos-7 bash -c "mvn clean install rpm:rpm -DskipTests -Drat.skip=true"
 else
   docker start -i ambari-rpm-build
 fi

--- a/dev-support/docker/centos7/build-containers.sh
+++ b/dev-support/docker/centos7/build-containers.sh
@@ -15,6 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo -e "\033[32mInstall mvn\033[0m"
+if [ ! "$(command -v mvn)" ]; then
+  echo "mvn not found and will be installed" >&2
+  yum install -y maven
+fi
+
 echo -e "\033[32mCompiling ambari\033[0m"
 cd ../../../
 mvn clean install rpm:rpm -DskipTests -Drat.skip=true

--- a/dev-support/docker/centos7/clear-containers.sh
+++ b/dev-support/docker/centos7/clear-containers.sh
@@ -19,9 +19,6 @@ echo -e "\033[32mRemoving container ambari-rpm-build\033[0m"
 docker rm -f ambari-rpm-build
 
 echo -e "\033[32mRemoving container ambari-server\033[0m"
-docker rm -f ambari-rpm-build
-
-echo -e "\033[32mRemoving container ambari-server\033[0m"
 docker rm -f ambari-server
 
 echo -e "\033[32mRemoving container ambari-agent-01\033[0m"

--- a/dev-support/docker/centos7/clear-containers.sh
+++ b/dev-support/docker/centos7/clear-containers.sh
@@ -15,9 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo -e "\033[32mRemoving container ambari-rpm-build\033[0m"
-docker rm -f ambari-rpm-build
-
 echo -e "\033[32mRemoving container ambari-server\033[0m"
 docker rm -f ambari-server
 

--- a/dev-support/docker/centos7/clear-containers.sh
+++ b/dev-support/docker/centos7/clear-containers.sh
@@ -16,6 +16,9 @@
 # limitations under the License.
 
 echo -e "\033[32mRemoving container ambari-server\033[0m"
+docker rm -f ambari-rpm-build
+
+echo -e "\033[32mRemoving container ambari-server\033[0m"
 docker rm -f ambari-server
 
 echo -e "\033[32mRemoving container ambari-agent-01\033[0m"

--- a/dev-support/docker/centos7/clear-containers.sh
+++ b/dev-support/docker/centos7/clear-containers.sh
@@ -15,6 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo -e "\033[32mStopping container ambari-rpm-build and maven process\033[0m"
+if [ `docker inspect --format '{{.State.Running}}' ambari-rpm-build` == true ];then
+  docker exec ambari-rpm-build bash -c "pkill -KILL -f maven"
+  docker stop ambari-rpm-build
+fi
+
 echo -e "\033[32mRemoving container ambari-server\033[0m"
 docker rm -f ambari-server
 

--- a/dev-support/docker/centos7/clear-containers.sh
+++ b/dev-support/docker/centos7/clear-containers.sh
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo -e "\033[32mRemoving container ambari-rpm-build\033[0m"
+docker rm -f ambari-rpm-build
+
 echo -e "\033[32mRemoving container ambari-server\033[0m"
 docker rm -f ambari-server
 


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/AMBARI-25746](url)
## What changes were proposed in this pull request?
An error is reported when run ./dev-support/docker/centos7/build-containers.sh
as follows：
`No package /root/ambari-agent.rpm available.
Error: Nothing to do
Setting up mariadb-server
Created symlink from /etc/systemd/system/multi-user.target.wants/mariadb.service to /usr/lib/systemd/system/mariadb.service.
ERROR at line 1: Failed to open file '/var/lib/ambari-server/resources/Ambari-DDL-MySQL-CREATE.sql', error: 2
Setting up ambari-server
bash: ambari-server: command not found
bash: ambari-server: command not found`

reason：
I am building in a new server environment, the server does not have mvn installed by default

solve：
Install mvn before compiling

## How was this patch tested?
Use Docker cluster environment for tests(scripts are under ./dev-support/docker/centos7/build-containers.sh)