### PR TITLE
fix(sec): upgrade org.quartz-scheduler:quartz to 2.3.2

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -1580,7 +1580,7 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.2.1</version>
+      <version>2.3.2</version>
       <exclusions>
         <exclusion>
           <groupId>c3p0</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.quartz-scheduler:quartz 2.2.1
- [CVE-2019-13990](https://www.oscs1024.com/hd/CVE-2019-13990)


### What did I do？
Upgrade org.quartz-scheduler:quartz from 2.2.1 to 2.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS