### PR TITLE
AMBARI-25753：Web Should Not Support Enabling NameNode Federation If Hosts Number Less than 4

### DIFF
--- a/ambari-web/app/models/host_component.js
+++ b/ambari-web/app/models/host_component.js
@@ -573,7 +573,7 @@ App.HostComponentActionMap = {
         action: 'openNameNodeFederationWizard',
         label: Em.I18n.t('admin.nameNodeFederation.button.enable'),
         cssClass: 'icon icon-sitemap',
-        disabled: !App.get('isHaEnabled')
+        disabled: !App.get('isHaEnabled') || App.get('allHostNames.length') < 4
       },
       UPDATE_REPLICATION: {
         action: 'updateHBaseReplication',


### PR DESCRIPTION
## What changes were proposed in this pull request?

If hosts number is less than 4, namenode federation wizard shoud not be allowed.

![image](https://user-images.githubusercontent.com/13212217/194757989-d48986bf-093e-4cc9-870b-0980034cbacd.png)
![image](https://user-images.githubusercontent.com/13212217/194758356-409ac456-e022-4c4a-8d52-0a545d4e79bd.png)



## How was this patch tested?
Tested in local vm cluster,
After applying this patch, if hosts number is less than 4, the button Add New HDFS Namespace is gray and cann't enable nn federation .

![1e4117c6b1ef9064444186498628c16](https://user-images.githubusercontent.com/13212217/194758566-354938de-3f8f-4a2b-bcaa-496e16211f3a.jpg)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.