### PR TITLE
AMBARI-25296: alert_ldap_password for Hive service check does not allow single-quotes

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
@@ -22,6 +22,7 @@ from resource_management.core import global_lock
 from resource_management.core.resources import Execute
 from resource_management.libraries.functions import format
 from resource_management.core.signal_utils import TerminateStrategy
+from resource_management.core.shell import quote_bash_args
 
 
 def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd=None, smokeuser='ambari-qa',
@@ -51,10 +52,13 @@ def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd
   if hive_auth == "NOSASL":
     beeline_url.append('auth=noSasl')
 
-  credential_str = ""
+  credential_str = "-n {hive_user}"
+
   # append username and password for LDAP
   if hive_auth == "LDAP":
-    credential_str = "-n '{ldap_username}' -p '{ldap_password!p}'"
+    # password might contain special characters that need to be escaped
+    quoted_ldap_password = quote_bash_args(ldap_password)
+    credential_str = "-n {ldap_username} -p {quoted_ldap_password!p}"
 
   # append url according to ssl configuration
   if ssl and ssl_keystore is not None and ssl_password is not None:
@@ -74,9 +78,9 @@ def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd
 
   # -n the user to connect as (ignored when using the hive principal in the URL, can be different from the user running the beeline command)
   # -e ';' executes a SQL commmand of NOOP
-  cmd = ("beeline -n %s -u '%s' %s -e ';' 2>&1 | awk '{print}' | grep -i " + \
+  cmd = ("beeline -u '%s' %s -e ';' 2>&1 | awk '{print}' | grep -i " + \
          "-e 'Connected to:' -e 'Transaction isolation:' -e 'inactive HS2 instance; use service discovery'") % \
-              (format(hive_user), format(";".join(beeline_url)), format(credential_str))
+        (format(";".join(beeline_url)), format(credential_str))
 
   Execute(cmd,
     user=smokeuser,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [f7b740c](https://github.com/apache/ambari/commit/f7b740c43e46eb0354418f721661d8436d490db1) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.