### PR TITLE
fix(sec): upgrade junit:junit to 4.13.1

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -610,7 +610,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
+        <version>4.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.shell</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in junit:junit 4.10
- [CVE-2020-15250](https://www.oscs1024.com/hd/CVE-2020-15250)


### What did I do？
Upgrade junit:junit from 4.10 to 4.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS