### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.2.4

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -48,7 +48,7 @@
     <stackHooksLocation>src/main/resources/stack-hooks</stackHooksLocation>
     <stacksSrcLocation>src/main/resources/stacks/${stack.distribution}</stacksSrcLocation>
     <tarballResourcesFolder>src/main/resources</tarballResourcesFolder>
-    <hadoop.version>2.7.2</hadoop.version>
+    <hadoop.version>3.2.4</hadoop.version>
     <ambari.metrics.version>2.7.0.0.0</ambari.metrics.version>
     <empty.dir>src/main/package</empty.dir> <!-- any directory in project with not very big amount of files (not to waste-load them) -->
     <el.log>ALL</el.log> <!-- log level for EclipseLink eclipselink-staticweave-maven-plugin -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-common 2.7.2
- [CVE-2017-15713](https://www.oscs1024.com/hd/CVE-2017-15713)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 2.7.2 to 3.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS