### PR TITLE
AMBARI-25272: Ambari UI default Ajax Timeout is 3 minutes but some op…

### DIFF
--- a/ambari-web/app/config.js
+++ b/ambari-web/app/config.js
@@ -32,7 +32,7 @@ App.defaultStackVersion = 'HDP-2.3';
 App.defaultWindowsStackVersion = 'HDPWIN-2.1';
 
 App.defaultJavaHome = '/usr/jdk/jdk1.6.0_31';
-App.timeout = 180000; // default AJAX timeout
+App.timeout = 300000; // default AJAX timeout
 App.maxRetries = 3; // max number of retries for certain AJAX calls
 App.sessionKeepAliveInterval  = 60000;
 App.bgOperationsUpdateInterval = 6000;


### PR DESCRIPTION
…erations in server can take more than that

## What changes were proposed in this pull request?
Forward port commit [017a85e](https://github.com/apache/ambari/commit/017a85e2bdd8a148c4daaf25870f0066c052a97d) on branch-2.7
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.