### PR TITLE
fix(sec): upgrade org.springframework:spring-beans to 5.2.20.RELEASE

### DIFF
--- a/ambari-views/examples/phone-list-upgrade-view/pom.xml
+++ b/ambari-views/examples/phone-list-upgrade-view/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>3.1.2.RELEASE</version>
+      <version>5.2.20.RELEASE</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-beans 3.1.2.RELEASE
- [CVE-2022-22965](https://www.oscs1024.com/hd/CVE-2022-22965)


### What did I do？
Upgrade org.springframework:spring-beans from 3.1.2.RELEASE to 5.2.20.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS