### PR TITLE
AMBARI-25234: Ambari audit log shows "null" user when executing an AP…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/AmbariAuthenticationEventHandlerImpl.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/security/authentication/AmbariAuthenticationEventHandlerImpl.java
@@ -153,19 +153,5 @@ public class AmbariAuthenticationEventHandlerImpl implements AmbariAuthenticatio
 
   @Override
   public void beforeAttemptAuthentication(AmbariAuthenticationFilter filter, ServletRequest servletRequest, ServletResponse servletResponse) {
-    HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-
-    // Using the Ambari audit logger, log this event (if enabled)
-    if (auditLogger.isEnabled() && filter.shouldApply(httpServletRequest) && (AuthorizationHelper.getAuthenticatedName() == null)) {
-      AuditEvent loginFailedAuditEvent = LoginAuditEvent.builder()
-          .withRemoteIp(RequestUtils.getRemoteAddress(httpServletRequest))
-          .withTimestamp(System.currentTimeMillis())
-          .withReasonOfFailure("Authentication required")
-          .withUserName(null)
-          .withProxyUserName(null)
-          .build();
-      auditLogger.log(loginFailedAuditEvent);
-    }
-
   }
 }


### PR DESCRIPTION
…I call as admin

## What changes were proposed in this pull request?
Forward port commit [adc9d02](https://github.com/apache/ambari/commit/adc9d02ebef3ecf48618b8bf3e1d9a39d9c7c3ab) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.