### PR TITLE
AMBARI-25199: Ambari does not update "dfs.namenode.lifeline.rpc-addre…

### DIFF
--- a/ambari-web/app/utils/configs/move_namenode_config_initializer.js
+++ b/ambari-web/app/utils/configs/move_namenode_config_initializer.js
@@ -32,6 +32,7 @@ App.MoveNameNodeConfigInitializer = App.MoveComponentConfigInitializerClass.crea
     'dfs.namenode.https-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(50470),
     'dfs.namenode.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8020),
     'dfs.namenode.servicerpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8021),
+    'dfs.namenode.lifeline.rpc-address.{{namespaceId}}.{{suffix}}': App.MoveComponentConfigInitializerClass.getTargetHostConfig(8050)
   },
 
   uniqueInitializers: {


### PR DESCRIPTION
…ss" during Namenode move operation

## What changes were proposed in this pull request?
Forward port commit [8fe784d](https://github.com/apache/ambari/commit/8fe784d6ebabbcfb236e0613219395a9cd123d3b) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.