### PR TITLE
AMBARI-25200: Ambari returns stack trace in HTML doc when an error oc…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserPrivilegeResourceProvider.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/controller/internal/UserPrivilegeResourceProvider.java
@@ -278,7 +278,7 @@ public class UserPrivilegeResourceProvider extends ReadOnlyResourceProvider {
             }
           }
           usersCache.get().putAll(userNames);
-          userEntity = usersCache.get().getUnchecked(userName);
+          userEntity = usersCache.get().getIfPresent(userName);
         }
 
         if (userEntity == null) {
@@ -286,7 +286,7 @@ public class UserPrivilegeResourceProvider extends ReadOnlyResourceProvider {
         }
 
         if (userEntity == null) {
-          throw new SystemException("User was not found");
+          throw new NoSuchParentResourceException("User was not found");
         }
 
         final Collection<PrivilegeEntity> privileges = users.getUserPrivileges(userEntity);


### PR DESCRIPTION
…curs retrieving details for a user resource that does not exist

## What changes were proposed in this pull request?
Forward port commit [d7248a3](https://github.com/apache/ambari/commit/d7248a3177bebbba66f7df9004ee85cb548e643b) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.