### PR TITLE
AMBARI-24548: Allow skipping Hive Metastore schema creation for sysprepped cluster

### DIFF
--- a/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/configuration/cluster-env.xml
+++ b/ambari-server/src/main/resources/stacks/BIGTOP/3.2.0/configuration/cluster-env.xml
@@ -81,6 +81,17 @@
     <on-ambari-upgrade add="true"/>
   </property>
   <property>
+    <name>sysprep_skip_hive_schema_create</name>
+    <display-name>Whether to skip creating the Hive Metastore DB schema on sysprepped cluster</display-name>
+    <value>false</value>
+    <description>Whether to skip creating the Hive Metastore DB schema on sysprepped cluster, during fresh install</description>
+    <value-attributes>
+      <overridable>true</overridable>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="true"/>
+  </property>
+  <property>
     <name>smokeuser</name>
     <display-name>Smoke User</display-name>
     <value>ambari-qa</value>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport [9904962](https://github.com/apache/ambari/commit/990496261fcd42ff4c123535b5a2aaf6d8c584b0) from HDP to BIGTOP on branch-2.7

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.