### PR TITLE
AMBARI-25747: 500 Server Error Occurrs When Access to /api/stomp/v1/xxx/xxxx/xhr_send for branch-2.7

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -40,8 +40,8 @@
     <reload4j.version>1.2.22</reload4j.version>
     <logback.version>1.2.10</logback.version>
     <guice.version>4.1.0</guice.version>
-    <spring.version>5.1.18.RELEASE</spring.version>
-    <spring.security.version>5.1.13.RELEASE</spring.security.version>
+    <spring.version>5.3.22</spring.version>
+    <spring.security.version>5.7.2</spring.security.version>
     <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
     <postgres.version>42.2.2</postgres.version>

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/AgentStompConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/AgentStompConfig.java
@@ -71,7 +71,7 @@ public class AgentStompConfig extends AbstractWebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/v1").setHandshakeHandler(getHandshakeHandler())
-        .setAllowedOrigins("*");
+        .setAllowedOriginPatterns("*");
 
   }
 

--- a/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiStompConfig.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/configuration/spring/ApiStompConfig.java
@@ -59,7 +59,7 @@ public class ApiStompConfig extends AbstractWebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/v1")
-      .setAllowedOrigins("*")
+      .setAllowedOriginPatterns("*")
       .withSockJS().setHeartbeatTime(configuration.getAPIHeartbeatInterval());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade Spring to 5.3.22 and fix websockt errors for branch-2.7 
Please see #3336  &  #3377 

(Please fill in changes proposed in this fix)

## How was this patch tested?
ambari-server project can be compiled successfully in local


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.