### PR TITLE
AMBARI-25399: Add hive PAM support for service check and alerts

### DIFF
--- a/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
+++ b/ambari-common/src/main/python/resource_management/libraries/functions/hive_check.py
@@ -28,7 +28,7 @@ from resource_management.core.shell import quote_bash_args
 def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd=None, smokeuser='ambari-qa',
                            hive_user='hive', transport_mode="binary", http_endpoint="cliservice",
                            ssl=False, ssl_keystore=None, ssl_password=None, check_command_timeout=30,
-                           ldap_username="", ldap_password=""):
+                           ldap_username="", ldap_password="", pam_username="", pam_password=""):
   """
   Hive thrift SASL port check
   """
@@ -59,6 +59,12 @@ def check_thrift_port_sasl(address, port, hive_auth="NOSASL", key=None, kinitcmd
     # password might contain special characters that need to be escaped
     quoted_ldap_password = quote_bash_args(ldap_password)
     credential_str = "-n {ldap_username} -p {quoted_ldap_password!p}"
+
+  # append username and password for PAM
+  if hive_auth == "PAM":
+    # password might contain special characters that need to be escaped
+    quoted_pam_password = quote_bash_args(pam_password)
+    credential_str = "-n '{pam_username}' -p '{quoted_pam_password!p}'"
 
   # append url according to ssl configuration
   if ssl and ssl_keystore is not None and ssl_password is not None:


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [2dbaddb](https://github.com/apache/ambari/commit/2dbaddb2ca7e75a28d41992dae0767748cc50c45) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.