### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -43,7 +43,7 @@
     <spring.security.version>5.7.2</spring.security.version>
     <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.9.9.3</fasterxml.jackson.databind.version>
-    <postgres.version>42.2.2</postgres.version>
+    <postgres.version>42.4.1</postgres.version>
     <testContainers.version>1.10.2</testContainers.version>
     <forkCount>4</forkCount>
     <reuseForks>false</reuseForks>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.2.2
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.2.2 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS