### PR TITLE
AMBARI-25252: Disable directory Indexing at /resources

### DIFF
--- a/ambari-server/src/main/assemblies/server.xml
+++ b/ambari-server/src/main/assemblies/server.xml
@@ -409,6 +409,11 @@
     </file>
     <file>
       <fileMode>755</fileMode>
+      <source>src/main/resources/index.html</source>
+      <outputDirectory>/var/lib/ambari-server/resources</outputDirectory>
+    </file>
+    <file>
+      <fileMode>755</fileMode>
       <source>src/main/resources/kerberos.json</source>
       <outputDirectory>/var/lib/ambari-server/resources</outputDirectory>
     </file>

--- a/ambari-server/src/main/resources/index.html
+++ b/ambari-server/src/main/resources/index.html
@@ -1,0 +1,17 @@
+<!--
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+-->


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [18f895c](https://github.com/apache/ambari/commit/18f895ca0130ab3d0058eae8d3b262d9d47b6909) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.