### PR TITLE
AMBARI-25748: HDFS Service Check Fails in NameNode HA cluster

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
@@ -81,13 +81,14 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
     params.HdfsResource(None, action="execute")
 
     if params.has_journalnode_hosts:
-      journalnode_web_path = "/journalnode.html"
+      journalnode_web_path = "/index.html"
       if params.security_enabled:
         for host in params.journalnode_hosts:
           if params.https_only:
-            uri = format("https://{host}:{journalnode_port}{journalnode_web_path}")
+            uri = format("https://{host}:{journalnode_port}")
           else:
-            uri = format("http://{host}:{journalnode_port}{journalnode_web_path}")
+            uri = format("http://{host}:{journalnode_port}")
+          uri += journalnode_web_path
           response, errmsg, time_millis = curl_krb_request(params.tmp_dir, params.smoke_user_keytab,
                                                            params.smokeuser_principal, uri, "jn_service_check",
                                                            params.kinit_path_local, False, None, params.smoke_user)
@@ -95,7 +96,6 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
             Logger.error("Cannot access WEB UI on: {0}. Error : {1}", uri, errmsg)
             return 1
       else:
-        journalnode_port = params.journalnode_port
         checkWebUIFileName = "checkWebUI.py"
         checkWebUIFilePath = format("{tmp_dir}/{checkWebUIFileName}")
         comma_sep_jn_hosts = ",".join(params.journalnode_hosts)

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
@@ -81,12 +81,13 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
     params.HdfsResource(None, action="execute")
 
     if params.has_journalnode_hosts:
+      journalnode_web_path = "/journalnode.html"
       if params.security_enabled:
         for host in params.journalnode_hosts:
           if params.https_only:
-            uri = format("https://{host}:{journalnode_port}")
+            uri = format("https://{host}:{journalnode_port}{journalnode_web_path}")
           else:
-            uri = format("http://{host}:{journalnode_port}")
+            uri = format("http://{host}:{journalnode_port}{journalnode_web_path}")
           response, errmsg, time_millis = curl_krb_request(params.tmp_dir, params.smoke_user_keytab,
                                                            params.smokeuser_principal, uri, "jn_service_check",
                                                            params.kinit_path_local, False, None, params.smoke_user)
@@ -99,7 +100,7 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
         checkWebUIFilePath = format("{tmp_dir}/{checkWebUIFileName}")
         comma_sep_jn_hosts = ",".join(params.journalnode_hosts)
 
-        checkWebUICmd = format("ambari-python-wrap {checkWebUIFilePath} -m {comma_sep_jn_hosts} -p {journalnode_port} -s {https_only} -o {script_https_protocol}")
+        checkWebUICmd = format("ambari-python-wrap {checkWebUIFilePath} -m {comma_sep_jn_hosts} -p {journalnode_port} -s {https_only} -o {script_https_protocol} -a {journalnode_web_path}")
         File(checkWebUIFilePath,
              content=StaticFile(checkWebUIFileName),
              mode=0775)

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
@@ -81,7 +81,6 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
     params.HdfsResource(None, action="execute")
 
     if params.has_journalnode_hosts:
-      journalnode_web_path = "/index.html"
       if params.security_enabled:
         for host in params.journalnode_hosts:
           if params.https_only:

--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/services/HDFS/package/scripts/service_check.py
@@ -88,7 +88,6 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
             uri = format("https://{host}:{journalnode_port}")
           else:
             uri = format("http://{host}:{journalnode_port}")
-          uri += journalnode_web_path
           response, errmsg, time_millis = curl_krb_request(params.tmp_dir, params.smoke_user_keytab,
                                                            params.smokeuser_principal, uri, "jn_service_check",
                                                            params.kinit_path_local, False, None, params.smoke_user)
@@ -96,11 +95,12 @@ class HdfsServiceCheckDefault(HdfsServiceCheck):
             Logger.error("Cannot access WEB UI on: {0}. Error : {1}", uri, errmsg)
             return 1
       else:
+        journalnode_port = params.journalnode_port
         checkWebUIFileName = "checkWebUI.py"
         checkWebUIFilePath = format("{tmp_dir}/{checkWebUIFileName}")
         comma_sep_jn_hosts = ",".join(params.journalnode_hosts)
 
-        checkWebUICmd = format("ambari-python-wrap {checkWebUIFilePath} -m {comma_sep_jn_hosts} -p {journalnode_port} -s {https_only} -o {script_https_protocol} -a {journalnode_web_path}")
+        checkWebUICmd = format("ambari-python-wrap {checkWebUIFilePath} -m {comma_sep_jn_hosts} -p {journalnode_port} -s {https_only} -o {script_https_protocol}")
         File(checkWebUIFilePath,
              content=StaticFile(checkWebUIFileName),
              mode=0775)


### PR DESCRIPTION
## What changes were proposed in this pull request?
In NameNode HA cluster, hdfs service check fails, as shown in following log.

<pre>
2022-10-02 13:25:04,065 - File['/var/lib/ambari-agent/tmp/checkWebUI.py'] {'content': StaticFile('checkWebUI.py'), 'mode': 0775}
2022-10-02 13:25:04,067 - Execute['ambari-python-wrap /var/lib/ambari-agent/tmp/checkWebUI.py -m bigtop3,bigtop4,bigtop1 -p 8480 -s False -o PROTOCOL_TLSv1_2'] {'logoutput': True, 'tries': 5, 'user': 'ambari-qa', 'try_sleep': 3}
Cannot access WEB UI on: http://bigtop3:8480
2022-10-02 13:25:04,279 - Retrying after 3 seconds. Reason: Execution of 'ambari-python-wrap /var/lib/ambari-agent/tmp/checkWebUI.py -m bigtop3,bigtop4,bigtop1 -p 8480 -s False -o PROTOCOL_TLSv1_2' returned 1. Cannot access WEB UI on: http://bigtop3:8480
Cannot access WEB UI on: http://bigtop3:8480
2022-10-02 13:25:07,462 - Retrying after 3 seconds. Reason: Execution of 'ambari-python-wrap /var/lib/ambari-agent/tmp/checkWebUI.py -m bigtop3,bigtop4,bigtop1 -p 8480 -s False -o PROTOCOL_TLSv1_2' returned 1. Cannot access WEB UI on: http://bigtop3:8480
Cannot access WEB UI on: http://bigtop3:8480
2022-10-02 13:25:10,706 - Retrying after 3 seconds. Reason: Execution of 'ambari-python-wrap /var/lib/ambari-agent/tmp/checkWebUI.py -m bigtop3,bigtop4,bigtop1 -p 8480 -s False -o PROTOCOL_TLSv1_2' returned 1. Cannot access WEB UI on: http://bigtop3:8480
Cannot access WEB UI on: http://bigtop3:8480
2022-10-02 13:25:13,890 - Retrying after 3 seconds. Reason: Execution of 'ambari-python-wrap /var/lib/ambari-agent/tmp/checkWebUI.py -m bigtop3,bigtop4,bigtop1 -p 8480 -s False -o PROTOCOL_TLSv1_2' returned 1. Cannot access WEB UI on: http://bigtop3:8480
Cannot access WEB UI on: http://bigtop3:8480
</pre>

The reason is that http response code is 302 when access to http://bigtop3:8480/.
And the code in checkWebUI.py at line 81 will see the reponse code 302 as a failure.
## How was this patch tested?
Tested in local vm cluster, including kerberos authentication.

hdfs service check before enabling kerberos authentication .

![image](https://user-images.githubusercontent.com/13212217/193444574-81d3c650-570e-4ca5-8b19-04f83a6878c8.png)

hdfs service check after enabling kerberos authentication.

![image](https://user-images.githubusercontent.com/13212217/193444593-9f37be5c-9748-4dfa-a870-ffac6a4e3dc8.png)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.