### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 4.3.29.RELEASE

### DIFF
--- a/ambari-views/examples/hello-spring-view/pom.xml
+++ b/ambari-views/examples/hello-spring-view/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>4.0.5.RELEASE</version>
+      <version>4.3.29.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 4.0.5.RELEASE
- [CVE-2020-5421](https://www.oscs1024.com/hd/CVE-2020-5421)


### What did I do？
Upgrade org.springframework:spring-web from 4.0.5.RELEASE to 4.3.29.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS