### PR TITLE
AMBARI-25386. dfs_ha_initial_* properties should be removed during up…

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/SchemaUpgradeHelper.java
@@ -191,6 +191,7 @@ public class SchemaUpgradeHelper {
       catalogBinder.addBinding().to(UpgradeCatalog270.class);
       catalogBinder.addBinding().to(UpgradeCatalog271.class);
       catalogBinder.addBinding().to(UpgradeCatalog272.class);
+      catalogBinder.addBinding().to(UpgradeCatalog275.class);
       catalogBinder.addBinding().to(UpgradeCatalog280.class);
       catalogBinder.addBinding().to(UpdateAlertScriptPaths.class);
       catalogBinder.addBinding().to(FinalUpgradeCatalog.class);

--- a/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog275.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/upgrade/UpgradeCatalog275.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.upgrade;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ambari.server.AmbariException;
+import org.apache.ambari.server.orm.dao.BlueprintDAO;
+import org.apache.ambari.server.orm.entities.BlueprintConfigEntity;
+import org.apache.ambari.server.orm.entities.BlueprintEntity;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+/**
+ * The {@link UpgradeCatalog275} upgrades Ambari from 2.7.4 to 2.7.5.
+ */
+public class UpgradeCatalog275 extends AbstractUpgradeCatalog {
+
+  static final Gson GSON = new Gson();
+
+
+  @Inject
+  public UpgradeCatalog275(Injector injector) {
+    super(injector);
+  }
+
+  @Override
+  public String getSourceVersion() {
+    return "2.7.4";
+  }
+
+  @Override
+  public String getTargetVersion() {
+    return "2.7.5";
+  }
+
+  /**
+   * Perform database schema transformation. Can work only before persist service start
+   *
+   * @throws AmbariException
+   * @throws SQLException
+   */
+  @Override
+  protected void executeDDLUpdates() throws AmbariException, SQLException {
+
+  }
+
+  /**
+   * Perform data insertion before running normal upgrade of data, requires started persist service
+   *
+   * @throws AmbariException
+   * @throws SQLException
+   */
+  @Override
+  protected void executePreDMLUpdates() throws AmbariException, SQLException {
+    removeDfsHAInitial();
+  }
+
+  /**
+   * Performs normal data upgrade
+   *
+   * @throws AmbariException
+   * @throws SQLException
+   */
+  @Override
+  protected void executeDMLUpdates() throws AmbariException, SQLException {
+    addNewConfigurationsFromXml();
+  }
+
+  protected void removeDfsHAInitial() {
+    BlueprintDAO blueprintDAO = injector.getInstance(BlueprintDAO.class);
+    List<BlueprintEntity> blueprintEntityList = blueprintDAO.findAll();
+    List<BlueprintEntity> changedBlueprints = new ArrayList<>();
+    for (BlueprintEntity blueprintEntity : blueprintEntityList){
+      boolean changed = false;
+      Collection<BlueprintConfigEntity> blueprintConfigurations = blueprintEntity.getConfigurations();
+      for (BlueprintConfigEntity blueprintConfigEntity : blueprintConfigurations) {
+        if (blueprintConfigEntity.getType().equals("hadoop-env")) {
+          String configData = blueprintConfigEntity.getConfigData();
+
+          Map<String, String> typeProperties = GSON.<Map<String, String>>fromJson(
+            configData, Map.class);
+
+          typeProperties.remove("dfs_ha_initial_namenode_standby");
+          typeProperties.remove("dfs_ha_initial_namenode_active");
+
+          blueprintConfigEntity.setConfigData(GSON.toJson(typeProperties));
+          changed = true;
+        }
+      }
+      if (changed) {
+        changedBlueprints.add(blueprintEntity);
+      }
+    }
+    for (BlueprintEntity blueprintEntity : changedBlueprints) {
+      blueprintDAO.merge(blueprintEntity);
+    }
+  }
+}

--- a/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog275Test.java
+++ b/ambari-server/src/test/java/org/apache/ambari/server/upgrade/UpgradeCatalog275Test.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ambari.server.upgrade;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ambari.server.orm.dao.BlueprintDAO;
+import org.apache.ambari.server.orm.entities.BlueprintConfigEntity;
+import org.apache.ambari.server.orm.entities.BlueprintEntity;
+import org.easymock.Capture;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.inject.Injector;
+
+public class UpgradeCatalog275Test {
+
+  @Test
+  public void testRemoveDfsHAInitial() {
+    Injector injector = createNiceMock(Injector.class);
+    BlueprintDAO blueprintDAO = createMock(BlueprintDAO.class);
+
+    BlueprintConfigEntity blueprintConfigEntity = new BlueprintConfigEntity();
+    blueprintConfigEntity.setType("hadoop-env");
+    blueprintConfigEntity.setConfigData("{\"dfs_ha_initial_namenode_standby\":\"%HOSTGROUP::master_2%\"," +
+                                          "\"dfs_ha_initial_namenode_active\":\"u1602.ambari.apache.org\"}");
+
+    List<BlueprintConfigEntity> blueprintConfigurations = Collections.singletonList(blueprintConfigEntity);
+
+    BlueprintEntity blueprintEntity = new BlueprintEntity();
+    blueprintEntity.setConfigurations(blueprintConfigurations);
+
+    List<BlueprintEntity> blueprintEntityList = Collections.singletonList(blueprintEntity);
+
+    expect(injector.getInstance(BlueprintDAO.class)).andReturn(blueprintDAO);
+    expect(blueprintDAO.findAll()).andReturn(blueprintEntityList);
+
+    Capture<BlueprintEntity> blueprintEntityCapture = Capture.newInstance();
+    expect(blueprintDAO.merge(capture(blueprintEntityCapture))).andReturn(null);
+
+    replay(injector, blueprintDAO);
+
+    UpgradeCatalog275 upgradeCatalog275 = new UpgradeCatalog275(injector);
+    upgradeCatalog275.removeDfsHAInitial();
+
+    verify(injector, blueprintDAO);
+
+    Assert.assertNotNull(blueprintEntityCapture.getValues());
+    Assert.assertEquals(1, blueprintEntityCapture.getValues().size());
+
+    BlueprintEntity blueprintEntityToMerge = blueprintEntityCapture.getValue();
+
+    Collection<BlueprintConfigEntity> resultConfigurations = blueprintEntityToMerge.getConfigurations();
+    for (BlueprintConfigEntity resultConfiguration : resultConfigurations) {
+      if (resultConfiguration.getType().equals("hadoop-env")) {
+        String configData = resultConfiguration.getConfigData();
+
+        Map<String, String> typeProperties = UpgradeCatalog275.GSON.<Map<String, String>>fromJson(
+          configData, Map.class);
+        Assert.assertEquals(0, typeProperties.size());
+        return;
+      }
+    }
+    Assert.fail("No \"hadoop-env\" config type was found in result configuration");
+  }
+}


### PR DESCRIPTION
AMBARI-25386. dfs_ha_initial_* properties should be removed during upgrade.

## What changes were proposed in this pull request?

AMBARI-25386. dfs_ha_initial_* properties should be removed during upgrade.

## How was this patch tested?


Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.