### PR TITLE
AMBARI-25184: configs.py cannot set an empty property value

### DIFF
--- a/ambari-server/src/main/resources/scripts/configs.py
+++ b/ambari-server/src/main/resources/scripts/configs.py
@@ -349,7 +349,7 @@ def main():
   accessor = api_accessor(host, user, password, protocol, port, options.unsafe)
   if action == SET_ACTION:
 
-    if not options.file and (not options.key or not options.value):
+    if not options.file and (not options.key or options.value is None):
       parser.error("You should use option (-f) to set file where entire configurations are saved OR (-k) key and (-v) value for one property")
     if options.file:
       action_args = [options.file]


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [4140a03](https://github.com/apache/ambari/commit/4140a034c015b878e92adb2dce552dbb246ddafc) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.