### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 9.4.41

### DIFF
--- a/ambari-project/pom.xml
+++ b/ambari-project/pom.xml
@@ -30,7 +30,7 @@
     <solr.version>5.5.2</solr.version>
     <ambari.dir>${project.parent.basedir}</ambari.dir>
     <powermock.version>1.6.3</powermock.version>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.4.41</jetty.version>
     <ldap-api.version>1.0.0</ldap-api.version>
     <checkstyle.version>8.9</checkstyle.version>
     <swagger.version>1.5.19</swagger.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.12.v20180830
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.12.v20180830 to 9.4.41 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS