### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1193,7 +1193,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.193</version>
+      <version>2.1.210</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.h2database:h2 1.4.193
- [CVE-2018-14335](https://www.oscs1024.com/hd/CVE-2018-14335)


### What did I do？
Upgrade com.h2database:h2 from 1.4.193 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS